### PR TITLE
Enhance logging and status updates for ISO and USB creation

### DIFF
--- a/src/Foundry/Logging/FoundryLogging.cs
+++ b/src/Foundry/Logging/FoundryLogging.cs
@@ -4,19 +4,15 @@ namespace Foundry.Logging;
 
 internal static class FoundryLogging
 {
-    private const int RetentionDays = 7;
     private const string OutputTemplate =
         "{UtcTimestamp:yyyy-MM-dd HH:mm:ss} UTC | {Level:u3} | {SourceContext} | {Message:lj}{NewLine}{Exception}";
+    private const string LogFileName = "Foundry.log";
 
     public static ILogger CreateApplicationLogger()
     {
-        string logsDirectoryPath = ResolveLogsDirectoryPath();
+        string logsDirectoryPath = GetLogsDirectoryPath();
         Directory.CreateDirectory(logsDirectoryPath);
-        PurgeExpiredLogs(logsDirectoryPath);
-
-        string filePath = Path.Combine(
-            logsDirectoryPath,
-            $"foundry-{DateTimeOffset.UtcNow:yyyyMMdd-HHmmss}.log");
+        string filePath = Path.Combine(logsDirectoryPath, LogFileName);
 
         return new LoggerConfiguration()
             .MinimumLevel.Verbose()
@@ -27,7 +23,7 @@ internal static class FoundryLogging
             .CreateLogger();
     }
 
-    private static string ResolveLogsDirectoryPath()
+    public static string GetLogsDirectoryPath()
     {
         string localAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         if (!string.IsNullOrWhiteSpace(localAppDataPath))
@@ -36,27 +32,6 @@ internal static class FoundryLogging
         }
 
         return Path.Combine(Path.GetTempPath(), "Foundry", "Logs");
-    }
-
-    private static void PurgeExpiredLogs(string logsDirectoryPath)
-    {
-        DateTime cutoffUtc = DateTime.UtcNow.AddDays(-RetentionDays);
-
-        foreach (string path in Directory.EnumerateFiles(logsDirectoryPath, "*.log", SearchOption.TopDirectoryOnly))
-        {
-            try
-            {
-                DateTime lastWriteUtc = File.GetLastWriteTimeUtc(path);
-                if (lastWriteUtc < cutoffUtc)
-                {
-                    File.Delete(path);
-                }
-            }
-            catch
-            {
-                // Best-effort retention cleanup.
-            }
-        }
     }
 }
 

--- a/src/Foundry/MainWindow.xaml
+++ b/src/Foundry/MainWindow.xaml
@@ -74,7 +74,7 @@
                 </MenuItem>
                 <!--  Tools  -->
                 <MenuItem Header="{Binding Strings[MenuTools]}">
-                    <MenuItem Header="{Binding Strings[MenuLogs]}" />
+                    <MenuItem Command="{Binding OpenLogFolderCommand}" Header="{Binding Strings[MenuLogs]}" />
                 </MenuItem>
                 <!--  Help  -->
                 <MenuItem Header="{Binding Strings[MenuHelp]}">

--- a/src/Foundry/Resources/AppStrings.en-US.resx
+++ b/src/Foundry/Resources/AppStrings.en-US.resx
@@ -142,7 +142,7 @@
     <value>_Tools</value>
   </data>
   <data name="MenuLogs" xml:space="preserve">
-    <value>_Logs</value>
+    <value>Open _Log Folder</value>
   </data>
   <data name="LanguageEnglish" xml:space="preserve">
     <value>_English</value>

--- a/src/Foundry/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry/Resources/AppStrings.fr-FR.resx
@@ -142,7 +142,7 @@
     <value>_Outils</value>
   </data>
   <data name="MenuLogs" xml:space="preserve">
-    <value>_Logs</value>
+    <value>Ouvrir le _dossier des logs</value>
   </data>
   <data name="LanguageEnglish" xml:space="preserve">
     <value>_Anglais</value>

