### PR TITLE
chore(github): simplify repository labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,14 +1,14 @@
 # Auto-labeler configuration for Foundry
 # https://github.com/actions/labeler
 
-# Main application
-app:
+# Foundry desktop application
+'project: foundry':
   - changed-files:
       - any-glob-to-any-file:
           - 'src/Foundry/**'
 
-# OS deployment (WinPE)
-deploy:
+# Foundry deployment application
+'project: foundry-deploy':
   - changed-files:
       - any-glob-to-any-file:
           - 'src/Foundry.Deploy/**'
@@ -39,16 +39,6 @@ documentation:
       - any-glob-to-any-file:
           - '**/*.md'
           - 'docs/**'
-
-# General source code (shared pieces)
-source:
-  - changed-files:
-      - any-glob-to-any-file:
-          - 'src/**/*.cs'
-          - 'src/**/*.csproj'
-          - 'src/**/*.sln*'
-          - 'src/*.cs'
-          - 'src/*.sln*'
 
 # Dependencies and project metadata
 dependencies:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,199 +1,101 @@
 # Repository Labels Configuration
-# This file defines all labels used in the repository
-# Run the sync-labels workflow to create/update these labels
+# This file defines all labels used in the repository.
+# Run the sync-labels workflow to create or update these labels.
 
-# =============================================================================
-# TYPE LABELS - What kind of change is this?
-# =============================================================================
+# Type labels
 
 - name: bug
   color: 'd73a4a'
-  description: Something isn't working
-
-- name: bugfix
-  color: 'd73a4a'
-  description: Fix for a bug
-
-- name: fix
-  color: 'd73a4a'
-  description: A fix for an issue
-
-- name: enhancement
-  color: 'a2eeef'
-  description: New feature or request
+  description: Bug fix or regression correction
 
 - name: feature
   color: 'a2eeef'
-  description: New feature implementation
+  description: New behavior or capability
 
 - name: documentation
   color: '0075ca'
-  description: Improvements or additions to documentation
+  description: Documentation updates
 
 - name: breaking-change
   color: 'b60205'
-  description: Breaking change that requires major version bump
+  description: Introduces a breaking change
 
 - name: security
   color: 'ee0701'
-  description: Security related issue or fix
-
-- name: maintenance
-  color: 'fbca04'
-  description: Maintenance work
+  description: Security-related change or report
 
 - name: chore
   color: 'fbca04'
-  description: Routine tasks and maintenance
+  description: Maintenance or routine repository work
 
 - name: refactor
   color: 'fbca04'
-  description: Code refactoring without functionality changes
+  description: Internal code change without intended behavior changes
 
 - name: dependencies
   color: '0366d6'
-  description: Pull requests that update a dependency file
+  description: Dependency version or package management change
 
 - name: tests
   color: 'bfd4f2'
-  description: Test related changes
+  description: Test coverage or test infrastructure change
 
-# =============================================================================
-# AREA LABELS - What part of the codebase?
-# =============================================================================
+# Project labels
 
-- name: source
-  color: 'c5def5'
-  description: Source code changes across the solution
-
-- name: app
+- name: 'project: foundry'
   color: '1d76db'
-  description: Main Foundry application (WPF)
+  description: Changes in the Foundry desktop application
 
-- name: deploy
+- name: 'project: foundry-deploy'
   color: '0e8a16'
-  description: OS deployment tooling (WinPE)
+  description: Changes in the Foundry.Deploy deployment application
 
 - name: ui
   color: '7057ff'
-  description: User interface and XAML changes
+  description: User interface or XAML changes
 
 - name: ci
   color: 'f9d0c4'
-  description: CI/CD and workflow changes
+  description: CI, automation, or workflow changes
 
 - name: config
   color: 'fef2c0'
-  description: Repository and build configuration
+  description: Repository or build configuration changes
 
