### PR TITLE
Enhance Foundry with expert configuration and UI improvements

### DIFF
--- a/findings.md
+++ b/findings.md
@@ -1,0 +1,273 @@
+# Findings & Decisions
+
+## Requirements
+- The user wants to brainstorm the Foundry project window architecture before implementation.
+- The window should support a `Simple/Standard` mode and an `Expert` mode.
+- The user wants a switch between modes.
+- The top menu should remain present.
+- In Expert mode, the user wants left-side navigation grouped by configuration category such as network and personalization.
+- The current content under `standard configuration` and `advanced options` should effectively define the current Standard mode baseline.
+- The architecture should stay modular so new advanced options can be added later.
+- The user wants import/export of configuration.
+- Advanced/exported configuration may need to be written to a separate file that `foundry deploy` can consume.
+- For advanced options with sub-options, the parent checkbox should enable or disable the whole option group.
+- When the parent option is disabled, child controls should be disabled.
+- The user does not want a subproject or a separate test project.
+- The user explicitly asked to use Context7.
+- `Simple` and `Standard` are the same mode.
+- In Expert mode, the user wants to see the same values as Standard plus more sections.
+- Expert mode left navigation should contain categories only, not subpages.
+- Initial expert categories should start with `Network`, `Localization`, and `Customization`.
+- The mode switch should likely live in the top menu under a dedicated `Mode` entry.
+- Import/export should be exposed as `File` menu actions.
+- Expert mode should have two explicit exports:
+  - a full Foundry expert config
+  - a deploy-consumable JSON file
+- The deploy-consumable file is not user-editable and should be generated automatically from Expert selections.
+- The deploy-consumable file should likely live under `X:\Foundry\Config`.
+- Standard mode should not inject any deploy-consumable file when building new media.
+- When switching back to Standard mode, expert-only settings should not be applied and no warning/banner should be shown.
+- For export, disabled child settings should be stripped from JSON.
+- For `Network`, the first controls should cover 802.1X enablement, certificate import, and Wi-Fi in WinPE. Logic is out of scope for now; controls only.
+- For `Localization`, the expert config should constrain which Windows language choices are exposed in `Foundry.Deploy`, support a default override, and optionally force the only available choice.
+- The generated deploy file name should be explicit: `foundry.deploy.config.json`.
+- Expert values should stay in memory when switching back to Standard mode.
+- `Foundry.Deploy` should auto-load the generated expert config silently, with no banner.
+- For `Customization`, machine naming should be the first implemented group; Autopilot, APPX, and custom-config areas can start as placeholders.
+- `Foundry.Deploy` should consume the generated expert config through a dedicated optional loader service, not directly in `Program.cs`.
+- The Expert localization registry should be stored as an embedded JSON resource in `Foundry`.
+- In `Customization` v1, only `MachineNaming` should produce persisted/exported config; `Autopilot`, `APPX removal`, and `Custom deploy config` should remain UI-only placeholders.
+- For `Customization`, the expert config should cover machine naming behavior and may later include Autopilot, config injection, and APPX removal.
+
+## Research Findings
+- The `planning-with-files` skill requires persistent project files: `task_plan.md`, `findings.md`, and `progress.md`.
+- Initial repository inspection shows root folders: `.github`, `Assets`, `scripts`, and `src`.
+- The environment cannot execute `rg.exe`; PowerShell search must be used instead.
+- `Foundry` is a WPF desktop app targeting `net10.0-windows` and using `CommunityToolkit.Mvvm`.
+- The current main window keeps a top `Menu` and uses a single flat page layout in `src/Foundry/MainWindow.xaml`.
+- The current window already has two major sections that match the user's framing:
+  - `Section: standard configuration`
+  - `Section: advanced options`
+- The existing advanced UI is currently a single `Expander`, not a category-based expert workspace.
+- The current `MainWindowViewModel` directly exposes window state as observable properties rather than through grouped configuration objects.
+- Current media creation already passes structured records to services:
+  - `IsoOutputOptions`
+  - `UsbOutputOptions`
+- Those option records already mix booleans, enums, strings, and nullable string fields, which is a good base for a future export model.
+- `Foundry.Deploy` already has a richer configuration surface, and its `DeploymentContext` uses concrete booleans such as `ApplyFirmwareUpdates`, `UseFullAutopilot`, and `AllowAutopilotDeferredCompletion`.
+- The current `Foundry` window contains properties like `EnablePcaRemediation` and `PcaRemediationScriptPath` in the view model, which suggests some advanced settings are already anticipated even if the XAML does not surface them yet.
+- Context7 confirmed the relevant library is official WPF (`/dotnet/wpf`). The returned guidance is generic, but it aligns with a container-based MVVM layout where grouped controls bind against view-model state.
+- The WinPE/bootstrap side consistently treats `X:\Foundry` as the runtime root and already uses subfolders such as `Logs`, `Seed`, `Tools`, and `Runtime`.
+- Based on the existing root layout, `X:\Foundry\Config` is a coherent location for injected expert-mode configuration files.
+- `Foundry.Deploy` currently uses `X:\Foundry\Runtime` for transient runtime/cache behavior, so `Config` should be treated as input/configuration and `Runtime` as operational state.
+- `Foundry.Deploy` currently sources operating system and language options from the operating system catalog service rather than a static built-in language registry.
+- The deploy view model normalizes and selects language codes from the current catalog-backed filter list.
+- Official .NET documentation via Context7 (`/dotnet/docs`) confirms `System.Text.Json` supports omitting null properties during serialization with `JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull`.
+- That JSON behavior fits the desired export rule: parent feature flag remains explicit, while disabled child values can be stripped from exported files by serializing them as `null` and omitting nulls on write.
+- Official .NET documentation via Context7 also confirms that `System.Text.Json` ignores unknown JSON properties by default during deserialization, while .NET 8+ can be configured to disallow them.
+- This makes forward-compatible import practical: ignore unknown fields by default, but validate required fields and consider surfacing a non-blocking notice.
+
+## Technical Decisions
+| Decision | Rationale |
+|----------|-----------|
+| Delay concrete UI recommendations until the current window implementation is inspected | Recommendations should fit the existing codebase rather than assume a stack or layout |
+| Treat parent expert toggles as a first-class model concern, not only a UI concern | Enablement, serialization, import/export, and deploy generation all depend on the same state model |
+| Favor introducing an explicit shared configuration model over exporting raw window state | The current view model is UI-oriented, while import/export and deploy integration need stable contracts |
+| Preserve the top menu and treat Expert mode as a shell/layout change inside the main content area | This matches the user's preferred UX direction and the current XAML structure |
+| Recommend preserving disabled child values in memory, but stripping them from exported JSON | Better UX for toggling settings on/off without losing work, while keeping export clean and semantically accurate |
+| Recommend a top-menu `Mode` menu with mutually exclusive mode choices | The app already uses a top menu for app-wide concerns, and mode changes the whole shell rather than a local panel |
+| Recommend ignoring unknown fields on expert-config import, with validation and a non-blocking notice | This is the best forward-compatibility tradeoff for user-owned config files |
+| Recommend a hybrid localization source: built-in curated language registry for Expert config UI, validated/intersected with catalog-backed deploy choices when available | Keeps Expert configuration stable and offline-friendly without drifting completely away from deploy reality |
+| Recommend a dedicated optional config loader service inside `Foundry.Deploy` | Startup config application is view-model/state logic, not bootstrap logic |
+| Recommend embedded JSON for the built-in localization registry | Easier maintenance than hardcoded lists and more appropriate than environment config |
+| Recommend keeping future customization groups UI-only until their contracts are real | Prevents speculative export schema growth |
+
+## Implementation-Ready Architecture Draft
+
+### 1. Window Shell
+- Keep the existing top menu in `Foundry`.
+- Add a new top-level `Mode` menu with two mutually exclusive items:
+  - `Standard`
+  - `Expert`
+- Extend the existing `File` menu with:
+  - `Import Expert Configuration`
+  - `Export Expert Configuration`
+  - `Export Deploy Configuration`
+- Keep Standard mode visually close to the current single-page layout.
+- In Expert mode, replace the current single-page content area with a two-column settings shell:
+  - left column: category navigation
+  - right column: category content host
+- Implement left navigation with a simple MVVM-friendly item source such as a `ListBox`, and host the selected category content through a `ContentControl` with DataTemplates.
+- Preserve the current status/progress/footer regions below the main configuration area.
+
+### 2. Expert Categories
+- `General`
+  - Contains everything currently shown in Standard mode:
+    - current `standard configuration`
+    - current `advanced options`
+- `Network`
+  - 802.1X enablement
+  - certificate import controls
+  - Wi-Fi in WinPE controls
+  - controls only in v1; no functional implementation yet
+- `Localization`
+  - visible language list for `Foundry.Deploy`
+  - default language override
+  - force single visible language option
+- `Customization`
+  - `MachineNaming` as the only persisted/exported v1 group
+  - `Autopilot`, `APPX removal`, and `Custom deploy config` as UI-only placeholders
+
+### 3. ViewModel Split
+- Keep `MainWindowViewModel` as the shell-level coordinator.
+- Move long-term settings state into a canonical configuration object rather than keeping everything as flat UI properties.
+- Recommended shell responsibilities for `MainWindowViewModel`:
+  - current mode
+  - current expert category
+  - top-menu commands
+  - import/export commands
+  - operation/progress state
+  - adaptation between current window commands and configuration-backed values
+- Recommended child view models or section models:
+  - `GeneralSettingsViewModel`
+  - `NetworkSettingsViewModel`
+  - `LocalizationSettingsViewModel`
+  - `CustomizationSettingsViewModel`
+- Keep the Standard view bound to the same underlying config-backed state as Expert.
+- Do not create a separate persisted Standard model.
+
+### 4. Canonical Config Model
+- Introduce one canonical persisted model inside `Foundry`, for example:
+  - `FoundryExpertConfigurationDocument`
+- Recommended top-level fields:
+  - `schemaVersion`
+  - `general`
+  - `network`
+  - `localization`
+  - `customization`
+- `schemaVersion` should be explicit from v1.
+- The model should contain only persisted settings, not transient UI state such as:
+  - current mode
+  - selected navigation category
+  - expander open/closed state
+  - progress text
+- Standard mode edits should write into the same underlying settings represented by `general`.
+
+### 5. Parent/Child Toggle Pattern
+- For any Expert feature with sub-options, use a consistent persisted shape:
+  - `isEnabled`
+  - child properties
+- UI behavior:
+  - parent checkbox controls `isEnabled`
+  - child container binds `IsEnabled` to the parent toggle
+  - when disabled, child values stay in memory
+- Export behavior:
+  - parent `isEnabled` stays explicit
+  - child values are omitted when disabled by serializing them as `null` and using null-ignore serialization
+
+### 6. Full Expert Config Export
+- `Foundry` full expert config is user-owned and importable.
+- Recommended file purpose:
+  - long-term editable/exportable expert settings snapshot
+- Recommended characteristics:
+  - JSON
+  - includes `schemaVersion`
+  - ignores unknown fields on import
+  - validates known required fields
+  - omits disabled child values
+
+### 7. Deploy Config Export
+- Generate a second, narrower JSON contract specifically for `Foundry.Deploy`.
+- Recommended file path when injected into media:
+  - `X:\Foundry\Config\foundry.deploy.config.json`
+- Standard mode:
+  - do not generate or inject this file
+- Expert mode:
+  - generate and inject this file
+- This deploy contract should contain only values that `Foundry.Deploy` actually consumes.
+
+### 8. `Foundry.Deploy` Consumption Contract
+- Add a dedicated optional loader service in `Foundry.Deploy`, for example:
+  - `IExpertDeployConfigLoader`
+- Responsibilities:
+  - read `X:\Foundry\Config\foundry.deploy.config.json` if present
+  - deserialize it
+  - validate it
+  - expose a typed result to `MainWindowViewModel`
+- Apply config in two stages:
+  - stage 1: immediate scalar values
+  - stage 2: catalog-dependent values after catalog data is loaded
+- Startup behavior:
+  - silent
+  - no banner
+  - logging only
+- Invalid or unknown fields:
+  - unknown fields ignored
+  - known invalid values logged and skipped
+  - app continues with safe defaults
+
+### 9. Embedded Localization Registry
+- Keep the Expert localization registry inside `Foundry` as an embedded JSON resource.
+- Recommended data shape per language entry:
+  - `code`
+  - `displayName`
+  - `englishName`
+  - optional `sortOrder`
+- Use this registry for the Expert editor UI only.
+- During deploy export or deploy load, validate/intersect language codes against real deploy-supported options.
+
+### 10. Suggested File/Folder Additions
+- `src/Foundry/Models/Configuration/FoundryExpertConfigurationDocument.cs`
+- `src/Foundry/Models/Configuration/GeneralSettings.cs`
+- `src/Foundry/Models/Configuration/NetworkSettings.cs`
+- `src/Foundry/Models/Configuration/LocalizationSettings.cs`
+- `src/Foundry/Models/Configuration/CustomizationSettings.cs`
+- `src/Foundry/Models/Configuration/MachineNamingSettings.cs`
+- `src/Foundry/Models/Configuration/FeatureToggle*.cs` or equivalent grouped option models
+- `src/Foundry/Services/Configuration/IExpertConfigurationService.cs`
+- `src/Foundry/Services/Configuration/ExpertConfigurationService.cs`
+- `src/Foundry/Services/Configuration/IDeployConfigurationGenerator.cs`
+- `src/Foundry/Services/Configuration/DeployConfigurationGenerator.cs`
+- `src/Foundry/Services/Configuration/ILanguageRegistryService.cs`
+- `src/Foundry/Services/Configuration/EmbeddedLanguageRegistryService.cs`
+- `src/Foundry/ViewModels/Expert/ExpertSectionItem.cs`
+- `src/Foundry/ViewModels/Expert/GeneralSettingsViewModel.cs`
+- `src/Foundry/ViewModels/Expert/NetworkSettingsViewModel.cs`
+- `src/Foundry/ViewModels/Expert/LocalizationSettingsViewModel.cs`
+- `src/Foundry/ViewModels/Expert/CustomizationSettingsViewModel.cs`
+- `src/Foundry/Assets/Configuration/languages.json`
+- `src/Foundry.Deploy/Services/Configuration/IExpertDeployConfigLoader.cs`
+- `src/Foundry.Deploy/Services/Configuration/ExpertDeployConfigLoader.cs`
+- `src/Foundry.Deploy/Models/Configuration/DeployExpertConfiguration.cs`
+
+### 11. Suggested Delivery Order
+- Step 1: introduce canonical config models and serialization services
+- Step 2: add top-menu `Mode` and File-menu import/export commands
+- Step 3: refactor `MainWindowViewModel` to bind through canonical config-backed state
+- Step 4: implement Expert shell with left navigation and `General` category
+- Step 5: add `Network`, `Localization`, and `Customization` categories
+- Step 6: generate deploy-consumable JSON in Expert mode only
+- Step 7: add optional silent loader service in `Foundry.Deploy`
+
+## Issues Encountered
+| Issue | Resolution |
+|-------|------------|
+| `rg` search is unavailable due to an execution/access error | Use `Get-ChildItem` and `Select-String` |
+
+## Open Questions / Potential Inconsistencies
+- The exact sequencing for applying expert config versus catalog-loaded data in `Foundry.Deploy` still needs to be specified during technical design.
+- The first embedded localization registry schema still needs to be defined precisely.
+- The post-v1 priority order for future Expert groups still needs to be chosen.
+
+## Resources
+- Planning skill: `C:\Users\mchav\.codex\skills\planning-with-files\SKILL.md`
+- Repo root: `E:\Github\Foundry`
+- `E:\Github\Foundry\src\Foundry\MainWindow.xaml`
+- `E:\Github\Foundry\src\Foundry\ViewModels\MainWindowViewModel.cs`
+- `E:\Github\Foundry\src\Foundry\Services\WinPe\IsoOutputOptions.cs`
+- `E:\Github\Foundry\src\Foundry\Services\WinPe\UsbOutputOptions.cs`
+- `E:\Github\Foundry\src\Foundry.Deploy\Services\Deployment\DeploymentContext.cs`
+- Context7 WPF docs: `/dotnet/wpf`
+
+## Visual/Browser Findings
+- None yet.

--- a/progress.md
+++ b/progress.md
@@ -1,0 +1,89 @@
+# Progress Log
+
+## Session: 2026-03-15
+
+### Phase 1: Requirements & Discovery
+- **Status:** complete
+- **Started:** 2026-03-15 20:36
+- Actions taken:
+  - Read the `planning-with-files` skill instructions.
+  - Listed the repository root contents.
+  - Reviewed planning file templates.
+  - Created planning files for this discovery session.
+  - Captured the initial user requirements and constraints.
+  - Noted the `rg` environment failure and switched to PowerShell search.
+  - Inspected `MainWindow.xaml` and `MainWindowViewModel.cs` for the current Foundry window structure.
+  - Inspected `IsoOutputOptions` and `UsbOutputOptions` to understand current option serialization targets.
+  - Inspected deploy-side `GatherDeploymentVariablesStep` and `DeploymentContext` to understand how deploy currently models configuration.
+  - Queried Context7 for official WPF documentation relevant to grouped settings UI and parent-driven enablement.
+  - Inspected the bootstrap/runtime path conventions to validate where an injected config file should live in WinPE.
+  - Queried official .NET docs via Context7 for `System.Text.Json` null-omission behavior to support export semantics.
+  - Captured the user's decisions for mode behavior, expert categories, import/export placement, and initial expert settings.
+  - Queried official .NET docs via Context7 for unknown-field handling during JSON import.
+  - Inspected deploy-side language sourcing to decide between static and catalog-driven Expert localization options.
+- Files created/modified:
+  - `task_plan.md` (created)
+  - `findings.md` (created)
+  - `progress.md` (created)
+
+### Phase 2: Product Structure Proposal
+- **Status:** complete
+- Actions taken:
+  - Consolidated user decisions for Standard versus Expert mode behavior.
+  - Confirmed the `Mode` menu, `General` expert category, and File-menu import/export direction.
+  - Confirmed deploy config naming and path conventions.
+  - Resolved Standard-mode media generation behavior: no deploy-consumable config should be injected in Standard mode.
+  - Resolved deploy startup UX: auto-load expert config silently with logging only and no banner.
+  - Resolved the deploy integration direction: use a dedicated optional config loader service inside `Foundry.Deploy`.
+  - Resolved the localization registry direction: use an embedded JSON resource in `Foundry`.
+  - Resolved v1 customization scope: only `MachineNaming` persists; other customization groups stay UI-only placeholders.
+  - Wrote the implementation-ready Standard/Expert architecture draft.
+- Files created/modified:
+  - `task_plan.md` (updated)
+  - `findings.md` (updated)
+  - `progress.md` (updated)
+
+### Phase 3: Technical Direction
+- **Status:** complete
+- Actions taken:
+  - Defined the canonical expert configuration document and section boundaries.
+  - Defined the parent/child toggle serialization rule.
+  - Defined the deploy-consumable contract boundary.
+  - Defined the embedded localization registry direction.
+  - Defined the recommended file and service additions for both `Foundry` and `Foundry.Deploy`.
+- Files created/modified:
+  - `task_plan.md` (updated)
+  - `findings.md` (updated)
+  - `progress.md` (updated)
+
+### Phase 4: UI and Integration Mapping
+- **Status:** complete
+- Actions taken:
+  - Mapped the target shell to the current `MainWindow.xaml` layout.
+  - Mapped shell responsibilities versus section view models.
+  - Defined the startup/config integration approach for `Foundry.Deploy`.
+  - Defined the suggested implementation order.
+- Files created/modified:
+  - `task_plan.md` (updated)
+  - `findings.md` (updated)
+  - `progress.md` (updated)
+
+## Test Results
+| Test | Input | Expected | Actual | Status |
+|------|-------|----------|--------|--------|
+| Repo inspection | `Get-ChildItem -Force` | See repo structure | Repo structure listed successfully | PASS |
+| Search utility | `rg -n ... src` | Search current UI files | `rg.exe` failed with access denied | FAIL |
+
+## Error Log
+| Timestamp | Error | Attempt | Resolution |
+|-----------|-------|---------|------------|
+| 2026-03-15 20:37 | `rg.exe` access denied during source search | 1 | Switched to PowerShell search |
+
+## 5-Question Reboot Check
+| Question | Answer |
+|----------|--------|
+| Where am I? | Phase 2 |
+| Where am I going? | Finish the product structure proposal, then map it onto a concrete config and UI architecture |
+| What's the goal? | Define the architecture for Standard and Expert window modes plus config import/export and deploy integration behavior |
+| What have I learned? | Product direction is mostly settled; the remaining gaps are about integration and exact config ownership |
+| What have I done? | Completed discovery, validated core technical assumptions, and updated the plan with concrete next phases |

--- a/src/Foundry.Deploy/MainWindow.xaml
+++ b/src/Foundry.Deploy/MainWindow.xaml
@@ -117,6 +117,7 @@
                                 <TextBox
                                     x:Name="TargetComputerNameTextBox"
                                     Margin="0,8,0,0"
+                                    IsReadOnly="{Binding IsTargetComputerNameReadOnly}"
                                     MaxLength="{x:Static rules:ComputerNameRules.MaxLength}"
                                     PreviewTextInput="TargetComputerNameTextBox_PreviewTextInput"
                                     Text="{Binding TargetComputerName, UpdateSourceTrigger=PropertyChanged}" />
@@ -224,6 +225,7 @@
                                         <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Language" />
                                         <ComboBox
                                             Margin="0,8,0,0"
+                                            IsEnabled="{Binding IsLanguageSelectionEnabled}"
                                             ItemsSource="{Binding LanguageFilters}"
                                             SelectedItem="{Binding SelectedLanguageCode}" />
                                     </StackPanel>

