### PR TITLE
Introduce OS support validation and refactor related services

### DIFF
--- a/src/Foundry.Deploy/Converters/OsCatalogFilterDisplayConverter.cs
+++ b/src/Foundry.Deploy/Converters/OsCatalogFilterDisplayConverter.cs
@@ -17,7 +17,6 @@ public sealed class OsCatalogFilterDisplayConverter : IValueConverter
         {
             "LICENSECHANNEL" => OperatingSystemDisplayFormatter.FormatLicenseChannel(source),
             "EDITION" => OperatingSystemDisplayFormatter.FormatEdition(source),
-            "WINDOWSRELEASE" => OperatingSystemDisplayFormatter.FormatWindowsRelease(source),
             _ => source
         };
     }

--- a/src/Foundry.Deploy/MainWindow.xaml
+++ b/src/Foundry.Deploy/MainWindow.xaml
@@ -200,19 +200,10 @@
                                         <ColumnDefinition Width="*" />
                                     </Grid.ColumnDefinitions>
 
-                                    <!--  OS family and release  -->
+                                    <!--  OS family -->
                                     <StackPanel Margin="0,0,8,8">
                                         <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Operating System" />
-                                        <ComboBox
-                                            Margin="0,8,0,0"
-                                            ItemsSource="{Binding WindowsReleaseFilters}"
-                                            SelectedItem="{Binding SelectedWindowsRelease}">
-                                            <ComboBox.ItemTemplate>
-                                                <DataTemplate>
-                                                    <TextBlock Text="{Binding ., Converter={StaticResource OsCatalogFilterDisplayConverter}, ConverterParameter=WindowsRelease}" />
-                                                </DataTemplate>
-                                            </ComboBox.ItemTemplate>
-                                        </ComboBox>
+                                        <TextBox Margin="0,8,0,0" Text="Windows 11" IsReadOnly="True" />
                                     </StackPanel>
 
                                     <!--  Release identifier  -->

