### PR TITLE
Fix boot error without USB

### DIFF
--- a/src/Foundry/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry/Services/WinPe/WinPeUsbMediaService.cs
@@ -28,7 +28,8 @@ internal sealed class WinPeUsbMediaService
         _logger.LogInformation("Querying USB disk candidates. WorkingDirectory={WorkingDirectory}", workingDirectory);
         string script = @"
 $disks = Get-Disk | Where-Object { $_.BusType -eq 'USB' }
-$result = foreach ($disk in $disks) {
+$result = @(
+foreach ($disk in $disks) {
     $letters = @(
         Get-Partition -DiskNumber $disk.Number -ErrorAction SilentlyContinue |
             Where-Object { $null -ne $_.DriveLetter } |
@@ -48,8 +49,14 @@ $result = foreach ($disk in $disks) {
         Size = [uint64]$disk.Size
     }
 }
+)
 
-$result | ConvertTo-Json -Compress
+if ($result.Count -eq 0) {
+    '[]'
+}
+else {
+    $result | ConvertTo-Json -Compress
+}
 ";
         WinPeResult<string> result = await RunPowerShellAsync(script, tools, workingDirectory, cancellationToken).ConfigureAwait(false);
         if (!result.IsSuccess)


### PR DESCRIPTION
This pull request updates the PowerShell script used in the `GetUsbCandi` method to improve how USB disk candidates are collected and serialized. The main changes ensure that the script consistently outputs a valid JSON array, even when no USB disks are found.

Improvements to PowerShell script output:

* Changed the `$result` assignment to use the `@()` array syntax, ensuring that the output is always an array regardless of the number of candidates.
* Added logic to output `'[]'` when no USB disk candidates are found, and to serialize the results to JSON when candidates exist, improving robustness and consistency of the output.