### PR TITLE
Add app manifest to require administrator privileges at startup

### DIFF
--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <StartupObject>Foundry.Program</StartupObject>
+    <Win32Manifest>app.manifest</Win32Manifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Foundry/app.manifest
+++ b/src/Foundry/app.manifest
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="Foundry.app" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>


### PR DESCRIPTION
This pull request introduces a new application manifest to the project and configures the build to use it. The manifest ensures that the application requests administrator privileges on launch.

Project configuration:

* Updated `Foundry.csproj` to include the new `app.manifest` file via the `<Win32Manifest>` property, so the application uses the specified manifest at build time.

Application privileges:

* Added a new `app.manifest` file that sets the application to require administrator privileges (`requireAdministrator`) on startup.