--- a/src/Foundry.Deploy/MainWindow.xaml.cs
+++ b/src/Foundry.Deploy/MainWindow.xaml.cs
@@ -30,6 +30,12 @@ public partial class MainWindow : Window
 
     private void TargetComputerNameTextBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
     {
+        if (sender is TextBox { IsReadOnly: true })
+        {
+            e.Handled = true;
+            return;
+        }
+
         if (!ComputerNameRules.IsAllowedText(e.Text))
         {
             e.Handled = true;
@@ -39,6 +45,12 @@ public partial class MainWindow : Window
     private void TargetComputerNameTextBox_OnPaste(object sender, DataObjectPastingEventArgs e)
     {
         if (sender is not TextBox textBox)
+        {
+            e.CancelCommand();
+            return;
+        }
+
+        if (textBox.IsReadOnly)
         {
             e.CancelCommand();
             return;

--- a/src/Foundry.Deploy/Models/Configuration/DeployCustomizationSettings.cs
+++ b/src/Foundry.Deploy/Models/Configuration/DeployCustomizationSettings.cs
@@ -1,0 +1,6 @@
+namespace Foundry.Deploy.Models.Configuration;
+
+public sealed record DeployCustomizationSettings
+{
+    public DeployMachineNamingSettings MachineNaming { get; init; } = new();
+}

--- a/src/Foundry.Deploy/Models/Configuration/DeployLocalizationSettings.cs
+++ b/src/Foundry.Deploy/Models/Configuration/DeployLocalizationSettings.cs
@@ -1,0 +1,8 @@
+namespace Foundry.Deploy.Models.Configuration;
+
+public sealed record DeployLocalizationSettings
+{
+    public IReadOnlyList<string> VisibleLanguageCodes { get; init; } = Array.Empty<string>();
+    public string? DefaultLanguageCodeOverride { get; init; }
+    public bool ForceSingleVisibleLanguage { get; init; }
+}

--- a/src/Foundry.Deploy/Models/Configuration/DeployMachineNamingSettings.cs
+++ b/src/Foundry.Deploy/Models/Configuration/DeployMachineNamingSettings.cs
@@ -1,0 +1,9 @@
+namespace Foundry.Deploy.Models.Configuration;
+
+public sealed record DeployMachineNamingSettings
+{
+    public bool IsEnabled { get; init; }
+    public string? Prefix { get; init; }
+    public bool AutoGenerateName { get; init; }
+    public bool AllowManualSuffixEdit { get; init; } = true;
+}

--- a/src/Foundry.Deploy/Models/Configuration/FoundryDeployConfigurationDocument.cs
+++ b/src/Foundry.Deploy/Models/Configuration/FoundryDeployConfigurationDocument.cs
@@ -1,0 +1,10 @@
+namespace Foundry.Deploy.Models.Configuration;
+
+public sealed record FoundryDeployConfigurationDocument
+{
+    public const int CurrentSchemaVersion = 1;
+
+    public int SchemaVersion { get; init; } = CurrentSchemaVersion;
+    public DeployLocalizationSettings Localization { get; init; } = new();
+    public DeployCustomizationSettings Customization { get; init; } = new();
+}

--- a/src/Foundry.Deploy/Program.cs
+++ b/src/Foundry.Deploy/Program.cs
@@ -3,6 +3,7 @@ using Foundry.Deploy.Services.ApplicationShell;
 using Foundry.Deploy.Services.Autopilot;
 using Foundry.Deploy.Services.Cache;
 using Foundry.Deploy.Services.Catalog;
+using Foundry.Deploy.Services.Configuration;
 using Foundry.Deploy.Services.Deployment;
 using Foundry.Deploy.Services.Deployment.Steps;
 using Foundry.Deploy.Services.Download;
@@ -144,6 +145,7 @@ public static class Program
         services.AddSingleton<IThemeService, ThemeService>();
         services.AddSingleton<IApplicationShellService, ApplicationShellService>();
         services.AddSingleton<IOperationProgressService, OperationProgressService>();
+        services.AddSingleton<IExpertDeployConfigurationService, ExpertDeployConfigurationService>();
         services.AddSingleton<IProcessRunner, ProcessRunner>();
         services.AddSingleton<IArchiveExtractionService, ArchiveExtractionService>();
         services.AddSingleton<ICacheLocatorService, CacheLocatorService>();

--- a/src/Foundry.Deploy/Services/Configuration/ConfigurationJsonDefaults.cs
+++ b/src/Foundry.Deploy/Services/Configuration/ConfigurationJsonDefaults.cs
@@ -1,0 +1,17 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Foundry.Deploy.Services.Configuration;
+
+internal static class ConfigurationJsonDefaults
+{
+    public static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        AllowTrailingCommas = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        WriteIndented = true
+    };
+}

--- a/src/Foundry.Deploy/Services/Configuration/ExpertDeployConfigurationLoadResult.cs
+++ b/src/Foundry.Deploy/Services/Configuration/ExpertDeployConfigurationLoadResult.cs
@@ -1,0 +1,11 @@
+using Foundry.Deploy.Models.Configuration;
+
+namespace Foundry.Deploy.Services.Configuration;
+
+public sealed record ExpertDeployConfigurationLoadResult
+{
+    public string ConfigurationPath { get; init; } = ExpertDeployConfigurationService.DefaultConfigurationPath;
+    public bool Exists { get; init; }
+    public FoundryDeployConfigurationDocument? Document { get; init; }
+    public string? FailureMessage { get; init; }
+}

--- a/src/Foundry.Deploy/Services/Configuration/ExpertDeployConfigurationService.cs
+++ b/src/Foundry.Deploy/Services/Configuration/ExpertDeployConfigurationService.cs
@@ -1,0 +1,89 @@
+using System.IO;
+using System.Text.Json;
+using Foundry.Deploy.Models.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Foundry.Deploy.Services.Configuration;
+
+public sealed class ExpertDeployConfigurationService(
+    ILogger<ExpertDeployConfigurationService> logger) : IExpertDeployConfigurationService
+{
+    public const string DefaultConfigurationPath = @"X:\Foundry\Config\foundry.deploy.config.json";
+
+    private readonly ILogger<ExpertDeployConfigurationService> _logger = logger;
+
+    public ExpertDeployConfigurationLoadResult LoadOptional()
+    {
+        if (!File.Exists(DefaultConfigurationPath))
+        {
+            _logger.LogInformation(
+                "No expert deploy configuration was found at '{ConfigurationPath}'.",
+                DefaultConfigurationPath);
+
+            return new ExpertDeployConfigurationLoadResult
+            {
+                ConfigurationPath = DefaultConfigurationPath,
+                Exists = false
+            };
+        }
+
+        try
+        {
+            using FileStream stream = File.OpenRead(DefaultConfigurationPath);
+            FoundryDeployConfigurationDocument? document = JsonSerializer.Deserialize<FoundryDeployConfigurationDocument>(
+                stream,
+                ConfigurationJsonDefaults.SerializerOptions);
+
+            if (document is null)
+            {
+                const string failureMessage = "The configuration file was empty or could not be parsed.";
+                _logger.LogWarning(
+                    "Expert deploy configuration at '{ConfigurationPath}' could not be parsed: {FailureMessage}",
+                    DefaultConfigurationPath,
+                    failureMessage);
+
+                return new ExpertDeployConfigurationLoadResult
+                {
+                    ConfigurationPath = DefaultConfigurationPath,
+                    Exists = true,
+                    FailureMessage = failureMessage
+                };
+            }
+
+            if (document.SchemaVersion > FoundryDeployConfigurationDocument.CurrentSchemaVersion)
+            {
+                _logger.LogWarning(
+                    "Expert deploy configuration at '{ConfigurationPath}' uses schema version {SchemaVersion}, newer than supported schema version {SupportedSchemaVersion}. Unknown properties will be ignored.",
+                    DefaultConfigurationPath,
+                    document.SchemaVersion,
+                    FoundryDeployConfigurationDocument.CurrentSchemaVersion);
+            }
+
+            _logger.LogInformation(
+                "Loaded expert deploy configuration from '{ConfigurationPath}' (SchemaVersion={SchemaVersion}).",
+                DefaultConfigurationPath,
+                document.SchemaVersion);
+
+            return new ExpertDeployConfigurationLoadResult
+            {
+                ConfigurationPath = DefaultConfigurationPath,
+                Exists = true,
+                Document = document
+            };
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to load expert deploy configuration from '{ConfigurationPath}'.",
+                DefaultConfigurationPath);
+
+            return new ExpertDeployConfigurationLoadResult
+            {
+                ConfigurationPath = DefaultConfigurationPath,
+                Exists = true,
+                FailureMessage = ex.Message
+            };
+        }
+    }
+}

--- a/src/Foundry.Deploy/Services/Configuration/IExpertDeployConfigurationService.cs
+++ b/src/Foundry.Deploy/Services/Configuration/IExpertDeployConfigurationService.cs
@@ -1,0 +1,6 @@
+namespace Foundry.Deploy.Services.Configuration;
+
+public interface IExpertDeployConfigurationService
+{
+    ExpertDeployConfigurationLoadResult LoadOptional();
+}

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -9,9 +9,11 @@ using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Foundry.Deploy;
+using Foundry.Deploy.Models.Configuration;
 using Foundry.Deploy.Models;
 using Foundry.Deploy.Services.ApplicationShell;
 using Foundry.Deploy.Services.Catalog;
+using Foundry.Deploy.Services.Configuration;
 using Foundry.Deploy.Services.Deployment;
 using Foundry.Deploy.Services.DriverPacks;
 using Foundry.Deploy.Services.Hardware;
@@ -80,6 +82,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private readonly IThemeService _themeService;
     private readonly IApplicationShellService _applicationShellService;
     private readonly IOperationProgressService _operationProgressService;
+    private readonly IExpertDeployConfigurationService _expertDeployConfigurationService;
     private readonly IOperatingSystemCatalogService _operatingSystemCatalogService;
     private readonly IDriverPackCatalogService _driverPackCatalogService;
     private readonly IDeploymentOrchestrator _deploymentOrchestrator;
@@ -92,12 +95,20 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private readonly Dispatcher _dispatcher;
     private readonly DeploymentMode _resolvedDeploymentMode;
     private readonly string? _resolvedUsbCacheRuntimeRoot;
+    private readonly HashSet<string> _configuredVisibleLanguageCodes = new(StringComparer.OrdinalIgnoreCase);
     private HardwareProfile? _detectedHardware;
+    private DeployMachineNamingSettings _machineNamingConfiguration = new();
     private DispatcherTimer? _elapsedTimeTimer;
     private DispatcherTimer? _rebootCountdownTimer;
     private DateTimeOffset? _deploymentStartTimeUtc;
     private int _activeStepIndex;
+    private string? _configuredDefaultLanguageCodeOverride;
     private string _lastLogsDirectoryPath = string.Empty;
+    private string _lockedComputerNamePrefix = string.Empty;
+    private bool _forceSingleVisibleLanguageSelection;
+    private bool _hasLoggedUnavailableConfiguredLanguages;
+    private bool _hasLoggedUnavailableDefaultLanguageOverride;
+    private bool _isApplyingManagedComputerName;
     private bool _isUpdatingOsFilters;
     private bool _isUpdatingDriverPackOptionSelection;
     private bool _hasUserSelectedDriverPackOption;
@@ -173,6 +184,9 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(StartDeploymentCommand))]
     private string targetComputerName = string.Empty;
+
+    [ObservableProperty]
+    private bool isTargetComputerNameReadOnly;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasTargetComputerNameValidationError))]
@@ -299,6 +313,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     public bool IsDriverPackModelSelectionEnabled => IsOemDriverSourceSelected && DriverPackModelOptions.Count > 0;
     public bool IsDriverPackVersionSelectionEnabled => IsDriverPackModelSelectionEnabled && DriverPackVersionOptions.Count > 0;
     public bool IsFirmwareUpdatesOptionEnabled => _detectedHardware?.IsVirtualMachine != true;
+    public bool IsLanguageSelectionEnabled => !(_forceSingleVisibleLanguageSelection && LanguageFilters.Count == 1);
     public string SelectedDriverPackSelectionDisplay => BuildSelectedDriverPackSelectionDisplay();
     public bool HasTargetComputerNameValidationError => !string.IsNullOrWhiteSpace(TargetComputerNameValidationMessage);
     public string VersionDisplay => $"Version: {AppVersion}";
@@ -322,6 +337,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         IThemeService themeService,
         IApplicationShellService applicationShellService,
         IOperationProgressService operationProgressService,
+        IExpertDeployConfigurationService expertDeployConfigurationService,
         IOperatingSystemCatalogService operatingSystemCatalogService,
         IDriverPackCatalogService driverPackCatalogService,
         IDeploymentOrchestrator deploymentOrchestrator,
@@ -335,6 +351,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         _themeService = themeService;
         _applicationShellService = applicationShellService;
         _operationProgressService = operationProgressService;
+        _expertDeployConfigurationService = expertDeployConfigurationService;
         _operatingSystemCatalogService = operatingSystemCatalogService;
         _driverPackCatalogService = driverPackCatalogService;
         _deploymentOrchestrator = deploymentOrchestrator;
@@ -352,6 +369,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         _operationProgressService.ProgressChanged += OnOperationProgressChanged;
         _deploymentOrchestrator.StepProgressChanged += OnStepProgressChanged;
 
+        LoadExpertDeployConfiguration();
         EnsureCachePathForMode();
 
         if (IsDebugSafeMode)
@@ -363,6 +381,48 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         _ = LoadHardwareProfileAsync();
         _ = RefreshTargetDisksAsync();
         _ = RefreshCatalogsAsync();
+    }
+
+    private void LoadExpertDeployConfiguration()
+    {
+        ExpertDeployConfigurationLoadResult loadResult = _expertDeployConfigurationService.LoadOptional();
+        if (loadResult.Document is null)
+        {
+            return;
+        }
+
+        ApplyExpertDeployConfiguration(loadResult.Document);
+    }
+
+    private void ApplyExpertDeployConfiguration(FoundryDeployConfigurationDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        _configuredVisibleLanguageCodes.Clear();
+        foreach (string languageCode in document.Localization.VisibleLanguageCodes)
+        {
+            string normalized = NormalizeLanguageCode(languageCode);
+            if (!string.IsNullOrWhiteSpace(normalized))
+            {
+                _configuredVisibleLanguageCodes.Add(normalized);
+            }
+        }
+
+        _configuredDefaultLanguageCodeOverride = NormalizeOptionalLanguageCode(document.Localization.DefaultLanguageCodeOverride);
+        _forceSingleVisibleLanguageSelection = document.Localization.ForceSingleVisibleLanguage;
+        _machineNamingConfiguration = document.Customization.MachineNaming ?? new DeployMachineNamingSettings();
+        _lockedComputerNamePrefix = ComputerNameRules.Normalize(_machineNamingConfiguration.Prefix);
+        IsTargetComputerNameReadOnly = _machineNamingConfiguration.IsEnabled && !_machineNamingConfiguration.AllowManualSuffixEdit;
+
+        if (_machineNamingConfiguration.IsEnabled)
+        {
+            string seed = string.IsNullOrWhiteSpace(TargetComputerName)
+                ? ResolveInitialComputerName()
+                : TargetComputerName;
+            ApplyManagedComputerNameValue(BuildConfiguredComputerName(seed));
+        }
+
+        OnPropertyChanged(nameof(IsLanguageSelectionEnabled));
     }
 
     [RelayCommand]
@@ -741,10 +801,16 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
     partial void OnTargetComputerNameChanged(string value)
     {
-        string normalized = ComputerNameRules.Normalize(value);
+        if (_isApplyingManagedComputerName)
+        {
+            TargetComputerNameValidationMessage = ComputerNameRules.GetValidationMessage(value);
+            return;
+        }
+
+        string normalized = NormalizeManagedComputerNameValue(value);
         if (!normalized.Equals(value, StringComparison.Ordinal))
         {
-            TargetComputerName = normalized;
+            ApplyManagedComputerNameValue(normalized);
             return;
         }
 
@@ -1317,10 +1383,27 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
                 selectFirstWhenNoMatch: true);
 
             IEnumerable<OperatingSystemCatalogItem> languageScope = ApplyReleaseIdFilter(releaseScope);
+            IEnumerable<string> effectiveLanguageValues = BuildEffectiveLanguageFilterValues(languageScope);
             SelectedLanguageCode = UpdateLanguageFilterSelection(
                 LanguageFilters,
-                languageScope.Select(GetLanguageFilterValue),
+                effectiveLanguageValues,
                 previousLanguageCode);
+
+            string configuredDefaultLanguageCode = EnsureLanguageSelection(
+                _configuredDefaultLanguageCodeOverride ?? string.Empty,
+                LanguageFilters);
+            if (!string.IsNullOrWhiteSpace(configuredDefaultLanguageCode))
+            {
+                SelectedLanguageCode = configuredDefaultLanguageCode;
+            }
+            else if (!_hasLoggedUnavailableDefaultLanguageOverride &&
+                     !string.IsNullOrWhiteSpace(_configuredDefaultLanguageCodeOverride))
+            {
+                _logger.LogWarning(
+                    "Configured default language override '{LanguageCode}' is not available in the current catalog scope and was ignored.",
+                    _configuredDefaultLanguageCodeOverride);
+                _hasLoggedUnavailableDefaultLanguageOverride = true;
+            }
 
             IEnumerable<OperatingSystemCatalogItem> licenseScope = ApplyLanguageFilter(languageScope);
             SelectedLicenseChannel = UpdateFilterSelection(
@@ -1342,6 +1425,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         finally
         {
             _isUpdatingOsFilters = false;
+            OnPropertyChanged(nameof(IsLanguageSelectionEnabled));
         }
     }
 
@@ -1369,6 +1453,40 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         return IsFilterUnset(SelectedLanguageCode)
             ? source
             : source.Where(item => GetLanguageFilterValue(item).Equals(SelectedLanguageCode, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private IEnumerable<string> BuildEffectiveLanguageFilterValues(IEnumerable<OperatingSystemCatalogItem> source)
+    {
+        string[] availableLanguageValues = source
+            .Select(GetLanguageFilterValue)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (_configuredVisibleLanguageCodes.Count == 0)
+        {
+            return availableLanguageValues;
+        }
+
+        string[] filteredLanguageValues = availableLanguageValues
+            .Where(value => _configuredVisibleLanguageCodes.Contains(NormalizeLanguageCode(value)))
+            .ToArray();
+
+        if (filteredLanguageValues.Length > 0)
+        {
+            return filteredLanguageValues;
+        }
+
+        if (!_hasLoggedUnavailableConfiguredLanguages)
+        {
+            string configuredLanguages = string.Join(", ", _configuredVisibleLanguageCodes.OrderBy(value => value, StringComparer.OrdinalIgnoreCase));
+            _logger.LogWarning(
+                "Configured visible languages [{ConfiguredLanguages}] do not match the current catalog scope. Falling back to the catalog languages.",
+                configuredLanguages);
+            _hasLoggedUnavailableConfiguredLanguages = true;
+        }
+
+        return availableLanguageValues;
     }
 
     private IEnumerable<OperatingSystemCatalogItem> ApplyLicenseChannelFilter(IEnumerable<OperatingSystemCatalogItem> source)
@@ -1591,9 +1709,136 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         return FallbackLanguageCode;
     }
 
+    private static string? NormalizeOptionalLanguageCode(string? languageCode)
+    {
+        if (string.IsNullOrWhiteSpace(languageCode))
+        {
+            return null;
+        }
+
+        string normalized = NormalizeLanguageCode(languageCode);
+        return string.IsNullOrWhiteSpace(normalized)
+            ? null
+            : normalized;
+    }
+
     private static string NormalizeLanguageCode(string languageCode)
     {
         return languageCode.Trim().Replace('_', '-').ToLowerInvariant();
+    }
+
+    private string NormalizeManagedComputerNameValue(string? value)
+    {
+        string normalized = ComputerNameRules.Normalize(value);
+        if (!_machineNamingConfiguration.IsEnabled)
+        {
+            return normalized;
+        }
+
+        if (string.IsNullOrWhiteSpace(_lockedComputerNamePrefix))
+        {
+            return normalized;
+        }
+
+        if (!_machineNamingConfiguration.AllowManualSuffixEdit)
+        {
+            return BuildConfiguredComputerName(normalized);
+        }
+
+        string suffix = normalized.StartsWith(_lockedComputerNamePrefix, StringComparison.OrdinalIgnoreCase)
+            ? normalized[_lockedComputerNamePrefix.Length..]
+            : normalized;
+
+        return CombineComputerName(_lockedComputerNamePrefix, suffix);
+    }
+
+    private string BuildConfiguredComputerName(string seed)
+    {
+        string normalizedSeed = ComputerNameRules.Normalize(seed);
+        if (!_machineNamingConfiguration.IsEnabled)
+        {
+            return normalizedSeed;
+        }
+
+        if (string.IsNullOrWhiteSpace(_lockedComputerNamePrefix))
+        {
+            return _machineNamingConfiguration.AutoGenerateName
+                ? NormalizeAutoGeneratedComputerNameSuffix(normalizedSeed)
+                : normalizedSeed;
+        }
+
+        if (_machineNamingConfiguration.AutoGenerateName)
+        {
+            string generatedSuffix = NormalizeAutoGeneratedComputerNameSuffix(
+                ExtractComputerNameSuffix(normalizedSeed, _lockedComputerNamePrefix));
+            return CombineComputerName(_lockedComputerNamePrefix, generatedSuffix);
+        }
+
+        string existingSuffix = ExtractComputerNameSuffix(TargetComputerName, _lockedComputerNamePrefix);
+        return CombineComputerName(_lockedComputerNamePrefix, existingSuffix);
+    }
+
+    private void ApplyManagedComputerNameValue(string value)
+    {
+        _isApplyingManagedComputerName = true;
+
+        try
+        {
+            TargetComputerName = value;
+            TargetComputerNameValidationMessage = ComputerNameRules.GetValidationMessage(value);
+        }
+        finally
+        {
+            _isApplyingManagedComputerName = false;
+        }
+    }
+
+    private static string CombineComputerName(string prefix, string suffix)
+    {
+        string normalizedPrefix = ComputerNameRules.Normalize(prefix);
+        if (normalizedPrefix.Length >= ComputerNameRules.MaxLength)
+        {
+            return normalizedPrefix[..ComputerNameRules.MaxLength];
+        }
+
+        string normalizedSuffix = ComputerNameRules.Normalize(suffix);
+        int remainingLength = ComputerNameRules.MaxLength - normalizedPrefix.Length;
+        if (remainingLength <= 0)
+        {
+            return normalizedPrefix;
+        }
+
+        if (normalizedSuffix.Length > remainingLength)
+        {
+            normalizedSuffix = normalizedSuffix[..remainingLength];
+        }
+
+        return $"{normalizedPrefix}{normalizedSuffix}";
+    }
+
+    private static string ExtractComputerNameSuffix(string? computerName, string prefix)
+    {
+        string normalizedPrefix = ComputerNameRules.Normalize(prefix);
+        if (string.IsNullOrWhiteSpace(normalizedPrefix))
+        {
+            return ComputerNameRules.Normalize(computerName);
+        }
+
+        string normalizedComputerName = ComputerNameRules.Normalize(computerName);
+        if (normalizedComputerName.StartsWith(normalizedPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return normalizedComputerName[normalizedPrefix.Length..];
+        }
+
+        return normalizedComputerName;
+    }
+
+    private static string NormalizeAutoGeneratedComputerNameSuffix(string? value)
+    {
+        string normalized = ComputerNameRules.Normalize(value);
+        return string.IsNullOrWhiteSpace(normalized)
+            ? ComputerNameRules.FallbackName
+            : normalized;
     }
 
     private void RefreshDriverPackOptions()
@@ -2260,9 +2505,9 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
                 return;
             }
 
-            TargetComputerName = effectiveName;
-            ComputerNameText = effectiveName;
-            TargetComputerNameValidationMessage = ComputerNameRules.GetValidationMessage(effectiveName);
+            string configuredName = BuildConfiguredComputerName(effectiveName);
+            ApplyManagedComputerNameValue(configuredName);
+            ComputerNameText = TargetComputerName;
         });
     }
 

