### PR TITLE
fix(winpe): start wlansvc for wireless boot images

### DIFF
--- a/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
+++ b/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
@@ -461,6 +461,49 @@ function Save-WebFile {
     }
 }
 
+function Start-WinPeWirelessServiceIfSupported {
+    [CmdletBinding()]
+    param ()
+
+    if (-not [string]::Equals($env:SystemDrive, 'X:', [System.StringComparison]::OrdinalIgnoreCase)) {
+        Write-Log 'Skipping WlanSvc startup because the bootstrap is not running from the WinPE system drive.' -Level Debug
+        return
+    }
+
+    $system32Path = Join-Path $env:SystemRoot 'System32'
+    $requiredDependencyPaths = @(
+        (Join-Path $system32Path 'dmcmnutils.dll'),
+        (Join-Path $system32Path 'mdmregistration.dll')
+    )
+    $missingDependencyPaths = @($requiredDependencyPaths | Where-Object { -not (Test-Path -Path $_ -PathType Leaf) })
+    if ($missingDependencyPaths.Count -gt 0) {
+        Write-Log 'Skipping WlanSvc startup because WinRE wireless dependencies are not present in the boot image.' -Level Debug
+        return
+    }
+
+    try {
+        $service = Get-Service -Name 'WlanSvc' -ErrorAction Stop
+    }
+    catch {
+        Write-Log "WlanSvc is unavailable even though WinRE wireless dependencies are present: $($_.Exception.Message)." -Level Warning -ConsoleMessage 'Wi-Fi service unavailable. Continuing.'
+        return
+    }
+
+    if ([string]::Equals([string]$service.Status, 'Running', [System.StringComparison]::OrdinalIgnoreCase)) {
+        Write-Log 'WlanSvc is already running.' -ConsoleMessage 'Wi-Fi service: already running.'
+        return
+    }
+
+    try {
+        Start-Service -Name 'WlanSvc' -ErrorAction Stop
+        $service.Refresh()
+        Write-Log "WlanSvc started successfully. CurrentStatus='$($service.Status)'." -ConsoleMessage 'Wi-Fi service: started.'
+    }
+    catch {
+        Write-Log "Failed to start WlanSvc: $($_.Exception.Message)." -Level Warning -ConsoleMessage 'Wi-Fi service start failed. Continuing.'
+    }
+}
+
 function Sync-WinPeInternetDateTime {
     [CmdletBinding()]
     param(
@@ -1266,6 +1309,7 @@ try {
     Write-Log "Deployment mode resolved to '$deploymentMode'." -ConsoleMessage "Mode: $deploymentMode"
 
     $env:FOUNDRY_DEPLOYMENT_MODE = $deploymentMode
+    Start-WinPeWirelessServiceIfSupported
     Sync-WinPeInternetDateTime -ThresholdMinutes 5
     Set-WinPeTimeZone -FallbackTimeZoneId $DefaultWinPeTimeZoneId
 


### PR DESCRIPTION
## Summary
Start `WlanSvc` during WinPE bootstrap when the wireless WinRE dependencies are present.

## Why
Wi-Fi-enabled boot images already stage `dmcmnutils.dll` and `mdmregistration.dll`, but the bootstrap did not start the wireless auto-config service before running network-dependent startup logic.

## Changes
- add a bootstrap helper that checks for `dmcmnutils.dll` and `mdmregistration.dll` in `X:\Windows\System32`
- start `WlanSvc` only when both dependencies are present
- invoke the helper before clock sync and timezone detection
- keep the bootstrap resilient when the service is unavailable or fails to start

## Testing
- parsed `src/Foundry/Assets/WinPe/FoundryBootstrap.ps1` successfully with the PowerShell parser
- did not run a full WinPE build or boot-time validation in this environment

## Notes
- aligns the bootstrap behavior with the existing WinRE Wi-Fi dependency staging flow