### PR TITLE
feat(localization): localize Foundry.Connect UI

### DIFF
--- a/src/Foundry.Connect/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Connect/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Foundry.Connect.Services.ApplicationLifetime;
 using Foundry.Connect.Services.ApplicationShell;
 using Foundry.Connect.Services.Configuration;
+using Foundry.Connect.Services.Localization;
 using Foundry.Connect.Services.Network;
 using Foundry.Connect.Services.Theme;
 using Foundry.Connect.ViewModels;
@@ -21,6 +22,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IApplicationLifetimeService, ApplicationLifetimeService>();
         services.AddSingleton<IConnectConfigurationService, ConnectConfigurationService>();
         services.AddSingleton(sp => sp.GetRequiredService<IConnectConfigurationService>().Load());
+        services.AddSingleton<ILocalizationService, LocalizationService>();
         services.AddSingleton<INetworkBootstrapService, NetworkBootstrapService>();
         services.AddSingleton<INetworkStatusService, NetworkStatusService>();
         services.AddSingleton<IThemeService, ThemeService>();

--- a/src/Foundry.Connect/MainWindow.xaml
+++ b/src/Foundry.Connect/MainWindow.xaml
@@ -36,20 +36,24 @@
             </Grid.ColumnDefinitions>
 
             <Menu Grid.Column="0">
-                <MenuItem Header="_Theme">
-                    <MenuItem Command="{Binding SetSystemThemeCommand}" Header="System" />
-                    <MenuItem Command="{Binding SetLightThemeCommand}" Header="Light" />
-                    <MenuItem Command="{Binding SetDarkThemeCommand}" Header="Dark" />
+                <MenuItem Header="{Binding Strings[Menu.Theme]}">
+                    <MenuItem Command="{Binding SetSystemThemeCommand}" Header="{Binding Strings[Theme.System]}" />
+                    <MenuItem Command="{Binding SetLightThemeCommand}" Header="{Binding Strings[Theme.Light]}" />
+                    <MenuItem Command="{Binding SetDarkThemeCommand}" Header="{Binding Strings[Theme.Dark]}" />
                 </MenuItem>
-                <MenuItem Header="_Tools">
-                    <MenuItem Command="{Binding RefreshStatusCommand}" Header="Refresh Status" />
+                <MenuItem Header="{Binding Strings[Menu.Language]}">
+                    <MenuItem Command="{Binding SetCultureCommand}" CommandParameter="en-US" Header="{Binding Strings[Language.English]}" />
+                    <MenuItem Command="{Binding SetCultureCommand}" CommandParameter="fr-FR" Header="{Binding Strings[Language.French]}" />
                 </MenuItem>
-                <MenuItem Header="_Debug" Visibility="{Binding IsDebugMenuVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <MenuItem Command="{Binding UseRuntimeDebugLayoutCommand}" Header="Use Runtime Layout" />
-                    <MenuItem Command="{Binding ShowEthernetOnlyDebugLayoutCommand}" Header="Show Ethernet Only" />
-                    <MenuItem Command="{Binding ShowEthernetWifiDebugLayoutCommand}" Header="Show Ethernet + Wi-Fi" />
+                <MenuItem Header="{Binding Strings[Menu.Tools]}">
+                    <MenuItem Command="{Binding RefreshStatusCommand}" Header="{Binding Strings[Tools.RefreshStatus]}" />
                 </MenuItem>
-                <MenuItem Command="{Binding ShowAboutCommand}" Header="_About" />
+                <MenuItem Header="{Binding Strings[Menu.Debug]}" Visibility="{Binding IsDebugMenuVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <MenuItem Command="{Binding UseRuntimeDebugLayoutCommand}" Header="{Binding Strings[Debug.UseRuntimeLayout]}" />
+                    <MenuItem Command="{Binding ShowEthernetOnlyDebugLayoutCommand}" Header="{Binding Strings[Debug.ShowEthernetOnly]}" />
+                    <MenuItem Command="{Binding ShowEthernetWifiDebugLayoutCommand}" Header="{Binding Strings[Debug.ShowEthernetWifi]}" />
+                </MenuItem>
+                <MenuItem Command="{Binding ShowAboutCommand}" Header="{Binding Strings[Menu.About]}" />
             </Menu>
 
             <TextBlock
@@ -139,7 +143,7 @@
                                 Width="140"
                                 HorizontalAlignment="Right"
                                 Command="{Binding ContinueBootstrapCommand}"
-                                Content="Continue"
+                                Content="{Binding Strings[Action.Continue]}"
                                 Style="{DynamicResource AccentButtonStyle}"
                                 Visibility="{Binding CanContinueBootstrap, Converter={StaticResource BooleanToVisibilityConverter}}" />
                             <TextBlock

--- a/src/Foundry.Connect/Models/Network/NetworkStatusSnapshot.cs
+++ b/src/Foundry.Connect/Models/Network/NetworkStatusSnapshot.cs
@@ -20,15 +20,15 @@ public sealed class NetworkStatusSnapshot
 
     public bool HasWirelessAdapter { get; init; }
 
-    public string EthernetStatusText { get; init; } = "No ethernet adapter detected.";
+    public string EthernetStatusText { get; init; } = string.Empty;
 
     public string EthernetSecondaryStatusText { get; init; } = string.Empty;
 
-    public string EthernetAdapterName { get; init; } = "Unavailable";
+    public string EthernetAdapterName { get; init; } = string.Empty;
 
-    public string EthernetIpAddress { get; init; } = "Unavailable";
+    public string EthernetIpAddress { get; init; } = string.Empty;
 
-    public string EthernetGateway { get; init; } = "Unavailable";
+    public string EthernetGateway { get; init; } = string.Empty;
 
     public string? ConnectedWifiSsid { get; init; }
 