--- a/src/Foundry/Resources/AppStrings.resx
+++ b/src/Foundry/Resources/AppStrings.resx
@@ -142,7 +142,7 @@
     <value>_Tools</value>
   </data>
   <data name="MenuLogs" xml:space="preserve">
-    <value>_Logs</value>
+    <value>Open _Log Folder</value>
   </data>
   <data name="LanguageEnglish" xml:space="preserve">
     <value>_English</value>

--- a/src/Foundry/Services/ApplicationShell/ApplicationShellService.cs
+++ b/src/Foundry/Services/ApplicationShell/ApplicationShellService.cs
@@ -1,5 +1,6 @@
 using Foundry.Services.Localization;
 using Microsoft.Win32;
+using System.Diagnostics;
 using System.Windows;
 
 namespace Foundry.Services.ApplicationShell;
@@ -57,6 +58,18 @@ public sealed class ApplicationShellService : IApplicationShellService
         }
 
         return dialog.ShowDialog() == true ? dialog.FolderName : null;
+    }
+
+    public void OpenFolder(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = "explorer.exe",
+            Arguments = $"\"{path}\"",
+            UseShellExecute = true
+        });
     }
 
     public bool ConfirmWarning(string title, string message)

--- a/src/Foundry/Services/ApplicationShell/IApplicationShellService.cs
+++ b/src/Foundry/Services/ApplicationShell/IApplicationShellService.cs
@@ -10,5 +10,7 @@ public interface IApplicationShellService
 
     string? PickFolderPath(string title, string? initialPath = null);
 
+    void OpenFolder(string path);
+
     bool ConfirmWarning(string title, string message);
 }

--- a/src/Foundry/Services/WinPe/MediaOutputService.cs
+++ b/src/Foundry/Services/WinPe/MediaOutputService.cs
@@ -133,6 +133,10 @@ public sealed class MediaOutputService : IMediaOutputService
             }
 
             WinPeToolPaths tools = toolsResult.Value!;
