### PR TITLE
chore(release): use stable installer names for latest downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
                   throw "Expected Foundry executable not found: '$foundryExecutable'."
               }
 
-              $foundryAssetPath = Join-Path $releaseRoot "Foundry-$($env:RELEASE_VERSION)_${architecture}.exe"
+              $foundryAssetPath = Join-Path $releaseRoot "Foundry-${architecture}.exe"
               Copy-Item -Path $foundryExecutable -Destination $foundryAssetPath -Force
 
               $deployPublishPath = Join-Path $publishRoot (Join-Path 'Foundry.Deploy' $runtimeIdentifier)
@@ -164,8 +164,8 @@ jobs:
           $releaseTag = '${{ github.event.release.tag_name }}'
           $releaseRoot = Join-Path $env:GITHUB_WORKSPACE 'artifacts\release'
           $assets = @(
-              (Join-Path $releaseRoot "Foundry-$($env:RELEASE_VERSION)_x64.exe"),
-              (Join-Path $releaseRoot "Foundry-$($env:RELEASE_VERSION)_arm64.exe"),
+              (Join-Path $releaseRoot 'Foundry-x64.exe'),
+              (Join-Path $releaseRoot 'Foundry-arm64.exe'),
               (Join-Path $releaseRoot 'Foundry.Connect-win-x64.zip'),
               (Join-Path $releaseRoot 'Foundry.Connect-win-arm64.zip'),
               (Join-Path $releaseRoot 'Foundry.Deploy-win-x64.zip'),

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@
   <a href="https://github.com/foundry-osd/foundry/blob/main/LICENSE">License</a>
 </p>
 
+## Download
+
+Use the direct links below to always download the latest Foundry installer for your architecture.
+
+| Architecture | Installer | Download |
+| --- | --- | --- |
+| x64 | `Foundry-x64.exe` | [Download latest x64](https://github.com/foundry-osd/foundry/releases/latest/download/Foundry-x64.exe) |
+| ARM64 | `Foundry-arm64.exe` | [Download latest ARM64](https://github.com/foundry-osd/foundry/releases/latest/download/Foundry-arm64.exe) |
+
+Need release notes or checksums? Open the [latest release](https://github.com/foundry-osd/foundry/releases/latest) or browse [all releases](https://github.com/foundry-osd/foundry/releases).
+
 ![Foundry preview](Assets/GitHub/social-preview.png)
 
 ## What Foundry Does
@@ -60,7 +71,7 @@ Instead of relying on a fully manual process, Foundry helps you boot a device, s
 
 ### Use a release
 
-Download the latest packaged build from the [Releases](https://github.com/foundry-osd/foundry/releases) page.
+Download the latest packaged build from the [Download](#download) section above or from the [Releases](https://github.com/foundry-osd/foundry/releases) page.
 
 Use Foundry to create deployment media, then boot that media on the target device to start the deployment experience.
 


### PR DESCRIPTION
## Summary
- switch release installer assets to stable filenames for x64 and ARM64
- add a top-level README download section with direct latest-release links

## Reason
Versioned installer filenames prevent a stable `releases/latest/download/...` URL, which makes it harder to expose permanent download links in the README and docs.

## Main changes
- publish `Foundry-x64.exe` and `Foundry-arm64.exe` in the release workflow
- update the README to show direct latest-download links near the top
- keep the release notes and checksum links pointing to the latest release page

## Testing notes
- reviewed the workflow and README diffs
- ran `git diff --check`
- verified the docs site change separately with `npm run build` in `foundry-osd.github.io`