--- a/src/Foundry.Connect/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry.Connect/Resources/AppStrings.fr-FR.resx
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="App.Name" xml:space="preserve">
+    <value>Foundry Connect</value>
+  </data>
+  <data name="App.WindowTitle" xml:space="preserve">
+    <value>Foundry Connect</value>
+  </data>
+  <data name="About.Title" xml:space="preserve">
+    <value>À propos de Foundry Connect</value>
+  </data>
+  <data name="About.DescriptionLine1" xml:space="preserve">
+    <value>Foundry Connect valide la connectivité réseau dans WinPE avant que le bootstrap Foundry ne se poursuive.</value>
+  </data>
+  <data name="About.DescriptionLine2" xml:space="preserve">
+    <value>Ce logiciel est fourni tel quel. Vérifiez l'accès réseau avant de poursuivre le déploiement.</value>
+  </data>
+  <data name="About.Footer" xml:space="preserve">
+    <value>Copyright (c) 2026 Foundry Contributors. Sous licence MIT.</value>
+  </data>
+  <data name="Menu.Theme" xml:space="preserve">
+    <value>Thème</value>
+  </data>
+  <data name="Menu.Language" xml:space="preserve">
+    <value>Langue</value>
+  </data>
+  <data name="Menu.Tools" xml:space="preserve">
+    <value>Outils</value>
+  </data>
+  <data name="Menu.Debug" xml:space="preserve">
+    <value>Débogage</value>
+  </data>
+  <data name="Menu.About" xml:space="preserve">
+    <value>À propos</value>
+  </data>
+  <data name="Theme.System" xml:space="preserve">
+    <value>Système</value>
+  </data>
+  <data name="Theme.Light" xml:space="preserve">
+    <value>Clair</value>
+  </data>
+  <data name="Theme.Dark" xml:space="preserve">
+    <value>Sombre</value>
+  </data>
+  <data name="Language.English" xml:space="preserve">
+    <value>Anglais</value>
+  </data>
+  <data name="Language.French" xml:space="preserve">
+    <value>Français</value>
+  </data>
+  <data name="Tools.RefreshStatus" xml:space="preserve">
+    <value>Actualiser l'état</value>
+  </data>
+  <data name="Debug.UseRuntimeLayout" xml:space="preserve">
+    <value>Utiliser la disposition runtime</value>
+  </data>
+  <data name="Debug.ShowEthernetOnly" xml:space="preserve">
+    <value>Afficher Ethernet uniquement</value>
+  </data>
+  <data name="Debug.ShowEthernetWifi" xml:space="preserve">
+    <value>Afficher Ethernet + Wi-Fi</value>
+  </data>
+  <data name="Action.Continue" xml:space="preserve">
+    <value>Continuer</value>
+  </data>
+  <data name="Action.Connect" xml:space="preserve">
+    <value>Connecter</value>
+  </data>
+  <data name="Action.Disconnect" xml:space="preserve">
+    <value>Déconnecter</value>
+  </data>
+  <data name="Common.VersionFormat" xml:space="preserve">
+    <value>Version : {0}</value>
+  </data>
+  <data name="Common.ConfigurationFromPathFormat" xml:space="preserve">
+    <value>Configuration : {0}</value>
+  </data>
+  <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
+    <value>Configuration : valeurs par défaut intégrées</value>
+  </data>
+  <data name="Common.RefreshIntervalFormat" xml:space="preserve">
+    <value>Actualisation : toutes les {0} secondes</value>
+  </data>
+  <data name="Common.LastUpdatePending" xml:space="preserve">
+    <value>Dernière mise à jour : en attente</value>
+  </data>
+  <data name="Common.LastUpdateFormat" xml:space="preserve">
+    <value>Dernière mise à jour : {0:HH:mm:ss}</value>
+  </data>
+  <data name="Common.Unavailable" xml:space="preserve">
+    <value>Indisponible</value>
+  </data>
+  <data name="Common.Connected" xml:space="preserve">
+    <value>Connecté</value>
+  </data>
+  <data name="Status.WaitingForNetworkTitle" xml:space="preserve">
+    <value>En attente du réseau</value>
+  </data>
+  <data name="Status.WaitingForNetworkDescription" xml:space="preserve">
+    <value>L'accès Internet n'a pas encore été validé.</value>
+  </data>
+  <data name="Status.NetworkReadyTitle" xml:space="preserve">
+    <value>Réseau prêt</value>
+  </data>
+  <data name="Status.NetworkReadyDescription" xml:space="preserve">
+    <value>L'accès Internet est validé. Vous pouvez continuer.</value>
+  </data>
+  <data name="Status.NetworkRefreshFailedTitle" xml:space="preserve">
+    <value>L'actualisation du réseau a échoué</value>
+  </data>
+  <data name="Status.AutoContinueFormat" xml:space="preserve">
+    <value>Poursuite automatique dans {0}s</value>
+  </data>
+  <data name="Ethernet.Title" xml:space="preserve">
+    <value>Ethernet</value>
+  </data>
+  <data name="Ethernet.AdapterLabel" xml:space="preserve">
+    <value>Adaptateur</value>
+  </data>
+  <data name="Ethernet.Ipv4Label" xml:space="preserve">
+    <value>IPv4</value>
+  </data>
+  <data name="Ethernet.GatewayLabel" xml:space="preserve">
+    <value>Passerelle</value>
+  </data>
+  <data name="Ethernet.NoAdapterDetected" xml:space="preserve">
+    <value>Aucun adaptateur Ethernet détecté.</value>
+  </data>
+  <data name="Ethernet.NoActiveLink" xml:space="preserve">
+    <value>Aucun lien actif</value>
+  </data>
+  <data name="Ethernet.WaitingConfiguration" xml:space="preserve">
+    <value>En attente de la configuration réseau</value>
+  </data>
+  <data name="Ethernet.CheckCable" xml:space="preserve">
+    <value>Vérifiez la connexion du câble</value>
+  </data>
+  <data name="Ethernet.WaitingDhcp" xml:space="preserve">
+    <value>En attente du DHCP ou d'une configuration réseau statique</value>
+  </data>
+  <data name="Ethernet.DhcpLeaseDetected" xml:space="preserve">
+    <value>Bail DHCP détecté</value>
+  </data>
+  <data name="Ethernet.StaticConfigurationDetected" xml:space="preserve">
+    <value>Configuration réseau statique détectée</value>
+  </data>
+  <data name="Wifi.Title" xml:space="preserve">
+    <value>Wi-Fi</value>
+  </data>
+  <data name="Wifi.ProvisionedTitle" xml:space="preserve">
+    <value>Wi-Fi provisionné</value>
+  </data>
+  <data name="Wifi.ProfileLabel" xml:space="preserve">
+    <value>Profil</value>
+  </data>
+  <data name="Wifi.AuthenticationLabel" xml:space="preserve">
+    <value>Authentification</value>
+  </data>
+  <data name="Wifi.ProvisionedProfileRequired" xml:space="preserve">
+    <value>Un profil provisionné est requis dans cette build.</value>
+  </data>
+  <data name="Wifi.NoNetworksVisible" xml:space="preserve">
+    <value>Aucun réseau Wi-Fi n'est actuellement visible.</value>
+  </data>
+  <data name="Wifi.NoProvisionedProfile" xml:space="preserve">
+    <value>Aucun profil provisionné n'est disponible dans cette image de démarrage.</value>
+  </data>
+  <data name="Wifi.UnavailableAtRuntime" xml:space="preserve">
+    <value>La prise en charge Wi-Fi n'est pas disponible à l'exécution.</value>
+  </data>
+  <data name="Wifi.NoAdapterDetected" xml:space="preserve">
+    <value>Aucun adaptateur sans fil n'est actuellement détecté.</value>
+  </data>
+  <data name="Wifi.NoAdapterAvailable" xml:space="preserve">
+    <value>Aucun adaptateur sans fil n'est disponible.</value>
+  </data>
+  <data name="Wifi.EnterpriseProfile" xml:space="preserve">
+    <value>Profil d'entreprise</value>
+  </data>
+  <data name="Wifi.UnnamedProvisionedProfile" xml:space="preserve">
+    <value>Profil provisionné sans nom</value>
+  </data>
+  <data name="Wifi.BootImageSettings" xml:space="preserve">
+    <value>Paramètres de l'image de démarrage</value>
+  </data>
+  <data name="Wifi.SourceWithCertificateFormat" xml:space="preserve">
+    <value>{0} · Certificat inclus</value>
+  </data>
+  <data name="Wifi.ConfiguredProfile" xml:space="preserve">
+    <value>Profil configuré</value>
+  </data>
+  <data name="Wifi.StatusUnavailable" xml:space="preserve">
+    <value>Wi-Fi indisponible</value>
+  </data>
+  <data name="Wifi.StatusNoAdapter" xml:space="preserve">
+    <value>Aucun adaptateur sans fil disponible</value>
+  </data>
+  <data name="Wifi.StatusAnotherNetworkActive" xml:space="preserve">
+    <value>Un autre réseau Wi-Fi est actif</value>
+  </data>
+  <data name="Wifi.StatusReadyToConnect" xml:space="preserve">
+    <value>Prêt à se connecter</value>
+  </data>
+  <data name="Wifi.ConnectionChipEthernet" xml:space="preserve">
+    <value>Ethernet</value>
+  </data>
+  <data name="Wifi.ConnectionChipProvisionedFormat" xml:space="preserve">
+    <value>Wi-Fi provisionné · {0}</value>
+  </data>
+  <data name="Wifi.ConnectionChipFormat" xml:space="preserve">
+    <value>Wi-Fi · {0}</value>
+  </data>
+  <data name="Wifi.ActionSelectedNotSupported" xml:space="preserve">
+    <value>Ce réseau Wi-Fi n'est pas pris en charge dans cette build.</value>
+  </data>
+  <data name="Wifi.ActionConnectFailed" xml:space="preserve">
+    <value>Impossible de se connecter. Vérifiez le mot de passe et réessayez.</value>
+  </data>
+  <data name="Wifi.ActionProvisionedProfileUnavailable" xml:space="preserve">
+    <value>Le profil Wi-Fi provisionné n'est pas disponible.</value>
+  </data>
+  <data name="Wifi.ActionProvisionedConnectFailed" xml:space="preserve">
+    <value>Impossible de connecter le profil Wi-Fi provisionné. Réessayez.</value>
+  </data>
+  <data name="Wifi.ActionProvisionedDisconnectFailed" xml:space="preserve">
+    <value>Impossible de déconnecter le profil Wi-Fi provisionné. Réessayez.</value>
+  </data>
+  <data name="Wifi.ActionDisconnectFailed" xml:space="preserve">
+    <value>Impossible de se déconnecter. Réessayez.</value>
+  </data>
+  <data name="Wifi.ActionApplyProvisionedFailed" xml:space="preserve">
+    <value>Impossible d'appliquer les paramètres réseau provisionnés.</value>
+  </data>
+  <data name="Wifi.ActionTryAgain" xml:space="preserve">
+    <value>Impossible d'exécuter l'action Wi-Fi. Réessayez.</value>
+  </data>
+  <data name="Wifi.SecurityWpa2Wpa3Personal" xml:space="preserve">
+    <value>WPA2/WPA3 Personnel</value>
+  </data>
+  <data name="Wifi.SecurityWpa2Personal" xml:space="preserve">
+    <value>WPA2 Personnel</value>
+  </data>
+  <data name="Wifi.SecurityWpa3Personal" xml:space="preserve">
+    <value>WPA3 Personnel</value>
+  </data>
+  <data name="Wifi.SecurityPersonal" xml:space="preserve">
+    <value>Personnel</value>
+  </data>
+  <data name="Wifi.SecurityWpa3Enterprise" xml:space="preserve">
+    <value>WPA3 Entreprise</value>
+  </data>
+  <data name="Wifi.SecurityWpa3Enterprise192" xml:space="preserve">
+    <value>WPA3 Entreprise 192 bits</value>
+  </data>
+  <data name="Wifi.SecurityWpa2Wpa3Enterprise" xml:space="preserve">
+    <value>WPA2/WPA3 Entreprise</value>
+  </data>
+  <data name="Wifi.SecurityWpa2Enterprise" xml:space="preserve">
+    <value>WPA2 Entreprise</value>
+  </data>
+  <data name="Wifi.SecurityEnterprise" xml:space="preserve">
+    <value>Entreprise</value>
+  </data>
+  <data name="Wifi.SecurityMachineFormat" xml:space="preserve">
+    <value>{0} (poste)</value>
+  </data>
+  <data name="Wifi.SecurityMachineOrUserFormat" xml:space="preserve">
+    <value>{0} (poste ou utilisateur)</value>
+  </data>
+</root>

--- a/src/Foundry.Connect/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry.Connect/Resources/AppStrings.fr-FR.resx
@@ -246,6 +246,27 @@
   <data name="Wifi.ActionTryAgain" xml:space="preserve">
     <value>Impossible d'exécuter l'action Wi-Fi. Réessayez.</value>
   </data>
+  <data name="Wifi.HiddenNetwork" xml:space="preserve">
+    <value>Réseau masqué</value>
+  </data>
+  <data name="Wifi.SecurityOpen" xml:space="preserve">
+    <value>Ouvert</value>
+  </data>
+  <data name="Wifi.SecurityWep" xml:space="preserve">
+    <value>WEP</value>
+  </data>
+  <data name="Wifi.SecurityWpaPersonal" xml:space="preserve">
+    <value>WPA Personnel</value>
+  </data>
+  <data name="Wifi.SecurityWpaNone" xml:space="preserve">
+    <value>WPA Aucun</value>
+  </data>
+  <data name="Wifi.SecurityWpaEnterprise" xml:space="preserve">
+    <value>WPA Entreprise</value>
+  </data>
+  <data name="Wifi.SecurityVendorSpecific" xml:space="preserve">
+    <value>Spécifique au fournisseur</value>
+  </data>
   <data name="Wifi.SecurityWpa2Wpa3Personal" xml:space="preserve">
     <value>WPA2/WPA3 Personnel</value>
   </data>

--- a/src/Foundry.Connect/Resources/AppStrings.resx
+++ b/src/Foundry.Connect/Resources/AppStrings.resx
@@ -246,6 +246,27 @@
   <data name="Wifi.ActionTryAgain" xml:space="preserve">
     <value>Unable to complete the Wi-Fi action. Try again.</value>
   </data>
