### PR TITLE
fix(winpe): set user agent for driver downloads

### DIFF
--- a/src/Foundry/Services/WinPe/WinPeDriverPackageService.cs
+++ b/src/Foundry/Services/WinPe/WinPeDriverPackageService.cs
@@ -12,10 +12,7 @@ internal sealed record WinPePreparedDriverSet
 
 internal sealed class WinPeDriverPackageService
 {
-    private static readonly HttpClient HttpClient = new()
-    {
-        Timeout = TimeSpan.FromMinutes(30)
-    };
+    private static readonly HttpClient HttpClient = CreateHttpClient();
 
     private readonly WinPeProcessRunner _processRunner;
     private readonly ILogger<WinPeDriverPackageService> _logger;
@@ -24,6 +21,16 @@ internal sealed class WinPeDriverPackageService
     {
         _processRunner = processRunner;
         _logger = logger;
+    }
+
+    private static HttpClient CreateHttpClient()
+    {
+        HttpClient client = new()
+        {
+            Timeout = TimeSpan.FromMinutes(30)
+        };
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("Foundry/1.0");
+        return client;
     }
 
     public async Task<WinPeResult<WinPePreparedDriverSet>> PrepareAsync(


### PR DESCRIPTION
## Summary
Add a `User-Agent` header to WinPE driver package downloads.

## Why
Intel's download endpoint returned `403 Forbidden` for the default .NET `HttpClient` request shape during WinPE ISO creation.

## Changes
- replace the static inline `HttpClient` initialization with a factory method
- keep the existing timeout configuration
- add `User-Agent: Foundry/1.0` to outbound WinPE driver download requests

## Testing
- reproduced the failing Intel download URL locally
- verified plain .NET `HttpClient` returned `403 Forbidden`
- verified the same request succeeded once a `User-Agent` was set
- ran `dotnet build src/Foundry/Foundry.csproj`

## Notes
- this change is intentionally limited to the WinPE driver download path