### PR TITLE
Refactor computer name handling

### DIFF
--- a/src/Foundry.Deploy/Program.cs
+++ b/src/Foundry.Deploy/Program.cs
@@ -148,6 +148,7 @@ public static class Program
         services.AddSingleton<ICacheLocatorService, CacheLocatorService>();
         services.AddSingleton<IDeploymentLogService, DeploymentLogService>();
         services.AddSingleton<IHardwareProfileService, HardwareProfileService>();
+        services.AddSingleton<IOfflineWindowsComputerNameService, OfflineWindowsComputerNameService>();
         services.AddSingleton<ITargetDiskService, TargetDiskService>();
         services.AddSingleton<IOperatingSystemCatalogService, OperatingSystemCatalogService>();
         services.AddSingleton<IDriverPackCatalogService, DriverPackCatalogService>();

--- a/src/Foundry.Deploy/Services/Hardware/IOfflineWindowsComputerNameService.cs
+++ b/src/Foundry.Deploy/Services/Hardware/IOfflineWindowsComputerNameService.cs
@@ -1,0 +1,11 @@
+namespace Foundry.Deploy.Services.Hardware;
+
+public interface IOfflineWindowsComputerNameService
+{
+    /// <summary>
+    /// Scans all available drive letters for an existing Windows installation and returns
+    /// the computer name stored in its offline SYSTEM registry hive.
+    /// Returns <c>null</c> if no Windows installation is found or the name cannot be read.
+    /// </summary>
+    Task<string?> TryGetOfflineComputerNameAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Foundry.Deploy/Services/Hardware/OfflineWindowsComputerNameService.cs
+++ b/src/Foundry.Deploy/Services/Hardware/OfflineWindowsComputerNameService.cs
@@ -1,0 +1,171 @@
+using System.IO;
+using Foundry.Deploy.Services.System;
+using Foundry.Deploy.Validation;
+using Microsoft.Extensions.Logging;
+using Microsoft.Win32;
+
+namespace Foundry.Deploy.Services.Hardware;
+
+public sealed class OfflineWindowsComputerNameService : IOfflineWindowsComputerNameService
+{
+    private const string TempHiveKeyName = "FOUNDRY_OFFLINE_SYSTEM";
+    private const string TempHiveKeyPath = @"HKLM\" + TempHiveKeyName;
+
+    private readonly IProcessRunner _processRunner;
+    private readonly ILogger<OfflineWindowsComputerNameService> _logger;
+
+    public OfflineWindowsComputerNameService(
+        IProcessRunner processRunner,
+        ILogger<OfflineWindowsComputerNameService> logger)
+    {
+        _processRunner = processRunner;
+        _logger = logger;
+    }
+
+    public async Task<string?> TryGetOfflineComputerNameAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Scanning drive letters for an existing Windows installation.");
+
+        foreach (char drive in GetCandidateDriveLetters())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            string hivePath = $@"{drive}:\Windows\System32\config\SYSTEM";
+            if (!File.Exists(hivePath))
+            {
+                continue;
+            }
+
+            _logger.LogInformation("Found potential Windows installation at {Drive}:\\. Attempting to read computer name.", drive);
+
+            string? name = await TryReadComputerNameFromHiveAsync(hivePath, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                _logger.LogInformation(
+                    "Resolved offline computer name from {Drive}:\\. ComputerName={ComputerName}",
+                    drive,
+                    name);
+                return name;
+            }
+        }
+
+        _logger.LogInformation("No offline Windows installation computer name found.");
+        return null;
+    }
+
+    private async Task<string?> TryReadComputerNameFromHiveAsync(string hivePath, CancellationToken cancellationToken)
+    {
+        bool hiveLoaded = false;
+
+        try
+        {
+            ProcessExecutionResult loadResult = await _processRunner
+                .RunAsync("reg.exe", $@"load ""{TempHiveKeyPath}"" ""{hivePath}""", Path.GetTempPath(), cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!loadResult.IsSuccess)
+            {
+                _logger.LogWarning(
+                    "Failed to load offline hive at {HivePath}. ExitCode={ExitCode}",
+                    hivePath,
+                    loadResult.ExitCode);
+                return null;
+            }
+
+            hiveLoaded = true;
+
+            string controlSetName = ResolveCurrentControlSetName();
+            string subKeyPath = $@"{TempHiveKeyName}\{controlSetName}\Control\ComputerName\ComputerName";
+
+            using RegistryKey? key = Registry.LocalMachine.OpenSubKey(subKeyPath);
+            if (key is null)
+            {
+                _logger.LogDebug("Computer name registry key not found at {SubKeyPath}.", subKeyPath);
+                return null;
+            }
+
+            string? rawName = key.GetValue("ComputerName") as string;
+            if (string.IsNullOrWhiteSpace(rawName))
+            {
+                return null;
+            }
+
+            string normalized = ComputerNameRules.Normalize(rawName);
+            return ComputerNameRules.IsValid(normalized) ? normalized : null;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Error reading computer name from offline hive at {HivePath}.", hivePath);
+            return null;
+        }
+        finally
+        {
+            if (hiveLoaded)
+            {
+                await TryUnloadHiveAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads the current control set number from the loaded offline hive's Select key,
+    /// falling back to ControlSet001 if it cannot be determined.
+    /// </summary>
+    private static string ResolveCurrentControlSetName()
+    {
+        try
+        {
+            using RegistryKey? selectKey = Registry.LocalMachine.OpenSubKey($@"{TempHiveKeyName}\Select");
+            if (selectKey?.GetValue("Current") is int currentSet && currentSet > 0)
+            {
+                return $"ControlSet{currentSet:D3}";
+            }
+        }
+        catch
+        {
+            // Fall through to default.
+        }
+
+        return "ControlSet001";
+    }
+
+    private async Task TryUnloadHiveAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Give the GC a chance to release any open handles on the hive before unloading.
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            ProcessExecutionResult unloadResult = await _processRunner
+                .RunAsync("reg.exe", $@"unload ""{TempHiveKeyPath}""", Path.GetTempPath(), cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!unloadResult.IsSuccess)
+            {
+                _logger.LogWarning("Failed to unload offline hive. ExitCode={ExitCode}", unloadResult.ExitCode);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Error while unloading offline hive.");
+        }
+    }
+
+    /// <summary>
+    /// Returns candidate drive letters to scan, excluding the current system drive (WinPE's X:)
+    /// and the legacy floppy drives (A:, B:).
+    /// </summary>
+    private static IEnumerable<char> GetCandidateDriveLetters()
+    {
+        string systemDrive = Environment.GetEnvironmentVariable("SystemDrive") ?? "X:";
+        char systemLetter = char.ToUpperInvariant(systemDrive.Length > 0 ? systemDrive[0] : 'X');
+
+        return Enumerable
+            .Range('C', 'Z' - 'C' + 1)
+            .Select(c => (char)c)
+            .Where(c => c != systemLetter);
+    }
+}

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -83,6 +83,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private readonly IDriverPackCatalogService _driverPackCatalogService;
     private readonly IDeploymentOrchestrator _deploymentOrchestrator;
     private readonly IHardwareProfileService _hardwareProfileService;
+    private readonly IOfflineWindowsComputerNameService _offlineWindowsComputerNameService;
     private readonly ITargetDiskService _targetDiskService;
     private readonly IDriverPackSelectionService _driverPackSelectionService;
     private readonly IProcessRunner _processRunner;
@@ -304,6 +305,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         IDriverPackCatalogService driverPackCatalogService,
         IDeploymentOrchestrator deploymentOrchestrator,
         IHardwareProfileService hardwareProfileService,
+        IOfflineWindowsComputerNameService offlineWindowsComputerNameService,
         ITargetDiskService targetDiskService,
         IDriverPackSelectionService driverPackSelectionService,
         IProcessRunner processRunner,
@@ -316,6 +318,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         _driverPackCatalogService = driverPackCatalogService;
         _deploymentOrchestrator = deploymentOrchestrator;
         _hardwareProfileService = hardwareProfileService;
+        _offlineWindowsComputerNameService = offlineWindowsComputerNameService;
         _targetDiskService = targetDiskService;
         _driverPackSelectionService = driverPackSelectionService;
         _processRunner = processRunner;
@@ -336,6 +339,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             DeploymentStatus = "Debug Safe Mode enabled: deployment actions are simulated.";
         }
 