+  <data name="Wifi.HiddenNetwork" xml:space="preserve">
+    <value>Hidden network</value>
+  </data>
+  <data name="Wifi.SecurityOpen" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="Wifi.SecurityWep" xml:space="preserve">
+    <value>WEP</value>
+  </data>
+  <data name="Wifi.SecurityWpaPersonal" xml:space="preserve">
+    <value>WPA Personal</value>
+  </data>
+  <data name="Wifi.SecurityWpaNone" xml:space="preserve">
+    <value>WPA None</value>
+  </data>
+  <data name="Wifi.SecurityWpaEnterprise" xml:space="preserve">
+    <value>WPA Enterprise</value>
+  </data>
+  <data name="Wifi.SecurityVendorSpecific" xml:space="preserve">
+    <value>Vendor-specific</value>
+  </data>
   <data name="Wifi.SecurityWpa2Wpa3Personal" xml:space="preserve">
     <value>WPA2/WPA3 Personal</value>
   </data>

--- a/src/Foundry.Connect/Resources/AppStrings.resx
+++ b/src/Foundry.Connect/Resources/AppStrings.resx
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="App.Name" xml:space="preserve">
+    <value>Foundry Connect</value>
+  </data>
+  <data name="App.WindowTitle" xml:space="preserve">
+    <value>Foundry Connect</value>
+  </data>
+  <data name="About.Title" xml:space="preserve">
+    <value>About Foundry Connect</value>
+  </data>
+  <data name="About.DescriptionLine1" xml:space="preserve">
+    <value>Foundry Connect validates network readiness in WinPE before the Foundry bootstrap continues.</value>
+  </data>
+  <data name="About.DescriptionLine2" xml:space="preserve">
+    <value>This software is provided as-is. Confirm network access before continuing deployment.</value>
+  </data>
+  <data name="About.Footer" xml:space="preserve">
+    <value>Copyright (c) 2026 Foundry Contributors. Licensed under the MIT License.</value>
+  </data>
+  <data name="Menu.Theme" xml:space="preserve">
+    <value>Theme</value>
+  </data>
+  <data name="Menu.Language" xml:space="preserve">
+    <value>Language</value>
+  </data>
+  <data name="Menu.Tools" xml:space="preserve">
+    <value>Tools</value>
+  </data>
+  <data name="Menu.Debug" xml:space="preserve">
+    <value>Debug</value>
+  </data>
+  <data name="Menu.About" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="Theme.System" xml:space="preserve">
+    <value>System</value>
+  </data>
+  <data name="Theme.Light" xml:space="preserve">
+    <value>Light</value>
+  </data>
+  <data name="Theme.Dark" xml:space="preserve">
+    <value>Dark</value>
+  </data>
+  <data name="Language.English" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="Language.French" xml:space="preserve">
+    <value>French</value>
+  </data>
+  <data name="Tools.RefreshStatus" xml:space="preserve">
+    <value>Refresh Status</value>
+  </data>
+  <data name="Debug.UseRuntimeLayout" xml:space="preserve">
+    <value>Use Runtime Layout</value>
+  </data>
+  <data name="Debug.ShowEthernetOnly" xml:space="preserve">
+    <value>Show Ethernet Only</value>
+  </data>
+  <data name="Debug.ShowEthernetWifi" xml:space="preserve">
+    <value>Show Ethernet + Wi-Fi</value>
+  </data>
+  <data name="Action.Continue" xml:space="preserve">
+    <value>Continue</value>
+  </data>
+  <data name="Action.Connect" xml:space="preserve">
+    <value>Connect</value>
+  </data>
+  <data name="Action.Disconnect" xml:space="preserve">
+    <value>Disconnect</value>
+  </data>
+  <data name="Common.VersionFormat" xml:space="preserve">
+    <value>Version: {0}</value>
+  </data>
+  <data name="Common.ConfigurationFromPathFormat" xml:space="preserve">
+    <value>Configuration: {0}</value>
+  </data>
+  <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
+    <value>Configuration: built-in defaults</value>
+  </data>
+  <data name="Common.RefreshIntervalFormat" xml:space="preserve">
+    <value>Refresh: every {0} seconds</value>
+  </data>
+  <data name="Common.LastUpdatePending" xml:space="preserve">
+    <value>Last update: pending</value>
+  </data>
+  <data name="Common.LastUpdateFormat" xml:space="preserve">
+    <value>Last update: {0:HH:mm:ss}</value>
+  </data>
+  <data name="Common.Unavailable" xml:space="preserve">
+    <value>Unavailable</value>
+  </data>
+  <data name="Common.Connected" xml:space="preserve">
+    <value>Connected</value>
+  </data>
+  <data name="Status.WaitingForNetworkTitle" xml:space="preserve">
+    <value>Waiting for network</value>
+  </data>
+  <data name="Status.WaitingForNetworkDescription" xml:space="preserve">
+    <value>Internet access has not been validated yet.</value>
+  </data>
+  <data name="Status.NetworkReadyTitle" xml:space="preserve">
+    <value>Network ready</value>
+  </data>
+  <data name="Status.NetworkReadyDescription" xml:space="preserve">
+    <value>Internet access is validated. You can continue now.</value>
+  </data>
+  <data name="Status.NetworkRefreshFailedTitle" xml:space="preserve">
+    <value>Network refresh failed</value>
+  </data>
+  <data name="Status.AutoContinueFormat" xml:space="preserve">
+    <value>Auto-continue in {0}s</value>
+  </data>
+  <data name="Ethernet.Title" xml:space="preserve">
+    <value>Ethernet</value>
+  </data>
+  <data name="Ethernet.AdapterLabel" xml:space="preserve">
+    <value>Adapter</value>
+  </data>
+  <data name="Ethernet.Ipv4Label" xml:space="preserve">
+    <value>IPv4</value>
+  </data>
+  <data name="Ethernet.GatewayLabel" xml:space="preserve">
+    <value>Gateway</value>
+  </data>
+  <data name="Ethernet.NoAdapterDetected" xml:space="preserve">
+    <value>No ethernet adapter detected.</value>
+  </data>
+  <data name="Ethernet.NoActiveLink" xml:space="preserve">
+    <value>No active link</value>
+  </data>
+  <data name="Ethernet.WaitingConfiguration" xml:space="preserve">
+    <value>Waiting for network configuration</value>
+  </data>
+  <data name="Ethernet.CheckCable" xml:space="preserve">
+    <value>Check the cable connection</value>
+  </data>
+  <data name="Ethernet.WaitingDhcp" xml:space="preserve">
+    <value>Waiting for DHCP or static network configuration</value>
+  </data>
+  <data name="Ethernet.DhcpLeaseDetected" xml:space="preserve">
+    <value>DHCP lease detected</value>
+  </data>
+  <data name="Ethernet.StaticConfigurationDetected" xml:space="preserve">
+    <value>Static network configuration detected</value>
+  </data>
+  <data name="Wifi.Title" xml:space="preserve">
+    <value>Wi-Fi</value>
+  </data>
+  <data name="Wifi.ProvisionedTitle" xml:space="preserve">
+    <value>Provisioned Wi-Fi</value>
+  </data>
+  <data name="Wifi.ProfileLabel" xml:space="preserve">
+    <value>Profile</value>
+  </data>
+  <data name="Wifi.AuthenticationLabel" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Wifi.ProvisionedProfileRequired" xml:space="preserve">
+    <value>Provisioned profile required in this build.</value>
+  </data>
+  <data name="Wifi.NoNetworksVisible" xml:space="preserve">
+    <value>No Wi-Fi networks are currently visible.</value>
+  </data>
+  <data name="Wifi.NoProvisionedProfile" xml:space="preserve">
+    <value>No provisioned profile is available in this boot image.</value>
+  </data>
+  <data name="Wifi.UnavailableAtRuntime" xml:space="preserve">
+    <value>Wi-Fi support is not available at runtime.</value>
+  </data>
+  <data name="Wifi.NoAdapterDetected" xml:space="preserve">
+    <value>No wireless adapter is currently detected.</value>
+  </data>
+  <data name="Wifi.NoAdapterAvailable" xml:space="preserve">
+    <value>No wireless adapter is available.</value>
+  </data>
+  <data name="Wifi.EnterpriseProfile" xml:space="preserve">
+    <value>Enterprise profile</value>
+  </data>
+  <data name="Wifi.UnnamedProvisionedProfile" xml:space="preserve">
+    <value>Unnamed provisioned profile</value>
+  </data>
+  <data name="Wifi.BootImageSettings" xml:space="preserve">
+    <value>Boot image settings</value>
+  </data>
+  <data name="Wifi.SourceWithCertificateFormat" xml:space="preserve">
+    <value>{0} · Certificate included</value>
+  </data>
+  <data name="Wifi.ConfiguredProfile" xml:space="preserve">
+    <value>Configured profile</value>
+  </data>
+  <data name="Wifi.StatusUnavailable" xml:space="preserve">
+    <value>Wi-Fi unavailable</value>
+  </data>
+  <data name="Wifi.StatusNoAdapter" xml:space="preserve">
+    <value>No wireless adapter available</value>
+  </data>
+  <data name="Wifi.StatusAnotherNetworkActive" xml:space="preserve">
+    <value>Another Wi-Fi network is active</value>
+  </data>
+  <data name="Wifi.StatusReadyToConnect" xml:space="preserve">
+    <value>Ready to connect</value>
+  </data>
+  <data name="Wifi.ConnectionChipEthernet" xml:space="preserve">
+    <value>Ethernet</value>
+  </data>
+  <data name="Wifi.ConnectionChipProvisionedFormat" xml:space="preserve">
+    <value>Provisioned Wi-Fi · {0}</value>
+  </data>
+  <data name="Wifi.ConnectionChipFormat" xml:space="preserve">
+    <value>Wi-Fi · {0}</value>
+  </data>
+  <data name="Wifi.ActionSelectedNotSupported" xml:space="preserve">
+    <value>This Wi-Fi network is not supported in this build.</value>
+  </data>
+  <data name="Wifi.ActionConnectFailed" xml:space="preserve">
+    <value>Unable to connect. Check the password and try again.</value>
+  </data>
+  <data name="Wifi.ActionProvisionedProfileUnavailable" xml:space="preserve">
+    <value>The provisioned Wi-Fi profile is not available.</value>
+  </data>
+  <data name="Wifi.ActionProvisionedConnectFailed" xml:space="preserve">
+    <value>Unable to connect the provisioned Wi-Fi profile. Try again.</value>
+  </data>
+  <data name="Wifi.ActionProvisionedDisconnectFailed" xml:space="preserve">
+    <value>Unable to disconnect the provisioned Wi-Fi profile. Try again.</value>
+  </data>
+  <data name="Wifi.ActionDisconnectFailed" xml:space="preserve">
+    <value>Unable to disconnect. Try again.</value>
+  </data>
+  <data name="Wifi.ActionApplyProvisionedFailed" xml:space="preserve">
+    <value>Unable to apply the provisioned network settings.</value>
+  </data>
+  <data name="Wifi.ActionTryAgain" xml:space="preserve">
+    <value>Unable to complete the Wi-Fi action. Try again.</value>
+  </data>
+  <data name="Wifi.SecurityWpa2Wpa3Personal" xml:space="preserve">
+    <value>WPA2/WPA3 Personal</value>
+  </data>
+  <data name="Wifi.SecurityWpa2Personal" xml:space="preserve">
+    <value>WPA2 Personal</value>
+  </data>
+  <data name="Wifi.SecurityWpa3Personal" xml:space="preserve">
+    <value>WPA3 Personal</value>
+  </data>
+  <data name="Wifi.SecurityPersonal" xml:space="preserve">
+    <value>Personal</value>
+  </data>
+  <data name="Wifi.SecurityWpa3Enterprise" xml:space="preserve">
+    <value>WPA3 Enterprise</value>
+  </data>
+  <data name="Wifi.SecurityWpa3Enterprise192" xml:space="preserve">
+    <value>WPA3 Enterprise 192-bit</value>
+  </data>
+  <data name="Wifi.SecurityWpa2Wpa3Enterprise" xml:space="preserve">
+    <value>WPA2/WPA3 Enterprise</value>
+  </data>
+  <data name="Wifi.SecurityWpa2Enterprise" xml:space="preserve">
+    <value>WPA2 Enterprise</value>
+  </data>
+  <data name="Wifi.SecurityEnterprise" xml:space="preserve">
+    <value>Enterprise</value>
+  </data>
+  <data name="Wifi.SecurityMachineFormat" xml:space="preserve">
+    <value>{0} (machine)</value>
+  </data>
+  <data name="Wifi.SecurityMachineOrUserFormat" xml:space="preserve">
+    <value>{0} (machine or user)</value>
+  </data>
+</root>