+            _logger.LogInformation(
+                "Resolved ADK tooling for ISO creation. DismPath={DismPath}, MakeWinPeMediaPath={MakeWinPeMediaPath}",
+                tools.DismPath,
+                tools.MakeWinPeMediaPath);
             _operationProgressService.Report(16, "Creating WinPE workspace.");
             WinPeResult<WinPeBuildArtifact> buildResult = await _buildService.BuildAsync(new WinPeBuildOptions
             {
@@ -163,18 +167,30 @@ public sealed class MediaOutputService : IMediaOutputService
                 return FailWithProgress(drivers.Error!);
             }
 
+            _logger.LogInformation(
+                "Resolved {DriverDirectoryCount} driver directory path(s) for ISO creation. WorkingDirectoryPath={WorkingDirectoryPath}",
+                drivers.Value!.Count,
+                artifact.WorkingDirectoryPath);
             _operationProgressService.Report(48, "Applying image customizations.");
+            _logger.LogInformation(
+                "Starting WinPE image customization for ISO creation. WorkingDirectoryPath={WorkingDirectoryPath}, DriverDirectoryCount={DriverDirectoryCount}, WinPeLanguage={WinPeLanguage}",
+                artifact.WorkingDirectoryPath,
+                drivers.Value!.Count,
+                options.WinPeLanguage);
             WinPeResult customize = await CustomizeImageAsync(artifact, tools, drivers.Value!, options.WinPeLanguage, cancellationToken).ConfigureAwait(false);
             if (!customize.IsSuccess)
             {
                 return FailWithProgress(customize.Error!);
             }
 
+            _logger.LogInformation("WinPE image customization completed for ISO creation. WorkingDirectoryPath={WorkingDirectoryPath}", artifact.WorkingDirectoryPath);
             _operationProgressService.Report(66, "Applying signature policy.");
             bool bootEx = false;
             if (options.SignatureMode == WinPeSignatureMode.Pca2023)
             {
+                _logger.LogInformation("Evaluating PCA2023 signature policy for ISO creation. WorkingDirectoryPath={WorkingDirectoryPath}", artifact.WorkingDirectoryPath);
                 bootEx = await _toolResolver.IsBootExSupportedAsync(tools, _processRunner, artifact.WorkingDirectoryPath, cancellationToken).ConfigureAwait(false);
+                _logger.LogInformation("PCA2023 signature policy evaluated for ISO creation. BootExSupported={BootExSupported}", bootEx);
                 if (!bootEx)
                 {
                     WinPeResult remediation = await RunRemediationIfConfiguredAsync(options.RunPca2023RemediationWhenBootExUnsupported, options.Pca2023RemediationScriptPath, artifact, tools, cancellationToken).ConfigureAwait(false);
@@ -182,22 +198,31 @@ public sealed class MediaOutputService : IMediaOutputService
                     {
                         return FailWithProgress(remediation.Error!);
                     }
+
+                    _logger.LogInformation("PCA2023 remediation fallback completed for ISO creation. WorkingDirectoryPath={WorkingDirectoryPath}", artifact.WorkingDirectoryPath);
                 }
             }
 
             _operationProgressService.Report(82, "Creating ISO media.");
             if (options.ForceOverwriteOutput && File.Exists(options.OutputIsoPath))
             {
+                _logger.LogInformation("Deleting existing ISO before overwrite. OutputIsoPath={OutputIsoPath}", options.OutputIsoPath);
                 File.Delete(options.OutputIsoPath);
             }
 
             string args = $"/ISO /F{(bootEx ? " /bootex" : string.Empty)} {WinPeProcessRunner.Quote(artifact.WorkingDirectoryPath)} {WinPeProcessRunner.Quote(options.OutputIsoPath)}";
+            _logger.LogInformation(
+                "Creating ISO media from prepared workspace. WorkingDirectoryPath={WorkingDirectoryPath}, OutputIsoPath={OutputIsoPath}, UseBootEx={UseBootEx}",
+                artifact.WorkingDirectoryPath,
+                options.OutputIsoPath,
+                bootEx);
             WinPeProcessExecution makeIso = await _processRunner.RunCmdScriptAsync(tools.MakeWinPeMediaPath, args, artifact.WorkingDirectoryPath, cancellationToken).ConfigureAwait(false);
             if (!makeIso.IsSuccess || !File.Exists(options.OutputIsoPath))
             {
                 return FailWithProgress(new WinPeDiagnostic(WinPeErrorCodes.IsoCreateFailed, "Failed to create ISO media.", makeIso.ToDiagnosticText()));
             }
 
+            _logger.LogInformation("ISO media file created successfully. OutputIsoPath={OutputIsoPath}", options.OutputIsoPath);
             _operationProgressService.Complete("ISO creation completed.");
             _logger.LogInformation("ISO creation completed successfully. OutputIsoPath={OutputIsoPath}", options.OutputIsoPath);
             return WinPeResult.Success();
@@ -213,6 +238,10 @@ public sealed class MediaOutputService : IMediaOutputService
             {
                 TryDeleteDirectory(artifact.WorkingDirectoryPath);
                 _logger.LogDebug("ISO working directory cleanup completed. WorkingDirectoryPath={WorkingDirectoryPath}", artifact.WorkingDirectoryPath);
+            }
+            else if (artifact is not null)
+            {
+                _logger.LogInformation("ISO working directory preserved. WorkingDirectoryPath={WorkingDirectoryPath}", artifact.WorkingDirectoryPath);
             }
         }
     }
@@ -249,6 +278,10 @@ public sealed class MediaOutputService : IMediaOutputService
             }
 
             WinPeToolPaths tools = toolsResult.Value!;