--- a/src/Foundry/App.xaml
+++ b/src/Foundry/App.xaml
@@ -9,7 +9,10 @@
                 <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Themes/Fluent.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+            <converters:CultureToBooleanConverter x:Key="CultureToBooleanConverter" />
             <converters:InverseBooleanConverter x:Key="InverseBooleanConverter" />
+            <converters:PartitionStyleAvailabilityConverter x:Key="PartitionStyleAvailabilityConverter" />
+            <converters:ThemeModeToBooleanConverter x:Key="ThemeModeToBooleanConverter" />
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/Foundry/Assets/Configuration/languages.json
+++ b/src/Foundry/Assets/Configuration/languages.json
@@ -1,0 +1,22 @@
+[
+  { "code": "en-US", "displayName": "English (United States)", "englishName": "English (United States)", "sortOrder": 10 },
+  { "code": "fr-FR", "displayName": "French (France)", "englishName": "French (France)", "sortOrder": 20 },
+  { "code": "de-DE", "displayName": "German (Germany)", "englishName": "German (Germany)", "sortOrder": 30 },
+  { "code": "es-ES", "displayName": "Spanish (Spain)", "englishName": "Spanish (Spain)", "sortOrder": 40 },
+  { "code": "it-IT", "displayName": "Italian (Italy)", "englishName": "Italian (Italy)", "sortOrder": 50 },
+  { "code": "nl-NL", "displayName": "Dutch (Netherlands)", "englishName": "Dutch (Netherlands)", "sortOrder": 60 },
+  { "code": "pt-BR", "displayName": "Portuguese (Brazil)", "englishName": "Portuguese (Brazil)", "sortOrder": 70 },
+  { "code": "pt-PT", "displayName": "Portuguese (Portugal)", "englishName": "Portuguese (Portugal)", "sortOrder": 80 },
+  { "code": "ja-JP", "displayName": "Japanese (Japan)", "englishName": "Japanese (Japan)", "sortOrder": 90 },
+  { "code": "ko-KR", "displayName": "Korean (Korea)", "englishName": "Korean (Korea)", "sortOrder": 100 },
+  { "code": "zh-CN", "displayName": "Chinese (Simplified, China)", "englishName": "Chinese (Simplified, China)", "sortOrder": 110 },
+  { "code": "zh-TW", "displayName": "Chinese (Traditional, Taiwan)", "englishName": "Chinese (Traditional, Taiwan)", "sortOrder": 120 },
+  { "code": "pl-PL", "displayName": "Polish (Poland)", "englishName": "Polish (Poland)", "sortOrder": 130 },
+  { "code": "sv-SE", "displayName": "Swedish (Sweden)", "englishName": "Swedish (Sweden)", "sortOrder": 140 },
+  { "code": "da-DK", "displayName": "Danish (Denmark)", "englishName": "Danish (Denmark)", "sortOrder": 150 },
+  { "code": "nb-NO", "displayName": "Norwegian Bokmal (Norway)", "englishName": "Norwegian Bokmal (Norway)", "sortOrder": 160 },
+  { "code": "fi-FI", "displayName": "Finnish (Finland)", "englishName": "Finnish (Finland)", "sortOrder": 170 },
+  { "code": "cs-CZ", "displayName": "Czech (Czech Republic)", "englishName": "Czech (Czech Republic)", "sortOrder": 180 },
+  { "code": "hu-HU", "displayName": "Hungarian (Hungary)", "englishName": "Hungarian (Hungary)", "sortOrder": 190 },
+  { "code": "ro-RO", "displayName": "Romanian (Romania)", "englishName": "Romanian (Romania)", "sortOrder": 200 }
+]

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -33,6 +33,9 @@
     <EmbeddedResource Include="Assets\WinPe\FoundryBootstrap.ps1">
       <LogicalName>Foundry.WinPe.BootstrapScript</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="Assets\Configuration\languages.json">
+      <LogicalName>Foundry.Configuration.Languages</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Foundry/MainWindow.xaml
+++ b/src/Foundry/MainWindow.xaml
@@ -8,11 +8,12 @@
     xmlns:viewModels="clr-namespace:Foundry.ViewModels"
     xmlns:views="clr-namespace:Foundry.Views"
     Title="Foundry"
-    Width="960"
-    MinWidth="860"
+    Width="1180"
+    Height="860"
+    MinWidth="1180"
+    MinHeight="860"
     Icon="/Assets/Icons/app.ico"
     ResizeMode="CanResize"
-    SizeToContent="Height"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
     <Window.Resources>

--- a/src/Foundry/MainWindow.xaml
+++ b/src/Foundry/MainWindow.xaml
@@ -219,7 +219,9 @@
                 </Border>
 
                 <ScrollViewer Grid.Column="2" VerticalScrollBarVisibility="Auto">
-                    <ContentControl Content="{Binding SelectedExpertSection.ViewModel}" />
+                    <Border Padding="0,0,16,0">
+                        <ContentControl Content="{Binding SelectedExpertSection.ViewModel}" />
+                    </Border>
                 </ScrollViewer>
             </Grid>
 

--- a/src/Foundry/MainWindow.xaml
+++ b/src/Foundry/MainWindow.xaml
@@ -219,7 +219,7 @@
                 </Border>
 
                 <ScrollViewer Grid.Column="2" VerticalScrollBarVisibility="Auto">
-                    <Border Padding="0,0,16,0">
+                    <Border Padding="0,0,24,0">
                         <ContentControl Content="{Binding SelectedExpertSection.ViewModel}" />
                     </Border>
                 </ScrollViewer>

--- a/src/Foundry/MainWindow.xaml
+++ b/src/Foundry/MainWindow.xaml
@@ -270,7 +270,7 @@
 
                 <StackPanel
                     Grid.Column="2"
-                    Margin="24,8,12,8"
+                    Margin="24,8,24,8"
                     VerticalAlignment="Center"
                     Orientation="Horizontal">
                     <Button

--- a/src/Foundry/MainWindow.xaml
+++ b/src/Foundry/MainWindow.xaml
@@ -223,16 +223,18 @@
 
         <Border
             Grid.Row="3"
-            Padding="12,8"
             BorderBrush="#404040"
             BorderThickness="0,1,0,1">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <Grid Grid.Column="0">
+                <Grid
+                    Grid.Column="0"
+                    Margin="12,8,12,8">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
@@ -262,24 +264,25 @@
 
                 <Border
                     Grid.Column="1"
-                    Margin="24,0,0,0"
-                    Padding="24,0,0,0"
                     BorderBrush="#404040"
                     BorderThickness="1,0,0,0">
-                    <StackPanel
-                        VerticalAlignment="Center"
-                        Orientation="Horizontal">
-                        <Button
-                            Width="140"
-                            Margin="0,0,24,0"
-                            Command="{Binding CreateIsoCommand}"
-                            Content="{Binding Strings[CreateIso]}" />
-                        <Button
-                            Width="140"
-                            Command="{Binding CreateUsbCommand}"
-                            Content="{Binding Strings[CreateUsb]}" />
-                    </StackPanel>
                 </Border>
+
+                <StackPanel
+                    Grid.Column="2"
+                    Margin="24,8,12,8"
+                    VerticalAlignment="Center"
+                    Orientation="Horizontal">
+                    <Button
+                        Width="140"
+                        Margin="0,0,24,0"
+                        Command="{Binding CreateIsoCommand}"
+                        Content="{Binding Strings[CreateIso]}" />
+                    <Button
+                        Width="140"
+                        Command="{Binding CreateUsbCommand}"
+                        Content="{Binding Strings[CreateUsb]}" />
+                </StackPanel>
             </Grid>
         </Border>
 

--- a/src/Foundry/MainWindow.xaml
+++ b/src/Foundry/MainWindow.xaml
@@ -5,22 +5,37 @@
     xmlns:converters="clr-namespace:Foundry.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:viewModels="clr-namespace:Foundry.ViewModels"
+    xmlns:views="clr-namespace:Foundry.Views"
     Title="Foundry"
-    Width="700"
+    Width="960"
+    MinWidth="860"
     Icon="/Assets/Icons/app.ico"
-    ResizeMode="CanMinimize"
+    ResizeMode="CanResize"
     SizeToContent="Height"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
     <Window.Resources>
-        <!--  Converters used by view bindings  -->
         <converters:CultureToBooleanConverter x:Key="CultureToBooleanConverter" />
         <converters:ThemeModeToBooleanConverter x:Key="ThemeModeToBooleanConverter" />
         <converters:PartitionStyleAvailabilityConverter x:Key="PartitionStyleAvailabilityConverter" />
+        <converters:InverseBooleanConverter x:Key="InverseBooleanConverter" />
+
+        <DataTemplate DataType="{x:Type viewModels:MainWindowViewModel}">
+            <views:GeneralSettingsView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type viewModels:NetworkSettingsViewModel}">
+            <views:NetworkSettingsView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type viewModels:LocalizationSettingsViewModel}">
+            <views:LocalizationSettingsView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type viewModels:CustomizationSettingsViewModel}">
+            <views:CustomizationSettingsView />
+        </DataTemplate>
     </Window.Resources>
 
     <Grid>
-        <!--  Main vertical window layout  -->
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -29,17 +44,30 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <!--  Row 0: Main menu  -->
         <Border
             Grid.Row="0"
             BorderBrush="#404040"
             BorderThickness="0,0,0,1">
             <Menu>
-                <!--  File  -->
                 <MenuItem Header="{Binding Strings[MenuFile]}">
+                    <MenuItem Command="{Binding ImportExpertConfigurationCommand}" Header="{Binding Strings[MenuImportExpertConfig]}" />
+                    <MenuItem Command="{Binding ExportExpertConfigurationCommand}" Header="{Binding Strings[MenuExportExpertConfig]}" />
+                    <MenuItem Command="{Binding ExportDeployConfigurationCommand}" Header="{Binding Strings[MenuExportDeployConfig]}" />
+                    <Separator />
                     <MenuItem Command="{Binding ExitCommand}" Header="{Binding Strings[MenuExit]}" />
                 </MenuItem>
-                <!--  Theme  -->
+                <MenuItem Header="{Binding Strings[MenuMode]}">
+                    <MenuItem
+                        Command="{Binding SetStandardModeCommand}"
+                        Header="{Binding Strings[ModeStandard]}"
+                        IsCheckable="True"
+                        IsChecked="{Binding IsExpertMode, Converter={StaticResource InverseBooleanConverter}, Mode=OneWay}" />
+                    <MenuItem
+                        Command="{Binding SetExpertModeCommand}"
+                        Header="{Binding Strings[ModeExpert]}"
+                        IsCheckable="True"
+                        IsChecked="{Binding IsExpertMode, Mode=OneWay}" />
+                </MenuItem>
                 <MenuItem Header="{Binding Strings[MenuTheme]}">
                     <MenuItem
                         Command="{Binding SetSystemThemeCommand}"
@@ -57,7 +85,6 @@
                         IsCheckable="True"
                         IsChecked="{Binding CurrentTheme, Converter={StaticResource ThemeModeToBooleanConverter}, ConverterParameter=Dark, Mode=OneWay}" />
                 </MenuItem>
-                <!--  Language  -->
                 <MenuItem Header="{Binding Strings[MenuLanguage]}">
                     <MenuItem
                         Command="{Binding SetCultureCommand}"
@@ -72,18 +99,15 @@
                         IsCheckable="True"
                         IsChecked="{Binding CurrentCulture, Converter={StaticResource CultureToBooleanConverter}, ConverterParameter=fr-FR, Mode=OneWay}" />
                 </MenuItem>
-                <!--  Tools  -->
                 <MenuItem Header="{Binding Strings[MenuTools]}">
                     <MenuItem Command="{Binding OpenLogFolderCommand}" Header="{Binding Strings[MenuLogs]}" />
                 </MenuItem>
-                <!--  Help  -->
                 <MenuItem Header="{Binding Strings[MenuHelp]}">
                     <MenuItem Command="{Binding ShowAboutCommand}" Header="{Binding Strings[MenuAbout]}" />
                 </MenuItem>
             </Menu>
         </Border>
 
-        <!--  Row 1: ADK alert banner (missing/incompatible)  -->
         <Border
             Grid.Row="1"
             Padding="16,12"
@@ -98,7 +122,6 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <!--  Alert indicator  -->
                 <Border
                     Grid.Column="0"
                     Width="24"
@@ -116,7 +139,6 @@
                         Text="!" />
                 </Border>
 
-                <!--  ADK missing message  -->
                 <TextBlock
                     Grid.Column="1"
                     VerticalAlignment="Center"
@@ -126,7 +148,6 @@
                     TextWrapping="Wrap"
                     Visibility="{Binding IsAdkMissing, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-                <!--  ADK incompatible message  -->
                 <TextBlock
                     Grid.Column="1"
                     VerticalAlignment="Center"
@@ -136,7 +157,6 @@
                     TextWrapping="Wrap"
                     Visibility="{Binding IsAdkIncompatible, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-                <!--  ADK install action  -->
                 <Button
                     Grid.Column="2"
                     MinWidth="132"
@@ -146,7 +166,6 @@
                     IsEnabled="{Binding IsOperationInProgress, Converter={StaticResource InverseBooleanConverter}}"
                     Visibility="{Binding IsAdkMissing, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-                <!--  ADK upgrade action  -->
                 <Button
                     Grid.Column="2"
                     MinWidth="132"
@@ -158,270 +177,54 @@
             </Grid>
         </Border>
 
-        <!--  Row 2: Configuration and actions area  -->
         <Grid Grid.Row="2" Margin="16,16,16,12">
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <!--  Section: standard configuration  -->
-            <StackPanel Grid.Row="0" Margin="0,0,0,24">
-                <TextBlock
-                    Margin="0,0,0,8"
-                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                    Style="{StaticResource TitleTextBlockStyle}"
-                    Text="{Binding Strings[StandardConfigurationSectionTitle]}" />
-                <Separator Margin="0,0,0,12" Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
+            <ContentControl Grid.Row="0" Content="{Binding}" Visibility="{Binding IsStandardMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-                <Grid Margin="0,0,0,12">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="140" />
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
+            <Grid Grid.Row="0" Visibility="{Binding IsExpertMode, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="220" />
+                    <ColumnDefinition Width="24" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
 
-                    <TextBlock
-                        Grid.Column="0"
-                        Margin="0,0,8,0"
-                        VerticalAlignment="Center"
-                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding Strings[IsoOutputPathLabel]}" />
-
-                    <!--  Read-only ISO output folder field  -->
-                    <TextBox
-                        Grid.Column="1"
-                        Margin="0,0,8,0"
-                        IsReadOnly="True"
-                        Text="{Binding IsoOutputPath, Mode=OneWay}" />
-
-                    <!--  ISO folder browse button  -->
-                    <Button
-                        Grid.Column="2"
-                        Width="130"
-                        Command="{Binding BrowseIsoOutputPathCommand}"
-                        Content="{Binding Strings[IsoBrowseButton]}" />
-                </Grid>
-
-                <Grid Margin="0,0,0,12">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="140" />
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock
-                        Grid.Column="0"
-                        Margin="0,0,8,0"
-                        VerticalAlignment="Center"
-                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding Strings[UsbSectionTitle]}" />
-
-                    <!--  List of detected USB disks  -->
-                    <ComboBox
-                        Grid.Column="1"
-                        Margin="0,0,8,0"
-                        DisplayMemberPath="DisplayLabel"
-                        ItemsSource="{Binding UsbDiskCandidates}"
-                        SelectedItem="{Binding SelectedUsbDiskCandidate}" />
-
-                    <!--  Refresh USB devices  -->
-                    <Button
-                        Grid.Column="2"
-                        Width="130"
-                        Command="{Binding RefreshUsbCandidatesCommand}"
-                        Content="{Binding Strings[UsbRefreshDisks]}"
-                        IsEnabled="{Binding IsRefreshingUsbCandidates, Converter={StaticResource InverseBooleanConverter}}" />
-                </Grid>
-
-                <Grid Margin="0,0,0,8">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="140" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock
-                        Grid.Column="0"
-                        Margin="0,0,8,0"
-                        VerticalAlignment="Center"
-                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding Strings[ArchitectureLabel]}" />
-
-                    <!--  Target architecture selection  -->
-                    <ComboBox
-                        Grid.Column="1"
-                        ItemsSource="{Binding AvailableArchitectures}"
-                        SelectedItem="{Binding SelectedArchitecture}" />
-                </Grid>
-
-                <Grid Margin="0,0,0,8">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="140" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock
-                        Grid.Column="0"
-                        Margin="0,0,8,0"
-                        VerticalAlignment="Center"
-                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding Strings[WinPeLanguageLabel]}" />
-
-                    <!--  WinPE language selection  -->
-                    <ComboBox
-                        Grid.Column="1"
-                        MinWidth="220"
-                        DisplayMemberPath="DisplayName"
-                        ItemsSource="{Binding AvailableWinPeLanguages}"
-                        SelectedItem="{Binding SelectedWinPeLanguage}" />
-                </Grid>
-
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="140" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock
-                        Grid.Column="0"
-                        Margin="0,0,8,0"
-                        VerticalAlignment="Center"
-                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding Strings[WinPeDriversLabel]}" />
-
-                    <!--  Driver pack selection  -->
-                    <StackPanel Grid.Column="1" Orientation="Horizontal">
-                        <CheckBox
-                            Margin="0,0,16,0"
-                            Content="{Binding Strings[DriverDellLabel]}"
-                            IsChecked="{Binding IncludeDellDrivers}" />
-                        <CheckBox Content="{Binding Strings[DriverHpLabel]}" IsChecked="{Binding IncludeHpDrivers}" />
+                <Border
+                    Grid.Column="0"
+                    Padding="12"
+                    Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8">
+                    <StackPanel>
+                        <TextBlock
+                            Margin="0,0,0,12"
+                            Style="{StaticResource BodyStrongTextBlockStyle}"
+                            Text="{Binding Strings[ExpertNavigationTitle]}" />
+                        <ListBox
+                            BorderThickness="0"
+                            ItemsSource="{Binding ExpertSections}"
+                            SelectedItem="{Binding SelectedExpertSection}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Title}" />
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
                     </StackPanel>
-                </Grid>
-            </StackPanel>
+                </Border>
 
-            <!--  Section: advanced options  -->
-            <Expander
-                Grid.Row="1"
-                Margin="0,0,0,24"
-                IsExpanded="{Binding IsAdvancedOptionsExpanded}">
-                <Expander.Header>
-                    <TextBlock
-                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding Strings[AdvancedOptionsHeader]}" />
-                </Expander.Header>
+                <ScrollViewer Grid.Column="2" VerticalScrollBarVisibility="Auto">
+                    <ContentControl Content="{Binding SelectedExpertSection.ViewModel}" />
+                </ScrollViewer>
+            </Grid>
 
-                <StackPanel Margin="0,12,0,0">
-                    <CheckBox
-                        Margin="0,0,0,12"
-                        Content="{Binding Strings[SignatureCa2023Label]}"
-                        IsChecked="{Binding UseCa2023}" />
-
-                    <Grid Margin="0,0,0,8">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="140" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-
-                        <TextBlock
-                            Grid.Column="0"
-                            Margin="0,0,8,0"
-                            VerticalAlignment="Center"
-                            Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding Strings[UsbPartitionStyleLabel]}" />
-
-                        <!--  USB partition style (enabled based on architecture)  -->
-                        <ComboBox
-                            Grid.Column="1"
-                            ItemsSource="{Binding AvailablePartitionStyles}"
-                            SelectedItem="{Binding SelectedPartitionStyle}">
-                            <ComboBox.ItemContainerStyle>
-                                <Style TargetType="ComboBoxItem">
-                                    <Setter Property="IsEnabled">
-                                        <Setter.Value>
-                                            <MultiBinding Converter="{StaticResource PartitionStyleAvailabilityConverter}">
-                                                <Binding Path="DataContext.SelectedArchitecture" RelativeSource="{RelativeSource AncestorType=Window}" />
-                                                <Binding />
-                                            </MultiBinding>
-                                        </Setter.Value>
-                                    </Setter>
-                                </Style>
-                            </ComboBox.ItemContainerStyle>
-                        </ComboBox>
-                    </Grid>
-
-                    <TextBlock
-                        Margin="0,0,0,12"
-                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding UsbPartitionStyleArm64Hint}"
-                        Visibility="{Binding ShowUsbPartitionStyleArm64Hint, Converter={StaticResource BooleanToVisibilityConverter}}" />
-
-                    <!--  USB drive format mode  -->
-                    <Grid Margin="0,0,0,12">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="140" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-
-                        <TextBlock
-                            Grid.Column="0"
-                            Margin="0,0,8,0"
-                            VerticalAlignment="Center"
-                            Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding Strings[UsbFormatModeLabel]}" />
-
-                        <ComboBox
-                            Grid.Column="1"
-                            DisplayMemberPath="DisplayName"
-                            ItemsSource="{Binding AvailableUsbFormatModes}"
-                            SelectedValue="{Binding SelectedUsbFormatMode}"
-                            SelectedValuePath="Mode" />
-                    </Grid>
-
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="140" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-
-                        <TextBlock
-                            Grid.Column="0"
-                            Margin="0,0,8,0"
-                            VerticalAlignment="Center"
-                            Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding Strings[CustomDriverPathLabel]}" />
-
-                        <!--  Custom driver directory  -->
-                        <TextBox
-                            Grid.Column="1"
-                            Margin="0,0,8,0"
-                            Text="{Binding CustomDriverDirectoryPath, UpdateSourceTrigger=PropertyChanged}" />
-
-                        <!--  Browse driver directory  -->
-                        <Button
-                            Grid.Column="2"
-                            Command="{Binding BrowseCustomDriverDirectoryCommand}"
-                            Content="{Binding Strings[BrowseFolderButton]}" />
-                    </Grid>
-                </StackPanel>
-            </Expander>
-
-            <!--  Section: main actions  -->
             <StackPanel
