### PR TITLE
fix(winpe): provision extracted Foundry Connect runtime

### DIFF
--- a/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
+++ b/src/Foundry/Assets/WinPe/FoundryBootstrap.ps1
@@ -12,7 +12,6 @@ $FileLogLevel = 'Debug'
 $Owner = 'mchave3'
 $Repository = 'Foundry'
 $ReleaseApiBaseUrl = "https://api.github.com/repos/$Owner/$Repository/releases"
-$EmbeddedConnectArchivePath = Join-Path $WinPeRoot 'Seed\Foundry.Connect.zip'
 $EmbeddedConnectConfigurationPath = Join-Path $WinPeRoot 'Config\foundry.connect.config.json'
 $EmbeddedDeployArchivePath = Join-Path $WinPeRoot 'Seed\Foundry.Deploy.zip'
 $EmbeddedDeployConfigurationPath = Join-Path $WinPeRoot 'Config\foundry.deploy.config.json'
@@ -1346,7 +1345,7 @@ function Get-EmbeddedArchivePath {
     )
 
     switch ($ApplicationName) {
-        'Foundry.Connect' { return $EmbeddedConnectArchivePath }
+        'Foundry.Connect' { return '' }
         'Foundry.Deploy' { return $EmbeddedDeployArchivePath }
     }
 }