+            _logger.LogInformation(
+                "Resolved ADK tooling for USB creation. DismPath={DismPath}, MakeWinPeMediaPath={MakeWinPeMediaPath}",
+                tools.DismPath,
+                tools.MakeWinPeMediaPath);
             _operationProgressService.Report(16, "Creating WinPE workspace.");
             WinPeResult<WinPeBuildArtifact> buildResult = await _buildService.BuildAsync(new WinPeBuildOptions
             {
@@ -279,13 +312,23 @@ public sealed class MediaOutputService : IMediaOutputService
                 return FailWithProgress(drivers.Error!);
             }
 
+            _logger.LogInformation(
+                "Resolved {DriverDirectoryCount} driver directory path(s) for USB creation. WorkingDirectoryPath={WorkingDirectoryPath}",
+                drivers.Value!.Count,
+                artifact.WorkingDirectoryPath);
             _operationProgressService.Report(48, "Applying image customizations.");
+            _logger.LogInformation(
+                "Starting WinPE image customization for USB creation. WorkingDirectoryPath={WorkingDirectoryPath}, DriverDirectoryCount={DriverDirectoryCount}, WinPeLanguage={WinPeLanguage}",
+                artifact.WorkingDirectoryPath,
+                drivers.Value!.Count,
+                options.WinPeLanguage);
             WinPeResult customize = await CustomizeImageAsync(artifact, tools, drivers.Value!, options.WinPeLanguage, cancellationToken).ConfigureAwait(false);
             if (!customize.IsSuccess)
             {
                 return FailWithProgress(customize.Error!);
             }
 
+            _logger.LogInformation("WinPE image customization completed for USB creation. WorkingDirectoryPath={WorkingDirectoryPath}", artifact.WorkingDirectoryPath);
             _operationProgressService.Report(62, "Applying signature policy.");
             if (options.SignatureMode == WinPeSignatureMode.Pca2023)
             {
@@ -294,15 +337,26 @@ public sealed class MediaOutputService : IMediaOutputService
                 {
                     return FailWithProgress(remediation.Error!);
                 }
+
+                _logger.LogInformation("PCA2023 remediation workflow completed for USB creation. WorkingDirectoryPath={WorkingDirectoryPath}", artifact.WorkingDirectoryPath);
             }
 
             _operationProgressService.Report(80, "Provisioning and populating USB.");
+            _logger.LogInformation(
+                "Starting USB provisioning and media population. WorkingDirectoryPath={WorkingDirectoryPath}, TargetDiskNumber={TargetDiskNumber}",
+                artifact.WorkingDirectoryPath,
+                options.TargetDiskNumber);
             WinPeResult<WinPeUsbProvisionResult> usb = await _usbMediaService.ProvisionAndPopulateAsync(options, artifact, tools, cancellationToken).ConfigureAwait(false);
             if (!usb.IsSuccess)
             {
                 return FailWithProgress(usb.Error!);
             }
 
+            _logger.LogInformation(
+                "USB provisioning and media population completed. TargetDiskNumber={TargetDiskNumber}, BootDrive={BootDrive}, CacheDrive={CacheDrive}",
+                options.TargetDiskNumber,
+                usb.Value?.BootDriveLetter,
+                usb.Value?.CacheDriveLetter);
             _operationProgressService.Complete("USB creation completed.");
             _logger.LogInformation("USB creation completed successfully. TargetDiskNumber={TargetDiskNumber}", options.TargetDiskNumber);
             return WinPeResult.Success();
@@ -318,6 +372,10 @@ public sealed class MediaOutputService : IMediaOutputService
             {
                 TryDeleteDirectory(artifact.WorkingDirectoryPath);
                 _logger.LogDebug("USB working directory cleanup completed. WorkingDirectoryPath={WorkingDirectoryPath}", artifact.WorkingDirectoryPath);
+            }
+            else if (artifact is not null)
+            {
+                _logger.LogInformation("USB working directory preserved. WorkingDirectoryPath={WorkingDirectoryPath}", artifact.WorkingDirectoryPath);
             }
         }
     }
@@ -432,6 +490,11 @@ public sealed class MediaOutputService : IMediaOutputService
                 $"Selected language: '{canonicalLocale}'.");
         }
 
