### PR TITLE
Move WinPE and ADK staging to ProgramData

### DIFF
--- a/src/Foundry/Services/Adk/AdkService.cs
+++ b/src/Foundry/Services/Adk/AdkService.cs
@@ -1,5 +1,6 @@
 using Foundry.Services.Localization;
 using Foundry.Services.Operations;
+using Foundry.Services.WinPe;
 using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
 using System.Diagnostics;
@@ -552,7 +553,7 @@ public sealed class AdkService : IAdkService
     }
 
     /// <summary>
-    /// Ensures ADK and WinPE setup binaries are present in temp storage, downloading when required.
+    /// Ensures ADK and WinPE setup binaries are present in shared cache storage, downloading when required.
     /// </summary>
     private async Task EnsureInstallersDownloadedAsync(int progressStart, int progressEnd, bool forceDownload)
     {
@@ -561,15 +562,18 @@ public sealed class AdkService : IAdkService
             throw new ArgumentOutOfRangeException(nameof(progressEnd), "The end progress must be greater than or equal to the start progress.");
         }
 
-        var tempPath = Path.GetTempPath();
-        var adkInstallerPath = Path.Combine(tempPath, "adksetup.exe");
-        var winPeInstallerPath = Path.Combine(tempPath, "adkwinpesetup.exe");
+        string installerCacheDirectoryPath = WinPeDefaults.GetInstallerCacheDirectoryPath();
+        Directory.CreateDirectory(installerCacheDirectoryPath);
+
+        var adkInstallerPath = Path.Combine(installerCacheDirectoryPath, "adksetup.exe");
+        var winPeInstallerPath = Path.Combine(installerCacheDirectoryPath, "adkwinpesetup.exe");
         var midpoint = progressStart + ((progressEnd - progressStart) / 2);
         var adkInstallerName = L("AdkComponentInstaller");
         var winPeInstallerName = L("AdkComponentWinPeInstaller");
         _logger.LogInformation(
-            "Ensuring ADK installers are available. ForceDownload={ForceDownload}, AdkPath={AdkInstallerPath}, WinPePath={WinPeInstallerPath}",
+            "Ensuring ADK installers are available. ForceDownload={ForceDownload}, InstallerCacheDirectoryPath={InstallerCacheDirectoryPath}, AdkPath={AdkInstallerPath}, WinPePath={WinPeInstallerPath}",
             forceDownload,
+            installerCacheDirectoryPath,
             adkInstallerPath,
             winPeInstallerPath);
 

--- a/src/Foundry/Services/WinPe/MediaOutputService.cs
+++ b/src/Foundry/Services/WinPe/MediaOutputService.cs
@@ -83,7 +83,7 @@ internal sealed class MediaOutputService : IMediaOutputService
             return WinPeResult<IReadOnlyList<WinPeUsbDiskCandidate>>.Failure(tools.Error!);
         }
 
-        string work = Path.Combine(Path.GetTempPath(), "Foundry", "UsbQuery");
+        string work = WinPeDefaults.GetUsbQueryWorkingDirectoryPath();
         Directory.CreateDirectory(work);
         WinPeResult<IReadOnlyList<WinPeUsbDiskCandidate>> result =
             await _usbMediaService.GetUsbCandidatesAsync(tools.Value!, work, cancellationToken).ConfigureAwait(false);
@@ -119,6 +119,8 @@ internal sealed class MediaOutputService : IMediaOutputService
         }
 
         WinPeBuildArtifact? artifact = null;
