### PR TITLE
Implement computer name validation in deployment process

### DIFF
--- a/src/Foundry.Deploy/MainWindow.xaml
+++ b/src/Foundry.Deploy/MainWindow.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="clr-namespace:Foundry.Deploy.Controls"
+    xmlns:rules="clr-namespace:Foundry.Deploy.Validation"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     Title="Foundry.Deploy"
@@ -93,6 +94,27 @@
                                     Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                     Style="{StaticResource CaptionTextBlockStyle}"
                                     Text="Cache strategy is determined automatically from WinPE startup context." />
+                                <TextBlock
+                                    Margin="0,12,0,0"
+                                    Style="{StaticResource BodyStrongTextBlockStyle}"
+                                    Text="Computer Name" />
+                                <TextBox
+                                    x:Name="TargetComputerNameTextBox"
+                                    Margin="0,8,0,0"
+                                    MaxLength="{x:Static rules:ComputerNameRules.MaxLength}"
+                                    PreviewTextInput="TargetComputerNameTextBox_PreviewTextInput"
+                                    Text="{Binding TargetComputerName, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBlock
+                                    Margin="0,8,0,0"
+                                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                    Style="{StaticResource CaptionTextBlockStyle}"
+                                    Text="1-15 characters. A-Z, a-z, 0-9, and hyphen only." />
+                                <TextBlock
+                                    Margin="0,4,0,0"
+                                    Foreground="#FFC42B1C"
+                                    Style="{StaticResource CaptionTextBlockStyle}"
+                                    Text="{Binding TargetComputerNameValidationMessage}"
+                                    Visibility="{Binding HasTargetComputerNameValidationError, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                 <TextBlock
                                     Margin="0,12,0,0"
                                     Style="{StaticResource BodyStrongTextBlockStyle}"

--- a/src/Foundry.Deploy/MainWindow.xaml.cs
+++ b/src/Foundry.Deploy/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using Foundry.Deploy.Validation;
 using Foundry.Deploy.ViewModels;
 
 namespace Foundry.Deploy;
@@ -10,6 +11,7 @@ public partial class MainWindow : Window
     public MainWindow(MainWindowViewModel viewModel)
     {
         InitializeComponent();
+        DataObject.AddPastingHandler(TargetComputerNameTextBox, TargetComputerNameTextBox_OnPaste);
         DataContext = viewModel;
     }
 
@@ -26,8 +28,49 @@ public partial class MainWindow : Window
         }
     }
 
