### PR TITLE
fix(connect): stabilize wifi discovery in winpe

### DIFF
--- a/src/Foundry.Connect/Services/Network/NativeWifiApi.cs
+++ b/src/Foundry.Connect/Services/Network/NativeWifiApi.cs
@@ -1,0 +1,419 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text;
+using Foundry.Connect.Models.Network;
+
+namespace Foundry.Connect.Services.Network;
+
+internal static class NativeWifiApi
+{
+    private const uint ClientVersion = 2;
+    private const uint AvailableNetworkIncludeAllAdhocProfiles = 0x00000001;
+    private const int WlanMaxPhyTypeNumber = 8;
+
+    public static bool IsRuntimeAvailable()
+    {
+        IntPtr clientHandle = IntPtr.Zero;
+
+        try
+        {
+            clientHandle = OpenClientHandle();
+            return true;
+        }
+        finally
+        {
+            CloseClientHandle(clientHandle);
+        }
+    }
+
+    public static IReadOnlyList<WifiNetworkSummary> GetAvailableNetworks()
+    {
+        IntPtr clientHandle = IntPtr.Zero;
+        IntPtr interfaceListPointer = IntPtr.Zero;
+
+        try
+        {
+            clientHandle = OpenClientHandle();
+            ThrowIfError(
+                WlanEnumInterfaces(clientHandle, IntPtr.Zero, out interfaceListPointer),
+                nameof(WlanEnumInterfaces));
+
+            List<Guid> interfaceIds = ReadInterfaceIds(interfaceListPointer);
+            Dictionary<string, WifiNetworkSummary> networks = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (Guid interfaceId in interfaceIds)
+        {
+            IReadOnlyList<WifiNetworkSummary> interfaceNetworks = ReadAvailableNetworks(clientHandle, interfaceId);
+            TryStartScan(clientHandle, interfaceId);
+
+            foreach (WifiNetworkSummary network in interfaceNetworks)
+            {
+                if (networks.TryGetValue(network.Ssid, out WifiNetworkSummary? existing) &&
+                    existing.SignalStrengthPercent >= network.SignalStrengthPercent)
+                    {
+                        continue;
+                    }
+
+                    networks[network.Ssid] = network;
+                }
+            }
+
+            return networks.Values
+                .OrderByDescending(static network => network.SignalStrengthPercent)
+                .ThenBy(static network => network.Ssid, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+        finally
+        {
+            FreeMemory(interfaceListPointer);
+            CloseClientHandle(clientHandle);
+        }
+    }
+
+    private static List<Guid> ReadInterfaceIds(IntPtr interfaceListPointer)
+    {
+        if (interfaceListPointer == IntPtr.Zero)
+        {
+            return [];
+        }
+
+        WlanInterfaceInfoListHeader header = Marshal.PtrToStructure<WlanInterfaceInfoListHeader>(interfaceListPointer);
+        List<Guid> interfaceIds = new(header.NumberOfItems);
+        int itemOffset = Marshal.SizeOf<WlanInterfaceInfoListHeader>();
+        int itemSize = Marshal.SizeOf<WlanInterfaceInfo>();
+
+        for (int index = 0; index < header.NumberOfItems; index++)
+        {
+            IntPtr itemPointer = IntPtr.Add(interfaceListPointer, itemOffset + (index * itemSize));
+            WlanInterfaceInfo item = Marshal.PtrToStructure<WlanInterfaceInfo>(itemPointer);
+            interfaceIds.Add(item.InterfaceGuid);
+        }
+
+        return interfaceIds;
+    }
+
+    private static IReadOnlyList<WifiNetworkSummary> ReadAvailableNetworks(IntPtr clientHandle, Guid interfaceId)
+    {
+        IntPtr availableNetworkListPointer = IntPtr.Zero;
+
+        try
+        {
+            ThrowIfError(
+                WlanGetAvailableNetworkList(
+                    clientHandle,
+                    interfaceId,
+                    AvailableNetworkIncludeAllAdhocProfiles,
+                    IntPtr.Zero,
+                    out availableNetworkListPointer),
+                nameof(WlanGetAvailableNetworkList));
+
+            if (availableNetworkListPointer == IntPtr.Zero)
+            {
+                return [];
+            }
+
+            WlanAvailableNetworkListHeader header = Marshal.PtrToStructure<WlanAvailableNetworkListHeader>(availableNetworkListPointer);
+            List<WifiNetworkSummary> networks = new(header.NumberOfItems);
+            int itemOffset = Marshal.SizeOf<WlanAvailableNetworkListHeader>();
+            int itemSize = Marshal.SizeOf<WlanAvailableNetwork>();
+
+            for (int index = 0; index < header.NumberOfItems; index++)
+            {
+                IntPtr itemPointer = IntPtr.Add(availableNetworkListPointer, itemOffset + (index * itemSize));
+                WlanAvailableNetwork item = Marshal.PtrToStructure<WlanAvailableNetwork>(itemPointer);
+                networks.Add(new WifiNetworkSummary
+                {
+                    Ssid = ReadSsid(item.Ssid),
+                    SignalStrengthPercent = (int)Math.Clamp(item.SignalQuality, 0u, 100u),
+                    Authentication = FormatAuthentication(item.DefaultAuthAlgorithm, item.SecurityEnabled),
+                    Encryption = FormatEncryption(item.DefaultCipherAlgorithm, item.SecurityEnabled)
+                });
+            }
+
+            return networks;
+        }
+        finally
+        {
+            FreeMemory(availableNetworkListPointer);
+        }
+    }
+
+    private static string ReadSsid(Dot11Ssid ssid)
+    {
+        if (ssid.Length == 0 || ssid.Value.Length == 0)
+        {
+            return "Hidden network";
+        }
+
+        int length = (int)Math.Min(ssid.Length, (uint)ssid.Value.Length);
+        string decoded = Encoding.UTF8.GetString(ssid.Value, 0, length).Trim();
+        return string.IsNullOrWhiteSpace(decoded) ? "Hidden network" : decoded;
+    }
+
+    private static string FormatAuthentication(Dot11AuthAlgorithm algorithm, bool securityEnabled)
+    {
+        if (!securityEnabled)
+        {
+            return "Open";
+        }
+
+        return algorithm switch
+        {
+            Dot11AuthAlgorithm.IhvStart or Dot11AuthAlgorithm.IhvEnd => "Vendor-specific",
+            Dot11AuthAlgorithm.Open80211 => "Open",
+            Dot11AuthAlgorithm.SharedKey => "WEP",
+            Dot11AuthAlgorithm.Wpa => "WPA-Enterprise",
+            Dot11AuthAlgorithm.WpaPsk => "WPA-Personal",
+            Dot11AuthAlgorithm.WpaNone => "WPA-None",
+            Dot11AuthAlgorithm.Rsna => "WPA2-Enterprise",
+            Dot11AuthAlgorithm.RsnaPsk => "WPA2-Personal",
+            Dot11AuthAlgorithm.Wpa3 => "WPA3-Enterprise",
+            Dot11AuthAlgorithm.Wpa3Sae => "WPA3-Personal",
+            Dot11AuthAlgorithm.Owe => "OWE",
+            _ => $"Unknown ({(uint)algorithm})"
+        };
+    }
+
+    private static string FormatEncryption(Dot11CipherAlgorithm algorithm, bool securityEnabled)
+    {
+        if (!securityEnabled)
+        {
+            return "None";
+        }
+
+        return algorithm switch
+        {
+            Dot11CipherAlgorithm.None => "None",
+            Dot11CipherAlgorithm.Wep40 => "WEP40",
+            Dot11CipherAlgorithm.Tkip => "TKIP",
+            Dot11CipherAlgorithm.Ccmp => "CCMP",
+            Dot11CipherAlgorithm.Wep104 => "WEP104",
+            Dot11CipherAlgorithm.Wep => "WEP",
+            Dot11CipherAlgorithm.Gcmp => "GCMP",
+            Dot11CipherAlgorithm.Gcmp256 => "GCMP-256",
+            Dot11CipherAlgorithm.Ccmp256 => "CCMP-256",
+            Dot11CipherAlgorithm.BipGmac128 => "BIP-GMAC-128",
+            Dot11CipherAlgorithm.BipGmac256 => "BIP-GMAC-256",
+            Dot11CipherAlgorithm.BipCmac256 => "BIP-CMAC-256",
+            Dot11CipherAlgorithm.IhvStart or Dot11CipherAlgorithm.IhvEnd => "Vendor-specific",
+            _ => $"Unknown ({(uint)algorithm})"
+        };
+    }
+
+    private static void TryStartScan(IntPtr clientHandle, Guid interfaceId)
+    {
+        _ = WlanScan(clientHandle, interfaceId, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+    }
+
+    private static IntPtr OpenClientHandle()
+    {
+        ThrowIfError(
+            WlanOpenHandle(ClientVersion, IntPtr.Zero, out _, out IntPtr clientHandle),
+            nameof(WlanOpenHandle));
+
+        return clientHandle;
+    }
+
+    private static void CloseClientHandle(IntPtr clientHandle)
+    {
+        if (clientHandle == IntPtr.Zero)
+        {
+            return;
+        }
+
+        _ = WlanCloseHandle(clientHandle, IntPtr.Zero);
+    }
+
+    private static void FreeMemory(IntPtr pointer)
+    {
+        if (pointer != IntPtr.Zero)
+        {
+            WlanFreeMemory(pointer);
+        }
+    }
+
+    private static void ThrowIfError(uint errorCode, string operation)
+    {
+        if (errorCode != 0)
+        {
+            throw new Win32Exception((int)errorCode, $"{operation} failed with error code {errorCode}.");
+        }
+    }
+
+    [DllImport("wlanapi.dll")]
+    private static extern uint WlanOpenHandle(
+        uint clientVersion,
+        IntPtr reserved,
+        out uint negotiatedVersion,
+        out IntPtr clientHandle);
+
+    [DllImport("wlanapi.dll")]
+    private static extern uint WlanCloseHandle(
+        IntPtr clientHandle,
+        IntPtr reserved);
+
+    [DllImport("wlanapi.dll")]
+    private static extern uint WlanEnumInterfaces(
+        IntPtr clientHandle,
+        IntPtr reserved,
+        out IntPtr interfaceList);
+
+    [DllImport("wlanapi.dll")]
+    private static extern uint WlanGetAvailableNetworkList(
+        IntPtr clientHandle,
+        Guid interfaceGuid,
+        uint flags,
+        IntPtr reserved,
+        out IntPtr availableNetworkList);
+
+    [DllImport("wlanapi.dll")]
+    private static extern uint WlanScan(
+        IntPtr clientHandle,
+        Guid interfaceGuid,
+        IntPtr dot11Ssid,
+        IntPtr ieData,
+        IntPtr reserved);
+
+    [DllImport("wlanapi.dll")]
+    private static extern void WlanFreeMemory(IntPtr memory);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WlanInterfaceInfoListHeader
+    {
+        public int NumberOfItems;
+        public int Index;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct WlanInterfaceInfo
+    {
+        public Guid InterfaceGuid;
+
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 256)]
+        public string InterfaceDescription;
+
+        public WlanInterfaceState State;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WlanAvailableNetworkListHeader
+    {
+        public int NumberOfItems;
+        public int Index;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Dot11Ssid
+    {
+        public uint Length;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
+        public byte[] Value;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct WlanAvailableNetwork
+    {
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 256)]
+        public string ProfileName;
+
+        public Dot11Ssid Ssid;
+        public Dot11BssType BssType;
+        public uint NumberOfBssids;
+
+        [MarshalAs(UnmanagedType.Bool)]
+        public bool NetworkConnectable;
+
+        public uint NotConnectableReason;
+        public uint NumberOfPhyTypes;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = WlanMaxPhyTypeNumber)]
+        public Dot11PhyType[] PhyTypes;
+
+        [MarshalAs(UnmanagedType.Bool)]
+        public bool MorePhyTypes;
+
+        public uint SignalQuality;
+
+        [MarshalAs(UnmanagedType.Bool)]
+        public bool SecurityEnabled;
+
+        public Dot11AuthAlgorithm DefaultAuthAlgorithm;
+        public Dot11CipherAlgorithm DefaultCipherAlgorithm;
+        public uint Flags;
+        public uint Reserved;
+    }
+
+    private enum WlanInterfaceState
+    {
+        NotReady = 0,
+        Connected = 1,
+        AdHocNetworkFormed = 2,
+        Disconnecting = 3,
+        Disconnected = 4,
+        Associating = 5,
+        Discovering = 6,
+        Authenticating = 7
+    }
+
+    private enum Dot11BssType
+    {
+        Infrastructure = 1,
+        Independent = 2,
+        Any = 3
+    }
+
+    private enum Dot11PhyType
+    {
+        Unknown = 0,
+        Any = 0,
+        Fhss = 1,
+        Dsss = 2,
+        IrBaseband = 3,
+        Ofdm = 4,
+        Hrdsss = 5,
+        Erp = 6,
+        Ht = 7,
+        Vht = 8,
+        Dmg = 9,
+        He = 10,
+        Eht = 11,
+        IhvStart = unchecked((int)0x80000000),
+        IhvEnd = unchecked((int)0xffffffff)
+    }
+
+    private enum Dot11AuthAlgorithm : uint
+    {
+        Open80211 = 1,
+        SharedKey = 2,
+        Wpa = 3,
+        WpaPsk = 4,
+        WpaNone = 5,
+        Rsna = 6,
+        RsnaPsk = 7,
+        Wpa3 = 8,
+        Wpa3Sae = 9,
+        Owe = 10,
+        IhvStart = 0x80000000,
+        IhvEnd = 0xffffffff
+    }
+
+    private enum Dot11CipherAlgorithm : uint
+    {
+        None = 0x00,
+        Wep40 = 0x01,
+        Tkip = 0x02,
+        Ccmp = 0x04,
+        Wep104 = 0x05,
+        Bip = 0x06,
+        Gcmp = 0x08,
+        Gcmp256 = 0x09,
+        Ccmp256 = 0x0A,
+        BipGmac128 = 0x0B,
+        BipGmac256 = 0x0C,
+        BipCmac256 = 0x0D,
+        Wep = 0x101,
+        IhvStart = 0x80000000,
+        IhvEnd = 0xffffffff
+    }
+}

--- a/src/Foundry.Connect/Services/Network/NetworkStatusService.cs
+++ b/src/Foundry.Connect/Services/Network/NetworkStatusService.cs
@@ -1,8 +1,6 @@
-using System.Diagnostics;
 using System.Net.Http;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
-using System.Text.RegularExpressions;
 using Foundry.Connect.Models;
 using Foundry.Connect.Models.Configuration;
 using Foundry.Connect.Models.Network;
@@ -10,15 +8,18 @@ using Microsoft.Extensions.Logging;
 
 namespace Foundry.Connect.Services.Network;
 
-public sealed partial class NetworkStatusService : INetworkStatusService
+public sealed class NetworkStatusService : INetworkStatusService
 {
     private static readonly HttpClient HttpClient = new(new HttpClientHandler
     {
         AllowAutoRedirect = true
     });
+    private static readonly TimeSpan WifiDiscoveryGracePeriod = TimeSpan.FromSeconds(15);
 
     private readonly FoundryConnectConfiguration _configuration;
     private readonly ILogger<NetworkStatusService> _logger;
+    private IReadOnlyList<WifiNetworkSummary> _lastStableWifiNetworks = Array.Empty<WifiNetworkSummary>();
+    private DateTimeOffset? _lastStableWifiNetworksAt;
 
     public NetworkStatusService(
         FoundryConnectConfiguration configuration,
@@ -132,175 +133,52 @@ public sealed partial class NetworkStatusService : INetworkStatusService
         return false;
     }
 
-    private async Task<bool> IsWifiRuntimeAvailableAsync(CancellationToken cancellationToken)
+    private Task<bool> IsWifiRuntimeAvailableAsync(CancellationToken cancellationToken)
     {
-        ProcessExecutionResult result = await ExecuteProcessAsync("netsh", "wlan show interfaces", cancellationToken).ConfigureAwait(false);
-        if (result.ExitCode != 0)
-        {
-            return false;
-        }
+        cancellationToken.ThrowIfCancellationRequested();
 
-        string output = $"{result.StandardOutput}\n{result.StandardError}";
-        return !output.Contains("wlansvc", StringComparison.OrdinalIgnoreCase) &&
-               !output.Contains("wireless autoconfig service", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private async Task<IReadOnlyList<WifiNetworkSummary>> DiscoverWifiNetworksAsync(CancellationToken cancellationToken)
-    {
-        ProcessExecutionResult result = await ExecuteProcessAsync("netsh", "wlan show networks mode=bssid", cancellationToken).ConfigureAwait(false);
-        if (result.ExitCode != 0)
-        {
-            return Array.Empty<WifiNetworkSummary>();
-        }
-
-        return ParseWifiNetworks(result.StandardOutput);
-    }
-
-    private static IReadOnlyList<WifiNetworkSummary> ParseWifiNetworks(string output)
-    {
-        if (string.IsNullOrWhiteSpace(output))
-        {
-            return Array.Empty<WifiNetworkSummary>();
-        }
-
-        Dictionary<string, WifiNetworkSummary> networks = new(StringComparer.OrdinalIgnoreCase);
-        string? currentSsid = null;
-        string authentication = "Unknown";
-        string encryption = "Unknown";
-        int signal = 0;
-
-        foreach (string rawLine in output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries))
-        {
-            string line = rawLine.Trim();
-            Match ssidMatch = SsidRegex().Match(line);
-            if (ssidMatch.Success)
-            {
-                CommitNetwork(networks, currentSsid, signal, authentication, encryption);
-                currentSsid = NormalizeSsid(ssidMatch.Groups["ssid"].Value);
-                authentication = "Unknown";
-                encryption = "Unknown";
-                signal = 0;
-                continue;
-            }
-
-            if (currentSsid is null)
-            {
-                continue;
-            }
-
-            if (TryReadValue(line, "authentication", out string authValue))
-            {
-                authentication = authValue;
-                continue;
-            }
-
-            if (TryReadValue(line, "encryption", out string encryptionValue))
-            {
-                encryption = encryptionValue;
-                continue;
-            }
-
-            Match signalMatch = SignalRegex().Match(line);
-            if (signalMatch.Success &&
-                int.TryParse(signalMatch.Groups["value"].Value, out int parsedSignal))
-            {
-                signal = Math.Max(signal, parsedSignal);
-            }
-        }
-
-        CommitNetwork(networks, currentSsid, signal, authentication, encryption);
-
-        return networks.Values
-            .OrderByDescending(static network => network.SignalStrengthPercent)
-            .ThenBy(static network => network.Ssid, StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-    }
-
-    private static void CommitNetwork(
-        IDictionary<string, WifiNetworkSummary> networks,
-        string? ssid,
-        int signal,
-        string authentication,
-        string encryption)
-    {
-        if (string.IsNullOrWhiteSpace(ssid))
-        {
-            return;
-        }
-
-        if (networks.TryGetValue(ssid, out WifiNetworkSummary? existing) &&
-            existing.SignalStrengthPercent >= signal)
-        {
-            return;
-        }
-
-        networks[ssid] = new WifiNetworkSummary
-        {
-            Ssid = ssid,
-            SignalStrengthPercent = Math.Clamp(signal, 0, 100),
-            Authentication = authentication,
-            Encryption = encryption
-        };
-    }
-
-    private static string NormalizeSsid(string value)
-    {
-        string normalized = value.Trim();
-        return string.IsNullOrWhiteSpace(normalized) ? "Hidden network" : normalized;
-    }
-
-    private static bool TryReadValue(string line, string key, out string value)
-    {
-        int separatorIndex = line.IndexOf(':');
-        if (separatorIndex <= 0)
-        {
-            value = string.Empty;
-            return false;
-        }
-
-        string left = line[..separatorIndex].Trim();
-        if (!left.Contains(key, StringComparison.OrdinalIgnoreCase))
-        {
-            value = string.Empty;
-            return false;
-        }
-
-        value = line[(separatorIndex + 1)..].Trim();
-        return !string.IsNullOrWhiteSpace(value);
-    }
-
-    private async Task<ProcessExecutionResult> ExecuteProcessAsync(string fileName, string arguments, CancellationToken cancellationToken)
-    {
         try
         {
-            using Process process = new()
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = fileName,
-                    Arguments = arguments,
-                    CreateNoWindow = true,
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true
-                }
-            };
-
-            process.Start();
-            Task<string> outputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
-            Task<string> errorTask = process.StandardError.ReadToEndAsync(cancellationToken);
-
-            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-
-            return new ProcessExecutionResult(
-                process.ExitCode,
-                await outputTask.ConfigureAwait(false),
-                await errorTask.ConfigureAwait(false));
+            return Task.FromResult(NativeWifiApi.IsRuntimeAvailable());
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Process execution failed for {FileName} {Arguments}.", fileName, arguments);
-            return new ProcessExecutionResult(-1, string.Empty, ex.Message);
+            _logger.LogDebug(ex, "Native Wi-Fi runtime is unavailable.");
+            return Task.FromResult(false);
+        }
+    }
+
+    private Task<IReadOnlyList<WifiNetworkSummary>> DiscoverWifiNetworksAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            IReadOnlyList<WifiNetworkSummary> networks = NativeWifiApi.GetAvailableNetworks();
+            if (networks.Count > 0)
+            {
+                _lastStableWifiNetworks = networks;
+                _lastStableWifiNetworksAt = DateTimeOffset.UtcNow;
+                return Task.FromResult(networks);
+            }
+
+            if (_lastStableWifiNetworks.Count > 0 &&
+                _lastStableWifiNetworksAt is DateTimeOffset lastStableWifiNetworksAt &&
+                DateTimeOffset.UtcNow - lastStableWifiNetworksAt <= WifiDiscoveryGracePeriod)
+            {
+                _logger.LogDebug(
+                    "Native Wi-Fi discovery returned no networks. Reusing {WifiNetworkCount} cached network(s) from {DiscoveredAt}.",
+                    _lastStableWifiNetworks.Count,
+                    lastStableWifiNetworksAt);
+                return Task.FromResult(_lastStableWifiNetworks);
+            }
+
+            return Task.FromResult<IReadOnlyList<WifiNetworkSummary>>(Array.Empty<WifiNetworkSummary>());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Native Wi-Fi network discovery failed.");
+            return Task.FromResult<IReadOnlyList<WifiNetworkSummary>>(Array.Empty<WifiNetworkSummary>());
         }
     }
 
