### PR TITLE
Enhance download functionality and error handling for curl.exe

### DIFF
--- a/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
+++ b/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
@@ -4,8 +4,6 @@ $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 $PSNativeCommandUseErrorActionPreference = $true
 
-[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
-
 $WinPeRoot = 'X:\Foundry'
 $LogPath = Join-Path $WinPeRoot 'Logs\FoundryDeploy.log'
 $Owner = 'mchave3'
@@ -236,6 +234,7 @@ function Test-CommandCurlExe {
 }
 
 function Download-FileViaWebRequest {
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
         [string]$SourceUrl,
@@ -243,106 +242,101 @@ function Download-FileViaWebRequest {
         [string]$DestinationPath
     )
 
-    $destinationDirectory = Split-Path -Path $DestinationPath -Parent
-    if ([string]::IsNullOrWhiteSpace($destinationDirectory)) {
-        throw "Could not resolve destination directory from '$DestinationPath'."
+    $DestinationDirectory = Split-Path -Path $DestinationPath -Parent
+    $DestinationName = Split-Path -Path $DestinationPath -Leaf
+
+    if ([string]::IsNullOrWhiteSpace($DestinationDirectory) -or [string]::IsNullOrWhiteSpace($DestinationName)) {
+        throw "Could not resolve DestinationDirectory or DestinationName from '$DestinationPath'."
     }
 
-    Ensure-Directory -Path $destinationDirectory
-    Remove-FileIfPresent -Path $DestinationPath
+    if (Test-Path "$DestinationDirectory") {
+    }
+    else {
+        New-Item -Path "$DestinationDirectory" -ItemType Directory -Force -ErrorAction Stop | Out-Null
+    }
+
+    $DestinationNewItem = New-Item -Path (Join-Path $DestinationDirectory "$(Get-Random).txt") -ItemType File
+
+    if (Test-Path $DestinationNewItem.FullName) {
+        $DestinationDirectory = $DestinationNewItem | Select-Object -ExpandProperty Directory
+        Remove-Item -Path $DestinationNewItem.FullName -Force | Out-Null
+    }
+    else {
+        Write-Warning 'Unable to write to Destination Directory'
+        return $null
+    }
+
+    $DestinationDirectoryItem = (Get-Item $DestinationDirectory -Force).FullName
+    $DestinationFullName = Join-Path $DestinationDirectoryItem $DestinationName
 
     $SourceUrl = [Uri]::EscapeUriString($SourceUrl.Replace('%', '~')).Replace('~', '%')
-    $UseWebClient = $false
 
+    $UseWebClient = $false
     if (([System.Net.WebRequest]::DefaultWebProxy).Address) {
         $UseWebClient = $true
-        Write-Log 'Default proxy detected; using WebClient.'
     }
     elseif (!(Test-CommandCurlExe)) {
         $UseWebClient = $true
-        Write-Log 'curl.exe was not found; using WebClient.'
     }
 
     if ($UseWebClient -eq $true) {
-        Write-Log "Downloading via WebClient: $SourceUrl"
-        [System.Net.ServicePointManager]::SecurityProtocol = `
-            [System.Net.ServicePointManager]::SecurityProtocol -bor `
-            [System.Net.SecurityProtocolType]::Tls12
-
-        $webClient = New-Object System.Net.WebClient
-        try {
-            $webClient.Headers.Add('User-Agent', 'FoundryBootstrap/1.0')
-            $webClient.DownloadFile($SourceUrl, $DestinationPath)
-        }
-        finally {
-            $webClient.Dispose()
-        }
+        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls1
+        $WebClient = New-Object System.Net.WebClient
+        $WebClient.DownloadFile($SourceUrl, $DestinationFullName)
+        $WebClient.Dispose()
     }
     else {
-        $remoteLength = $null
-        $remoteAcceptsRanges = $false
+        $remote = Invoke-WebRequest -UseBasicParsing -Method Head -Uri $SourceUrl
+        $remoteLength = [Int64]($remote.Headers.'Content-Length' | Select-Object -First 1)
+        $remoteAcceptsRanges = ($remote.Headers.'Accept-Ranges' | Select-Object -First 1) -eq 'bytes'
 
-        try {
-            $invokeWebRequestCommand = Get-Command -Name 'Invoke-WebRequest' -ErrorAction Stop
-            $headArguments = @{
-                Method = 'Head'
-                Uri = $SourceUrl
-                Headers = @{ 'User-Agent' = 'FoundryBootstrap/1.0' }
-                ErrorAction = 'Stop'
-            }
+        $curlCommandExpression = "& curl.exe --insecure --location --output `"$DestinationFullName`" --url `"$SourceUrl`""
 
-            if ($invokeWebRequestCommand.Parameters.ContainsKey('UseBasicParsing')) {
-                $headArguments['UseBasicParsing'] = $true
-            }
-
-            $remote = Invoke-WebRequest @headArguments
-            $remoteLength = [Int64]($remote.Headers.'Content-Length' | Select-Object -First 1)
-            $remoteAcceptsRanges = ([string]($remote.Headers.'Accept-Ranges' | Select-Object -First 1)) -eq 'bytes'
+        if ($host.name -match 'PowerShell ISE Host') {
+            $Quiet = Invoke-Expression ($curlCommandExpression + ' 2>&1')
         }
-        catch {
-            Write-Log "HEAD request failed for '$SourceUrl': $($_.Exception.Message)"
+        else {
+            Invoke-Expression $curlCommandExpression
         }
 
-        Write-Log "Downloading via curl.exe: $SourceUrl"
-        & curl.exe --silent --show-error --insecure --location --output $DestinationPath --url $SourceUrl
-        if ($LASTEXITCODE -ne 0) {
-            throw "curl.exe failed with exit code $LASTEXITCODE downloading '$SourceUrl'."
+        if (Test-Path $DestinationFullName) {
+            $localExists = $true
         }
 
-        $localExists = Test-Path -Path $DestinationPath -PathType Leaf
-        $retryDelaySeconds = 1
-        $maxRetryCount = 10
-        $retryCount = 0
-
+        $RetryDelaySeconds = 1
+        $MaxRetryCount = 10
+        $RetryCount = 0
         while (
-            $localExists -and `
-            ($remoteLength -is [long]) -and `
-            ((Get-Item -Path $DestinationPath).Length -lt $remoteLength) -and `
-            $remoteAcceptsRanges -and `
-            ($retryCount -lt $maxRetryCount)
+            $localExists `
+                -and ((Get-Item $DestinationFullName).Length -lt $remoteLength) `
+                -and $remoteAcceptsRanges `
+                -and ($RetryCount -lt $MaxRetryCount)
         ) {
-            Write-Log "Download is incomplete; retrying with curl --continue-at in $retryDelaySeconds second(s)."
-            Start-Sleep -Seconds $retryDelaySeconds
-            $retryDelaySeconds = [Math]::Min($retryDelaySeconds * 2, 20)
-            $retryCount++
+            Start-Sleep -Seconds $RetryDelaySeconds
+            $RetryDelaySeconds *= 2
+            $RetryCount += 1
+            $curlCommandExpression = "& curl.exe --insecure --location --continue-at - --output `"$DestinationFullName`" --url `"$SourceUrl`""
 
-            & curl.exe --silent --show-error --insecure --location --continue-at - --output $DestinationPath --url $SourceUrl
-            if ($LASTEXITCODE -ne 0) {
-                throw "curl.exe resume failed with exit code $LASTEXITCODE downloading '$SourceUrl'."
+            if ($host.name -match 'PowerShell ISE Host') {
+                $Quiet = Invoke-Expression ($curlCommandExpression + ' 2>&1')
+            }
+            else {
+                Invoke-Expression $curlCommandExpression
             }
         }
 
-        if (
-            $localExists -and `
-            ($remoteLength -is [long]) -and `
-            ((Get-Item -Path $DestinationPath).Length -lt $remoteLength)
-        ) {
-            throw "curl.exe download is incomplete for '$SourceUrl' after $retryCount retry attempt(s)."
+        if ($localExists -and ((Get-Item $DestinationFullName).Length -lt $remoteLength)) {
+            Write-Warning "Could not download $DestinationFullName"
+            return $null
         }
     }
 
-    if (-not (Test-Path -Path $DestinationPath -PathType Leaf)) {
-        throw "Download did not create '$DestinationPath'."
+    if (Test-Path $DestinationFullName) {
+        return Get-Item $DestinationFullName -Force
+    }
+    else {
+        Write-Warning "Could not download $DestinationFullName"
+        return $null
     }
 }
 

--- a/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
+++ b/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
@@ -4,6 +4,8 @@ $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 $PSNativeCommandUseErrorActionPreference = $true
 
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+
 $WinPeRoot = 'X:\Foundry'
 $LogPath = Join-Path $WinPeRoot 'Logs\FoundryDeploy.log'
 $Owner = 'mchave3'
@@ -221,6 +223,14 @@ function Get-DeployExecutablePath {
     return Join-Path $RootPath 'Foundry.Deploy.exe'
 }
 
+function Test-CommandCurlExe {
+    if (Get-Command -Name 'curl.exe' -ErrorAction SilentlyContinue) {
+        return $true
+    }
+
+    return $false
+}
+
 function Download-FileViaWebRequest {
     param(
         [Parameter(Mandatory = $true)]
@@ -232,34 +242,126 @@ function Download-FileViaWebRequest {
     Invoke-WithRetry -Action {
         Remove-FileIfPresent -Path $DestinationPath
 
-        $invokeWebRequestCommand = Get-Command -Name Invoke-WebRequest -ErrorAction Stop
-        $requestArguments = @{
-            Uri = $SourceUrl
-            OutFile = $DestinationPath
-            Headers = @{
-                'User-Agent' = 'FoundryBootstrap/1.0'
+        $sourceUrlEscaped = [Uri]::EscapeUriString($SourceUrl.Replace('%', '~')).Replace('~', '%')
+
+        $useWebClient = $false
+        if (([System.Net.WebRequest]::DefaultWebProxy).Address) {
+            $useWebClient = $true
+            Write-Log "Default web proxy detected; using WebClient."
+        }
+        elseif (-not (Test-CommandCurlExe)) {
+            $useWebClient = $true
+        }
+
+        if ($useWebClient) {
+            Write-Log "Downloading via WebClient: $sourceUrlEscaped"
+            [System.Net.ServicePointManager]::SecurityProtocol = `
+                [System.Net.ServicePointManager]::SecurityProtocol -bor `
+                [System.Net.SecurityProtocolType]::Tls12
+            $webClient = New-Object System.Net.WebClient
+            try {
+                $webClient.Headers.Add('User-Agent', 'FoundryBootstrap/1.0')
+                $webClient.DownloadFile($sourceUrlEscaped, $DestinationPath)
             }
-            ErrorAction = 'Stop'
-        }
+            finally {
+                $webClient.Dispose()
+            }
 
-        if ($invokeWebRequestCommand.Parameters.ContainsKey('UseBasicParsing')) {
-            $requestArguments['UseBasicParsing'] = $true
-        }
+            if (-not (Test-Path -Path $DestinationPath -PathType Leaf)) {
+                throw "WebClient download did not create '$DestinationPath'."
+            }
 
-        if ($invokeWebRequestCommand.Parameters.ContainsKey('SkipCertificateCheck')) {
-            $requestArguments['SkipCertificateCheck'] = $true
-            Invoke-WebRequest @requestArguments
             return
         }
 
-        # WinPE commonly uses Windows PowerShell 5.1 where SkipCertificateCheck is unavailable.
-        $previousCertificateValidationCallback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
+        Write-Log "Downloading via curl.exe: $sourceUrlEscaped"
+
+        $remoteLength = $null
+        $remoteAcceptsRanges = $false
         try {
-            [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
-            Invoke-WebRequest @requestArguments
+            $invokeWebRequestCommand = Get-Command -Name 'Invoke-WebRequest' -ErrorAction Stop
+            $headRequestArguments = @{
+                Method = 'Head'
+                Uri = $sourceUrlEscaped
+                Headers = @{ 'User-Agent' = 'FoundryBootstrap/1.0' }
+                ErrorAction = 'Stop'
+            }
+
+            if ($invokeWebRequestCommand.Parameters.ContainsKey('UseBasicParsing')) {
+                $headRequestArguments['UseBasicParsing'] = $true
+            }
+
+            $headResponse = Invoke-WebRequest @headRequestArguments
+
+            $contentLengthHeader = [string]($headResponse.Headers.'Content-Length' | Select-Object -First 1)
+            if (-not [string]::IsNullOrWhiteSpace($contentLengthHeader)) {
+                [Int64]$parsedLength = 0
+                if ([Int64]::TryParse($contentLengthHeader, [ref]$parsedLength)) {
+                    $remoteLength = $parsedLength
+                }
+            }
+
+            $acceptRangesHeader = [string]($headResponse.Headers.'Accept-Ranges' | Select-Object -First 1)
+            $remoteAcceptsRanges = [string]::Equals(
+                $acceptRangesHeader,
+                'bytes',
+                [System.StringComparison]::OrdinalIgnoreCase
+            )
         }
-        finally {
-            [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $previousCertificateValidationCallback
+        catch {
+            Write-Log "HEAD request failed for '$sourceUrlEscaped': $($_.Exception.Message). Continuing without resume metadata."
+        }
+
+        & curl.exe `
+            --silent `
+            --show-error `
+            --insecure `
+            --location `
+            --output $DestinationPath `
+            --url $sourceUrlEscaped
+        if ($LASTEXITCODE -ne 0) {
+            throw "curl.exe failed with exit code $LASTEXITCODE downloading '$sourceUrlEscaped'."
+        }
+
+        $retryDelaySeconds = 1
+        $maxRetryCount = 10
+        $retryCount = 0
+
+        while (
+            (Test-Path -Path $DestinationPath -PathType Leaf) -and `
+            ($remoteLength -is [long]) -and `
+            ((Get-Item -Path $DestinationPath).Length -lt $remoteLength) -and `
+            $remoteAcceptsRanges -and `
+            ($retryCount -lt $maxRetryCount)
+        ) {
+            Write-Log "Download is incomplete; retrying with curl resume in $retryDelaySeconds second(s)."
+            Start-Sleep -Seconds $retryDelaySeconds
+            $retryDelaySeconds = [Math]::Min($retryDelaySeconds * 2, 20)
+            $retryCount++
+
+            & curl.exe `
+                --silent `
+                --show-error `
+                --insecure `
+                --location `
+                --continue-at - `
+                --output $DestinationPath `
+                --url $sourceUrlEscaped
+            if ($LASTEXITCODE -ne 0) {
+                throw "curl.exe resume failed with exit code $LASTEXITCODE downloading '$sourceUrlEscaped'."
+            }
+        }
+
+        if (
+            (Test-Path -Path $DestinationPath -PathType Leaf) -and `
+            ($remoteLength -is [long]) -and `
+            ((Get-Item -Path $DestinationPath).Length -lt $remoteLength)
+        ) {
+            throw "curl.exe download is incomplete for '$sourceUrlEscaped'."
+        }
+
+        if (-not (Test-Path -Path $DestinationPath -PathType Leaf)) {
+            throw "curl.exe download did not create '$DestinationPath'."
         }
     }
 }
@@ -699,7 +801,7 @@ try {
         }
 
         if (Test-HttpUrl -Value $archiveOverride) {
-            Write-Log "Downloading override archive via Invoke-WebRequest (insecure TLS): $archiveOverride"
+            Write-Log "Downloading override archive (curl.exe/WebClient): $archiveOverride"
             Download-FileViaWebRequest `
                 -SourceUrl $archiveOverride `
                 -DestinationPath $downloadPath
@@ -754,7 +856,7 @@ try {
             }
             else {
                 try {
-                    Write-Log "Downloading asset via Invoke-WebRequest (insecure TLS): $($asset.browser_download_url)"
+                    Write-Log "Downloading asset (curl.exe/WebClient): $($asset.browser_download_url)"
                     Download-FileViaWebRequest `
                         -SourceUrl $asset.browser_download_url `
                         -DestinationPath $downloadPath

--- a/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
+++ b/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
@@ -224,11 +224,15 @@ function Get-DeployExecutablePath {
 }
 
 function Test-CommandCurlExe {
-    if (Get-Command -Name 'curl.exe' -ErrorAction SilentlyContinue) {
+    [CmdletBinding()]
+    param ()
+
+    if (Get-Command 'curl.exe' -ErrorAction SilentlyContinue) {
         return $true
     }
-
-    return $false
+    else {
+        return $false
+    }
 }
 
 function Download-FileViaWebRequest {
@@ -239,130 +243,106 @@ function Download-FileViaWebRequest {
         [string]$DestinationPath
     )
 
-    Invoke-WithRetry -Action {
-        Remove-FileIfPresent -Path $DestinationPath
+    $destinationDirectory = Split-Path -Path $DestinationPath -Parent
+    if ([string]::IsNullOrWhiteSpace($destinationDirectory)) {
+        throw "Could not resolve destination directory from '$DestinationPath'."
+    }
 
-        $sourceUrlEscaped = [Uri]::EscapeUriString($SourceUrl.Replace('%', '~')).Replace('~', '%')
+    Ensure-Directory -Path $destinationDirectory
+    Remove-FileIfPresent -Path $DestinationPath
 
-        $useWebClient = $false
-        if (([System.Net.WebRequest]::DefaultWebProxy).Address) {
-            $useWebClient = $true
-            Write-Log "Default web proxy detected; using WebClient."
+    $SourceUrl = [Uri]::EscapeUriString($SourceUrl.Replace('%', '~')).Replace('~', '%')
+    $UseWebClient = $false
+
+    if (([System.Net.WebRequest]::DefaultWebProxy).Address) {
+        $UseWebClient = $true
+        Write-Log 'Default proxy detected; using WebClient.'
+    }
+    elseif (!(Test-CommandCurlExe)) {
+        $UseWebClient = $true
+        Write-Log 'curl.exe was not found; using WebClient.'
+    }
+
+    if ($UseWebClient -eq $true) {
+        Write-Log "Downloading via WebClient: $SourceUrl"
+        [System.Net.ServicePointManager]::SecurityProtocol = `
+            [System.Net.ServicePointManager]::SecurityProtocol -bor `
+            [System.Net.SecurityProtocolType]::Tls12
+
+        $webClient = New-Object System.Net.WebClient
+        try {
+            $webClient.Headers.Add('User-Agent', 'FoundryBootstrap/1.0')
+            $webClient.DownloadFile($SourceUrl, $DestinationPath)
         }
-        elseif (-not (Test-CommandCurlExe)) {
-            $useWebClient = $true
+        finally {
+            $webClient.Dispose()
         }
-
-        if ($useWebClient) {
-            Write-Log "Downloading via WebClient: $sourceUrlEscaped"
-            [System.Net.ServicePointManager]::SecurityProtocol = `
-                [System.Net.ServicePointManager]::SecurityProtocol -bor `
-                [System.Net.SecurityProtocolType]::Tls12
-            $webClient = New-Object System.Net.WebClient
-            try {
-                $webClient.Headers.Add('User-Agent', 'FoundryBootstrap/1.0')
-                $webClient.DownloadFile($sourceUrlEscaped, $DestinationPath)
-            }
-            finally {
-                $webClient.Dispose()
-            }
-
-            if (-not (Test-Path -Path $DestinationPath -PathType Leaf)) {
-                throw "WebClient download did not create '$DestinationPath'."
-            }
-
-            return
-        }
-
-        Write-Log "Downloading via curl.exe: $sourceUrlEscaped"
-
+    }
+    else {
         $remoteLength = $null
         $remoteAcceptsRanges = $false
+
         try {
             $invokeWebRequestCommand = Get-Command -Name 'Invoke-WebRequest' -ErrorAction Stop
-            $headRequestArguments = @{
+            $headArguments = @{
                 Method = 'Head'
-                Uri = $sourceUrlEscaped
+                Uri = $SourceUrl
                 Headers = @{ 'User-Agent' = 'FoundryBootstrap/1.0' }
                 ErrorAction = 'Stop'
             }
 
             if ($invokeWebRequestCommand.Parameters.ContainsKey('UseBasicParsing')) {
-                $headRequestArguments['UseBasicParsing'] = $true
+                $headArguments['UseBasicParsing'] = $true
             }
 
-            $headResponse = Invoke-WebRequest @headRequestArguments
-
-            $contentLengthHeader = [string]($headResponse.Headers.'Content-Length' | Select-Object -First 1)
-            if (-not [string]::IsNullOrWhiteSpace($contentLengthHeader)) {
-                [Int64]$parsedLength = 0
-                if ([Int64]::TryParse($contentLengthHeader, [ref]$parsedLength)) {
-                    $remoteLength = $parsedLength
-                }
-            }
-
-            $acceptRangesHeader = [string]($headResponse.Headers.'Accept-Ranges' | Select-Object -First 1)
-            $remoteAcceptsRanges = [string]::Equals(
-                $acceptRangesHeader,
-                'bytes',
-                [System.StringComparison]::OrdinalIgnoreCase
-            )
+            $remote = Invoke-WebRequest @headArguments
+            $remoteLength = [Int64]($remote.Headers.'Content-Length' | Select-Object -First 1)
+            $remoteAcceptsRanges = ([string]($remote.Headers.'Accept-Ranges' | Select-Object -First 1)) -eq 'bytes'
         }
         catch {
-            Write-Log "HEAD request failed for '$sourceUrlEscaped': $($_.Exception.Message). Continuing without resume metadata."
+            Write-Log "HEAD request failed for '$SourceUrl': $($_.Exception.Message)"
         }
 
-        & curl.exe `
-            --silent `
-            --show-error `
-            --insecure `
-            --location `
-            --output $DestinationPath `
-            --url $sourceUrlEscaped
+        Write-Log "Downloading via curl.exe: $SourceUrl"
+        & curl.exe --silent --show-error --insecure --location --output $DestinationPath --url $SourceUrl
         if ($LASTEXITCODE -ne 0) {
-            throw "curl.exe failed with exit code $LASTEXITCODE downloading '$sourceUrlEscaped'."
+            throw "curl.exe failed with exit code $LASTEXITCODE downloading '$SourceUrl'."
         }
 
+        $localExists = Test-Path -Path $DestinationPath -PathType Leaf
         $retryDelaySeconds = 1
         $maxRetryCount = 10
         $retryCount = 0
 
         while (
-            (Test-Path -Path $DestinationPath -PathType Leaf) -and `
+            $localExists -and `
             ($remoteLength -is [long]) -and `
             ((Get-Item -Path $DestinationPath).Length -lt $remoteLength) -and `
             $remoteAcceptsRanges -and `
             ($retryCount -lt $maxRetryCount)
         ) {
-            Write-Log "Download is incomplete; retrying with curl resume in $retryDelaySeconds second(s)."
+            Write-Log "Download is incomplete; retrying with curl --continue-at in $retryDelaySeconds second(s)."
             Start-Sleep -Seconds $retryDelaySeconds
             $retryDelaySeconds = [Math]::Min($retryDelaySeconds * 2, 20)
             $retryCount++
 
-            & curl.exe `
-                --silent `
-                --show-error `
-                --insecure `
-                --location `
-                --continue-at - `
-                --output $DestinationPath `
-                --url $sourceUrlEscaped
+            & curl.exe --silent --show-error --insecure --location --continue-at - --output $DestinationPath --url $SourceUrl
             if ($LASTEXITCODE -ne 0) {
-                throw "curl.exe resume failed with exit code $LASTEXITCODE downloading '$sourceUrlEscaped'."
+                throw "curl.exe resume failed with exit code $LASTEXITCODE downloading '$SourceUrl'."
             }
         }
 
         if (
-            (Test-Path -Path $DestinationPath -PathType Leaf) -and `
+            $localExists -and `
             ($remoteLength -is [long]) -and `
             ((Get-Item -Path $DestinationPath).Length -lt $remoteLength)
         ) {
-            throw "curl.exe download is incomplete for '$sourceUrlEscaped'."
+            throw "curl.exe download is incomplete for '$SourceUrl' after $retryCount retry attempt(s)."
         }
+    }
 
-        if (-not (Test-Path -Path $DestinationPath -PathType Leaf)) {
-            throw "curl.exe download did not create '$DestinationPath'."
-        }
+    if (-not (Test-Path -Path $DestinationPath -PathType Leaf)) {
+        throw "Download did not create '$DestinationPath'."
     }
 }
 


### PR DESCRIPTION
This pull request refactors and improves the file download logic in `FoundryBootstrap.ps1` to better support different environments, particularly WinPE, by adding support for `curl.exe` and falling back to `WebClient` when necessary. It also enhances error handling and logging for download operations.

**Download mechanism improvements:**

* Added a new function `Test-CommandCurlExe` to check for the presence of `curl.exe`, enabling conditional use of curl for downloads.
* Refactored `Download-FileViaWebRequest` to use `curl.exe` if available, or `WebClient` as a fallback, improving compatibility and reliability in WinPE and proxy environments. The function now includes logic for directory creation, file existence checks, and retrying partial downloads with curl if supported.

**Logging and messaging enhancements:**

* Updated log messages to reflect the new download methods (`curl.exe/WebClient`) instead of just `Invoke-WebRequest`, providing clearer information to users and maintainers. [[1]](diffhunk://#diff-4b660ae68b340bcd8361c3376ff20de53c652938f55559bcef1225ae82cb0854L702-R778) [[2]](diffhunk://#diff-4b660ae68b340bcd8361c3376ff20de53c652938f55559bcef1225ae82cb0854L757-R833)