+        _ = LoadOfflineComputerNameAsync();
         _ = LoadHardwareProfileAsync();
         _ = RefreshTargetDisksAsync();
         _ = RefreshCatalogsAsync();
@@ -2188,6 +2192,30 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         string leftKey = string.IsNullOrWhiteSpace(left.Url) ? left.FileName : left.Url;
         string rightKey = string.IsNullOrWhiteSpace(right.Url) ? right.FileName : right.Url;
         return leftKey.Equals(rightKey, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task LoadOfflineComputerNameAsync()
+    {
+        try
+        {
+            string? offlineName = await _offlineWindowsComputerNameService
+                .TryGetOfflineComputerNameAsync()
+                .ConfigureAwait(false);
+
+            if (!string.IsNullOrWhiteSpace(offlineName))
+            {
+                RunOnUi(() =>
+                {
+                    TargetComputerName = offlineName;
+                    ComputerNameText = offlineName;
+                    TargetComputerNameValidationMessage = ComputerNameRules.GetValidationMessage(offlineName);
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load offline Windows computer name.");
+        }
     }
 
     private static string ResolveInitialComputerName()

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -164,11 +164,11 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private string currentStepProgressText = "Waiting for progress...";
 
     [ObservableProperty]
-    private string computerNameText = ResolveInitialComputerName();
+    private string computerNameText = string.Empty;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(StartDeploymentCommand))]
-    private string targetComputerName = ResolveInitialComputerName();
+    private string targetComputerName = string.Empty;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasTargetComputerNameValidationError))]
@@ -327,7 +327,6 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         (DeploymentMode resolvedMode, string? resolvedUsbCacheRuntimeRoot) = ResolveDeploymentRuntimeContext();
         _resolvedDeploymentMode = resolvedMode;
         _resolvedUsbCacheRuntimeRoot = resolvedUsbCacheRuntimeRoot;
