### PR TITLE
Add CI workflow and update README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (${{ matrix.platform }})
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - x64
+          - ARM64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore solution
+        run: dotnet restore .\src\Foundry.slnx --nologo
+
+      - name: Build solution
+        run: dotnet build .\src\Foundry.slnx -c Release -p:Platform=${{ matrix.platform }} -p:ContinuousIntegrationBuild=true --no-restore --nologo

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 <h1 align="center">Foundry</h1>
 
 <p align="center">
-  <a href="https://github.com/mchave3/Foundry/releases/latest"><img src="https://img.shields.io/github/v/release/mchave3/Foundry?display_name=tag&sort=semver&style=flat-square&label=Version&color=2563EB" alt="Latest release"></a>
-  <a href="https://github.com/mchave3/Foundry/releases"><img src="https://img.shields.io/github/downloads/mchave3/Foundry/total?style=flat-square&label=Downloads&color=CA8A04" alt="Downloads"></a>
-  <a href="https://github.com/mchave3/Foundry/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/mchave3/Foundry/release.yml?branch=main&style=flat-square&label=CI/CD" alt="Foundry release"></a>
+  <a href="https://github.com/mchave3/Foundry/releases/latest"><img src="https://img.shields.io/github/v/release/mchave3/Foundry?display_name=tag&sort=semver&style=flat-square&label=Version" alt="Latest release"></a>
+  <a href="https://github.com/mchave3/Foundry/releases"><img src="https://img.shields.io/github/downloads/mchave3/Foundry/total?style=flat-square&label=Downloads" alt="Total release asset downloads"></a>
+  <a href="https://github.com/mchave3/Foundry/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/mchave3/Foundry/ci.yml?branch=main&style=flat-square&label=CI" alt="Foundry CI"></a>
   <a href="https://github.com/mchave3/Foundry.Automation/actions/workflows/run-scripts-daily.yml"><img src="https://img.shields.io/github/actions/workflow/status/mchave3/Foundry.Automation/run-scripts-daily.yml?branch=main&style=flat-square&label=Catalog" alt="Foundry.Automation"></a>
-  <a href="https://github.com/mchave3/Foundry/blob/main/LICENSE"><img src="https://img.shields.io/github/license/mchave3/Foundry?style=flat-square&label=License&color=16A34A" alt="License"></a>
-  <img src="https://img.shields.io/badge/Windows-11-0078D6?style=flat-square" alt="Windows 11">
+  <a href="https://github.com/mchave3/Foundry/blob/main/LICENSE"><img src="https://img.shields.io/github/license/mchave3/Foundry?style=flat-square&label=License" alt="License"></a>
+  <img src="https://img.shields.io/badge/Windows-11-2563EB?style=flat-square" alt="Windows 11">
   <img src="https://img.shields.io/badge/Architecture-x64%20%2F%20ARM64-2563EB?style=flat-square" alt="Architecture x64 / ARM64">
-  <img src="https://img.shields.io/badge/.NET-10-512BD4?style=flat-square" alt=".NET 10">
+  <img src="https://img.shields.io/badge/.NET-10-2563EB?style=flat-square" alt=".NET 10">
 </p>
 
 <p align="center">


### PR DESCRIPTION
This pull request introduces a new continuous integration (CI) workflow for the project and updates the README badges to reflect these changes and improve clarity. The most significant updates are the addition of a new GitHub Actions workflow for building the project on multiple platforms and adjustments to the README's status badges.

**Continuous Integration Improvements:**

* Added a new `.github/workflows/ci.yml` workflow that builds the solution on both x64 and ARM64 platforms using the .NET 10 SDK, with steps for checkout, restore, and build. This workflow runs on pushes, pull requests, and manual dispatches, and includes concurrency controls.

**README and Badge Updates:**

* Updated the CI badge in `README.md` to reference the new `ci.yml` workflow and changed the label from "CI/CD" to "CI".
* Improved badge clarity by removing hardcoded colors, updating alt text, and making the Windows and .NET badges use a consistent color scheme.
* Updated the Downloads badge alt text for greater clarity.