### PR TITLE
Remove fallback for USB cache marker folder

### DIFF
--- a/src/Foundry.Deploy/Services/Cache/CacheLocatorService.cs
+++ b/src/Foundry.Deploy/Services/Cache/CacheLocatorService.cs
@@ -9,7 +9,6 @@ public sealed class CacheLocatorService : ICacheLocatorService
     private const string WinPeTransientRoot = @"X:\Foundry";
     private const string WinPeTransientRuntimeRoot = @"X:\Foundry\Runtime";
     private const string CacheVolumeLabel = "Foundry Cache";
-    private const string CacheMarkerFolderName = "Foundry Cache";
     private const string RuntimeFolderName = "Runtime";
     private readonly ILogger<CacheLocatorService> _logger;
 
@@ -51,7 +50,7 @@ public sealed class CacheLocatorService : ICacheLocatorService
     {
         // USB mode:
         // 1) honor explicit preferred path when it is not the WinPE transient placeholder
-        // 2) locate dedicated cache partition (label or marker folder)
+        // 2) locate dedicated cache partition by volume label
         // 3) use transient WinPE runtime root as fallback.
         if (!string.IsNullOrWhiteSpace(preferredRoot) &&
             !IsWinPeTransientPlaceholder(preferredRoot))
@@ -105,11 +104,6 @@ public sealed class CacheLocatorService : ICacheLocatorService
                 // Ignore drives that cannot expose label.
             }
 
-            string markerPath = Path.Combine(drive.RootDirectory.FullName, CacheMarkerFolderName);
-            if (Directory.Exists(markerPath))
-            {
-                return Path.Combine(drive.RootDirectory.FullName, RuntimeFolderName);
-            }
         }
 
         return null;

--- a/src/Foundry.Deploy/Services/Runtime/DeploymentRuntimeContextService.cs
+++ b/src/Foundry.Deploy/Services/Runtime/DeploymentRuntimeContextService.cs
@@ -7,7 +7,6 @@ public sealed class DeploymentRuntimeContextService : IDeploymentRuntimeContextS
 {
     private const string DeploymentModeEnvironmentVariable = "FOUNDRY_DEPLOYMENT_MODE";
     private const string CacheVolumeLabel = "Foundry Cache";
-    private const string CacheMarkerFolderName = "Foundry Cache";
     private const string RuntimeFolderName = "Runtime";
 
     public DeploymentRuntimeContext Resolve()
@@ -67,11 +66,6 @@ public sealed class DeploymentRuntimeContextService : IDeploymentRuntimeContextS
                 // Ignore drives that cannot expose a label.
             }
 
-            string markerPath = Path.Combine(drive.RootDirectory.FullName, CacheMarkerFolderName);
-            if (Directory.Exists(markerPath))
-            {
-                return Path.Combine(drive.RootDirectory.FullName, RuntimeFolderName);
-            }
         }
 
         return null;

--- a/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
+++ b/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
@@ -128,10 +128,6 @@ function Get-UsbCacheRuntimeRoot {
             # Ignore drives that do not expose a readable volume label.
         }
 
-        $markerPath = Join-Path $rootPath 'Foundry Cache'
-        if (Test-Path -Path $markerPath -PathType Container) {
-            return Join-Path $rootPath 'Runtime'
-        }
     }
 
     return $null

--- a/src/Foundry/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry/Services/WinPe/WinPeUsbMediaService.cs
@@ -229,8 +229,6 @@ else {
         }
 
         _logger.LogInformation("Verified USB boot artifacts successfully. BootRoot={BootRoot}, Architecture={Architecture}", bootRoot, artifact.Architecture);
-        string cacheMarkerPath = Path.Combine(cacheRoot, "Foundry Cache");
-        Directory.CreateDirectory(cacheMarkerPath);
         Directory.CreateDirectory(Path.Combine(cacheRoot, "Runtime"));
         Directory.CreateDirectory(Path.Combine(cacheRoot, "OperatingSystem"));
         Directory.CreateDirectory(Path.Combine(cacheRoot, "DriverPack"));


### PR DESCRIPTION
This pull request simplifies the logic for detecting and creating the Foundry cache partition on USB drives by removing the use of a marker folder ("Foundry Cache"). Instead, cache detection now relies solely on the USB volume label. The changes affect both C# and PowerShell code, ensuring consistent cache partition identification and reducing unnecessary directory creation.

**Cache detection and creation simplification:**

* Removed the use of the `CacheMarkerFolderName` constant and all logic that checked for or created a "Foundry Cache" marker folder across the codebase, including in `CacheLocatorService`, `DeploymentRuntimeContextService`, and PowerShell scripts. [[1]](diffhunk://#diff-0df0aca529a1474be34d8489a1fd20941ce626f4b60d5629f2fdf86ef31a0829L12) [[2]](diffhunk://#diff-d99490ad599b2014f532d1dce77156f548f98956d273cb391ec28a62a8cabc5cL10) [[3]](diffhunk://#diff-4b660ae68b340bcd8361c3376ff20de53c652938f55559bcef1225ae82cb0854L131-L134) [[4]](diffhunk://#diff-0df0aca529a1474be34d8489a1fd20941ce626f4b60d5629f2fdf86ef31a0829L108-L112) [[5]](diffhunk://#diff-d99490ad599b2014f532d1dce77156f548f98956d273cb391ec28a62a8cabc5cL70-L74) [[6]](diffhunk://#diff-da0749efccf3541be8972dcc8d0fa2d540d5ccdec88de560ab5b4fb09a7d4c28L232-L233)
* Updated cache partition detection logic to rely solely on the USB volume label ("Foundry Cache") instead of checking for a marker folder, simplifying the detection process and reducing filesystem operations.

These changes streamline the cache detection process, reduce potential sources of error, and make the code easier to maintain.