### PR TITLE
Remove cache root details from deployment UI

### DIFF
--- a/src/Foundry.Deploy/MainWindow.xaml
+++ b/src/Foundry.Deploy/MainWindow.xaml
@@ -101,18 +101,7 @@
                             <!--  Step 1 details and toggles  -->
                             <StackPanel Grid.Row="0">
                                 <StackPanel DataContext="{Binding Preparation}">
-                                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Cache Root" />
-                                    <TextBox
-                                        Margin="0,8,0,0"
-                                        IsReadOnly="True"
-                                        Text="{Binding CacheRootPath}" />
                                     <TextBlock
-                                        Margin="0,8,0,0"
-                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                        Style="{StaticResource CaptionTextBlockStyle}"
-                                        Text="Cache strategy is determined automatically from WinPE startup context." />
-                                    <TextBlock
-                                        Margin="0,12,0,0"
                                         Style="{StaticResource BodyStrongTextBlockStyle}"
                                         Text="Computer Name" />
                                     <TextBox
@@ -333,9 +322,6 @@
                                 Margin="0,0,0,12"
                                 Style="{StaticResource TitleTextBlockStyle}"
                                 Text="Deployment Summary" />
-
-                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Cache Root" />
-                            <TextBlock Margin="0,0,0,8" Text="{Binding Preparation.CacheRootPath}" />
 
                             <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Target Disk" />
                             <TextBlock Margin="0,0,0,8" Text="{Binding Preparation.SelectedTargetDisk.DisplayLabel, TargetNullValue=No disk selected}" />


### PR DESCRIPTION
This pull request makes minor UI adjustments to the deployment preparation and summary sections in `MainWindow.xaml`. The changes mainly involve removing references to the cache root information, streamlining the user interface.

UI cleanup and simplification:

* Removed the display of "Cache Root" label and its associated readonly textbox from the preparation section, as well as related explanatory text about cache strategy. (`src/Foundry.Deploy/MainWindow.xaml`)
* Removed the "Cache Root" label and its value from the deployment summary section. (`src/Foundry.Deploy/MainWindow.xaml`)