### PR TITLE
feat(wifi): add owe and enterprise auth options

### DIFF
--- a/src/Foundry.Connect/Services/Configuration/ProvisionedWifiProfileResolver.cs
+++ b/src/Foundry.Connect/Services/Configuration/ProvisionedWifiProfileResolver.cs
@@ -1,10 +1,13 @@
 using System.IO;
+using System.Xml.Linq;
 using Foundry.Connect.Models.Configuration;
 
 namespace Foundry.Connect.Services.Configuration;
 
 internal static class ProvisionedWifiProfileResolver
 {
+    private static readonly XNamespace WlanProfileNamespace = "http://www.microsoft.com/networking/WLAN/profile/v1";
+
     public static string? ResolveAssetPath(string? value, string? configurationPath)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -63,5 +66,26 @@ internal static class ProvisionedWifiProfileResolver
         return string.IsNullOrWhiteSpace(profileName)
             ? null
             : profileName;
+    }
+
+    public static string? TryReadProfileAuthentication(string? profilePath)
+    {
+        if (string.IsNullOrWhiteSpace(profilePath) || !File.Exists(profilePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            XDocument document = XDocument.Load(profilePath);
+            return document
+                .Descendants(WlanProfileNamespace + "authentication")
+                .Select(static element => element.Value?.Trim())
+                .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
+        }
+        catch
+        {
+            return null;
+        }
     }
 }

