### PR TITLE
feat(update): add startup release check dialog

### DIFF
--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Foundry.Services.Autopilot;
 using Foundry.Services.Adk;
+using Foundry.Services.ApplicationUpdate;
 using Foundry.Services.ApplicationShell;
 using Foundry.Services.Configuration;
 using Foundry.Services.Localization;
@@ -21,6 +22,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<AutopilotSettingsViewModel>();
 
         services.AddSingleton<IApplicationShellService, ApplicationShellService>();
+        services.AddSingleton<IApplicationUpdateService, ApplicationUpdateService>();
         services.AddSingleton<IAutopilotProfileService, AutopilotProfileService>();
         services.AddSingleton<IExpertConfigurationService, ExpertConfigurationService>();
         services.AddSingleton<IFoundryConnectProvisioningService, FoundryConnectProvisioningService>();

--- a/src/Foundry/FoundryApplicationInfo.cs
+++ b/src/Foundry/FoundryApplicationInfo.cs
@@ -12,6 +12,7 @@ public static class FoundryApplicationInfo
     public const string RepositoryUrl = RepositoryBaseUrl;
     public const string IssuesUrl = RepositoryBaseUrl + "/issues";
     public const string LatestReleaseUrl = RepositoryBaseUrl + "/releases/latest";
+    public const string LatestReleaseApiUrl = "https://api.github.com/repos/mchave3/Foundry/releases/latest";
     public const string LicenseUrl = RepositoryBaseUrl + "/blob/main/LICENSE";
     public const string AuthorsUrl = RepositoryBaseUrl + "/graphs/contributors";
     public const string SupportUrl = IssuesUrl;

--- a/src/Foundry/MainWindow.xaml
+++ b/src/Foundry/MainWindow.xaml
@@ -106,6 +106,9 @@
                 <MenuItem Header="{Binding Strings[MenuTools]}">
                     <MenuItem Command="{Binding OpenLogFolderCommand}" Header="{Binding Strings[MenuLogs]}" />
                 </MenuItem>
+                <MenuItem Header="{Binding Strings[MenuDebug]}" Visibility="{Binding IsDebugMenuVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <MenuItem Command="{Binding CheckForUpdatesCommand}" Header="{Binding Strings[MenuDebugCheckForUpdates]}" />
+                </MenuItem>
                 <MenuItem Header="{Binding Strings[MenuHelp]}">
                     <MenuItem Command="{Binding OpenDocumentationCommand}" Header="{Binding Strings[MenuDocumentation]}" />
                     <MenuItem Command="{Binding OpenGitHubRepositoryCommand}" Header="{Binding Strings[MenuGitHubRepository]}" />

--- a/src/Foundry/MainWindow.xaml.cs
+++ b/src/Foundry/MainWindow.xaml.cs
@@ -5,10 +5,20 @@ namespace Foundry;
 
 public partial class MainWindow : Window
 {
+    private readonly MainWindowViewModel _viewModel;
+
     public MainWindow(MainWindowViewModel viewModel)
     {
         InitializeComponent();
+        _viewModel = viewModel;
         DataContext = viewModel;
-        Loaded += (_, _) => _ = viewModel.RefreshUsbCandidatesCommand.ExecuteAsync(null);
+        Loaded += OnLoadedAsync;
+    }
+
+    private async void OnLoadedAsync(object sender, RoutedEventArgs e)
+    {
+        Loaded -= OnLoadedAsync;
+        _ = _viewModel.RefreshUsbCandidatesCommand.ExecuteAsync(null);
+        await _viewModel.RunStartupUpdateCheckAsync();
     }
 }

--- a/src/Foundry/Resources/AppStrings.en-US.resx
+++ b/src/Foundry/Resources/AppStrings.en-US.resx
@@ -141,6 +141,12 @@
   <data name="MenuTools" xml:space="preserve">
     <value>_Tools</value>
   </data>
+  <data name="MenuDebug" xml:space="preserve">
+    <value>_Debug</value>
+  </data>
+  <data name="MenuDebugCheckForUpdates" xml:space="preserve">
+    <value>Show _Update Check</value>
+  </data>
   <data name="MenuLogs" xml:space="preserve">
     <value>Open _Log Folder</value>
   </data>
@@ -184,16 +190,16 @@
     <value>Update available</value>
   </data>
   <data name="UpdateAvailableHeading" xml:space="preserve">
-    <value>A newer version of Foundry is available.</value>
+    <value>A new version of Foundry is available!</value>
   </data>
-  <data name="UpdateAvailableDescription" xml:space="preserve">
-    <value>Foundry found a newer stable release on GitHub. This application does not download or install updates automatically.</value>
+  <data name="UpdateAvailableSummaryFormat" xml:space="preserve">
+    <value>{0} is available. You are running {1}.</value>
   </data>
   <data name="UpdateAvailableCurrentVersionLabel" xml:space="preserve">
     <value>Current version</value>
   </data>
   <data name="UpdateAvailableLatestVersionLabel" xml:space="preserve">
-    <value>Latest version</value>
+    <value>New version</value>
   </data>
   <data name="UpdateAvailableReleaseLabel" xml:space="preserve">
     <value>Release</value>

--- a/src/Foundry/Resources/AppStrings.en-US.resx
+++ b/src/Foundry/Resources/AppStrings.en-US.resx
@@ -168,6 +168,54 @@
   <data name="MenuCheckForUpdates" xml:space="preserve">
     <value>Check for _Updates...</value>
   </data>
+  <data name="UpdateCheckUpToDateTitle" xml:space="preserve">
+    <value>No update available</value>
+  </data>
+  <data name="UpdateCheckUpToDateMessage" xml:space="preserve">
+    <value>You are already using the latest available version of Foundry.</value>
+  </data>
+  <data name="UpdateCheckFailedTitle" xml:space="preserve">
+    <value>Update check failed</value>
+  </data>
+  <data name="UpdateCheckFailedMessage" xml:space="preserve">
+    <value>Foundry could not check GitHub Releases right now. Try again later.</value>
+  </data>
+  <data name="UpdateAvailableTitle" xml:space="preserve">
+    <value>Update available</value>
+  </data>
+  <data name="UpdateAvailableHeading" xml:space="preserve">
+    <value>A newer version of Foundry is available.</value>
+  </data>
+  <data name="UpdateAvailableDescription" xml:space="preserve">
+    <value>Foundry found a newer stable release on GitHub. This application does not download or install updates automatically.</value>
+  </data>
+  <data name="UpdateAvailableCurrentVersionLabel" xml:space="preserve">
+    <value>Current version</value>
+  </data>
+  <data name="UpdateAvailableLatestVersionLabel" xml:space="preserve">
+    <value>Latest version</value>
+  </data>
+  <data name="UpdateAvailableReleaseLabel" xml:space="preserve">
+    <value>Release</value>
+  </data>
+  <data name="UpdateAvailablePublishedLabel" xml:space="preserve">
+    <value>Published</value>
+  </data>
+  <data name="UpdateAvailablePublishedUnknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="UpdateAvailableReleaseNotes" xml:space="preserve">
+    <value>Release notes</value>
+  </data>
+  <data name="UpdateAvailableNotesEmpty" xml:space="preserve">
+    <value>No release notes were provided for this release.</value>
+  </data>
+  <data name="UpdateAvailableOpenRelease" xml:space="preserve">
+    <value>Open release</value>
+  </data>
+  <data name="UpdateAvailableLater" xml:space="preserve">
+    <value>Later</value>
+  </data>
   <data name="AdkBannerMissing" xml:space="preserve">
     <value>Windows ADK is not installed. Please install ADK 11 24H2 to enable ISO and USB creation.</value>
   </data>

--- a/src/Foundry/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry/Resources/AppStrings.fr-FR.resx
@@ -141,6 +141,12 @@
   <data name="MenuTools" xml:space="preserve">
     <value>_Outils</value>
   </data>
+  <data name="MenuDebug" xml:space="preserve">
+    <value>_Debug</value>
+  </data>
+  <data name="MenuDebugCheckForUpdates" xml:space="preserve">
+    <value>Afficher la vérification des _mises à jour</value>
+  </data>
   <data name="MenuLogs" xml:space="preserve">
     <value>Ouvrir le _dossier des logs</value>
   </data>
@@ -184,16 +190,16 @@
     <value>Mise à jour disponible</value>
   </data>
   <data name="UpdateAvailableHeading" xml:space="preserve">
-    <value>Une version plus récente de Foundry est disponible.</value>
+    <value>Une nouvelle version de Foundry est disponible !</value>
   </data>
-  <data name="UpdateAvailableDescription" xml:space="preserve">
-    <value>Foundry a détecté une nouvelle release stable sur GitHub. Cette application ne télécharge ni n'installe les mises à jour automatiquement.</value>
+  <data name="UpdateAvailableSummaryFormat" xml:space="preserve">
+    <value>{0} est disponible. Vous utilisez actuellement la version {1}.</value>
   </data>
   <data name="UpdateAvailableCurrentVersionLabel" xml:space="preserve">
     <value>Version actuelle</value>
   </data>
   <data name="UpdateAvailableLatestVersionLabel" xml:space="preserve">