-        TargetComputerNameValidationMessage = ComputerNameRules.GetValidationMessage(TargetComputerName);
 
         _operationProgressService.ProgressChanged += OnOperationProgressChanged;
         _deploymentOrchestrator.StepProgressChanged += OnStepProgressChanged;
@@ -2196,26 +2195,34 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
     private async Task LoadOfflineComputerNameAsync()
     {
+        string? resolvedName = null;
         try
         {
-            string? offlineName = await _offlineWindowsComputerNameService
+            resolvedName = await _offlineWindowsComputerNameService
                 .TryGetOfflineComputerNameAsync()
                 .ConfigureAwait(false);
-
-            if (!string.IsNullOrWhiteSpace(offlineName))
-            {
-                RunOnUi(() =>
-                {
-                    TargetComputerName = offlineName;
-                    ComputerNameText = offlineName;
-                    TargetComputerNameValidationMessage = ComputerNameRules.GetValidationMessage(offlineName);
-                });
-            }
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to load offline Windows computer name.");
         }
+
+        string effectiveName = !string.IsNullOrWhiteSpace(resolvedName)
+            ? resolvedName
+            : ResolveInitialComputerName();
+
+        RunOnUi(() =>
+        {
+            // Only apply if the user hasn't typed anything yet.
+            if (!string.IsNullOrEmpty(TargetComputerName))
+            {
+                return;
+            }
+
+            TargetComputerName = effectiveName;
+            ComputerNameText = effectiveName;
+            TargetComputerNameValidationMessage = ComputerNameRules.GetValidationMessage(effectiveName);
+        });
     }
 
     private static string ResolveInitialComputerName()


### PR DESCRIPTION
This pull request introduces a new service for detecting and loading the computer name from an offline Windows installation, and integrates it into the main application workflow. The changes improve how the application initializes and displays the target computer name, especially in deployment scenarios where the OS may not be running.

**Integration of offline computer name detection:**

* Added the `IOfflineWindowsComputerNameService` interface and its implementation `OfflineWindowsComputerNameService`, which scans available drives for offline Windows installations and extracts the computer name from the SYSTEM registry hive. [[1]](diffhunk://#diff-a243a58c5911deda85fdb89896114eb34dc042d6001f1c962e05bcc34c865b51R1-R11) [[2]](diffhunk://#diff-9ae18347b6990a412bc81a02c38e3e0d58fd58c2973745b0ea4b5e47142650f1R1-R171)
* Registered `OfflineWindowsComputerNameService` as a singleton in the dependency injection container in `Program.cs`.

**Main window initialization and workflow changes:**

* Injected `IOfflineWindowsComputerNameService` into `MainWindowViewModel` and updated constructor and fields accordingly. ([src/Foundry.Deploy/ViewModels/MainWindowViewModel.csR86](diffhunk://#diff-a8500263d6daea4cd0a1ae47c814137e62bd6ee12b4403a60be2ff620a062dbfR86), F993bdc5L305R305, F993bdc5L318R318)
* Changed the initialization of `computerNameText` and `targetComputerName` to start as empty strings, and deferred loading their values until after attempting to resolve the offline computer name.
* Added asynchronous loading of the offline computer name during view model initialization, updating UI fields only if the user has not already entered a name. (F993bdc5L338R338, [src/Foundry.Deploy/ViewModels/MainWindowViewModel.csR2196-R2227](diffhunk://#diff-a8500263d6daea4cd0a1ae47c814137e62bd6ee12b4403a60be2ff620a062dbfR2196-R2227))

These updates ensure that the application can automatically detect and suggest the correct computer name from an offline Windows environment, improving user experience and deployment reliability.