-                Grid.Row="2"
-                Margin="0,0,0,12"
+                Grid.Row="1"
+                Margin="0,24,0,12"
                 HorizontalAlignment="Center"
                 Orientation="Horizontal">
                 <Button
@@ -436,7 +239,6 @@
             </StackPanel>
         </Grid>
 
-        <!--  Row 3: Global status and progress  -->
         <Border
             Grid.Row="3"
             Padding="12,8"
@@ -471,7 +273,6 @@
             </Grid>
         </Border>
 
-        <!--  Row 4: Info bar (devices/version)  -->
         <Grid Grid.Row="4">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />

--- a/src/Foundry/MainWindow.xaml
+++ b/src/Foundry/MainWindow.xaml
@@ -179,14 +179,9 @@
         </Border>
 
         <Grid Grid.Row="2" Margin="16,16,16,12">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
+            <ContentControl Content="{Binding}" Visibility="{Binding IsStandardMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-            <ContentControl Grid.Row="0" Content="{Binding}" Visibility="{Binding IsStandardMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
-
-            <Grid Grid.Row="0" Visibility="{Binding IsExpertMode, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Grid Visibility="{Binding IsExpertMode, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="220" />
                     <ColumnDefinition Width="24" />
@@ -224,22 +219,6 @@
                     </Border>
                 </ScrollViewer>
             </Grid>
-
-            <StackPanel
-                Grid.Row="1"
-                Margin="0,24,0,12"
-                HorizontalAlignment="Center"
-                Orientation="Horizontal">
-                <Button
-                    Width="140"
-                    Margin="0,0,32,0"
-                    Command="{Binding CreateIsoCommand}"
-                    Content="{Binding Strings[CreateIso]}" />
-                <Button
-                    Width="140"
-                    Command="{Binding CreateUsbCommand}"
-                    Content="{Binding Strings[CreateUsb]}" />
-            </StackPanel>
         </Grid>
 
         <Border
@@ -248,31 +227,59 @@
             BorderBrush="#404040"
             BorderThickness="0,1,0,1">
             <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
 
-                <TextBlock
-                    Grid.Row="0"
-                    Margin="0,0,0,8"
-                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                    Text="{Binding GlobalOperationStatusDisplay}" />
+                <Grid Grid.Column="0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
 
-                <ProgressBar
-                    Grid.Row="1"
-                    Height="14"
-                    Maximum="100"
-                    Minimum="0"
-                    Value="{Binding GlobalOperationProgress, Mode=OneWay}" />
+                    <TextBlock
+                        Grid.Row="0"
+                        Margin="0,0,0,8"
+                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                        Text="{Binding GlobalOperationStatusDisplay}" />
 
-                <TextBlock
-                    Grid.Row="2"
-                    Margin="0,8,0,0"
-                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                    Style="{StaticResource CaptionTextBlockStyle}"
-                    Text="{Binding MediaActionMessage}" />
+                    <ProgressBar
+                        Grid.Row="1"
+                        Height="14"
+                        Maximum="100"
+                        Minimum="0"
+                        Value="{Binding GlobalOperationProgress, Mode=OneWay}" />
+
+                    <TextBlock
+                        Grid.Row="2"
+                        Margin="0,8,0,0"
+                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{Binding MediaActionMessage}" />
+                </Grid>
+
+                <Border
+                    Grid.Column="1"
+                    Margin="24,0,0,0"
+                    Padding="24,0,0,0"
+                    BorderBrush="#404040"
+                    BorderThickness="1,0,0,0">
+                    <StackPanel
+                        VerticalAlignment="Center"
+                        Orientation="Horizontal">
+                        <Button
+                            Width="140"
+                            Margin="0,0,24,0"
+                            Command="{Binding CreateIsoCommand}"
+                            Content="{Binding Strings[CreateIso]}" />
+                        <Button
+                            Width="140"
+                            Command="{Binding CreateUsbCommand}"
+                            Content="{Binding Strings[CreateUsb]}" />
+                    </StackPanel>
+                </Border>
             </Grid>
         </Border>
 

--- a/src/Foundry/MainWindow.xaml
+++ b/src/Foundry/MainWindow.xaml
@@ -8,10 +8,10 @@
     xmlns:viewModels="clr-namespace:Foundry.ViewModels"
     xmlns:views="clr-namespace:Foundry.Views"
     Title="Foundry"
-    Width="1180"
-    Height="860"
-    MinWidth="1180"
-    MinHeight="860"
+    Width="1200"
+    Height="850"
+    MinWidth="1200"
+    MinHeight="850"
     Icon="/Assets/Icons/app.ico"
     ResizeMode="CanResize"
     WindowStartupLocation="CenterScreen"
@@ -179,7 +179,11 @@
         </Border>
 
         <Grid Grid.Row="2" Margin="16,16,16,12">
-            <ContentControl Content="{Binding}" Visibility="{Binding IsStandardMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
+            <Border
+                Padding="24,0,24,0"
+                Visibility="{Binding IsStandardMode, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <ContentControl Content="{Binding}" />
+            </Border>
 
             <Grid Visibility="{Binding IsExpertMode, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <Grid.ColumnDefinitions>

--- a/src/Foundry/Models/Configuration/CustomizationSettings.cs
+++ b/src/Foundry/Models/Configuration/CustomizationSettings.cs
@@ -1,0 +1,6 @@
+namespace Foundry.Models.Configuration;
+
+public sealed record CustomizationSettings
+{
+    public MachineNamingSettings MachineNaming { get; init; } = new();
+}

--- a/src/Foundry/Models/Configuration/Deploy/DeployCustomizationSettings.cs
+++ b/src/Foundry/Models/Configuration/Deploy/DeployCustomizationSettings.cs
@@ -1,0 +1,6 @@
+namespace Foundry.Models.Configuration.Deploy;
+
+public sealed record DeployCustomizationSettings
+{
+    public DeployMachineNamingSettings MachineNaming { get; init; } = new();
+}

--- a/src/Foundry/Models/Configuration/Deploy/DeployLocalizationSettings.cs
+++ b/src/Foundry/Models/Configuration/Deploy/DeployLocalizationSettings.cs
@@ -1,0 +1,8 @@
+namespace Foundry.Models.Configuration.Deploy;
+
+public sealed record DeployLocalizationSettings
+{
+    public IReadOnlyList<string> VisibleLanguageCodes { get; init; } = Array.Empty<string>();
+    public string? DefaultLanguageCodeOverride { get; init; }
+    public bool ForceSingleVisibleLanguage { get; init; }
+}

--- a/src/Foundry/Models/Configuration/Deploy/DeployMachineNamingSettings.cs
+++ b/src/Foundry/Models/Configuration/Deploy/DeployMachineNamingSettings.cs
@@ -1,0 +1,9 @@
+namespace Foundry.Models.Configuration.Deploy;
+
+public sealed record DeployMachineNamingSettings
+{
+    public bool IsEnabled { get; init; }
+    public string? Prefix { get; init; }
+    public bool AutoGenerateName { get; init; }
+    public bool AllowManualSuffixEdit { get; init; } = true;
+}

--- a/src/Foundry/Models/Configuration/Deploy/FoundryDeployConfigurationDocument.cs
+++ b/src/Foundry/Models/Configuration/Deploy/FoundryDeployConfigurationDocument.cs
@@ -1,0 +1,10 @@
+namespace Foundry.Models.Configuration.Deploy;
+
+public sealed record FoundryDeployConfigurationDocument
+{
+    public const int CurrentSchemaVersion = 1;
+
+    public int SchemaVersion { get; init; } = CurrentSchemaVersion;
+    public DeployLocalizationSettings Localization { get; init; } = new();
+    public DeployCustomizationSettings Customization { get; init; } = new();
+}

--- a/src/Foundry/Models/Configuration/Dot1xSettings.cs
+++ b/src/Foundry/Models/Configuration/Dot1xSettings.cs
@@ -1,0 +1,7 @@
+namespace Foundry.Models.Configuration;
+
+public sealed record Dot1xSettings
+{
+    public bool IsEnabled { get; init; }
+    public string? CertificatePath { get; init; }
+}

--- a/src/Foundry/Models/Configuration/FoundryExpertConfigurationDocument.cs
+++ b/src/Foundry/Models/Configuration/FoundryExpertConfigurationDocument.cs
@@ -1,0 +1,12 @@
+namespace Foundry.Models.Configuration;
+
+public sealed record FoundryExpertConfigurationDocument
+{
+    public const int CurrentSchemaVersion = 1;
+
+    public int SchemaVersion { get; init; } = CurrentSchemaVersion;
+    public GeneralSettings General { get; init; } = new();
+    public NetworkSettings Network { get; init; } = new();
+    public LocalizationSettings Localization { get; init; } = new();
+    public CustomizationSettings Customization { get; init; } = new();
+}

--- a/src/Foundry/Models/Configuration/GeneralSettings.cs
+++ b/src/Foundry/Models/Configuration/GeneralSettings.cs
@@ -13,6 +13,4 @@ public sealed record GeneralSettings
     public bool IncludeDellDrivers { get; init; }
     public bool IncludeHpDrivers { get; init; }
     public string? CustomDriverDirectoryPath { get; init; }
-    public bool EnablePcaRemediation { get; init; }
-    public string? PcaRemediationScriptPath { get; init; }
 }

--- a/src/Foundry/Models/Configuration/GeneralSettings.cs
+++ b/src/Foundry/Models/Configuration/GeneralSettings.cs
@@ -1,0 +1,18 @@
+using Foundry.Services.WinPe;
+
+namespace Foundry.Models.Configuration;
+
+public sealed record GeneralSettings
+{
+    public string? IsoOutputPath { get; init; }
+    public WinPeArchitecture Architecture { get; init; } = WinPeArchitecture.X64;
+    public string? WinPeLanguage { get; init; }
+    public bool UseCa2023 { get; init; }
+    public UsbPartitionStyle UsbPartitionStyle { get; init; } = UsbPartitionStyle.Gpt;
+    public UsbFormatMode UsbFormatMode { get; init; } = UsbFormatMode.Quick;
+    public bool IncludeDellDrivers { get; init; }
+    public bool IncludeHpDrivers { get; init; }
+    public string? CustomDriverDirectoryPath { get; init; }
+    public bool EnablePcaRemediation { get; init; }
+    public string? PcaRemediationScriptPath { get; init; }
+}

--- a/src/Foundry/Models/Configuration/LanguageRegistryEntry.cs
+++ b/src/Foundry/Models/Configuration/LanguageRegistryEntry.cs
@@ -1,0 +1,9 @@
+namespace Foundry.Models.Configuration;
+
+public sealed record LanguageRegistryEntry
+{
+    public string Code { get; init; } = string.Empty;
+    public string DisplayName { get; init; } = string.Empty;
+    public string EnglishName { get; init; } = string.Empty;
+    public int SortOrder { get; init; }
+}

--- a/src/Foundry/Models/Configuration/LocalizationSettings.cs
+++ b/src/Foundry/Models/Configuration/LocalizationSettings.cs
@@ -1,0 +1,8 @@
+namespace Foundry.Models.Configuration;
+
+public sealed record LocalizationSettings
+{
+    public IReadOnlyList<string> VisibleLanguageCodes { get; init; } = Array.Empty<string>();
+    public string? DefaultLanguageCodeOverride { get; init; }
+    public bool ForceSingleVisibleLanguage { get; init; }
+}

--- a/src/Foundry/Models/Configuration/MachineNamingSettings.cs
+++ b/src/Foundry/Models/Configuration/MachineNamingSettings.cs
@@ -1,0 +1,9 @@
+namespace Foundry.Models.Configuration;
+
+public sealed record MachineNamingSettings
+{
+    public bool IsEnabled { get; init; }
+    public string? Prefix { get; init; }
+    public bool AutoGenerateName { get; init; }
+    public bool AllowManualSuffixEdit { get; init; } = true;
+}

--- a/src/Foundry/Models/Configuration/NetworkSettings.cs
+++ b/src/Foundry/Models/Configuration/NetworkSettings.cs
@@ -1,0 +1,7 @@
+namespace Foundry.Models.Configuration;
+
+public sealed record NetworkSettings
+{
+    public Dot1xSettings Dot1x { get; init; } = new();
+    public WifiSettings Wifi { get; init; } = new();
+}

--- a/src/Foundry/Models/Configuration/WifiSettings.cs
+++ b/src/Foundry/Models/Configuration/WifiSettings.cs
@@ -1,0 +1,8 @@
+namespace Foundry.Models.Configuration;
+
+public sealed record WifiSettings
+{
+    public bool IsEnabled { get; init; }
+    public string? Ssid { get; init; }
+    public string? SecurityType { get; init; }
+}

--- a/src/Foundry/Program.cs
+++ b/src/Foundry/Program.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Windows.Threading;
 using Foundry.Logging;
+using Foundry.Services.Configuration;
 using Foundry.Services.Adk;
 using Foundry.Services.ApplicationShell;
 using Foundry.Services.Localization;
@@ -61,6 +62,9 @@ public static class Program
         services.AddSingleton<MainWindowViewModel>();
 
         services.AddSingleton<IApplicationShellService, ApplicationShellService>();
+        services.AddSingleton<IExpertConfigurationService, ExpertConfigurationService>();
+        services.AddSingleton<IDeployConfigurationGenerator, DeployConfigurationGenerator>();
+        services.AddSingleton<ILanguageRegistryService, EmbeddedLanguageRegistryService>();
         services.AddSingleton<IThemeService, ThemeService>();
         services.AddSingleton<ILocalizationService, LocalizationService>();
         services.AddSingleton<IOperationProgressService, OperationProgressService>();

--- a/src/Foundry/Resources/AppStrings.en-US.resx
+++ b/src/Foundry/Resources/AppStrings.en-US.resx
@@ -425,4 +425,130 @@ MVVM bootstrap ready.</value>
   <data name="IsoPickerFilter" xml:space="preserve">
     <value>ISO image (*.iso)|*.iso</value>
   </data>
+  <data name="MenuMode" xml:space="preserve">
+    <value>_Mode</value>
+  </data>
+  <data name="ModeStandard" xml:space="preserve">
+    <value>_Standard</value>
+  </data>
+  <data name="ModeExpert" xml:space="preserve">
+    <value>_Expert</value>
+  </data>
+  <data name="MenuImportExpertConfig" xml:space="preserve">
+    <value>_Import Expert Configuration</value>
+  </data>
+  <data name="MenuExportExpertConfig" xml:space="preserve">
+    <value>Export Expert _Configuration</value>
+  </data>
+  <data name="MenuExportDeployConfig" xml:space="preserve">
+    <value>Export _Deploy Configuration</value>
+  </data>
+  <data name="JsonPickerFilter" xml:space="preserve">
+    <value>JSON file (*.json)|*.json</value>
+  </data>
+  <data name="ExpertConfigImportTitle" xml:space="preserve">
+    <value>Import expert configuration</value>
+  </data>
+  <data name="ExpertConfigExportTitle" xml:space="preserve">
+    <value>Export expert configuration</value>
+  </data>
+  <data name="DeployConfigExportTitle" xml:space="preserve">
+    <value>Export deploy configuration</value>
+  </data>
+  <data name="ExpertConfigImportedFormat" xml:space="preserve">
+    <value>Expert configuration imported: {0}</value>
+  </data>
+  <data name="ExpertConfigImportFailedFormat" xml:space="preserve">
+    <value>Expert configuration import failed: {0}</value>
+  </data>
+  <data name="ExpertConfigExportedFormat" xml:space="preserve">
+    <value>Expert configuration exported: {0}</value>
+  </data>
+  <data name="ExpertConfigExportFailedFormat" xml:space="preserve">
+    <value>Expert configuration export failed: {0}</value>
+  </data>
+  <data name="DeployConfigExportedFormat" xml:space="preserve">
+    <value>Deploy configuration exported: {0}</value>
+  </data>
+  <data name="DeployConfigExportFailedFormat" xml:space="preserve">
+    <value>Deploy configuration export failed: {0}</value>
+  </data>
+  <data name="ExpertNavigationTitle" xml:space="preserve">
+    <value>Expert sections</value>
+  </data>
+  <data name="ExpertSectionGeneral" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="ExpertSectionNetwork" xml:space="preserve">
+    <value>Network</value>
+  </data>
+  <data name="ExpertSectionLocalization" xml:space="preserve">
+    <value>Localization</value>
+  </data>
+  <data name="ExpertSectionCustomization" xml:space="preserve">
+    <value>Customization</value>
+  </data>
+  <data name="Dot1xEnableLabel" xml:space="preserve">
+    <value>Enable 802.1X in WinPE</value>
+  </data>
+  <data name="Dot1xCertificateLabel" xml:space="preserve">
+    <value>Certificate file</value>
+  </data>
+  <data name="Dot1xCertificatePickerTitle" xml:space="preserve">
+    <value>Select 802.1X certificate</value>
+  </data>
+  <data name="CertificatePickerFilter" xml:space="preserve">
+    <value>Certificate file (*.cer;*.crt;*.pfx)|*.cer;*.crt;*.pfx|All files (*.*)|*.*</value>
+  </data>
+  <data name="BrowseFileButton" xml:space="preserve">
+    <value>Browse file...</value>
+  </data>
+  <data name="WifiEnableLabel" xml:space="preserve">
+    <value>Enable Wi-Fi in WinPE</value>
+  </data>
+  <data name="WifiSsidLabel" xml:space="preserve">
+    <value>SSID</value>
+  </data>
+  <data name="WifiSecurityTypeLabel" xml:space="preserve">
+    <value>Security type</value>
+  </data>
+  <data name="LocalizationVisibleLanguagesLabel" xml:space="preserve">
+    <value>Visible languages in Foundry.Deploy</value>
+  </data>
+  <data name="LocalizationDefaultOverrideLabel" xml:space="preserve">
+    <value>Default language override</value>
+  </data>
+  <data name="LocalizationForceSingleLabel" xml:space="preserve">
+    <value>Force the only visible language when a single choice remains</value>
+  </data>
+  <data name="MachineNamingEnableLabel" xml:space="preserve">
+    <value>Enable machine naming rules</value>
+  </data>
+  <data name="MachineNamingPrefixLabel" xml:space="preserve">
+    <value>Prefix</value>
+  </data>
+  <data name="MachineNamingAutoGenerateLabel" xml:space="preserve">
+    <value>Auto-generate the suffix after the prefix</value>
+  </data>
+  <data name="MachineNamingAllowManualSuffixLabel" xml:space="preserve">
+    <value>Allow manual editing after the prefix</value>
+  </data>
+  <data name="CustomizationAutopilotPlaceholder" xml:space="preserve">
+    <value>Autopilot</value>
+  </data>
+  <data name="CustomizationAppxPlaceholder" xml:space="preserve">
+    <value>APPX removal</value>
+  </data>
+  <data name="CustomizationDeployConfigPlaceholder" xml:space="preserve">
+    <value>Custom deploy configuration</value>
+  </data>
+  <data name="ComingLaterLabel" xml:space="preserve">
+    <value>Coming later</value>
+  </data>
+  <data name="PcaRemediationLabel" xml:space="preserve">
+    <value>Enable PCA2023 remediation fallback</value>
+  </data>
+  <data name="PcaRemediationScriptLabel" xml:space="preserve">
+    <value>Remediation script path</value>
+  </data>
 </root>

--- a/src/Foundry/Resources/AppStrings.en-US.resx
+++ b/src/Foundry/Resources/AppStrings.en-US.resx
@@ -545,10 +545,4 @@ MVVM bootstrap ready.</value>
   <data name="ComingLaterLabel" xml:space="preserve">
     <value>Coming later</value>
   </data>
-  <data name="PcaRemediationLabel" xml:space="preserve">
-    <value>Enable PCA2023 remediation fallback</value>
-  </data>
-  <data name="PcaRemediationScriptLabel" xml:space="preserve">
-    <value>Remediation script path</value>
-  </data>
 </root>

--- a/src/Foundry/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry/Resources/AppStrings.fr-FR.resx
@@ -545,10 +545,4 @@ Initialisation MVVM prete.</value>
   <data name="ComingLaterLabel" xml:space="preserve">
     <value>Bientôt disponible</value>
   </data>
-  <data name="PcaRemediationLabel" xml:space="preserve">
-    <value>Activer le contournement PCA2023</value>
-  </data>
-  <data name="PcaRemediationScriptLabel" xml:space="preserve">
-    <value>Chemin du script de contournement</value>
-  </data>
 </root>

--- a/src/Foundry/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry/Resources/AppStrings.fr-FR.resx
@@ -425,4 +425,130 @@ Initialisation MVVM prete.</value>
   <data name="IsoPickerFilter" xml:space="preserve">
     <value>Image ISO (*.iso)|*.iso</value>
   </data>
+  <data name="MenuMode" xml:space="preserve">
+    <value>_Mode</value>
+  </data>
+  <data name="ModeStandard" xml:space="preserve">
+    <value>_Standard</value>
+  </data>
+  <data name="ModeExpert" xml:space="preserve">
+    <value>E_xpert</value>
+  </data>
+  <data name="MenuImportExpertConfig" xml:space="preserve">
+    <value>_Importer la configuration Expert</value>
+  </data>
+  <data name="MenuExportExpertConfig" xml:space="preserve">
+    <value>Exporter la configuration _Expert</value>
+  </data>
+  <data name="MenuExportDeployConfig" xml:space="preserve">
+    <value>Exporter la configuration _Deploy</value>
+  </data>
+  <data name="JsonPickerFilter" xml:space="preserve">
+    <value>Fichier JSON (*.json)|*.json</value>
+  </data>
+  <data name="ExpertConfigImportTitle" xml:space="preserve">
+    <value>Importer une configuration Expert</value>
+  </data>
+  <data name="ExpertConfigExportTitle" xml:space="preserve">
+    <value>Exporter la configuration Expert</value>
+  </data>
+  <data name="DeployConfigExportTitle" xml:space="preserve">
+    <value>Exporter la configuration Deploy</value>
+  </data>
+  <data name="ExpertConfigImportedFormat" xml:space="preserve">
+    <value>Configuration Expert importée : {0}</value>
+  </data>
+  <data name="ExpertConfigImportFailedFormat" xml:space="preserve">
+    <value>Échec de l'import de la configuration Expert : {0}</value>
+  </data>
+  <data name="ExpertConfigExportedFormat" xml:space="preserve">
+    <value>Configuration Expert exportée : {0}</value>
+  </data>
+  <data name="ExpertConfigExportFailedFormat" xml:space="preserve">
+    <value>Échec de l'export de la configuration Expert : {0}</value>
+  </data>
+  <data name="DeployConfigExportedFormat" xml:space="preserve">
+    <value>Configuration Deploy exportée : {0}</value>
+  </data>
+  <data name="DeployConfigExportFailedFormat" xml:space="preserve">
+    <value>Échec de l'export de la configuration Deploy : {0}</value>
+  </data>
+  <data name="ExpertNavigationTitle" xml:space="preserve">
+    <value>Sections Expert</value>
+  </data>
+  <data name="ExpertSectionGeneral" xml:space="preserve">
+    <value>Général</value>
+  </data>
+  <data name="ExpertSectionNetwork" xml:space="preserve">
+    <value>Réseau</value>
+  </data>
+  <data name="ExpertSectionLocalization" xml:space="preserve">
+    <value>Localisation</value>
+  </data>
+  <data name="ExpertSectionCustomization" xml:space="preserve">
+    <value>Personnalisation</value>
+  </data>
+  <data name="Dot1xEnableLabel" xml:space="preserve">
+    <value>Activer 802.1X dans WinPE</value>
+  </data>
+  <data name="Dot1xCertificateLabel" xml:space="preserve">
+    <value>Fichier certificat</value>
+  </data>
+  <data name="Dot1xCertificatePickerTitle" xml:space="preserve">
+    <value>Sélectionner le certificat 802.1X</value>
+  </data>
+  <data name="CertificatePickerFilter" xml:space="preserve">
+    <value>Fichier certificat (*.cer;*.crt;*.pfx)|*.cer;*.crt;*.pfx|Tous les fichiers (*.*)|*.*</value>
+  </data>
+  <data name="BrowseFileButton" xml:space="preserve">
+    <value>Parcourir...</value>
+  </data>
+  <data name="WifiEnableLabel" xml:space="preserve">
+    <value>Activer le Wi-Fi dans WinPE</value>
+  </data>
+  <data name="WifiSsidLabel" xml:space="preserve">
+    <value>SSID</value>
+  </data>
+  <data name="WifiSecurityTypeLabel" xml:space="preserve">
+    <value>Type de sécurité</value>
+  </data>
+  <data name="LocalizationVisibleLanguagesLabel" xml:space="preserve">
+    <value>Langues visibles dans Foundry.Deploy</value>
+  </data>
+  <data name="LocalizationDefaultOverrideLabel" xml:space="preserve">
+    <value>Surcharge de langue par défaut</value>
+  </data>
+  <data name="LocalizationForceSingleLabel" xml:space="preserve">
+    <value>Forcer l'unique langue visible lorsqu'un seul choix reste</value>
+  </data>
+  <data name="MachineNamingEnableLabel" xml:space="preserve">
+    <value>Activer les règles de nommage machine</value>
+  </data>
+  <data name="MachineNamingPrefixLabel" xml:space="preserve">
+    <value>Préfixe</value>
+  </data>
+  <data name="MachineNamingAutoGenerateLabel" xml:space="preserve">
+    <value>Générer automatiquement le suffixe après le préfixe</value>
+  </data>
+  <data name="MachineNamingAllowManualSuffixLabel" xml:space="preserve">
+    <value>Autoriser l'édition manuelle après le préfixe</value>
+  </data>
+  <data name="CustomizationAutopilotPlaceholder" xml:space="preserve">
+    <value>Autopilot</value>
+  </data>
+  <data name="CustomizationAppxPlaceholder" xml:space="preserve">
+    <value>Suppression APPX</value>
+  </data>
+  <data name="CustomizationDeployConfigPlaceholder" xml:space="preserve">
+    <value>Configuration Deploy personnalisée</value>
+  </data>
+  <data name="ComingLaterLabel" xml:space="preserve">
+    <value>Bientôt disponible</value>
+  </data>
+  <data name="PcaRemediationLabel" xml:space="preserve">
+    <value>Activer le contournement PCA2023</value>
+  </data>
+  <data name="PcaRemediationScriptLabel" xml:space="preserve">
+    <value>Chemin du script de contournement</value>
+  </data>
 </root>

--- a/src/Foundry/Resources/AppStrings.resx
+++ b/src/Foundry/Resources/AppStrings.resx
@@ -425,4 +425,130 @@ MVVM bootstrap ready.</value>
   <data name="IsoPickerFilter" xml:space="preserve">
     <value>ISO image (*.iso)|*.iso</value>
   </data>
+  <data name="MenuMode" xml:space="preserve">
+    <value>_Mode</value>
+  </data>
+  <data name="ModeStandard" xml:space="preserve">
+    <value>_Standard</value>
+  </data>
+  <data name="ModeExpert" xml:space="preserve">
+    <value>_Expert</value>
+  </data>
+  <data name="MenuImportExpertConfig" xml:space="preserve">
+    <value>_Import Expert Configuration</value>
+  </data>
+  <data name="MenuExportExpertConfig" xml:space="preserve">
+    <value>Export Expert _Configuration</value>
+  </data>
+  <data name="MenuExportDeployConfig" xml:space="preserve">
+    <value>Export _Deploy Configuration</value>
+  </data>
+  <data name="JsonPickerFilter" xml:space="preserve">
+    <value>JSON file (*.json)|*.json</value>
+  </data>
+  <data name="ExpertConfigImportTitle" xml:space="preserve">
+    <value>Import expert configuration</value>
+  </data>
+  <data name="ExpertConfigExportTitle" xml:space="preserve">
+    <value>Export expert configuration</value>
+  </data>
+  <data name="DeployConfigExportTitle" xml:space="preserve">
+    <value>Export deploy configuration</value>
+  </data>
+  <data name="ExpertConfigImportedFormat" xml:space="preserve">
+    <value>Expert configuration imported: {0}</value>
+  </data>
+  <data name="ExpertConfigImportFailedFormat" xml:space="preserve">
+    <value>Expert configuration import failed: {0}</value>
+  </data>
+  <data name="ExpertConfigExportedFormat" xml:space="preserve">
+    <value>Expert configuration exported: {0}</value>
+  </data>
+  <data name="ExpertConfigExportFailedFormat" xml:space="preserve">
+    <value>Expert configuration export failed: {0}</value>
+  </data>
+  <data name="DeployConfigExportedFormat" xml:space="preserve">
+    <value>Deploy configuration exported: {0}</value>
+  </data>
+  <data name="DeployConfigExportFailedFormat" xml:space="preserve">
+    <value>Deploy configuration export failed: {0}</value>
+  </data>
+  <data name="ExpertNavigationTitle" xml:space="preserve">
+    <value>Expert sections</value>
+  </data>
+  <data name="ExpertSectionGeneral" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="ExpertSectionNetwork" xml:space="preserve">
+    <value>Network</value>
+  </data>
+  <data name="ExpertSectionLocalization" xml:space="preserve">
+    <value>Localization</value>
+  </data>
+  <data name="ExpertSectionCustomization" xml:space="preserve">
+    <value>Customization</value>
+  </data>
+  <data name="Dot1xEnableLabel" xml:space="preserve">
+    <value>Enable 802.1X in WinPE</value>
+  </data>
+  <data name="Dot1xCertificateLabel" xml:space="preserve">
+    <value>Certificate file</value>
+  </data>
+  <data name="Dot1xCertificatePickerTitle" xml:space="preserve">
+    <value>Select 802.1X certificate</value>
+  </data>
+  <data name="CertificatePickerFilter" xml:space="preserve">
+    <value>Certificate file (*.cer;*.crt;*.pfx)|*.cer;*.crt;*.pfx|All files (*.*)|*.*</value>
+  </data>
+  <data name="BrowseFileButton" xml:space="preserve">
+    <value>Browse file...</value>
+  </data>
+  <data name="WifiEnableLabel" xml:space="preserve">
+    <value>Enable Wi-Fi in WinPE</value>
+  </data>
+  <data name="WifiSsidLabel" xml:space="preserve">
+    <value>SSID</value>
+  </data>
+  <data name="WifiSecurityTypeLabel" xml:space="preserve">
+    <value>Security type</value>
+  </data>
+  <data name="LocalizationVisibleLanguagesLabel" xml:space="preserve">
+    <value>Visible languages in Foundry.Deploy</value>
+  </data>
+  <data name="LocalizationDefaultOverrideLabel" xml:space="preserve">
+    <value>Default language override</value>
+  </data>
+  <data name="LocalizationForceSingleLabel" xml:space="preserve">
+    <value>Force the only visible language when a single choice remains</value>
+  </data>
+  <data name="MachineNamingEnableLabel" xml:space="preserve">
+    <value>Enable machine naming rules</value>
+  </data>
+  <data name="MachineNamingPrefixLabel" xml:space="preserve">
+    <value>Prefix</value>
+  </data>
+  <data name="MachineNamingAutoGenerateLabel" xml:space="preserve">
+    <value>Auto-generate the suffix after the prefix</value>
+  </data>
+  <data name="MachineNamingAllowManualSuffixLabel" xml:space="preserve">
+    <value>Allow manual editing after the prefix</value>
+  </data>
+  <data name="CustomizationAutopilotPlaceholder" xml:space="preserve">
+    <value>Autopilot</value>
+  </data>
+  <data name="CustomizationAppxPlaceholder" xml:space="preserve">
+    <value>APPX removal</value>
+  </data>
+  <data name="CustomizationDeployConfigPlaceholder" xml:space="preserve">
+    <value>Custom deploy configuration</value>
+  </data>
+  <data name="ComingLaterLabel" xml:space="preserve">
+    <value>Coming later</value>
+  </data>
+  <data name="PcaRemediationLabel" xml:space="preserve">
+    <value>Enable PCA2023 remediation fallback</value>
+  </data>
+  <data name="PcaRemediationScriptLabel" xml:space="preserve">
+    <value>Remediation script path</value>
+  </data>
 </root>

--- a/src/Foundry/Resources/AppStrings.resx
+++ b/src/Foundry/Resources/AppStrings.resx
@@ -545,10 +545,4 @@ MVVM bootstrap ready.</value>
   <data name="ComingLaterLabel" xml:space="preserve">
     <value>Coming later</value>
   </data>
-  <data name="PcaRemediationLabel" xml:space="preserve">
-    <value>Enable PCA2023 remediation fallback</value>
-  </data>
-  <data name="PcaRemediationScriptLabel" xml:space="preserve">
-    <value>Remediation script path</value>
-  </data>
 </root>

--- a/src/Foundry/Services/ApplicationShell/ApplicationShellService.cs
+++ b/src/Foundry/Services/ApplicationShell/ApplicationShellService.cs
@@ -45,6 +45,35 @@ public sealed class ApplicationShellService : IApplicationShellService
         return dialog.ShowDialog() == true ? dialog.FileName : null;
     }
 
