### PR TITLE
fix(deploy): use WinExe for Foundry.Deploy

### DIFF
--- a/src/Foundry.Deploy/Foundry.Deploy.csproj
+++ b/src/Foundry.Deploy/Foundry.Deploy.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <StartupObject>Foundry.Deploy.Program</StartupObject>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
Switch `Foundry.Deploy` from `Exe` to `WinExe` so the WPF application starts without opening a console window.

## Why
`Foundry.Deploy` was built with the console subsystem, which caused an unwanted command prompt window to appear at startup in WinPE.

## Changes
- Change `Foundry.Deploy` project output type from `Exe` to `WinExe`
- Keep the existing custom startup object and WPF startup flow unchanged

## Testing
- `dotnet build E:\Github\Foundry\src\Foundry.Deploy\Foundry.Deploy.csproj`

## Notes
- This only affects the `Foundry.Deploy` application binary. Any separate WinPE bootstrap console remains unchanged.