--- a/src/Foundry.Deploy/Models/OperatingSystemSupportMatrix.cs
+++ b/src/Foundry.Deploy/Models/OperatingSystemSupportMatrix.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+namespace Foundry.Deploy.Models;
+
+internal static class OperatingSystemSupportMatrix
+{
+    public const string SupportedWindowsRelease = "11";
+    public const string DefaultReleaseId = "25H2";
+
+    private static readonly string[] SupportedReleaseIdOrder =
+    [
+        "25H2",
+        "24H2",
+        "23H2"
+    ];
+
+    private static readonly HashSet<string> SupportedReleaseIds = new(SupportedReleaseIdOrder, StringComparer.OrdinalIgnoreCase);
+
+    public static IReadOnlyList<string> ReleaseSearchOrder => SupportedReleaseIdOrder;
+
+    public static bool IsSupported(OperatingSystemCatalogItem item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        return IsSupportedWindowsRelease(item.WindowsRelease) && IsSupportedReleaseId(item.ReleaseId);
+    }
+
+    public static bool IsSupportedWindowsRelease(string windowsRelease)
+    {
+        return !string.IsNullOrWhiteSpace(windowsRelease) &&
+               SupportedWindowsRelease.Equals(windowsRelease.Trim(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static bool IsSupportedReleaseId(string releaseId)
+    {
+        return !string.IsNullOrWhiteSpace(releaseId) &&
+               SupportedReleaseIds.Contains(releaseId.Trim());
+    }
+}

--- a/src/Foundry.Deploy/Services/Catalog/OperatingSystemCatalogService.cs
+++ b/src/Foundry.Deploy/Services/Catalog/OperatingSystemCatalogService.cs
@@ -33,16 +33,30 @@ public sealed class OperatingSystemCatalogService : IOperatingSystemCatalogServi
                 .ConfigureAwait(false);
             XDocument document = XDocument.Parse(xmlContent);
 
-            OperatingSystemCatalogItem[] items = document
+            OperatingSystemCatalogItem[] parsedItems = document
                 .Descendants("Item")
                 .Select(ParseItem)
                 .Where(item => !string.IsNullOrWhiteSpace(item.Url))
+                .ToArray();
+
+            OperatingSystemCatalogItem[] items = parsedItems
+                .Where(OperatingSystemSupportMatrix.IsSupported)
                 .OrderByDescending(item => item.BuildMajor)
                 .ThenByDescending(item => item.BuildUbr)
                 .ThenBy(item => item.Architecture, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(item => item.LanguageCode, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(item => item.Edition, StringComparer.OrdinalIgnoreCase)
                 .ToArray();
+
+            int filteredCount = parsedItems.Length - items.Length;
+            if (filteredCount > 0)
+            {
+                _logger.LogInformation(
+                    "Filtered {FilteredCount} unsupported operating system entries. SupportedScope=Windows {WindowsRelease} {ReleaseIds}",
+                    filteredCount,
+                    OperatingSystemSupportMatrix.SupportedWindowsRelease,
+                    string.Join(", ", OperatingSystemSupportMatrix.ReleaseSearchOrder));
+            }
 
             _logger.LogInformation("Loaded {ItemCount} operating system catalog entries.", items.Length);
             return items;

--- a/src/Foundry.Deploy/Services/DriverPacks/DriverPackSelectionService.cs
+++ b/src/Foundry.Deploy/Services/DriverPacks/DriverPackSelectionService.cs
@@ -33,11 +33,21 @@ public sealed class DriverPackSelectionService : IDriverPackSelectionService
             };
         }
 
+        if (!OperatingSystemSupportMatrix.IsSupported(operatingSystem))
+        {
+            return new DriverPackSelectionResult
+            {
+                DriverPack = null,
+                SelectionReason =
+                    $"Unsupported operating system selection. Foundry.Deploy supports Windows {OperatingSystemSupportMatrix.SupportedWindowsRelease} 23H2, 24H2, and 25H2 only."
+            };
+        }
+
         string osArch = NormalizeArchitecture(operatingSystem.Architecture);
         string manufacturer = NormalizeManufacturer(hardware.Manufacturer);
         string model = Normalize(hardware.Model);
         string product = Normalize(hardware.Product);
-        string targetOsName = operatingSystem.WindowsRelease == "11" ? "Windows 11" : "Windows 10";
+        string targetOsName = "Windows 11";
         string targetReleaseId = Normalize(operatingSystem.ReleaseId);
 
         IEnumerable<DriverPackCatalogItem> query = catalog

--- a/src/Foundry.Deploy/Services/DriverPacks/MicrosoftUpdateCatalogSupport.cs
+++ b/src/Foundry.Deploy/Services/DriverPacks/MicrosoftUpdateCatalogSupport.cs
@@ -6,29 +6,19 @@ namespace Foundry.Deploy.Services.DriverPacks;
 
 internal static partial class MicrosoftUpdateCatalogSupport
 {
-    private static readonly string[] BaseReleaseSearchOrder =
-    [
-        "25H2",
-        "24H2",
-        "23H2",
-        "22H2",
-        "21H2",
-        "Vibranium",
-        "1903",
-        "1809"
-    ];
-
     public static string[] BuildReleaseSearchOrder(string targetReleaseId)
     {
         var order = new List<string>();
-        string normalizedTarget = targetReleaseId.Trim();
+        string normalizedTarget = string.IsNullOrWhiteSpace(targetReleaseId)
+            ? string.Empty
+            : targetReleaseId.Trim();
 
-        if (!string.IsNullOrWhiteSpace(normalizedTarget))
+        if (OperatingSystemSupportMatrix.IsSupportedReleaseId(normalizedTarget))
         {
             order.Add(normalizedTarget);
         }
 
-        foreach (string release in BaseReleaseSearchOrder)
+        foreach (string release in OperatingSystemSupportMatrix.ReleaseSearchOrder)
         {
             if (!order.Contains(release, StringComparer.OrdinalIgnoreCase))
             {

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -28,8 +28,8 @@ namespace Foundry.Deploy.ViewModels;
 
 public partial class MainWindowViewModel : ObservableObject, IDisposable
 {
-    private const string DefaultWindowsRelease = "11";
-    private const string DefaultReleaseId = "25H2";
+    private const string DefaultWindowsRelease = OperatingSystemSupportMatrix.SupportedWindowsRelease;
+    private const string DefaultReleaseId = OperatingSystemSupportMatrix.DefaultReleaseId;
     private const string DefaultLicenseChannel = "RET";
     private const string DefaultEdition = "Pro";
     private const string FallbackLanguageCode = "en-us";
@@ -1366,13 +1366,14 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
     private IEnumerable<OperatingSystemCatalogItem> BuildOsQueryWithArchitecture(IEnumerable<OperatingSystemCatalogItem> source)
     {
+        IEnumerable<OperatingSystemCatalogItem> supportedSource = source.Where(OperatingSystemSupportMatrix.IsSupported);
         string architecture = NormalizeArchitecture(EffectiveOsArchitecture);
         if (string.IsNullOrWhiteSpace(architecture))
         {
-            return source;
+            return supportedSource;
         }
 
-        return source.Where(item => IsArchitectureMatch(item.Architecture, architecture));
+        return supportedSource.Where(item => IsArchitectureMatch(item.Architecture, architecture));
     }
 
     private IEnumerable<OperatingSystemCatalogItem> ApplyWindowsReleaseFilter(IEnumerable<OperatingSystemCatalogItem> source)

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -28,7 +28,6 @@ namespace Foundry.Deploy.ViewModels;
 
 public partial class MainWindowViewModel : ObservableObject, IDisposable
 {
-    private const string DefaultWindowsRelease = OperatingSystemSupportMatrix.SupportedWindowsRelease;
     private const string DefaultReleaseId = OperatingSystemSupportMatrix.DefaultReleaseId;
     private const string DefaultLicenseChannel = "RET";
     private const string DefaultEdition = "Pro";
@@ -262,9 +261,6 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private string effectiveOsArchitecture = NormalizeArchitecture(Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") ?? string.Empty);
 
     [ObservableProperty]
-    private string selectedWindowsRelease = DefaultWindowsRelease;
-
-    [ObservableProperty]
     private string selectedReleaseId = DefaultReleaseId;
 
     [ObservableProperty]
@@ -277,7 +273,6 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private string selectedEdition = DefaultEdition;
 
     public ObservableCollection<OperatingSystemCatalogItem> OperatingSystems { get; } = [];
-    public ObservableCollection<string> WindowsReleaseFilters { get; } = [];
     public ObservableCollection<string> ReleaseIdFilters { get; } = [];
     public ObservableCollection<string> LanguageFilters { get; } = [];
     public ObservableCollection<string> LicenseChannelFilters { get; } = [];
@@ -784,11 +779,6 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         RefreshDriverPackOptions();
     }
 
-    partial void OnSelectedWindowsReleaseChanged(string value)
-    {
-        HandleOsFilterSelectionChanged();
-    }
-
     partial void OnSelectedReleaseIdChanged(string value)
     {
         HandleOsFilterSelectionChanged();
@@ -1251,7 +1241,6 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     {
         return !IsCatalogLoading &&
                OperatingSystems.Count > 0 &&
-               WindowsReleaseFilters.Count > 0 &&
                ReleaseIdFilters.Count > 0 &&
                LanguageFilters.Count > 0 &&
                LicenseChannelFilters.Count > 0 &&
@@ -1312,7 +1301,6 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
         try
         {
-            string previousWindowsRelease = SelectedWindowsRelease;
             string previousReleaseId = SelectedReleaseId;
             string previousLanguageCode = SelectedLanguageCode;
             string previousLicenseChannel = SelectedLicenseChannel;
@@ -1320,14 +1308,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
             IEnumerable<OperatingSystemCatalogItem> baseQuery = BuildOsQueryWithArchitecture(OperatingSystems);
 
-            SelectedWindowsRelease = UpdateFilterSelection(
-                WindowsReleaseFilters,
-                baseQuery.Select(item => item.WindowsRelease),
-                previousWindowsRelease,
-                DefaultWindowsRelease,
-                selectFirstWhenNoMatch: true);
-
-            IEnumerable<OperatingSystemCatalogItem> releaseScope = ApplyWindowsReleaseFilter(baseQuery);
+            IEnumerable<OperatingSystemCatalogItem> releaseScope = baseQuery;
             SelectedReleaseId = UpdateFilterSelection(
                 ReleaseIdFilters,
                 releaseScope.Select(item => item.ReleaseId),
@@ -1374,13 +1355,6 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         }
 
         return supportedSource.Where(item => IsArchitectureMatch(item.Architecture, architecture));
-    }
-
-    private IEnumerable<OperatingSystemCatalogItem> ApplyWindowsReleaseFilter(IEnumerable<OperatingSystemCatalogItem> source)
-    {
-        return IsFilterUnset(SelectedWindowsRelease)
-            ? source
-            : source.Where(item => item.WindowsRelease.Equals(SelectedWindowsRelease, StringComparison.OrdinalIgnoreCase));
     }
 
     private IEnumerable<OperatingSystemCatalogItem> ApplyReleaseIdFilter(IEnumerable<OperatingSystemCatalogItem> source)
@@ -2161,7 +2135,6 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private OperatingSystemCatalogItem[] BuildFilteredOperatingSystems()
     {
         IEnumerable<OperatingSystemCatalogItem> query = BuildOsQueryWithArchitecture(OperatingSystems);
-        query = ApplyWindowsReleaseFilter(query);
         query = ApplyReleaseIdFilter(query);
         query = ApplyLanguageFilter(query);
         query = ApplyLicenseChannelFilter(query);


### PR DESCRIPTION
This pull request refactors the application to exclusively support Windows 11 (release IDs 23H2, 24H2, and 25H2), simplifying the user interface and internal logic by removing support for multiple Windows releases. It introduces a new `OperatingSystemSupportMatrix` class to centralize supported release logic, updates filtering in services and view models, and removes the Windows release selection from the UI.

**Support scope and filtering changes:**

* Added `OperatingSystemSupportMatrix` class to define supported Windows releases (only Windows 11, release IDs 23H2, 24H2, 25H2) and provide methods for checking support and release order. (`src/Foundry.Deploy/Models/OperatingSystemSupportMatrix.cs`)
* Updated `OperatingSystemCatalogService` to filter catalog entries using `OperatingSystemSupportMatrix.IsSupported`, logging the number of filtered unsupported entries. (`src/Foundry.Deploy/Services/Catalog/OperatingSystemCatalogService.cs`)
* Updated `DriverPackSelectionService` to reject unsupported operating system selections and always use "Windows 11" as the target OS name. (`src/Foundry.Deploy/Services/DriverPacks/DriverPackSelectionService.cs`)

**UI and view model simplification:**

* Removed Windows release selection from the UI (`MainWindow.xaml`), replacing the combo box with a read-only text box displaying "Windows 11". (`src/Foundry.Deploy/MainWindow.xaml`)
* Refactored `MainWindowViewModel` to remove Windows release filter logic and properties, updating filter and query methods to only use supported releases and architecture. (`src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs`) (F294a8edL33R33, [[1]](diffhunk://#diff-a8500263d6daea4cd0a1ae47c814137e62bd6ee12b4403a60be2ff620a062dbfL264-L266) [[2]](diffhunk://#diff-a8500263d6daea4cd0a1ae47c814137e62bd6ee12b4403a60be2ff620a062dbfL280) [[3]](diffhunk://#diff-a8500263d6daea4cd0a1ae47c814137e62bd6ee12b4403a60be2ff620a062dbfL787-L791) [[4]](diffhunk://#diff-a8500263d6daea4cd0a1ae47c814137e62bd6ee12b4403a60be2ff620a062dbfL1254) [[5]](diffhunk://#diff-a8500263d6daea4cd0a1ae47c814137e62bd6ee12b4403a60be2ff620a062dbfL1315-R1311) [[6]](diffhunk://#diff-a8500263d6daea4cd0a1ae47c814137e62bd6ee12b4403a60be2ff620a062dbfR1350-R1357) [[7]](diffhunk://#diff-a8500263d6daea4cd0a1ae47c814137e62bd6ee12b4403a60be2ff620a062dbfL2163)

**Catalog and driver pack release ordering:**

* Modified release search order in `MicrosoftUpdateCatalogSupport` to use `OperatingSystemSupportMatrix.ReleaseSearchOrder` instead of a hardcoded array. (`src/Foundry.Deploy/Services/DriverPacks/MicrosoftUpdateCatalogSupport.cs`)

**Miscellaneous:**

* Removed the `WINDOWSRELEASE` case from `OsCatalogFilterDisplayConverter`. (`src/Foundry.Deploy/Converters/OsCatalogFilterDisplayConverter.cs`)