+        string? isoWorkspacePath = null;
+        string? preparedIsoOutputPath = null;
         try
         {
             WinPeResult<WinPePreparedMediaWorkspace> preparedWorkspace = await PrepareWorkspaceAsync(
@@ -147,29 +149,36 @@ internal sealed class MediaOutputService : IMediaOutputService
             }
 
             artifact = preparedWorkspace.Value!.Artifact;
+            EnsureIsoOutputDirectoryExists(options.OutputIsoPath);
+            isoWorkspacePath = PrepareIsoWorkspacePath(artifact.WorkingDirectoryPath);
+            preparedIsoOutputPath = PrepareIsoOutputPath(options.OutputIsoPath);
 
             _operationProgressService.Report(82, "Creating ISO media.");
-            if (options.ForceOverwriteOutput && File.Exists(options.OutputIsoPath))
+            if (options.ForceOverwriteOutput && File.Exists(preparedIsoOutputPath))
             {
-                _logger.LogInformation("Deleting existing ISO before overwrite. OutputIsoPath={OutputIsoPath}", options.OutputIsoPath);
-                File.Delete(options.OutputIsoPath);
+                _logger.LogInformation("Deleting existing ISO before overwrite. OutputIsoPath={OutputIsoPath}", preparedIsoOutputPath);
+                File.Delete(preparedIsoOutputPath);
             }
 
-            string args = $"/ISO /F {WinPeProcessRunner.Quote(artifact.WorkingDirectoryPath)} {WinPeProcessRunner.Quote(options.OutputIsoPath)}{(preparedWorkspace.Value.UseBootEx ? " /bootex" : string.Empty)}";
+            string args = $"/ISO /F {WinPeProcessRunner.Quote(isoWorkspacePath)} {WinPeProcessRunner.Quote(preparedIsoOutputPath)}{(preparedWorkspace.Value.UseBootEx ? " /bootex" : string.Empty)}";
             _logger.LogInformation(
-                "Creating ISO media from prepared workspace. WorkingDirectoryPath={WorkingDirectoryPath}, OutputIsoPath={OutputIsoPath}, UseBootEx={UseBootEx}",
+                "Creating ISO media from prepared workspace. SourceWorkspacePath={SourceWorkspacePath}, IsoWorkspacePath={IsoWorkspacePath}, PreparedIsoOutputPath={PreparedIsoOutputPath}, RequestedOutputIsoPath={RequestedOutputIsoPath}, UseBootEx={UseBootEx}",
                 artifact.WorkingDirectoryPath,
+                isoWorkspacePath,
+                preparedIsoOutputPath,
                 options.OutputIsoPath,
                 preparedWorkspace.Value.UseBootEx);
             WinPeProcessExecution makeIso = await _processRunner.RunCmdScriptAsync(
                 preparedWorkspace.Value.Tools.MakeWinPeMediaPath,
                 args,
-                artifact.WorkingDirectoryPath,
+                isoWorkspacePath,
                 cancellationToken).ConfigureAwait(false);
-            if (!makeIso.IsSuccess || !File.Exists(options.OutputIsoPath))
+            if (!makeIso.IsSuccess || !File.Exists(preparedIsoOutputPath))
             {
                 return FailWithProgress(new WinPeDiagnostic(WinPeErrorCodes.IsoCreateFailed, "Failed to create ISO media.", makeIso.ToDiagnosticText()));
             }
+
+            FinalizeIsoOutput(preparedIsoOutputPath, options.OutputIsoPath);
 
             _logger.LogInformation("ISO media file created successfully. OutputIsoPath={OutputIsoPath}", options.OutputIsoPath);
             _operationProgressService.Complete("ISO creation completed.");
@@ -183,6 +192,8 @@ internal sealed class MediaOutputService : IMediaOutputService
         }
         finally
         {
+            CleanupPreparedIsoOutput(options.OutputIsoPath, preparedIsoOutputPath);
+            CleanupIsoWorkspace(artifact?.WorkingDirectoryPath, isoWorkspacePath);
             CleanupWorkspace(artifact, options.PreserveBuildWorkspace, "ISO");
         }
     }
@@ -387,6 +398,32 @@ internal sealed class MediaOutputService : IMediaOutputService
         }
     }
 