@@ -1460,9 +1459,11 @@ function Resolve-ApplicationExecutable {
     $archiveOverride = Get-ArchiveOverridePath -ApplicationName $ApplicationName
     $archiveOverrideSha256 = Get-ArchiveOverrideSha256 -ApplicationName $ApplicationName
     $embeddedArchivePath = Get-EmbeddedArchivePath -ApplicationName $ApplicationName
+    $hasEmbeddedArchiveFallback = -not [string]::IsNullOrWhiteSpace($embeddedArchivePath) -and (Test-Path -Path $embeddedArchivePath -PathType Leaf)
+    $releaseLookupFallbackDescription = if ($hasEmbeddedArchiveFallback) { 'the existing cache or embedded archive' } else { 'the existing cache' }
     $executable = $null
 
-    if ($SkipReleaseLookup -and [string]::IsNullOrWhiteSpace($archiveOverride) -and (Test-Path -Path $embeddedArchivePath -PathType Leaf)) {
+    if ($SkipReleaseLookup -and [string]::IsNullOrWhiteSpace($archiveOverride) -and $hasEmbeddedArchiveFallback) {
         $archiveOverride = $embeddedArchivePath
         Write-Log "Using embedded $ApplicationName archive from '$embeddedArchivePath'." -ConsoleMessage "Using embedded $ApplicationName archive."
     }
@@ -1510,12 +1511,12 @@ function Resolve-ApplicationExecutable {
             $release = Invoke-WithRetry -Action { Invoke-RestMethod -Uri $releaseApiUrl -Headers $Headers -Method Get }
         }
         catch {
-            Write-Log "Failed to resolve $ApplicationName release metadata: $($_.Exception.Message). Falling back to the existing cache or embedded archive." -Level Warning -ConsoleMessage "$ApplicationName release lookup failed. Falling back."
+            Write-Log "Failed to resolve $ApplicationName release metadata: $($_.Exception.Message). Falling back to $releaseLookupFallbackDescription." -Level Warning -ConsoleMessage "$ApplicationName release lookup failed. Falling back."
             try {
                 $executable = Resolve-CachedExecutable -RuntimeCacheRoot $runtimeCacheRoot -ApplicationName $ApplicationName
             }
             catch {
-                if (Test-Path -Path $embeddedArchivePath -PathType Leaf) {
+                if ($hasEmbeddedArchiveFallback) {
                     Write-Log "Falling back to the embedded $ApplicationName archive because no cached executable was available." -Level Warning -ConsoleMessage "Using embedded $ApplicationName archive as fallback."
                     $archiveSha256 = Get-FileSha256 -Path $embeddedArchivePath
                     $executable = Update-CacheFromArchiveFile `
@@ -1585,12 +1586,12 @@ function Resolve-ApplicationExecutable {
                         -ArchiveSha256 $archiveSha256
                 }
                 catch {
-                    Write-Log "Failed to refresh the $ApplicationName cache: $($_.Exception.Message). Falling back to the existing cache or embedded archive." -Level Warning -ConsoleMessage "$ApplicationName cache refresh failed. Falling back."
+                    Write-Log "Failed to refresh the $ApplicationName cache: $($_.Exception.Message). Falling back to $releaseLookupFallbackDescription." -Level Warning -ConsoleMessage "$ApplicationName cache refresh failed. Falling back."
                     try {
                         $executable = Resolve-CachedExecutable -RuntimeCacheRoot $runtimeCacheRoot -ApplicationName $ApplicationName
                     }
                     catch {
-                        if (Test-Path -Path $embeddedArchivePath -PathType Leaf) {
+                        if ($hasEmbeddedArchiveFallback) {
                             Write-Log "Falling back to the embedded $ApplicationName archive because the cache could not be refreshed." -Level Warning -ConsoleMessage "Using embedded $ApplicationName archive as fallback."
                             $archiveSha256 = Get-FileSha256 -Path $embeddedArchivePath
                             $executable = Update-CacheFromArchiveFile `
@@ -1738,7 +1739,7 @@ try {
     Set-WinPeTimeZone -FallbackTimeZoneId $DefaultWinPeTimeZoneId
 
     if ($skipConnectReleaseLookup) {
-        Write-Log "Skipping Foundry.Connect cache verification because the embedded provisioning source is local." -ConsoleMessage 'Foundry.Connect local provisioning detected. Skipping update check.'
+        Write-Log 'Skipping Foundry.Connect cache verification because the provisioned runtime is local.' -ConsoleMessage 'Foundry.Connect local runtime detected. Skipping update check.'
     }
     else {
         try {

--- a/src/Foundry/Services/WinPe/IWinPeLocalConnectEmbeddingService.cs
+++ b/src/Foundry/Services/WinPe/IWinPeLocalConnectEmbeddingService.cs
@@ -4,6 +4,7 @@ internal interface IWinPeLocalConnectEmbeddingService
 {
     Task<WinPeResult> ProvisionAsync(
         string mountedImagePath,
+        string mediaDirectoryPath,
         WinPeArchitecture architecture,
         string workingDirectoryPath,
         CancellationToken cancellationToken);

--- a/src/Foundry/Services/WinPe/WinPeLocalConnectEmbeddingService.cs
+++ b/src/Foundry/Services/WinPe/WinPeLocalConnectEmbeddingService.cs
@@ -22,14 +22,17 @@ internal sealed class WinPeLocalConnectEmbeddingService : IWinPeLocalConnectEmbe
 
     public async Task<WinPeResult> ProvisionAsync(
         string mountedImagePath,
+        string mediaDirectoryPath,
         WinPeArchitecture architecture,
         string workingDirectoryPath,
         CancellationToken cancellationToken)
     {
+        string runtimeIdentifier = architecture.ToDotnetRuntimeIdentifier();
         bool useLocalOverride = IsEnabledEnvironmentFlag(Environment.GetEnvironmentVariable(WinPeDefaults.LocalConnectEnableEnvironmentVariable));
         _logger.LogInformation(
-            "Provisioning Foundry.Connect archive into mounted WinPE image. Architecture={Architecture}, UseLocalOverride={UseLocalOverride}",
+            "Provisioning Foundry.Connect runtime into WinPE outputs. Architecture={Architecture}, RuntimeIdentifier={RuntimeIdentifier}, UseLocalOverride={UseLocalOverride}",
             architecture,
+            runtimeIdentifier,
             useLocalOverride);
 
         WinPeResult<string> archiveResult = useLocalOverride
@@ -44,34 +47,66 @@ internal sealed class WinPeLocalConnectEmbeddingService : IWinPeLocalConnectEmbe
             return WinPeResult.Failure(archiveResult.Error!);
         }
 
-        string destinationPath = Path.Combine(mountedImagePath, WinPeDefaults.EmbeddedConnectArchivePathInImage);
-        string? destinationDirectory = Path.GetDirectoryName(destinationPath);
-        if (string.IsNullOrWhiteSpace(destinationDirectory))
-        {
-            return WinPeResult.Failure(
-                WinPeErrorCodes.InternalError,
-                "Failed to resolve destination path for local Foundry.Connect archive.",
-                $"Destination: '{destinationPath}'.");
-        }
+        string extractionRoot = Path.Combine(workingDirectoryPath, "FoundryConnectExtracted", runtimeIdentifier);
+        string mountedImageRuntimeRoot = GetRuntimeRoot(mountedImagePath, runtimeIdentifier);
+        string stagedMediaRuntimeRoot = GetRuntimeRoot(mediaDirectoryPath, runtimeIdentifier);
+        string mountedImageLegacyArchivePath = Path.Combine(mountedImagePath, WinPeDefaults.EmbeddedConnectArchivePathInImage);
+        string stagedMediaLegacyArchivePath = Path.Combine(mediaDirectoryPath, WinPeDefaults.EmbeddedConnectArchivePathInImage);
 
         try
         {
-            Directory.CreateDirectory(destinationDirectory);
+            WinPeFileSystemHelper.EnsureDirectoryClean(extractionRoot);
             _logger.LogInformation(
-                "Copying local Foundry.Connect archive into mounted WinPE image. ArchivePath={ArchivePath}, DestinationPath={DestinationPath}",
+                "Extracting Foundry.Connect runtime for WinPE provisioning. ArchivePath={ArchivePath}, ExtractionRoot={ExtractionRoot}",
                 archiveResult.Value!,
-                destinationPath);
-            File.Copy(archiveResult.Value!, destinationPath, overwrite: true);
-            _logger.LogInformation("Copied local Foundry.Connect archive into mounted WinPE image successfully. DestinationPath={DestinationPath}", destinationPath);
+                extractionRoot);
+            ZipFile.ExtractToDirectory(archiveResult.Value!, extractionRoot);
+
+            string extractedExecutablePath = Path.Combine(extractionRoot, "Foundry.Connect.exe");
+            if (!File.Exists(extractedExecutablePath))
+            {
+                return WinPeResult.Failure(
+                    WinPeErrorCodes.BuildFailed,
+                    "The Foundry.Connect runtime archive did not contain the expected executable.",
+                    $"Expected executable: '{extractedExecutablePath}'.");
+            }
+
+            _logger.LogInformation(
+                "Copying extracted Foundry.Connect runtime into mounted WinPE image. SourceRoot={SourceRoot}, DestinationRoot={DestinationRoot}",
+                extractionRoot,
+                mountedImageRuntimeRoot);
+            CopyDirectory(extractionRoot, mountedImageRuntimeRoot);
+            TryDeleteFile(mountedImageLegacyArchivePath);
+            _logger.LogInformation(
+                "Copied extracted Foundry.Connect runtime into mounted WinPE image successfully. DestinationRoot={DestinationRoot}",
+                mountedImageRuntimeRoot);
+
+            _logger.LogInformation(
+                "Copying extracted Foundry.Connect runtime into staged WinPE media workspace. SourceRoot={SourceRoot}, DestinationRoot={DestinationRoot}",
+                extractionRoot,
+                stagedMediaRuntimeRoot);
+            CopyDirectory(extractionRoot, stagedMediaRuntimeRoot);
+            TryDeleteFile(stagedMediaLegacyArchivePath);
+            _logger.LogInformation(
+                "Copied extracted Foundry.Connect runtime into staged WinPE media workspace successfully. DestinationRoot={DestinationRoot}",
+                stagedMediaRuntimeRoot);
             return WinPeResult.Success();
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to copy local Foundry.Connect archive into mounted WinPE image. DestinationPath={DestinationPath}", destinationPath);
+            _logger.LogError(
+                ex,
+                "Failed to provision extracted Foundry.Connect runtime for WinPE. MountedImageRuntimeRoot={MountedImageRuntimeRoot}, StagedMediaRuntimeRoot={StagedMediaRuntimeRoot}",
+                mountedImageRuntimeRoot,
+                stagedMediaRuntimeRoot);
             return WinPeResult.Failure(
                 WinPeErrorCodes.BuildFailed,
-                "Failed to copy local Foundry.Connect archive into mounted WinPE image.",
+                "Failed to provision the extracted Foundry.Connect runtime for WinPE.",
                 ex.ToString());
+        }
+        finally
+        {
+            TryDeleteDirectory(extractionRoot);
         }
     }
 
@@ -342,6 +377,55 @@ internal sealed class WinPeLocalConnectEmbeddingService : IWinPeLocalConnectEmbe
             "ON" => true,
             _ => false
         };
+    }
+
+    private static string GetRuntimeRoot(string rootPath, string runtimeIdentifier)
+    {
+        return Path.Combine(rootPath, "Foundry", "Runtime", "Foundry.Connect", runtimeIdentifier);
+    }
+
+    private static void CopyDirectory(string sourceDirectoryPath, string destinationDirectoryPath)
+    {
+        if (!Directory.Exists(sourceDirectoryPath))
+        {
+            throw new DirectoryNotFoundException($"Source directory not found: '{sourceDirectoryPath}'.");
+        }
+
+        WinPeFileSystemHelper.EnsureDirectoryClean(destinationDirectoryPath);
+
+        foreach (string directoryPath in Directory.EnumerateDirectories(sourceDirectoryPath, "*", SearchOption.AllDirectories))
+        {
+            string relativeDirectoryPath = Path.GetRelativePath(sourceDirectoryPath, directoryPath);
+            Directory.CreateDirectory(Path.Combine(destinationDirectoryPath, relativeDirectoryPath));
+        }
+
+        foreach (string filePath in Directory.EnumerateFiles(sourceDirectoryPath, "*", SearchOption.AllDirectories))
+        {
+            string relativeFilePath = Path.GetRelativePath(sourceDirectoryPath, filePath);
+            string destinationFilePath = Path.Combine(destinationDirectoryPath, relativeFilePath);
+            string? destinationDirectory = Path.GetDirectoryName(destinationFilePath);
+            if (!string.IsNullOrWhiteSpace(destinationDirectory))
+            {
+                Directory.CreateDirectory(destinationDirectory);
+            }
+
+            File.Copy(filePath, destinationFilePath, overwrite: true);
+        }
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
     }
 
     private static void TryDeleteDirectory(string path)

--- a/src/Foundry/Services/WinPe/WinPeMountedImageCustomizationService.cs
+++ b/src/Foundry/Services/WinPe/WinPeMountedImageCustomizationService.cs
@@ -138,6 +138,7 @@ internal sealed class WinPeMountedImageCustomizationService : IWinPeMountedImage
         ReportProgress(request.Progress, 66, "Provisioning Foundry.Connect payload.");
         WinPeResult localConnectProvisioning = await _localConnectEmbeddingService.ProvisionAsync(
             session.MountDirectoryPath,
+            request.Artifact.MediaDirectoryPath,
             request.Artifact.Architecture,
             request.Artifact.WorkingDirectoryPath,
             cancellationToken).ConfigureAwait(false);

--- a/src/Foundry/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry/Services/WinPe/WinPeUsbMediaService.cs
@@ -260,18 +260,21 @@ else {
 
     private WinPeResult ProvisionFoundryConnectRuntime(string cacheRoot, WinPeBuildArtifact artifact)
     {
-        string sourceArchivePath = Path.Combine(
+        string runtimeIdentifier = artifact.Architecture.ToDotnetRuntimeIdentifier();
+        string sourceRuntimeRoot = Path.Combine(
             artifact.MediaDirectoryPath,
-            WinPeDefaults.EmbeddedConnectArchivePathInImage);
-        if (!File.Exists(sourceArchivePath))
+            "Foundry",
+            "Runtime",
+            "Foundry.Connect",
+            runtimeIdentifier);
+        if (!Directory.Exists(sourceRuntimeRoot))
         {
             return WinPeResult.Failure(
                 WinPeErrorCodes.ToolNotFound,
-                "Foundry.Connect archive was not found in the prepared USB media workspace.",
-                $"Expected path: '{sourceArchivePath}'.");
+                "Foundry.Connect runtime was not found in the prepared USB media workspace.",
+                $"Expected path: '{sourceRuntimeRoot}'.");
         }
 
-        string runtimeIdentifier = artifact.Architecture.ToDotnetRuntimeIdentifier();
         string applicationRoot = Path.Combine(cacheRoot, "Runtime", "Foundry.Connect");
         string destinationRoot = Path.Combine(applicationRoot, runtimeIdentifier);
         string stagingRoot = $"{destinationRoot}.staging";
@@ -279,8 +282,8 @@ else {
         try
         {
             _logger.LogInformation(
-                "Provisioning Foundry.Connect runtime into USB cache partition. SourceArchivePath={SourceArchivePath}, DestinationRoot={DestinationRoot}",
-                sourceArchivePath,
+                "Provisioning Foundry.Connect runtime into USB cache partition. SourceRuntimeRoot={SourceRuntimeRoot}, DestinationRoot={DestinationRoot}",
+                sourceRuntimeRoot,
                 destinationRoot);
 
             if (Directory.Exists(stagingRoot))
@@ -289,14 +292,14 @@ else {
             }
 
             Directory.CreateDirectory(applicationRoot);
-            ZipFile.ExtractToDirectory(sourceArchivePath, stagingRoot);
+            CopyDirectory(sourceRuntimeRoot, stagingRoot);
 
             string executablePath = Path.Combine(stagingRoot, "Foundry.Connect.exe");
             if (!File.Exists(executablePath))
             {
                 return WinPeResult.Failure(
                     WinPeErrorCodes.BuildFailed,
-                    "The Foundry.Connect archive could not be extracted into the USB cache runtime.",
+                    "The Foundry.Connect runtime could not be provisioned into the USB cache partition.",
                     $"Expected executable: '{executablePath}'.");
             }
 
@@ -315,8 +318,8 @@ else {
         {
             _logger.LogError(
                 ex,
-                "Failed to provision Foundry.Connect runtime into USB cache partition. SourceArchivePath={SourceArchivePath}, DestinationRoot={DestinationRoot}",
-                sourceArchivePath,
+                "Failed to provision Foundry.Connect runtime into USB cache partition. SourceRuntimeRoot={SourceRuntimeRoot}, DestinationRoot={DestinationRoot}",
+                sourceRuntimeRoot,
                 destinationRoot);
             return WinPeResult.Failure(
                 WinPeErrorCodes.BuildFailed,
@@ -329,6 +332,35 @@ else {
             {
                 Directory.Delete(stagingRoot, recursive: true);
             }
+        }
+    }
+
+    private static void CopyDirectory(string sourceDirectoryPath, string destinationDirectoryPath)
+    {
+        if (!Directory.Exists(sourceDirectoryPath))
+        {
+            throw new DirectoryNotFoundException($"Source directory not found: '{sourceDirectoryPath}'.");
+        }
+
+        WinPeFileSystemHelper.EnsureDirectoryClean(destinationDirectoryPath);
+
+        foreach (string directoryPath in Directory.EnumerateDirectories(sourceDirectoryPath, "*", SearchOption.AllDirectories))
+        {
+            string relativeDirectoryPath = Path.GetRelativePath(sourceDirectoryPath, directoryPath);
+            Directory.CreateDirectory(Path.Combine(destinationDirectoryPath, relativeDirectoryPath));
+        }
+
+        foreach (string filePath in Directory.EnumerateFiles(sourceDirectoryPath, "*", SearchOption.AllDirectories))
+        {
+            string relativeFilePath = Path.GetRelativePath(sourceDirectoryPath, filePath);
+            string destinationFilePath = Path.Combine(destinationDirectoryPath, relativeFilePath);
+            string? destinationDirectory = Path.GetDirectoryName(destinationFilePath);
+            if (!string.IsNullOrWhiteSpace(destinationDirectory))
+            {
+                Directory.CreateDirectory(destinationDirectory);
+            }
+
+            File.Copy(filePath, destinationFilePath, overwrite: true);
         }
     }
 


### PR DESCRIPTION
## Summary
Align Foundry.Connect WinPE provisioning with the runtime-only model for ISO and USB outputs.

## Why
The previous flow kept `Foundry.Connect.zip` in the staged media/boot image and relied on later extraction. That no longer matches the intended behavior: final ISO and USB outputs should contain only provisioned runtime content.

## Changes
- Extract Foundry.Connect during WinPE preparation and provision the extracted runtime into the image runtime root.
- Stage the extracted runtime in the prepared media workspace so USB creation can copy it into the cache partition.
- Update USB provisioning to consume the staged extracted runtime instead of a staged zip archive.
- Remove obsolete Foundry.Connect embedded-archive fallback logic from the WinPE bootstrap while preserving the existing update flow for release-based provisioning.
- Keep compatibility cleanup for any stale legacy `Foundry.Connect.zip` output left in reused workspaces.

## Testing
- `dotnet build src\Foundry\Foundry.csproj`
- Published `Foundry` in `Release` for `win-x64`
- User confirmed the published x64 build works for production-style testing

## Notes
- Foundry.Connect still keeps the bootstrap update logic when the provisioning source is `release`.
- Local provisioning still skips the update check by design.