--- a/src/Foundry.Connect/Services/Network/NetworkBootstrapService.cs
+++ b/src/Foundry.Connect/Services/Network/NetworkBootstrapService.cs
@@ -13,7 +13,12 @@ namespace Foundry.Connect.Services.Network;
 
 public sealed class NetworkBootstrapService : INetworkBootstrapService
 {
+    private const string OpenSecurityType = "Open";
     private const string EnterpriseSecurityType = "Enterprise";
+    private const string WifiSecurityPersonal = "WPA2/WPA3-Personal";
+    private const string WifiSecurityLegacyWpa2Personal = "WPA2-Personal";
+    private const string WifiSecurityWpa3Personal = "WPA3-Personal";
+    private const string WifiSecurityLegacyPersonal = "Personal";
     private const string TemporaryWifiProfileFileName = "wifi-profile.xml";
     private static readonly TimeSpan WifiConnectionTimeout = TimeSpan.FromSeconds(15);
     private static readonly TimeSpan WifiConnectionPollInterval = TimeSpan.FromMilliseconds(500);
@@ -551,10 +556,8 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
         string ssidHex = string.IsNullOrWhiteSpace(ssidHexOverride)
             ? ConvertSsidToHex(ssidValue.Trim())
             : ssidHexOverride.Trim();
-        bool isOpen = string.Equals(securityType, "Open", StringComparison.OrdinalIgnoreCase);
-        bool isPersonal = string.Equals(securityType, "WPA2-Personal", StringComparison.OrdinalIgnoreCase) ||
-                          string.Equals(securityType, "WPA2/WPA3-Personal", StringComparison.OrdinalIgnoreCase) ||
-                          string.Equals(securityType, "WPA3-Personal", StringComparison.OrdinalIgnoreCase);
+        bool isOpen = string.Equals(securityType, OpenSecurityType, StringComparison.OrdinalIgnoreCase);
+        bool isPersonal = IsPersonalSecurityType(securityType);
 
         if (isOpen)
         {
@@ -589,6 +592,12 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
         if (isPersonal)
         {
             string passphrase = SecurityElement.Escape(passphraseValue?.Trim() ?? string.Empty) ?? string.Empty;
+            string authentication = ResolvePersonalAuthentication(securityType);
+            string transitionMode = string.Equals(securityType, WifiSecurityPersonal, StringComparison.OrdinalIgnoreCase)
+                ? """
+        <transitionMode xmlns="http://www.microsoft.com/networking/WLAN/profile/v4">true</transitionMode>
+"""
+                : string.Empty;
             return $$"""
 <?xml version="1.0"?>
 <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
@@ -604,10 +613,10 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
   <MSM>
     <security>
       <authEncryption>
-        <authentication>WPA2PSK</authentication>
+        <authentication>{{authentication}}</authentication>
         <encryption>AES</encryption>
         <useOneX>false</useOneX>
-      </authEncryption>
+{{transitionMode}}      </authEncryption>
       <sharedKey>
         <keyType>passPhrase</keyType>
         <protected>false</protected>
@@ -629,16 +638,41 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
     {
         if (authentication.Contains("open", StringComparison.OrdinalIgnoreCase))
         {
-            return "Open";
+            return OpenSecurityType;
+        }
+
+        if (authentication.Contains("sae", StringComparison.OrdinalIgnoreCase) ||
+            authentication.Contains("wpa3", StringComparison.OrdinalIgnoreCase))
+        {
+            return WifiSecurityWpa3Personal;
         }
 
         if (authentication.Contains("personal", StringComparison.OrdinalIgnoreCase) ||
             authentication.Contains("psk", StringComparison.OrdinalIgnoreCase))
         {
-            return "WPA2-Personal";
+            return WifiSecurityLegacyWpa2Personal;
         }
 
         return EnterpriseSecurityType;
+    }
+
+    private static bool IsPersonalSecurityType(string securityType)
+    {
+        return string.Equals(securityType, WifiSecurityLegacyWpa2Personal, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(securityType, WifiSecurityPersonal, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(securityType, WifiSecurityWpa3Personal, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(securityType, WifiSecurityLegacyPersonal, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ResolvePersonalAuthentication(string securityType)
+    {
+        if (string.Equals(securityType, WifiSecurityPersonal, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(securityType, WifiSecurityWpa3Personal, StringComparison.OrdinalIgnoreCase))
+        {
+            return "WPA3SAE";
+        }
+
+        return "WPA2PSK";
     }
 
     private static string ConvertSsidToHex(string value)

--- a/src/Foundry.Connect/Services/Network/NetworkBootstrapService.cs
+++ b/src/Foundry.Connect/Services/Network/NetworkBootstrapService.cs
@@ -14,6 +14,7 @@ namespace Foundry.Connect.Services.Network;
 public sealed class NetworkBootstrapService : INetworkBootstrapService
 {
     private const string OpenSecurityType = "Open";
+    private const string OweSecurityType = "OWE";
     private const string EnterpriseSecurityType = "Enterprise";
     private const string WifiSecurityPersonal = "WPA2/WPA3-Personal";
     private const string WifiSecurityLegacyWpa2Personal = "WPA2-Personal";
@@ -557,6 +558,7 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
             ? ConvertSsidToHex(ssidValue.Trim())
             : ssidHexOverride.Trim();
         bool isOpen = string.Equals(securityType, OpenSecurityType, StringComparison.OrdinalIgnoreCase);
+        bool isOwe = string.Equals(securityType, OweSecurityType, StringComparison.OrdinalIgnoreCase);
         bool isPersonal = IsPersonalSecurityType(securityType);
 
         if (isOpen)
@@ -631,14 +633,54 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
 """;
         }
 
+        if (isOwe)
+        {
+            return $$"""
+<?xml version="1.0"?>
+<WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
+  <name>{{ssid}}</name>
+  <SSIDConfig>
+    <SSID>
+      <hex>{{ssidHex}}</hex>
+      <name>{{ssid}}</name>
+    </SSID>
+  </SSIDConfig>
+  <connectionType>ESS</connectionType>
+  <connectionMode>manual</connectionMode>
+  <MSM>
+    <security>
+      <authEncryption>
+        <authentication>OWE</authentication>
+        <encryption>AES</encryption>
+        <useOneX>false</useOneX>
+      </authEncryption>
+    </security>
+  </MSM>
+  <MacRandomization xmlns="http://www.microsoft.com/networking/WLAN/profile/v3">
+    <enableRandomization>false</enableRandomization>
+  </MacRandomization>
+</WLANProfile>
+""";
+        }
+
         throw new InvalidOperationException($"Unsupported Wi-Fi security type '{securityType}'.");
     }
 
     private static string ResolveDiscoveredWifiSecurityType(string authentication)
     {
+        if (authentication.Contains("enterprise", StringComparison.OrdinalIgnoreCase))
+        {
+            return EnterpriseSecurityType;
+        }
+
         if (authentication.Contains("open", StringComparison.OrdinalIgnoreCase))
         {
             return OpenSecurityType;
+        }
+
+        if (authentication.Contains("owe", StringComparison.OrdinalIgnoreCase))
+        {
+            return OweSecurityType;
         }
 
         if (authentication.Contains("sae", StringComparison.OrdinalIgnoreCase) ||

--- a/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
@@ -1174,12 +1174,13 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     {
         if (_configuration.Wifi.HasEnterpriseProfile)
         {
-            return _configuration.Wifi.EnterpriseAuthenticationMode switch
-            {
-                NetworkAuthenticationMode.MachineOnly => "WPA2-Enterprise (machine)",
-                NetworkAuthenticationMode.MachineOrUser => "WPA2-Enterprise (machine or user)",
-                _ => "WPA2-Enterprise"
-            };
+            string? profilePath = ProvisionedWifiProfileResolver.ResolveAssetPath(
+                _configuration.Wifi.EnterpriseProfileTemplatePath,
+                _configurationService.ConfigurationPath);
+            string? profileAuthentication = ProvisionedWifiProfileResolver.TryReadProfileAuthentication(profilePath);
+            return ResolveProvisionedEnterpriseSecurityDisplayText(
+                profileAuthentication ?? _configuration.Wifi.SecurityType,
+                _configuration.Wifi.EnterpriseAuthenticationMode);
         }
 
         return ResolveProvisionedPersonalSecurityDisplayText(_configuration.Wifi.SecurityType);
@@ -1208,11 +1209,35 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
         return securityType.Trim() switch
         {
+            "OWE" => "OWE",
             "WPA2/WPA3-Personal" => "WPA2/WPA3 Personal",
             "WPA2-Personal" => "WPA2 Personal",
             "WPA3-Personal" => "WPA3 Personal",
             "Personal" => "Personal",
             _ => securityType.Trim()
+        };
+    }
+
+    private static string ResolveProvisionedEnterpriseSecurityDisplayText(
+        string? securityType,
+        NetworkAuthenticationMode authenticationMode)
+    {
+        string baseSecurityText = securityType?.Trim() switch
+        {
+            "WPA3ENT" => "WPA3 Enterprise",
+            "WPA3ENT192" or "WPA3" => "WPA3 Enterprise 192-bit",
+            "WPA2/WPA3-Enterprise" => "WPA2/WPA3 Enterprise",
+            "WPA2-Enterprise" => "WPA2 Enterprise",
+            "WPA3-Enterprise" => "WPA3 Enterprise",
+            "Enterprise" => "Enterprise",
+            _ => "WPA2/WPA3 Enterprise"
+        };
+
+        return authenticationMode switch
+        {
+            NetworkAuthenticationMode.MachineOnly => $"{baseSecurityText} (machine)",
+            NetworkAuthenticationMode.MachineOrUser => $"{baseSecurityText} (machine or user)",
+            _ => baseSecurityText
         };
     }
 
@@ -1286,7 +1311,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
     private static bool CanDirectConnect(string authentication)
     {
-        return ClassifyDiscoveredWifi(authentication) is DiscoveredWifiType.Open or DiscoveredWifiType.Personal;
+        return ClassifyDiscoveredWifi(authentication) is DiscoveredWifiType.Open or DiscoveredWifiType.Owe or DiscoveredWifiType.Personal;
     }
 
     private static bool RequiresPassphrase(string authentication)
@@ -1301,6 +1326,11 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             return DiscoveredWifiType.Open;
         }
 
+        if (authentication.Contains("owe", StringComparison.OrdinalIgnoreCase))
+        {
+            return DiscoveredWifiType.Owe;
+        }
+
         if (authentication.Contains("personal", StringComparison.OrdinalIgnoreCase) ||
             authentication.Contains("psk", StringComparison.OrdinalIgnoreCase))
         {
@@ -1313,6 +1343,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private enum DiscoveredWifiType
     {
         Open,
+        Owe,
         Personal,
         Enterprise
     }

--- a/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
@@ -1182,9 +1182,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             };
         }
 
-        return string.IsNullOrWhiteSpace(_configuration.Wifi.SecurityType)
-            ? "Configured profile"
-            : _configuration.Wifi.SecurityType.Trim();
+        return ResolveProvisionedPersonalSecurityDisplayText(_configuration.Wifi.SecurityType);
     }
 
     private string BuildProvisionedWifiSourceHintText()