+    private void CleanupIsoWorkspace(string? sourceWorkspacePath, string? isoWorkspacePath)
+    {
+        if (string.IsNullOrWhiteSpace(sourceWorkspacePath) ||
+            string.IsNullOrWhiteSpace(isoWorkspacePath) ||
+            string.Equals(sourceWorkspacePath, isoWorkspacePath, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        TryDeleteDirectory(isoWorkspacePath);
+        _logger.LogDebug("ASCII-safe ISO workspace cleanup completed. WorkingDirectoryPath={WorkingDirectoryPath}", isoWorkspacePath);
+    }
+
+    private void CleanupPreparedIsoOutput(string requestedIsoOutputPath, string? preparedIsoOutputPath)
+    {
+        if (string.IsNullOrWhiteSpace(preparedIsoOutputPath) ||
+            string.Equals(requestedIsoOutputPath, preparedIsoOutputPath, StringComparison.OrdinalIgnoreCase) ||
+            !File.Exists(preparedIsoOutputPath))
+        {
+            return;
+        }
+
+        TryDeleteFile(preparedIsoOutputPath);
+        _logger.LogDebug("ASCII-safe prepared ISO output cleanup completed. OutputIsoPath={OutputIsoPath}", preparedIsoOutputPath);
+    }
+
     private static WinPeDiagnostic? ValidateIsoOptions(IsoOutputOptions? options)
     {
         if (options is null) return new WinPeDiagnostic(WinPeErrorCodes.ValidationFailed, "ISO options are required.");
@@ -432,6 +469,129 @@ internal sealed class MediaOutputService : IMediaOutputService
         catch
         {
             // Best-effort cleanup.
+        }
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private void EnsureIsoOutputDirectoryExists(string outputIsoPath)
+    {
+        string? outputDirectoryPath = Path.GetDirectoryName(outputIsoPath);
+        if (string.IsNullOrWhiteSpace(outputDirectoryPath))
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(outputDirectoryPath);
+    }
+
+    private string PrepareIsoOutputPath(string requestedOutputIsoPath)
+    {
+        if (!ContainsNonAscii(requestedOutputIsoPath))
+        {
+            return requestedOutputIsoPath;
+        }
+
+        string isoOutputRoot = WinPeDefaults.GetIsoOutputTempRootPath();
+        Directory.CreateDirectory(isoOutputRoot);
+
+        string fileName = Path.GetFileName(requestedOutputIsoPath);
+        string safeFileName = string.IsNullOrWhiteSpace(fileName)
+            ? $"foundry-winpe-{DateTime.UtcNow:yyyyMMdd_HHmmssfff}.iso"
+            : WinPeFileSystemHelper.SanitizePathSegment(fileName);
+        if (!safeFileName.EndsWith(".iso", StringComparison.OrdinalIgnoreCase))
+        {
+            safeFileName += ".iso";
+        }
+
+        string preparedIsoOutputPath = Path.Combine(isoOutputRoot, safeFileName);
+        _logger.LogInformation(
+            "Redirecting ISO creation to ASCII-safe output path. RequestedOutputIsoPath={RequestedOutputIsoPath}, PreparedIsoOutputPath={PreparedIsoOutputPath}",
+            requestedOutputIsoPath,
+            preparedIsoOutputPath);
+
+        return preparedIsoOutputPath;
+    }
+
+    private void FinalizeIsoOutput(string preparedIsoOutputPath, string requestedOutputIsoPath)
+    {
+        if (string.Equals(preparedIsoOutputPath, requestedOutputIsoPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        string? requestedOutputDirectoryPath = Path.GetDirectoryName(requestedOutputIsoPath);
+        if (!string.IsNullOrWhiteSpace(requestedOutputDirectoryPath))
+        {
+            Directory.CreateDirectory(requestedOutputDirectoryPath);
+        }
+
+        File.Copy(preparedIsoOutputPath, requestedOutputIsoPath, overwrite: true);
+        _logger.LogInformation(
+            "Copied prepared ISO from ASCII-safe output path to requested destination. PreparedIsoOutputPath={PreparedIsoOutputPath}, RequestedOutputIsoPath={RequestedOutputIsoPath}",
+            preparedIsoOutputPath,
+            requestedOutputIsoPath);
+    }
+
+    private string PrepareIsoWorkspacePath(string sourceWorkspacePath)
+    {
+        if (!ContainsNonAscii(sourceWorkspacePath))
+        {
+            return sourceWorkspacePath;
+        }
+
+        string isoWorkspaceRoot = WinPeDefaults.GetIsoWorkspaceRootPath();
+        string directoryName = $"{WinPeFileSystemHelper.SanitizePathSegment(Path.GetFileName(sourceWorkspacePath))}_{DateTime.UtcNow:yyyyMMdd_HHmmssfff}";
+        string isoWorkspacePath = Path.Combine(isoWorkspaceRoot, directoryName);
+
+        _logger.LogInformation(
+            "Mirroring WinPE workspace to ASCII-safe path for ISO creation. SourceWorkspacePath={SourceWorkspacePath}, IsoWorkspacePath={IsoWorkspacePath}",
+            sourceWorkspacePath,
+            isoWorkspacePath);
+
+        CopyDirectory(sourceWorkspacePath, isoWorkspacePath);
+        return isoWorkspacePath;
+    }
+
+    private static bool ContainsNonAscii(string value)
+    {
+        return value.Any(character => character > 127);
+    }
+
+    private static void CopyDirectory(string sourceDirectoryPath, string destinationDirectoryPath)
+    {
+        Directory.CreateDirectory(destinationDirectoryPath);
+
+        foreach (string directoryPath in Directory.EnumerateDirectories(sourceDirectoryPath, "*", SearchOption.AllDirectories))
+        {
+            string relativePath = Path.GetRelativePath(sourceDirectoryPath, directoryPath);
+            Directory.CreateDirectory(Path.Combine(destinationDirectoryPath, relativePath));
+        }
+
+        foreach (string filePath in Directory.EnumerateFiles(sourceDirectoryPath, "*", SearchOption.AllDirectories))
+        {
+            string relativePath = Path.GetRelativePath(sourceDirectoryPath, filePath);
+            string destinationFilePath = Path.Combine(destinationDirectoryPath, relativePath);
+            string? destinationParentPath = Path.GetDirectoryName(destinationFilePath);
+            if (!string.IsNullOrWhiteSpace(destinationParentPath))
+            {
+                Directory.CreateDirectory(destinationParentPath);
+            }
+
+            File.Copy(filePath, destinationFilePath, overwrite: true);
         }
     }
 

--- a/src/Foundry/Services/WinPe/WinPeDefaults.cs
+++ b/src/Foundry/Services/WinPe/WinPeDefaults.cs
@@ -21,6 +21,38 @@ internal static class WinPeDefaults
     public const string LocalDeployArchiveEnvironmentVariable = "FOUNDRY_WINPE_LOCAL_DEPLOY_ARCHIVE";
     public const string LocalDeployProjectEnvironmentVariable = "FOUNDRY_WINPE_LOCAL_DEPLOY_PROJECT";
 
+    public static string GetProgramDataRootPath()
+    {
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+            "Foundry");
+    }
+
+    public static string GetWinPeWorkspaceRootPath()
+    {
+        return Path.Combine(GetProgramDataRootPath(), "WinPeWorkspace");
+    }
+
+    public static string GetUsbQueryWorkingDirectoryPath()
+    {
+        return Path.Combine(GetProgramDataRootPath(), "UsbQuery");
+    }
+
+    public static string GetInstallerCacheDirectoryPath()
+    {
+        return Path.Combine(GetProgramDataRootPath(), "Installers");
+    }
+
+    public static string GetIsoWorkspaceRootPath()
+    {
+        return Path.Combine(GetProgramDataRootPath(), "IsoWorkspace");
+    }
+
+    public static string GetIsoOutputTempRootPath()
+    {
+        return Path.Combine(GetProgramDataRootPath(), "IsoOutputTemp");
+    }
+
     public static string GetDefaultBootstrapScriptContent()
     {
         return BootstrapScriptContent.Value;

--- a/src/Foundry/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry/ViewModels/MainWindowViewModel.cs
@@ -131,7 +131,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     public string UsbPartitionStyleArm64Hint => Strings["UsbPartitionStyleArm64Hint"];
     public bool IsStandardMode => !IsExpertMode;
 
-    private static string StagingDirectoryPath => Path.Combine(Path.GetTempPath(), "FoundryMedia");
+    private static string StagingDirectoryPath => WinPeDefaults.GetWinPeWorkspaceRootPath();
 
     private static string ResolveAppVersion()
     {


### PR DESCRIPTION
This pull request introduces significant improvements to how temporary files and working directories are managed throughout the Foundry WinPE and ADK services. The main focus is on replacing the use of system temp directories with dedicated, application-specific directories under `ProgramData\Foundry`, improving file safety, reliability, and compatibility (especially with non-ASCII paths). It also adds robust handling for ISO creation and cleanup, ensuring ASCII-safe paths are used and cleaned up as needed.

**Key changes include:**

### Directory and Path Management Improvements

* Introduced new methods in `WinPeDefaults` to provide dedicated, application-specific directories for workspaces, installer caches, ISO output, and USB queries, all under `ProgramData\Foundry` instead of the system temp directory.
* Updated `MainWindowViewModel` and `MediaOutputService` to use these new directory methods for staging and working directories, ensuring consistency and avoiding conflicts in shared temp locations. [[1]](diffhunk://#diff-f9417da880039ed587033c7a7bbe281693399041dc5a6eabb1f5e38e030d46daL134-R134) [[2]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602L86-R86) [[3]](diffhunk://#diff-d43a9cc62866ef3d3000b6e4bb14ce26bd4553d444d6093cdb485de3e6d257b4L564-R576)

### ADK and Installer Handling

* Changed the ADK and WinPE installer download logic to use a shared cache directory (`WinPeDefaults.GetInstallerCacheDirectoryPath()`) instead of the system temp path, and clarified logging for these paths. [[1]](diffhunk://#diff-d43a9cc62866ef3d3000b6e4bb14ce26bd4553d444d6093cdb485de3e6d257b4R3) [[2]](diffhunk://#diff-d43a9cc62866ef3d3000b6e4bb14ce26bd4553d444d6093cdb485de3e6d257b4L555-R556) [[3]](diffhunk://#diff-d43a9cc62866ef3d3000b6e4bb14ce26bd4553d444d6093cdb485de3e6d257b4L564-R576)

### ISO Creation and Output Robustness

* Refactored ISO creation to ensure output paths and workspaces are ASCII-safe. If non-ASCII paths are detected, the process now mirrors files to safe locations, creates the ISO there, then copies the result to the requested path. [[1]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R122-R123) [[2]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R152-R182) [[3]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R401-R426) [[4]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R475-R597)
* Added helper methods for: ensuring output directories exist, preparing ASCII-safe paths, copying directories, and finalizing/copying ISO outputs.

### Cleanup and Error Handling

* Added robust cleanup logic for temporary ISO workspaces and prepared output files, ensuring no orphaned files or directories are left behind, even in the event of errors. [[1]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R195-R196) [[2]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R401-R426) [[3]](diffhunk://#diff-3557dca607e16ecf4d110e27b8783a752ce8f1a84c30c406688be78f4ec81602R475-R597)

These changes collectively improve reliability, security, and compatibility, especially when dealing with file paths that may include non-ASCII characters.