### PR TITLE
chore(github): add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,78 @@
+name: Bug report
+description: Report a reproducible problem in Foundry
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search existing issues before opening a new bug report.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected scope
+      description: Select the current repository label that best matches the problem.
+      options:
+        - "project: foundry"
+        - "project: foundry-deploy"
+        - ui
+        - ci
+        - config
+        - unknown
+    validations:
+      required: true
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current behavior
+      description: Describe the problem and what is failing.
+      placeholder: A concise description of the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Describe what you expected to happen instead.
+      placeholder: A concise description of the expected result.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide a reliable reproduction path.
+      placeholder: |
+        1. Open ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include anything relevant for troubleshooting.
+      placeholder: |
+        Foundry version:
+        Windows version:
+        Architecture:
+        Device or OEM:
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste logs or add screenshots if they help explain the issue.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched for existing issues before submitting this report.
+          required: true
+        - label: I can reproduce this issue on a current version of Foundry.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,63 @@
+name: Feature request
+description: Suggest an improvement or a new capability
+title: "[Feature]: "
+labels:
+  - feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Keep feature requests focused and tied to a concrete deployment or usage scenario.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected scope
+      description: Select the current repository label that best matches the request.
+      options:
+        - "project: foundry"
+        - "project: foundry-deploy"
+        - ui
+        - ci
+        - config
+        - unknown
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: Describe the current limitation or friction.
+      placeholder: What is difficult, missing, or unclear today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the change you would like to see.
+      placeholder: What should Foundry do differently?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any workaround or alternative you considered.
+      placeholder: Optional, but useful for tradeoff discussion.
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: Explain when and why this would be used.
+      placeholder: Real deployment scenario, workflow, or contributor need.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched for existing issues before submitting this request.
+          required: true
+        - label: This request describes a specific improvement, not a general question.
+          required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,70 @@
+name: Question
+description: Ask a usage, setup, or contribution question about Foundry
+title: "[Question]: "
+labels:
+  - question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for focused questions about using, building, or contributing to Foundry.
+        Do not use this form to report bugs or request new features.
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Question scope
+      description: Select the area that best matches your question.
+      options:
+        - "project: foundry"
+        - "project: foundry-deploy"
+        - ui
+        - ci
+        - config
+        - other
+    validations:
+      required: true
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Question type
+      description: Select the kind of help you need.
+      options:
+        - Usage
+        - Setup
+        - Build
+        - Deployment workflow
+        - Contribution
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: Ask the question as clearly as possible.
+      placeholder: What are you trying to do, and where are you blocked?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Add any relevant details that would help answer the question.
+      placeholder: |
+        Foundry version:
+        Windows version:
+        Architecture:
+        What you already tried:
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste logs or add screenshots if they help explain the question.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and documentation before submitting this question.
+          required: true

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -72,6 +72,10 @@
   color: '7057ff'
   description: Suitable for a first contribution
 
+- name: question
+  color: 'd876e3'
+  description: Usage, setup, or contribution question
+
 - name: blocked
   color: 'b60205'
   description: Blocked by another task or external dependency

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+<!--
+Pull request title rules:
+- Use an English Conventional Commit title
+- Keep it concise and specific
+
+Examples:
+- feat(ui): add deployment summary step
+- fix(deploy): handle missing driver package
+-->
+
+## Summary
+
+Short summary of the change.
+
+## Why
+
+Explain why this change was needed.
+
+## Changes
+
+- Main change 1
+- Main change 2
+
+## Testing
+
+- [ ] `dotnet build .\src\Foundry.slnx`
+- [ ] Manual testing completed
+- [ ] Not applicable
+
+## Notes
+
+- Breaking changes:
+- Related issues:
+- Screenshots or recordings, if relevant:


### PR DESCRIPTION
## Summary
Add repository templates for issues and pull requests.

## Why
The repository did not yet provide a structured way to report bugs, request features, ask questions, or open pull requests with the expected format.

## Changes
- Add GitHub issue forms for bug reports, feature requests, and questions
- Add issue template configuration under .github/ISSUE_TEMPLATE
- Add a repository pull request template aligned with the Codex PR instructions
- Add the question label and connect it to the question issue form
- Align issue form options with the current repository label taxonomy

## Testing
- Verified the generated template files locally
- Ran git diff --check
- Did not run dotnet build because the change only affects GitHub metadata and templates

## Notes
- No breaking changes
- Related issues: none
- Screenshots or recordings, if relevant: not applicable