-    <value>Dernière version</value>
+    <value>Nouvelle version</value>
   </data>
   <data name="UpdateAvailableReleaseLabel" xml:space="preserve">
     <value>Release</value>

--- a/src/Foundry/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry/Resources/AppStrings.fr-FR.resx
@@ -168,6 +168,54 @@
   <data name="MenuCheckForUpdates" xml:space="preserve">
     <value>Rechercher les _mises à jour...</value>
   </data>
+  <data name="UpdateCheckUpToDateTitle" xml:space="preserve">
+    <value>Aucune mise à jour disponible</value>
+  </data>
+  <data name="UpdateCheckUpToDateMessage" xml:space="preserve">
+    <value>Vous utilisez déjà la dernière version disponible de Foundry.</value>
+  </data>
+  <data name="UpdateCheckFailedTitle" xml:space="preserve">
+    <value>Échec de la vérification des mises à jour</value>
+  </data>
+  <data name="UpdateCheckFailedMessage" xml:space="preserve">
+    <value>Foundry n'a pas pu vérifier les GitHub Releases pour le moment. Réessayez plus tard.</value>
+  </data>
+  <data name="UpdateAvailableTitle" xml:space="preserve">
+    <value>Mise à jour disponible</value>
+  </data>
+  <data name="UpdateAvailableHeading" xml:space="preserve">
+    <value>Une version plus récente de Foundry est disponible.</value>
+  </data>
+  <data name="UpdateAvailableDescription" xml:space="preserve">
+    <value>Foundry a détecté une nouvelle release stable sur GitHub. Cette application ne télécharge ni n'installe les mises à jour automatiquement.</value>
+  </data>
+  <data name="UpdateAvailableCurrentVersionLabel" xml:space="preserve">
+    <value>Version actuelle</value>
+  </data>
+  <data name="UpdateAvailableLatestVersionLabel" xml:space="preserve">
+    <value>Dernière version</value>
+  </data>
+  <data name="UpdateAvailableReleaseLabel" xml:space="preserve">
+    <value>Release</value>
+  </data>
+  <data name="UpdateAvailablePublishedLabel" xml:space="preserve">
+    <value>Publication</value>
+  </data>
+  <data name="UpdateAvailablePublishedUnknown" xml:space="preserve">
+    <value>Inconnue</value>
+  </data>
+  <data name="UpdateAvailableReleaseNotes" xml:space="preserve">
+    <value>Notes de version</value>
+  </data>
+  <data name="UpdateAvailableNotesEmpty" xml:space="preserve">
+    <value>Aucune note de version n'a été fournie pour cette release.</value>
+  </data>
+  <data name="UpdateAvailableOpenRelease" xml:space="preserve">
+    <value>Ouvrir la release</value>
+  </data>
+  <data name="UpdateAvailableLater" xml:space="preserve">
+    <value>Plus tard</value>
+  </data>
   <data name="AdkBannerMissing" xml:space="preserve">
     <value>Windows ADK n’est pas installé. Merci d’installer ADK 11 24H2 pour activer la création d’ISO et USB.</value>
   </data>

--- a/src/Foundry/Resources/AppStrings.resx
+++ b/src/Foundry/Resources/AppStrings.resx
@@ -141,6 +141,12 @@
   <data name="MenuTools" xml:space="preserve">
     <value>_Tools</value>
   </data>
+  <data name="MenuDebug" xml:space="preserve">
+    <value>_Debug</value>
+  </data>
+  <data name="MenuDebugCheckForUpdates" xml:space="preserve">
+    <value>Show _Update Check</value>
+  </data>
   <data name="MenuLogs" xml:space="preserve">
     <value>Open _Log Folder</value>
   </data>
@@ -184,16 +190,16 @@
     <value>Update available</value>
   </data>
   <data name="UpdateAvailableHeading" xml:space="preserve">
-    <value>A newer version of Foundry is available.</value>
+    <value>A new version of Foundry is available!</value>
   </data>
-  <data name="UpdateAvailableDescription" xml:space="preserve">
-    <value>Foundry found a newer stable release on GitHub. This application does not download or install updates automatically.</value>
+  <data name="UpdateAvailableSummaryFormat" xml:space="preserve">
+    <value>{0} is available. You are running {1}.</value>
   </data>
   <data name="UpdateAvailableCurrentVersionLabel" xml:space="preserve">
     <value>Current version</value>
   </data>
   <data name="UpdateAvailableLatestVersionLabel" xml:space="preserve">
-    <value>Latest version</value>
+    <value>New version</value>
   </data>
   <data name="UpdateAvailableReleaseLabel" xml:space="preserve">
     <value>Release</value>

--- a/src/Foundry/Resources/AppStrings.resx
+++ b/src/Foundry/Resources/AppStrings.resx
@@ -168,6 +168,54 @@
   <data name="MenuCheckForUpdates" xml:space="preserve">
     <value>Check for _Updates...</value>
   </data>
+  <data name="UpdateCheckUpToDateTitle" xml:space="preserve">
+    <value>No update available</value>
+  </data>
+  <data name="UpdateCheckUpToDateMessage" xml:space="preserve">
+    <value>You are already using the latest available version of Foundry.</value>
+  </data>
+  <data name="UpdateCheckFailedTitle" xml:space="preserve">
+    <value>Update check failed</value>
+  </data>
+  <data name="UpdateCheckFailedMessage" xml:space="preserve">
+    <value>Foundry could not check GitHub Releases right now. Try again later.</value>
+  </data>
+  <data name="UpdateAvailableTitle" xml:space="preserve">
+    <value>Update available</value>
+  </data>
+  <data name="UpdateAvailableHeading" xml:space="preserve">
+    <value>A newer version of Foundry is available.</value>
+  </data>
+  <data name="UpdateAvailableDescription" xml:space="preserve">
+    <value>Foundry found a newer stable release on GitHub. This application does not download or install updates automatically.</value>
+  </data>
+  <data name="UpdateAvailableCurrentVersionLabel" xml:space="preserve">
+    <value>Current version</value>
+  </data>
+  <data name="UpdateAvailableLatestVersionLabel" xml:space="preserve">
+    <value>Latest version</value>
+  </data>
+  <data name="UpdateAvailableReleaseLabel" xml:space="preserve">
+    <value>Release</value>
+  </data>
+  <data name="UpdateAvailablePublishedLabel" xml:space="preserve">
+    <value>Published</value>
+  </data>
+  <data name="UpdateAvailablePublishedUnknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="UpdateAvailableReleaseNotes" xml:space="preserve">
+    <value>Release notes</value>
+  </data>
+  <data name="UpdateAvailableNotesEmpty" xml:space="preserve">
+    <value>No release notes were provided for this release.</value>
+  </data>
+  <data name="UpdateAvailableOpenRelease" xml:space="preserve">
+    <value>Open release</value>
+  </data>
+  <data name="UpdateAvailableLater" xml:space="preserve">
+    <value>Later</value>
+  </data>
   <data name="AdkBannerMissing" xml:space="preserve">
     <value>Windows ADK is not installed. Please install ADK 11 24H2 to enable ISO and USB creation.</value>
   </data>

--- a/src/Foundry/Services/ApplicationShell/ApplicationShellService.cs
+++ b/src/Foundry/Services/ApplicationShell/ApplicationShellService.cs
@@ -1,4 +1,5 @@
 using Foundry.Models.Configuration;
+using Foundry.Services.ApplicationUpdate;
 using Foundry.Services.Localization;
 using Foundry.ViewModels;
 using Foundry.Views;
@@ -40,6 +41,31 @@ public sealed class ApplicationShellService : IApplicationShellService
         {
             viewModel.Dispose();
         }
+    }
+
+    public void ShowUpdateAvailable(ApplicationUpdateInfo updateInfo)
+    {
+        ArgumentNullException.ThrowIfNull(updateInfo);
+
+        InvokeOnUiThread(() =>
+        {
+            var viewModel = new UpdateAvailableDialogViewModel(_localizationService, this, updateInfo);
+            var dialog = new UpdateAvailableDialog
+            {
+                DataContext = viewModel,
+                Owner = ResolveOwnerWindow()
+            };
+
+            try
+            {
+                viewModel.CloseRequested += (_, _) => dialog.Close();
+                _ = dialog.ShowDialog();
+            }
+            finally
+            {
+                viewModel.Dispose();
+            }
+        });
     }
 
     public void OpenUrl(string url)
@@ -155,6 +181,18 @@ public sealed class ApplicationShellService : IApplicationShellService
         });
     }
 
