### PR TITLE
fix(deploy): move about to top-level menu

### DIFF
--- a/src/Foundry.Deploy/MainWindow.xaml
+++ b/src/Foundry.Deploy/MainWindow.xaml
@@ -43,9 +43,8 @@
                         IsEnabled="{Binding Session.IsStartupReady}" />
                     <MenuItem Command="{Binding Session.OpenLogFileCommand}" Header="Open Log File" />
                 </MenuItem>
-                <MenuItem Header="_Help">
-                    <MenuItem Command="{Binding ShowAboutCommand}" Header="_About" />
-                </MenuItem>
+                <!--  About  -->
+                <MenuItem Command="{Binding ShowAboutCommand}" Header="_About" />
             </Menu>
 
             <TextBlock


### PR DESCRIPTION
## Summary
Move the About entry from the Help submenu to a top-level menu item in Foundry.Deploy.

## Why
The extra Help level is unnecessary for a single About action and makes the menu less direct.

## Changes
- remove the Help parent menu item
- bind About directly as a top-level menu item in the main menu bar

## Testing
- dotnet build src/Foundry.Deploy/Foundry.Deploy.csproj

## Notes
- no functional changes outside the menu structure