+        _logger.LogInformation(
+            "Mounting WinPE image for customization. BootWimPath={BootWimPath}, MountDirectoryPath={MountDirectoryPath}, WinPeLanguage={WinPeLanguage}",
+            artifact.BootWimPath,
+            artifact.MountDirectoryPath,
+            normalizedLocale);
         WinPeResult<WinPeMountSession> mount = await WinPeMountSession.MountAsync(_processRunner, tools.DismPath, artifact.BootWimPath, artifact.MountDirectoryPath, artifact.WorkingDirectoryPath, cancellationToken).ConfigureAwait(false);
         if (!mount.IsSuccess)
         {
@@ -439,8 +502,13 @@ public sealed class MediaOutputService : IMediaOutputService
         }
 
         await using WinPeMountSession session = mount.Value!;
+        _logger.LogInformation("Mounted WinPE image for customization. MountDirectoryPath={MountDirectoryPath}", session.MountDirectoryPath);
         if (driverDirectories.Count > 0)
         {
+            _logger.LogInformation(
+                "Starting driver injection into mounted WinPE image. DriverDirectoryCount={DriverDirectoryCount}, MountDirectoryPath={MountDirectoryPath}",
+                driverDirectories.Count,
+                session.MountDirectoryPath);
             WinPeResult inject = await _driverInjectionService.InjectAsync(new WinPeDriverInjectionOptions
             {
                 MountedImagePath = session.MountDirectoryPath,
@@ -455,8 +523,15 @@ public sealed class MediaOutputService : IMediaOutputService
                 await session.DiscardAsync(cancellationToken).ConfigureAwait(false);
                 return inject;
             }
+
+            _logger.LogInformation("Driver injection completed for mounted WinPE image. MountDirectoryPath={MountDirectoryPath}", session.MountDirectoryPath);
+        }
+        else
+        {
+            _logger.LogInformation("Skipping driver injection because no driver directories were resolved. MountDirectoryPath={MountDirectoryPath}", session.MountDirectoryPath);
         }
 
+        _logger.LogInformation("Adding required WinPE optional components. MountDirectoryPath={MountDirectoryPath}, WinPeLanguage={WinPeLanguage}", session.MountDirectoryPath, normalizedLocale);
         WinPeResult addComponentsResult = await AddRequiredOptionalComponentsAsync(
             session.MountDirectoryPath,
             artifact.Architecture,
@@ -470,6 +545,8 @@ public sealed class MediaOutputService : IMediaOutputService
             return addComponentsResult;
         }
 
+        _logger.LogInformation("Required WinPE optional components added successfully. MountDirectoryPath={MountDirectoryPath}", session.MountDirectoryPath);
+        _logger.LogInformation("Applying WinPE international settings. CanonicalLocale={CanonicalLocale}, InputLocale={InputLocale}", canonicalLocale, inputLocale);
         WinPeResult intlResult = await ApplyInternationalSettingsAsync(
             session.MountDirectoryPath,
             tools,
@@ -483,6 +560,7 @@ public sealed class MediaOutputService : IMediaOutputService
             return intlResult;
         }
 
+        _logger.LogInformation("Applied WinPE international settings successfully. MountDirectoryPath={MountDirectoryPath}", session.MountDirectoryPath);
         string system32 = Path.Combine(session.MountDirectoryPath, "Windows", "System32");
         Directory.CreateDirectory(system32);
         string bootstrapScriptContent;
@@ -505,6 +583,7 @@ public sealed class MediaOutputService : IMediaOutputService
             bootstrapScriptContent,
             new UTF8Encoding(false),
             cancellationToken).ConfigureAwait(false);
+        _logger.LogInformation("Wrote bootstrap script into mounted WinPE image. System32Path={System32Path}", system32);
 
         WinPeResult localDeployProvisioning = await ProvisionLocalDeployArchiveInImageAsync(
             session.MountDirectoryPath,
@@ -517,6 +596,7 @@ public sealed class MediaOutputService : IMediaOutputService
             return localDeployProvisioning;
         }
 
+        _logger.LogInformation("Provisioned local Foundry.Deploy archive into mounted WinPE image. MountDirectoryPath={MountDirectoryPath}", session.MountDirectoryPath);
         WinPeResult sevenZipProvisioning = ProvisionBundledSevenZipInImage(
             session.MountDirectoryPath,
             artifact.Architecture);