@@ -1199,6 +1197,23 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         }
 
         return sourceText;
+    }
+
+    private static string ResolveProvisionedPersonalSecurityDisplayText(string? securityType)
+    {
+        if (string.IsNullOrWhiteSpace(securityType))
+        {
+            return "Configured profile";
+        }
+
+        return securityType.Trim() switch
+        {
+            "WPA2/WPA3-Personal" => "WPA2/WPA3 Personal",
+            "WPA2-Personal" => "WPA2 Personal",
+            "WPA3-Personal" => "WPA3 Personal",
+            "Personal" => "Personal",
+            _ => securityType.Trim()
+        };
     }
 
     private string BuildProvisionedWifiStatusText()

--- a/src/Foundry/Resources/AppStrings.en-US.resx
+++ b/src/Foundry/Resources/AppStrings.en-US.resx
@@ -552,11 +552,20 @@
   <data name="WifiSecurityTypeOpen" xml:space="preserve">
     <value>Open</value>
   </data>
+  <data name="WifiSecurityTypeOwe" xml:space="preserve">
+    <value>OWE (Opportunistic Wireless Encryption)</value>
+  </data>
   <data name="WifiSecurityTypePersonal" xml:space="preserve">
     <value>WPA2/WPA3 Personal</value>
   </data>
   <data name="WifiSecurityTypeEnterprise" xml:space="preserve">
     <value>WPA2/WPA3 Enterprise</value>
+  </data>
+  <data name="WifiSecurityTypeEnterpriseWpa3" xml:space="preserve">
+    <value>WPA3 Enterprise (WPA3ENT)</value>
+  </data>
+  <data name="WifiSecurityTypeEnterpriseWpa3192" xml:space="preserve">
+    <value>WPA3 Enterprise 192-bit (WPA3ENT192)</value>
   </data>
   <data name="NetworkEthernetSectionTitle" xml:space="preserve">
     <value>Ethernet</value>
@@ -571,7 +580,7 @@
     <value>Enable this only if the boot image should include Wi-Fi support and Wi-Fi profiles for WinPE startup.</value>
   </data>
   <data name="NetworkWifiPersonalHelperText" xml:space="preserve">
-    <value>When Wi-Fi support is provisioned, Foundry.Connect can list nearby networks and guide connection to open or personal Wi-Fi networks at runtime.</value>
+    <value>When Wi-Fi support is provisioned, Foundry.Connect can list nearby networks and guide connection to open, OWE, or personal Wi-Fi networks at runtime.</value>
   </data>
   <data name="NetworkEnterpriseTemplateDrivenHelperText" xml:space="preserve">
     <value>Enterprise behavior is driven by the profile template in this build. Runtime-entered 802.1X credentials are not provisioned here.</value>

--- a/src/Foundry/Resources/AppStrings.en-US.resx
+++ b/src/Foundry/Resources/AppStrings.en-US.resx
@@ -553,7 +553,7 @@
     <value>Open</value>
   </data>
   <data name="WifiSecurityTypePersonal" xml:space="preserve">
-    <value>WPA2 Personal</value>
+    <value>WPA2/WPA3 Personal</value>
   </data>
   <data name="WifiSecurityTypeEnterprise" xml:space="preserve">
     <value>WPA2/WPA3 Enterprise</value>

--- a/src/Foundry/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry/Resources/AppStrings.fr-FR.resx
@@ -553,7 +553,7 @@
     <value>Ouvert</value>
   </data>
   <data name="WifiSecurityTypePersonal" xml:space="preserve">
-    <value>WPA2 Personal</value>
+    <value>WPA2/WPA3 Personal</value>
   </data>
   <data name="WifiSecurityTypeEnterprise" xml:space="preserve">
     <value>WPA2/WPA3 entreprise</value>

