### PR TITLE
docs(licensing): clarify MIT project notices

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <Authors>Mickaël CHAVE &amp; Foundry Contributors</Authors>
     <Company>Mickaël CHAVE</Company>
-    <Copyright>Copyright (c) Foundry Project. All rights reserved.</Copyright>
+    <Copyright>Copyright (c) 2026 Foundry Contributors. Licensed under the MIT License.</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/mchave3/Foundry</PackageProjectUrl>
     <RepositoryUrl>https://github.com/mchave3/Foundry.git</RepositoryUrl>

--- a/src/Foundry.Deploy/FoundryDeployApplicationInfo.cs
+++ b/src/Foundry.Deploy/FoundryDeployApplicationInfo.cs
@@ -10,7 +10,7 @@ public static class FoundryDeployApplicationInfo
     public const string AboutTitle = "About Foundry Deploy";
     public const string DescriptionLine1 = "Foundry Deploy is the WinPE deployment experience for Foundry.";
     public const string DescriptionLine2 = "This software is provided as-is. Review your deployment settings before use.";
-    public const string Footer = "Copyright (c) Project Foundry. All rights reserved.";
+    public const string Footer = "Copyright (c) 2026 Foundry Contributors. Licensed under the MIT License.";
 
     public static string Version => AppVersion;
 

--- a/src/Foundry/Resources/AppStrings.en-US.resx
+++ b/src/Foundry/Resources/AppStrings.en-US.resx
@@ -445,7 +445,7 @@
     <value>Support</value>
   </data>
   <data name="AboutFooter" xml:space="preserve">
-    <value>Copyright (c) Foundry Project. All rights reserved.</value>
+    <value>Copyright (c) 2026 Foundry Contributors. Licensed under the MIT License.</value>
   </data>
   <data name="IsoPickerTitle" xml:space="preserve">
     <value>Select ISO output path</value>

--- a/src/Foundry/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry/Resources/AppStrings.fr-FR.resx
@@ -445,7 +445,7 @@
     <value>Support</value>
   </data>
   <data name="AboutFooter" xml:space="preserve">
-    <value>Copyright (c) Projet Foundry. Tous droits réservés.</value>
+    <value>Copyright (c) 2026 Contributeurs Foundry. Sous licence MIT.</value>
   </data>
   <data name="IsoPickerTitle" xml:space="preserve">
     <value>Selectionner le chemin de sortie ISO</value>

--- a/src/Foundry/Resources/AppStrings.resx
+++ b/src/Foundry/Resources/AppStrings.resx
@@ -445,7 +445,7 @@
     <value>Support</value>
   </data>
   <data name="AboutFooter" xml:space="preserve">
-    <value>Copyright (c) Foundry Project. All rights reserved.</value>
+    <value>Copyright (c) 2026 Foundry Contributors. Licensed under the MIT License.</value>
   </data>
   <data name="IsoPickerTitle" xml:space="preserve">
     <value>Select ISO output path</value>


### PR DESCRIPTION
## Summary
Clarify project-owned copyright and license notices to match Foundry's MIT open-source status.

## Why
Some project-owned UI footers and shared metadata still implied reserved rights wording that did not clearly reflect the current MIT licensing model.

## Changes
- update shared assembly and package copyright metadata
- normalize the Foundry desktop About footer wording
- normalize the Foundry.Deploy About footer wording
- keep third-party bundled license files unchanged

## Testing
- dotnet build .\\src\\Foundry.slnx -c Debug --nologo

## Notes
- third-party 7-Zip license files still contain their original notices and were intentionally left untouched