@@ -381,12 +259,4 @@ public sealed partial class NetworkStatusService : INetworkStatusService
 
         return "Waiting for an active network path.";
     }
-
-    [GeneratedRegex(@"^SSID\s+\d+\s*:\s*(?<ssid>.*)$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
-    private static partial Regex SsidRegex();
-
-    [GeneratedRegex(@"(?<value>\d{1,3})\s*%", RegexOptions.CultureInvariant)]
-    private static partial Regex SignalRegex();
-
-    private readonly record struct ProcessExecutionResult(int ExitCode, string StandardOutput, string StandardError);
 }

--- a/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
+++ b/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
@@ -561,27 +561,7 @@ function Start-WinPeWirelessServiceIfSupported {
         return
     }
 
-    try {
-        $service = Get-Service -Name 'WlanSvc' -ErrorAction Stop
-    }
-    catch {
-        Write-Log "WlanSvc is unavailable even though WinRE wireless dependencies are present: $($_.Exception.Message)." -Level Warning -ConsoleMessage 'Wi-Fi service unavailable. Continuing.'
-        return
-    }
-
-    if ([string]::Equals([string]$service.Status, 'Running', [System.StringComparison]::OrdinalIgnoreCase)) {
-        Write-Log 'WlanSvc is already running.' -ConsoleMessage 'Wi-Fi service: already running.'
-        return
-    }
-
-    try {
-        Start-Service -Name 'WlanSvc' -ErrorAction Stop
-        $service.Refresh()
-        Write-Log "WlanSvc started successfully. CurrentStatus='$($service.Status)'." -ConsoleMessage 'Wi-Fi service: started.'
-    }
-    catch {
-        Write-Log "Failed to start WlanSvc: $($_.Exception.Message)." -Level Warning -ConsoleMessage 'Wi-Fi service start failed. Continuing.'
-    }
+    [void](Ensure-ServiceRunning -ServiceName 'WlanSvc' -FriendlyName 'Wi-Fi AutoConfig')
 }
 
 function Sync-WinPeInternetDateTime {
@@ -1724,6 +1704,7 @@ try {
     }
 
     [void](Ensure-ServiceRunning -ServiceName 'dot3svc' -FriendlyName 'Wired AutoConfig')
+    Start-WinPeWirelessServiceIfSupported
 
     $connectProvisioningSource = Get-EmbeddedProvisioningSource -ApplicationName 'Foundry.Connect'
     $deployProvisioningSource = Get-EmbeddedProvisioningSource -ApplicationName 'Foundry.Deploy'


### PR DESCRIPTION
## Summary
Stabilize Foundry.Connect Wi-Fi discovery in WinPE and replace localized `netsh` parsing with the Native Wi-Fi API.

## Why
Foundry.Connect could fail to show visible Wi-Fi networks on non-English systems because discovery depended on parsing localized `netsh` output. WinPE startup also did not explicitly start the Wi-Fi service before launching Foundry.Connect. In testing, transient empty WLAN results could also clear the visible network list between refreshes.

## Changes
- start the WinPE Wi-Fi AutoConfig service before launching Foundry.Connect
- reuse the existing bootstrap service-start helper for `WlanSvc`
- replace Wi-Fi runtime detection and network discovery with Native Wi-Fi API calls
- add a small interop wrapper around `WlanOpenHandle`, `WlanEnumInterfaces`, `WlanScan`, and `WlanGetAvailableNetworkList`
- keep the last non-empty Wi-Fi discovery result briefly to avoid clearing the UI on transient empty scans

## Testing
- `dotnet build src\\Foundry.Connect\\Foundry.Connect.csproj`
- manual log inspection of `FoundryConnect.log` during laptop testing

## Notes
- Wi-Fi connection/profile application still uses `netsh`; this PR only moves discovery/runtime checks to the WLAN API.
- Planning files were intentionally left out of the commit.