@@ -526,6 +606,7 @@ public sealed class MediaOutputService : IMediaOutputService
             return sevenZipProvisioning;
         }
 
+        _logger.LogInformation("Provisioned bundled 7-Zip tools into mounted WinPE image. MountDirectoryPath={MountDirectoryPath}", session.MountDirectoryPath);
         string startnet = Path.Combine(session.MountDirectoryPath, WinPeDefaults.DefaultStartnetPathInImage);
         string[] lines = File.Exists(startnet) ? await File.ReadAllLinesAsync(startnet, cancellationToken).ConfigureAwait(false) : ["wpeinit"];
         var merged = lines.ToList();
@@ -534,8 +615,16 @@ public sealed class MediaOutputService : IMediaOutputService
             merged.Add(WinPeDefaults.DefaultBootstrapInvocation);
         }
         await File.WriteAllLinesAsync(startnet, merged, cancellationToken).ConfigureAwait(false);
+        _logger.LogInformation("Updated startnet.cmd in mounted WinPE image. StartnetPath={StartnetPath}", startnet);
 
-        return await session.CommitAsync(cancellationToken).ConfigureAwait(false);
+        _logger.LogInformation("Committing mounted WinPE image changes. MountDirectoryPath={MountDirectoryPath}", session.MountDirectoryPath);
+        WinPeResult commit = await session.CommitAsync(cancellationToken).ConfigureAwait(false);
+        if (commit.IsSuccess)
+        {
+            _logger.LogInformation("Committed mounted WinPE image changes successfully. MountDirectoryPath={MountDirectoryPath}", session.MountDirectoryPath);
+        }
+
+        return commit;
     }
 
     private async Task<WinPeResult> ApplyInternationalSettingsAsync(

--- a/src/Foundry/Services/WinPe/WinPeDriverInjectionService.cs
+++ b/src/Foundry/Services/WinPe/WinPeDriverInjectionService.cs
@@ -1,8 +1,16 @@
+using Microsoft.Extensions.Logging;
+
 namespace Foundry.Services.WinPe;
 
 public sealed class WinPeDriverInjectionService : IWinPeDriverInjectionService
 {
     private readonly WinPeProcessRunner _processRunner = new();
+    private readonly ILogger<WinPeDriverInjectionService> _logger;
+
+    public WinPeDriverInjectionService(ILogger<WinPeDriverInjectionService> logger)
+    {
+        _logger = logger;
+    }
 
     public async Task<WinPeResult> InjectAsync(
         WinPeDriverInjectionOptions options,
@@ -28,6 +36,12 @@ public sealed class WinPeDriverInjectionService : IWinPeDriverInjectionService
                 $"Expected path: '{dismPath}'.");
         }
 
+        _logger.LogInformation(
+            "Injecting {DriverPathCount} driver package path(s) into mounted image. MountedImagePath={MountedImagePath}, RecurseSubdirectories={RecurseSubdirectories}",
+            options.DriverPackagePaths.Count,
+            options.MountedImagePath,
+            options.RecurseSubdirectories);
+
         foreach (string packagePath in options.DriverPackagePaths)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -35,6 +49,8 @@ public sealed class WinPeDriverInjectionService : IWinPeDriverInjectionService
             string normalizedPath = packagePath.Trim();
             string recurse = options.RecurseSubdirectories ? " /Recurse" : string.Empty;
             string args = $"/Image:{WinPeProcessRunner.Quote(options.MountedImagePath)} /Add-Driver /Driver:{WinPeProcessRunner.Quote(normalizedPath)}{recurse}";
+
+            _logger.LogDebug("Injecting driver package path into mounted image. DriverPackagePath={DriverPackagePath}", normalizedPath);
 
             WinPeProcessExecution result = await _processRunner.RunAsync(
                 dismPath,
@@ -51,6 +67,7 @@ public sealed class WinPeDriverInjectionService : IWinPeDriverInjectionService
             }
         }
 