--- a/src/Foundry.Connect/Services/ApplicationShell/ApplicationShellService.cs
+++ b/src/Foundry.Connect/Services/ApplicationShell/ApplicationShellService.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using Foundry.Connect.Services.Localization;
 using Foundry.Connect.ViewModels;
 using Foundry.Connect.Views;
 
@@ -6,15 +7,22 @@ namespace Foundry.Connect.Services.ApplicationShell;
 
 public sealed class ApplicationShellService : IApplicationShellService
 {
+    private readonly ILocalizationService _localizationService;
+
+    public ApplicationShellService(ILocalizationService localizationService)
+    {
+        _localizationService = localizationService;
+    }
+
     public void ShowAbout()
     {
         var viewModel = new AboutDialogViewModel(
-            FoundryConnectApplicationInfo.AboutTitle,
-            FoundryConnectApplicationInfo.AppName,
+            _localizationService.Strings["About.Title"],
+            _localizationService.Strings["App.Name"],
             FoundryConnectApplicationInfo.Version,
-            FoundryConnectApplicationInfo.DescriptionLine1,
-            FoundryConnectApplicationInfo.DescriptionLine2,
-            FoundryConnectApplicationInfo.Footer);
+            _localizationService.Strings["About.DescriptionLine1"],
+            _localizationService.Strings["About.DescriptionLine2"],
+            _localizationService.Strings["About.Footer"]);
         var dialog = new AboutDialog
         {
             DataContext = viewModel,

--- a/src/Foundry.Connect/Services/Localization/ILocalizationService.cs
+++ b/src/Foundry.Connect/Services/Localization/ILocalizationService.cs
@@ -1,0 +1,11 @@
+using System.Globalization;
+
+namespace Foundry.Connect.Services.Localization;
+
+public interface ILocalizationService
+{
+    CultureInfo CurrentCulture { get; }
+    StringsWrapper Strings { get; }
+    event EventHandler? LanguageChanged;
+    void SetCulture(CultureInfo culture);
+}

--- a/src/Foundry.Connect/Services/Localization/LocalizationService.cs
+++ b/src/Foundry.Connect/Services/Localization/LocalizationService.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Resources;
+
+namespace Foundry.Connect.Services.Localization;
+
+public sealed class LocalizationService : ILocalizationService, INotifyPropertyChanged
+{
+    private readonly ResourceManager _resourceManager;
+    private readonly StringsWrapper _stringsWrapper;
+    private CultureInfo _currentCulture;
+
+    public LocalizationService()
+    {
+        _resourceManager = new ResourceManager("Foundry.Connect.Resources.AppStrings", typeof(LocalizationService).Assembly);
+        _currentCulture = CultureInfo.CurrentUICulture;
+        _stringsWrapper = new StringsWrapper(_resourceManager, _currentCulture);
+    }
+
+    public CultureInfo CurrentCulture
+    {
+        get => _currentCulture;
+        private set
+        {
+            if (_currentCulture != value)
+            {
+                _currentCulture = value;
+                CultureInfo.CurrentUICulture = _currentCulture;
+                _stringsWrapper.SetCulture(_currentCulture);
+                OnPropertyChanged(nameof(CurrentCulture));
+            }
+        }
+    }
+
+    public StringsWrapper Strings => _stringsWrapper;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    public event EventHandler? LanguageChanged;
+
+    public void SetCulture(CultureInfo culture)
+    {
+        CurrentCulture = culture;
+        LanguageChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/Foundry.Connect/Services/Localization/StringsWrapper.cs
+++ b/src/Foundry.Connect/Services/Localization/StringsWrapper.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Resources;
+
+namespace Foundry.Connect.Services.Localization;
+
+public sealed class StringsWrapper : INotifyPropertyChanged
+{
+    private readonly ResourceManager _resourceManager;
+    private CultureInfo _currentCulture;
+
+    public StringsWrapper(ResourceManager resourceManager, CultureInfo currentCulture)
+    {
+        _resourceManager = resourceManager;
+        _currentCulture = currentCulture;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public string this[string key] => _resourceManager.GetString(key, _currentCulture) ?? key;
+
+    public void SetCulture(CultureInfo culture)
+    {
+        if (_currentCulture != culture)
+        {
+            _currentCulture = culture;
+            OnPropertyChanged("Item[]");
+        }
+    }
+
+    private void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/Foundry.Connect/Services/Localization/StringsWrapper.cs
+++ b/src/Foundry.Connect/Services/Localization/StringsWrapper.cs
@@ -17,7 +17,11 @@ public sealed class StringsWrapper : INotifyPropertyChanged
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    public string this[string key] => _resourceManager.GetString(key, _currentCulture) ?? key;
+    public string this[string key]
+    {
+        get => _resourceManager.GetString(key, _currentCulture) ?? key;
+        set { /* No-op to support WPF controls that default to TwoWay/OneWayToSource binding */ }
+    }
 
     public void SetCulture(CultureInfo culture)
     {

--- a/src/Foundry.Connect/Services/Network/NetworkStatusService.cs
+++ b/src/Foundry.Connect/Services/Network/NetworkStatusService.cs
@@ -4,6 +4,7 @@ using System.Net.Sockets;
 using System.Diagnostics;
 using Foundry.Connect.Models;
 using Foundry.Connect.Models.Configuration;
+using Foundry.Connect.Services.Localization;
 using Foundry.Connect.Models.Network;
 using Microsoft.Extensions.Logging;
 
@@ -18,15 +19,18 @@ public sealed class NetworkStatusService : INetworkStatusService
     private static readonly TimeSpan WifiDiscoveryGracePeriod = TimeSpan.FromSeconds(15);
 
     private readonly FoundryConnectConfiguration _configuration;
+    private readonly ILocalizationService _localizationService;
     private readonly ILogger<NetworkStatusService> _logger;
     private IReadOnlyList<WifiNetworkSummary> _lastStableWifiNetworks = Array.Empty<WifiNetworkSummary>();
     private DateTimeOffset? _lastStableWifiNetworksAt;
 
     public NetworkStatusService(
         FoundryConnectConfiguration configuration,
+        ILocalizationService localizationService,
         ILogger<NetworkStatusService> logger)
     {
         _configuration = configuration;
+        _localizationService = localizationService;
         _logger = logger;
     }
 
@@ -77,9 +81,9 @@ public sealed class NetworkStatusService : INetworkStatusService
             HasWirelessAdapter = hasWirelessAdapter,
             EthernetStatusText = BuildEthernetStatusText(hasEthernetAdapter, isEthernetConnected, hasEthernetIpv4),
             EthernetSecondaryStatusText = BuildEthernetSecondaryStatusText(hasEthernetAdapter, isEthernetConnected, hasEthernetIpv4, hasDhcpLease),
-            EthernetAdapterName = ethernetDisplayAdapter?.Name ?? "Unavailable",
-            EthernetIpAddress = ethernetIpv4Information?.Address.ToString() ?? "Unavailable",
-            EthernetGateway = ethernetGatewayInformation?.Address.ToString() ?? "Unavailable",
+            EthernetAdapterName = ethernetDisplayAdapter?.Name ?? GetString("Common.Unavailable"),
+            EthernetIpAddress = ethernetIpv4Information?.Address.ToString() ?? GetString("Common.Unavailable"),
+            EthernetGateway = ethernetGatewayInformation?.Address.ToString() ?? GetString("Common.Unavailable"),
             ConnectedWifiSsid = connectedWifiSsid,
             WifiNetworks = wifiNetworks
         };
@@ -187,24 +191,24 @@ public sealed class NetworkStatusService : INetworkStatusService
         }
     }
 
-    private static string BuildEthernetStatusText(bool hasEthernetAdapter, bool isEthernetConnected, bool hasEthernetIpv4)
+    private string BuildEthernetStatusText(bool hasEthernetAdapter, bool isEthernetConnected, bool hasEthernetIpv4)
     {
         if (!hasEthernetAdapter)
         {
-            return "No ethernet adapter detected.";
+            return GetString("Ethernet.NoAdapterDetected");
         }
 
         if (!isEthernetConnected)
         {
-            return "No active link";
+            return GetString("Ethernet.NoActiveLink");
         }
 
         return hasEthernetIpv4
-            ? "Connected"
-            : "Waiting for network configuration";
+            ? GetString("Common.Connected")
+            : GetString("Ethernet.WaitingConfiguration");
     }
 
-    private static string BuildEthernetSecondaryStatusText(bool hasEthernetAdapter, bool isEthernetConnected, bool hasEthernetIpv4, bool hasDhcpLease)
+    private string BuildEthernetSecondaryStatusText(bool hasEthernetAdapter, bool isEthernetConnected, bool hasEthernetIpv4, bool hasDhcpLease)
     {
         if (!hasEthernetAdapter)
         {
@@ -213,16 +217,21 @@ public sealed class NetworkStatusService : INetworkStatusService
 
         if (!isEthernetConnected)
         {
-            return "Check the cable connection";
+            return GetString("Ethernet.CheckCable");
         }
 
         if (!hasEthernetIpv4)
         {
-            return "Waiting for DHCP or static network configuration";
+            return GetString("Ethernet.WaitingDhcp");
         }
 
         return hasDhcpLease
-            ? "DHCP lease detected"
-            : "Static network configuration detected";
+            ? GetString("Ethernet.DhcpLeaseDetected")
+            : GetString("Ethernet.StaticConfigurationDetected");
+    }
+
+    private string GetString(string key)
+    {
+        return _localizationService.Strings[key];
     }
 }

--- a/src/Foundry.Connect/ViewModels/LocalizedViewModelBase.cs
+++ b/src/Foundry.Connect/ViewModels/LocalizedViewModelBase.cs
@@ -1,0 +1,53 @@
+using System.Windows;
+using System.Windows.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Foundry.Connect.Services.Localization;
+
+namespace Foundry.Connect.ViewModels;
+
+public abstract class LocalizedViewModelBase : ObservableObject, IDisposable
+{
+    private readonly ILocalizationService _localizationService;
+    private readonly Dispatcher _dispatcher;
+    private bool _isDisposed;
+
+    protected LocalizedViewModelBase(ILocalizationService localizationService)
+    {
+        _localizationService = localizationService ?? throw new ArgumentNullException(nameof(localizationService));
+        _dispatcher = Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
+        _localizationService.LanguageChanged += OnLanguageChanged;
+    }
+
+    public StringsWrapper Strings => _localizationService.Strings;
+
+    protected ILocalizationService LocalizationService => _localizationService;
+
+    public virtual void Dispose()
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        _localizationService.LanguageChanged -= OnLanguageChanged;
+        _isDisposed = true;
+    }
+
+    protected void RunOnUiThread(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (_dispatcher.CheckAccess())
+        {
+            action();
+            return;
+        }
+
+        _dispatcher.Invoke(action);
+    }
+
+    private void OnLanguageChanged(object? sender, EventArgs e)
+    {
+        RunOnUiThread(() => OnPropertyChanged(nameof(Strings)));
+    }
+}

--- a/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -10,6 +11,7 @@ using Foundry.Connect.Models.Network;
 using Foundry.Connect.Services.ApplicationShell;
 using Foundry.Connect.Services.ApplicationLifetime;
 using Foundry.Connect.Services.Configuration;
+using Foundry.Connect.Services.Localization;
 using Foundry.Connect.Services.Network;
 using Foundry.Connect.Services.Theme;
 using Microsoft.Extensions.Logging;
@@ -17,7 +19,7 @@ using ConnectThemeMode = Foundry.Connect.Services.Theme.ThemeMode;
 
 namespace Foundry.Connect.ViewModels;
 
-public partial class MainWindowViewModel : ObservableObject, IDisposable
+public partial class MainWindowViewModel : LocalizedViewModelBase
 {
     private const string PendingStatusGlyph = "\uE709";
     private const string ReadyStatusGlyph = "\uE73E";
@@ -60,10 +62,10 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private string primaryStatusGlyph = PendingStatusGlyph;
 
     [ObservableProperty]
-    private string primaryStatusTitle = "Waiting for network";
+    private string primaryStatusTitle = string.Empty;
 
     [ObservableProperty]
-    private string primaryStatusDescription = "Internet access has not been validated yet.";
+    private string primaryStatusDescription = string.Empty;
 
     [ObservableProperty]
     private bool isPrimaryStatusSuccessful;
@@ -75,19 +77,19 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private string ethernetGlyph = EthernetErrorGlyph;
 
     [ObservableProperty]
-    private string ethernetStatusText = "No ethernet adapter detected.";
+    private string ethernetStatusText = string.Empty;
 
     [ObservableProperty]
     private string ethernetSecondaryStatusText = string.Empty;
 
     [ObservableProperty]
-    private string ethernetAdapterName = "Unavailable";
+    private string ethernetAdapterName = string.Empty;
 
     [ObservableProperty]
-    private string ethernetIpAddress = "Unavailable";
+    private string ethernetIpAddress = string.Empty;
 
     [ObservableProperty]
-    private string ethernetGateway = "Unavailable";
+    private string ethernetGateway = string.Empty;
 
     [ObservableProperty]
     private bool hasInternetAccess;
@@ -133,6 +135,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
     public MainWindowViewModel(
         IThemeService themeService,
+        ILocalizationService localizationService,
         IApplicationShellService applicationShellService,
         IApplicationLifetimeService applicationLifetimeService,
         IConnectConfigurationService configurationService,
@@ -140,6 +143,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         INetworkBootstrapService networkBootstrapService,
         INetworkStatusService networkStatusService,
         ILogger<MainWindowViewModel> logger)
+        : base(localizationService)
     {
         _themeService = themeService;
         _applicationShellService = applicationShellService;
@@ -152,30 +156,30 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         _dispatcher = Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
         _isAutoCloseEnabled = !Debugger.IsAttached;
         LayoutMode = NetworkLayoutMode.EthernetOnly;
-        VersionDisplay = $"Version: {FoundryConnectApplicationInfo.Version}";
-        ConfigurationSourceText = _configurationService.IsLoadedFromDisk && !string.IsNullOrWhiteSpace(_configurationService.ConfigurationPath)
-            ? $"Configuration: {_configurationService.ConfigurationPath}"
-            : "Configuration: built-in defaults";
-        RefreshIntervalText = $"Refresh: every {FoundryConnectApplicationInfo.DefaultRefreshIntervalSeconds} seconds";
+        LocalizationService.LanguageChanged += OnLanguageChanged;
+        ApplyLocalizedDefaults();
     }
 
     public ObservableCollection<WifiNetworkItemViewModel> WifiNetworks { get; } = [];
 
+    public CultureInfo CurrentCulture => LocalizationService.CurrentCulture;
     public ConnectThemeMode CurrentTheme => _themeService.CurrentTheme;
 
-    public string VersionDisplay { get; }
+    public string VersionDisplay => Format("Common.VersionFormat", FoundryConnectApplicationInfo.Version);
 
-    public string ConfigurationSourceText { get; }
+    public string ConfigurationSourceText => _configurationService.IsLoadedFromDisk && !string.IsNullOrWhiteSpace(_configurationService.ConfigurationPath)
+        ? Format("Common.ConfigurationFromPathFormat", _configurationService.ConfigurationPath!)
+        : GetString("Common.ConfigurationBuiltInDefaults");
 
-    public string RefreshIntervalText { get; }
+    public string RefreshIntervalText => Format("Common.RefreshIntervalFormat", FoundryConnectApplicationInfo.DefaultRefreshIntervalSeconds);
 
-    public string WindowTitle => FoundryConnectApplicationInfo.WindowTitle;
+    public string WindowTitle => GetString("App.WindowTitle");
 
-    public string AutoContinueText => $"Auto-continue in {CountdownSecondsRemaining}s";
+    public string AutoContinueText => Format("Status.AutoContinueFormat", CountdownSecondsRemaining);
 
     public string LastUpdatedText => LastUpdatedAt is null
-        ? "Last update: pending"
-        : $"Last update: {LastUpdatedAt.Value.LocalDateTime:HH:mm:ss}";
+        ? GetString("Common.LastUpdatePending")
+        : Format("Common.LastUpdateFormat", LastUpdatedAt.Value.LocalDateTime);
 
     public bool HasWifiNetworks => WifiNetworks.Count > 0;
 
@@ -254,6 +258,12 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     {
         _themeService.SetTheme(ConnectThemeMode.Dark);
         OnPropertyChanged(nameof(CurrentTheme));
+    }
+
+    [RelayCommand]
+    private void SetCulture(string cultureName)
+    {
+        LocalizationService.SetCulture(new CultureInfo(cultureName));
     }
 
     [RelayCommand]
@@ -402,7 +412,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             {
                 IsPrimaryStatusSuccessful = false;
                 PrimaryStatusGlyph = PendingStatusGlyph;
-                PrimaryStatusTitle = "Network refresh failed";
+                PrimaryStatusTitle = GetString("Status.NetworkRefreshFailedTitle");
                 PrimaryStatusDescription = ex.Message;
             }).ConfigureAwait(false);
         }
@@ -435,7 +445,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         RefreshDerivedConnectionState(snapshot);
 
         SyncWifiNetworks(snapshot.WifiNetworks, snapshot.ConnectedWifiSsid);
-        ApplyPrimaryStatus(snapshot);
+        ApplyPrimaryStatus(snapshot.HasInternetAccess);
         UpdateCountdown(snapshot);
 
         if (!snapshot.HasInternetAccess &&
@@ -457,21 +467,21 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         }
     }
 
-    private void ApplyPrimaryStatus(NetworkStatusSnapshot snapshot)
+    private void ApplyPrimaryStatus(bool hasInternetAccess)
     {
-        if (snapshot.HasInternetAccess)
+        if (hasInternetAccess)
         {
             IsPrimaryStatusSuccessful = true;
             PrimaryStatusGlyph = ReadyStatusGlyph;
-            PrimaryStatusTitle = "Network ready";
-            PrimaryStatusDescription = "Internet access is validated. You can continue now.";
+            PrimaryStatusTitle = GetString("Status.NetworkReadyTitle");
+            PrimaryStatusDescription = GetString("Status.NetworkReadyDescription");
             return;
         }
 
         IsPrimaryStatusSuccessful = false;
         PrimaryStatusGlyph = PendingStatusGlyph;
-        PrimaryStatusTitle = "Waiting for network";
-        PrimaryStatusDescription = "Internet access has not been validated yet.";
+        PrimaryStatusTitle = GetString("Status.WaitingForNetworkTitle");
+        PrimaryStatusDescription = GetString("Status.WaitingForNetworkDescription");
     }
 
     private void UpdateCountdown(NetworkStatusSnapshot snapshot)
@@ -686,18 +696,20 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         return _dispatcher.InvokeAsync(action).Task;
     }
 
