### PR TITLE
Refactor command execution methods

### DIFF
--- a/src/Foundry/Services/WinPe/MediaOutputService.cs
+++ b/src/Foundry/Services/WinPe/MediaOutputService.cs
@@ -210,7 +210,7 @@ public sealed class MediaOutputService : IMediaOutputService
                 File.Delete(options.OutputIsoPath);
             }
 
-            string args = $"/ISO /F{(bootEx ? " /bootex" : string.Empty)} {WinPeProcessRunner.Quote(artifact.WorkingDirectoryPath)} {WinPeProcessRunner.Quote(options.OutputIsoPath)}";
+            string args = $"/ISO /F {WinPeProcessRunner.Quote(artifact.WorkingDirectoryPath)} {WinPeProcessRunner.Quote(options.OutputIsoPath)}{(bootEx ? " /bootex" : string.Empty)}";
             _logger.LogInformation(
                 "Creating ISO media from prepared workspace. WorkingDirectoryPath={WorkingDirectoryPath}, OutputIsoPath={OutputIsoPath}, UseBootEx={UseBootEx}",
                 artifact.WorkingDirectoryPath,

--- a/src/Foundry/Services/WinPe/WinPeProcessRunner.cs
+++ b/src/Foundry/Services/WinPe/WinPeProcessRunner.cs
@@ -181,6 +181,40 @@ internal sealed class WinPeProcessRunner
         return RunAsync(cmdPath, arguments, workingDirectory, cancellationToken, environmentOverrides);
     }
 
+    public Task<WinPeProcessExecution> RunCmdScriptDirectAsync(
+        string scriptPath,
+        string scriptArguments,
+        string workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(scriptPath))
+        {
+            throw new ArgumentException("Script path is required.", nameof(scriptPath));
+        }
+
+        var cmdPath = Environment.GetEnvironmentVariable("ComSpec");
+        if (string.IsNullOrWhiteSpace(cmdPath))
+        {
+            cmdPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "System32", "cmd.exe");
+        }
+
+        string normalizedScriptArguments = string.IsNullOrWhiteSpace(scriptArguments)
+            ? string.Empty
+            : $" {scriptArguments}";
+
+        string command = $"{Quote(scriptPath)}{normalizedScriptArguments}";
+        IReadOnlyDictionary<string, string>? environmentOverrides = BuildAdkEnvironmentOverrides(scriptPath);
+        if (environmentOverrides is not null &&
+            environmentOverrides.TryGetValue(InternalSetEnvKey, out string? setEnvPath) &&
+            !string.IsNullOrWhiteSpace(setEnvPath))
+        {
+            command = $"call {Quote(setEnvPath)} >nul 2>&1 && {command}";
+        }
+
+        string arguments = $"/d /c \"{command}\"";
+        return RunAsync(cmdPath, arguments, workingDirectory, cancellationToken, environmentOverrides);
+    }
+
     public static string Quote(string value)
     {
         return value.Contains(' ', StringComparison.Ordinal)

--- a/src/Foundry/Services/WinPe/WinPeProcessRunner.cs
+++ b/src/Foundry/Services/WinPe/WinPeProcessRunner.cs
@@ -153,32 +153,13 @@ internal sealed class WinPeProcessRunner
         string workingDirectory,
         CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(scriptPath))
-        {
-            throw new ArgumentException("Script path is required.", nameof(scriptPath));
-        }
-
-        var cmdPath = Environment.GetEnvironmentVariable("ComSpec");
-        if (string.IsNullOrWhiteSpace(cmdPath))
-        {
-            cmdPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "System32", "cmd.exe");
-        }
-
-        string normalizedScriptArguments = string.IsNullOrWhiteSpace(scriptArguments)
-            ? string.Empty
-            : $" {scriptArguments}";
-
-        string command = $"call {Quote(scriptPath)}{normalizedScriptArguments}";
-        IReadOnlyDictionary<string, string>? environmentOverrides = BuildAdkEnvironmentOverrides(scriptPath);
-        if (environmentOverrides is not null &&
-            environmentOverrides.TryGetValue(InternalSetEnvKey, out string? setEnvPath) &&
-            !string.IsNullOrWhiteSpace(setEnvPath))
-        {
-            command = $"call {Quote(setEnvPath)} >nul 2>&1 && {command}";
-        }
-
-        string arguments = $"/d /s /c \"{command}\"";
-        return RunAsync(cmdPath, arguments, workingDirectory, cancellationToken, environmentOverrides);
+        return RunCmdScriptCoreAsync(
+            scriptPath,
+            scriptArguments,
+            workingDirectory,
+            cancellationToken,
+            callTargetScript: true,
+            useCommandExtensionsStripQuoteRules: true);
     }
 
     public Task<WinPeProcessExecution> RunCmdScriptDirectAsync(
@@ -187,22 +168,37 @@ internal sealed class WinPeProcessRunner
         string workingDirectory,
         CancellationToken cancellationToken)
     {
+        return RunCmdScriptCoreAsync(
+            scriptPath,
+            scriptArguments,
+            workingDirectory,
+            cancellationToken,
+            callTargetScript: false,
+            useCommandExtensionsStripQuoteRules: false);
+    }
+
+    private Task<WinPeProcessExecution> RunCmdScriptCoreAsync(
+        string scriptPath,
+        string scriptArguments,
+        string workingDirectory,
+        CancellationToken cancellationToken,
+        bool callTargetScript,
+        bool useCommandExtensionsStripQuoteRules)
+    {
         if (string.IsNullOrWhiteSpace(scriptPath))
         {
             throw new ArgumentException("Script path is required.", nameof(scriptPath));
-        }
-
-        var cmdPath = Environment.GetEnvironmentVariable("ComSpec");
-        if (string.IsNullOrWhiteSpace(cmdPath))
-        {
-            cmdPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "System32", "cmd.exe");
         }
 
         string normalizedScriptArguments = string.IsNullOrWhiteSpace(scriptArguments)
             ? string.Empty
             : $" {scriptArguments}";
 
