### PR TITLE
feat(wifi): support wpa2/wpa3 personal provisioning

### DIFF
--- a/src/Foundry.Connect/Services/Network/NetworkBootstrapService.cs
+++ b/src/Foundry.Connect/Services/Network/NetworkBootstrapService.cs
@@ -13,7 +13,12 @@ namespace Foundry.Connect.Services.Network;
 
 public sealed class NetworkBootstrapService : INetworkBootstrapService
 {
+    private const string OpenSecurityType = "Open";
     private const string EnterpriseSecurityType = "Enterprise";
+    private const string WifiSecurityPersonal = "WPA2/WPA3-Personal";
+    private const string WifiSecurityLegacyWpa2Personal = "WPA2-Personal";
+    private const string WifiSecurityWpa3Personal = "WPA3-Personal";
+    private const string WifiSecurityLegacyPersonal = "Personal";
     private const string TemporaryWifiProfileFileName = "wifi-profile.xml";
     private static readonly TimeSpan WifiConnectionTimeout = TimeSpan.FromSeconds(15);
     private static readonly TimeSpan WifiConnectionPollInterval = TimeSpan.FromMilliseconds(500);
@@ -551,10 +556,8 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
         string ssidHex = string.IsNullOrWhiteSpace(ssidHexOverride)
             ? ConvertSsidToHex(ssidValue.Trim())
             : ssidHexOverride.Trim();
-        bool isOpen = string.Equals(securityType, "Open", StringComparison.OrdinalIgnoreCase);
-        bool isPersonal = string.Equals(securityType, "WPA2-Personal", StringComparison.OrdinalIgnoreCase) ||
-                          string.Equals(securityType, "WPA2/WPA3-Personal", StringComparison.OrdinalIgnoreCase) ||
-                          string.Equals(securityType, "WPA3-Personal", StringComparison.OrdinalIgnoreCase);
+        bool isOpen = string.Equals(securityType, OpenSecurityType, StringComparison.OrdinalIgnoreCase);
+        bool isPersonal = IsPersonalSecurityType(securityType);
 
         if (isOpen)
         {
@@ -589,6 +592,12 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
         if (isPersonal)
         {
             string passphrase = SecurityElement.Escape(passphraseValue?.Trim() ?? string.Empty) ?? string.Empty;
+            string authentication = ResolvePersonalAuthentication(securityType);
+            string transitionMode = string.Equals(securityType, WifiSecurityPersonal, StringComparison.OrdinalIgnoreCase)
+                ? """
+        <transitionMode xmlns="http://www.microsoft.com/networking/WLAN/profile/v4">true</transitionMode>
+"""
+                : string.Empty;
             return $$"""
 <?xml version="1.0"?>
 <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
@@ -604,10 +613,10 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
   <MSM>
     <security>
       <authEncryption>
-        <authentication>WPA2PSK</authentication>
+        <authentication>{{authentication}}</authentication>
         <encryption>AES</encryption>
         <useOneX>false</useOneX>
-      </authEncryption>
+{{transitionMode}}      </authEncryption>
       <sharedKey>
         <keyType>passPhrase</keyType>
         <protected>false</protected>
@@ -629,16 +638,41 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
     {
         if (authentication.Contains("open", StringComparison.OrdinalIgnoreCase))
         {
-            return "Open";
+            return OpenSecurityType;
+        }
+
+        if (authentication.Contains("sae", StringComparison.OrdinalIgnoreCase) ||
+            authentication.Contains("wpa3", StringComparison.OrdinalIgnoreCase))
+        {
+            return WifiSecurityWpa3Personal;
         }
 
         if (authentication.Contains("personal", StringComparison.OrdinalIgnoreCase) ||
             authentication.Contains("psk", StringComparison.OrdinalIgnoreCase))
         {
-            return "WPA2-Personal";
+            return WifiSecurityLegacyWpa2Personal;
         }
 
         return EnterpriseSecurityType;
+    }
+
+    private static bool IsPersonalSecurityType(string securityType)
+    {
+        return string.Equals(securityType, WifiSecurityLegacyWpa2Personal, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(securityType, WifiSecurityPersonal, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(securityType, WifiSecurityWpa3Personal, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(securityType, WifiSecurityLegacyPersonal, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ResolvePersonalAuthentication(string securityType)
+    {
+        if (string.Equals(securityType, WifiSecurityPersonal, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(securityType, WifiSecurityWpa3Personal, StringComparison.OrdinalIgnoreCase))
+        {
+            return "WPA3SAE";
+        }
+
+        return "WPA2PSK";
     }
 
     private static string ConvertSsidToHex(string value)

--- a/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
@@ -1182,9 +1182,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             };
         }
 
-        return string.IsNullOrWhiteSpace(_configuration.Wifi.SecurityType)
-            ? "Configured profile"
-            : _configuration.Wifi.SecurityType.Trim();
+        return ResolveProvisionedPersonalSecurityDisplayText(_configuration.Wifi.SecurityType);
     }
 
     private string BuildProvisionedWifiSourceHintText()
@@ -1199,6 +1197,23 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         }
 
         return sourceText;
+    }
+
+    private static string ResolveProvisionedPersonalSecurityDisplayText(string? securityType)
+    {
+        if (string.IsNullOrWhiteSpace(securityType))
+        {
+            return "Configured profile";
+        }
+
+        return securityType.Trim() switch
+        {
+            "WPA2/WPA3-Personal" => "WPA2/WPA3 Personal",
+            "WPA2-Personal" => "WPA2 Personal",
+            "WPA3-Personal" => "WPA3 Personal",
+            "Personal" => "Personal",
+            _ => securityType.Trim()
+        };
     }
 
     private string BuildProvisionedWifiStatusText()

--- a/src/Foundry/Resources/AppStrings.en-US.resx
+++ b/src/Foundry/Resources/AppStrings.en-US.resx
@@ -553,7 +553,7 @@
     <value>Open</value>
   </data>
   <data name="WifiSecurityTypePersonal" xml:space="preserve">
-    <value>WPA2 Personal</value>
+    <value>WPA2/WPA3 Personal</value>
   </data>
   <data name="WifiSecurityTypeEnterprise" xml:space="preserve">
     <value>WPA2/WPA3 Enterprise</value>

--- a/src/Foundry/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry/Resources/AppStrings.fr-FR.resx
@@ -553,7 +553,7 @@
     <value>Ouvert</value>
   </data>
   <data name="WifiSecurityTypePersonal" xml:space="preserve">
-    <value>WPA2 Personal</value>
+    <value>WPA2/WPA3 Personal</value>
   </data>
   <data name="WifiSecurityTypeEnterprise" xml:space="preserve">
     <value>WPA2/WPA3 entreprise</value>

--- a/src/Foundry/Resources/AppStrings.resx
+++ b/src/Foundry/Resources/AppStrings.resx
@@ -553,7 +553,7 @@
     <value>Open</value>
   </data>
   <data name="WifiSecurityTypePersonal" xml:space="preserve">
-    <value>WPA2 Personal</value>
+    <value>WPA2/WPA3 Personal</value>
   </data>
   <data name="WifiSecurityTypeEnterprise" xml:space="preserve">
     <value>WPA2/WPA3 Enterprise</value>

--- a/src/Foundry/Services/Configuration/FoundryConnectProvisioningService.cs
+++ b/src/Foundry/Services/Configuration/FoundryConnectProvisioningService.cs
@@ -5,6 +5,11 @@ namespace Foundry.Services.Configuration;
 
 public sealed class FoundryConnectProvisioningService : IFoundryConnectProvisioningService
 {
+    private const string WifiSecurityPersonal = "WPA2/WPA3-Personal";
+    private const string WifiSecurityEnterprise = "WPA2/WPA3-Enterprise";
+    private static readonly string[] LegacyWifiSecurityPersonalValues = ["WPA2-Personal", "WPA3-Personal", "Personal"];
+    private static readonly string[] LegacyWifiSecurityEnterpriseValues = ["WPA2-Enterprise", "WPA3-Enterprise", "Enterprise"];
+
     public FoundryConnectProvisioningBundle Prepare(FoundryExpertConfigurationDocument document, string stagingDirectoryPath)
     {
         ArgumentNullException.ThrowIfNull(document);
@@ -109,22 +114,15 @@ public sealed class FoundryConnectProvisioningService : IFoundryConnectProvision
             throw new InvalidOperationException("Wi-Fi configuration requires an SSID.");
         }
 
-        bool isPersonal = string.Equals(settings.Wifi.SecurityType, "WPA2-Personal", StringComparison.OrdinalIgnoreCase) ||
-                          string.Equals(settings.Wifi.SecurityType, "WPA2/WPA3-Personal", StringComparison.OrdinalIgnoreCase) ||
-                          string.Equals(settings.Wifi.SecurityType, "WPA3-Personal", StringComparison.OrdinalIgnoreCase) ||
-                          string.Equals(settings.Wifi.SecurityType, "Personal", StringComparison.OrdinalIgnoreCase);
-        bool isEnterprise = settings.Wifi.HasEnterpriseProfile ||
-                            string.Equals(settings.Wifi.SecurityType, "WPA2/WPA3-Enterprise", StringComparison.OrdinalIgnoreCase) ||
-                            string.Equals(settings.Wifi.SecurityType, "WPA2-Enterprise", StringComparison.OrdinalIgnoreCase) ||
-                            string.Equals(settings.Wifi.SecurityType, "WPA3-Enterprise", StringComparison.OrdinalIgnoreCase) ||
-                            string.Equals(settings.Wifi.SecurityType, "Enterprise", StringComparison.OrdinalIgnoreCase);
+        bool isPersonal = IsPersonalSecurityType(settings.Wifi.SecurityType);
+        bool isEnterprise = settings.Wifi.HasEnterpriseProfile || IsEnterpriseSecurityType(settings.Wifi.SecurityType);
 
         if (isPersonal)
         {
             int passphraseLength = settings.Wifi.Passphrase?.Trim().Length ?? 0;
             if (passphraseLength is < 8 or > 63)
             {
-                throw new InvalidOperationException("WPA2 Personal Wi-Fi requires an 8 to 63 character passphrase.");
+                throw new InvalidOperationException("Personal Wi-Fi requires an 8 to 63 character passphrase.");
             }
         }
 
@@ -177,6 +175,18 @@ public sealed class FoundryConnectProvisioningService : IFoundryConnectProvision
     private static string NormalizeEmbeddedRelativePath(string relativePath)
     {
         return relativePath.Replace('/', '\\').TrimStart('\\');
+    }
+
+    private static bool IsPersonalSecurityType(string? securityType)
+    {
+        return string.Equals(securityType, WifiSecurityPersonal, StringComparison.OrdinalIgnoreCase) ||
+               LegacyWifiSecurityPersonalValues.Any(value => string.Equals(securityType, value, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsEnterpriseSecurityType(string? securityType)
+    {
+        return string.Equals(securityType, WifiSecurityEnterprise, StringComparison.OrdinalIgnoreCase) ||
+               LegacyWifiSecurityEnterpriseValues.Any(value => string.Equals(securityType, value, StringComparison.OrdinalIgnoreCase));
     }
 
     private static void EnsureDirectoryClean(string path)

--- a/src/Foundry/ViewModels/NetworkSettingsViewModel.cs
+++ b/src/Foundry/ViewModels/NetworkSettingsViewModel.cs
@@ -11,7 +11,7 @@ namespace Foundry.ViewModels;
 public partial class NetworkSettingsViewModel : LocalizedViewModelBase
 {
     private const string WifiSecurityOpen = "Open";
-    private const string WifiSecurityPersonal = "WPA2-Personal";
+    private const string WifiSecurityPersonal = "WPA2/WPA3-Personal";
     private const string WifiSecurityEnterprise = "WPA2/WPA3-Enterprise";
     private static readonly string[] LegacyWifiSecurityPersonalValues = ["WPA2-Personal", "WPA3-Personal", "Personal"];
     private static readonly string[] LegacyWifiSecurityEnterpriseValues = ["WPA2-Enterprise", "WPA3-Enterprise", "Enterprise"];
@@ -441,7 +441,7 @@ public partial class NetworkSettingsViewModel : LocalizedViewModelBase
             string passphrase = WifiPassphrase.Trim();
             if (passphrase.Length < 8 || passphrase.Length > 63)
             {
-                return "WPA2 Personal Wi-Fi requires an 8 to 63 character passphrase.";
+                return "Personal Wi-Fi requires an 8 to 63 character passphrase.";
             }
         }
 


### PR DESCRIPTION
## Summary
Add real WPA2/WPA3 Personal support for pre-provisioned Wi-Fi and align Foundry.Connect profile generation with the selected personal security mode.

## Why
The UI previously exposed personal Wi-Fi in a way that suggested broader coverage than the generated Windows WLAN profile actually provided. The change makes the stored value, displayed label, and generated profile behavior consistent.

## Changes
- switch the canonical Foundry personal Wi-Fi value to `WPA2/WPA3-Personal` while keeping legacy normalization support
- update localized labels and personal validation wording
- keep Foundry Connect provisioning validation backward-compatible for existing personal security tokens
- generate differentiated personal WLAN profiles in Foundry.Connect for WPA2, WPA3, and WPA2/WPA3 transition mode
- improve provisioned personal Wi-Fi authentication text in Foundry.Connect
- remove redundant touched-scope compatibility code where it became unnecessary

## Testing
- `dotnet build src\\Foundry\\Foundry.csproj`
- `dotnet build src\\Foundry.Connect\\Foundry.Connect.csproj`

## Notes
- draft PR
- a reflection-based runtime XML spot check was attempted locally but was blocked by an `Access denied` error in the environment; compile validation succeeded