+    public void ShowMessage(string title, string message, MessageBoxImage image)
+    {
+        InvokeOnUiThread(() =>
+        {
+            MessageBox.Show(
+                message,
+                title,
+                MessageBoxButton.OK,
+                image);
+        });
+    }
+
     public bool ConfirmWarning(string title, string message)
     {
         MessageBoxResult result = MessageBox.Show(
@@ -183,5 +221,18 @@ public sealed class ApplicationShellService : IApplicationShellService
         }
 
         return Application.Current.MainWindow;
+    }
+
+    private static void InvokeOnUiThread(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (Application.Current?.Dispatcher is not { } dispatcher || dispatcher.CheckAccess())
+        {
+            action();
+            return;
+        }
+
+        dispatcher.Invoke(action);
     }
 }

--- a/src/Foundry/Services/ApplicationShell/IApplicationShellService.cs
+++ b/src/Foundry/Services/ApplicationShell/IApplicationShellService.cs
@@ -1,4 +1,6 @@
+using System.Windows;
 using Foundry.Models.Configuration;
+using Foundry.Services.ApplicationUpdate;
 
 namespace Foundry.Services.ApplicationShell;
 
@@ -7,6 +9,8 @@ public interface IApplicationShellService
     void Shutdown();
 
     void ShowAbout();
+
+    void ShowUpdateAvailable(ApplicationUpdateInfo updateInfo);
 
     void OpenUrl(string url);
 
@@ -21,6 +25,8 @@ public interface IApplicationShellService
     string? PickFolderPath(string title, string? initialPath = null);
 
     void OpenFolder(string path);
+
+    void ShowMessage(string title, string message, MessageBoxImage image);
 
     bool ConfirmWarning(string title, string message);
 }

--- a/src/Foundry/Services/ApplicationUpdate/ApplicationUpdateInfo.cs
+++ b/src/Foundry/Services/ApplicationUpdate/ApplicationUpdateInfo.cs
@@ -6,4 +6,10 @@ public sealed record ApplicationUpdateInfo(
     string ReleaseTitle,
     string ReleaseUrl,
     DateTimeOffset? PublishedAt,
-    string ReleaseNotes);
+    string ReleaseNotes)
+{
+    public string SummaryReleaseTitle =>
+        string.IsNullOrWhiteSpace(ReleaseTitle)
+            ? LatestVersion
+            : ReleaseTitle;
+}

--- a/src/Foundry/Services/ApplicationUpdate/ApplicationUpdateInfo.cs
+++ b/src/Foundry/Services/ApplicationUpdate/ApplicationUpdateInfo.cs
@@ -1,0 +1,9 @@
+namespace Foundry.Services.ApplicationUpdate;
+
+public sealed record ApplicationUpdateInfo(
+    string CurrentVersion,
+    string LatestVersion,
+    string ReleaseTitle,
+    string ReleaseUrl,
+    DateTimeOffset? PublishedAt,
+    string ReleaseNotes);

--- a/src/Foundry/Services/ApplicationUpdate/ApplicationUpdateService.cs
+++ b/src/Foundry/Services/ApplicationUpdate/ApplicationUpdateService.cs
@@ -1,0 +1,290 @@
+using System.Windows;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Foundry.Services.ApplicationShell;
+using Foundry.Services.Localization;
+using Microsoft.Extensions.Logging;
+
+namespace Foundry.Services.ApplicationUpdate;
+
+public sealed class ApplicationUpdateService : IApplicationUpdateService
+{
+    private const string GitHubApiVersion = "2022-11-28";
+    private static readonly HttpClient HttpClient = CreateHttpClient();
+    private static readonly Regex VersionPattern = new(@"(?<version>\d+(?:\.\d+){1,3})", RegexOptions.Compiled);
+
+    private readonly IApplicationShellService _applicationShellService;
+    private readonly ILocalizationService _localizationService;
+    private readonly ILogger<ApplicationUpdateService> _logger;
+    private readonly SemaphoreSlim _checkGate = new(1, 1);
+
+    private int _startupCheckCompleted;
+
+    public ApplicationUpdateService(
+        IApplicationShellService applicationShellService,
+        ILocalizationService localizationService,
+        ILogger<ApplicationUpdateService> logger)
+    {
+        _applicationShellService = applicationShellService;
+        _localizationService = localizationService;
+        _logger = logger;
+    }
+
+    public Task CheckForUpdatesAsync(CancellationToken cancellationToken = default)
+    {
+        return CheckForUpdatesCoreAsync(notifyWhenCurrent: true, notifyWhenFailure: true, cancellationToken);
+    }
+
+    public async Task CheckForUpdatesOnStartupAsync(CancellationToken cancellationToken = default)
+    {
+        if (Interlocked.Exchange(ref _startupCheckCompleted, 1) != 0)
+        {
+            return;
+        }
+
+        if (IsPlaceholderVersion(FoundryApplicationInfo.Version))
+        {
+            _logger.LogInformation(
+                "Skipping automatic startup update check because the current version is the placeholder development version. CurrentVersion={CurrentVersion}",
+                FoundryApplicationInfo.Version);
+            return;
+        }
+
+        try
+        {
+            await CheckForUpdatesCoreAsync(notifyWhenCurrent: false, notifyWhenFailure: false, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private async Task CheckForUpdatesCoreAsync(
+        bool notifyWhenCurrent,
+        bool notifyWhenFailure,
+        CancellationToken cancellationToken)
+    {
+        await _checkGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            UpdateCheckResult result = await GetUpdateCheckResultAsync(cancellationToken).ConfigureAwait(false);
+
+            switch (result.Status)
+            {
+                case UpdateCheckStatus.UpdateAvailable:
+                    _applicationShellService.ShowUpdateAvailable(result.UpdateInfo!);
+                    break;
+
+                case UpdateCheckStatus.UpToDate:
+                    if (notifyWhenCurrent)
+                    {
+                        _applicationShellService.ShowMessage(
+                            _localizationService.Strings["UpdateCheckUpToDateTitle"],
+                            _localizationService.Strings["UpdateCheckUpToDateMessage"],
+                            MessageBoxImage.Information);
+                    }
+                    break;
+
+                case UpdateCheckStatus.Failed:
+                    if (notifyWhenFailure)
+                    {
+                        _applicationShellService.ShowMessage(
+                            _localizationService.Strings["UpdateCheckFailedTitle"],
+                            _localizationService.Strings["UpdateCheckFailedMessage"],
+                            MessageBoxImage.Error);
+                    }
+                    break;
+            }
+        }
+        finally
+        {
+            _checkGate.Release();
+        }
+    }
+
+    private async Task<UpdateCheckResult> GetUpdateCheckResultAsync(CancellationToken cancellationToken)
+    {
+        string currentVersionDisplay = FoundryApplicationInfo.Version;
+        Version? currentVersion = TryParseVersion(currentVersionDisplay);
+        if (currentVersion is null)
+        {
+            _logger.LogWarning("Unable to parse the current Foundry version for update checks. CurrentVersion={CurrentVersion}", currentVersionDisplay);
+            return UpdateCheckResult.Failed();
+        }
+
+        try
+        {
+            GitHubReleaseInfo latestRelease = await GetLatestReleaseAsync(cancellationToken).ConfigureAwait(false);
+            Version? latestVersion = TryParseVersion(latestRelease.TagName);
+            if (latestVersion is null)
+            {
+                _logger.LogWarning("Unable to parse the latest GitHub release tag for update checks. TagName={TagName}", latestRelease.TagName);
+                return UpdateCheckResult.Failed();
+            }
+
+            if (latestVersion <= currentVersion)
+            {
+                _logger.LogInformation(
+                    "Foundry is up to date. CurrentVersion={CurrentVersion}, LatestVersion={LatestVersion}",
+                    currentVersion,
+                    latestVersion);
+                return UpdateCheckResult.UpToDate();
+            }
+
+            _logger.LogInformation(
+                "Foundry update available. CurrentVersion={CurrentVersion}, LatestVersion={LatestVersion}, ReleaseUrl={ReleaseUrl}",
+                currentVersion,
+                latestVersion,
+                latestRelease.ReleaseUrl);
+
+            return UpdateCheckResult.UpdateAvailable(new ApplicationUpdateInfo(
+                CurrentVersion: currentVersionDisplay,
+                LatestVersion: latestRelease.TagName,
+                ReleaseTitle: latestRelease.ReleaseTitle,
+                ReleaseUrl: latestRelease.ReleaseUrl,
+                PublishedAt: latestRelease.PublishedAt,
+                ReleaseNotes: latestRelease.ReleaseNotes));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Foundry failed to query the latest GitHub release.");
+            return UpdateCheckResult.Failed();
+        }
+    }
+
+    private static async Task<GitHubReleaseInfo> GetLatestReleaseAsync(CancellationToken cancellationToken)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Get, FoundryApplicationInfo.LatestReleaseApiUrl);
+        request.Headers.Accept.ParseAdd("application/vnd.github+json");
+        request.Headers.Add("X-GitHub-Api-Version", GitHubApiVersion);
+
+        using HttpResponseMessage response = await HttpClient.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        await using Stream contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using JsonDocument document = await JsonDocument.ParseAsync(contentStream, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        JsonElement root = document.RootElement;
+        string tagName = ReadString(root, "tag_name");
+        string releaseTitle = FirstNonEmpty(ReadString(root, "name"), tagName, "Latest release");
+        string releaseUrl = FirstNonEmpty(ReadString(root, "html_url"), FoundryApplicationInfo.LatestReleaseUrl);
+        string releaseNotes = NormalizeReleaseNotes(ReadString(root, "body"));
+
+        return new GitHubReleaseInfo(
+            tagName,
+            releaseTitle,
+            releaseUrl,
+            ReadDateTimeOffset(root, "published_at"),
+            releaseNotes);
+    }
+
+    private static string ReadString(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out JsonElement property) &&
+               property.ValueKind == JsonValueKind.String
+            ? property.GetString()?.Trim() ?? string.Empty
+            : string.Empty;
+    }
+
+    private static DateTimeOffset? ReadDateTimeOffset(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out JsonElement property) ||
+            property.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        return DateTimeOffset.TryParse(property.GetString(), out DateTimeOffset parsed)
+            ? parsed
+            : null;
+    }
+
+    private static string NormalizeReleaseNotes(string notes)
+    {
+        if (string.IsNullOrWhiteSpace(notes))
+        {
+            return string.Empty;
+        }
+
+        return notes
+            .Replace("\r\n", Environment.NewLine, StringComparison.Ordinal)
+            .Replace("\n", Environment.NewLine, StringComparison.Ordinal)
+            .Trim();
+    }
+
+    private static Version? TryParseVersion(string? rawVersion)
+    {
+        if (string.IsNullOrWhiteSpace(rawVersion))
+        {
+            return null;
+        }
+
+        Match match = VersionPattern.Match(rawVersion.Trim());
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        return Version.TryParse(match.Groups["version"].Value, out Version? parsedVersion)
+            ? parsedVersion
+            : null;
+    }
+
+    private static bool IsPlaceholderVersion(string? rawVersion)
+    {
+        Version? version = TryParseVersion(rawVersion);
+        return version is not null && version == new Version(1, 0, 0, 0);
+    }
+
+    private static string FirstNonEmpty(params string[] values)
+    {
+        return values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value)) ?? string.Empty;
+    }
+
+    private static HttpClient CreateHttpClient()
+    {
+        HttpClient client = new()
+        {
+            Timeout = TimeSpan.FromSeconds(15)
+        };
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("Foundry");
+        return client;
+    }
+
+    private enum UpdateCheckStatus
+    {
+        UpdateAvailable,
+        UpToDate,
+        Failed
+    }
+
+    private sealed record UpdateCheckResult(UpdateCheckStatus Status, ApplicationUpdateInfo? UpdateInfo = null)
+    {
+        public static UpdateCheckResult UpdateAvailable(ApplicationUpdateInfo updateInfo)
+        {
+            return new(UpdateCheckStatus.UpdateAvailable, updateInfo);
+        }
+
+        public static UpdateCheckResult UpToDate()
+        {
+            return new(UpdateCheckStatus.UpToDate);
+        }
+
+        public static UpdateCheckResult Failed()
+        {
+            return new(UpdateCheckStatus.Failed);
+        }
+    }
+
+    private sealed record GitHubReleaseInfo(
+        string TagName,
+        string ReleaseTitle,
+        string ReleaseUrl,
+        DateTimeOffset? PublishedAt,
+        string ReleaseNotes);
+}