+        _logger.LogInformation("Driver injection completed successfully. MountedImagePath={MountedImagePath}", options.MountedImagePath);
         return WinPeResult.Success();
     }
 

--- a/src/Foundry/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry/Services/WinPe/WinPeUsbMediaService.cs
@@ -172,6 +172,12 @@ else {
                 "Free at least one drive letter between D: and Z: and retry.");
         }
 
+        _logger.LogInformation(
+            "Resolved USB target disk identity and drive letters. DiskNumber={DiskNumber}, FriendlyName={FriendlyName}, BootDriveLetter={BootDriveLetter}, CacheDriveLetter={CacheDriveLetter}",
+            diskNumber,
+            disk.FriendlyName,
+            $"{bootDriveLetter}:",
+            $"{cacheDriveLetter}:");
         WinPeResult provisioningResult = await ProvisionDiskAsync(
             diskNumber,
             options.PartitionStyle,
@@ -191,7 +197,9 @@ else {
 
         string bootRoot = $"{bootDriveLetter}:\\";
         string cacheRoot = $"{cacheDriveLetter}:\\";
+        _logger.LogInformation("USB disk partitioning and formatting completed. DiskNumber={DiskNumber}, BootRoot={BootRoot}, CacheRoot={CacheRoot}", diskNumber, bootRoot, cacheRoot);
 
+        _logger.LogInformation("Copying prepared WinPE media to USB boot partition. SourceMediaDirectoryPath={SourceMediaDirectoryPath}, BootRoot={BootRoot}", artifact.MediaDirectoryPath, bootRoot);
         WinPeResult copyResult = await CopyMediaAsync(artifact.MediaDirectoryPath, bootRoot, artifact.WorkingDirectoryPath, cancellationToken).ConfigureAwait(false);
         if (!copyResult.IsSuccess)
         {
@@ -199,6 +207,7 @@ else {
             return WinPeResult<WinPeUsbProvisionResult>.Failure(copyResult.Error!);
         }
 
+        _logger.LogInformation("Copied prepared WinPE media to USB boot partition successfully. BootRoot={BootRoot}", bootRoot);
         WinPeResult verifyResult = VerifyBootArtifacts(bootRoot, artifact.Architecture);
         if (!verifyResult.IsSuccess)
         {
@@ -206,11 +215,13 @@ else {
             return WinPeResult<WinPeUsbProvisionResult>.Failure(verifyResult.Error!);
         }
 
+        _logger.LogInformation("Verified USB boot artifacts successfully. BootRoot={BootRoot}, Architecture={Architecture}", bootRoot, artifact.Architecture);
         string cacheMarkerPath = Path.Combine(cacheRoot, "Foundry Cache");
         Directory.CreateDirectory(cacheMarkerPath);
         Directory.CreateDirectory(Path.Combine(cacheRoot, "Runtime"));
         Directory.CreateDirectory(Path.Combine(cacheRoot, "OperatingSystem"));
         Directory.CreateDirectory(Path.Combine(cacheRoot, "DriverPack"));
+        _logger.LogInformation("Initialized USB cache partition directories. CacheRoot={CacheRoot}", cacheRoot);
 
         WinPeResult<WinPeUsbProvisionResult> success = WinPeResult<WinPeUsbProvisionResult>.Success(new WinPeUsbProvisionResult
         {

--- a/src/Foundry/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry/ViewModels/MainWindowViewModel.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Foundry.Logging;
 using Foundry.Services.Adk;
 using Foundry.Services.ApplicationShell;
 using Foundry.Services.Localization;
@@ -183,6 +184,22 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private void ShowAbout()
     {
         _applicationShellService.ShowAbout();
+    }
+
+    [RelayCommand]
+    private void OpenLogFolder()
+    {
+        string logFolderPath = FoundryLogging.GetLogsDirectoryPath();
+
+        try
+        {
+            Directory.CreateDirectory(logFolderPath);
+            _applicationShellService.OpenFolder(logFolderPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to open log folder. LogFolderPath={LogFolderPath}", logFolderPath);
+        }
     }
 
     [RelayCommand]

--- a/src/Foundry/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry/ViewModels/MainWindowViewModel.cs
@@ -333,7 +333,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     {
         try
         {
-            MediaActionMessage = string.Empty;
+            MediaActionMessage = Strings["OperationInProgress"];
             Directory.CreateDirectory(StagingDirectoryPath);
 
             WinPeResult result = await _mediaOutputService.CreateIsoAsync(new IsoOutputOptions
@@ -395,7 +395,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
         try
         {
-            MediaActionMessage = string.Empty;
+            MediaActionMessage = Strings["OperationInProgress"];
             Directory.CreateDirectory(StagingDirectoryPath);
 
             WinPeResult result = await _mediaOutputService.CreateUsbAsync(new UsbOutputOptions

--- a/src/Foundry/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry/ViewModels/MainWindowViewModel.cs
@@ -333,6 +333,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     {
         try
         {
+            MediaActionMessage = string.Empty;
             Directory.CreateDirectory(StagingDirectoryPath);
 
             WinPeResult result = await _mediaOutputService.CreateIsoAsync(new IsoOutputOptions
@@ -394,6 +395,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
         try
         {
+            MediaActionMessage = string.Empty;
             Directory.CreateDirectory(StagingDirectoryPath);
 
             WinPeResult result = await _mediaOutputService.CreateUsbAsync(new UsbOutputOptions


### PR DESCRIPTION
This pull request introduces improvements to logging, user experience, and operational transparency in the Foundry application. The main changes include simplifying log file management, enhancing user access to logs, and adding detailed logging throughout the WinPE media creation process for both ISO and USB workflows.

### Logging and Log File Management

* Simplified log file naming to always use `Foundry.log`, removed timestamp-based log file creation, and eliminated old log retention and purging logic from `FoundryLogging.cs`. The logs directory resolution method is now public as `GetLogsDirectoryPath`. [[1]](diffhunk://#diff-c79b5563161f7844be39ec0aead397440d470794b781ae42624a639e4495aad1L7-R15) [[2]](diffhunk://#diff-c79b5563161f7844be39ec0aead397440d470794b781ae42624a639e4495aad1L30-R26) [[3]](diffhunk://#diff-c79b5563161f7844be39ec0aead397440d470794b781ae42624a639e4495aad1L40-L60)

### User Experience Improvements

* Updated the Tools menu in `MainWindow.xaml` to bind the Logs menu item to a new `OpenLogFolderCommand`, allowing users to open the log folder directly from the UI.
* Changed the log menu string in all resource files to "Open Log Folder" (and the French equivalent), clarifying the action for users. [[1]](diffhunk://#diff-bbc928ab2d3a892d8c57b90c9e9d12e94e40637abcaa182f6908aee286953385L145-R145) [[2]](diffhunk://#diff-efb382b3dd636bdcdcd0810c7d1f7e890a89799273406ac27a396f44a9e0de63L145-R145)
* Added `OpenFolder(string path)` to `IApplicationShellService` and its implementation, enabling folder opening via Windows Explorer. [[1]](diffhunk://#diff-94ae824149d3f92da1b7a88e87f4ea2d9c7cd1bc6152d048472cc6199752c7f7R63-R74) [[2]](diffhunk://#diff-ab7ad6da133542135e1798ea4162ebc7df0da2fcc01bd79c3110b12f5f7ae6a4R13-R14)

### Operational Logging Enhancements

* Added extensive, step-by-step informational logging throughout the WinPE ISO and USB creation processes in `MediaOutputService.cs`. This includes logging tool resolution, driver injection, image customization, signature policy evaluation, ISO/USB provisioning, and artifact cleanup/preservation. [[1]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R136-R139) [[2]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R170-R225) [[3]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R242-R245) [[4]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R281-R284) [[5]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R315-R331) [[6]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R340-R359) [[7]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R376-R379) [[8]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R493-R511) [[9]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R526-R534) [[10]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R548-R549) [[11]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R563) [[12]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R586)