### PR TITLE
Refactor cache resolution logic and remove USB cache index update

### DIFF
--- a/src/Foundry.Deploy/Services/Cache/CacheLocatorService.cs
+++ b/src/Foundry.Deploy/Services/Cache/CacheLocatorService.cs
@@ -29,28 +29,25 @@ public sealed class CacheLocatorService : ICacheLocatorService
         _logger.LogInformation("Resolving cache strategy. Mode={Mode}, PreferredRootPath={PreferredRootPath}", mode, preferredRoot);
         CacheResolution resolution = mode switch
         {
-            DeploymentMode.Iso => ResolveIso(mode, preferredRoot),
-            _ => ResolveUsb(mode, preferredRoot)
+            DeploymentMode.Iso => ResolveIso(preferredRoot),
+            _ => ResolveUsb(preferredRoot)
         };
 
-        _logger.LogInformation("Resolved cache strategy. RootPath={RootPath}, Source={Source}, IsPersistent={IsPersistent}",
+        _logger.LogInformation("Resolved cache strategy. RootPath={RootPath}, Source={Source}",
             resolution.RootPath,
-            resolution.Source,
-            resolution.IsPersistent);
+            resolution.Source);
         return Task.FromResult(resolution);
     }
 
-    private static CacheResolution ResolveIso(DeploymentMode mode, string preferredRoot)
+    private static CacheResolution ResolveIso(string preferredRoot)
     {
         bool hasPreferred = !string.IsNullOrWhiteSpace(preferredRoot);
         return CreateResolution(
-            mode,
             hasPreferred ? preferredRoot : WinPeTransientRuntimeRoot,
-            hasPreferred ? "Preferred path" : "ISO policy root",
-            isPersistent: false);
+            hasPreferred ? "Preferred path" : "ISO policy root");
     }
 
-    private static CacheResolution ResolveUsb(DeploymentMode mode, string preferredRoot)
+    private static CacheResolution ResolveUsb(string preferredRoot)
     {
         // USB mode:
         // 1) honor explicit preferred path when it is not the WinPE transient placeholder
@@ -59,35 +56,31 @@ public sealed class CacheLocatorService : ICacheLocatorService
         if (!string.IsNullOrWhiteSpace(preferredRoot) &&
             !IsWinPeTransientPlaceholder(preferredRoot))
         {
-            return CreateResolution(mode, preferredRoot, "Preferred path", isPersistent: false);
+            return CreateResolution(preferredRoot, "Preferred path");
         }
 
         string? cacheRuntimePath = FindUsbCacheRuntimeRoot();
         if (!string.IsNullOrWhiteSpace(cacheRuntimePath))
         {
-            return CreateResolution(mode, cacheRuntimePath, "Detected USB cache partition", isPersistent: true);
+            return CreateResolution(cacheRuntimePath, "Detected USB cache partition");
         }
 
         if (!string.IsNullOrWhiteSpace(preferredRoot))
         {
-            return CreateResolution(mode, preferredRoot, "USB preferred transient root", isPersistent: false);
+            return CreateResolution(preferredRoot, "USB preferred transient root");
         }
 
-        return CreateResolution(mode, WinPeTransientRuntimeRoot, "USB fallback in WinPE temp", isPersistent: false);
+        return CreateResolution(WinPeTransientRuntimeRoot, "USB fallback in WinPE temp");
     }
 
     private static CacheResolution CreateResolution(
-        DeploymentMode mode,
         string rootPath,
-        string source,
-        bool isPersistent)
+        string source)
     {
         return new CacheResolution
         {
-            Mode = mode,
             RootPath = rootPath,
-            Source = source,
-            IsPersistent = isPersistent
+            Source = source
         };
     }
 

--- a/src/Foundry.Deploy/Services/Cache/CacheResolution.cs
+++ b/src/Foundry.Deploy/Services/Cache/CacheResolution.cs
@@ -1,11 +1,7 @@
-using Foundry.Deploy.Models;
-
 namespace Foundry.Deploy.Services.Cache;
 
 public sealed record CacheResolution
 {
-    public required DeploymentMode Mode { get; init; }
     public required string RootPath { get; init; }
     public required string Source { get; init; }
-    public required bool IsPersistent { get; init; }
 }

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentStepExecutionContext.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentStepExecutionContext.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Text.Json;
 using Foundry.Deploy.Models;
 using Foundry.Deploy.Services.Cache;
 using Foundry.Deploy.Services.Download;