--- a/src/Foundry/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry/Resources/AppStrings.fr-FR.resx
@@ -552,11 +552,20 @@
   <data name="WifiSecurityTypeOpen" xml:space="preserve">
     <value>Ouvert</value>
   </data>
+  <data name="WifiSecurityTypeOwe" xml:space="preserve">
+    <value>OWE (Opportunistic Wireless Encryption)</value>
+  </data>
   <data name="WifiSecurityTypePersonal" xml:space="preserve">
     <value>WPA2/WPA3 Personal</value>
   </data>
   <data name="WifiSecurityTypeEnterprise" xml:space="preserve">
     <value>WPA2/WPA3 entreprise</value>
+  </data>
+  <data name="WifiSecurityTypeEnterpriseWpa3" xml:space="preserve">
+    <value>WPA3 entreprise (WPA3ENT)</value>
+  </data>
+  <data name="WifiSecurityTypeEnterpriseWpa3192" xml:space="preserve">
+    <value>WPA3 entreprise 192 bits (WPA3ENT192)</value>
   </data>
   <data name="NetworkEthernetSectionTitle" xml:space="preserve">
     <value>Ethernet</value>
@@ -571,7 +580,7 @@
     <value>Activez ceci uniquement si l'image de boot doit inclure la prise en charge Wi-Fi et des profils Wi-Fi pour le démarrage WinPE.</value>
   </data>
   <data name="NetworkWifiPersonalHelperText" xml:space="preserve">
-    <value>Lorsque la prise en charge Wi-Fi est provisionnée, Foundry.Connect peut lister les réseaux disponibles et guider la connexion aux réseaux ouverts ou personnels au runtime.</value>
+    <value>Lorsque la prise en charge Wi-Fi est provisionnée, Foundry.Connect peut lister les réseaux disponibles et guider la connexion aux réseaux ouverts, OWE ou personnels au runtime.</value>
   </data>
   <data name="NetworkEnterpriseTemplateDrivenHelperText" xml:space="preserve">
     <value>Enterprise behavior is driven by the profile template in this build. Runtime-entered 802.1X credentials are not provisioned here.</value>

--- a/src/Foundry/Resources/AppStrings.resx
+++ b/src/Foundry/Resources/AppStrings.resx
@@ -552,11 +552,20 @@
   <data name="WifiSecurityTypeOpen" xml:space="preserve">
     <value>Open</value>
   </data>
+  <data name="WifiSecurityTypeOwe" xml:space="preserve">
+    <value>OWE (Opportunistic Wireless Encryption)</value>
+  </data>
   <data name="WifiSecurityTypePersonal" xml:space="preserve">
     <value>WPA2/WPA3 Personal</value>
   </data>
   <data name="WifiSecurityTypeEnterprise" xml:space="preserve">
     <value>WPA2/WPA3 Enterprise</value>
+  </data>
+  <data name="WifiSecurityTypeEnterpriseWpa3" xml:space="preserve">
+    <value>WPA3 Enterprise (WPA3ENT)</value>
+  </data>
+  <data name="WifiSecurityTypeEnterpriseWpa3192" xml:space="preserve">
+    <value>WPA3 Enterprise 192-bit (WPA3ENT192)</value>
   </data>
   <data name="NetworkEthernetSectionTitle" xml:space="preserve">
     <value>Ethernet</value>
@@ -571,7 +580,7 @@
     <value>Enable this only if the boot image should include Wi-Fi support and Wi-Fi profiles for WinPE startup.</value>
   </data>
   <data name="NetworkWifiPersonalHelperText" xml:space="preserve">
-    <value>When Wi-Fi support is provisioned, Foundry.Connect can list nearby networks and guide connection to open or personal Wi-Fi networks at runtime.</value>
+    <value>When Wi-Fi support is provisioned, Foundry.Connect can list nearby networks and guide connection to open, OWE, or personal Wi-Fi networks at runtime.</value>
   </data>
   <data name="NetworkEnterpriseTemplateDrivenHelperText" xml:space="preserve">
     <value>Enterprise behavior is driven by the profile template in this build. Runtime-entered 802.1X credentials are not provisioned here.</value>

--- a/src/Foundry/Resources/AppStrings.resx
+++ b/src/Foundry/Resources/AppStrings.resx
@@ -553,7 +553,7 @@
     <value>Open</value>
   </data>
   <data name="WifiSecurityTypePersonal" xml:space="preserve">
-    <value>WPA2 Personal</value>
+    <value>WPA2/WPA3 Personal</value>
   </data>
   <data name="WifiSecurityTypeEnterprise" xml:space="preserve">
     <value>WPA2/WPA3 Enterprise</value>

--- a/src/Foundry/Services/Configuration/FoundryConnectProvisioningService.cs
+++ b/src/Foundry/Services/Configuration/FoundryConnectProvisioningService.cs
@@ -1,14 +1,18 @@
 using System.Text.Json;