-    public void Dispose()
+    public override void Dispose()
     {
         if (_isDisposed)
         {
             return;
         }
 
+        LocalizationService.LanguageChanged -= OnLanguageChanged;
         _disposeCts.Cancel();
         CancelCountdown();
         _countdownCts?.Dispose();
         _disposeCts.Dispose();
         _refreshGate.Dispose();
+        base.Dispose();
         _isDisposed = true;
     }
 
@@ -779,6 +791,40 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         OnPropertyChanged(nameof(EffectiveLayoutMode));
     }
 
+    private void OnLanguageChanged(object? sender, EventArgs e)
+    {
+        RunOnUiThread(() =>
+        {
+            ApplyPrimaryStatus(HasInternetAccess);
+            CurrentConnectionChipText = BuildCurrentConnectionChipText(IsEthernetConnected);
+            OnPropertyChanged(nameof(CurrentCulture));
+            OnPropertyChanged(nameof(VersionDisplay));
+            OnPropertyChanged(nameof(ConfigurationSourceText));
+            OnPropertyChanged(nameof(RefreshIntervalText));
+            OnPropertyChanged(nameof(WindowTitle));
+            OnPropertyChanged(nameof(AutoContinueText));
+            OnPropertyChanged(nameof(LastUpdatedText));
+            OnPropertyChanged(nameof(ProvisionedWifiProfileName));
+            OnPropertyChanged(nameof(ProvisionedWifiAuthenticationText));
+            OnPropertyChanged(nameof(ProvisionedWifiSourceHintText));
+            OnPropertyChanged(nameof(ProvisionedWifiStatusText));
+            OnPropertyChanged(nameof(ProvisionedWifiPlaceholderText));
+            OnPropertyChanged(nameof(WifiDiscoveryEmptyStateText));
+        });
+
+        _ = RefreshCoreAsync(_disposeCts.Token);
+    }
+
+    private void ApplyLocalizedDefaults()
+    {
+        PrimaryStatusTitle = GetString("Status.WaitingForNetworkTitle");
+        PrimaryStatusDescription = GetString("Status.WaitingForNetworkDescription");
+        EthernetStatusText = GetString("Ethernet.NoAdapterDetected");
+        EthernetAdapterName = GetString("Common.Unavailable");
+        EthernetIpAddress = GetString("Common.Unavailable");
+        EthernetGateway = GetString("Common.Unavailable");
+    }
+
     private async Task ApplyProvisionedSettingsAsync(CancellationToken cancellationToken)
     {
         if (_disposeCts.IsCancellationRequested)
@@ -802,7 +848,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         catch (Exception ex)
         {
             _logger.LogError(ex, "Provisioned settings initialization failed.");
-            await RunOnUiAsync(() => ProvisionedWifiActionFeedbackText = "Unable to apply the provisioned network settings.").ConfigureAwait(false);
+            await RunOnUiAsync(() => ProvisionedWifiActionFeedbackText = GetString("Wifi.ActionApplyProvisionedFailed")).ConfigureAwait(false);
         }
     }
 
