### PR TITLE
Require administrator privileges at application startup

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "bloop.vibe-kanban"
+  ]
+}

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <StartupObject>Foundry.Program</StartupObject>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Foundry/Program.cs
+++ b/src/Foundry/Program.cs
@@ -5,6 +5,8 @@ using Foundry.Services.Operations;
 using Foundry.Services.Theme;
 using Foundry.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
+using System.Security.Principal;
+using System.Windows;
 
 namespace Foundry;
 
@@ -13,6 +15,16 @@ public static class Program
     [STAThread]
     public static void Main()
     {
+        if (!IsRunningAsAdministrator())
+        {
+            MessageBox.Show(
+                "Foundry must be started with administrator privileges.",
+                "Administrator privileges required",
+                MessageBoxButton.OK,
+                MessageBoxImage.Error);
+            return;
+        }
+
         using ServiceProvider serviceProvider = BuildServiceProvider();
 
         App app = serviceProvider.GetRequiredService<App>();
@@ -37,5 +49,17 @@ public static class Program
         services.AddSingleton<IAdkService, AdkService>();
 
         return services.BuildServiceProvider();
+    }
+
+    private static bool IsRunningAsAdministrator()
+    {
+        WindowsIdentity? identity = WindowsIdentity.GetCurrent();
+        if (identity is null)
+        {
+            return false;
+        }
+
+        WindowsPrincipal principal = new(identity);
+        return principal.IsInRole(WindowsBuiltInRole.Administrator);
     }
 }

--- a/src/Foundry/app.manifest
+++ b/src/Foundry/app.manifest
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="Foundry.app" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>


### PR DESCRIPTION
The application must require administrator privileges at startup.

This requirement is necessary to ensure access to system-level resources and functionalities that are restricted to elevated permissions. Without administrator rights, certain features may not function correctly or could cause unexpected errors.

The application should therefore verify that it is running with elevated privileges when launched and prevent execution if the required permissions are not granted.