### PR TITLE
chore(labels): add Foundry.Connect project label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -16,6 +16,7 @@ body:
       options:
         - "project: foundry"
         - "project: foundry-deploy"
+        - "project: foundry-connect"
         - ui
         - ci
         - config

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -16,6 +16,7 @@ body:
       options:
         - "project: foundry"
         - "project: foundry-deploy"
+        - "project: foundry-connect"
         - ui
         - ci
         - config

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,6 +13,12 @@
       - any-glob-to-any-file:
           - 'src/Foundry.Deploy/**'
 
+# Foundry WinPE network bootstrap application
+'project: foundry-connect':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/Foundry.Connect/**'
+
 # UI assets and views
 ui:
   - changed-files:
@@ -23,6 +29,9 @@ ui:
           - 'src/Foundry/Assets/**'
           - 'src/Foundry.Deploy/ViewModels/**'
           - 'src/Foundry.Deploy/Converters/**'
+          - 'src/Foundry.Connect/ViewModels/**'
+          - 'src/Foundry.Connect/Converters/**'
+          - 'src/Foundry.Connect/Assets/**'
 
 # Tests
 tests:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -50,6 +50,10 @@
   color: '0e8a16'
   description: Changes in the Foundry.Deploy deployment application
 
+- name: 'project: foundry-connect'
+  color: '5319e7'
+  description: Changes in the Foundry.Connect WinPE network bootstrap application
+
 - name: ui
   color: '7057ff'
   description: User interface or XAML changes


### PR DESCRIPTION
## Summary
Add the missing `project: foundry-connect` repository label and wire it into the GitHub automation and issue templates.

## Why
`Foundry.Connect` is now a first-class project in the repository, but the label catalog and issue/PR labeling automation on `main` still only account for `Foundry` and `Foundry.Deploy`.

## Changes
- add the `project: foundry-connect` label to `.github/labels.yml`
- update `.github/labeler.yml` so changes under `src/Foundry.Connect/**` receive the new project label
- add the new project label option to the bug report and feature request issue templates

## Testing
- reviewed the YAML diff for the label catalog, auto-labeler paths, and issue-template dropdowns

## Notes
- this PR is intentionally isolated from the ongoing `Foundry.Connect` implementation branch