-        string command = $"{Quote(scriptPath)}{normalizedScriptArguments}";
+        string scriptCommand = $"{Quote(scriptPath)}{normalizedScriptArguments}";
+        string command = callTargetScript
+            ? $"call {scriptCommand}"
+            : scriptCommand;
+
         IReadOnlyDictionary<string, string>? environmentOverrides = BuildAdkEnvironmentOverrides(scriptPath);
         if (environmentOverrides is not null &&
             environmentOverrides.TryGetValue(InternalSetEnvKey, out string? setEnvPath) &&
@@ -211,8 +207,9 @@ internal sealed class WinPeProcessRunner
             command = $"call {Quote(setEnvPath)} >nul 2>&1 && {command}";
         }
 
-        string arguments = $"/d /c \"{command}\"";
-        return RunAsync(cmdPath, arguments, workingDirectory, cancellationToken, environmentOverrides);
+        string switchS = useCommandExtensionsStripQuoteRules ? " /s" : string.Empty;
+        string arguments = $"/d{switchS} /c \"{command}\"";
+        return RunAsync(GetCommandProcessorPath(), arguments, workingDirectory, cancellationToken, environmentOverrides);
     }
 
     public static string Quote(string value)
@@ -220,6 +217,17 @@ internal sealed class WinPeProcessRunner
         return value.Contains(' ', StringComparison.Ordinal)
             ? $"\"{value}\""
             : value;
+    }
+
+    private static string GetCommandProcessorPath()
+    {
+        var cmdPath = Environment.GetEnvironmentVariable("ComSpec");
+        if (!string.IsNullOrWhiteSpace(cmdPath))
+        {
+            return cmdPath;
+        }
+
+        return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "System32", "cmd.exe");
     }
 
     private static IReadOnlyDictionary<string, string>? BuildAdkEnvironmentOverrides(string scriptPath)

--- a/src/Foundry/Services/WinPe/WinPeToolResolver.cs
+++ b/src/Foundry/Services/WinPe/WinPeToolResolver.cs
@@ -77,7 +77,7 @@ internal sealed class WinPeToolResolver
         string workingDirectory,
         CancellationToken cancellationToken)
     {
-        WinPeProcessExecution helpResult = await processRunner.RunCmdScriptAsync(
+        WinPeProcessExecution helpResult = await processRunner.RunCmdScriptDirectAsync(
             toolPaths.MakeWinPeMediaPath,
             "/?",
             workingDirectory,


### PR DESCRIPTION
This pull request introduces improvements and refactoring to the command execution logic in the WinPE media output and process runner services. The main focus is on adding more flexibility to script execution, enhancing command argument handling, and improving code maintainability.

Enhancements to script execution and command handling:

* Added a new method `RunCmdScriptDirectAsync` to `WinPeProcessRunner`, allowing scripts to be run directly without the `call` prefix and with customized command extension handling. This provides more control over how scripts are executed.
* Refactored the script execution logic by introducing a shared private method `RunCmdScriptCoreAsync`, which consolidates the logic for both `RunCmdScriptAsync` and `RunCmdScriptDirectAsync`. This improves maintainability and reduces code duplication.
* Improved command argument construction by making the `/s` switch optional based on the `useCommandExtensionsStripQuoteRules` parameter, allowing for more precise control of command processing.
* Added a helper method `GetCommandProcessorPath` to reliably determine the path to `cmd.exe`, using the `ComSpec` environment variable or falling back to the default Windows path.

Integration and bug fixes:

* Updated `IsBootExSupportedAsync` in `WinPeToolResolver` to use the new `RunCmdScriptDirectAsync` method, ensuring scripts are executed with the intended semantics.
* Corrected the construction of ISO creation arguments in `MediaOutputService`, ensuring the `/F` flag is properly formatted and `/bootex` is appended only when necessary.