### PR TITLE
Release deployment log sessions before cleanup

### DIFF
--- a/src/Foundry.Deploy/Services/Deployment/DeploymentStepExecutionContext.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentStepExecutionContext.cs
@@ -136,19 +136,24 @@ public sealed class DeploymentStepExecutionContext
         string targetFoundryRoot,
         CancellationToken cancellationToken = default)
     {
+        DeploymentLogSession previousSession = LogSession;
         DeploymentLogSession rebound = _deploymentLogService.Initialize(targetFoundryRoot);
-        CopyDirectoryContents(LogSession.LogsDirectoryPath, rebound.LogsDirectoryPath);
-        CopyDirectoryContents(LogSession.StateDirectoryPath, rebound.StateDirectoryPath);
+        CopyDirectoryContents(previousSession.LogsDirectoryPath, rebound.LogsDirectoryPath);
+        CopyDirectoryContents(previousSession.StateDirectoryPath, rebound.StateDirectoryPath);
 
         await _deploymentLogService
             .AppendAsync(
                 rebound,
                 DeploymentLogLevel.Info,
-                $"Log session transferred from '{LogSession.RootPath}' to '{targetFoundryRoot}'.",
+                $"Log session transferred from '{previousSession.RootPath}' to '{targetFoundryRoot}'.",
                 cancellationToken)
             .ConfigureAwait(false);
 
         LogSession = rebound;
+        if (!previousSession.LogFilePath.Equals(rebound.LogFilePath, StringComparison.OrdinalIgnoreCase))
+        {
+            _deploymentLogService.Release(previousSession);
+        }
     }
 
     public async Task<(TargetDiskInfo? SelectedDisk, DeploymentStepResult? Failure)> TryGetValidatedTargetDiskAsync(

--- a/src/Foundry.Deploy/Services/Logging/DeploymentLogService.cs
+++ b/src/Foundry.Deploy/Services/Logging/DeploymentLogService.cs
@@ -67,6 +67,16 @@ public sealed class DeploymentLogService : IDeploymentLogService, IDisposable
         await File.WriteAllTextAsync(session.StateFilePath, json, cancellationToken).ConfigureAwait(false);
     }
 
+    public void Release(DeploymentLogSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        if (_sessionLoggers.TryRemove(session.LogFilePath, out ILogger? logger))
+        {
+            (logger as IDisposable)?.Dispose();
+        }
+    }
+
     public void Dispose()
     {
         foreach (ILogger logger in _sessionLoggers.Values)

--- a/src/Foundry.Deploy/Services/Logging/IDeploymentLogService.cs
+++ b/src/Foundry.Deploy/Services/Logging/IDeploymentLogService.cs
@@ -5,4 +5,5 @@ public interface IDeploymentLogService
     DeploymentLogSession Initialize(string rootPath);
     Task AppendAsync(DeploymentLogSession session, DeploymentLogLevel level, string message, CancellationToken cancellationToken = default);
     Task SaveStateAsync<TState>(DeploymentLogSession session, TState state, CancellationToken cancellationToken = default);
+    void Release(DeploymentLogSession session);
 }


### PR DESCRIPTION
This pull request improves resource management for deployment log sessions by ensuring that previous log sessions are properly released and disposed of when rebinding to a new target. It introduces a new `Release` method in the log service, updates the interface, and refactors the log session rebinding logic to utilize this method.

Resource management improvements:

* Added a `Release` method to `IDeploymentLogService` and its implementation in `DeploymentLogService` to dispose of loggers and remove them from the internal session logger dictionary. [[1]](diffhunk://#diff-d0d43e429efd1dd927011884440dabae980f4ab20c8aa7c736b8844390fdfa3fR8) [[2]](diffhunk://#diff-655904483d3c73b9aee248a487f272d342aaa9db06b64c37ea535d5f58cab5adR70-R79)
* Updated `RebindLogSessionToTargetAsync` in `DeploymentStepExecutionContext` to call the new `Release` method on the previous log session if the log file paths differ, ensuring proper cleanup of resources.