+    public string? PickOpenJsonFilePath(string title, string filter)
+    {
+        var dialog = new OpenFileDialog
+        {
+            Title = title,
+            Filter = filter,
+            DefaultExt = ".json",
+            CheckFileExists = true,
+            Multiselect = false
+        };
+
+        return dialog.ShowDialog() == true ? dialog.FileName : null;
+    }
+
+    public string? PickSaveJsonFilePath(string title, string filter, string defaultFileName)
+    {
+        var dialog = new SaveFileDialog
+        {
+            Title = title,
+            Filter = filter,
+            DefaultExt = ".json",
+            AddExtension = true,
+            FileName = defaultFileName,
+            OverwritePrompt = true
+        };
+
+        return dialog.ShowDialog() == true ? dialog.FileName : null;
+    }
+
     public string? PickFolderPath(string title, string? initialPath = null)
     {
         var dialog = new OpenFolderDialog

--- a/src/Foundry/Services/ApplicationShell/IApplicationShellService.cs
+++ b/src/Foundry/Services/ApplicationShell/IApplicationShellService.cs
@@ -8,6 +8,10 @@ public interface IApplicationShellService
 
     string? PickIsoOutputPath(string defaultFileName);
 
+    string? PickOpenJsonFilePath(string title, string filter);
+
+    string? PickSaveJsonFilePath(string title, string filter, string defaultFileName);
+
     string? PickFolderPath(string title, string? initialPath = null);
 
     void OpenFolder(string path);

--- a/src/Foundry/Services/Configuration/ConfigurationJsonDefaults.cs
+++ b/src/Foundry/Services/Configuration/ConfigurationJsonDefaults.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Foundry.Services.Configuration;
+
+internal static class ConfigurationJsonDefaults
+{
+    public static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+}

--- a/src/Foundry/Services/Configuration/DeployConfigurationGenerator.cs
+++ b/src/Foundry/Services/Configuration/DeployConfigurationGenerator.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+using Foundry.Models.Configuration;
+using Foundry.Models.Configuration.Deploy;
+
+namespace Foundry.Services.Configuration;
+
+public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
+{
+    public FoundryDeployConfigurationDocument Generate(FoundryExpertConfigurationDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        return new FoundryDeployConfigurationDocument
+        {
+            Localization = new DeployLocalizationSettings
+            {
+                VisibleLanguageCodes = document.Localization.VisibleLanguageCodes,
+                DefaultLanguageCodeOverride = document.Localization.DefaultLanguageCodeOverride,
+                ForceSingleVisibleLanguage = document.Localization.ForceSingleVisibleLanguage
+            },
+            Customization = new DeployCustomizationSettings
+            {
+                MachineNaming = new DeployMachineNamingSettings
+                {
+                    IsEnabled = document.Customization.MachineNaming.IsEnabled,
+                    Prefix = document.Customization.MachineNaming.IsEnabled
+                        ? document.Customization.MachineNaming.Prefix
+                        : null,
+                    AutoGenerateName = document.Customization.MachineNaming.IsEnabled &&
+                                       document.Customization.MachineNaming.AutoGenerateName,
+                    AllowManualSuffixEdit = !document.Customization.MachineNaming.IsEnabled ||
+                                            document.Customization.MachineNaming.AllowManualSuffixEdit
+                }
+            }
+        };
+    }
+
+    public string Serialize(FoundryDeployConfigurationDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        return JsonSerializer.Serialize(document, ConfigurationJsonDefaults.SerializerOptions);
+    }
+}

--- a/src/Foundry/Services/Configuration/EmbeddedLanguageRegistryService.cs
+++ b/src/Foundry/Services/Configuration/EmbeddedLanguageRegistryService.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using System.Text.Json;
+using Foundry.Models.Configuration;
+
+namespace Foundry.Services.Configuration;
+
+public sealed class EmbeddedLanguageRegistryService : ILanguageRegistryService
+{
+    private const string ResourceName = "Foundry.Configuration.Languages";
+
+    private readonly Lazy<IReadOnlyList<LanguageRegistryEntry>> _languages = new(LoadLanguages);
+
+    public IReadOnlyList<LanguageRegistryEntry> GetLanguages()
+    {
+        return _languages.Value;
+    }
+
+    private static IReadOnlyList<LanguageRegistryEntry> LoadLanguages()
+    {
+        Assembly assembly = typeof(EmbeddedLanguageRegistryService).Assembly;
+        using Stream? stream = assembly.GetManifestResourceStream(ResourceName);
+        if (stream is null)
+        {
+            throw new InvalidOperationException($"Embedded language registry resource '{ResourceName}' was not found.");
+        }
+
+        LanguageRegistryEntry[]? languages = JsonSerializer.Deserialize<LanguageRegistryEntry[]>(
+            stream,
+            ConfigurationJsonDefaults.SerializerOptions);
+
+        return (languages ?? Array.Empty<LanguageRegistryEntry>())
+            .Where(entry => !string.IsNullOrWhiteSpace(entry.Code))
+            .OrderBy(entry => entry.SortOrder)
+            .ThenBy(entry => entry.Code, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+}

--- a/src/Foundry/Services/Configuration/ExpertConfigurationService.cs
+++ b/src/Foundry/Services/Configuration/ExpertConfigurationService.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using Foundry.Models.Configuration;
+
+namespace Foundry.Services.Configuration;
+
+public sealed class ExpertConfigurationService : IExpertConfigurationService
+{
+    public async Task SaveAsync(string path, FoundryExpertConfigurationDocument document, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(document);
+
+        string? directoryPath = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directoryPath))
+        {
+            Directory.CreateDirectory(directoryPath);
+        }
+
+        await using FileStream stream = File.Create(path);
+        await JsonSerializer.SerializeAsync(stream, document, ConfigurationJsonDefaults.SerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<FoundryExpertConfigurationDocument> LoadAsync(string path, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        await using FileStream stream = File.OpenRead(path);
+        FoundryExpertConfigurationDocument? document = await JsonSerializer.DeserializeAsync<FoundryExpertConfigurationDocument>(
+                stream,
+                ConfigurationJsonDefaults.SerializerOptions,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return document ?? new FoundryExpertConfigurationDocument();
+    }
+
+    public string Serialize(FoundryExpertConfigurationDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        return JsonSerializer.Serialize(document, ConfigurationJsonDefaults.SerializerOptions);
+    }
+
+    public FoundryExpertConfigurationDocument Deserialize(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+        return JsonSerializer.Deserialize<FoundryExpertConfigurationDocument>(json, ConfigurationJsonDefaults.SerializerOptions)
+            ?? new FoundryExpertConfigurationDocument();
+    }
+}

--- a/src/Foundry/Services/Configuration/IDeployConfigurationGenerator.cs
+++ b/src/Foundry/Services/Configuration/IDeployConfigurationGenerator.cs
@@ -1,0 +1,11 @@
+using Foundry.Models.Configuration;
+using Foundry.Models.Configuration.Deploy;
+
+namespace Foundry.Services.Configuration;
+
+public interface IDeployConfigurationGenerator
+{
+    FoundryDeployConfigurationDocument Generate(FoundryExpertConfigurationDocument document);
+
+    string Serialize(FoundryDeployConfigurationDocument document);
+}

--- a/src/Foundry/Services/Configuration/IExpertConfigurationService.cs
+++ b/src/Foundry/Services/Configuration/IExpertConfigurationService.cs
@@ -1,0 +1,14 @@
+using Foundry.Models.Configuration;
+
+namespace Foundry.Services.Configuration;
+
+public interface IExpertConfigurationService
+{
+    Task SaveAsync(string path, FoundryExpertConfigurationDocument document, CancellationToken cancellationToken = default);
+
+    Task<FoundryExpertConfigurationDocument> LoadAsync(string path, CancellationToken cancellationToken = default);
+
+    string Serialize(FoundryExpertConfigurationDocument document);
+
+    FoundryExpertConfigurationDocument Deserialize(string json);
+}

--- a/src/Foundry/Services/Configuration/ILanguageRegistryService.cs
+++ b/src/Foundry/Services/Configuration/ILanguageRegistryService.cs
@@ -1,0 +1,8 @@
+using Foundry.Models.Configuration;
+
+namespace Foundry.Services.Configuration;
+
+public interface ILanguageRegistryService
+{
+    IReadOnlyList<LanguageRegistryEntry> GetLanguages();
+}

--- a/src/Foundry/Services/WinPe/IsoOutputOptions.cs
+++ b/src/Foundry/Services/WinPe/IsoOutputOptions.cs
@@ -17,8 +17,5 @@ public sealed record IsoOutputOptions
 
     public bool ForceOverwriteOutput { get; init; } = true;
     public bool PreserveBuildWorkspace { get; init; }
-
-    public bool RunPca2023RemediationWhenBootExUnsupported { get; init; }
-    public string? Pca2023RemediationScriptPath { get; init; }
     public string? ExpertDeployConfigurationJson { get; init; }
 }

--- a/src/Foundry/Services/WinPe/IsoOutputOptions.cs
+++ b/src/Foundry/Services/WinPe/IsoOutputOptions.cs
@@ -20,4 +20,5 @@ public sealed record IsoOutputOptions
 
     public bool RunPca2023RemediationWhenBootExUnsupported { get; init; }
     public string? Pca2023RemediationScriptPath { get; init; }
+    public string? ExpertDeployConfigurationJson { get; init; }
 }

--- a/src/Foundry/Services/WinPe/MediaOutputService.cs
+++ b/src/Foundry/Services/WinPe/MediaOutputService.cs
@@ -199,13 +199,9 @@ public sealed class MediaOutputService : IMediaOutputService
                 _logger.LogInformation("PCA2023 signature policy evaluated for ISO creation. BootExSupported={BootExSupported}", bootEx);
                 if (!bootEx)
                 {
-                    WinPeResult remediation = await RunRemediationIfConfiguredAsync(options.RunPca2023RemediationWhenBootExUnsupported, options.Pca2023RemediationScriptPath, artifact, tools, cancellationToken).ConfigureAwait(false);
-                    if (!remediation.IsSuccess)
-                    {
-                        return FailWithProgress(remediation.Error!);
-                    }
-
-                    _logger.LogInformation("PCA2023 remediation fallback completed for ISO creation. WorkingDirectoryPath={WorkingDirectoryPath}", artifact.WorkingDirectoryPath);
+                    return FailWithProgress(new WinPeDiagnostic(
+                        WinPeErrorCodes.BootExUnsupported,
+                        "PCA2023 requires /bootex support in the WinPE workspace."));
                 }
             }
 
@@ -350,13 +346,9 @@ public sealed class MediaOutputService : IMediaOutputService
                 _logger.LogInformation("PCA2023 signature policy evaluated for USB creation. BootExSupported={BootExSupported}", bootEx);
                 if (!bootEx)
                 {
-                    WinPeResult remediation = await RunRemediationIfConfiguredAsync(options.RunPca2023RemediationWhenBootExUnsupported, options.Pca2023RemediationScriptPath, artifact, tools, cancellationToken).ConfigureAwait(false);
-                    if (!remediation.IsSuccess)
-                    {
-                        return FailWithProgress(remediation.Error!);
-                    }
-
-                    _logger.LogInformation("PCA2023 remediation fallback completed for USB creation. WorkingDirectoryPath={WorkingDirectoryPath}", artifact.WorkingDirectoryPath);
+                    return FailWithProgress(new WinPeDiagnostic(
+                        WinPeErrorCodes.BootExUnsupported,
+                        "PCA2023 requires /bootex support in the WinPE workspace."));
                 }
             }
 