@@ -211,62 +210,6 @@ public sealed class DeploymentStepExecutionContext
             ?? throw new InvalidOperationException("Target Foundry root is unavailable.");
     }
 
-    public async Task UpdateCacheIndexAsync(
-        string artifactType,
-        string sourceUrl,
-        string destinationPath,
-        long sizeBytes,
-        string? expectedHash,
-        CancellationToken cancellationToken = default)
-    {
-        if (!ShouldMaintainUsbCacheIndex(RuntimeState))
-        {
-            return;
-        }
-
-        string runtimeRoot = EnsureResolvedCache();
-        Directory.CreateDirectory(runtimeRoot);
-        string indexPath = Path.Combine(runtimeRoot, "cache-index.json");
-
-        CacheIndexDocument document = await ReadCacheIndexAsync(indexPath, cancellationToken).ConfigureAwait(false);
-        string normalizedSourceUrl = sourceUrl.Trim();
-        CacheIndexEntry? entry = document.Items.FirstOrDefault(item =>
-            item.SourceUrl.Equals(normalizedSourceUrl, StringComparison.OrdinalIgnoreCase));
-
-        string normalizedHash = string.IsNullOrWhiteSpace(expectedHash)
-            ? string.Empty
-            : expectedHash.Trim();
-        DateTimeOffset nowUtc = DateTimeOffset.UtcNow;
-
-        if (entry is null)
-        {
-            document.Items.Add(new CacheIndexEntry
-            {
-                ArtifactType = artifactType,
-                SourceUrl = normalizedSourceUrl,
-                DestinationPath = destinationPath,
-                SizeBytes = sizeBytes,
-                ExpectedHash = normalizedHash,
-                LastUpdatedAtUtc = nowUtc
-            });
-        }
-        else
-        {
-            entry.ArtifactType = artifactType;
-            entry.DestinationPath = destinationPath;
-            entry.SizeBytes = sizeBytes;
-            entry.ExpectedHash = normalizedHash;
-            entry.LastUpdatedAtUtc = nowUtc;
-        }
-
-        document.UpdatedAtUtc = nowUtc;
-        string json = JsonSerializer.Serialize(document, new JsonSerializerOptions
-        {
-            WriteIndented = true
-        });
-        await File.WriteAllTextAsync(indexPath, json, cancellationToken).ConfigureAwait(false);
-    }
-
     public IProgress<DownloadProgress> CreateDownloadProgressReporter(string artifactLabel)
     {
         double? lastReportedPercent = null;
@@ -397,13 +340,6 @@ public sealed class DeploymentStepExecutionContext
         return ResolveCacheBaseRoot(EnsureResolvedCache());
     }
 
-    private static bool ShouldMaintainUsbCacheIndex(DeploymentRuntimeState runtimeState)
-    {
-        return runtimeState.Mode == DeploymentMode.Usb &&
-               runtimeState.ResolvedCache is not null &&
-               runtimeState.ResolvedCache.IsPersistent;
-    }
-
     private static string ResolveWorkspaceRoot(DeploymentRuntimeState runtimeState)
     {
         return string.IsNullOrWhiteSpace(runtimeState.WorkspaceRoot)
@@ -438,31 +374,6 @@ public sealed class DeploymentStepExecutionContext
         return string.IsNullOrWhiteSpace(parent)
             ? runtimeRoot
             : parent;
-    }
-
-    private static async Task<CacheIndexDocument> ReadCacheIndexAsync(string indexPath, CancellationToken cancellationToken)
-    {
-        if (!File.Exists(indexPath))
-        {
-            return new CacheIndexDocument();
-        }
-
-        try
-        {
-            string json = await File.ReadAllTextAsync(indexPath, cancellationToken).ConfigureAwait(false);
-            CacheIndexDocument? parsed = JsonSerializer.Deserialize<CacheIndexDocument>(json);
-            if (parsed is null)
-            {
-                return new CacheIndexDocument();
-            }
-
-            parsed.Items ??= [];
-            return parsed;
-        }
-        catch
-        {
-            return new CacheIndexDocument();
-        }
     }
 
     private static int CalculateStepProgressPercent(int stepIndex, int stepCount)