-# =============================================================================
-# STATUS LABELS - Current state of the issue/PR
-# =============================================================================
+# Collaboration labels
 
 - name: help wanted
   color: '008672'
-  description: Extra attention is needed
+  description: Maintainers would welcome an external contribution
 
 - name: good first issue
   color: '7057ff'
-  description: Good for newcomers
-
-- name: question
-  color: 'd876e3'
-  description: Further information is requested
-
-- name: discussion
-  color: 'd876e3'
-  description: Discussion needed before proceeding
-
-- name: needs-review
-  color: 'fbca04'
-  description: Needs code review
-
-- name: needs-testing
-  color: 'fbca04'
-  description: Requires testing before merge
-
-- name: work-in-progress
-  color: 'fef2c0'
-  description: Work in progress, not ready for review
+  description: Suitable for a first contribution
 
 - name: blocked
   color: 'b60205'
-  description: Blocked by another issue or external factor
+  description: Blocked by another task or external dependency
 
-- name: on-hold
-  color: 'c2e0c6'
-  description: Temporarily on hold
-
-# =============================================================================
-# PRIORITY LABELS
-# =============================================================================
-
-- name: priority-critical
-  color: 'b60205'
-  description: Critical priority - needs immediate attention
-
-- name: priority-high
-  color: 'd93f0b'
-  description: High priority
-
-- name: priority-medium
-  color: 'fbca04'
-  description: Medium priority
-
-- name: priority-low
-  color: '0e8a16'
-  description: Low priority
-
-# =============================================================================
-# RESOLUTION LABELS
-# =============================================================================
+# Resolution labels
 
 - name: duplicate
   color: 'cfd3d7'
-  description: This issue or pull request already exists
+  description: Already tracked elsewhere
 
 - name: invalid
   color: 'cfd3d7'
-  description: This doesn't seem right
+  description: Not actionable as submitted
 
 - name: wontfix
   color: 'cfd3d7'
-  description: This will not be worked on
+  description: Intentionally not planned
 
 - name: stale
   color: 'cfd3d7'
   description: No recent activity
 
-- name: skip-changelog
-  color: 'ededed'
-  description: Exclude from release notes
-
-# =============================================================================
-# VERSION LABELS - For release drafter
-# =============================================================================
-
-- name: major
-  color: 'b60205'
-  description: Major version bump (breaking changes)
-
-- name: minor
-  color: 'fbca04'
-  description: Minor version bump (new features)
-
-- name: patch
-  color: '0e8a16'
-  description: Patch version bump (bug fixes)
-
-# =============================================================================
-# SPECIAL LABELS
-# =============================================================================
+# Special labels
 
 - name: pinned
   color: '006b75'
-  description: Pinned issue - will not be marked as stale
-
-- name: sponsored
-  color: 'ea4aaa'
-  description: Sponsored feature or issue
+  description: Exempt from stale handling

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -58,8 +58,8 @@ jobs:
             If you'd like to continue working on this, feel free to reopen it or create a new PR.
 
           # Labels to exempt from stale
-          exempt-issue-labels: 'pinned,security,blocked,on-hold'
-          exempt-pr-labels: 'pinned,security,work-in-progress,blocked,on-hold'
+          exempt-issue-labels: 'pinned,security,blocked'
+          exempt-pr-labels: 'pinned,security,blocked'
 
           # Don't stale issues/PRs with these assignees
           exempt-all-assignees: true


### PR DESCRIPTION
## Summary
Simplify the repository label taxonomy and make project labels explicit.

## Why
The current label set had redundant labels, low-signal labels, and vague project names that did not make it obvious which application a PR touched.

## Changes
- remove redundant and unused labels from the synced label set
- rename project labels to `project: foundry` and `project: foundry-deploy`
- update auto-labeling rules to apply the new project labels
- align stale workflow exemptions with the remaining labels

## Testing
- not run; configuration-only change

## Notes
- live repository labels will update when the `Sync Labels` workflow runs or is triggered manually