@@ -1158,25 +1150,6 @@ public sealed class MediaOutputService : IMediaOutputService
             "ON" => true,
             _ => false
         };
-    }
-
-    private async Task<WinPeResult> RunRemediationIfConfiguredAsync(bool enabled, string? scriptPath, WinPeBuildArtifact artifact, WinPeToolPaths tools, CancellationToken cancellationToken)
-    {
-        if (!enabled)
-        {
-            return WinPeResult.Failure(WinPeErrorCodes.BootExUnsupported, "PCA2023 requires /bootex or remediation fallback.");
-        }
-
-        if (string.IsNullOrWhiteSpace(scriptPath) || !File.Exists(scriptPath))
-        {
-            return WinPeResult.Failure(WinPeErrorCodes.BootExUnsupported, "Remediation script was not found.", $"Path: '{scriptPath ?? "<null>"}'.");
-        }
-
-        string args = $"-NoProfile -NonInteractive -ExecutionPolicy Bypass -File {WinPeProcessRunner.Quote(scriptPath)} -MediaPath {WinPeProcessRunner.Quote(artifact.MediaDirectoryPath)}";
-        WinPeProcessExecution run = await _processRunner.RunAsync(tools.PowerShellPath, args, artifact.WorkingDirectoryPath, cancellationToken).ConfigureAwait(false);
-        return run.IsSuccess
-            ? WinPeResult.Success()
-            : WinPeResult.Failure(WinPeErrorCodes.PcaRemediationFailed, "PCA2023 remediation fallback failed.", run.ToDiagnosticText());
     }
 
     private WinPeResult FailWithProgress(WinPeDiagnostic diagnostic)

--- a/src/Foundry/Services/WinPe/MediaOutputService.cs
+++ b/src/Foundry/Services/WinPe/MediaOutputService.cs
@@ -177,7 +177,13 @@ public sealed class MediaOutputService : IMediaOutputService
                 artifact.WorkingDirectoryPath,
                 drivers.Value!.Count,
                 options.WinPeLanguage);
-            WinPeResult customize = await CustomizeImageAsync(artifact, tools, drivers.Value!, options.WinPeLanguage, cancellationToken).ConfigureAwait(false);
+            WinPeResult customize = await CustomizeImageAsync(
+                artifact,
+                tools,
+                drivers.Value!,
+                options.WinPeLanguage,
+                options.ExpertDeployConfigurationJson,
+                cancellationToken).ConfigureAwait(false);
             if (!customize.IsSuccess)
             {
                 return FailWithProgress(customize.Error!);
@@ -322,7 +328,13 @@ public sealed class MediaOutputService : IMediaOutputService
                 artifact.WorkingDirectoryPath,
                 drivers.Value!.Count,
                 options.WinPeLanguage);
-            WinPeResult customize = await CustomizeImageAsync(artifact, tools, drivers.Value!, options.WinPeLanguage, cancellationToken).ConfigureAwait(false);
+            WinPeResult customize = await CustomizeImageAsync(
+                artifact,
+                tools,
+                drivers.Value!,
+                options.WinPeLanguage,
+                options.ExpertDeployConfigurationJson,
+                cancellationToken).ConfigureAwait(false);
             if (!customize.IsSuccess)
             {
                 return FailWithProgress(customize.Error!);
@@ -487,6 +499,7 @@ public sealed class MediaOutputService : IMediaOutputService
         WinPeToolPaths tools,
         IReadOnlyList<string> driverDirectories,
         string winPeLanguage,
+        string? expertDeployConfigurationJson,
         CancellationToken cancellationToken)
     {
         string normalizedLocale = NormalizeWinPeLanguageCode(winPeLanguage);
@@ -615,6 +628,21 @@ public sealed class MediaOutputService : IMediaOutputService
         }
 
         _logger.LogInformation("Provisioned bundled 7-Zip tools into mounted WinPE image. MountDirectoryPath={MountDirectoryPath}", session.MountDirectoryPath);
+        WinPeResult deployConfigurationProvisioning = await ProvisionDeployConfigurationInImageAsync(
+            session.MountDirectoryPath,
+            expertDeployConfigurationJson,
+            cancellationToken).ConfigureAwait(false);
+        if (!deployConfigurationProvisioning.IsSuccess)
+        {
+            await session.DiscardAsync(cancellationToken).ConfigureAwait(false);
+            return deployConfigurationProvisioning;
+        }
+
+        if (!string.IsNullOrWhiteSpace(expertDeployConfigurationJson))
+        {
+            _logger.LogInformation("Provisioned Foundry.Deploy expert configuration into mounted WinPE image. MountDirectoryPath={MountDirectoryPath}", session.MountDirectoryPath);
+        }
+
         string startnet = Path.Combine(session.MountDirectoryPath, WinPeDefaults.DefaultStartnetPathInImage);
         string[] lines = File.Exists(startnet) ? await File.ReadAllLinesAsync(startnet, cancellationToken).ConfigureAwait(false) : ["wpeinit"];
         var merged = lines.ToList();
@@ -902,6 +930,46 @@ public sealed class MediaOutputService : IMediaOutputService
             return WinPeResult.Failure(
                 WinPeErrorCodes.BuildFailed,
                 "Failed to provision bundled 7-Zip executable into mounted WinPE image.",
+                ex.ToString());
+        }
+    }
+
+    private async Task<WinPeResult> ProvisionDeployConfigurationInImageAsync(
+        string mountedImagePath,
+        string? expertDeployConfigurationJson,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(expertDeployConfigurationJson))
+        {
+            return WinPeResult.Success();
+        }
+
+        string destinationPath = Path.Combine(mountedImagePath, WinPeDefaults.EmbeddedDeployConfigPathInImage);
+        string? destinationDirectoryPath = Path.GetDirectoryName(destinationPath);
+        if (string.IsNullOrWhiteSpace(destinationDirectoryPath))
+        {
+            return WinPeResult.Failure(
+                WinPeErrorCodes.InternalError,
+                "Failed to resolve destination path for Foundry.Deploy expert configuration.",
+                $"Destination file: '{destinationPath}'.");
+        }
+
+        try
+        {
+            Directory.CreateDirectory(destinationDirectoryPath);
+            await File.WriteAllTextAsync(
+                destinationPath,
+                expertDeployConfigurationJson,
+                new UTF8Encoding(false),
+                cancellationToken).ConfigureAwait(false);
+            return WinPeResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to provision Foundry.Deploy expert configuration into mounted WinPE image. DestinationPath={DestinationPath}", destinationPath);
+            return WinPeResult.Failure(
+                WinPeErrorCodes.BuildFailed,
+                "Failed to provision Foundry.Deploy expert configuration into mounted WinPE image.",
                 ex.ToString());
         }
     }

--- a/src/Foundry/Services/WinPe/UsbOutputOptions.cs
+++ b/src/Foundry/Services/WinPe/UsbOutputOptions.cs
@@ -19,9 +19,6 @@ public sealed record UsbOutputOptions
     public IReadOnlyList<WinPeVendorSelection> DriverVendors { get; init; } = Array.Empty<WinPeVendorSelection>();
     public string DriverCatalogUri { get; init; } = WinPeDefaults.DefaultUnifiedCatalogUri;
     public string? CustomDriverDirectoryPath { get; init; }
-
-    public bool RunPca2023RemediationWhenBootExUnsupported { get; init; }
-    public string? Pca2023RemediationScriptPath { get; init; }
     public string? ExpertDeployConfigurationJson { get; init; }
 
     public bool PreserveBuildWorkspace { get; init; }

--- a/src/Foundry/Services/WinPe/UsbOutputOptions.cs
+++ b/src/Foundry/Services/WinPe/UsbOutputOptions.cs
@@ -22,6 +22,7 @@ public sealed record UsbOutputOptions
 
     public bool RunPca2023RemediationWhenBootExUnsupported { get; init; }
     public string? Pca2023RemediationScriptPath { get; init; }
+    public string? ExpertDeployConfigurationJson { get; init; }
 
     public bool PreserveBuildWorkspace { get; init; }
 }

--- a/src/Foundry/Services/WinPe/WinPeDefaults.cs
+++ b/src/Foundry/Services/WinPe/WinPeDefaults.cs
@@ -13,6 +13,7 @@ internal static class WinPeDefaults
     public const string DefaultBootstrapInvocation = @"powershell.exe -ExecutionPolicy Bypass -NoProfile -File X:\Windows\System32\FoundryBootstrap.ps1";
     public const string DefaultBootstrapScriptResourceName = "Foundry.WinPe.BootstrapScript";
     public const string EmbeddedDeployArchivePathInImage = @"Foundry\Seed\Foundry.Deploy.zip";
+    public const string EmbeddedDeployConfigPathInImage = @"Foundry\Config\foundry.deploy.config.json";
     public const string EmbeddedSevenZipToolsPathInImage = @"Foundry\Tools\7zip";
     public const string BundledSevenZipRelativePath = @"Assets\7z";
     public const string LocalDeployEnableEnvironmentVariable = "FOUNDRY_WINPE_LOCAL_DEPLOY";

--- a/src/Foundry/Services/WinPe/WinPeErrorCodes.cs
+++ b/src/Foundry/Services/WinPe/WinPeErrorCodes.cs
@@ -16,7 +16,6 @@ public static class WinPeErrorCodes
     public const string HashMismatch = "WINPE_HASH_MISMATCH";
     public const string IsoCreateFailed = "WINPE_ISO_CREATE_FAILED";
     public const string BootExUnsupported = "WINPE_BOOTEX_UNSUPPORTED";
-    public const string PcaRemediationFailed = "WINPE_PCA_REMEDIATION_FAILED";
     public const string UsbQueryFailed = "WINPE_USB_QUERY_FAILED";
     public const string UsbUnsafeTarget = "WINPE_USB_UNSAFE_TARGET";
     public const string UsbIdentityMismatch = "WINPE_USB_IDENTITY_MISMATCH";

--- a/src/Foundry/ViewModels/CustomizationSettingsViewModel.cs
+++ b/src/Foundry/ViewModels/CustomizationSettingsViewModel.cs
@@ -1,0 +1,45 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Foundry.Models.Configuration;
+
+namespace Foundry.ViewModels;
+
+public partial class CustomizationSettingsViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private bool isMachineNamingEnabled;
+
+    [ObservableProperty]
+    private string machineNamePrefix = string.Empty;
+
+    [ObservableProperty]
+    private bool machineNameAutoGenerate;
+
+    [ObservableProperty]
+    private bool allowManualSuffixEdit = true;
+
+    public CustomizationSettings BuildSettings()
+    {
+        return new CustomizationSettings
+        {
+            MachineNaming = new MachineNamingSettings
+            {
+                IsEnabled = IsMachineNamingEnabled,
+                Prefix = IsMachineNamingEnabled && !string.IsNullOrWhiteSpace(MachineNamePrefix)
+                    ? MachineNamePrefix.Trim()
+                    : null,
+                AutoGenerateName = IsMachineNamingEnabled && MachineNameAutoGenerate,
+                AllowManualSuffixEdit = !IsMachineNamingEnabled || AllowManualSuffixEdit
+            }
+        };
+    }
+
+    public void ApplySettings(CustomizationSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        IsMachineNamingEnabled = settings.MachineNaming.IsEnabled;
+        MachineNamePrefix = settings.MachineNaming.Prefix ?? string.Empty;
+        MachineNameAutoGenerate = settings.MachineNaming.AutoGenerateName;
+        AllowManualSuffixEdit = settings.MachineNaming.AllowManualSuffixEdit;
+    }
+}

--- a/src/Foundry/ViewModels/ExpertSectionItem.cs
+++ b/src/Foundry/ViewModels/ExpertSectionItem.cs
@@ -1,0 +1,3 @@
+namespace Foundry.ViewModels;
+
+public sealed record ExpertSectionItem(string Key, string Title, object ViewModel);

--- a/src/Foundry/ViewModels/LocalizationSettingsViewModel.cs
+++ b/src/Foundry/ViewModels/LocalizationSettingsViewModel.cs
@@ -1,0 +1,111 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Foundry.Models.Configuration;
+
+namespace Foundry.ViewModels;
+
+public partial class LocalizationSettingsViewModel : ObservableObject
+{
+    public LocalizationSettingsViewModel(IReadOnlyList<LanguageRegistryEntry> languages)
+    {
+        foreach (LanguageRegistryEntry language in languages)
+        {
+            var option = new SelectableLanguageOptionViewModel(language);
+            option.PropertyChanged += OnLanguageOptionPropertyChanged;
+            AvailableLanguages.Add(option);
+        }
+
+        VisibleLanguages.CollectionChanged += OnVisibleLanguagesCollectionChanged;
+        RefreshVisibleLanguages();
+    }
+
+    [ObservableProperty]
+    private string selectedDefaultLanguageCode = string.Empty;
+
+    [ObservableProperty]
+    private bool forceSingleVisibleLanguage;
+
+    public ObservableCollection<SelectableLanguageOptionViewModel> AvailableLanguages { get; } = [];
+
+    public ObservableCollection<LanguageRegistryEntry> VisibleLanguages { get; } = [];
+
+    public LocalizationSettings BuildSettings()
+    {
+        string[] visibleCodes = VisibleLanguages
+            .Select(language => language.Code)
+            .ToArray();
+
+        string? defaultCode = visibleCodes.Any(code =>
+                code.Equals(SelectedDefaultLanguageCode, StringComparison.OrdinalIgnoreCase))
+            ? SelectedDefaultLanguageCode
+            : null;
+
+        return new LocalizationSettings
+        {
+            VisibleLanguageCodes = visibleCodes,
+            DefaultLanguageCodeOverride = defaultCode,
+            ForceSingleVisibleLanguage = ForceSingleVisibleLanguage
+        };
+    }
+
+    public void ApplySettings(LocalizationSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        HashSet<string> selectedCodes = settings.VisibleLanguageCodes
+            .Where(code => !string.IsNullOrWhiteSpace(code))
+            .Select(code => code.Trim())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (SelectableLanguageOptionViewModel option in AvailableLanguages)
+        {
+            option.IsSelected = selectedCodes.Contains(option.Code);
+        }
+
+        RefreshVisibleLanguages();
+        ForceSingleVisibleLanguage = settings.ForceSingleVisibleLanguage;
+
+        SelectedDefaultLanguageCode = VisibleLanguages.Any(language =>
+                language.Code.Equals(settings.DefaultLanguageCodeOverride, StringComparison.OrdinalIgnoreCase))
+            ? settings.DefaultLanguageCodeOverride ?? string.Empty
+            : string.Empty;
+    }
+
+    private void OnLanguageOptionPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (!string.Equals(e.PropertyName, nameof(SelectableLanguageOptionViewModel.IsSelected), StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        RefreshVisibleLanguages();
+    }
+
+    private void OnVisibleLanguagesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (VisibleLanguages.Any(language =>
+                language.Code.Equals(SelectedDefaultLanguageCode, StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+
+        SelectedDefaultLanguageCode = string.Empty;
+    }
+
+    private void RefreshVisibleLanguages()
+    {
+        LanguageRegistryEntry[] selected = AvailableLanguages
+            .Where(option => option.IsSelected)
+            .Select(option => option.Language)
+            .OrderBy(option => option.SortOrder)
+            .ThenBy(option => option.Code, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        VisibleLanguages.Clear();
+        foreach (LanguageRegistryEntry language in selected)
+        {
+            VisibleLanguages.Add(language);
+        }
+    }
+}

--- a/src/Foundry/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry/ViewModels/MainWindowViewModel.cs
@@ -7,8 +7,10 @@ using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Foundry.Logging;
+using Foundry.Models.Configuration;
 using Foundry.Services.Adk;
 using Foundry.Services.ApplicationShell;
+using Foundry.Services.Configuration;
 using Foundry.Services.Localization;
 using Foundry.Services.Operations;
 using Foundry.Services.Theme;
@@ -20,6 +22,8 @@ namespace Foundry.ViewModels;
 public partial class MainWindowViewModel : ObservableObject, IDisposable
 {
     private const string DefaultIsoFileName = "foundry-winpe.iso";
+    private const string DefaultExpertConfigFileName = "foundry.expert.config.json";
+    private const string DefaultDeployConfigFileName = "foundry.deploy.config.json";
     private const string IsoVolumeLabel = "FOUNDRY_WINPE";
     private static readonly string AppVersion = ResolveAppVersion();
 
@@ -29,6 +33,8 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private readonly IOperationProgressService _operationProgressService;
     private readonly IAdkService _adkService;
     private readonly IMediaOutputService _mediaOutputService;
+    private readonly IExpertConfigurationService _expertConfigurationService;
+    private readonly IDeployConfigurationGenerator _deployConfigurationGenerator;
     private readonly ILogger<MainWindowViewModel> _logger;
     private readonly Dispatcher _dispatcher;
 
@@ -95,9 +101,20 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private WinPeLanguageOption? selectedWinPeLanguage;
 
+    [ObservableProperty]
+    private bool isExpertMode;
+
+    [ObservableProperty]
+    private ExpertSectionItem? selectedExpertSection;
+
     public ObservableCollection<WinPeUsbDiskCandidate> UsbDiskCandidates { get; } = [];
     public ObservableCollection<WinPeLanguageOption> AvailableWinPeLanguages { get; } = [];
     public ObservableCollection<UsbFormatModeOption> AvailableUsbFormatModes { get; } = [];
+    public ObservableCollection<ExpertSectionItem> ExpertSections { get; } = [];
+
+    public NetworkSettingsViewModel Network { get; }
+    public LocalizationSettingsViewModel Localization { get; }
+    public CustomizationSettingsViewModel Customization { get; }
 
     public IReadOnlyList<WinPeArchitecture> AvailableArchitectures { get; } = Enum.GetValues<WinPeArchitecture>();
     public IReadOnlyList<UsbPartitionStyle> AvailablePartitionStyles { get; } = Enum.GetValues<UsbPartitionStyle>();
@@ -117,6 +134,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         string.Format(CurrentCulture, Strings["VersionFormat"], AppVersion);
     public bool ShowUsbPartitionStyleArm64Hint => SelectedArchitecture == WinPeArchitecture.Arm64;
     public string UsbPartitionStyleArm64Hint => Strings["UsbPartitionStyleArm64Hint"];
+    public bool IsStandardMode => !IsExpertMode;
 
     private static string StagingDirectoryPath => Path.Combine(Path.GetTempPath(), "FoundryMedia");
 
@@ -142,6 +160,9 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         IOperationProgressService operationProgressService,
         IAdkService adkService,
         IMediaOutputService mediaOutputService,
+        IExpertConfigurationService expertConfigurationService,
+        IDeployConfigurationGenerator deployConfigurationGenerator,
+        ILanguageRegistryService languageRegistryService,
         ILogger<MainWindowViewModel> logger)
     {
         _applicationShellService = applicationShellService;
@@ -150,8 +171,14 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         _operationProgressService = operationProgressService;
         _adkService = adkService;
         _mediaOutputService = mediaOutputService;
+        _expertConfigurationService = expertConfigurationService;
+        _deployConfigurationGenerator = deployConfigurationGenerator;
         _logger = logger;
         _dispatcher = System.Windows.Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
+
+        Network = new NetworkSettingsViewModel();
+        Localization = new LocalizationSettingsViewModel(languageRegistryService.GetLanguages());
+        Customization = new CustomizationSettingsViewModel();
 
         _localizationService.LanguageChanged += OnLanguageChanged;
         _operationProgressService.ProgressChanged += OnOperationProgressChanged;
@@ -159,6 +186,8 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         _adkService.OperationProgressChanged += OnAdkOperationProgressChanged;
         UsbDiskCandidates.CollectionChanged += OnUsbDiskCandidatesCollectionChanged;
 
+        RefreshExpertSections();
+        SelectedExpertSection = ExpertSections.FirstOrDefault();
         UpdateAdkStatus();
         RefreshWinPeLanguages(preserveSelection: false);
         RefreshUsbFormatModes();
@@ -199,6 +228,97 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to open log folder. LogFolderPath={LogFolderPath}", logFolderPath);
+        }
+    }
+
+    [RelayCommand]
+    private void SetStandardMode()
+    {
+        IsExpertMode = false;
+    }
+
+    [RelayCommand]
+    private void SetExpertMode()
+    {
+        IsExpertMode = true;
+        SelectedExpertSection ??= ExpertSections.FirstOrDefault();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanImportExpertConfiguration))]
+    private async Task ImportExpertConfigurationAsync()
+    {
+        string? path = _applicationShellService.PickOpenJsonFilePath(
+            Strings["ExpertConfigImportTitle"],
+            Strings["JsonPickerFilter"]);
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        try
+        {
+            FoundryExpertConfigurationDocument document = await _expertConfigurationService.LoadAsync(path).ConfigureAwait(false);
+            RunOnUiThread(() =>
+            {
+                ApplyExpertConfigurationDocument(document);
+                IsExpertMode = true;
+                SelectedExpertSection = ExpertSections.FirstOrDefault(section => string.Equals(section.Key, "general", StringComparison.OrdinalIgnoreCase));
+                MediaActionMessage = string.Format(CurrentCulture, Strings["ExpertConfigImportedFormat"], Path.GetFileName(path));
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to import expert configuration. Path={Path}", path);
+            MediaActionMessage = string.Format(CurrentCulture, Strings["ExpertConfigImportFailedFormat"], ex.Message);
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanExportExpertConfiguration))]
+    private async Task ExportExpertConfigurationAsync()
+    {
+        string? path = _applicationShellService.PickSaveJsonFilePath(
+            Strings["ExpertConfigExportTitle"],
+            Strings["JsonPickerFilter"],
+            DefaultExpertConfigFileName);
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        try
+        {
+            await _expertConfigurationService.SaveAsync(path, BuildExpertConfigurationDocument()).ConfigureAwait(false);
+            MediaActionMessage = string.Format(CurrentCulture, Strings["ExpertConfigExportedFormat"], Path.GetFileName(path));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to export expert configuration. Path={Path}", path);
+            MediaActionMessage = string.Format(CurrentCulture, Strings["ExpertConfigExportFailedFormat"], ex.Message);
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanExportDeployConfiguration))]
+    private async Task ExportDeployConfigurationAsync()
+    {
+        string? path = _applicationShellService.PickSaveJsonFilePath(
+            Strings["DeployConfigExportTitle"],
+            Strings["JsonPickerFilter"],
+            DefaultDeployConfigFileName);
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        try
+        {
+            string json = BuildDeployConfigurationJsonForCurrentMode() ?? string.Empty;
+            await File.WriteAllTextAsync(path, json).ConfigureAwait(false);
+            MediaActionMessage = string.Format(CurrentCulture, Strings["DeployConfigExportedFormat"], Path.GetFileName(path));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to export deploy configuration. Path={Path}", path);
+            MediaActionMessage = string.Format(CurrentCulture, Strings["DeployConfigExportFailedFormat"], ex.Message);
         }
     }
 
@@ -252,6 +372,18 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         if (!string.IsNullOrWhiteSpace(selectedPath))
         {
             CustomDriverDirectoryPath = selectedPath;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanBrowseDot1xCertificate))]