@@ -533,28 +444,6 @@ public sealed class DeploymentStepExecutionContext
 
             File.Copy(sourceFilePath, destinationPath, overwrite: true);
         }
-    }
-
-    private sealed class CacheIndexDocument
-    {
-        public DateTimeOffset UpdatedAtUtc { get; set; } = DateTimeOffset.UtcNow;
-
-        public List<CacheIndexEntry> Items { get; set; } = [];
-    }
-
-    private sealed class CacheIndexEntry
-    {
-        public string ArtifactType { get; set; } = string.Empty;
-
-        public string SourceUrl { get; set; } = string.Empty;
-
-        public string DestinationPath { get; set; } = string.Empty;
-
-        public long SizeBytes { get; set; }
-
-        public string ExpectedHash { get; set; } = string.Empty;
-
-        public DateTimeOffset LastUpdatedAtUtc { get; set; } = DateTimeOffset.UtcNow;
     }
 
     private sealed class DelegateProgress<T> : IProgress<T>

--- a/src/Foundry.Deploy/Services/Deployment/Steps/DownloadAndPrepareDriverPackStep.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Steps/DownloadAndPrepareDriverPackStep.cs
@@ -79,13 +79,6 @@ public sealed class DownloadAndPrepareDriverPackStep : DeploymentStepBase
                     .ConfigureAwait(false);
 
                 context.RuntimeState.DownloadedDriverPackPath = download.DestinationPath;
