### PR TITLE
feat(deploy): add startup splash screen

### DIFF
--- a/src/Foundry.Deploy/DeploymentPage.cs
+++ b/src/Foundry.Deploy/DeploymentPage.cs
@@ -2,6 +2,7 @@ namespace Foundry.Deploy;
 
 public enum DeploymentPage
 {
+    Splash,
     Wizard,
     Progress,
     Success,

--- a/src/Foundry.Deploy/MainWindow.xaml
+++ b/src/Foundry.Deploy/MainWindow.xaml
@@ -37,7 +37,10 @@
                 <!--  Tools  -->
                 <MenuItem Header="_Tools">
                     <MenuItem Command="{Binding RefreshCatalogsCommand}" Header="Refresh Catalogs" />
-                    <MenuItem Command="{Binding Preparation.RefreshTargetDisksCommand}" Header="Refresh Target Disks" />
+                    <MenuItem
+                        Command="{Binding Preparation.RefreshTargetDisksCommand}"
+                        Header="Refresh Target Disks"
+                        IsEnabled="{Binding Session.IsStartupReady}" />
                     <MenuItem Command="{Binding Session.OpenLogFileCommand}" Header="Open Log File" />
                 </MenuItem>
             </Menu>
@@ -101,9 +104,7 @@
                             <!--  Step 1 details and toggles  -->
                             <StackPanel Grid.Row="0">
                                 <StackPanel DataContext="{Binding Preparation}">
-                                    <TextBlock
-                                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                                        Text="Computer Name" />
+                                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Computer Name" />
                                     <TextBox
                                         x:Name="TargetComputerNameTextBox"
                                         Margin="0,8,0,0"
@@ -421,9 +422,7 @@
             </Grid>
 
             <!--  Progress page (execution flow)  -->
-            <Grid
-                DataContext="{Binding Session}"
-                Visibility="{Binding IsProgressPage, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Grid DataContext="{Binding Session}" Visibility="{Binding IsProgressPage, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
@@ -559,9 +558,7 @@
             </Grid>
 
             <!--  Success page (completion flow)  -->
-            <Grid
-                DataContext="{Binding Session}"
-                Visibility="{Binding IsSuccessPage, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Grid DataContext="{Binding Session}" Visibility="{Binding IsSuccessPage, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
@@ -646,9 +643,7 @@
             </Grid>
 
             <!--  Error page (failure flow)  -->
-            <Grid
-                DataContext="{Binding Session}"
-                Visibility="{Binding IsErrorPage, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Grid DataContext="{Binding Session}" Visibility="{Binding IsErrorPage, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
@@ -758,5 +753,45 @@
         <StatusBar Grid.Row="2" Visibility="{Binding Session.IsWizardPage, Converter={StaticResource BooleanToVisibilityConverter}}">
             <StatusBarItem Content="{Binding Session.DeploymentStatus}" />
         </StatusBar>
+
+        <!--  Splash page (startup flow)  -->
+        <Grid
+            Grid.RowSpan="3"
+            Panel.ZIndex="1"
+            Visibility="{Binding Session.IsSplashPage, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Grid Margin="16">
+                <TextBlock
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Style="{StaticResource DisplayTextBlockStyle}"
+                    Text="Welcome"
+                    TextAlignment="Center" />
+
+                <StackPanel
+                    Width="360"
+                    Margin="0,160,0,0"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Visibility="{Binding Session.IsStartupInitializing, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <ProgressBar Height="6" IsIndeterminate="True" />
+                    <TextBlock
+                        Margin="0,12,0,0"
+                        HorizontalAlignment="Center"
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource BodyTextBlockStyle}"
+                        Text="Initializing components..."
+                        TextAlignment="Center" />
+                </StackPanel>
+
+                <Button
+                    Width="160"
+                    Margin="0,0,0,24"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Bottom"
+                    Command="{Binding BeginWizardCommand}"
+                    Content="Begin"
+                    Visibility="{Binding Session.IsStartupInitializing, Converter={StaticResource InverseBooleanConverter}}" />
+            </Grid>
+        </Grid>
     </Grid>
 </Window>

--- a/src/Foundry.Deploy/ViewModels/DeploymentSessionViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentSessionViewModel.cs
@@ -51,11 +51,16 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
     }
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsStartupReady))]
+    private bool isStartupInitializing = true;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsSplashPage))]
     [NotifyPropertyChangedFor(nameof(IsWizardPage))]
     [NotifyPropertyChangedFor(nameof(IsProgressPage))]
     [NotifyPropertyChangedFor(nameof(IsSuccessPage))]
     [NotifyPropertyChangedFor(nameof(IsErrorPage))]