--- a/src/Foundry/Services/ApplicationUpdate/ApplicationUpdateService.cs
+++ b/src/Foundry/Services/ApplicationUpdate/ApplicationUpdateService.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Diagnostics;
 using Foundry.Services.ApplicationShell;
 using Foundry.Services.Localization;
 using Microsoft.Extensions.Logging;
@@ -43,11 +44,10 @@ public sealed class ApplicationUpdateService : IApplicationUpdateService
             return;
         }
 
-        if (IsPlaceholderVersion(FoundryApplicationInfo.Version))
+        if (IsVisualStudioDebugSession())
         {
             _logger.LogInformation(
-                "Skipping automatic startup update check because the current version is the placeholder development version. CurrentVersion={CurrentVersion}",
-                FoundryApplicationInfo.Version);
+                "Skipping automatic startup update check because Foundry is running in a Visual Studio debug session.");
             return;
         }
 
@@ -235,12 +235,6 @@ public sealed class ApplicationUpdateService : IApplicationUpdateService
             : null;
     }
 
-    private static bool IsPlaceholderVersion(string? rawVersion)
-    {
-        Version? version = TryParseVersion(rawVersion);
-        return version is not null && version == new Version(1, 0, 0, 0);
-    }
-
     private static string NormalizeVersionDisplay(string? rawVersion)
     {
         Version? version = TryParseVersion(rawVersion);
@@ -260,6 +254,15 @@ public sealed class ApplicationUpdateService : IApplicationUpdateService
     private static string FirstNonEmpty(params string[] values)
     {
         return values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value)) ?? string.Empty;
+    }
+
+    private static bool IsVisualStudioDebugSession()
+    {
+#if DEBUG
+        return Debugger.IsAttached;
+#else
+        return false;
+#endif
     }
 
     private static HttpClient CreateHttpClient()

--- a/src/Foundry/Services/ApplicationUpdate/ApplicationUpdateService.cs
+++ b/src/Foundry/Services/ApplicationUpdate/ApplicationUpdateService.cs
@@ -140,9 +140,9 @@ public sealed class ApplicationUpdateService : IApplicationUpdateService
                 latestRelease.ReleaseUrl);
 
             return UpdateCheckResult.UpdateAvailable(new ApplicationUpdateInfo(
-                CurrentVersion: currentVersionDisplay,
-                LatestVersion: latestRelease.TagName,
-                ReleaseTitle: latestRelease.ReleaseTitle,
+                CurrentVersion: NormalizeVersionDisplay(currentVersionDisplay),
+                LatestVersion: NormalizeVersionDisplay(latestRelease.TagName),
+                ReleaseTitle: NormalizeReleaseTitle(latestRelease.ReleaseTitle),
                 ReleaseUrl: latestRelease.ReleaseUrl,
                 PublishedAt: latestRelease.PublishedAt,
                 ReleaseNotes: latestRelease.ReleaseNotes));
@@ -239,6 +239,22 @@ public sealed class ApplicationUpdateService : IApplicationUpdateService
     {
         Version? version = TryParseVersion(rawVersion);
         return version is not null && version == new Version(1, 0, 0, 0);
+    }
+
+    private static string NormalizeVersionDisplay(string? rawVersion)
+    {
+        Version? version = TryParseVersion(rawVersion);
+        return version?.ToString() ?? rawVersion?.Trim() ?? string.Empty;
+    }
+
+    private static string NormalizeReleaseTitle(string? releaseTitle)
+    {
+        if (string.IsNullOrWhiteSpace(releaseTitle))
+        {
+            return string.Empty;
+        }
+
+        return VersionPattern.Replace(releaseTitle.Trim(), match => NormalizeVersionDisplay(match.Value));
     }
 
     private static string FirstNonEmpty(params string[] values)

--- a/src/Foundry/Services/ApplicationUpdate/ApplicationUpdateService.cs
+++ b/src/Foundry/Services/ApplicationUpdate/ApplicationUpdateService.cs
@@ -34,13 +34,15 @@ public sealed class ApplicationUpdateService : IApplicationUpdateService
 
     public Task CheckForUpdatesAsync(CancellationToken cancellationToken = default)
     {
-        return CheckForUpdatesCoreAsync(notifyWhenCurrent: true, notifyWhenFailure: true, cancellationToken);
+        _logger.LogInformation("Manual update check requested.");
+        return CheckForUpdatesCoreAsync(UpdateCheckTrigger.Manual, notifyWhenCurrent: true, notifyWhenFailure: true, cancellationToken);
     }
 
     public async Task CheckForUpdatesOnStartupAsync(CancellationToken cancellationToken = default)
     {
         if (Interlocked.Exchange(ref _startupCheckCompleted, 1) != 0)
         {
+            _logger.LogDebug("Skipping automatic startup update check because it has already been completed for this application session.");
             return;
         }
 
@@ -51,16 +53,20 @@ public sealed class ApplicationUpdateService : IApplicationUpdateService
             return;
         }
 
+        _logger.LogDebug("Automatic startup update check requested.");
+
         try
         {
-            await CheckForUpdatesCoreAsync(notifyWhenCurrent: false, notifyWhenFailure: false, cancellationToken).ConfigureAwait(false);
+            await CheckForUpdatesCoreAsync(UpdateCheckTrigger.Startup, notifyWhenCurrent: false, notifyWhenFailure: false, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            _logger.LogDebug("Automatic startup update check was canceled.");
         }
     }
 
     private async Task CheckForUpdatesCoreAsync(
+        UpdateCheckTrigger trigger,
         bool notifyWhenCurrent,
         bool notifyWhenFailure,
         CancellationToken cancellationToken)