@@ -858,7 +904,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         catch (Exception ex)
         {
             _logger.LogError(ex, "Provisioned network action failed.");
-            await RunOnUiAsync(() => ProvisionedWifiActionFeedbackText = "Unable to complete the provisioned Wi-Fi action. Try again.").ConfigureAwait(false);
+            await RunOnUiAsync(() => ProvisionedWifiActionFeedbackText = GetString("Wifi.ActionTryAgain")).ConfigureAwait(false);
         }
         finally
         {
@@ -916,7 +962,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         catch (Exception ex)
         {
             _logger.LogError(ex, "Selected Wi-Fi action failed.");
-            await RunOnUiAsync(() => SelectedWifiActionFeedbackText = "Unable to complete the Wi-Fi action. Try again.").ConfigureAwait(false);
+            await RunOnUiAsync(() => SelectedWifiActionFeedbackText = GetString("Wifi.ActionTryAgain")).ConfigureAwait(false);
         }
         finally
         {
@@ -928,7 +974,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         }
     }
 
-    private static string? BuildSelectedWifiConnectFeedback(string status)
+    private string? BuildSelectedWifiConnectFeedback(string status)
     {
         if (status.StartsWith("Wi-Fi connected to ", StringComparison.Ordinal))
         {
@@ -937,18 +983,18 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
         if (status.Contains("not supported in this build", StringComparison.OrdinalIgnoreCase))
         {
-            return "This Wi-Fi network is not supported in this build.";
+            return GetString("Wifi.ActionSelectedNotSupported");
         }
 
         if (status.Contains("No wireless adapter", StringComparison.OrdinalIgnoreCase))
         {
-            return "No wireless adapter is available.";
+            return GetString("Wifi.NoAdapterAvailable");
         }
 
-        return "Unable to connect. Check the password and try again.";
+        return GetString("Wifi.ActionConnectFailed");
     }
 
-    private static string? BuildProvisionedWifiConnectFeedback(string status)
+    private string? BuildProvisionedWifiConnectFeedback(string status)
     {
         if (status.Contains("Wi-Fi connected to ", StringComparison.Ordinal))
         {
@@ -957,19 +1003,19 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
         if (status.Contains("No wireless adapter", StringComparison.OrdinalIgnoreCase))
         {
-            return "No wireless adapter is available.";
+            return GetString("Wifi.NoAdapterAvailable");
         }
 
         if (status.Contains("not provisioned for this image", StringComparison.OrdinalIgnoreCase) ||
             status.Contains("No Wi-Fi profile is available", StringComparison.OrdinalIgnoreCase))
         {
-            return "The provisioned Wi-Fi profile is not available.";
+            return GetString("Wifi.ActionProvisionedProfileUnavailable");
         }
 
-        return "Unable to connect the provisioned Wi-Fi profile. Try again.";
+        return GetString("Wifi.ActionProvisionedConnectFailed");
     }
 
-    private static string? BuildProvisionedWifiDisconnectFeedback(string status)
+    private string? BuildProvisionedWifiDisconnectFeedback(string status)
     {
         if (status.StartsWith("Wi-Fi disconnected from ", StringComparison.Ordinal) ||
             status.StartsWith("Wi-Fi is already disconnected.", StringComparison.Ordinal))
@@ -979,10 +1025,10 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
         if (status.Contains("No wireless adapter", StringComparison.OrdinalIgnoreCase))
         {
-            return "No wireless adapter is available.";
+            return GetString("Wifi.NoAdapterAvailable");
         }
 
-        return "Unable to disconnect the provisioned Wi-Fi profile. Try again.";
+        return GetString("Wifi.ActionProvisionedDisconnectFailed");
     }
 
     private string? BuildProvisionedWifiInitializationFeedback(string status)
@@ -999,13 +1045,18 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             status.Contains("not supported", StringComparison.OrdinalIgnoreCase) ||
             status.Contains("No Wi-Fi profile", StringComparison.OrdinalIgnoreCase))
         {
-            return status;
+            if (status.Contains("No Wi-Fi profile", StringComparison.OrdinalIgnoreCase))
+            {
+                return GetString("Wifi.ActionProvisionedProfileUnavailable");
+            }
+
+            return GetString("Wifi.ActionApplyProvisionedFailed");
         }
 
         return null;
     }
 
-    private static string? BuildSelectedWifiDisconnectFeedback(string status)
+    private string? BuildSelectedWifiDisconnectFeedback(string status)
     {
         if (status.StartsWith("Wi-Fi disconnected from ", StringComparison.Ordinal) ||
             status.StartsWith("Wi-Fi is already disconnected.", StringComparison.Ordinal))
@@ -1015,10 +1066,10 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
         if (status.Contains("No wireless adapter", StringComparison.OrdinalIgnoreCase))
         {
-            return "No wireless adapter is available.";
+            return GetString("Wifi.NoAdapterAvailable");
         }
 
-        return "Unable to disconnect. Try again.";
+        return GetString("Wifi.ActionDisconnectFailed");
     }
 
     public sealed class WifiNetworkItemViewModel : ObservableObject
