### PR TITLE
Fix USB PCA2023 boot and provisioning flow

### DIFF
--- a/src/Foundry/Services/WinPe/MediaOutputService.cs
+++ b/src/Foundry/Services/WinPe/MediaOutputService.cs
@@ -330,23 +330,31 @@ public sealed class MediaOutputService : IMediaOutputService
 
             _logger.LogInformation("WinPE image customization completed for USB creation. WorkingDirectoryPath={WorkingDirectoryPath}", artifact.WorkingDirectoryPath);
             _operationProgressService.Report(62, "Applying signature policy.");
+            bool bootEx = false;
             if (options.SignatureMode == WinPeSignatureMode.Pca2023)
             {
-                WinPeResult remediation = await RunRemediationIfConfiguredAsync(options.RunPca2023RemediationWhenBootExUnsupported, options.Pca2023RemediationScriptPath, artifact, tools, cancellationToken).ConfigureAwait(false);
-                if (!remediation.IsSuccess)
+                _logger.LogInformation("Evaluating PCA2023 signature policy for USB creation. WorkingDirectoryPath={WorkingDirectoryPath}", artifact.WorkingDirectoryPath);
+                bootEx = await _toolResolver.IsBootExSupportedAsync(tools, _processRunner, artifact.WorkingDirectoryPath, cancellationToken).ConfigureAwait(false);
+                _logger.LogInformation("PCA2023 signature policy evaluated for USB creation. BootExSupported={BootExSupported}", bootEx);
+                if (!bootEx)
                 {
-                    return FailWithProgress(remediation.Error!);
-                }
+                    WinPeResult remediation = await RunRemediationIfConfiguredAsync(options.RunPca2023RemediationWhenBootExUnsupported, options.Pca2023RemediationScriptPath, artifact, tools, cancellationToken).ConfigureAwait(false);
+                    if (!remediation.IsSuccess)
+                    {
+                        return FailWithProgress(remediation.Error!);
+                    }
 
-                _logger.LogInformation("PCA2023 remediation workflow completed for USB creation. WorkingDirectoryPath={WorkingDirectoryPath}", artifact.WorkingDirectoryPath);
+                    _logger.LogInformation("PCA2023 remediation fallback completed for USB creation. WorkingDirectoryPath={WorkingDirectoryPath}", artifact.WorkingDirectoryPath);
+                }
             }
 
             _operationProgressService.Report(80, "Provisioning and populating USB.");
             _logger.LogInformation(
-                "Starting USB provisioning and media population. WorkingDirectoryPath={WorkingDirectoryPath}, TargetDiskNumber={TargetDiskNumber}",
+                "Starting USB provisioning and media population. WorkingDirectoryPath={WorkingDirectoryPath}, TargetDiskNumber={TargetDiskNumber}, UseBootEx={UseBootEx}",
                 artifact.WorkingDirectoryPath,
-                options.TargetDiskNumber);
-            WinPeResult<WinPeUsbProvisionResult> usb = await _usbMediaService.ProvisionAndPopulateAsync(options, artifact, tools, cancellationToken).ConfigureAwait(false);
+                options.TargetDiskNumber,
+                bootEx);
+            WinPeResult<WinPeUsbProvisionResult> usb = await _usbMediaService.ProvisionAndPopulateAsync(options, artifact, tools, bootEx, cancellationToken).ConfigureAwait(false);
             if (!usb.IsSuccess)
             {
                 return FailWithProgress(usb.Error!);

--- a/src/Foundry/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry/Services/WinPe/WinPeUsbMediaService.cs
@@ -185,7 +185,6 @@ else {
             options.FormatMode,
             bootDriveLetter,
             cacheDriveLetter,
-            tools,
             artifact.WorkingDirectoryPath,
             cancellationToken).ConfigureAwait(false);
         if (!provisioningResult.IsSuccess)
@@ -403,7 +402,6 @@ else {
         UsbFormatMode formatMode,
         char bootDriveLetter,
         char cacheDriveLetter,
-        WinPeToolPaths tools,
         string workingDirectory,
         CancellationToken cancellationToken)
     {

--- a/src/Foundry/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry/Services/WinPe/WinPeUsbMediaService.cs
@@ -211,7 +211,7 @@ else {
         if (useBootEx)
         {
             _logger.LogInformation("Reconfiguring USB boot files with BootEx support. BootRoot={BootRoot}, PartitionStyle={PartitionStyle}", bootRoot, options.PartitionStyle);
-            WinPeResult bootConfigResult = await ConfigureBootFilesAsync(bootRoot, options.PartitionStyle, artifact, tools, cancellationToken).ConfigureAwait(false);
+            WinPeResult bootConfigResult = ConfigureBootFiles(bootRoot, artifact);
             if (!bootConfigResult.IsSuccess)
             {
                 _logger.LogWarning("USB BootEx boot file configuration failed. Code={ErrorCode}, Message={ErrorMessage}", bootConfigResult.Error?.Code, bootConfigResult.Error?.Message);
@@ -249,85 +249,38 @@ else {
         return success;
     }
 
-    private async Task<WinPeResult> ConfigureBootFilesAsync(
+    private WinPeResult ConfigureBootFiles(
         string bootRoot,
-        UsbPartitionStyle partitionStyle,
-        WinPeBuildArtifact artifact,
-        WinPeToolPaths tools,
-        CancellationToken cancellationToken)
+        WinPeBuildArtifact artifact)
     {
-        string bootWimPath = Path.Combine(bootRoot, "sources", "boot.wim");
-        if (!File.Exists(bootWimPath))
-        {
-            return WinPeResult.Failure(
-                WinPeErrorCodes.UsbProvisioningFailed,
-                "USB boot configuration failed: boot.wim not found.",
-                $"Expected '{bootWimPath}'.");
-        }
-
-        string bcdbootPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "System32", "bcdboot.exe");
-        if (!File.Exists(bcdbootPath))
-        {
-            bcdbootPath = "bcdboot.exe";
-        }
-
-        WinPeProcessExecution helpResult = await _processRunner.RunAsync(
-            bcdbootPath,
-            "/?",
-            artifact.WorkingDirectoryPath,
-            cancellationToken).ConfigureAwait(false);
-
-        string combinedHelp = string.Concat(helpResult.StandardOutput, "\n", helpResult.StandardError);
-        if (combinedHelp.IndexOf("/bootex", StringComparison.OrdinalIgnoreCase) < 0)
+        string bootManagerSourcePath = Path.Combine(artifact.WorkingDirectoryPath, "bootbins", "bootmgfw_EX.efi");
+        if (!File.Exists(bootManagerSourcePath))
         {
             return WinPeResult.Failure(
                 WinPeErrorCodes.BootExUnsupported,
-                "PCA2023 USB creation requires BCDBoot support for /bootex or remediation fallback.",
-                helpResult.ToDiagnosticText());
+                "PCA2023 USB creation requires BootEx EFI binaries in the WinPE workspace.",
+                $"Expected '{bootManagerSourcePath}'.");
         }
 
-        string mountDirectoryPath = Path.Combine(artifact.WorkingDirectoryPath, "bootex-bcdboot-mount");
-        if (Directory.Exists(mountDirectoryPath))
+        string efiBootPath = Path.Combine(bootRoot, "EFI", "Boot", artifact.Architecture.ToBootEfiName());
+        if (File.Exists(efiBootPath))
         {
-            Directory.Delete(mountDirectoryPath, recursive: true);
+            File.Copy(bootManagerSourcePath, efiBootPath, overwrite: true);
         }
 
-        WinPeResult<WinPeMountSession> mountResult = await WinPeMountSession.MountAsync(
-            _processRunner,
-            tools.DismPath,
-            bootWimPath,
-            mountDirectoryPath,
-            artifact.WorkingDirectoryPath,
-            cancellationToken).ConfigureAwait(false);
-        if (!mountResult.IsSuccess)
-        {
-            return WinPeResult.Failure(mountResult.Error!);
-        }
-
-        await using WinPeMountSession mount = mountResult.Value!;
-        string windowsPath = Path.Combine(mount.MountDirectoryPath, "Windows");
-        if (!Directory.Exists(windowsPath))
+        string efiMicrosoftBootManagerPath = Path.Combine(bootRoot, "EFI", "Microsoft", "Boot", "bootmgfw.efi");
+        string? efiMicrosoftBootDirectoryPath = Path.GetDirectoryName(efiMicrosoftBootManagerPath);
+        if (string.IsNullOrWhiteSpace(efiMicrosoftBootDirectoryPath))
         {
             return WinPeResult.Failure(
                 WinPeErrorCodes.UsbProvisioningFailed,
-                "USB boot configuration failed: mounted WinPE Windows folder not found.",
-                $"Expected '{windowsPath}'.");
+                "USB boot configuration failed: EFI Microsoft boot manager path is invalid.",
+                $"Expected '{efiMicrosoftBootManagerPath}'.");
         }
 
-        string firmwareMode = partitionStyle == UsbPartitionStyle.Gpt ? "UEFI" : "ALL";
-        string arguments = $"{WinPeProcessRunner.Quote(windowsPath)} /s {WinPeProcessRunner.Quote(bootRoot)} /f {firmwareMode} /c /bootex";
-        WinPeProcessExecution result = await _processRunner.RunAsync(
-            bcdbootPath,
-            arguments,
-            artifact.WorkingDirectoryPath,
-            cancellationToken).ConfigureAwait(false);
-
-        return result.IsSuccess
-            ? WinPeResult.Success()
-            : WinPeResult.Failure(
-                WinPeErrorCodes.UsbProvisioningFailed,
-                "Failed to configure USB boot files with /bootex.",
-                result.ToDiagnosticText());
+        Directory.CreateDirectory(efiMicrosoftBootDirectoryPath);
+        File.Copy(bootManagerSourcePath, efiMicrosoftBootManagerPath, overwrite: true);
+        return WinPeResult.Success();
     }
 
     private static WinPeResult ValidateDiskSafety(UsbOutputOptions options, DiskIdentityInfo disk)

--- a/src/Foundry/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry/Services/WinPe/WinPeUsbMediaService.cs
@@ -112,6 +112,7 @@ else {
         UsbOutputOptions options,
         WinPeBuildArtifact artifact,
         WinPeToolPaths tools,
+        bool useBootEx,
         CancellationToken cancellationToken)
     {
         _logger.LogInformation("Starting USB provisioning for TargetDiskNumber={TargetDiskNumber}, PartitionStyle={PartitionStyle}, FormatMode={FormatMode}",
@@ -208,6 +209,19 @@ else {
         }
 
         _logger.LogInformation("Copied prepared WinPE media to USB boot partition successfully. BootRoot={BootRoot}", bootRoot);
+        if (useBootEx)
+        {
+            _logger.LogInformation("Reconfiguring USB boot files with BootEx support. BootRoot={BootRoot}, PartitionStyle={PartitionStyle}", bootRoot, options.PartitionStyle);
+            WinPeResult bootConfigResult = await ConfigureBootFilesAsync(bootRoot, options.PartitionStyle, artifact, tools, cancellationToken).ConfigureAwait(false);
+            if (!bootConfigResult.IsSuccess)
+            {
+                _logger.LogWarning("USB BootEx boot file configuration failed. Code={ErrorCode}, Message={ErrorMessage}", bootConfigResult.Error?.Code, bootConfigResult.Error?.Message);
+                return WinPeResult<WinPeUsbProvisionResult>.Failure(bootConfigResult.Error!);
+            }
+
+            _logger.LogInformation("USB boot files reconfigured with BootEx support successfully. BootRoot={BootRoot}", bootRoot);
+        }
+
         WinPeResult verifyResult = VerifyBootArtifacts(bootRoot, artifact.Architecture);
         if (!verifyResult.IsSuccess)
         {
@@ -234,6 +248,87 @@ else {
             success.Value?.BootDriveLetter,
             success.Value?.CacheDriveLetter);
         return success;
+    }
+
+    private async Task<WinPeResult> ConfigureBootFilesAsync(
+        string bootRoot,
+        UsbPartitionStyle partitionStyle,
+        WinPeBuildArtifact artifact,
+        WinPeToolPaths tools,
+        CancellationToken cancellationToken)
+    {
+        string bootWimPath = Path.Combine(bootRoot, "sources", "boot.wim");
+        if (!File.Exists(bootWimPath))
+        {
+            return WinPeResult.Failure(
+                WinPeErrorCodes.UsbProvisioningFailed,
+                "USB boot configuration failed: boot.wim not found.",
+                $"Expected '{bootWimPath}'.");
+        }
+
+        string bcdbootPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "System32", "bcdboot.exe");
+        if (!File.Exists(bcdbootPath))
+        {
+            bcdbootPath = "bcdboot.exe";
+        }
+
+        WinPeProcessExecution helpResult = await _processRunner.RunAsync(
+            bcdbootPath,
+            "/?",
+            artifact.WorkingDirectoryPath,
+            cancellationToken).ConfigureAwait(false);
+
+        string combinedHelp = string.Concat(helpResult.StandardOutput, "\n", helpResult.StandardError);
+        if (combinedHelp.IndexOf("/bootex", StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            return WinPeResult.Failure(
+                WinPeErrorCodes.BootExUnsupported,
+                "PCA2023 USB creation requires BCDBoot support for /bootex or remediation fallback.",
+                helpResult.ToDiagnosticText());
+        }
+
+        string mountDirectoryPath = Path.Combine(artifact.WorkingDirectoryPath, "bootex-bcdboot-mount");
+        if (Directory.Exists(mountDirectoryPath))
+        {
+            Directory.Delete(mountDirectoryPath, recursive: true);
+        }
+
+        WinPeResult<WinPeMountSession> mountResult = await WinPeMountSession.MountAsync(
+            _processRunner,
+            tools.DismPath,
+            bootWimPath,
+            mountDirectoryPath,
+            artifact.WorkingDirectoryPath,
+            cancellationToken).ConfigureAwait(false);
+        if (!mountResult.IsSuccess)
+        {
+            return WinPeResult.Failure(mountResult.Error!);
+        }
+
+        await using WinPeMountSession mount = mountResult.Value!;
+        string windowsPath = Path.Combine(mount.MountDirectoryPath, "Windows");
+        if (!Directory.Exists(windowsPath))
+        {
+            return WinPeResult.Failure(
+                WinPeErrorCodes.UsbProvisioningFailed,
+                "USB boot configuration failed: mounted WinPE Windows folder not found.",
+                $"Expected '{windowsPath}'.");
+        }
+
+        string firmwareMode = partitionStyle == UsbPartitionStyle.Gpt ? "UEFI" : "ALL";
+        string arguments = $"{WinPeProcessRunner.Quote(windowsPath)} /s {WinPeProcessRunner.Quote(bootRoot)} /f {firmwareMode} /c /bootex";
+        WinPeProcessExecution result = await _processRunner.RunAsync(
+            bcdbootPath,
+            arguments,
+            artifact.WorkingDirectoryPath,
+            cancellationToken).ConfigureAwait(false);
+
+        return result.IsSuccess
+            ? WinPeResult.Success()
+            : WinPeResult.Failure(
+                WinPeErrorCodes.UsbProvisioningFailed,
+                "Failed to configure USB boot files with /bootex.",
+                result.ToDiagnosticText());
     }
 
     private static WinPeResult ValidateDiskSafety(UsbOutputOptions options, DiskIdentityInfo disk)
@@ -325,12 +420,16 @@ else {
             "clean",
             ..conversionLines,
             "create partition primary size=4096",
-            $"format fs=fat32{formatSuffix} label=BOOT",
+            "select partition 1",
             $"assign letter={bootDriveLetter}",
+            $"select volume={bootDriveLetter}",
+            $"format fs=fat32{formatSuffix} label=BOOT",
             activeLine,
             "create partition primary",
-            $"format fs=ntfs{formatSuffix} label=\"Foundry Cache\"",
-            $"assign letter={cacheDriveLetter}"
+            "select partition 2",
+            $"assign letter={cacheDriveLetter}",
+            $"select volume={cacheDriveLetter}",
+            $"format fs=ntfs{formatSuffix} label=\"Foundry Cache\""
         ];
 
         string[] effectiveScriptLines = scriptLines


### PR DESCRIPTION
This pull request enhances the WinPE USB creation workflow to support BootEx (PCA2023) signature policy and improves the reliability of USB provisioning. The main changes include conditional BootEx support detection, reconfiguration of boot files when BootEx is required, and improvements to disk provisioning logic.

**BootEx (PCA2023) support and workflow improvements:**

* Added logic in `MediaOutputService.cs` to detect if BootEx is supported when the PCA2023 signature mode is selected, and to run remediation or fallback steps if not supported. The provisioning workflow now logs BootEx support status and passes this information to the USB provisioning service.
* Updated the `ProvisionAndPopulateAsync` method in `WinPeUsbMediaService.cs` to accept a `useBootEx` parameter and, if enabled, reconfigure USB boot files by copying the BootEx EFI binaries to the appropriate locations. Failure to configure BootEx results in an error. [[1]](diffhunk://#diff-da0749efccf3541be8972dcc8d0fa2d540d5ccdec88de560ab5b4fb09a7d4c28R115) [[2]](diffhunk://#diff-da0749efccf3541be8972dcc8d0fa2d540d5ccdec88de560ab5b4fb09a7d4c28R211-R223) [[3]](diffhunk://#diff-da0749efccf3541be8972dcc8d0fa2d540d5ccdec88de560ab5b4fb09a7d4c28R252-R285)

**Disk provisioning and formatting improvements:**

* Refined the diskpart script in `ProvisionDiskAsync` to explicitly select and assign drive letters to partitions before formatting, improving reliability and compatibility with various disk configurations.
* Removed unused `tools` parameter from internal provisioning methods to simplify method signatures. [[1]](diffhunk://#diff-da0749efccf3541be8972dcc8d0fa2d540d5ccdec88de560ab5b4fb09a7d4c28L187) [[2]](diffhunk://#diff-da0749efccf3541be8972dcc8d0fa2d540d5ccdec88de560ab5b4fb09a7d4c28L311)

These changes make the USB creation process more robust, especially for new signature requirements, and ensure the correct configuration of boot files for BootEx-enabled devices.