+    private void TargetComputerNameTextBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
+    {
+        if (!ComputerNameRules.IsAllowedText(e.Text))
+        {
+            e.Handled = true;
+        }
+    }
+
+    private void TargetComputerNameTextBox_OnPaste(object sender, DataObjectPastingEventArgs e)
+    {
+        if (sender is not TextBox textBox)
+        {
+            e.CancelCommand();
+            return;
+        }
+
+        string? pastedText = e.DataObject.GetDataPresent(DataFormats.UnicodeText)
+            ? e.DataObject.GetData(DataFormats.UnicodeText) as string
+            : e.DataObject.GetDataPresent(DataFormats.Text)
+                ? e.DataObject.GetData(DataFormats.Text) as string
+                : null;
+
+        if (pastedText is null || !ComputerNameRules.IsAllowedText(pastedText))
+        {
+            e.CancelCommand();
+            return;
+        }
+
+        string currentText = textBox.Text ?? string.Empty;
+        int selectionStart = Math.Clamp(textBox.SelectionStart, 0, currentText.Length);
+        int selectionLength = Math.Clamp(textBox.SelectionLength, 0, currentText.Length - selectionStart);
+        string nextText = currentText.Remove(selectionStart, selectionLength).Insert(selectionStart, pastedText);
+
+        if (textBox.MaxLength > 0 && nextText.Length > textBox.MaxLength)
+        {
+            e.CancelCommand();
+        }
+    }
+
     protected override void OnClosed(EventArgs e)
     {
+        DataObject.RemovePastingHandler(TargetComputerNameTextBox, TargetComputerNameTextBox_OnPaste);
+
         if (DataContext is MainWindowViewModel viewModel)
         {
             viewModel.Dispose();

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentContext.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentContext.cs
@@ -7,6 +7,7 @@ public sealed record DeploymentContext
     public required DeploymentMode Mode { get; init; }
     public required string CacheRootPath { get; init; }
     public required int TargetDiskNumber { get; init; }
+    public required string TargetComputerName { get; init; }
     public required OperatingSystemCatalogItem OperatingSystem { get; init; }
     public required DriverPackSelectionKind DriverPackSelectionKind { get; init; }
     public DriverPackCatalogItem? DriverPack { get; init; }

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentOrchestrator.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentOrchestrator.cs
@@ -34,6 +34,7 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
         "Download operating system image",
         "Download and prepare driver pack",
         "Apply operating system image",
+        "Configure target computer name",
         "Configure recovery environment",
         "Apply offline drivers",
         "Seal recovery partition",
@@ -85,10 +86,11 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
 
     public async Task<DeploymentResult> RunAsync(DeploymentContext context, CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Starting deployment orchestration. Mode={Mode}, IsDryRun={IsDryRun}, TargetDiskNumber={TargetDiskNumber}, DriverPackSelectionKind={DriverPackSelectionKind}",
+        _logger.LogInformation("Starting deployment orchestration. Mode={Mode}, IsDryRun={IsDryRun}, TargetDiskNumber={TargetDiskNumber}, TargetComputerName={TargetComputerName}, DriverPackSelectionKind={DriverPackSelectionKind}",
             context.Mode,
             context.IsDryRun,
             context.TargetDiskNumber,
+            context.TargetComputerName,
             context.DriverPackSelectionKind);
 
         if (!_operationProgressService.TryStart(OperationKind.Deploy, "Starting Foundry.Deploy orchestration.", 0))
@@ -110,6 +112,7 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
             IsDryRun = context.IsDryRun,
             RequestedCacheRootPath = context.CacheRootPath,
             TargetDiskNumber = context.TargetDiskNumber,
+            TargetComputerName = context.TargetComputerName,
             OperatingSystemFileName = context.OperatingSystem.FileName,
             OperatingSystemUrl = context.OperatingSystem.Url,
             DriverPackSelectionKind = context.DriverPackSelectionKind,
@@ -552,6 +555,34 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
                     return StepExecutionOutcome.Succeeded("Operating system image applied.");
                 }
 
+            case "Configure target computer name":
+                {
+                    if (string.IsNullOrWhiteSpace(runtimeState.TargetWindowsPartitionRoot))
+                    {
+                        return StepExecutionOutcome.Failed("Target Windows partition is unavailable.");
+                    }
+
+                    string targetFoundryRoot = EnsureTargetFoundryRoot(runtimeState);
+                    string workingDirectory = Path.Combine(targetFoundryRoot, "Temp", "Deployment");
+                    Directory.CreateDirectory(workingDirectory);
+
+                    await _windowsDeploymentService
+                        .ConfigureOfflineComputerNameAsync(
+                            runtimeState.TargetWindowsPartitionRoot,
+                            runtimeState.TargetComputerName,
+                            context.OperatingSystem.Architecture,
+                            workingDirectory,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+
+                    await AppendLogAsync(
+                        logSession,
+                        DeploymentLogLevel.Info,
+                        $"Target computer name configured: {runtimeState.TargetComputerName}.",
+                        cancellationToken).ConfigureAwait(false);
+                    return StepExecutionOutcome.Succeeded("Target computer name configured.");
+                }
+
             case "Configure recovery environment":
                 {
                     if (string.IsNullOrWhiteSpace(runtimeState.TargetWindowsPartitionRoot) ||
@@ -881,6 +912,35 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
                     return StepExecutionOutcome.Succeeded("Operating system image applied (simulation).");
                 }
 
+            case "Configure target computer name":
+                {
+                    if (string.IsNullOrWhiteSpace(runtimeState.TargetWindowsPartitionRoot))
+                    {
+                        return StepExecutionOutcome.Failed("Target Windows partition is unavailable.");
+                    }
+
+                    string targetFoundryRoot = EnsureTargetFoundryRoot(runtimeState);
+                    string workingDirectory = Path.Combine(targetFoundryRoot, "Temp", "Deployment");
+                    Directory.CreateDirectory(workingDirectory);
+
+                    await _windowsDeploymentService
+                        .ConfigureOfflineComputerNameAsync(
+                            runtimeState.TargetWindowsPartitionRoot,
+                            runtimeState.TargetComputerName,
+                            context.OperatingSystem.Architecture,
+                            workingDirectory,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+
+                    await AppendLogAsync(
+                        logSession,
+                        DeploymentLogLevel.Info,
+                        $"[DRY-RUN] Simulated target computer name configuration: {runtimeState.TargetComputerName}.",
+                        cancellationToken).ConfigureAwait(false);
+                    await Task.Delay(120, cancellationToken).ConfigureAwait(false);
+                    return StepExecutionOutcome.Succeeded("Target computer name configured (simulation).");
+                }
+
             case "Configure recovery environment":
                 {
                     if (string.IsNullOrWhiteSpace(runtimeState.TargetRecoveryPartitionRoot))
@@ -1160,6 +1220,7 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
                 mode = context.Mode.ToString(),
                 cacheRootPath = context.CacheRootPath,
                 targetDiskNumber = context.TargetDiskNumber,
+                targetComputerName = context.TargetComputerName,
                 driverPackSelectionKind = context.DriverPackSelectionKind.ToString(),
                 useFullAutopilot = context.UseFullAutopilot,
                 allowAutopilotDeferredCompletion = context.AllowAutopilotDeferredCompletion,
@@ -1422,6 +1483,7 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
             mode = runtimeState.Mode.ToString(),
             isDryRun = runtimeState.IsDryRun,
             targetDiskNumber = runtimeState.TargetDiskNumber,
+            targetComputerName = runtimeState.TargetComputerName,
             operatingSystemFileName = runtimeState.OperatingSystemFileName,
             operatingSystemUrl = runtimeState.OperatingSystemUrl,
             downloadedOperatingSystemPath = runtimeState.DownloadedOperatingSystemPath,

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentRuntimeState.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentRuntimeState.cs
@@ -12,6 +12,7 @@ public sealed record DeploymentRuntimeState
     public bool IsDryRun { get; init; }
     public string RequestedCacheRootPath { get; init; } = string.Empty;
     public int TargetDiskNumber { get; init; } = -1;
+    public string TargetComputerName { get; set; } = string.Empty;
     public CacheResolution? ResolvedCache { get; set; }
     public HardwareProfile? HardwareProfile { get; set; }
     public string OperatingSystemFileName { get; init; } = string.Empty;

--- a/src/Foundry.Deploy/Services/Deployment/IWindowsDeploymentService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/IWindowsDeploymentService.cs
@@ -27,6 +27,13 @@ public interface IWindowsDeploymentService
         string workingDirectory,
         CancellationToken cancellationToken = default);
 
+    Task ConfigureOfflineComputerNameAsync(
+        string windowsPartitionRoot,
+        string computerName,
+        string processorArchitecture,
+        string workingDirectory,
+        CancellationToken cancellationToken = default);
+
     Task ConfigureRecoveryEnvironmentAsync(
         string windowsPartitionRoot,
         string recoveryPartitionRoot,

--- a/src/Foundry.Deploy/Services/Deployment/WindowsDeploymentService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/WindowsDeploymentService.cs
@@ -1,6 +1,8 @@
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using Foundry.Deploy.Services.System;
+using Foundry.Deploy.Validation;
 using Microsoft.Extensions.Logging;
 
 namespace Foundry.Deploy.Services.Deployment;
@@ -14,6 +16,12 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
     private const string RecoveryPartitionGuid = "de94bba4-06d1-4d40-a16a-bfd50179d6ac";
     private const string RecoveryPartitionAttributes = "0x8000000000000001";
     private const string WinReImageFileName = "winre.wim";
+    private const string UnattendNamespaceUri = "urn:schemas-microsoft-com:unattend";
+    private const string UnattendFileName = "unattend.xml";
+    private const string ShellSetupComponentName = "Microsoft-Windows-Shell-Setup";
+    private const string ShellSetupPublicKeyToken = "31bf3856ad364e35";
+    private const string ShellSetupLanguage = "neutral";
+    private const string ShellSetupVersionScope = "nonSxS";
 
     private readonly IProcessRunner _processRunner;
     private readonly ILogger<WindowsDeploymentService> _logger;
@@ -243,6 +251,95 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
 
         _logger.LogInformation("Detected applied Windows edition. Edition={Edition}", edition);
         return edition;
+    }
+
+    public Task ConfigureOfflineComputerNameAsync(
+        string windowsPartitionRoot,
+        string computerName,
+        string processorArchitecture,
+        string workingDirectory,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(windowsPartitionRoot))
+        {
+            throw new ArgumentException("Windows partition root is required.", nameof(windowsPartitionRoot));
+        }
+
+        if (!ComputerNameRules.IsValid(computerName))
+        {
+            throw new ArgumentException(
+                "Computer name must contain 1 to 15 valid characters (letters, numbers, or hyphen).",
+                nameof(computerName));
+        }
+
+        Directory.CreateDirectory(workingDirectory);
+
+        if (string.IsNullOrWhiteSpace(processorArchitecture))
+        {
+            _logger.LogWarning("Processor architecture was not provided when configuring the offline computer name. Falling back to amd64.");
+        }
+
+        string normalizedArchitecture = NormalizeUnattendProcessorArchitecture(processorArchitecture);
+        string pantherDirectory = Path.Combine(windowsPartitionRoot, "Windows", "Panther");
+        Directory.CreateDirectory(pantherDirectory);
+
+        string unattendPath = Path.Combine(pantherDirectory, UnattendFileName);
+        XNamespace unattendNamespace = UnattendNamespaceUri;
+        XDocument document = File.Exists(unattendPath)
+            ? XDocument.Load(unattendPath, LoadOptions.PreserveWhitespace)
+            : new XDocument(
+                new XDeclaration("1.0", "utf-8", "yes"),
+                new XElement(unattendNamespace + "unattend"));
+
+        XElement root = EnsureUnattendRoot(document, unattendNamespace);
+        XElement settings = root
+            .Elements(unattendNamespace + "settings")
+            .FirstOrDefault(element => string.Equals((string?)element.Attribute("pass"), "specialize", StringComparison.OrdinalIgnoreCase))
+            ?? new XElement(unattendNamespace + "settings", new XAttribute("pass", "specialize"));
+
+        if (settings.Parent is null)
+        {
+            root.Add(settings);
+        }
+
+        XElement component = settings
+            .Elements(unattendNamespace + "component")
+            .FirstOrDefault(element => string.Equals((string?)element.Attribute("name"), ShellSetupComponentName, StringComparison.OrdinalIgnoreCase))
+            ?? new XElement(unattendNamespace + "component");
+
+        if (component.Parent is null)
+        {
+            settings.Add(component);
+        }
+
+        component.SetAttributeValue("name", ShellSetupComponentName);
+        component.SetAttributeValue("processorArchitecture", normalizedArchitecture);
+        component.SetAttributeValue("publicKeyToken", ShellSetupPublicKeyToken);
+        component.SetAttributeValue("language", ShellSetupLanguage);
+        component.SetAttributeValue("versionScope", ShellSetupVersionScope);
+
+        XElement computerNameElement = component.Element(unattendNamespace + "ComputerName")
+            ?? new XElement(unattendNamespace + "ComputerName");
+
+        if (computerNameElement.Parent is null)
+        {
+            component.Add(computerNameElement);
+        }
+
+        computerNameElement.Value = computerName;
+
+        document.Declaration ??= new XDeclaration("1.0", "utf-8", "yes");
+        document.Save(unattendPath);
+
+        _logger.LogInformation(
+            "Offline computer name configured. ComputerName={ComputerName}, UnattendPath={UnattendPath}, ProcessorArchitecture={ProcessorArchitecture}",
+            computerName,
+            unattendPath,
+            normalizedArchitecture);
+
+        return Task.CompletedTask;
     }
 
     public async Task ConfigureRecoveryEnvironmentAsync(
@@ -617,6 +714,45 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
         }
 
         return path;
+    }
+
+    private static XElement EnsureUnattendRoot(XDocument document, XNamespace unattendNamespace)
+    {
+        if (document.Root is null)
+        {
+            XElement root = new(unattendNamespace + "unattend");
+            document.Add(root);
+            return root;
+        }
+
+        if (document.Root.Name == unattendNamespace + "unattend")
+        {
+            return document.Root;
+        }
+
+        XNode[] existingNodes = document.Root.Nodes().ToArray();
+        XElement replacementRoot = new(unattendNamespace + "unattend");
+        foreach (XNode node in existingNodes)
+        {
+            replacementRoot.Add(node);
+        }
+
+        document.Root.ReplaceWith(replacementRoot);
+        return replacementRoot;
+    }
+
+    private static string NormalizeUnattendProcessorArchitecture(string value)
+    {
+        string normalized = value.Trim().ToLowerInvariant();
+        return normalized switch
+        {
+            "" => "amd64",
+            "amd64" => "amd64",
+            "x64" => "amd64",
+            "arm64" => "arm64",
+            "x86" => "x86",
+            _ => normalized
+        };
     }
 
     private static IReadOnlyList<ImageIndexDescriptor> ParseImageDescriptors(string output)

--- a/src/Foundry.Deploy/Validation/ComputerNameRules.cs
+++ b/src/Foundry.Deploy/Validation/ComputerNameRules.cs
@@ -1,0 +1,86 @@
+using System.Text;
+
+namespace Foundry.Deploy.Validation;
+
+public static class ComputerNameRules
+{
+    public const int MaxLength = 15;
+    public const string FallbackName = "PC";
+    public const string ValidationMessage = "Computer name must contain 1 to 15 characters using A-Z, a-z, 0-9, or -.";
+
+    public static string Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(MaxLength);
+        foreach (char character in value)
+        {
+            if (!IsAllowedCharacter(character))
+            {
+                continue;
+            }
+
+            builder.Append(character);
+            if (builder.Length >= MaxLength)
+            {
+                break;
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    public static bool IsValid(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || value.Length > MaxLength)
+        {
+            return false;
+        }
+
+        foreach (char character in value)
+        {
+            if (!IsAllowedCharacter(character))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static bool IsAllowedText(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return false;
+        }
+
+        foreach (char character in value)
+        {
+            if (!IsAllowedCharacter(character))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static string GetValidationMessage(string? value)
+    {
+        return IsValid(value)
+            ? string.Empty
+            : ValidationMessage;
+    }
+
+    public static bool IsAllowedCharacter(char character)
+    {
+        return (character >= 'A' && character <= 'Z') ||
+               (character >= 'a' && character <= 'z') ||
+               (character >= '0' && character <= '9') ||
+               character == '-';
+    }
+}

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -19,6 +19,7 @@ using Foundry.Deploy.Services.Operations;
 using Foundry.Deploy.Services.Runtime;
 using Foundry.Deploy.Services.System;
 using Foundry.Deploy.Services.Theme;
+using Foundry.Deploy.Validation;
 using Microsoft.Extensions.Logging;
 using DeployThemeMode = Foundry.Deploy.Services.Theme.ThemeMode;
 
@@ -162,7 +163,15 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private string currentStepProgressText = "Waiting for progress...";
 
     [ObservableProperty]
-    private string computerNameText = Environment.MachineName;
+    private string computerNameText = ResolveInitialComputerName();
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(StartDeploymentCommand))]
+    private string targetComputerName = ResolveInitialComputerName();
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasTargetComputerNameValidationError))]
+    private string targetComputerNameValidationMessage = string.Empty;
 
     [ObservableProperty]
     private string ipAddress = "N/A";
@@ -285,6 +294,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     public bool IsDriverPackModelSelectionEnabled => IsOemDriverSourceSelected && DriverPackModelOptions.Count > 0;
     public bool IsDriverPackVersionSelectionEnabled => IsDriverPackModelSelectionEnabled && DriverPackVersionOptions.Count > 0;
     public string SelectedDriverPackSelectionDisplay => BuildSelectedDriverPackSelectionDisplay();
+    public bool HasTargetComputerNameValidationError => !string.IsNullOrWhiteSpace(TargetComputerNameValidationMessage);
 
     public MainWindowViewModel(
         IThemeService themeService,
@@ -314,6 +324,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         (DeploymentMode resolvedMode, string? resolvedUsbCacheRuntimeRoot) = ResolveDeploymentRuntimeContext();
         _resolvedDeploymentMode = resolvedMode;
         _resolvedUsbCacheRuntimeRoot = resolvedUsbCacheRuntimeRoot;
+        TargetComputerNameValidationMessage = ComputerNameRules.GetValidationMessage(TargetComputerName);
 
         _operationProgressService.ProgressChanged += OnOperationProgressChanged;
         _deploymentOrchestrator.StepProgressChanged += OnStepProgressChanged;
@@ -490,6 +501,18 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             return;
         }
 
+        string normalizedComputerName = ComputerNameRules.Normalize(TargetComputerName);
+        if (!ComputerNameRules.IsValid(normalizedComputerName))
+        {
+            DeploymentStatus = "Enter a valid computer name.";
+            return;
+        }
+
+        if (!normalizedComputerName.Equals(TargetComputerName, StringComparison.Ordinal))
+        {
+            TargetComputerName = normalizedComputerName;
+        }
+
         TargetDiskInfo? effectiveTargetDisk = SelectedTargetDisk;
         if (effectiveTargetDisk is null && IsDebugSafeMode)
         {
@@ -540,6 +563,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             Mode = _resolvedDeploymentMode,
             CacheRootPath = CacheRootPath,
             TargetDiskNumber = effectiveTargetDisk.DiskNumber,
+            TargetComputerName = normalizedComputerName,
             OperatingSystem = SelectedOperatingSystem,
             DriverPackSelectionKind = effectiveDriverPackKind,
             DriverPack = effectiveDriverPack,
@@ -632,8 +656,9 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         InitializeProgressState();
         DeploymentProgress = 42;
         UpdateGlobalProgressVisuals(DeploymentProgress);
+        ComputerNameText = TargetComputerName;
         CurrentStepName = "Apply operating system image";
-        StepCounterText = "Step: 7 of 10";
+        StepCounterText = BuildStepCounterText(8);
         CurrentStepProgress = 65;
         IsCurrentStepProgressIndeterminate = false;
         CurrentStepProgressText = "Applying image: 65%";
@@ -648,8 +673,9 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         ClearFailureDetails();
         DeploymentProgress = 100;
         UpdateGlobalProgressVisuals(DeploymentProgress);
+        ComputerNameText = TargetComputerName;
         CurrentStepName = "Finalize deployment and write logs";
-        StepCounterText = "Step: 10 of 10";
+        StepCounterText = BuildStepCounterText(_deploymentOrchestrator.PlannedSteps.Count);
         CurrentStepProgress = 100;
         IsCurrentStepProgressIndeterminate = false;
         CurrentStepProgressText = "Step completed.";
@@ -661,6 +687,8 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private void ShowDebugErrorPage()
     {
         StopElapsedTimeTracking();
+        ComputerNameText = TargetComputerName;
+        StepCounterText = BuildStepCounterText(8);
         SetFailureDetails(
             "Apply operating system image",
             "Debug preview: DISM apply failed because the target partition is read-only.\n\n" +
@@ -684,6 +712,18 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     partial void OnSelectedOperatingSystemChanged(OperatingSystemCatalogItem? value)
     {
         RefreshDriverPackOptions();
+    }
+
+    partial void OnTargetComputerNameChanged(string value)
+    {
+        string normalized = ComputerNameRules.Normalize(value);
+        if (!normalized.Equals(value, StringComparison.Ordinal))
+        {
+            TargetComputerName = normalized;
+            return;
+        }
+
+        TargetComputerNameValidationMessage = ComputerNameRules.GetValidationMessage(normalized);
     }
 
     partial void OnSelectedDriverPackOptionChanged(DriverPackOptionItem? value)
@@ -851,10 +891,8 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         IsCurrentStepProgressIndeterminate = true;
         CurrentStepProgressText = "Waiting for progress...";
 
-        int plannedStepCount = _deploymentOrchestrator.PlannedSteps.Count;
-        StepCounterText = plannedStepCount > 0 ? $"Step: 0 of {plannedStepCount}" : "Step: ? of ?";
-
-        ComputerNameText = Environment.MachineName;
+        StepCounterText = BuildStepCounterText(0);
+        ComputerNameText = TargetComputerName;
         CaptureNetworkSnapshot();
 
         _deploymentStartTimeUtc = DateTimeOffset.Now;
@@ -1193,6 +1231,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
                !IsCatalogLoading &&
                !IsTargetDiskLoading &&
                WizardStepIndex == 3 &&
+               ComputerNameRules.IsValid(TargetComputerName) &&
                SelectedOperatingSystem is not null &&
                hasTargetDisk &&
                HasValidDriverPackSelection();
@@ -2117,6 +2156,18 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         return os.Equals(driver, StringComparison.OrdinalIgnoreCase);
     }
 
+    private string BuildStepCounterText(int currentStep)
+    {
+        int plannedStepCount = _deploymentOrchestrator.PlannedSteps.Count;
+        if (plannedStepCount <= 0)
+        {
+            return "Step: ? of ?";
+        }
+
+        int normalizedStep = Math.Clamp(currentStep, 0, plannedStepCount);
+        return $"Step: {normalizedStep} of {plannedStepCount}";
+    }
+
     private OperatingSystemCatalogItem ApplyEditionSelection(OperatingSystemCatalogItem item)
     {
         if (IsFilterUnset(SelectedEdition))
@@ -2137,6 +2188,14 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         string leftKey = string.IsNullOrWhiteSpace(left.Url) ? left.FileName : left.Url;
         string rightKey = string.IsNullOrWhiteSpace(right.Url) ? right.FileName : right.Url;
         return leftKey.Equals(rightKey, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ResolveInitialComputerName()
+    {
+        string normalized = ComputerNameRules.Normalize(Environment.MachineName);
+        return normalized.Length > 0
+            ? normalized
+            : ComputerNameRules.FallbackName;
     }
 
     private static string NormalizeArchitecture(string architecture)


### PR DESCRIPTION
This pull request adds support for configuring the target computer name during the Windows deployment process. It introduces a new UI field for the computer name, validates input according to Windows naming rules, and updates the deployment orchestration to apply the computer name offline via the unattend XML file. The changes are grouped into UI enhancements, deployment orchestration updates, and implementation of the computer name configuration logic.

**UI enhancements:**

* Added a "Computer Name" field to the deployment wizard in `MainWindow.xaml`, with input validation and error messaging based on Windows computer naming rules.
* Registered handlers in `MainWindow.xaml.cs` to validate text input and pasted content for the computer name field, ensuring only valid characters and length are accepted. [[1]](diffhunk://#diff-0cb9be3c4f0a1f832c2a0dd43cd860f5f4576e1e6c2c7e9f01b99fe32666ab1bR14) [[2]](diffhunk://#diff-0cb9be3c4f0a1f832c2a0dd43cd860f5f4576e1e6c2c7e9f01b99fe32666ab1bR31-R73)

**Deployment orchestration updates:**

* Extended `DeploymentContext` and `DeploymentRuntimeState` to include the `TargetComputerName` property, passing it through the deployment pipeline and logging it in run context and summary outputs. [[1]](diffhunk://#diff-8edc8dae56001dba21370484624f5a98e90cd6a9871bec21c4869cfaaf845f8dR10) [[2]](diffhunk://#diff-ad428ecf8d46829864326184dceaf057732c869adb536cfc35ec85aae41dd022R15) [[3]](diffhunk://#diff-9f2b3608b11303f6a86aebff2e640967a93060e9762954535d3c8e800f3565b3R115) [[4]](diffhunk://#diff-9f2b3608b11303f6a86aebff2e640967a93060e9762954535d3c8e800f3565b3R1223) [[5]](diffhunk://#diff-9f2b3608b11303f6a86aebff2e640967a93060e9762954535d3c8e800f3565b3R1486)
* Added a new deployment step "Configure target computer name" to `DeploymentOrchestrator`, which applies the computer name using the new service method. [[1]](diffhunk://#diff-9f2b3608b11303f6a86aebff2e640967a93060e9762954535d3c8e800f3565b3R37) [[2]](diffhunk://#diff-9f2b3608b11303f6a86aebff2e640967a93060e9762954535d3c8e800f3565b3R558-R585) [[3]](diffhunk://#diff-9f2b3608b11303f6a86aebff2e640967a93060e9762954535d3c8e800f3565b3R915-R943)

**Computer name configuration logic:**

* Implemented `ConfigureOfflineComputerNameAsync` in `WindowsDeploymentService`, which edits or creates the unattend XML file to set the computer name offline, handling XML structure and processor architecture normalization. [[1]](diffhunk://#diff-d31740c1ed1a254ac0f9e53feb0056f4822bcf7ef0acea715ea328a293629e74R30-R36) [[2]](diffhunk://#diff-6d2453e65ebd22e894337f187bbb3840a83c8df7815cc573dfce789fb52a1b6fR256-R344) [[3]](diffhunk://#diff-6d2453e65ebd22e894337f187bbb3840a83c8df7815cc573dfce789fb52a1b6fR719-R757)