@@ -1110,14 +1161,14 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
     private string BuildWifiDiscoveryEmptyStateText()
     {
-        return BuildWifiUnavailableText() ?? "No Wi-Fi networks are currently visible.";
+        return BuildWifiUnavailableText() ?? GetString("Wifi.NoNetworksVisible");
     }
 
     private string BuildProvisionedWifiPlaceholderText()
     {
         if (!HasProvisionedWifiProfile)
         {
-            return "No provisioned profile is available in this boot image.";
+            return GetString("Wifi.NoProvisionedProfile");
         }
 
         return BuildWifiUnavailableText() ?? string.Empty;
@@ -1127,12 +1178,12 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     {
         if (!IsWifiRuntimeAvailable)
         {
-            return "Wi-Fi support is not available at runtime.";
+            return GetString("Wifi.UnavailableAtRuntime");
         }
 
         if (!HasWirelessAdapter)
         {
-            return "No wireless adapter is currently detected.";
+            return GetString("Wifi.NoAdapterDetected");
         }
 
         return null;
@@ -1142,7 +1193,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     {
         if (!HasProvisionedWifiProfile)
         {
-            return "Unavailable";
+            return GetString("Common.Unavailable");
         }
 
         if (_configuration.Wifi.HasEnterpriseProfile)
@@ -1162,11 +1213,11 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
                 _logger.LogDebug(ex, "Failed to resolve the provisioned Wi-Fi profile name.");
             }
 
-            return "Enterprise profile";
+            return GetString("Wifi.EnterpriseProfile");
         }
 
         return string.IsNullOrWhiteSpace(_configuration.Wifi.Ssid)
-            ? "Unnamed provisioned profile"
+            ? GetString("Wifi.UnnamedProvisionedProfile")
             : _configuration.Wifi.Ssid.Trim();
     }
 
@@ -1189,54 +1240,54 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     private string BuildProvisionedWifiSourceHintText()
     {
         string sourceText = _configuration.Wifi.HasEnterpriseProfile
-            ? "Enterprise profile"
-            : "Boot image settings";
+            ? GetString("Wifi.EnterpriseProfile")
+            : GetString("Wifi.BootImageSettings");
 
         if (_configuration.Wifi.RequiresCertificate || !string.IsNullOrWhiteSpace(_configuration.Wifi.CertificatePath))
         {
-            return $"{sourceText} · Certificate included";
+            return Format("Wifi.SourceWithCertificateFormat", sourceText);
         }
 
         return sourceText;
     }
 
-    private static string ResolveProvisionedPersonalSecurityDisplayText(string? securityType)
+    private string ResolveProvisionedPersonalSecurityDisplayText(string? securityType)
     {
         if (string.IsNullOrWhiteSpace(securityType))
         {
-            return "Configured profile";
+            return GetString("Wifi.ConfiguredProfile");
         }
 
         return securityType.Trim() switch
         {
             "OWE" => "OWE",
-            "WPA2/WPA3-Personal" => "WPA2/WPA3 Personal",
-            "WPA2-Personal" => "WPA2 Personal",
-            "WPA3-Personal" => "WPA3 Personal",
-            "Personal" => "Personal",
+            "WPA2/WPA3-Personal" => GetString("Wifi.SecurityWpa2Wpa3Personal"),
+            "WPA2-Personal" => GetString("Wifi.SecurityWpa2Personal"),
+            "WPA3-Personal" => GetString("Wifi.SecurityWpa3Personal"),
+            "Personal" => GetString("Wifi.SecurityPersonal"),
             _ => securityType.Trim()
         };
     }
 
-    private static string ResolveProvisionedEnterpriseSecurityDisplayText(
+    private string ResolveProvisionedEnterpriseSecurityDisplayText(
         string? securityType,
         NetworkAuthenticationMode authenticationMode)
     {
         string baseSecurityText = securityType?.Trim() switch
         {
-            "WPA3ENT" => "WPA3 Enterprise",
-            "WPA3ENT192" or "WPA3" => "WPA3 Enterprise 192-bit",
-            "WPA2/WPA3-Enterprise" => "WPA2/WPA3 Enterprise",
-            "WPA2-Enterprise" => "WPA2 Enterprise",
-            "WPA3-Enterprise" => "WPA3 Enterprise",
-            "Enterprise" => "Enterprise",
-            _ => "WPA2/WPA3 Enterprise"
+            "WPA3ENT" => GetString("Wifi.SecurityWpa3Enterprise"),
+            "WPA3ENT192" or "WPA3" => GetString("Wifi.SecurityWpa3Enterprise192"),
+            "WPA2/WPA3-Enterprise" => GetString("Wifi.SecurityWpa2Wpa3Enterprise"),
+            "WPA2-Enterprise" => GetString("Wifi.SecurityWpa2Enterprise"),
+            "WPA3-Enterprise" => GetString("Wifi.SecurityWpa3Enterprise"),
+            "Enterprise" => GetString("Wifi.SecurityEnterprise"),
+            _ => GetString("Wifi.SecurityWpa2Wpa3Enterprise")
         };
 
         return authenticationMode switch
         {
-            NetworkAuthenticationMode.MachineOnly => $"{baseSecurityText} (machine)",
-            NetworkAuthenticationMode.MachineOrUser => $"{baseSecurityText} (machine or user)",
+            NetworkAuthenticationMode.MachineOnly => Format("Wifi.SecurityMachineFormat", baseSecurityText),
+            NetworkAuthenticationMode.MachineOrUser => Format("Wifi.SecurityMachineOrUserFormat", baseSecurityText),
             _ => baseSecurityText
         };
     }
@@ -1250,32 +1301,37 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
         if (IsProvisionedWifiConnected)
         {
-            return "Connected";
+            return GetString("Common.Connected");
         }
 
         if (!IsWifiRuntimeAvailable)
         {
-            return "Wi-Fi unavailable";
+            return GetString("Wifi.StatusUnavailable");
         }
 
         if (!HasWirelessAdapter)
         {
-            return "No wireless adapter available";
+            return GetString("Wifi.StatusNoAdapter");
         }
 
         if (!string.IsNullOrWhiteSpace(_connectedWifiSsid))
         {
-            return "Another Wi-Fi network is active";
+            return GetString("Wifi.StatusAnotherNetworkActive");
         }
 
-        return "Ready to connect";
+        return GetString("Wifi.StatusReadyToConnect");
     }
 
     private string ResolveCurrentConnectionChipText(NetworkStatusSnapshot snapshot)
     {
-        if (snapshot.IsEthernetConnected)
+        return BuildCurrentConnectionChipText(snapshot.IsEthernetConnected);
+    }
+
+    private string BuildCurrentConnectionChipText(bool isEthernetConnected)
+    {
+        if (isEthernetConnected)
         {
-            return "Ethernet";
+            return GetString("Wifi.ConnectionChipEthernet");
         }
 
         if (string.IsNullOrWhiteSpace(_connectedWifiSsid))
@@ -1284,8 +1340,8 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         }
 
         return IsProvisionedWifiConnected
-            ? $"Provisioned Wi-Fi · {_connectedWifiSsid}"
-            : $"Wi-Fi · {_connectedWifiSsid}";
+            ? Format("Wifi.ConnectionChipProvisionedFormat", _connectedWifiSsid)
+            : Format("Wifi.ConnectionChipFormat", _connectedWifiSsid);
     }
 
     private bool IsProvisionedWifiConnection(string? ssid)
@@ -1305,7 +1361,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
         string profileName = ResolveProvisionedWifiProfileName();
         return !string.IsNullOrWhiteSpace(profileName) &&
-               !string.Equals(profileName, "Enterprise profile", StringComparison.OrdinalIgnoreCase) &&
+               !string.Equals(profileName, GetString("Wifi.EnterpriseProfile"), StringComparison.OrdinalIgnoreCase) &&
                string.Equals(trimmedSsid, profileName, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -1346,5 +1402,15 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         Owe,
         Personal,
         Enterprise
+    }
+
+    private string GetString(string key)
+    {
+        return Strings[key];
+    }
+
+    private string Format(string key, params object[] args)
+    {
+        return string.Format(LocalizationService.CurrentCulture, GetString(key), args);
     }
 }

--- a/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
@@ -589,6 +589,8 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
                 }
 
                 wifiNetwork.Update(
+                    network.Ssid == "Hidden network" ? GetString("Wifi.HiddenNetwork") : network.Ssid,
+                    TranslateDiscoveredWifiSecurity(network.Authentication),
                     network.SsidHex,
                     network.Authentication,
                     network.Encryption,
@@ -1074,7 +1076,9 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
 
     public sealed class WifiNetworkItemViewModel : ObservableObject
     {
+        private string _displaySsid = string.Empty;
         private string _authentication = string.Empty;
+        private string _displayAuthentication = string.Empty;
         private string? _ssidHex;
         private string _encryption = string.Empty;
         private int _signalStrengthPercent;
@@ -1090,6 +1094,12 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
 
         public string Ssid { get; }
 
+        public string DisplaySsid
+        {
+            get => _displaySsid;
+            private set => SetProperty(ref _displaySsid, value);
+        }
+
         public string? SsidHex
         {
             get => _ssidHex;
@@ -1100,6 +1110,12 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         {
             get => _authentication;
             private set => SetProperty(ref _authentication, value);
+        }
+
+        public string DisplayAuthentication
+        {
+            get => _displayAuthentication;
+            private set => SetProperty(ref _displayAuthentication, value);
         }
 
         public string Encryption
@@ -1139,6 +1155,8 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         }
 
         public void Update(
+            string displaySsid,
+            string displayAuthentication,
             string? ssidHex,
             string authentication,
             string encryption,
@@ -1148,6 +1166,8 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
             bool requiresPassphrase,
             bool isConnected)
         {
+            DisplaySsid = displaySsid;
+            DisplayAuthentication = displayAuthentication;
             SsidHex = ssidHex;
             Authentication = authentication;
             Encryption = encryption;
@@ -1249,6 +1269,25 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         }
 
         return sourceText;
+    }
+
+    private string TranslateDiscoveredWifiSecurity(string authentication)
+    {
+        return authentication switch
+        {
+            "Open" => GetString("Wifi.SecurityOpen"),
+            "WEP" => GetString("Wifi.SecurityWep"),
+            "WPA-Personal" => GetString("Wifi.SecurityWpaPersonal"),
+            "WPA-None" => GetString("Wifi.SecurityWpaNone"),
+            "WPA2-Personal" => GetString("Wifi.SecurityWpa2Personal"),
+            "WPA3-Personal" => GetString("Wifi.SecurityWpa3Personal"),
+            "WPA-Enterprise" => GetString("Wifi.SecurityWpaEnterprise"),
+            "WPA2-Enterprise" => GetString("Wifi.SecurityWpa2Enterprise"),
+            "WPA3-Enterprise" => GetString("Wifi.SecurityWpa3Enterprise"),
+            "Vendor-specific" => GetString("Wifi.SecurityVendorSpecific"),
+            "OWE" => "OWE",
+            _ => authentication
+        };
     }
 
     private string ResolveProvisionedPersonalSecurityDisplayText(string? securityType)

--- a/src/Foundry.Connect/Views/EthernetOnlyView.xaml
+++ b/src/Foundry.Connect/Views/EthernetOnlyView.xaml
@@ -21,7 +21,7 @@
                     Text="{Binding EthernetGlyph}" />
 
                 <StackPanel Grid.Column="1">
-                    <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="Ethernet" />
+                    <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="{Binding Strings[Ethernet.Title]}" />
                     <TextBlock
                         Margin="0,8,0,0"
                         Style="{StaticResource BodyTextBlockStyle}"
@@ -45,7 +45,7 @@
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
 
-                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Adapter" />
+                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Ethernet.AdapterLabel]}" />
                         <TextBlock
                             Grid.Column="1"
                             Margin="8,0,0,0"
