### PR TITLE
style(ui): accent strategic action buttons

### DIFF
--- a/src/Foundry.Deploy/MainWindow.xaml
+++ b/src/Foundry.Deploy/MainWindow.xaml
@@ -418,7 +418,8 @@
                         <Button
                             Width="160"
                             Command="{Binding StartDeploymentCommand}"
-                            Content="Start Deployment" />
+                            Content="Start Deployment"
+                            Style="{DynamicResource AccentButtonStyle}" />
                     </StackPanel>
                 </Grid>
             </Grid>
@@ -792,6 +793,7 @@
                     VerticalAlignment="Bottom"
                     Command="{Binding BeginWizardCommand}"
                     Content="Begin"
+                    Style="{DynamicResource AccentButtonStyle}"
                     Visibility="{Binding Session.IsStartupInitializing, Converter={StaticResource InverseBooleanConverter}}" />
             </Grid>
         </Grid>

--- a/src/Foundry/MainWindow.xaml
+++ b/src/Foundry/MainWindow.xaml
@@ -174,6 +174,7 @@
                     Command="{Binding InstallAdkCommand}"
                     Content="{Binding Strings[AdkInstall]}"
                     IsEnabled="{Binding IsOperationInProgress, Converter={StaticResource InverseBooleanConverter}}"
+                    Style="{DynamicResource AccentButtonStyle}"
                     Visibility="{Binding IsAdkMissing, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
                 <Button
@@ -183,6 +184,7 @@
                     Command="{Binding UpgradeAdkCommand}"
                     Content="{Binding Strings[AdkUpgrade]}"
                     IsEnabled="{Binding IsOperationInProgress, Converter={StaticResource InverseBooleanConverter}}"
+                    Style="{DynamicResource AccentButtonStyle}"
                     Visibility="{Binding IsAdkIncompatible, Converter={StaticResource BooleanToVisibilityConverter}}" />
             </Grid>
         </Border>
@@ -285,11 +287,13 @@
                         Width="140"
                         Margin="0,0,24,0"
                         Command="{Binding CreateIsoCommand}"
-                        Content="{Binding Strings[CreateIso]}" />
+                        Content="{Binding Strings[CreateIso]}"
+                        Style="{DynamicResource AccentButtonStyle}" />
                     <Button
                         Width="140"
                         Command="{Binding CreateUsbCommand}"
-                        Content="{Binding Strings[CreateUsb]}" />
+                        Content="{Binding Strings[CreateUsb]}"
+                        Style="{DynamicResource AccentButtonStyle}" />
                 </StackPanel>
             </Grid>
         </Border>

--- a/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml
+++ b/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml
@@ -80,9 +80,7 @@
                         <GridViewColumn Width="72">
                             <GridViewColumn.CellTemplate>
                                 <DataTemplate>
-                                    <CheckBox
-                                        HorizontalAlignment="Center"
-                                        IsChecked="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    <CheckBox HorizontalAlignment="Center" IsChecked="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                 </DataTemplate>
                             </GridViewColumn.CellTemplate>
                         </GridViewColumn>
@@ -116,7 +114,8 @@
                 Width="120"
                 Command="{Binding ImportSelectedProfilesCommand}"
                 Content="{Binding Strings[AutopilotTenantPickerImport]}"
-                IsDefault="True" />
+                IsDefault="True"
+                Style="{DynamicResource AccentButtonStyle}" />
         </StackPanel>
     </Grid>
 </Window>

--- a/src/Foundry/Views/AutopilotSettingsView.xaml
+++ b/src/Foundry/Views/AutopilotSettingsView.xaml
@@ -46,7 +46,8 @@
                     MinWidth="170"
                     Margin="0,0,8,0"
                     Command="{Binding DownloadProfilesCommand}"
-                    Content="{Binding Strings[AutopilotDownloadButton]}" />
+                    Content="{Binding Strings[AutopilotDownloadButton]}"
+                    Style="{DynamicResource AccentButtonStyle}" />
                 <Button
                     MinWidth="110"
                     Command="{Binding RemoveSelectedProfileCommand}"
@@ -101,9 +102,7 @@
                             ItemsSource="{Binding Profiles}"
                             SelectedItem="{Binding SelectedProfile}">
                             <ListView.InputBindings>
-                                <KeyBinding
-                                    Key="Delete"
-                                    Command="{Binding RemoveSelectedProfileCommand}" />
+                                <KeyBinding Key="Delete" Command="{Binding RemoveSelectedProfileCommand}" />
                             </ListView.InputBindings>
                             <ListView.View>
                                 <GridView>


### PR DESCRIPTION
## Summary
Apply `AccentButtonStyle` to the strategic action buttons across Foundry and Foundry.Deploy.

## Why
The main actions for media creation, ADK remediation, Autopilot profile import, and deployment start should stand out more clearly in the UI.

## Changes
- Apply `AccentButtonStyle` to `Create ISO` and `Create USB` in Foundry
- Apply `AccentButtonStyle` to `Install ADK` and `Upgrade ADK` in the ADK banner
- Apply `AccentButtonStyle` to the Autopilot tenant download and import confirmation buttons
- Apply `AccentButtonStyle` to `Begin` and `Start Deployment` in Foundry.Deploy
- Leave Foundry.Connect unchanged

## Testing
- Ran `dotnet build src/Foundry.slnx`
- User confirmed the UI changes work locally

## Notes
- This PR only changes button styling in XAML.
- The temporary planning files used during analysis were removed before commit.