### PR TITLE
Add IsVirtualMachine property to HardwareProfile and update logic

### DIFF
--- a/src/Foundry.Deploy/Models/HardwareProfile.cs
+++ b/src/Foundry.Deploy/Models/HardwareProfile.cs
@@ -7,6 +7,7 @@ public sealed record HardwareProfile
     public string Product { get; init; } = "Unknown";
     public string SerialNumber { get; init; } = "Unknown";
     public string Architecture { get; init; } = string.Empty;
+    public bool IsVirtualMachine { get; init; }
     public bool IsTpmPresent { get; init; }
     public bool IsAutopilotCapable { get; init; }
 

--- a/src/Foundry.Deploy/Services/Hardware/HardwareProfileService.cs
+++ b/src/Foundry.Deploy/Services/Hardware/HardwareProfileService.cs
@@ -59,6 +59,7 @@ $tpm = Get-CimInstance -Namespace 'ROOT\cimv2\Security\MicrosoftTpm' -ClassName 
             string product = ReadProperty(root, "Product");
             string serial = ReadProperty(root, "SerialNumber");
             string architecture = NormalizeArchitecture(ReadProperty(root, "Architecture"));
+            bool isVirtualMachine = IsVirtualMachine(manufacturer, model, product);
             bool isTpmPresent = ReadBoolProperty(root, "IsTpmPresent");
 
             bool isAutopilotCapable =
@@ -74,14 +75,16 @@ $tpm = Get-CimInstance -Namespace 'ROOT\cimv2\Security\MicrosoftTpm' -ClassName 
                 Product = NormalizeValue(product),
                 SerialNumber = NormalizeValue(serial),
                 Architecture = architecture,
+                IsVirtualMachine = isVirtualMachine,
                 IsTpmPresent = isTpmPresent,
                 IsAutopilotCapable = isAutopilotCapable
             };
 
-            _logger.LogInformation("Hardware profile detected. Manufacturer={Manufacturer}, Model={Model}, Architecture={Architecture}, IsAutopilotCapable={IsAutopilotCapable}",
+            _logger.LogInformation("Hardware profile detected. Manufacturer={Manufacturer}, Model={Model}, Architecture={Architecture}, IsVirtualMachine={IsVirtualMachine}, IsAutopilotCapable={IsAutopilotCapable}",
                 profile.Manufacturer,
                 profile.Model,
                 profile.Architecture,
+                profile.IsVirtualMachine,
                 profile.IsAutopilotCapable);
             return profile;
         }
@@ -102,6 +105,7 @@ $tpm = Get-CimInstance -Namespace 'ROOT\cimv2\Security\MicrosoftTpm' -ClassName 
             Product = "Unknown",
             SerialNumber = "Unknown",
             Architecture = architecture,
+            IsVirtualMachine = false,
             IsTpmPresent = false,
             IsAutopilotCapable = false
         };
@@ -123,6 +127,26 @@ $tpm = Get-CimInstance -Namespace 'ROOT\cimv2\Security\MicrosoftTpm' -ClassName 
 
         return value.ValueKind == JsonValueKind.True ||
                (value.ValueKind == JsonValueKind.String && bool.TryParse(value.GetString(), out bool parsed) && parsed);
+    }
+
+    private static bool IsVirtualMachine(string manufacturer, string model, string product)
+    {
+        string combined = string.Join(" | ", manufacturer, model, product).ToLowerInvariant();
+
+        if (combined.Contains("vmware") ||
+            combined.Contains("virtualbox") ||
+            combined.Contains("virtual machine") ||
+            combined.Contains("kvm") ||
+            combined.Contains("qemu") ||
+            combined.Contains("xen") ||
+            combined.Contains("hvm domu") ||
+            combined.Contains("parallels") ||
+            combined.Contains("bhyve"))
+        {
+            return true;
+        }
+
+        return combined.Contains("microsoft corporation") && combined.Contains("virtual");
     }
 
     private static string NormalizeManufacturer(string value)

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -1857,6 +1857,12 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             return options.FirstOrDefault(option => option.Kind == DriverPackSelectionKind.None) ?? options[0];
         }
 
+        if (_detectedHardware?.IsVirtualMachine == true)
+        {
+            return options.FirstOrDefault(option => option.Kind == DriverPackSelectionKind.MicrosoftUpdateCatalog)
+                   ?? options[0];
+        }
+
         if (_detectedHardware is not null && SelectedOperatingSystem is not null && DriverPacks.Count > 0)
         {
             DriverPackSelectionResult selection = _driverPackSelectionService.SelectBest(


### PR DESCRIPTION
This pull request enhances hardware detection by adding support for identifying virtual machines and updating related logic throughout the codebase. The most important changes are grouped below:

Hardware profile improvements:

* Added a new `IsVirtualMachine` property to the `HardwareProfile` record to indicate whether the detected hardware is a virtual machine.
* Updated the hardware profile construction logic in `HardwareProfileService` to set the `IsVirtualMachine` property based on manufacturer, model, and product information using a new detection method. [[1]](diffhunk://#diff-eb1576162f0e71c7053cc53df679fcf80becbc940ed4c722ac224535925fe7a6R62) [[2]](diffhunk://#diff-eb1576162f0e71c7053cc53df679fcf80becbc940ed4c722ac224535925fe7a6R78-R87)
* Modified the fallback hardware profile to default `IsVirtualMachine` to `false`.
* Implemented the `IsVirtualMachine` detection method, which checks for common virtualization vendor strings in hardware details.

Driver pack selection logic:

* Changed driver pack selection in `MainWindowViewModel` to prefer the Microsoft Update Catalog when running on a virtual machine, improving compatibility and reliability in virtualized environments.