-    private DeploymentPage currentPage = DeploymentPage.Wizard;
+    private DeploymentPage currentPage = DeploymentPage.Splash;
 
     [ObservableProperty]
     private string deploymentStatus = "Ready";
@@ -115,6 +120,8 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
     [ObservableProperty]
     private string failedStepErrorMessage = string.Empty;
 
+    public bool IsSplashPage => CurrentPage == DeploymentPage.Splash;
+
     public bool IsWizardPage => CurrentPage == DeploymentPage.Wizard;
 
     public bool IsProgressPage => CurrentPage == DeploymentPage.Progress;
@@ -122,6 +129,8 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
     public bool IsSuccessPage => CurrentPage == DeploymentPage.Success;
 
     public bool IsErrorPage => CurrentPage == DeploymentPage.Error;
+
+    public bool IsStartupReady => !IsStartupInitializing;
 
     public int PlannedStepCount => _deploymentOrchestrator.PlannedSteps.Count;
 
@@ -135,13 +144,17 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
         ComputerNameText = computerName;
     }
 
-    public void ResetToWizard(string? status = null)
+    public void CompleteStartupInitialization()
     {
-        _isDeploymentInProgress = false;
-        _lastLogsDirectoryPath = string.Empty;
-        if (!string.IsNullOrWhiteSpace(status))
+        IsStartupInitializing = false;
+        CurrentPage = DeploymentPage.Splash;
+    }
+
+    public void ShowWizard()
+    {
+        if (IsStartupInitializing)
         {
-            DeploymentStatus = status;
+            return;
         }
 
         CurrentPage = DeploymentPage.Wizard;

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -123,6 +123,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             _deploymentOrchestrator,
             processRunner,
             IsDebugSafeMode);
+        Session.PropertyChanged += OnSessionPropertyChanged;
     }
 
     public Task InitializeAsync()
@@ -221,6 +222,12 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         {
             WizardStepIndex++;
         }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanBeginWizard))]
+    private void BeginWizard()
+    {
+        Session.ShowWizard();
     }
 
     [RelayCommand(CanExecute = nameof(CanStartDeployment))]
@@ -326,6 +333,19 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         Session.SetStatus(message);
     }
 
+    private void OnSessionPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (!string.IsNullOrWhiteSpace(e.PropertyName) &&
+            e.PropertyName is not nameof(DeploymentSessionViewModel.IsStartupInitializing) &&
+            e.PropertyName is not nameof(DeploymentSessionViewModel.CurrentPage))
+        {
+            return;
+        }
+
+        RefreshCatalogsCommand.NotifyCanExecuteChanged();
+        BeginWizardCommand.NotifyCanExecuteChanged();
+    }
+
     private bool CanShowDebugPages()
     {
         return IsDebugSafeMode && !IsDeploymentRunning;
@@ -333,7 +353,12 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
     private bool CanRefreshCatalogs()
     {
-        return !IsCatalogLoading && !IsDeploymentRunning;
+        return Session.IsStartupReady && !IsCatalogLoading && !IsDeploymentRunning;
+    }
+
+    private bool CanBeginWizard()
+    {
+        return Session.IsSplashPage && Session.IsStartupReady;
     }
 
     private bool CanGoPrevious()
@@ -394,6 +419,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             !string.IsNullOrWhiteSpace(startupSnapshot.TargetDiskStatusMessage)
                 ? startupSnapshot.TargetDiskStatusMessage
                 : startupStatusMessage);
+        Session.CompleteStartupInitialization();
     }
 
     private void RunOnUi(Action action)
@@ -416,6 +442,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
         _wizardContext.StatusMessageGenerated -= OnWizardContextStatusMessageGenerated;
         _wizardContext.StateChanged -= OnWizardContextStateChanged;
+        Session.PropertyChanged -= OnSessionPropertyChanged;
         _wizardContext.Dispose();
         Session.Dispose();
         _isDisposed = true;


### PR DESCRIPTION
## Summary
Add a startup splash screen to Foundry.Deploy before the wizard.

## Why
The initial application loading was previously surfaced indirectly on the first wizard page by delaying the ability to continue. Moving that wait to a dedicated splash screen gives a clearer startup experience and keeps the wizard focused on configuration.

## Changes
- add a new splash page state to the deploy application flow
- keep the top menu visible while startup initialization runs
- show a centered Welcome title with startup loading feedback, then reveal a Begin button when initialization completes
- preserve the existing startup coordinator as the source of truth for readiness instead of duplicating loading logic
- adjust the splash layout so the title stays visually centered and the Begin button stays bottom-aligned

## Testing
- run dotnet build src\\Foundry.Deploy\\Foundry.Deploy.csproj
- verify the build completes with 0 warnings and 0 errors

## Notes
- the splash screen text now uses Initializing components...
- refresh actions remain gated until startup initialization is complete where applicable