### PR TITLE
Add package icon and adjust asset references

### DIFF
--- a/src/Foundry.Deploy/Foundry.Deploy.csproj
+++ b/src/Foundry.Deploy/Foundry.Deploy.csproj
@@ -7,6 +7,7 @@
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <StartupObject>Foundry.Deploy.Program</StartupObject>
     <ApplicationIcon>Assets\Icons\app.ico</ApplicationIcon>
+    <PackageIcon>app.ico</PackageIcon>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,7 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="Assets\Icons\app.ico" />
     <Resource Include="Assets\Icons\app.ico" />
   </ItemGroup>
 
@@ -34,6 +34,13 @@
       <Link>Assets\7z\%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Assets\Icons\app.ico">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -8,6 +8,7 @@
     <StartupObject>Foundry.Program</StartupObject>
     <Win32Manifest>app.manifest</Win32Manifest>
     <ApplicationIcon>Assets\Icons\app.ico</ApplicationIcon>
+    <PackageIcon>app.ico</PackageIcon>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,7 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="Assets\Icons\app.ico" />
     <Resource Include="Assets\Icons\app.ico" />
   </ItemGroup>
 
@@ -39,6 +39,13 @@
     <Content Include="Assets\7z\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Assets\Icons\app.ico">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request updates the packaging configuration for both `Foundry.Deploy` and `Foundry` projects to improve how the application icon is handled in NuGet packages. The main changes ensure the icon is correctly included and referenced in the package metadata and contents.

NuGet packaging improvements:

* Added the `<PackageIcon>` property to both `Foundry.Deploy.csproj` and `Foundry.csproj` so that the NuGet package metadata specifies the icon file (`app.ico`). [[1]](diffhunk://#diff-86939781e1e671f7efca81f65d6fd65196b8552f3e2121d7c1b36afd56fda0cbR10) [[2]](diffhunk://#diff-b09ea5db9447c1339a89a4f6f2ea9dbab5da2a7742ebc756895c3a9c739907b8R11)
* Updated the icon file (`Assets\Icons\app.ico`) to be packed into the NuGet package by adding a new `<ItemGroup>` with `<None Update="Assets\Icons\app.ico">` and setting `<Pack>True</Pack>` and `<PackagePath>\</PackagePath>`. [[1]](diffhunk://#diff-86939781e1e671f7efca81f65d6fd65196b8552f3e2121d7c1b36afd56fda0cbR39-R45) [[2]](diffhunk://#diff-b09ea5db9447c1339a89a4f6f2ea9dbab5da2a7742ebc756895c3a9c739907b8R44-R50)

Resource handling changes:

* Changed the resource inclusion for the icon file by removing the `<None Remove="Assets\Icons\app.ico" />` line and keeping `<Resource Include="Assets\Icons\app.ico" />` in both project files. [[1]](diffhunk://#diff-86939781e1e671f7efca81f65d6fd65196b8552f3e2121d7c1b36afd56fda0cbL28) [[2]](diffhunk://#diff-b09ea5db9447c1339a89a4f6f2ea9dbab5da2a7742ebc756895c3a9c739907b8L28)