+    private void BrowseDot1xCertificate()
+    {
+        string? selectedPath = _applicationShellService.PickOpenJsonFilePath(
+            Strings["Dot1xCertificatePickerTitle"],
+            Strings["CertificatePickerFilter"]);
+        if (!string.IsNullOrWhiteSpace(selectedPath))
+        {
+            Network.CertificatePath = selectedPath;
         }
     }
 
@@ -347,7 +479,8 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
                 DriverVendors = GetSelectedDriverVendors(),
                 CustomDriverDirectoryPath = NormalizeCustomDriverDirectoryPath(),
                 RunPca2023RemediationWhenBootExUnsupported = EnablePcaRemediation,
-                Pca2023RemediationScriptPath = string.IsNullOrWhiteSpace(PcaRemediationScriptPath) ? null : PcaRemediationScriptPath
+                Pca2023RemediationScriptPath = string.IsNullOrWhiteSpace(PcaRemediationScriptPath) ? null : PcaRemediationScriptPath,
+                ExpertDeployConfigurationJson = BuildDeployConfigurationJsonForCurrentMode()
             });
 
             MediaActionMessage = result.IsSuccess
@@ -413,7 +546,8 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
                 DriverVendors = GetSelectedDriverVendors(),
                 CustomDriverDirectoryPath = NormalizeCustomDriverDirectoryPath(),
                 RunPca2023RemediationWhenBootExUnsupported = EnablePcaRemediation,
-                Pca2023RemediationScriptPath = string.IsNullOrWhiteSpace(PcaRemediationScriptPath) ? null : PcaRemediationScriptPath
+                Pca2023RemediationScriptPath = string.IsNullOrWhiteSpace(PcaRemediationScriptPath) ? null : PcaRemediationScriptPath,
+                ExpertDeployConfigurationJson = BuildDeployConfigurationJsonForCurrentMode()
             });
 
             MediaActionMessage = result.IsSuccess
@@ -465,12 +599,39 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         UpdateOperationState();
     }
 
+    partial void OnIsExpertModeChanged(bool value)
+    {
+        OnPropertyChanged(nameof(IsStandardMode));
+        ExportExpertConfigurationCommand.NotifyCanExecuteChanged();
+        ExportDeployConfigurationCommand.NotifyCanExecuteChanged();
+    }
+
+    private bool CanImportExpertConfiguration()
+    {
+        return !IsOperationInProgress;
+    }
+
+    private bool CanExportExpertConfiguration()
+    {
+        return IsExpertMode && !IsOperationInProgress;
+    }
+
+    private bool CanExportDeployConfiguration()
+    {
+        return IsExpertMode && !IsOperationInProgress;
+    }
+
     private bool CanBrowseIsoOutputPath()
     {
         return !IsOperationInProgress;
     }
 
     private bool CanBrowseCustomDriverDirectory()
+    {
+        return !IsOperationInProgress;
+    }
+
+    private bool CanBrowseDot1xCertificate()
     {
         return !IsOperationInProgress;
     }
@@ -651,11 +812,100 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             : languageCode.Trim().Replace('_', '-').ToLowerInvariant();
     }
 
+    private void RefreshExpertSections()
+    {
+        string? selectedKey = SelectedExpertSection?.Key;
+        ExpertSectionItem[] sections =
+        [
+            new("general", Strings["ExpertSectionGeneral"], this),
+            new("network", Strings["ExpertSectionNetwork"], Network),
+            new("localization", Strings["ExpertSectionLocalization"], Localization),
+            new("customization", Strings["ExpertSectionCustomization"], Customization)
+        ];
+
+        ExpertSections.Clear();
+        foreach (ExpertSectionItem section in sections)
+        {
+            ExpertSections.Add(section);
+        }
+
+        SelectedExpertSection = ExpertSections.FirstOrDefault(section =>
+                                  string.Equals(section.Key, selectedKey, StringComparison.OrdinalIgnoreCase))
+                              ?? ExpertSections.FirstOrDefault();
+    }
+
+    private FoundryExpertConfigurationDocument BuildExpertConfigurationDocument()
+    {
+        return new FoundryExpertConfigurationDocument
+        {
+            General = new GeneralSettings
+            {
+                IsoOutputPath = string.IsNullOrWhiteSpace(IsoOutputPath) ? null : IsoOutputPath.Trim(),
+                Architecture = SelectedArchitecture,
+                WinPeLanguage = SelectedWinPeLanguage?.Code,
+                UseCa2023 = UseCa2023,
+                UsbPartitionStyle = SelectedPartitionStyle,
+                UsbFormatMode = SelectedUsbFormatMode,
+                IncludeDellDrivers = IncludeDellDrivers,
+                IncludeHpDrivers = IncludeHpDrivers,
+                CustomDriverDirectoryPath = NormalizeCustomDriverDirectoryPath(),
+                EnablePcaRemediation = EnablePcaRemediation,
+                PcaRemediationScriptPath = EnablePcaRemediation && !string.IsNullOrWhiteSpace(PcaRemediationScriptPath)
+                    ? PcaRemediationScriptPath.Trim()
+                    : null
+            },
+            Network = Network.BuildSettings(),
+            Localization = Localization.BuildSettings(),
+            Customization = Customization.BuildSettings()
+        };
+    }
+
+    private void ApplyExpertConfigurationDocument(FoundryExpertConfigurationDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        IsoOutputPath = document.General.IsoOutputPath ?? string.Empty;
+        SelectedArchitecture = document.General.Architecture;
+        UseCa2023 = document.General.UseCa2023;
+        SelectedPartitionStyle = document.General.UsbPartitionStyle;
+        SelectedUsbFormatMode = document.General.UsbFormatMode;
+        IncludeDellDrivers = document.General.IncludeDellDrivers;
+        IncludeHpDrivers = document.General.IncludeHpDrivers;
+        CustomDriverDirectoryPath = document.General.CustomDriverDirectoryPath ?? string.Empty;
+        EnablePcaRemediation = document.General.EnablePcaRemediation;
+        PcaRemediationScriptPath = document.General.PcaRemediationScriptPath ?? string.Empty;
+
+        RefreshWinPeLanguages(preserveSelection: false);
+        if (!string.IsNullOrWhiteSpace(document.General.WinPeLanguage))
+        {
+            SelectedWinPeLanguage = AvailableWinPeLanguages.FirstOrDefault(option =>
+                option.Code.Equals(document.General.WinPeLanguage, StringComparison.OrdinalIgnoreCase))
+                ?? SelectedWinPeLanguage;
+        }
+
+        Network.ApplySettings(document.Network);
+        Localization.ApplySettings(document.Localization);
+        Customization.ApplySettings(document.Customization);
+        UpdateOperationState();
+    }
+
+    private string? BuildDeployConfigurationJsonForCurrentMode()
+    {
+        if (!IsExpertMode)
+        {
+            return null;
+        }
+
+        return _deployConfigurationGenerator.Serialize(
+            _deployConfigurationGenerator.Generate(BuildExpertConfigurationDocument()));
+    }
+
     private void OnLanguageChanged(object? sender, EventArgs e)
     {
         RunOnUiThread(() =>
         {
             RefreshUsbFormatModes();
+            RefreshExpertSections();
             OnPropertyChanged(nameof(CurrentCulture));
             OnPropertyChanged(nameof(Strings));
             OnPropertyChanged(nameof(GlobalOperationStatusDisplay));
@@ -722,6 +972,10 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
         BrowseIsoOutputPathCommand.NotifyCanExecuteChanged();
         BrowseCustomDriverDirectoryCommand.NotifyCanExecuteChanged();
+        BrowseDot1xCertificateCommand.NotifyCanExecuteChanged();
+        ImportExpertConfigurationCommand.NotifyCanExecuteChanged();
+        ExportExpertConfigurationCommand.NotifyCanExecuteChanged();
+        ExportDeployConfigurationCommand.NotifyCanExecuteChanged();
         CreateIsoCommand.NotifyCanExecuteChanged();
         CreateUsbCommand.NotifyCanExecuteChanged();
     }

--- a/src/Foundry/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry/ViewModels/MainWindowViewModel.cs
@@ -84,12 +84,6 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private string customDriverDirectoryPath = string.Empty;
 
     [ObservableProperty]
-    private bool enablePcaRemediation;
-
-    [ObservableProperty]
-    private string pcaRemediationScriptPath = string.Empty;
-
-    [ObservableProperty]
     private WinPeUsbDiskCandidate? selectedUsbDiskCandidate;
 
     [ObservableProperty]
@@ -478,8 +472,6 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
                 WinPeLanguage = SelectedWinPeLanguage?.Code ?? string.Empty,
                 DriverVendors = GetSelectedDriverVendors(),
                 CustomDriverDirectoryPath = NormalizeCustomDriverDirectoryPath(),
-                RunPca2023RemediationWhenBootExUnsupported = EnablePcaRemediation,
-                Pca2023RemediationScriptPath = string.IsNullOrWhiteSpace(PcaRemediationScriptPath) ? null : PcaRemediationScriptPath,
                 ExpertDeployConfigurationJson = BuildDeployConfigurationJsonForCurrentMode()
             });
 
@@ -545,8 +537,6 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
                 WinPeLanguage = SelectedWinPeLanguage?.Code ?? string.Empty,
                 DriverVendors = GetSelectedDriverVendors(),
                 CustomDriverDirectoryPath = NormalizeCustomDriverDirectoryPath(),
-                RunPca2023RemediationWhenBootExUnsupported = EnablePcaRemediation,
-                Pca2023RemediationScriptPath = string.IsNullOrWhiteSpace(PcaRemediationScriptPath) ? null : PcaRemediationScriptPath,
                 ExpertDeployConfigurationJson = BuildDeployConfigurationJsonForCurrentMode()
             });
 
@@ -848,11 +838,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
                 UsbFormatMode = SelectedUsbFormatMode,
                 IncludeDellDrivers = IncludeDellDrivers,
                 IncludeHpDrivers = IncludeHpDrivers,
-                CustomDriverDirectoryPath = NormalizeCustomDriverDirectoryPath(),
-                EnablePcaRemediation = EnablePcaRemediation,
-                PcaRemediationScriptPath = EnablePcaRemediation && !string.IsNullOrWhiteSpace(PcaRemediationScriptPath)
-                    ? PcaRemediationScriptPath.Trim()
-                    : null
+                CustomDriverDirectoryPath = NormalizeCustomDriverDirectoryPath()
             },
             Network = Network.BuildSettings(),
             Localization = Localization.BuildSettings(),
@@ -872,8 +858,6 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         IncludeDellDrivers = document.General.IncludeDellDrivers;
         IncludeHpDrivers = document.General.IncludeHpDrivers;
         CustomDriverDirectoryPath = document.General.CustomDriverDirectoryPath ?? string.Empty;
-        EnablePcaRemediation = document.General.EnablePcaRemediation;
-        PcaRemediationScriptPath = document.General.PcaRemediationScriptPath ?? string.Empty;
 
         RefreshWinPeLanguages(preserveSelection: false);
         if (!string.IsNullOrWhiteSpace(document.General.WinPeLanguage))

--- a/src/Foundry/ViewModels/NetworkSettingsViewModel.cs
+++ b/src/Foundry/ViewModels/NetworkSettingsViewModel.cs
@@ -1,0 +1,66 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Foundry.Models.Configuration;
+
+namespace Foundry.ViewModels;
+
+public partial class NetworkSettingsViewModel : ObservableObject
+{
+    public IReadOnlyList<string> AvailableSecurityTypes { get; } =
+    [
+        "WPA2-Enterprise",
+        "WPA2-Personal",
+        "Open"
+    ];
+
+    [ObservableProperty]
+    private bool isDot1xEnabled;
+
+    [ObservableProperty]
+    private string certificatePath = string.Empty;
+
+    [ObservableProperty]
+    private bool isWifiEnabled;
+
+    [ObservableProperty]
+    private string wifiSsid = string.Empty;
+
+    [ObservableProperty]
+    private string wifiSecurityType = "WPA2-Enterprise";
+
+    public NetworkSettings BuildSettings()
+    {
+        return new NetworkSettings
+        {
+            Dot1x = new Dot1xSettings
+            {
+                IsEnabled = IsDot1xEnabled,
+                CertificatePath = IsDot1xEnabled && !string.IsNullOrWhiteSpace(CertificatePath)
+                    ? CertificatePath.Trim()
+                    : null
+            },
+            Wifi = new WifiSettings
+            {
+                IsEnabled = IsWifiEnabled,
+                Ssid = IsWifiEnabled && !string.IsNullOrWhiteSpace(WifiSsid)
+                    ? WifiSsid.Trim()
+                    : null,
+                SecurityType = IsWifiEnabled && !string.IsNullOrWhiteSpace(WifiSecurityType)
+                    ? WifiSecurityType.Trim()
+                    : null
+            }
+        };
+    }
+
+    public void ApplySettings(NetworkSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        IsDot1xEnabled = settings.Dot1x.IsEnabled;
+        CertificatePath = settings.Dot1x.CertificatePath ?? string.Empty;
+        IsWifiEnabled = settings.Wifi.IsEnabled;
+        WifiSsid = settings.Wifi.Ssid ?? string.Empty;
+        WifiSecurityType = string.IsNullOrWhiteSpace(settings.Wifi.SecurityType)
+            ? "WPA2-Enterprise"
+            : settings.Wifi.SecurityType;
+    }
+}

--- a/src/Foundry/ViewModels/SelectableLanguageOptionViewModel.cs
+++ b/src/Foundry/ViewModels/SelectableLanguageOptionViewModel.cs
@@ -1,0 +1,19 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Foundry.Models.Configuration;
+
+namespace Foundry.ViewModels;
+
+public partial class SelectableLanguageOptionViewModel : ObservableObject
+{
+    public SelectableLanguageOptionViewModel(LanguageRegistryEntry language)
+    {
+        Language = language;
+    }
+
+    public LanguageRegistryEntry Language { get; }
+    public string Code => Language.Code;
+    public string DisplayName => Language.DisplayName;
+
+    [ObservableProperty]
+    private bool isSelected;
+}

--- a/src/Foundry/Views/CustomizationSettingsView.xaml
+++ b/src/Foundry/Views/CustomizationSettingsView.xaml
@@ -1,0 +1,101 @@
+<UserControl
+    x:Class="Foundry.Views.CustomizationSettingsView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel>
+        <TextBlock
+            Margin="0,0,0,8"
+            Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+            Style="{StaticResource TitleTextBlockStyle}"
+            Text="{Binding DataContext.Strings[ExpertSectionCustomization], RelativeSource={RelativeSource AncestorType=Window}}" />
+        <Separator Margin="0,0,0,12" Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
+
+        <Border
+            Padding="12"
+            Margin="0,0,0,16"
+            BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+            BorderThickness="1"
+            CornerRadius="8">
+            <StackPanel>
+                <CheckBox
+                    Margin="0,0,0,12"
+                    Content="{Binding DataContext.Strings[MachineNamingEnableLabel], RelativeSource={RelativeSource AncestorType=Window}}"
+                    IsChecked="{Binding IsMachineNamingEnabled}" />
+
+                <Grid IsEnabled="{Binding IsMachineNamingEnabled}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="160" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        Margin="0,0,8,8"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{Binding DataContext.Strings[MachineNamingPrefixLabel], RelativeSource={RelativeSource AncestorType=Window}}" />
+                    <TextBox
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        Margin="0,0,0,8"
+                        Text="{Binding MachineNamePrefix, UpdateSourceTrigger=PropertyChanged}" />
+
+                    <CheckBox
+                        Grid.Row="1"
+                        Grid.ColumnSpan="2"
+                        Margin="0,0,0,8"
+                        Content="{Binding DataContext.Strings[MachineNamingAutoGenerateLabel], RelativeSource={RelativeSource AncestorType=Window}}"
+                        IsChecked="{Binding MachineNameAutoGenerate}" />
+
+                    <CheckBox
+                        Grid.Row="2"
+                        Grid.ColumnSpan="2"
+                        Content="{Binding DataContext.Strings[MachineNamingAllowManualSuffixLabel], RelativeSource={RelativeSource AncestorType=Window}}"
+                        IsChecked="{Binding AllowManualSuffixEdit}" />
+                </Grid>
+            </StackPanel>
+        </Border>
+
+        <Expander IsEnabled="False">
+            <Expander.Header>
+                <TextBlock
+                    Style="{StaticResource BodyStrongTextBlockStyle}"
+                    Text="{Binding DataContext.Strings[CustomizationAutopilotPlaceholder], RelativeSource={RelativeSource AncestorType=Window}}" />
+            </Expander.Header>
+            <TextBlock
+                Margin="0,12,0,0"
+                Style="{StaticResource CaptionTextBlockStyle}"
+                Text="{Binding DataContext.Strings[ComingLaterLabel], RelativeSource={RelativeSource AncestorType=Window}}" />
+        </Expander>
+
+        <Expander Margin="0,12,0,0" IsEnabled="False">
+            <Expander.Header>
+                <TextBlock
+                    Style="{StaticResource BodyStrongTextBlockStyle}"
+                    Text="{Binding DataContext.Strings[CustomizationAppxPlaceholder], RelativeSource={RelativeSource AncestorType=Window}}" />
+            </Expander.Header>
+            <TextBlock
+                Margin="0,12,0,0"
+                Style="{StaticResource CaptionTextBlockStyle}"
+                Text="{Binding DataContext.Strings[ComingLaterLabel], RelativeSource={RelativeSource AncestorType=Window}}" />
+        </Expander>
+
+        <Expander Margin="0,12,0,0" IsEnabled="False">
+            <Expander.Header>
+                <TextBlock
+                    Style="{StaticResource BodyStrongTextBlockStyle}"
+                    Text="{Binding DataContext.Strings[CustomizationDeployConfigPlaceholder], RelativeSource={RelativeSource AncestorType=Window}}" />
+            </Expander.Header>
+            <TextBlock
+                Margin="0,12,0,0"
+                Style="{StaticResource CaptionTextBlockStyle}"
+                Text="{Binding DataContext.Strings[ComingLaterLabel], RelativeSource={RelativeSource AncestorType=Window}}" />
+        </Expander>
+    </StackPanel>
+</UserControl>