+using System.Xml.Linq;
 using Foundry.Models.Configuration;
 
 namespace Foundry.Services.Configuration;
 
 public sealed class FoundryConnectProvisioningService : IFoundryConnectProvisioningService
 {
+    private const string WifiSecurityOwe = "OWE";
     private const string WifiSecurityPersonal = "WPA2/WPA3-Personal";
     private const string WifiSecurityEnterprise = "WPA2/WPA3-Enterprise";
+    private const string WifiSecurityEnterpriseWpa3 = "WPA3ENT";
+    private const string WifiSecurityEnterpriseWpa3192 = "WPA3ENT192";
     private static readonly string[] LegacyWifiSecurityPersonalValues = ["WPA2-Personal", "WPA3-Personal", "Personal"];
-    private static readonly string[] LegacyWifiSecurityEnterpriseValues = ["WPA2-Enterprise", "WPA3-Enterprise", "Enterprise"];
+    private static readonly string[] LegacyWifiSecurityEnterpriseValues = ["WPA2-Enterprise", "WPA3-Enterprise", "WPA3", "Enterprise"];
 
     public FoundryConnectProvisioningBundle Prepare(FoundryExpertConfigurationDocument document, string stagingDirectoryPath)
     {
@@ -114,8 +118,16 @@ public sealed class FoundryConnectProvisioningService : IFoundryConnectProvision
             throw new InvalidOperationException("Wi-Fi configuration requires an SSID.");
         }
 
+        bool isOpen = string.Equals(settings.Wifi.SecurityType, "Open", StringComparison.OrdinalIgnoreCase);
+        bool isOwe = string.Equals(settings.Wifi.SecurityType, WifiSecurityOwe, StringComparison.OrdinalIgnoreCase);
         bool isPersonal = IsPersonalSecurityType(settings.Wifi.SecurityType);
-        bool isEnterprise = settings.Wifi.HasEnterpriseProfile || IsEnterpriseSecurityType(settings.Wifi.SecurityType);
+        string? enterpriseSecurityType = NormalizeEnterpriseSecurityType(settings.Wifi.SecurityType);
+        bool isEnterprise = settings.Wifi.HasEnterpriseProfile || enterpriseSecurityType is not null;
+
+        if (!isOpen && !isOwe && !isPersonal && !isEnterprise)
+        {
+            throw new InvalidOperationException($"Unsupported Wi-Fi security type '{settings.Wifi.SecurityType}'.");
+        }
 
         if (isPersonal)
         {
@@ -131,6 +143,26 @@ public sealed class FoundryConnectProvisioningService : IFoundryConnectProvision
             if (string.IsNullOrWhiteSpace(settings.Wifi.EnterpriseProfileTemplatePath))
             {
                 throw new InvalidOperationException("Enterprise Wi-Fi requires a profile template.");
+            }
+
+            string fullTemplatePath = Path.GetFullPath(settings.Wifi.EnterpriseProfileTemplatePath);
+            if (!File.Exists(fullTemplatePath))
+            {
+                throw new InvalidOperationException("Enterprise Wi-Fi profile template file was not found.");
+            }
+
+            if (RequiresExplicitEnterpriseTemplateAuthentication(enterpriseSecurityType))
+            {
+                string? templateSecurityType = TryReadEnterpriseTemplateSecurityType(fullTemplatePath);
+                if (templateSecurityType is null)
+                {
+                    throw new InvalidOperationException("Enterprise Wi-Fi profile template must contain a supported enterprise authentication value.");
+                }
+
+                if (!string.Equals(templateSecurityType, enterpriseSecurityType, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException($"Selected enterprise Wi-Fi security type does not match the profile template authentication '{templateSecurityType}'.");
+                }
             }
 
             if (settings.Wifi.RequiresCertificate && string.IsNullOrWhiteSpace(settings.Wifi.CertificatePath))
@@ -185,8 +217,63 @@ public sealed class FoundryConnectProvisioningService : IFoundryConnectProvision
 
     private static bool IsEnterpriseSecurityType(string? securityType)
     {
-        return string.Equals(securityType, WifiSecurityEnterprise, StringComparison.OrdinalIgnoreCase) ||
-               LegacyWifiSecurityEnterpriseValues.Any(value => string.Equals(securityType, value, StringComparison.OrdinalIgnoreCase));
+        return NormalizeEnterpriseSecurityType(securityType) is not null;
+    }
+
+    private static string? NormalizeEnterpriseSecurityType(string? securityType)
+    {
+        if (string.IsNullOrWhiteSpace(securityType))
+        {
+            return null;
+        }
+
+        if (string.Equals(securityType, WifiSecurityEnterprise, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(securityType, "WPA2-Enterprise", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(securityType, "Enterprise", StringComparison.OrdinalIgnoreCase))
+        {
+            return WifiSecurityEnterprise;
+        }
+
+        if (string.Equals(securityType, WifiSecurityEnterpriseWpa3, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(securityType, "WPA3-Enterprise", StringComparison.OrdinalIgnoreCase))
+        {
+            return WifiSecurityEnterpriseWpa3;
+        }
+
+        if (string.Equals(securityType, WifiSecurityEnterpriseWpa3192, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(securityType, "WPA3", StringComparison.OrdinalIgnoreCase))
+        {
+            return WifiSecurityEnterpriseWpa3192;
+        }
+
+        return LegacyWifiSecurityEnterpriseValues.Any(value => string.Equals(securityType, value, StringComparison.OrdinalIgnoreCase))
+            ? WifiSecurityEnterprise
+            : null;
+    }
+
+    private static bool RequiresExplicitEnterpriseTemplateAuthentication(string? securityType)
+    {
+        return string.Equals(securityType, WifiSecurityEnterpriseWpa3, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(securityType, WifiSecurityEnterpriseWpa3192, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? TryReadEnterpriseTemplateSecurityType(string profileTemplatePath)
+    {
+        try
+        {
+            XDocument document = XDocument.Load(profileTemplatePath);
+            XNamespace wlanProfile = "http://www.microsoft.com/networking/WLAN/profile/v1";
+            string? authentication = document
+                .Descendants(wlanProfile + "authentication")
+                .Select(static element => element.Value?.Trim())
+                .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
+
+            return NormalizeEnterpriseSecurityType(authentication);
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static void EnsureDirectoryClean(string path)

--- a/src/Foundry/Services/Configuration/FoundryConnectProvisioningService.cs
+++ b/src/Foundry/Services/Configuration/FoundryConnectProvisioningService.cs
@@ -5,6 +5,11 @@ namespace Foundry.Services.Configuration;
 
 public sealed class FoundryConnectProvisioningService : IFoundryConnectProvisioningService
 {
+    private const string WifiSecurityPersonal = "WPA2/WPA3-Personal";
+    private const string WifiSecurityEnterprise = "WPA2/WPA3-Enterprise";
+    private static readonly string[] LegacyWifiSecurityPersonalValues = ["WPA2-Personal", "WPA3-Personal", "Personal"];
+    private static readonly string[] LegacyWifiSecurityEnterpriseValues = ["WPA2-Enterprise", "WPA3-Enterprise", "Enterprise"];
+
     public FoundryConnectProvisioningBundle Prepare(FoundryExpertConfigurationDocument document, string stagingDirectoryPath)
     {
         ArgumentNullException.ThrowIfNull(document);
@@ -109,22 +114,15 @@ public sealed class FoundryConnectProvisioningService : IFoundryConnectProvision
             throw new InvalidOperationException("Wi-Fi configuration requires an SSID.");
         }
 
-        bool isPersonal = string.Equals(settings.Wifi.SecurityType, "WPA2-Personal", StringComparison.OrdinalIgnoreCase) ||
-                          string.Equals(settings.Wifi.SecurityType, "WPA2/WPA3-Personal", StringComparison.OrdinalIgnoreCase) ||
-                          string.Equals(settings.Wifi.SecurityType, "WPA3-Personal", StringComparison.OrdinalIgnoreCase) ||
-                          string.Equals(settings.Wifi.SecurityType, "Personal", StringComparison.OrdinalIgnoreCase);
-        bool isEnterprise = settings.Wifi.HasEnterpriseProfile ||
-                            string.Equals(settings.Wifi.SecurityType, "WPA2/WPA3-Enterprise", StringComparison.OrdinalIgnoreCase) ||
-                            string.Equals(settings.Wifi.SecurityType, "WPA2-Enterprise", StringComparison.OrdinalIgnoreCase) ||
-                            string.Equals(settings.Wifi.SecurityType, "WPA3-Enterprise", StringComparison.OrdinalIgnoreCase) ||
-                            string.Equals(settings.Wifi.SecurityType, "Enterprise", StringComparison.OrdinalIgnoreCase);
+        bool isPersonal = IsPersonalSecurityType(settings.Wifi.SecurityType);
+        bool isEnterprise = settings.Wifi.HasEnterpriseProfile || IsEnterpriseSecurityType(settings.Wifi.SecurityType);
 
         if (isPersonal)
         {
             int passphraseLength = settings.Wifi.Passphrase?.Trim().Length ?? 0;
             if (passphraseLength is < 8 or > 63)
             {
-                throw new InvalidOperationException("WPA2 Personal Wi-Fi requires an 8 to 63 character passphrase.");
+                throw new InvalidOperationException("Personal Wi-Fi requires an 8 to 63 character passphrase.");
             }
         }
 
@@ -177,6 +175,18 @@ public sealed class FoundryConnectProvisioningService : IFoundryConnectProvision
     private static string NormalizeEmbeddedRelativePath(string relativePath)
     {
         return relativePath.Replace('/', '\\').TrimStart('\\');
+    }
+
+    private static bool IsPersonalSecurityType(string? securityType)
+    {
+        return string.Equals(securityType, WifiSecurityPersonal, StringComparison.OrdinalIgnoreCase) ||
+               LegacyWifiSecurityPersonalValues.Any(value => string.Equals(securityType, value, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsEnterpriseSecurityType(string? securityType)
+    {
+        return string.Equals(securityType, WifiSecurityEnterprise, StringComparison.OrdinalIgnoreCase) ||
+               LegacyWifiSecurityEnterpriseValues.Any(value => string.Equals(securityType, value, StringComparison.OrdinalIgnoreCase));
     }
 
     private static void EnsureDirectoryClean(string path)

--- a/src/Foundry/ViewModels/NetworkSettingsViewModel.cs
+++ b/src/Foundry/ViewModels/NetworkSettingsViewModel.cs
@@ -5,16 +5,20 @@ using Foundry.Services.ApplicationShell;
 using Foundry.Services.Localization;
 using Foundry.Services.Operations;
 using System.Collections.ObjectModel;
+using System.Xml.Linq;
 
 namespace Foundry.ViewModels;
 
 public partial class NetworkSettingsViewModel : LocalizedViewModelBase
 {
     private const string WifiSecurityOpen = "Open";
+    private const string WifiSecurityOwe = "OWE";
     private const string WifiSecurityPersonal = "WPA2/WPA3-Personal";
     private const string WifiSecurityEnterprise = "WPA2/WPA3-Enterprise";
+    private const string WifiSecurityEnterpriseWpa3 = "WPA3ENT";
+    private const string WifiSecurityEnterpriseWpa3192 = "WPA3ENT192";
     private static readonly string[] LegacyWifiSecurityPersonalValues = ["WPA2-Personal", "WPA3-Personal", "Personal"];
-    private static readonly string[] LegacyWifiSecurityEnterpriseValues = ["WPA2-Enterprise", "WPA3-Enterprise", "Enterprise"];
+    private static readonly string[] LegacyWifiSecurityEnterpriseValues = ["WPA2-Enterprise", "WPA3-Enterprise", "WPA3", "Enterprise"];
 
     private readonly IApplicationShellService _applicationShellService;
     private readonly IOperationProgressService _operationProgressService;
@@ -147,7 +151,7 @@ public partial class NetworkSettingsViewModel : LocalizedViewModelBase
     public bool IsWifiCertificatePathEnabled => IsWifiEnterpriseSectionEnabled && IsWifiCertificateRequired;
     public bool IsWifiOpenSelected => string.Equals(WifiSecurityType, WifiSecurityOpen, StringComparison.OrdinalIgnoreCase);
     public bool IsWifiPersonalSelected => string.Equals(WifiSecurityType, WifiSecurityPersonal, StringComparison.OrdinalIgnoreCase);
-    public bool IsWifiEnterpriseSelected => string.Equals(WifiSecurityType, WifiSecurityEnterprise, StringComparison.OrdinalIgnoreCase);
+    public bool IsWifiEnterpriseSelected => IsEnterpriseSecurityType(WifiSecurityType);
     public bool HasDot1xValidationError => !string.IsNullOrWhiteSpace(Dot1xValidationMessage);
     public string Dot1xValidationMessage => BuildDot1xValidationMessage();
     public bool HasWifiValidationError => !string.IsNullOrWhiteSpace(WifiValidationMessage);
@@ -362,8 +366,11 @@ public partial class NetworkSettingsViewModel : LocalizedViewModelBase
         ReplaceCollection(WifiSecurityTypes,
         [
             new SecurityTypeOption(WifiSecurityOpen, Strings["WifiSecurityTypeOpen"]),
+            new SecurityTypeOption(WifiSecurityOwe, Strings["WifiSecurityTypeOwe"]),
             new SecurityTypeOption(WifiSecurityPersonal, Strings["WifiSecurityTypePersonal"]),
-            new SecurityTypeOption(WifiSecurityEnterprise, Strings["WifiSecurityTypeEnterprise"])
+            new SecurityTypeOption(WifiSecurityEnterprise, Strings["WifiSecurityTypeEnterprise"]),
+            new SecurityTypeOption(WifiSecurityEnterpriseWpa3, Strings["WifiSecurityTypeEnterpriseWpa3"]),
+            new SecurityTypeOption(WifiSecurityEnterpriseWpa3192, Strings["WifiSecurityTypeEnterpriseWpa3192"])
         ]);
 
         OnPropertyChanged(nameof(WifiSecurityTypes));
@@ -385,17 +392,21 @@ public partial class NetworkSettingsViewModel : LocalizedViewModelBase
             return WifiSecurityOpen;
         }
 
+        if (string.Equals(settings.SecurityType, WifiSecurityOwe, StringComparison.OrdinalIgnoreCase))
+        {
+            return WifiSecurityOwe;
+        }
+
         if (string.Equals(settings.SecurityType, WifiSecurityPersonal, StringComparison.OrdinalIgnoreCase) ||
             LegacyWifiSecurityPersonalValues.Any(value => string.Equals(settings.SecurityType, value, StringComparison.OrdinalIgnoreCase)))
         {
             return WifiSecurityPersonal;
         }
 
-        if (string.Equals(settings.SecurityType, WifiSecurityEnterprise, StringComparison.OrdinalIgnoreCase) ||
-            LegacyWifiSecurityEnterpriseValues.Any(value => string.Equals(settings.SecurityType, value, StringComparison.OrdinalIgnoreCase)) ||
-            settings.HasEnterpriseProfile)
+        string? enterpriseSecurityType = NormalizeEnterpriseSecurityType(settings.SecurityType);
+        if (enterpriseSecurityType is not null || settings.HasEnterpriseProfile)
         {
-            return WifiSecurityEnterprise;
+            return enterpriseSecurityType ?? WifiSecurityEnterprise;
         }
 
         if (!string.IsNullOrWhiteSpace(settings.Passphrase))
@@ -404,6 +415,42 @@ public partial class NetworkSettingsViewModel : LocalizedViewModelBase
         }
 
         return WifiSecurityOpen;
+    }
+
+    private static bool IsEnterpriseSecurityType(string? securityType)
+    {
+        return NormalizeEnterpriseSecurityType(securityType) is not null;
+    }
+
+    private static string? NormalizeEnterpriseSecurityType(string? securityType)
+    {
+        if (string.IsNullOrWhiteSpace(securityType))
+        {
+            return null;
+        }
+
+        if (string.Equals(securityType, WifiSecurityEnterprise, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(securityType, "WPA2-Enterprise", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(securityType, "Enterprise", StringComparison.OrdinalIgnoreCase))
+        {
+            return WifiSecurityEnterprise;
+        }
+
+        if (string.Equals(securityType, WifiSecurityEnterpriseWpa3, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(securityType, "WPA3-Enterprise", StringComparison.OrdinalIgnoreCase))
+        {
+            return WifiSecurityEnterpriseWpa3;
+        }
+
+        if (string.Equals(securityType, WifiSecurityEnterpriseWpa3192, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(securityType, "WPA3", StringComparison.OrdinalIgnoreCase))
+        {
+            return WifiSecurityEnterpriseWpa3192;
+        }
+
+        return LegacyWifiSecurityEnterpriseValues.Any(value => string.Equals(securityType, value, StringComparison.OrdinalIgnoreCase))
+            ? WifiSecurityEnterprise
+            : null;
     }
 
     private string BuildDot1xValidationMessage()
@@ -452,6 +499,26 @@ public partial class NetworkSettingsViewModel : LocalizedViewModelBase
                 return "Enterprise Wi-Fi requires a profile template.";
             }
 
+            string trimmedTemplatePath = WifiEnterpriseProfileTemplatePath.Trim();
+            if (!File.Exists(Path.GetFullPath(trimmedTemplatePath)))
+            {
+                return "Enterprise Wi-Fi profile template file was not found.";
+            }
+
+            if (RequiresExplicitEnterpriseTemplateAuthentication(WifiSecurityType))
+            {
+                string? templateSecurityType = TryReadEnterpriseTemplateSecurityType(trimmedTemplatePath);
+                if (templateSecurityType is null)
+                {
+                    return "Enterprise Wi-Fi profile template must contain a supported enterprise authentication value.";
+                }
+
+                if (!string.Equals(templateSecurityType, WifiSecurityType, StringComparison.OrdinalIgnoreCase))
+                {
+                    return $"Selected enterprise Wi-Fi security type does not match the profile template authentication ({FormatEnterpriseSecurityTypeLabel(templateSecurityType)}).";
+                }
+            }
+
             if (IsWifiCertificateRequired && string.IsNullOrWhiteSpace(WifiCertificatePath))
             {
                 return "Enterprise Wi-Fi requires a trusted root CA certificate file when certificate trust is enabled.";
@@ -459,6 +526,41 @@ public partial class NetworkSettingsViewModel : LocalizedViewModelBase
         }
 
         return string.Empty;
+    }
+
+    private static bool RequiresExplicitEnterpriseTemplateAuthentication(string? securityType)
+    {
+        return string.Equals(securityType, WifiSecurityEnterpriseWpa3, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(securityType, WifiSecurityEnterpriseWpa3192, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? TryReadEnterpriseTemplateSecurityType(string profileTemplatePath)
+    {
+        try
+        {
+            XDocument document = XDocument.Load(Path.GetFullPath(profileTemplatePath));
+            XNamespace wlanProfile = "http://www.microsoft.com/networking/WLAN/profile/v1";
+            string? authentication = document
+                .Descendants(wlanProfile + "authentication")
+                .Select(static element => element.Value?.Trim())
+                .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
+
+            return NormalizeEnterpriseSecurityType(authentication);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string FormatEnterpriseSecurityTypeLabel(string securityType)
+    {
+        return securityType switch
+        {
+            WifiSecurityEnterpriseWpa3 => "WPA3 Enterprise",
+            WifiSecurityEnterpriseWpa3192 => "WPA3 Enterprise 192-bit",
+            _ => "WPA2/WPA3 Enterprise"
+        };
     }
     public sealed record SecurityTypeOption(string Value, string DisplayName);
 }

--- a/src/Foundry/ViewModels/NetworkSettingsViewModel.cs
+++ b/src/Foundry/ViewModels/NetworkSettingsViewModel.cs
@@ -11,7 +11,7 @@ namespace Foundry.ViewModels;
 public partial class NetworkSettingsViewModel : LocalizedViewModelBase
 {
     private const string WifiSecurityOpen = "Open";
-    private const string WifiSecurityPersonal = "WPA2-Personal";
+    private const string WifiSecurityPersonal = "WPA2/WPA3-Personal";
     private const string WifiSecurityEnterprise = "WPA2/WPA3-Enterprise";
     private static readonly string[] LegacyWifiSecurityPersonalValues = ["WPA2-Personal", "WPA3-Personal", "Personal"];
     private static readonly string[] LegacyWifiSecurityEnterpriseValues = ["WPA2-Enterprise", "WPA3-Enterprise", "Enterprise"];
@@ -441,7 +441,7 @@ public partial class NetworkSettingsViewModel : LocalizedViewModelBase
             string passphrase = WifiPassphrase.Trim();
             if (passphrase.Length < 8 || passphrase.Length > 63)
             {
-                return "WPA2 Personal Wi-Fi requires an 8 to 63 character passphrase.";
+                return "Personal Wi-Fi requires an 8 to 63 character passphrase.";
             }
         }
 


### PR DESCRIPTION
## Summary
Add first-class OWE and explicit WPA3 enterprise Wi-Fi options on top of the previous personal Wi-Fi provisioning work.

## Why
Foundry already exposed more Wi-Fi authentication detail from Windows than it could actually provision or connect directly. This change adds support for OWE as a real mode, adds explicit enterprise subtype options for clearer selection, and ensures enterprise subtype choices stay consistent with the imported WLAN template.

## Changes
- add first-class `OWE`, `WPA3ENT`, and `WPA3ENT192` Wi-Fi security options in Foundry
- preserve the existing generic `WPA2/WPA3-Enterprise` option for backward compatibility
- add OWE WLAN profile generation and direct-connect handling in Foundry.Connect
- validate explicit enterprise subtype selections against the authentication declared in the imported enterprise WLAN profile template
- read enterprise authentication from the resolved profile XML before displaying the provisioned authentication text in Foundry.Connect
- clarify Wi-Fi option labels with auth identifiers where that helps users choose correctly

## Testing
- `dotnet build src\\Foundry\\Foundry.csproj`
- `dotnet build src\\Foundry.Connect\\Foundry.Connect.csproj`

## Notes
- draft PR
- base branch is `codex/analyze-wifi-security-types` because this change depends on the previous Wi-Fi provisioning update