### PR TITLE
fix(winpe): cache Foundry.Connect runtime on USB media

### DIFF
--- a/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
+++ b/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
@@ -1708,7 +1708,7 @@ try {
 
     $connectProvisioningSource = Get-EmbeddedProvisioningSource -ApplicationName 'Foundry.Connect'
     $deployProvisioningSource = Get-EmbeddedProvisioningSource -ApplicationName 'Foundry.Deploy'
-    $skipConnectUpdateCheck = $connectProvisioningSource -eq 'local'
+    $skipConnectReleaseLookup = $connectProvisioningSource -eq 'local'
     $skipDeployReleaseLookup = $deployProvisioningSource -eq 'local'
 
     $connectExecutable = Resolve-ApplicationExecutable `
@@ -1716,7 +1716,7 @@ try {
         -BootstrapRoot $bootstrapRoot `
         -RuntimeIdentifier $runtimeIdentifier `
         -Headers $headers `
-        -SkipReleaseLookup
+        -SkipReleaseLookup:$skipConnectReleaseLookup
 
     $connectExitCode = Invoke-ConnectExecutable `
         -Executable $connectExecutable `
@@ -1737,7 +1737,7 @@ try {
     Sync-WinPeInternetDateTime -ThresholdMinutes 5
     Set-WinPeTimeZone -FallbackTimeZoneId $DefaultWinPeTimeZoneId
 
-    if ($skipConnectUpdateCheck) {
+    if ($skipConnectReleaseLookup) {
         Write-Log "Skipping Foundry.Connect cache verification because the embedded provisioning source is local." -ConsoleMessage 'Foundry.Connect local provisioning detected. Skipping update check.'
     }
     else {

--- a/src/Foundry/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry/Services/WinPe/WinPeUsbMediaService.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
@@ -234,6 +235,16 @@ else {
         Directory.CreateDirectory(Path.Combine(cacheRoot, "DriverPack"));
         _logger.LogInformation("Initialized USB cache partition directories. CacheRoot={CacheRoot}", cacheRoot);
 
+        WinPeResult connectRuntimeProvisioningResult = ProvisionFoundryConnectRuntime(cacheRoot, artifact);
+        if (!connectRuntimeProvisioningResult.IsSuccess)
+        {
+            _logger.LogWarning(
+                "USB Foundry.Connect runtime provisioning failed. Code={ErrorCode}, Message={ErrorMessage}",
+                connectRuntimeProvisioningResult.Error?.Code,
+                connectRuntimeProvisioningResult.Error?.Message);
+            return WinPeResult<WinPeUsbProvisionResult>.Failure(connectRuntimeProvisioningResult.Error!);
+        }
+
         WinPeResult<WinPeUsbProvisionResult> success = WinPeResult<WinPeUsbProvisionResult>.Success(new WinPeUsbProvisionResult
         {
             BootDriveLetter = $"{bootDriveLetter}:",
@@ -245,6 +256,80 @@ else {
             success.Value?.BootDriveLetter,
             success.Value?.CacheDriveLetter);
         return success;
+    }
+
+    private WinPeResult ProvisionFoundryConnectRuntime(string cacheRoot, WinPeBuildArtifact artifact)
+    {
+        string sourceArchivePath = Path.Combine(
+            artifact.MediaDirectoryPath,
+            WinPeDefaults.EmbeddedConnectArchivePathInImage);
+        if (!File.Exists(sourceArchivePath))
+        {
+            return WinPeResult.Failure(
+                WinPeErrorCodes.ToolNotFound,
+                "Foundry.Connect archive was not found in the prepared USB media workspace.",
+                $"Expected path: '{sourceArchivePath}'.");
+        }
+
+        string runtimeIdentifier = artifact.Architecture.ToDotnetRuntimeIdentifier();
+        string applicationRoot = Path.Combine(cacheRoot, "Runtime", "Foundry.Connect");
+        string destinationRoot = Path.Combine(applicationRoot, runtimeIdentifier);
+        string stagingRoot = $"{destinationRoot}.staging";
+
+        try
+        {
+            _logger.LogInformation(
+                "Provisioning Foundry.Connect runtime into USB cache partition. SourceArchivePath={SourceArchivePath}, DestinationRoot={DestinationRoot}",
+                sourceArchivePath,
+                destinationRoot);
+
+            if (Directory.Exists(stagingRoot))
+            {
+                Directory.Delete(stagingRoot, recursive: true);
+            }
+
+            Directory.CreateDirectory(applicationRoot);
+            ZipFile.ExtractToDirectory(sourceArchivePath, stagingRoot);
+
+            string executablePath = Path.Combine(stagingRoot, "Foundry.Connect.exe");
+            if (!File.Exists(executablePath))
+            {
+                return WinPeResult.Failure(
+                    WinPeErrorCodes.BuildFailed,
+                    "The Foundry.Connect archive could not be extracted into the USB cache runtime.",
+                    $"Expected executable: '{executablePath}'.");
+            }
+
+            if (Directory.Exists(destinationRoot))
+            {
+                Directory.Delete(destinationRoot, recursive: true);
+            }
+
+            Directory.Move(stagingRoot, destinationRoot);
+            _logger.LogInformation(
+                "Provisioned Foundry.Connect runtime into USB cache partition successfully. DestinationRoot={DestinationRoot}",
+                destinationRoot);
+            return WinPeResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to provision Foundry.Connect runtime into USB cache partition. SourceArchivePath={SourceArchivePath}, DestinationRoot={DestinationRoot}",
+                sourceArchivePath,
+                destinationRoot);
+            return WinPeResult.Failure(
+                WinPeErrorCodes.BuildFailed,
+                "Failed to provision Foundry.Connect runtime into the USB cache partition.",
+                ex.ToString());
+        }
+        finally
+        {
+            if (Directory.Exists(stagingRoot))
+            {
+                Directory.Delete(stagingRoot, recursive: true);
+            }
+        }
     }
 
     private WinPeResult ConfigureBootFiles(


### PR DESCRIPTION
## Summary
Align USB media creation with the intended Foundry.Connect runtime layout.

## Why
USB media should run `Foundry.Connect` from the cache partition runtime while keeping provisioning configuration in the boot image. The previous bootstrap path also forced an embedded archive refresh on startup, which made the new USB cache population redundant.

## Changes
- pre-populate `Foundry.Connect` into `Runtime\Foundry.Connect\<rid>` during USB media creation
- keep `Foundry.Connect` configuration in the boot image
- make `FoundryBootstrap.ps1` skip release lookup for `Foundry.Connect` only when the provisioning source is marked as local
- preserve the existing GitHub-based cache verification and update path for non-local provisioning

## Testing
- `dotnet build src\Foundry.slnx`

## Notes
- no UI changes
- USB media now carries the executable payload in the cache partition, while config and provisioned assets remain in the boot image