### PR TITLE
refactor(build): centralize shared WPF project properties

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -35,5 +35,10 @@
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
+    <ApplicationIcon>Assets\Icons\app.ico</ApplicationIcon>
+    <PackageIcon>app.ico</PackageIcon>
   </PropertyGroup>
 </Project>

--- a/src/Foundry.Deploy/Foundry.Deploy.csproj
+++ b/src/Foundry.Deploy/Foundry.Deploy.csproj
@@ -2,12 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0-windows</TargetFramework>
-    <UseWPF>true</UseWPF>
-    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <StartupObject>Foundry.Deploy.Program</StartupObject>
-    <ApplicationIcon>Assets\Icons\app.ico</ApplicationIcon>
-    <PackageIcon>app.ico</PackageIcon>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -2,13 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net10.0-windows</TargetFramework>
-    <UseWPF>true</UseWPF>
-    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <StartupObject>Foundry.Program</StartupObject>
     <Win32Manifest>app.manifest</Win32Manifest>
-    <ApplicationIcon>Assets\Icons\app.ico</ApplicationIcon>
-    <PackageIcon>app.ico</PackageIcon>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Centralize the shared WPF build properties used by both desktop projects.

## Reason
Reduce duplicated MSBuild configuration while keeping project-specific settings and workflow-managed version properties unchanged.

## Main changes
- Move `TargetFramework`, `UseWPF`, `RuntimeIdentifiers`, `ApplicationIcon`, and `PackageIcon` into `src/Directory.Build.props`
- Remove the duplicated property definitions from `src/Foundry/Foundry.csproj`
- Remove the duplicated property definitions from `src/Foundry.Deploy/Foundry.Deploy.csproj`

## Testing notes
- `dotnet build src/Foundry.slnx --nologo`