@@ -55,7 +55,7 @@
                         <TextBlock
                             Grid.Row="1"
                             Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="IPv4" />
+                            Text="{Binding Strings[Ethernet.Ipv4Label]}" />
                         <TextBlock
                             Grid.Row="1"
                             Grid.Column="1"
@@ -66,7 +66,7 @@
                         <TextBlock
                             Grid.Row="2"
                             Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="Gateway" />
+                            Text="{Binding Strings[Ethernet.GatewayLabel]}" />
                         <TextBlock
                             Grid.Row="2"
                             Grid.Column="1"

--- a/src/Foundry.Connect/Views/EthernetWifiView.xaml
+++ b/src/Foundry.Connect/Views/EthernetWifiView.xaml
@@ -41,6 +41,13 @@
                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                 Style="{StaticResource CaptionTextBlockStyle}"
                                 Text="{Binding Authentication}" />
+                            <TextBlock
+                                x:Name="WifiConnectedTextBlock"
+                                Margin="0,2,0,0"
+                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Text="{Binding DataContext.Strings[Common.Connected], RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                Visibility="Collapsed" />
                         </StackPanel>
 
                         <TextBlock
@@ -140,7 +147,7 @@
                                 Width="140"
                                 HorizontalAlignment="Right"
                                 Command="{Binding DataContext.ConnectSelectedWifiCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                Content="Connect"
+                                Content="{Binding DataContext.Strings[Action.Connect], RelativeSource={RelativeSource AncestorType=UserControl}}"
                                 IsEnabled="{Binding DataContext.CanConnectSelectedWifi, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                 Style="{DynamicResource AccentButtonStyle}" />
                         </Grid>
@@ -176,7 +183,7 @@
                                 Width="140"
                                 HorizontalAlignment="Right"
                                 Command="{Binding DataContext.DisconnectSelectedWifiCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                Content="Disconnect"
+                                Content="{Binding DataContext.Strings[Action.Disconnect], RelativeSource={RelativeSource AncestorType=UserControl}}"
                                 IsEnabled="{Binding DataContext.CanDisconnectSelectedWifi, RelativeSource={RelativeSource AncestorType=UserControl}}" />
                         </Grid>
                     </Grid>
@@ -187,7 +194,7 @@
                         Margin="0,12,0,0"
                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="Provisioned profile required in this build."
+                        Text="{Binding DataContext.Strings[Wifi.ProvisionedProfileRequired], RelativeSource={RelativeSource AncestorType=UserControl}}"
                         TextWrapping="Wrap"
                         Visibility="Collapsed" />
                 </Grid>
@@ -227,7 +234,8 @@
                     <Setter TargetName="PassphraseRow" Property="Visibility" Value="Collapsed" />
                     <Setter TargetName="ConnectButtonRow" Property="Visibility" Value="Collapsed" />
                     <Setter TargetName="DisconnectButtonRow" Property="Visibility" Value="Visible" />
-                    <Setter TargetName="WifiAuthenticationTextBlock" Property="Text" Value="Connected" />
+                    <Setter TargetName="WifiAuthenticationTextBlock" Property="Visibility" Value="Collapsed" />
+                    <Setter TargetName="WifiConnectedTextBlock" Property="Visibility" Value="Visible" />
                 </DataTrigger>
             </DataTemplate.Triggers>
         </DataTemplate>
@@ -261,7 +269,7 @@
                         Text="{Binding EthernetGlyph}" />
 
                     <StackPanel Grid.Column="1">
-                        <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="Ethernet" />
+                        <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="{Binding Strings[Ethernet.Title]}" />
                         <TextBlock
                             Margin="0,8,0,0"
                             Style="{StaticResource BodyTextBlockStyle}"
@@ -285,7 +293,7 @@
                                 <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
 
-                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Adapter" />
+                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Ethernet.AdapterLabel]}" />
                             <TextBlock
                                 Grid.Column="1"
                                 Margin="8,0,0,0"
@@ -295,7 +303,7 @@
                             <TextBlock
                                 Grid.Row="1"
                                 Style="{StaticResource BodyStrongTextBlockStyle}"
-                                Text="IPv4" />
+                                Text="{Binding Strings[Ethernet.Ipv4Label]}" />
                             <TextBlock
                                 Grid.Row="1"
                                 Grid.Column="1"
@@ -306,7 +314,7 @@
                             <TextBlock
                                 Grid.Row="2"
                                 Style="{StaticResource BodyStrongTextBlockStyle}"
-                                Text="Gateway" />
+                                Text="{Binding Strings[Ethernet.GatewayLabel]}" />
                             <TextBlock
                                 Grid.Row="2"
                                 Grid.Column="1"
@@ -344,7 +352,7 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
-                        <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="Provisioned Wi-Fi" />
+                        <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="{Binding Strings[Wifi.ProvisionedTitle]}" />
 
                         <Grid Grid.Column="1" Visibility="{Binding ShowProvisionedWifiContent, Converter={StaticResource BooleanToVisibilityConverter}}">
                             <Grid x:Name="ProvisionedHeaderConnectButtonRow" HorizontalAlignment="Right">
@@ -363,7 +371,7 @@
                                     Width="140"
                                     HorizontalAlignment="Right"
                                     Command="{Binding ConnectConfiguredWifiCommand}"
-                                    Content="Connect"
+                                    Content="{Binding Strings[Action.Connect]}"
                                     IsEnabled="{Binding CanConnectConfiguredWifi}"
                                     Style="{DynamicResource AccentButtonStyle}" />
                             </Grid>
@@ -384,7 +392,7 @@
                                     Width="140"
                                     HorizontalAlignment="Right"
                                     Command="{Binding DisconnectConfiguredWifiCommand}"
-                                    Content="Disconnect"
+                                    Content="{Binding Strings[Action.Disconnect]}"
                                     IsEnabled="{Binding CanDisconnectConfiguredWifi}" />
                             </Grid>
                         </Grid>
@@ -411,7 +419,7 @@
                                     <RowDefinition Height="Auto" />
                                 </Grid.RowDefinitions>
 
-                                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Profile" />
+                                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Wifi.ProfileLabel]}" />
                                 <TextBlock
                                     Grid.Column="1"
                                     Margin="8,0,0,0"
@@ -422,7 +430,7 @@
                                 <TextBlock
                                     Grid.Row="1"
                                     Style="{StaticResource BodyStrongTextBlockStyle}"
-                                    Text="Authentication" />
+                                    Text="{Binding Strings[Wifi.AuthenticationLabel]}" />
                                 <TextBlock
                                     Grid.Row="1"
                                     Grid.Column="1"
@@ -502,7 +510,7 @@
                     <TextBlock
                         Grid.Column="1"
                         Style="{StaticResource SubtitleTextBlockStyle}"
-                        Text="Wi-Fi" />
+                        Text="{Binding Strings[Wifi.Title]}" />
 
                     <Button
                         Grid.Column="2"

--- a/src/Foundry.Connect/Views/EthernetWifiView.xaml
+++ b/src/Foundry.Connect/Views/EthernetWifiView.xaml
@@ -34,13 +34,13 @@
                             Text="{Binding SignalGlyph}" />
 
                         <StackPanel Grid.Column="1">
-                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Ssid}" />
+                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DisplaySsid}" />
                             <TextBlock
                                 x:Name="WifiAuthenticationTextBlock"
                                 Margin="0,2,0,0"
                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                 Style="{StaticResource CaptionTextBlockStyle}"
-                                Text="{Binding Authentication}" />
+                                Text="{Binding DisplayAuthentication}" />
                             <TextBlock
                                 x:Name="WifiConnectedTextBlock"
                                 Margin="0,2,0,0"


### PR DESCRIPTION
## Summary
Add Foundry-style localization infrastructure to Foundry.Connect and migrate the user-facing UI text onto resource-backed strings.

## Why
Foundry.Connect had no localization layer, no resource files, and a large amount of hardcoded user-facing text in XAML and view-model status handling.

## Changes
- add `ILocalizationService`, `LocalizationService`, `StringsWrapper`, and a localized base view model to `src/Foundry.Connect`
- add `AppStrings.resx` and `AppStrings.fr-FR.resx` for Foundry.Connect
- register localization in DI and route about-dialog content through resources
- localize the main window, Ethernet/Wi-Fi views, and the main view-model display/status/feedback logic
- localize Ethernet status text emitted by `NetworkStatusService`

## Testing
- `dotnet build src/Foundry.Connect/Foundry.Connect.csproj`

## Notes
- scope is limited to `src/Foundry.Connect`
- internal bootstrap status parsing remains localized at the UI layer to keep the service contract stable in this first pass