-                await context.UpdateCacheIndexAsync(
-                    artifactType: "DriverPack",
-                    sourceUrl: driverPack.DownloadUrl,
-                    destinationPath: download.DestinationPath,
-                    sizeBytes: download.SizeBytes,
-                    expectedHash: driverPack.Sha256,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 string extractionRoot = Path.Combine(targetFoundryRoot, "Extracted", "Drivers");
                 DriverPackPreparationResult preparation = await _driverPackPreparationService

--- a/src/Foundry.Deploy/Services/Deployment/Steps/DownloadOperatingSystemImageStep.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Steps/DownloadOperatingSystemImageStep.cs
@@ -41,13 +41,6 @@ public sealed class DownloadOperatingSystemImageStep : DeploymentStepBase
             .ConfigureAwait(false);
 
         context.RuntimeState.DownloadedOperatingSystemPath = result.DestinationPath;
-        await context.UpdateCacheIndexAsync(
-            artifactType: "OperatingSystem",
-            sourceUrl: context.Request.OperatingSystem.Url,
-            destinationPath: result.DestinationPath,
-            sizeBytes: result.SizeBytes,
-            expectedHash: expectedOsHash,
-            cancellationToken: cancellationToken).ConfigureAwait(false);
         await context.AppendLogAsync(
             DeploymentLogLevel.Info,
             $"OS image {(result.Downloaded ? "downloaded" : "reused")} via {result.Method}: {result.DestinationPath}",

--- a/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
+++ b/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
@@ -356,7 +356,6 @@ try {
         New-Item -Path $BootstrapRoot -ItemType Directory -Force | Out-Null
     }
 
-    $ReleaseDescriptor = ''
     if (-not [string]::IsNullOrWhiteSpace($ArchiveOverride)) {
         if (-not [string]::IsNullOrWhiteSpace($ReleaseTagOverride)) {
             Write-Log "FOUNDRY_DEPLOY_ARCHIVE is set; ignoring FOUNDRY_RELEASE_TAG '$ReleaseTagOverride'."
@@ -368,7 +367,6 @@ try {
                 -SourceUrl $ArchiveOverride `
                 -DestinationPath $DownloadPath `
                 -Description "Foundry Deploy bootstrap override download ($RuntimeIdentifier)"
-            $ReleaseDescriptor = "archive-url:$ArchiveOverride"
         }
         else {
             if (-not (Test-Path -Path $ArchiveOverride -PathType Leaf)) {
@@ -378,7 +376,6 @@ try {
             Write-Log "Copying override archive from '$ArchiveOverride'."
             Remove-Item -Path $DownloadPath -Force -ErrorAction SilentlyContinue
             Copy-Item -Path $ArchiveOverride -Destination $DownloadPath -Force
-            $ReleaseDescriptor = "archive-file:$ArchiveOverride"
         }
 
         Verify-Sha256IfProvided -FilePath $DownloadPath -ExpectedSha256 $ArchiveOverrideSha256
@@ -413,7 +410,6 @@ try {
             -Description "Foundry Deploy bootstrap download ($RuntimeIdentifier)"
 
         Verify-DownloadDigestIfAvailable -Asset $Asset -FilePath $DownloadPath
-        $ReleaseDescriptor = "$($Release.tag_name)"
     }
 
     if (-not (Test-Path -Path $DownloadPath)) {
@@ -427,9 +423,6 @@ try {
     Expand-ZipVia7Zip -ArchivePath $DownloadPath -DestinationPath $ExtractPath -RuntimeIdentifier $RuntimeIdentifier
 
     $Executable = Resolve-DeployExecutable -RootPath $ExtractPath
-
-    $ReleaseInfoPath = Join-Path $BootstrapRoot 'latest-release.txt'
-    Set-Content -Path $ReleaseInfoPath -Value $ReleaseDescriptor -Encoding ascii
 
     Write-Log "Launching '$($Executable.FullName)'."
     Start-Process -FilePath $Executable.FullName -WorkingDirectory $Executable.DirectoryName | Out-Null

--- a/src/Foundry/Services/WinPe/MediaOutputService.cs
+++ b/src/Foundry/Services/WinPe/MediaOutputService.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Text.Json;
 using System.Globalization;
 using System.IO.Compression;
 using Foundry.Services.Operations;
@@ -199,8 +198,6 @@ public sealed class MediaOutputService : IMediaOutputService
                 return FailWithProgress(new WinPeDiagnostic(WinPeErrorCodes.IsoCreateFailed, "Failed to create ISO media.", makeIso.ToDiagnosticText()));
             }
 
-            _operationProgressService.Report(95, "Writing ISO metadata.");
-            await WriteMetadataAsync($"{options.OutputIsoPath}.json", options.Architecture, options.SignatureMode, "iso", null, cancellationToken).ConfigureAwait(false);
             _operationProgressService.Complete("ISO creation completed.");
             _logger.LogInformation("ISO creation completed successfully. OutputIsoPath={OutputIsoPath}", options.OutputIsoPath);
             return WinPeResult.Success();
@@ -306,8 +303,6 @@ public sealed class MediaOutputService : IMediaOutputService
                 return FailWithProgress(usb.Error!);
             }
 
-            _operationProgressService.Report(95, "Writing USB metadata.");
-            await WriteMetadataAsync(Path.Combine($"{usb.Value!.CacheDriveLetter}\\", "Runtime", "foundry-media-metadata.json"), options.Architecture, options.SignatureMode, "usb", usb.Value, cancellationToken).ConfigureAwait(false);
             _operationProgressService.Complete("USB creation completed.");
             _logger.LogInformation("USB creation completed successfully. TargetDiskNumber={TargetDiskNumber}", options.TargetDiskNumber);
             return WinPeResult.Success();
@@ -1073,24 +1068,6 @@ public sealed class MediaOutputService : IMediaOutputService
             if (!Directory.EnumerateFiles(customDirectory, "*.inf", SearchOption.AllDirectories).Any()) return new WinPeDiagnostic(WinPeErrorCodes.ValidationFailed, "Custom driver directory does not contain any .inf files.", customDirectory);
         }
         return null;
-    }
-
-    private static async Task WriteMetadataAsync(string path, WinPeArchitecture architecture, WinPeSignatureMode signatureMode, string mediaType, WinPeUsbProvisionResult? usb, CancellationToken cancellationToken)
-    {
-        string? directoryPath = Path.GetDirectoryName(path);
-        if (!string.IsNullOrWhiteSpace(directoryPath))
-        {
-            Directory.CreateDirectory(directoryPath);
-        }
-        string json = JsonSerializer.Serialize(new
-        {
-            createdAtUtc = DateTimeOffset.UtcNow,
-            mediaType,
-            architecture = architecture.ToString(),
-            signatureMode = signatureMode.ToString(),
-            usb
-        }, new JsonSerializerOptions { WriteIndented = true });
-        await File.WriteAllTextAsync(path, json, cancellationToken).ConfigureAwait(false);
     }
 
     private static void TryDeleteDirectory(string path)


### PR DESCRIPTION
This pull request removes the cache index and metadata writing functionality from the deployment and media output services, and simplifies the cache resolution logic by eliminating persistence tracking and related fields. The changes focus on cleaning up unused or obsolete features, streamlining cache strategy resolution, and removing unnecessary code and dependencies.

**Cache resolution and persistence logic simplification:**

* Removed the `IsPersistent` and `Mode` properties from the `CacheResolution` record in `CacheResolution.cs`, and updated all related methods to no longer track or use cache persistence. (`[[1]](diffhunk://#diff-0df0aca529a1474be34d8489a1fd20941ce626f4b60d5629f2fdf86ef31a0829L32-R50)`, `[[2]](diffhunk://#diff-0df0aca529a1474be34d8489a1fd20941ce626f4b60d5629f2fdf86ef31a0829L62-R83)`, `[[3]](diffhunk://#diff-56df73a7e4bce9c65e8ab9a3b9fe113510bf4ed24286b07bc7596869ef41a744L1-L10)`)
* Updated logging in `CacheLocatorService.cs` to remove references to persistence and deployment mode in cache strategy resolution. (`[src/Foundry.Deploy/Services/Cache/CacheLocatorService.csL32-R50](diffhunk://#diff-0df0aca529a1474be34d8489a1fd20941ce626f4b60d5629f2fdf86ef31a0829L32-R50)`)

**Removal of cache index and metadata writing:**

* Deleted the cache index update logic (`UpdateCacheIndexAsync`) and supporting types and methods from `DeploymentStepExecutionContext.cs`, and removed all calls to this logic from deployment steps. (`[[1]](diffhunk://#diff-91879d5f0403b2ac077cf1222fb5a1d779a82ff3f6ffd05ad1bd4e5f0a75ecfcL214-L269)`, `[[2]](diffhunk://#diff-91879d5f0403b2ac077cf1222fb5a1d779a82ff3f6ffd05ad1bd4e5f0a75ecfcL400-L406)`, `[[3]](diffhunk://#diff-91879d5f0403b2ac077cf1222fb5a1d779a82ff3f6ffd05ad1bd4e5f0a75ecfcL443-L467)`, `[[4]](diffhunk://#diff-a4f2a4e1c0fa3bd61fff660a7598105f10c376e87613fdede129f73decc2cd2dL82-L88)`, `[[5]](diffhunk://#diff-aa062c35a7bbd6e0dd1d6626439a97eed4350e6a2d756123212b1fdff31e55dcL44-L50)`)
* Removed the `WriteMetadataAsync` method and all related calls for writing ISO/USB metadata in `MediaOutputService.cs`. (`[[1]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602L202-L203)`, `[[2]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602L309-L310)`, `[[3]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602L1078-L1095)`)

**Code and dependency cleanup:**

* Removed unused `System.Text.Json` imports from several files. (`[[1]](diffhunk://#diff-91879d5f0403b2ac077cf1222fb5a1d779a82ff3f6ffd05ad1bd4e5f0a75ecfcL2)`, `[[2]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602L2)`)
* Deleted obsolete release descriptor and metadata writing logic from the PowerShell bootstrap script. (`[[1]](diffhunk://#diff-4b660ae68b340bcd8361c3376ff20de53c652938f55559bcef1225ae82cb0854L359)`, `[[2]](diffhunk://#diff-4b660ae68b340bcd8361c3376ff20de53c652938f55559bcef1225ae82cb0854L371)`, `[[3]](diffhunk://#diff-4b660ae68b340bcd8361c3376ff20de53c652938f55559bcef1225ae82cb0854L381)`, `[[4]](diffhunk://#diff-4b660ae68b340bcd8361c3376ff20de53c652938f55559bcef1225ae82cb0854L416)`, `[[5]](diffhunk://#diff-4b660ae68b340bcd8361c3376ff20de53c652938f55559bcef1225ae82cb0854L431-L433)`)