### PR TITLE
fix(connect): align provisioned wifi empty state

### DIFF
--- a/src/Foundry.Connect/Services/Network/NetworkBootstrapService.cs
+++ b/src/Foundry.Connect/Services/Network/NetworkBootstrapService.cs
@@ -268,6 +268,11 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
             return string.Join(" ", messages);
         }
 
+        if (NativeWifiApi.GetInterfaceIds().Count == 0)
+        {
+            return string.Join(" ", messages);
+        }
+
         ProcessExecutionResult addProfileResult = await ImportWifiProfileAsync(wifiProfilePath, cancellationToken).ConfigureAwait(false);
 
         if (addProfileResult.ExitCode != 0)

--- a/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
@@ -200,6 +200,9 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     public string ProvisionedWifiAuthenticationText => BuildProvisionedWifiAuthenticationText();
     public string ProvisionedWifiSourceHintText => BuildProvisionedWifiSourceHintText();
     public string ProvisionedWifiStatusText => BuildProvisionedWifiStatusText();
+    public bool ShowProvisionedWifiContent => HasProvisionedWifiProfile &&
+                                              string.IsNullOrWhiteSpace(BuildWifiUnavailableText());
+    public string ProvisionedWifiPlaceholderText => BuildProvisionedWifiPlaceholderText();
     public bool HasProvisionedWifiActionFeedback => !string.IsNullOrWhiteSpace(ProvisionedWifiActionFeedbackText);
     public string WifiDiscoveryEmptyStateText => BuildWifiDiscoveryEmptyStateText();
     public bool HasSelectedWifiActionFeedback => !string.IsNullOrWhiteSpace(SelectedWifiActionFeedbackText);
@@ -427,6 +430,8 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         LastUpdatedAt = DateTimeOffset.Now;
         OnPropertyChanged(nameof(LastUpdatedText));
         OnPropertyChanged(nameof(WifiDiscoveryEmptyStateText));
+        OnPropertyChanged(nameof(ShowProvisionedWifiContent));
+        OnPropertyChanged(nameof(ProvisionedWifiPlaceholderText));
         RefreshDerivedConnectionState(snapshot);
 
         SyncWifiNetworks(snapshot.WifiNetworks, snapshot.ConnectedWifiSsid);
@@ -1105,6 +1110,21 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
     private string BuildWifiDiscoveryEmptyStateText()
     {
+        return BuildWifiUnavailableText() ?? "No Wi-Fi networks are currently visible.";
+    }
+
+    private string BuildProvisionedWifiPlaceholderText()
+    {
+        if (!HasProvisionedWifiProfile)
+        {
+            return "No provisioned profile is available in this boot image.";
+        }
+
+        return BuildWifiUnavailableText() ?? string.Empty;
+    }
+
+    private string? BuildWifiUnavailableText()
+    {
         if (!IsWifiRuntimeAvailable)
         {
             return "Wi-Fi support is not available at runtime.";
@@ -1115,7 +1135,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             return "No wireless adapter is currently detected.";
         }
 
-        return "No Wi-Fi networks are currently visible.";
+        return null;
     }
 
     private string ResolveProvisionedWifiProfileName()

--- a/src/Foundry.Connect/Views/EthernetWifiView.xaml
+++ b/src/Foundry.Connect/Views/EthernetWifiView.xaml
@@ -321,23 +321,24 @@
 
             <Border Grid.Row="1" Style="{StaticResource SectionCardBorderStyle}">
                 <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
 
                     <TextBlock
+                        Grid.Row="0"
                         Margin="0,0,16,0"
                         VerticalAlignment="Top"
                         FontFamily="{StaticResource SymbolThemeFontFamily}"
                         FontSize="28"
                         Text="&#xF081;" />
 
-                    <Grid Grid.Column="1">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
+                    <Grid Grid.Row="0" Grid.Column="1">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
@@ -345,7 +346,7 @@
 
                         <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="Provisioned Wi-Fi" />
 
-                        <Grid Grid.Column="1" Visibility="{Binding HasProvisionedWifiProfile, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <Grid Grid.Column="1" Visibility="{Binding ShowProvisionedWifiContent, Converter={StaticResource BooleanToVisibilityConverter}}">
                             <Grid x:Name="ProvisionedHeaderConnectButtonRow" HorizontalAlignment="Right">
                                 <Grid.Style>
                                     <Style TargetType="Grid">
@@ -387,12 +388,13 @@
                                     IsEnabled="{Binding CanDisconnectConfiguredWifi}" />
                             </Grid>
                         </Grid>
+                    </Grid>
 
-                        <StackPanel
-                            Grid.Row="1"
-                            Grid.ColumnSpan="2"
-                            Margin="0,8,0,0"
-                            Visibility="{Binding HasProvisionedWifiProfile, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Grid
+                        Grid.Row="1"
+                        Grid.ColumnSpan="2"
+                        Margin="0,8,0,0">
+                        <StackPanel Margin="44,0,0,0" Visibility="{Binding ShowProvisionedWifiContent, Converter={StaticResource BooleanToVisibilityConverter}}">
                             <TextBlock
                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                 Style="{StaticResource BodyTextBlockStyle}"
@@ -454,19 +456,17 @@
                         </StackPanel>
 
                         <TextBlock
-                            Grid.Row="1"
-                            Grid.ColumnSpan="2"
                             HorizontalAlignment="Center"
                             VerticalAlignment="Center"
                             Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                            Text="No provisioned profile is available in this boot image."
+                            Text="{Binding ProvisionedWifiPlaceholderText}"
                             TextAlignment="Center"
                             TextWrapping="Wrap">
                             <TextBlock.Style>
                                 <Style BasedOn="{StaticResource BodyTextBlockStyle}" TargetType="TextBlock">
                                     <Setter Property="Visibility" Value="Collapsed" />
                                     <Style.Triggers>
-                                        <DataTrigger Binding="{Binding HasProvisionedWifiProfile}" Value="False">
+                                        <DataTrigger Binding="{Binding ShowProvisionedWifiContent}" Value="False">
                                             <Setter Property="Visibility" Value="Visible" />
                                         </DataTrigger>
                                     </Style.Triggers>


### PR DESCRIPTION
## Summary
Align the Foundry.Connect provisioned Wi-Fi empty state with the main Wi-Fi card and remove the misleading startup warning path when no wireless adapter is present.

## Why
When a provisioned Wi-Fi profile existed but no wireless adapter was available, the provisioned card displayed a yellow warning line and the placeholder text appeared visually offset to the right. The regular Wi-Fi card already had a cleaner centered empty state.

## Changes
- center the provisioned Wi-Fi placeholder against the full card body instead of the inner content column
- show the provisioned Wi-Fi card content only when a profile is available and Wi-Fi is usable
- reuse a single view model placeholder/content state for the provisioned card
- avoid surfacing a startup provisioned Wi-Fi import warning when no wireless adapter is present

## Testing
- `dotnet build src\Foundry.Connect\Foundry.Connect.csproj`
- published `Foundry` for `win-x64` and verified the updated layout in the test environment

## Notes
- planning files created for the local planning workflow were intentionally left untracked and are not part of this PR.