@@ -69,15 +75,26 @@ public sealed class ApplicationUpdateService : IApplicationUpdateService
 
         try
         {
-            UpdateCheckResult result = await GetUpdateCheckResultAsync(cancellationToken).ConfigureAwait(false);
+            UpdateCheckResult result = await GetUpdateCheckResultAsync(trigger, cancellationToken).ConfigureAwait(false);
 
             switch (result.Status)
             {
                 case UpdateCheckStatus.UpdateAvailable:
+                    _logger.LogInformation(
+                        "Update check completed with an available release. Trigger={Trigger}, CurrentVersion={CurrentVersion}, LatestVersion={LatestVersion}, ReleaseUrl={ReleaseUrl}",
+                        trigger,
+                        result.UpdateInfo!.CurrentVersion,
+                        result.UpdateInfo.LatestVersion,
+                        result.UpdateInfo.ReleaseUrl);
                     _applicationShellService.ShowUpdateAvailable(result.UpdateInfo!);
                     break;
 
                 case UpdateCheckStatus.UpToDate:
+                    _logger.LogInformation(
+                        "Update check completed with no available update. Trigger={Trigger}, CurrentVersion={CurrentVersion}, LatestVersion={LatestVersion}",
+                        trigger,
+                        NormalizeVersionDisplay(FoundryApplicationInfo.Version),
+                        result.LatestVersionDisplay ?? "unknown");
                     if (notifyWhenCurrent)
                     {
                         _applicationShellService.ShowMessage(
@@ -88,6 +105,7 @@ public sealed class ApplicationUpdateService : IApplicationUpdateService
                     break;
 
                 case UpdateCheckStatus.Failed:
+                    _logger.LogWarning("Update check failed. Trigger={Trigger}", trigger);
                     if (notifyWhenFailure)
                     {
                         _applicationShellService.ShowMessage(
@@ -104,13 +122,18 @@ public sealed class ApplicationUpdateService : IApplicationUpdateService
         }
     }
 
-    private async Task<UpdateCheckResult> GetUpdateCheckResultAsync(CancellationToken cancellationToken)
+    private async Task<UpdateCheckResult> GetUpdateCheckResultAsync(
+        UpdateCheckTrigger trigger,
+        CancellationToken cancellationToken)
     {
         string currentVersionDisplay = FoundryApplicationInfo.Version;
         Version? currentVersion = TryParseVersion(currentVersionDisplay);
         if (currentVersion is null)
         {
-            _logger.LogWarning("Unable to parse the current Foundry version for update checks. CurrentVersion={CurrentVersion}", currentVersionDisplay);
+            _logger.LogWarning(
+                "Unable to parse the current Foundry version for update checks. Trigger={Trigger}, CurrentVersion={CurrentVersion}",
+                trigger,
+                currentVersionDisplay);
             return UpdateCheckResult.Failed();
         }
 
@@ -120,24 +143,17 @@ public sealed class ApplicationUpdateService : IApplicationUpdateService
             Version? latestVersion = TryParseVersion(latestRelease.TagName);
             if (latestVersion is null)
             {
-                _logger.LogWarning("Unable to parse the latest GitHub release tag for update checks. TagName={TagName}", latestRelease.TagName);
+                _logger.LogWarning(
+                    "Unable to parse the latest GitHub release tag for update checks. Trigger={Trigger}, TagName={TagName}",
+                    trigger,
+                    latestRelease.TagName);
                 return UpdateCheckResult.Failed();
             }
 
             if (latestVersion <= currentVersion)
             {
-                _logger.LogInformation(
-                    "Foundry is up to date. CurrentVersion={CurrentVersion}, LatestVersion={LatestVersion}",
-                    currentVersion,
-                    latestVersion);
-                return UpdateCheckResult.UpToDate();
+                return UpdateCheckResult.UpToDate(NormalizeVersionDisplay(latestRelease.TagName));
             }
-
-            _logger.LogInformation(
-                "Foundry update available. CurrentVersion={CurrentVersion}, LatestVersion={LatestVersion}, ReleaseUrl={ReleaseUrl}",
-                currentVersion,
-                latestVersion,
-                latestRelease.ReleaseUrl);
 
             return UpdateCheckResult.UpdateAvailable(new ApplicationUpdateInfo(
                 CurrentVersion: NormalizeVersionDisplay(currentVersionDisplay),
@@ -149,7 +165,7 @@ public sealed class ApplicationUpdateService : IApplicationUpdateService
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            _logger.LogWarning(ex, "Foundry failed to query the latest GitHub release.");
+            _logger.LogWarning(ex, "Foundry failed to query the latest GitHub release. Trigger={Trigger}", trigger);
             return UpdateCheckResult.Failed();
         }
     }
@@ -282,16 +298,25 @@ public sealed class ApplicationUpdateService : IApplicationUpdateService
         Failed
     }
 
-    private sealed record UpdateCheckResult(UpdateCheckStatus Status, ApplicationUpdateInfo? UpdateInfo = null)
+    private enum UpdateCheckTrigger
+    {
+        Startup,
+        Manual
+    }
+
+    private sealed record UpdateCheckResult(
+        UpdateCheckStatus Status,
+        ApplicationUpdateInfo? UpdateInfo = null,
+        string? LatestVersionDisplay = null)
     {
         public static UpdateCheckResult UpdateAvailable(ApplicationUpdateInfo updateInfo)
         {
             return new(UpdateCheckStatus.UpdateAvailable, updateInfo);
         }
 
-        public static UpdateCheckResult UpToDate()
+        public static UpdateCheckResult UpToDate(string latestVersionDisplay)
         {
-            return new(UpdateCheckStatus.UpToDate);
+            return new(UpdateCheckStatus.UpToDate, LatestVersionDisplay: latestVersionDisplay);
         }
 
         public static UpdateCheckResult Failed()

--- a/src/Foundry/Services/ApplicationUpdate/IApplicationUpdateService.cs
+++ b/src/Foundry/Services/ApplicationUpdate/IApplicationUpdateService.cs
@@ -1,0 +1,8 @@
+namespace Foundry.Services.ApplicationUpdate;
+
+public interface IApplicationUpdateService
+{
+    Task CheckForUpdatesAsync(CancellationToken cancellationToken = default);
+
+    Task CheckForUpdatesOnStartupAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Foundry/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry/ViewModels/MainWindowViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
@@ -132,6 +133,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     public bool ShowUsbPartitionStyleArm64Hint => SelectedArchitecture == WinPeArchitecture.Arm64;
     public string UsbPartitionStyleArm64Hint => Strings["UsbPartitionStyleArm64Hint"];
     public bool IsStandardMode => !IsExpertMode;
+    public bool IsDebugMenuVisible => IsVisualStudioDebugSession();
 
     private static string StagingDirectoryPath => WinPeDefaults.GetWinPeWorkspaceRootPath();
 
@@ -1039,5 +1041,14 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         }
 
         _dispatcher.Invoke(action);
+    }
+
+    private static bool IsVisualStudioDebugSession()
+    {
+#if DEBUG
+        return Debugger.IsAttached;
+#else
+        return false;
+#endif
     }
 }

--- a/src/Foundry/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry/ViewModels/MainWindowViewModel.cs
@@ -9,6 +9,7 @@ using CommunityToolkit.Mvvm.Input;
 using Foundry.Logging;
 using Foundry.Models.Configuration;
 using Foundry.Services.Adk;
+using Foundry.Services.ApplicationUpdate;
 using Foundry.Services.ApplicationShell;
 using Foundry.Services.Configuration;
 using Foundry.Services.Localization;
@@ -27,6 +28,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private const string IsoVolumeLabel = "FOUNDRY_WINPE";
 
     private readonly IApplicationShellService _applicationShellService;
+    private readonly IApplicationUpdateService _applicationUpdateService;
     private readonly IThemeService _themeService;
     private readonly ILocalizationService _localizationService;
     private readonly IOperationProgressService _operationProgressService;
@@ -135,6 +137,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
     public MainWindowViewModel(
         IApplicationShellService applicationShellService,
+        IApplicationUpdateService applicationUpdateService,
         IThemeService themeService,
         ILocalizationService localizationService,
         IOperationProgressService operationProgressService,
@@ -148,6 +151,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         ILogger<MainWindowViewModel> logger)
     {
         _applicationShellService = applicationShellService;
+        _applicationUpdateService = applicationUpdateService;
         _themeService = themeService;
         _localizationService = localizationService;
         _operationProgressService = operationProgressService;
@@ -224,9 +228,14 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     }
 
     [RelayCommand]
-    private void CheckForUpdates()
+    private Task CheckForUpdatesAsync()
     {
-        _applicationShellService.OpenUrl(FoundryApplicationInfo.LatestReleaseUrl);
+        return _applicationUpdateService.CheckForUpdatesAsync();
+    }
+
+    public Task RunStartupUpdateCheckAsync()
+    {
+        return _applicationUpdateService.CheckForUpdatesOnStartupAsync();
     }
 
     [RelayCommand]

--- a/src/Foundry/ViewModels/UpdateAvailableDialogViewModel.cs
+++ b/src/Foundry/ViewModels/UpdateAvailableDialogViewModel.cs
@@ -26,14 +26,29 @@ public sealed partial class UpdateAvailableDialogViewModel : LocalizedViewModelB
 
     public string ReleaseTitle => _updateInfo.ReleaseTitle;
 
+    public bool HasDistinctReleaseTitle =>
+        !string.IsNullOrWhiteSpace(ReleaseTitle) &&
+        !ReleaseTitle.Contains(LatestVersion, StringComparison.OrdinalIgnoreCase);
+
     public string PublishedAtDisplay => _updateInfo.PublishedAt?.ToLocalTime().ToString("f", LocalizationService.CurrentCulture)
         ?? Strings["UpdateAvailablePublishedUnknown"];
 
-    public string ReleaseNotes => string.IsNullOrWhiteSpace(_updateInfo.ReleaseNotes)
+    public string ReleaseNotesMarkdown => string.IsNullOrWhiteSpace(_updateInfo.ReleaseNotes)
         ? Strings["UpdateAvailableNotesEmpty"]
         : _updateInfo.ReleaseNotes;
 
+    public string AvailabilitySummary => string.Format(
+        LocalizationService.CurrentCulture,
+        Strings["UpdateAvailableSummaryFormat"],
+        _updateInfo.SummaryReleaseTitle,
+        CurrentVersion);
+
     public event EventHandler? CloseRequested;
+
+    public void OpenExternalUrl(string url)
+    {
+        _applicationShellService.OpenUrl(url);
+    }
 
     [RelayCommand]
     private void OpenRelease()

--- a/src/Foundry/ViewModels/UpdateAvailableDialogViewModel.cs
+++ b/src/Foundry/ViewModels/UpdateAvailableDialogViewModel.cs
@@ -1,0 +1,50 @@
+using CommunityToolkit.Mvvm.Input;
+using Foundry.Services.ApplicationShell;
+using Foundry.Services.ApplicationUpdate;
+using Foundry.Services.Localization;
+
+namespace Foundry.ViewModels;
+
+public sealed partial class UpdateAvailableDialogViewModel : LocalizedViewModelBase
+{
+    private readonly IApplicationShellService _applicationShellService;
+    private readonly ApplicationUpdateInfo _updateInfo;
+
+    public UpdateAvailableDialogViewModel(
+        ILocalizationService localizationService,
+        IApplicationShellService applicationShellService,
+        ApplicationUpdateInfo updateInfo)
+        : base(localizationService)
+    {
+        _applicationShellService = applicationShellService;
+        _updateInfo = updateInfo ?? throw new ArgumentNullException(nameof(updateInfo));
+    }
+
+    public string CurrentVersion => _updateInfo.CurrentVersion;
+
+    public string LatestVersion => _updateInfo.LatestVersion;
+
+    public string ReleaseTitle => _updateInfo.ReleaseTitle;
+
+    public string PublishedAtDisplay => _updateInfo.PublishedAt?.ToLocalTime().ToString("f", LocalizationService.CurrentCulture)
+        ?? Strings["UpdateAvailablePublishedUnknown"];
+
+    public string ReleaseNotes => string.IsNullOrWhiteSpace(_updateInfo.ReleaseNotes)
+        ? Strings["UpdateAvailableNotesEmpty"]
+        : _updateInfo.ReleaseNotes;
+
+    public event EventHandler? CloseRequested;
+
+    [RelayCommand]
+    private void OpenRelease()
+    {
+        _applicationShellService.OpenUrl(_updateInfo.ReleaseUrl);
+        CloseRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    [RelayCommand]
+    private void Close()
+    {
+        CloseRequested?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/Foundry/Views/ReleaseNotesMarkdownDocumentBuilder.cs
+++ b/src/Foundry/Views/ReleaseNotesMarkdownDocumentBuilder.cs
@@ -1,0 +1,289 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Documents;
+using System.Windows.Media;
+
+namespace Foundry.Views;
+
+internal static class ReleaseNotesMarkdownDocumentBuilder
+{
+    private static readonly Regex HeadingPattern = new(@"^(#{1,3})\s+(?<text>.+?)\s*$", RegexOptions.Compiled);
+    private static readonly Regex BulletPattern = new(@"^\s*[-*]\s+(?<text>.+?)\s*$", RegexOptions.Compiled);
+    private static readonly Regex MarkdownLinkPattern = new(@"\[(?<text>[^\]]+)\]\((?<url>https?://[^\s)]+)\)", RegexOptions.Compiled);
+    private static readonly Regex BareUrlPattern = new(@"https?://[^\s]+", RegexOptions.Compiled);
+
+    public static FlowDocument Build(string markdown, Action<string> openUrl)
+    {
+        ArgumentNullException.ThrowIfNull(openUrl);
+
+        Brush foreground = ResolveBrush("TextFillColorPrimaryBrush", Brushes.White);
+        Brush hyperlinkBrush = ResolveBrush("AccentTextFillColorPrimaryBrush", ResolveBrush("AccentFillColorDefaultBrush", Brushes.DeepSkyBlue));
+
+        var document = new FlowDocument
+        {
+            PagePadding = new Thickness(0),
+            ColumnWidth = double.PositiveInfinity,
+            FontFamily = new FontFamily("Segoe UI"),
+            FontSize = 14,
+            Foreground = foreground
+        };
+
+        string[] lines = (markdown ?? string.Empty)
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n')
+            .Split('\n');
+
+        var paragraphBuffer = new StringBuilder();
+        List? currentList = null;
+
+        foreach (string rawLine in lines)
+        {
+            string line = rawLine.TrimEnd();
+
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                FlushParagraph(document, paragraphBuffer, openUrl, hyperlinkBrush);
+                FlushList(document, ref currentList);
+                continue;
+            }
+
+            Match headingMatch = HeadingPattern.Match(line);
+            if (headingMatch.Success)
+            {
+                FlushParagraph(document, paragraphBuffer, openUrl, hyperlinkBrush);
+                FlushList(document, ref currentList);
+                document.Blocks.Add(CreateHeading(
+                    headingMatch.Groups["text"].Value,
+                    headingMatch.Groups[1].Value.Length,
+                    openUrl,
+                    hyperlinkBrush));
+                continue;
+            }
+
+            Match bulletMatch = BulletPattern.Match(line);
+            if (bulletMatch.Success)
+            {
+                FlushParagraph(document, paragraphBuffer, openUrl, hyperlinkBrush);
+                currentList ??= CreateList();
+                currentList.ListItems.Add(CreateListItem(
+                    bulletMatch.Groups["text"].Value,
+                    openUrl,
+                    hyperlinkBrush));
+                continue;
+            }
+
+            if (paragraphBuffer.Length > 0)
+            {
+                paragraphBuffer.Append(' ');
+            }
+
+            paragraphBuffer.Append(line.Trim());
+        }
+
+        FlushParagraph(document, paragraphBuffer, openUrl, hyperlinkBrush);
+        FlushList(document, ref currentList);
+
+        if (document.Blocks.Count == 0)
+        {
+            document.Blocks.Add(new Paragraph(new Run(string.Empty)));
+        }
+
+        return document;
+    }
+
+    private static void FlushParagraph(
+        FlowDocument document,
+        StringBuilder paragraphBuffer,
+        Action<string> openUrl,
+        Brush hyperlinkBrush)
+    {
+        if (paragraphBuffer.Length == 0)
+        {
+            return;
+        }
+
+        document.Blocks.Add(CreateParagraph(paragraphBuffer.ToString(), openUrl, hyperlinkBrush));
+        paragraphBuffer.Clear();
+    }
+
+    private static void FlushList(FlowDocument document, ref List? currentList)
+    {
+        if (currentList is null)
+        {
+            return;
+        }
+
+        document.Blocks.Add(currentList);
+        currentList = null;
+    }
+
+    private static Paragraph CreateHeading(string text, int level, Action<string> openUrl, Brush hyperlinkBrush)
+    {
+        double fontSize = level switch
+        {
+            1 => 22,
+            2 => 18,
+            _ => 16
+        };
+
+        var paragraph = new Paragraph
+        {
+            Margin = new Thickness(0, 0, 0, 10),
+            FontWeight = FontWeights.SemiBold,
+            FontSize = fontSize
+        };
+
+        AddInlines(paragraph.Inlines, text, openUrl, hyperlinkBrush);
+        return paragraph;
+    }
+
+    private static Paragraph CreateParagraph(string text, Action<string> openUrl, Brush hyperlinkBrush)
+    {
+        var paragraph = new Paragraph
+        {
+            Margin = new Thickness(0, 0, 0, 12),
+            LineHeight = 22
+        };
+
+        AddInlines(paragraph.Inlines, text, openUrl, hyperlinkBrush);
+        return paragraph;
+    }
+
+    private static List CreateList()
+    {
+        return new List
+        {
+            MarkerStyle = TextMarkerStyle.Disc,
+            Margin = new Thickness(18, 0, 0, 12)
+        };
+    }
+
+    private static ListItem CreateListItem(string text, Action<string> openUrl, Brush hyperlinkBrush)
+    {
+        var paragraph = new Paragraph
+        {
+            Margin = new Thickness(0, 0, 0, 6),
+            LineHeight = 22
+        };
+
+        AddInlines(paragraph.Inlines, text, openUrl, hyperlinkBrush);
+        return new ListItem(paragraph);
+    }
+
+    private static void AddInlines(
+        InlineCollection inlines,
+        string text,
+        Action<string> openUrl,
+        Brush hyperlinkBrush)
+    {
+        int index = 0;
+
+        while (index < text.Length)
+        {
+            if (TryAddBold(inlines, text, ref index, openUrl, hyperlinkBrush))
+            {
+                continue;
+            }
+
+            Match markdownLinkMatch = MarkdownLinkPattern.Match(text, index);
+            if (markdownLinkMatch.Success && markdownLinkMatch.Index == index)
+            {
+                inlines.Add(CreateHyperlink(
+                    markdownLinkMatch.Groups["text"].Value,
+                    markdownLinkMatch.Groups["url"].Value,
+                    openUrl,
+                    hyperlinkBrush));
+                index += markdownLinkMatch.Length;
+                continue;
+            }
+
+            Match bareUrlMatch = BareUrlPattern.Match(text, index);
+            if (bareUrlMatch.Success && bareUrlMatch.Index == index)
+            {
+                string url = TrimTrailingPunctuation(bareUrlMatch.Value);
+                inlines.Add(CreateHyperlink(url, url, openUrl, hyperlinkBrush));
+                index += url.Length;
+                continue;
+            }
+
+            int nextSpecialIndex = FindNextSpecialIndex(text, index);
+            int length = (nextSpecialIndex >= 0 ? nextSpecialIndex : text.Length) - index;
+            if (length <= 0)
+            {
+                break;
+            }
+
+            inlines.Add(new Run(text.Substring(index, length)));
+            index += length;
+        }
+    }
+
+    private static bool TryAddBold(
+        InlineCollection inlines,
+        string text,
+        ref int index,
+        Action<string> openUrl,
+        Brush hyperlinkBrush)
+    {
+        if (!text.AsSpan(index).StartsWith("**", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        int closingIndex = text.IndexOf("**", index + 2, StringComparison.Ordinal);
+        if (closingIndex < 0)
+        {
+            return false;
+        }
+
+        string boldText = text.Substring(index + 2, closingIndex - (index + 2));
+        var bold = new Bold();
+        AddInlines(bold.Inlines, boldText, openUrl, hyperlinkBrush);
+        inlines.Add(bold);
+        index = closingIndex + 2;
+        return true;
+    }
+
+    private static int FindNextSpecialIndex(string text, int startIndex)
+    {
+        int[] indices =
+        [
+            text.IndexOf("**", startIndex, StringComparison.Ordinal),
+            text.IndexOf('[', startIndex),
+            text.IndexOf("http://", startIndex, StringComparison.Ordinal),
+            text.IndexOf("https://", startIndex, StringComparison.Ordinal)
+        ];
+
+        return indices
+            .Where(index => index >= 0)
+            .DefaultIfEmpty(-1)
+            .Min();
+    }
+
+    private static Hyperlink CreateHyperlink(
+        string displayText,
+        string url,
+        Action<string> openUrl,
+        Brush hyperlinkBrush)
+    {
+        var hyperlink = new Hyperlink(new Run(displayText))
+        {
+            Foreground = hyperlinkBrush
+        };
+
+        hyperlink.Click += (_, _) => openUrl(url);
+        return hyperlink;
+    }
+
+    private static string TrimTrailingPunctuation(string value)
+    {
+        return value.TrimEnd('.', ',', ';', ':', ')');
+    }
+
+    private static Brush ResolveBrush(string resourceKey, Brush fallback)
+    {
+        return Application.Current?.TryFindResource(resourceKey) as Brush ?? fallback;
+    }
+}

--- a/src/Foundry/Views/UpdateAvailableDialog.xaml
+++ b/src/Foundry/Views/UpdateAvailableDialog.xaml
@@ -1,0 +1,161 @@
+<Window
+    x:Class="Foundry.Views.UpdateAvailableDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="{Binding Strings[UpdateAvailableTitle], Mode=OneWay}"
+    Width="720"
+    Height="540"
+    MinWidth="640"
+    MinHeight="480"
+    Icon="/Assets/Icons/app.ico"
+    ResizeMode="CanResize"
+    ShowInTaskbar="False"
+    WindowStartupLocation="CenterOwner">
+    <Window.InputBindings>
+        <KeyBinding Key="Escape" Command="{Binding CloseCommand}" />
+    </Window.InputBindings>
+
+    <Grid Margin="24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <StackPanel>
+            <TextBlock
+                Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                Style="{DynamicResource TitleLargeTextBlockStyle}"
+                Text="{Binding Strings[UpdateAvailableHeading], Mode=OneWay}" />
+            <TextBlock
+                Margin="0,10,0,0"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Style="{DynamicResource BodyTextBlockStyle}"
+                Text="{Binding Strings[UpdateAvailableDescription], Mode=OneWay}"
+                TextWrapping="Wrap" />
+        </StackPanel>
+
+        <Grid Grid.Row="1" Margin="0,20,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="16" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <Border
+                Grid.Column="0"
+                Padding="16"
+                Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
+                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                BorderThickness="1"
+                CornerRadius="8">
+                <StackPanel>
+                    <TextBlock
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{Binding Strings[UpdateAvailableCurrentVersionLabel], Mode=OneWay}" />
+                    <TextBlock
+                        Margin="0,8,0,0"
+                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                        Style="{DynamicResource SubtitleTextBlockStyle}"
+                        Text="{Binding CurrentVersion}" />
+                </StackPanel>
+            </Border>
+
+            <Border
+                Grid.Column="2"
+                Padding="16"
+                Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
+                BorderBrush="{DynamicResource AccentFillColorDefaultBrush}"
+                BorderThickness="1"
+                CornerRadius="8">
+                <StackPanel>
+                    <TextBlock
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{Binding Strings[UpdateAvailableLatestVersionLabel], Mode=OneWay}" />
+                    <TextBlock
+                        Margin="0,8,0,0"
+                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                        Style="{DynamicResource SubtitleTextBlockStyle}"
+                        Text="{Binding LatestVersion}" />
+                    <TextBlock
+                        Margin="0,16,0,0"
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{Binding Strings[UpdateAvailableReleaseLabel], Mode=OneWay}" />
+                    <TextBlock
+                        Margin="0,4,0,0"
+                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                        Style="{DynamicResource BodyStrongTextBlockStyle}"
+                        Text="{Binding ReleaseTitle}"
+                        TextWrapping="Wrap" />
+                    <TextBlock
+                        Margin="0,16,0,0"
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{Binding Strings[UpdateAvailablePublishedLabel], Mode=OneWay}" />
+                    <TextBlock
+                        Margin="0,4,0,0"
+                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                        Style="{DynamicResource BodyTextBlockStyle}"
+                        Text="{Binding PublishedAtDisplay}"
+                        TextWrapping="Wrap" />
+                </StackPanel>
+            </Border>
+        </Grid>
+
+        <Border
+            Grid.Row="2"
+            Margin="0,20,0,0"
+            Padding="16"
+            Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
+            BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+            BorderThickness="1"
+            CornerRadius="8">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <TextBlock
+                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                    Style="{DynamicResource BodyStrongTextBlockStyle}"
+                    Text="{Binding Strings[UpdateAvailableReleaseNotes], Mode=OneWay}" />
+
+                <ScrollViewer
+                    Grid.Row="1"
+                    Margin="0,12,0,0"
+                    VerticalScrollBarVisibility="Auto">
+                    <TextBlock
+                        xml:space="preserve"
+                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                        Style="{DynamicResource BodyTextBlockStyle}"
+                        Text="{Binding ReleaseNotes}"
+                        TextWrapping="Wrap" />
+                </ScrollViewer>
+            </Grid>
+        </Border>
+
+        <StackPanel
+            Grid.Row="3"
+            Margin="0,20,0,0"
+            HorizontalAlignment="Right"
+            Orientation="Horizontal">
+            <Button
+                Width="120"
+                Margin="0,0,8,0"
+                Command="{Binding CloseCommand}"
+                Content="{Binding Strings[UpdateAvailableLater], Mode=OneWay}"
+                IsCancel="True" />
+            <Button
+                Width="160"
+                Command="{Binding OpenReleaseCommand}"
+                Content="{Binding Strings[UpdateAvailableOpenRelease], Mode=OneWay}"
+                IsDefault="True"
+                Style="{DynamicResource AccentButtonStyle}" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/Foundry/Views/UpdateAvailableDialog.xaml
+++ b/src/Foundry/Views/UpdateAvailableDialog.xaml
@@ -3,19 +3,21 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="{Binding Strings[UpdateAvailableTitle], Mode=OneWay}"
-    Width="720"
-    Height="540"
-    MinWidth="640"
-    MinHeight="480"
+    Width="960"
+    Height="760"
+    MinWidth="960"
+    MinHeight="760"
+    MaxWidth="960"
+    MaxHeight="760"
     Icon="/Assets/Icons/app.ico"
-    ResizeMode="CanResize"
+    ResizeMode="NoResize"
     ShowInTaskbar="False"
     WindowStartupLocation="CenterOwner">
     <Window.InputBindings>
         <KeyBinding Key="Escape" Command="{Binding CloseCommand}" />
     </Window.InputBindings>
 
-    <Grid Margin="24">
+    <Grid Margin="32">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -27,30 +29,59 @@
             <TextBlock
                 Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                 Style="{DynamicResource TitleLargeTextBlockStyle}"
-                Text="{Binding Strings[UpdateAvailableHeading], Mode=OneWay}" />
+                Text="{Binding Strings[UpdateAvailableHeading], Mode=OneWay}"
+                TextWrapping="Wrap" />
             <TextBlock
-                Margin="0,10,0,0"
-                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Margin="0,12,0,0"
+                Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                 Style="{DynamicResource BodyTextBlockStyle}"
-                Text="{Binding Strings[UpdateAvailableDescription], Mode=OneWay}"
+                Text="{Binding AvailabilitySummary}"
                 TextWrapping="Wrap" />
         </StackPanel>
 
-        <Grid Grid.Row="1" Margin="0,20,0,0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="16" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
+        <Border
+            Grid.Row="1"
+            Margin="0,24,0,0"
+            Padding="16"
+            Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
+            BorderBrush="{DynamicResource AccentFillColorDefaultBrush}"
+            BorderThickness="1"
+            CornerRadius="8">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2*" />
+                    <ColumnDefinition Width="24" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="24" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
 
-            <Border
-                Grid.Column="0"
-                Padding="16"
-                Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
-                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
-                BorderThickness="1"
-                CornerRadius="8">
-                <StackPanel>
+                <StackPanel Grid.Column="0">
+                    <TextBlock
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{Binding Strings[UpdateAvailableLatestVersionLabel], Mode=OneWay}" />
+                    <TextBlock
+                        Margin="0,8,0,0"
+                        Foreground="{DynamicResource SystemFillColorSuccessBrush}"
+                        Style="{DynamicResource SubtitleTextBlockStyle}"
+                        Text="{Binding LatestVersion}" />
+
+                    <StackPanel Margin="0,16,0,0" Visibility="{Binding HasDistinctReleaseTitle, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <TextBlock
+                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                            Style="{StaticResource CaptionTextBlockStyle}"
+                            Text="{Binding Strings[UpdateAvailableReleaseLabel], Mode=OneWay}" />
+                        <TextBlock
+                            Margin="0,4,0,0"
+                            Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                            Style="{DynamicResource BodyStrongTextBlockStyle}"
+                            Text="{Binding ReleaseTitle}"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
+                </StackPanel>
+
+                <StackPanel Grid.Column="2">
                     <TextBlock
                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
@@ -61,97 +92,64 @@
                         Style="{DynamicResource SubtitleTextBlockStyle}"
                         Text="{Binding CurrentVersion}" />
                 </StackPanel>
-            </Border>
 
-            <Border
-                Grid.Column="2"
-                Padding="16"
-                Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
-                BorderBrush="{DynamicResource AccentFillColorDefaultBrush}"
-                BorderThickness="1"
-                CornerRadius="8">
-                <StackPanel>
+                <StackPanel Grid.Column="4">
                     <TextBlock
-                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding Strings[UpdateAvailableLatestVersionLabel], Mode=OneWay}" />
-                    <TextBlock
-                        Margin="0,8,0,0"
-                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                        Style="{DynamicResource SubtitleTextBlockStyle}"
-                        Text="{Binding LatestVersion}" />
-                    <TextBlock
-                        Margin="0,16,0,0"
-                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding Strings[UpdateAvailableReleaseLabel], Mode=OneWay}" />
-                    <TextBlock
-                        Margin="0,4,0,0"
-                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                        Style="{DynamicResource BodyStrongTextBlockStyle}"
-                        Text="{Binding ReleaseTitle}"
-                        TextWrapping="Wrap" />
-                    <TextBlock
-                        Margin="0,16,0,0"
                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
                         Text="{Binding Strings[UpdateAvailablePublishedLabel], Mode=OneWay}" />
                     <TextBlock
-                        Margin="0,4,0,0"
+                        Margin="0,8,0,0"
                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                        Style="{DynamicResource BodyTextBlockStyle}"
+                        Style="{DynamicResource SubtitleTextBlockStyle}"
                         Text="{Binding PublishedAtDisplay}"
                         TextWrapping="Wrap" />
                 </StackPanel>
-            </Border>
-        </Grid>
-
-        <Border
-            Grid.Row="2"
-            Margin="0,20,0,0"
-            Padding="16"
-            Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
-            BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
-            BorderThickness="1"
-            CornerRadius="8">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
-
-                <TextBlock
-                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                    Style="{DynamicResource BodyStrongTextBlockStyle}"
-                    Text="{Binding Strings[UpdateAvailableReleaseNotes], Mode=OneWay}" />
-
-                <ScrollViewer
-                    Grid.Row="1"
-                    Margin="0,12,0,0"
-                    VerticalScrollBarVisibility="Auto">
-                    <TextBlock
-                        xml:space="preserve"
-                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                        Style="{DynamicResource BodyTextBlockStyle}"
-                        Text="{Binding ReleaseNotes}"
-                        TextWrapping="Wrap" />
-                </ScrollViewer>
             </Grid>
         </Border>
 
+        <Grid Grid.Row="2" Margin="0,24,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <TextBlock
+                Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                Style="{DynamicResource BodyStrongTextBlockStyle}"
+                Text="{Binding Strings[UpdateAvailableReleaseNotes], Mode=OneWay}" />
+
+            <Border
+                Grid.Row="1"
+                Margin="0,12,0,0"
+                Padding="16"
+                Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
+                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                BorderThickness="1"
+                CornerRadius="8">
+                <FlowDocumentScrollViewer
+                    x:Name="ReleaseNotesViewer"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                    IsToolBarVisible="False"
+                    VerticalScrollBarVisibility="Auto" />
+            </Border>
+        </Grid>
+
         <StackPanel
             Grid.Row="3"
-            Margin="0,20,0,0"
+            Margin="0,24,0,0"
             HorizontalAlignment="Right"
             Orientation="Horizontal">
             <Button
-                Width="120"
-                Margin="0,0,8,0"
+                Width="140"
+                Margin="0,0,10,0"
                 Command="{Binding CloseCommand}"
                 Content="{Binding Strings[UpdateAvailableLater], Mode=OneWay}"
                 IsCancel="True" />
             <Button
-                Width="160"
+                Width="170"
                 Command="{Binding OpenReleaseCommand}"
                 Content="{Binding Strings[UpdateAvailableOpenRelease], Mode=OneWay}"
                 IsDefault="True"

--- a/src/Foundry/Views/UpdateAvailableDialog.xaml.cs
+++ b/src/Foundry/Views/UpdateAvailableDialog.xaml.cs
@@ -1,4 +1,6 @@
 using System.Windows;
+using System.Windows.Documents;
+using Foundry.ViewModels;
 
 namespace Foundry.Views;
 
@@ -7,5 +9,19 @@ public partial class UpdateAvailableDialog : Window
     public UpdateAvailableDialog()
     {
         InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        if (e.NewValue is not UpdateAvailableDialogViewModel viewModel)
+        {
+            ReleaseNotesViewer.Document = new FlowDocument();
+            return;
+        }
+
+        ReleaseNotesViewer.Document = ReleaseNotesMarkdownDocumentBuilder.Build(
+            viewModel.ReleaseNotesMarkdown,
+            viewModel.OpenExternalUrl);
     }
 }

--- a/src/Foundry/Views/UpdateAvailableDialog.xaml.cs
+++ b/src/Foundry/Views/UpdateAvailableDialog.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows;
+
+namespace Foundry.Views;
+
+public partial class UpdateAvailableDialog : Window
+{
+    public UpdateAvailableDialog()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
Add a GitHub release check flow for Foundry with a dedicated update dialog.

## Why
Foundry should notify users when a new standalone release is available without implementing download or install behavior.

## Changes
- add a startup update check against GitHub Releases plus manual checks from Help and a Debug-only menu
- add a dedicated modal dialog with Fluent-aligned spacing and markdown release notes rendering
- normalize displayed version strings and skip automatic startup checks only in active Visual Studio debug sessions
- add coherent trigger-aware logging and localized strings for English and French

## Testing
- dotnet build .\\src\\Foundry.slnx -c Release --nologo
- dotnet build .\\src\\Foundry.slnx -c Debug --nologo

## Notes
- automatic checks only show the dialog when an update is available
- no download or install logic is included because Foundry ships as a standalone executable