### PR TITLE
Remove auto-select toggle for OEM driver pack

### DIFF
--- a/src/Foundry.Deploy/MainWindow.xaml
+++ b/src/Foundry.Deploy/MainWindow.xaml
@@ -161,9 +161,6 @@
                                         <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="Firmware: Microsoft Update Catalog update enabled." />
                                     </CheckBox>
                                 </StackPanel>
-                                <CheckBox Margin="0,12,0,0" IsChecked="{Binding DriverPackSelection.AutoSelectDriverPackWhenEmpty}">
-                                    <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="Auto-select OEM driver pack from detected hardware (fallback to Microsoft Update Catalog)." />
-                                </CheckBox>
                                 <CheckBox Margin="0,8,0,0" IsChecked="{Binding UseFullAutopilot}">
                                     <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="Autopilot: Full workflow enabled (V1 scope)." />
                                 </CheckBox>

--- a/src/Foundry.Deploy/ViewModels/DriverPackSelectionViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DriverPackSelectionViewModel.cs
@@ -52,9 +52,6 @@ public sealed partial class DriverPackSelectionViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(SelectedDriverPackSelectionDisplay))]
     private string selectedDriverPackVersion = string.Empty;
 
-    [ObservableProperty]
-    private bool autoSelectDriverPackWhenEmpty = true;
-
     public ObservableCollection<DriverPackCatalogItem> DriverPacks { get; } = [];
 
     public ObservableCollection<DriverPackOptionItem> DriverPackOptions { get; } = [];
@@ -155,11 +152,6 @@ public sealed partial class DriverPackSelectionViewModel : ObservableObject
     partial void OnSelectedDriverPackVersionChanged(string value)
     {
         NotifyDriverPackSelectionStateChanged();
-    }
-
-    partial void OnAutoSelectDriverPackWhenEmptyChanged(bool value)
-    {
-        RefreshDriverPackOptions();
     }
 
     public DriverPackCatalogItem? ResolveEffectiveDriverPackSelection()
@@ -452,11 +444,6 @@ public sealed partial class DriverPackSelectionViewModel : ObservableObject
         if (options.Count == 0)
         {
             return null;
-        }
-
-        if (!AutoSelectDriverPackWhenEmpty)
-        {
-            return options.FirstOrDefault(option => option.Kind == DriverPackSelectionKind.None) ?? options[0];
         }
 
         if (_detectedHardware?.IsVirtualMachine == true)


### PR DESCRIPTION
This pull request removes the "Auto-select OEM driver pack from detected hardware" option from both the UI and the underlying view model logic. This simplifies the driver pack selection process by always attempting to auto-select the OEM driver pack when appropriate, without allowing users to disable this behavior.

**UI changes:**

* Removed the checkbox for "Auto-select OEM driver pack from detected hardware" from the `MainWindow.xaml` UI, so users can no longer toggle this setting.

**ViewModel and logic changes:**

* Removed the `AutoSelectDriverPackWhenEmpty` property and associated logic from `DriverPackSelectionViewModel`, including its backing field, property changed handler, and all conditional checks that depended on it. [[1]](diffhunk://#diff-de0ee1867274cfd238973a2496106787dfac1fc7899e1c63b376800fc737e68eL55-L57) [[2]](diffhunk://#diff-de0ee1867274cfd238973a2496106787dfac1fc7899e1c63b376800fc737e68eL160-L164) [[3]](diffhunk://#diff-de0ee1867274cfd238973a2496106787dfac1fc7899e1c63b376800fc737e68eL457-L461)