--- a/src/Foundry/Views/CustomizationSettingsView.xaml.cs
+++ b/src/Foundry/Views/CustomizationSettingsView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Foundry.Views;
+
+public partial class CustomizationSettingsView : UserControl
+{
+    public CustomizationSettingsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Foundry/Views/GeneralSettingsView.xaml
+++ b/src/Foundry/Views/GeneralSettingsView.xaml
@@ -1,0 +1,269 @@
+<UserControl
+    x:Class="Foundry.Views.GeneralSettingsView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <StackPanel>
+        <TextBlock
+            Margin="0,0,0,8"
+            Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+            Style="{StaticResource TitleTextBlockStyle}"
+            Text="{Binding Strings[StandardConfigurationSectionTitle]}" />
+        <Separator Margin="0,0,0,12" Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
+
+        <Grid Margin="0,0,0,12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="140" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock
+                Grid.Column="0"
+                Margin="0,0,8,0"
+                VerticalAlignment="Center"
+                Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                Style="{StaticResource BodyStrongTextBlockStyle}"
+                Text="{Binding Strings[IsoOutputPathLabel]}" />
+
+            <TextBox
+                Grid.Column="1"
+                Margin="0,0,8,0"
+                IsReadOnly="True"
+                Text="{Binding IsoOutputPath, Mode=OneWay}" />
+
+            <Button
+                Grid.Column="2"
+                Width="130"
+                Command="{Binding BrowseIsoOutputPathCommand}"
+                Content="{Binding Strings[IsoBrowseButton]}" />
+        </Grid>
+
+        <Grid Margin="0,0,0,12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="140" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock
+                Grid.Column="0"
+                Margin="0,0,8,0"
+                VerticalAlignment="Center"
+                Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                Style="{StaticResource BodyStrongTextBlockStyle}"
+                Text="{Binding Strings[UsbSectionTitle]}" />
+
+            <ComboBox
+                Grid.Column="1"
+                Margin="0,0,8,0"
+                DisplayMemberPath="DisplayLabel"
+                ItemsSource="{Binding UsbDiskCandidates}"
+                SelectedItem="{Binding SelectedUsbDiskCandidate}" />
+
+            <Button
+                Grid.Column="2"
+                Width="130"
+                Command="{Binding RefreshUsbCandidatesCommand}"
+                Content="{Binding Strings[UsbRefreshDisks]}"
+                IsEnabled="{Binding IsRefreshingUsbCandidates, Converter={StaticResource InverseBooleanConverter}}" />
+        </Grid>
+
+        <Grid Margin="0,0,0,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="140" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock
+                Grid.Column="0"
+                Margin="0,0,8,0"
+                VerticalAlignment="Center"
+                Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                Style="{StaticResource BodyStrongTextBlockStyle}"
+                Text="{Binding Strings[ArchitectureLabel]}" />
+
+            <ComboBox
+                Grid.Column="1"
+                ItemsSource="{Binding AvailableArchitectures}"
+                SelectedItem="{Binding SelectedArchitecture}" />
+        </Grid>
+
+        <Grid Margin="0,0,0,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="140" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock
+                Grid.Column="0"
+                Margin="0,0,8,0"
+                VerticalAlignment="Center"
+                Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                Style="{StaticResource BodyStrongTextBlockStyle}"
+                Text="{Binding Strings[WinPeLanguageLabel]}" />
+
+            <ComboBox
+                Grid.Column="1"
+                MinWidth="220"
+                DisplayMemberPath="DisplayName"
+                ItemsSource="{Binding AvailableWinPeLanguages}"
+                SelectedItem="{Binding SelectedWinPeLanguage}" />
+        </Grid>
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="140" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock
+                Grid.Column="0"
+                Margin="0,0,8,0"
+                VerticalAlignment="Center"
+                Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                Style="{StaticResource BodyStrongTextBlockStyle}"
+                Text="{Binding Strings[WinPeDriversLabel]}" />
+
+            <StackPanel Grid.Column="1" Orientation="Horizontal">
+                <CheckBox
+                    Margin="0,0,16,0"
+                    Content="{Binding Strings[DriverDellLabel]}"
+                    IsChecked="{Binding IncludeDellDrivers}" />
+                <CheckBox Content="{Binding Strings[DriverHpLabel]}" IsChecked="{Binding IncludeHpDrivers}" />
+            </StackPanel>
+        </Grid>
+
+        <Expander
+            Margin="0,24,0,0"
+            IsExpanded="{Binding IsAdvancedOptionsExpanded}">
+            <Expander.Header>
+                <TextBlock
+                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                    Style="{StaticResource BodyStrongTextBlockStyle}"
+                    Text="{Binding Strings[AdvancedOptionsHeader]}" />
+            </Expander.Header>
+
+            <StackPanel Margin="0,12,0,0">
+                <CheckBox
+                    Margin="0,0,0,12"
+                    Content="{Binding Strings[SignatureCa2023Label]}"
+                    IsChecked="{Binding UseCa2023}" />
+
+                <Grid Margin="0,0,0,8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="140" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock
+                        Grid.Column="0"
+                        Margin="0,0,8,0"
+                        VerticalAlignment="Center"
+                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{Binding Strings[UsbPartitionStyleLabel]}" />
+
+                    <ComboBox
+                        Grid.Column="1"
+                        ItemsSource="{Binding AvailablePartitionStyles}"
+                        SelectedItem="{Binding SelectedPartitionStyle}">
+                        <ComboBox.ItemContainerStyle>
+                            <Style TargetType="ComboBoxItem">
+                                <Setter Property="IsEnabled">
+                                    <Setter.Value>
+                                        <MultiBinding Converter="{StaticResource PartitionStyleAvailabilityConverter}">
+                                            <Binding Path="SelectedArchitecture" />
+                                            <Binding />
+                                        </MultiBinding>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </ComboBox.ItemContainerStyle>
+                    </ComboBox>
+                </Grid>
+
+                <TextBlock
+                    Margin="0,0,0,12"
+                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{Binding UsbPartitionStyleArm64Hint}"
+                    Visibility="{Binding ShowUsbPartitionStyleArm64Hint, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                <Grid Margin="0,0,0,12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="140" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock
+                        Grid.Column="0"
+                        Margin="0,0,8,0"
+                        VerticalAlignment="Center"
+                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{Binding Strings[UsbFormatModeLabel]}" />
+
+                    <ComboBox
+                        Grid.Column="1"
+                        DisplayMemberPath="DisplayName"
+                        ItemsSource="{Binding AvailableUsbFormatModes}"
+                        SelectedValue="{Binding SelectedUsbFormatMode}"
+                        SelectedValuePath="Mode" />
+                </Grid>
+
+                <Grid Margin="0,0,0,12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="140" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock
+                        Grid.Column="0"
+                        Margin="0,0,8,0"
+                        VerticalAlignment="Center"
+                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{Binding Strings[CustomDriverPathLabel]}" />
+
+                    <TextBox
+                        Grid.Column="1"
+                        Margin="0,0,8,0"
+                        Text="{Binding CustomDriverDirectoryPath, UpdateSourceTrigger=PropertyChanged}" />
+
+                    <Button
+                        Grid.Column="2"
+                        Command="{Binding BrowseCustomDriverDirectoryCommand}"
+                        Content="{Binding Strings[BrowseFolderButton]}" />
+                </Grid>
+
+                <CheckBox
+                    Margin="0,0,0,12"
+                    Content="{Binding Strings[PcaRemediationLabel]}"
+                    IsChecked="{Binding EnablePcaRemediation}" />
+
+                <Grid IsEnabled="{Binding EnablePcaRemediation}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="140" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock
+                        Grid.Column="0"
+                        Margin="0,0,8,0"
+                        VerticalAlignment="Center"
+                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{Binding Strings[PcaRemediationScriptLabel]}" />
+
+                    <TextBox
+                        Grid.Column="1"
+                        Text="{Binding PcaRemediationScriptPath, UpdateSourceTrigger=PropertyChanged}" />
+                </Grid>
+            </StackPanel>
+        </Expander>
+    </StackPanel>
+</UserControl>

--- a/src/Foundry/Views/GeneralSettingsView.xaml
+++ b/src/Foundry/Views/GeneralSettingsView.xaml
@@ -171,7 +171,9 @@
                         ItemsSource="{Binding AvailablePartitionStyles}"
                         SelectedItem="{Binding SelectedPartitionStyle}">
                         <ComboBox.ItemContainerStyle>
-                            <Style TargetType="ComboBoxItem">
+                            <Style
+                                BasedOn="{StaticResource {x:Type ComboBoxItem}}"
+                                TargetType="ComboBoxItem">
                                 <Setter Property="IsEnabled">
                                     <Setter.Value>
                                         <MultiBinding Converter="{StaticResource PartitionStyleAvailabilityConverter}">

--- a/src/Foundry/Views/GeneralSettingsView.xaml
+++ b/src/Foundry/Views/GeneralSettingsView.xaml
@@ -239,30 +239,6 @@
                         Command="{Binding BrowseCustomDriverDirectoryCommand}"
                         Content="{Binding Strings[BrowseFolderButton]}" />
                 </Grid>
-
-                <CheckBox
-                    Margin="0,0,0,12"
-                    Content="{Binding Strings[PcaRemediationLabel]}"
-                    IsChecked="{Binding EnablePcaRemediation}" />
-
-                <Grid IsEnabled="{Binding EnablePcaRemediation}">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="140" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock
-                        Grid.Column="0"
-                        Margin="0,0,8,0"
-                        VerticalAlignment="Center"
-                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding Strings[PcaRemediationScriptLabel]}" />
-
-                    <TextBox
-                        Grid.Column="1"
-                        Text="{Binding PcaRemediationScriptPath, UpdateSourceTrigger=PropertyChanged}" />
-                </Grid>
             </StackPanel>
         </Expander>
     </StackPanel>

--- a/src/Foundry/Views/GeneralSettingsView.xaml.cs
+++ b/src/Foundry/Views/GeneralSettingsView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Foundry.Views;
+
+public partial class GeneralSettingsView : UserControl
+{
+    public GeneralSettingsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Foundry/Views/LocalizationSettingsView.xaml
+++ b/src/Foundry/Views/LocalizationSettingsView.xaml
@@ -1,0 +1,56 @@
+<UserControl
+    x:Class="Foundry.Views.LocalizationSettingsView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel>
+        <TextBlock
+            Margin="0,0,0,8"
+            Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+            Style="{StaticResource TitleTextBlockStyle}"
+            Text="{Binding DataContext.Strings[ExpertSectionLocalization], RelativeSource={RelativeSource AncestorType=Window}}" />
+        <Separator Margin="0,0,0,12" Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
+
+        <TextBlock
+            Margin="0,0,0,8"
+            Style="{StaticResource BodyStrongTextBlockStyle}"
+            Text="{Binding DataContext.Strings[LocalizationVisibleLanguagesLabel], RelativeSource={RelativeSource AncestorType=Window}}" />
+
+        <Border
+            Padding="12"
+            BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+            BorderThickness="1"
+            CornerRadius="8">
+            <ItemsControl ItemsSource="{Binding AvailableLanguages}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <CheckBox Content="{Binding DisplayName}" IsChecked="{Binding IsSelected}" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </Border>
+
+        <Grid Margin="0,16,0,12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="180" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock
+                Grid.Column="0"
+                Margin="0,0,8,0"
+                VerticalAlignment="Center"
+                Style="{StaticResource BodyStrongTextBlockStyle}"
+                Text="{Binding DataContext.Strings[LocalizationDefaultOverrideLabel], RelativeSource={RelativeSource AncestorType=Window}}" />
+            <ComboBox
+                Grid.Column="1"
+                DisplayMemberPath="DisplayName"
+                ItemsSource="{Binding VisibleLanguages}"
+                SelectedValue="{Binding SelectedDefaultLanguageCode}"
+                SelectedValuePath="Code" />
+        </Grid>
+
+        <CheckBox
+            Content="{Binding DataContext.Strings[LocalizationForceSingleLabel], RelativeSource={RelativeSource AncestorType=Window}}"
+            IsChecked="{Binding ForceSingleVisibleLanguage}" />
+    </StackPanel>
+</UserControl>

--- a/src/Foundry/Views/LocalizationSettingsView.xaml.cs
+++ b/src/Foundry/Views/LocalizationSettingsView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Foundry.Views;
+
+public partial class LocalizationSettingsView : UserControl
+{
+    public LocalizationSettingsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Foundry/Views/NetworkSettingsView.xaml
+++ b/src/Foundry/Views/NetworkSettingsView.xaml
@@ -1,0 +1,83 @@
+<UserControl
+    x:Class="Foundry.Views.NetworkSettingsView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel>
+        <TextBlock
+            Margin="0,0,0,8"
+            Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+            Style="{StaticResource TitleTextBlockStyle}"
+            Text="{Binding DataContext.Strings[ExpertSectionNetwork], RelativeSource={RelativeSource AncestorType=Window}}" />
+        <Separator Margin="0,0,0,12" Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
+
+        <CheckBox
+            Margin="0,0,0,12"
+            Content="{Binding DataContext.Strings[Dot1xEnableLabel], RelativeSource={RelativeSource AncestorType=Window}}"
+            IsChecked="{Binding IsDot1xEnabled}" />
+
+        <Grid Margin="0,0,0,24" IsEnabled="{Binding IsDot1xEnabled}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="160" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock
+                Grid.Column="0"
+                Margin="0,0,8,0"
+                VerticalAlignment="Center"
+                Style="{StaticResource BodyStrongTextBlockStyle}"
+                Text="{Binding DataContext.Strings[Dot1xCertificateLabel], RelativeSource={RelativeSource AncestorType=Window}}" />
+            <TextBox
+                Grid.Column="1"
+                Margin="0,0,8,0"
+                Text="{Binding CertificatePath, UpdateSourceTrigger=PropertyChanged}" />
+            <Button
+                Grid.Column="2"
+                Command="{Binding DataContext.BrowseDot1xCertificateCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                Content="{Binding DataContext.Strings[BrowseFileButton], RelativeSource={RelativeSource AncestorType=Window}}" />
+        </Grid>
+
+        <CheckBox
+            Margin="0,0,0,12"
+            Content="{Binding DataContext.Strings[WifiEnableLabel], RelativeSource={RelativeSource AncestorType=Window}}"
+            IsChecked="{Binding IsWifiEnabled}" />
+
+        <Grid IsEnabled="{Binding IsWifiEnabled}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="160" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <TextBlock
+                Grid.Row="0"
+                Grid.Column="0"
+                Margin="0,0,8,8"
+                VerticalAlignment="Center"
+                Style="{StaticResource BodyStrongTextBlockStyle}"
+                Text="{Binding DataContext.Strings[WifiSsidLabel], RelativeSource={RelativeSource AncestorType=Window}}" />
+            <TextBox
+                Grid.Row="0"
+                Grid.Column="1"
+                Margin="0,0,0,8"
+                Text="{Binding WifiSsid, UpdateSourceTrigger=PropertyChanged}" />
+
+            <TextBlock
+                Grid.Row="1"
+                Grid.Column="0"
+                Margin="0,0,8,0"
+                VerticalAlignment="Center"
+                Style="{StaticResource BodyStrongTextBlockStyle}"
+                Text="{Binding DataContext.Strings[WifiSecurityTypeLabel], RelativeSource={RelativeSource AncestorType=Window}}" />
+            <ComboBox
+                Grid.Row="1"
+                Grid.Column="1"
+                ItemsSource="{Binding AvailableSecurityTypes}"
+                SelectedItem="{Binding WifiSecurityType}" />
+        </Grid>
+    </StackPanel>
+</UserControl>

--- a/src/Foundry/Views/NetworkSettingsView.xaml.cs
+++ b/src/Foundry/Views/NetworkSettingsView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Foundry.Views;
+
+public partial class NetworkSettingsView : UserControl
+{
+    public NetworkSettingsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/task_plan.md
+++ b/task_plan.md
@@ -1,0 +1,86 @@
+# Task Plan: Foundry Window Standard and Expert Mode Architecture
+
+## Goal
+Define the product and UI architecture for a Foundry window that supports `Simple/Standard` and `Expert` modes, advanced grouped settings, import/export flows, and a modular configuration model that can later drive `foundry deploy`.
+
+## Current Phase
+Phase 2
+
+## Phases
+### Phase 1: Requirements & Discovery
+- [x] Understand user intent
+- [x] Identify constraints and requirements
+- [x] Inspect current Foundry window implementation
+- [x] Document findings in findings.md
+- [x] Collect open product questions for the user
+- **Status:** complete
+
+### Phase 2: Product Structure Proposal
+- [x] Define mode-switch behavior
+- [x] Define advanced navigation/grouping model
+- [x] Define parent/child option enablement rules
+- [x] Define import/export and config file strategy
+- [x] Resolve remaining behavior gaps and inconsistencies
+- [x] Produce the target UX architecture for Standard and Expert
+- **Status:** complete
+
+### Phase 3: Technical Direction
+- [x] Define the canonical config model and expert-only sections
+- [x] Define how Standard maps onto the canonical config model
+- [x] Define the generated deploy-consumable contract
+- [x] Identify extensibility points for future advanced options
+- [x] Identify persistence/model constraints
+- **Status:** complete
+
+### Phase 4: UI and Integration Mapping
+- [x] Map the proposal onto `MainWindow.xaml` and `MainWindowViewModel.cs`
+- [x] Decide what should become reusable view models or grouped section models
+- [x] Define how generated config reaches `X:\Foundry\Config\foundry.deploy.config.json`
+- [x] Capture any dependencies on `Foundry.Deploy`
+- **Status:** complete
+
+### Phase 5: Validation and Delivery
+- [ ] Verify the proposal against current implementation constraints
+- [ ] Capture unresolved decisions
+- [ ] Prepare implementation-ready next steps
+- [ ] Deliver the updated architecture summary to the user
+- **Status:** in_progress
+
+## Key Questions
+1. What is the exact startup/application order for catalog-dependent expert config values inside `Foundry.Deploy`?
+2. What should the embedded Expert localization registry schema look like in its first version?
+3. Which future Expert groups should be scheduled first after `MachineNaming`?
+
+## Decisions Made
+| Decision | Rationale |
+|----------|-----------|
+| Use the `planning-with-files` workflow for this turn | The task is multi-step and discovery-heavy |
+| Start with discovery and requirements questions before implementation | The user explicitly asked to brainstorm and clarify needs first |
+| Avoid proposing subprojects or test projects | Explicit user constraint |
+| Use Context7 against official WPF docs for framework grounding | Explicit user request to use Context7 |
+| Base the future expert mode on a stable configuration contract rather than the current flat window state | Needed for import/export and deploy compatibility |
+| Treat `Simple` and `Standard` as the same mode | User decision |
+| Keep the current Standard values visible in Expert under a first `General` category | User decision |
+| Put mode switching in a new top-menu `Mode` menu | Best fit for an app-wide shell change and accepted by the user |
+| Use File menu actions for import/export | User decision |
+| Keep full expert config export separate from deploy-consumable export | User decision |
+| Auto-generate `X:\\Foundry\\Config\\foundry.deploy.config.json` from Expert selections | User decision refined by codebase path conventions |
+| Do not inject `foundry.deploy.config.json` when building media in Standard mode | Standard mode should ignore expert-only settings and fresh media builds recreate the boot image from scratch |
+| `Foundry.Deploy` should auto-load the generated config silently, without any UI banner | User decision; keep startup friction-free and rely on logging instead of visible notification |
+| Keep expert values in memory when switching back to Standard | User decision |
+| Ignore unknown JSON fields on import, while validating known required values | Best forward-compatible behavior per official .NET docs |
+| Use a built-in curated language list for Expert localization, then validate/intersect it against deploy reality | Stable UX without binding the editor directly to live catalog data |
+| Strip disabled child values from exported JSON but preserve them in memory | Clean export and better editing UX |
+| Load the generated deploy config in `Foundry.Deploy` through a dedicated optional loader service rather than `Program.cs` | Keeps bootstrap clean and puts mapping logic near deploy state |
+| Store the Expert localization registry as an embedded JSON resource in `Foundry` | Product data should stay deterministic, offline, and easier to maintain than code constants |
+| Persist only `MachineNaming` in `Customization` for v1, with `Autopilot`, `APPX removal`, and `Custom deploy config` as UI-only placeholders | Avoids premature schema expansion while still showing the product direction |
+
+## Errors Encountered
+| Error | Attempt | Resolution |
+|-------|---------|------------|
+| `rg.exe` could not start with access denied in this environment | 1 | Switched to PowerShell-based file search |
+
+## Notes
+- Keep the solution modular so new expert sections/options can be added without reworking the window shell.
+- Keep proposals compatible with the existing top menu the user wants to preserve.
+- The implementation-ready draft now exists; remaining work is validation against actual code edits and final implementation sequencing.


### PR DESCRIPTION
This pull request establishes the groundwork for supporting Standard and Expert configuration modes in the Foundry project, focusing on requirements gathering, technical planning, and initial code changes for future deploy-side configuration extensibility. It introduces detailed planning and progress documentation, updates the deploy UI for future expert-mode integration, and adds initial deploy configuration models for customization and localization.

The most important changes are:

**Documentation and Planning**

* Added `findings.md` and `progress.md` files that capture requirements, research findings, technical decisions, architecture drafts, implementation order, and session-by-session progress logs. These documents will guide the implementation of Standard/Expert modes, import/export, and deploy integration. [[1]](diffhunk://#diff-5be547acff72c324b51d036785c5be0a125cfbbfc0f307798ccd3faeadda3a66R1-R273) [[2]](diffhunk://#diff-22c2a3755137d3855db905740872b5b57673166f657825f7b3b97046867d51e0R1-R89)

**Deploy UI Preparation**

* Updated `MainWindow.xaml` in `Foundry.Deploy` to bind the computer name textbox's read-only state and the language selection combo box's enabled state to new view model properties, paving the way for expert-mode-driven UI behavior. [[1]](diffhunk://#diff-1de692dab463f08fa5b6b8fa263c60442df134b4dff2cc294ca99a75cd864530R120) [[2]](diffhunk://#diff-1de692dab463f08fa5b6b8fa263c60442df134b4dff2cc294ca99a75cd864530R228)
* Updated event handlers in `MainWindow.xaml.cs` to respect the read-only state for the computer name textbox, preventing editing or pasting when the field is locked by configuration. [[1]](diffhunk://#diff-0cb9be3c4f0a1f832c2a0dd43cd860f5f4576e1e6c2c7e9f01b99fe32666ab1bR33-R38) [[2]](diffhunk://#diff-0cb9be3c4f0a1f832c2a0dd43cd860f5f4576e1e6c2c7e9f01b99fe32666ab1bR53-R58)

**Deploy Configuration Models**

* Added new configuration models: `DeployCustomizationSettings` and `DeployLocalizationSettings` in `Foundry.Deploy.Models.Configuration`. These records will represent customization and localization settings (such as machine naming and language visibility/selection) as part of the upcoming expert deploy configuration contract. [[1]](diffhunk://#diff-776a3f4fba2dc1c8068c799266d4039b01cf0d44694eace03bc5972939f7c6ccR1-R6) [[2]](diffhunk://#diff-b53e19dee080cbd9a3c3bfbab5aa2a4286f5af63ec0465915e37aae1c7e62a39R1-R8)