### PR TITLE
feat(localization): localize Foundry.Deploy UI

### DIFF
--- a/src/Foundry.Deploy/Converters/OperatingSystemDisplayFormatter.cs
+++ b/src/Foundry.Deploy/Converters/OperatingSystemDisplayFormatter.cs
@@ -11,7 +11,7 @@ internal static class OperatingSystemDisplayFormatter
         }
 
         return int.TryParse(normalized, out _)
-            ? $"Windows {normalized}"
+            ? $"{Foundry.Deploy.Services.Localization.LocalizationText.GetString("OperatingSystem.Windows")} {normalized}"
             : normalized;
     }
 
@@ -19,8 +19,8 @@ internal static class OperatingSystemDisplayFormatter
     {
         return channel.Trim().ToUpperInvariant() switch
         {
-            "RET" => "Retail",
-            "VOL" => "Volume",
+            "RET" => Foundry.Deploy.Services.Localization.LocalizationText.GetString("OperatingSystem.Retail"),
+            "VOL" => Foundry.Deploy.Services.Localization.LocalizationText.GetString("OperatingSystem.Volume"),
             _ => channel
         };
     }
@@ -29,8 +29,8 @@ internal static class OperatingSystemDisplayFormatter
     {
         return edition.Trim().ToUpperInvariant() switch
         {
-            "PRO" => "Professional",
-            "PRO N" => "Professional N",
+            "PRO" => Foundry.Deploy.Services.Localization.LocalizationText.GetString("OperatingSystem.Professional"),
+            "PRO N" => Foundry.Deploy.Services.Localization.LocalizationText.GetString("OperatingSystem.ProfessionalN"),
             _ => edition
         };
     }

--- a/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using Foundry.Deploy.Services.Download;
 using Foundry.Deploy.Services.DriverPacks;
 using Foundry.Deploy.Services.Hardware;
 using Foundry.Deploy.Services.Logging;
+using Foundry.Deploy.Services.Localization;
 using Foundry.Deploy.Services.Operations;
 using Foundry.Deploy.Services.Runtime;
 using Foundry.Deploy.Services.Startup;
@@ -28,6 +29,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<MainWindow>();
         services.AddSingleton<MainWindowViewModel>();
 
+        services.AddSingleton<ILocalizationService, LocalizationService>();
         services.AddSingleton<IThemeService, ThemeService>();
         services.AddSingleton<IApplicationShellService, ApplicationShellService>();
         services.AddSingleton<IDeploymentWizardStateService, DeploymentWizardStateService>();

--- a/src/Foundry.Deploy/MainWindow.xaml
+++ b/src/Foundry.Deploy/MainWindow.xaml
@@ -1,4 +1,5 @@
 <Window
+    x:Name="RootWindow"
     x:Class="Foundry.Deploy.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -6,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:rules="clr-namespace:Foundry.Deploy.Validation"
-    Title="Foundry.Deploy"
+    Title="{Binding WindowTitle}"
     Icon="/Assets/Icons/app.ico"
     ResizeMode="NoResize"
     WindowState="Maximized"
@@ -29,22 +30,26 @@
 
             <Menu Grid.Column="0">
                 <!--  Theme  -->
-                <MenuItem Header="_Theme">
-                    <MenuItem Command="{Binding SetSystemThemeCommand}" Header="System" />
-                    <MenuItem Command="{Binding SetLightThemeCommand}" Header="Light" />
-                    <MenuItem Command="{Binding SetDarkThemeCommand}" Header="Dark" />
+                <MenuItem Header="{Binding Strings[Menu.Theme]}">
+                    <MenuItem Command="{Binding SetSystemThemeCommand}" Header="{Binding Strings[Theme.System]}" />
+                    <MenuItem Command="{Binding SetLightThemeCommand}" Header="{Binding Strings[Theme.Light]}" />
+                    <MenuItem Command="{Binding SetDarkThemeCommand}" Header="{Binding Strings[Theme.Dark]}" />
+                </MenuItem>
+                <MenuItem Header="{Binding Strings[Menu.Language]}">
+                    <MenuItem Command="{Binding SetCultureCommand}" CommandParameter="en-US" Header="{Binding Strings[Language.English]}" />
+                    <MenuItem Command="{Binding SetCultureCommand}" CommandParameter="fr-FR" Header="{Binding Strings[Language.French]}" />
                 </MenuItem>
                 <!--  Tools  -->
-                <MenuItem Header="_Tools">
-                    <MenuItem Command="{Binding RefreshCatalogsCommand}" Header="Refresh Catalogs" />
+                <MenuItem Header="{Binding Strings[Menu.Tools]}">
+                    <MenuItem Command="{Binding RefreshCatalogsCommand}" Header="{Binding Strings[Tools.RefreshCatalogs]}" />
                     <MenuItem
                         Command="{Binding Preparation.RefreshTargetDisksCommand}"
-                        Header="Refresh Target Disks"
+                        Header="{Binding Strings[Tools.RefreshTargetDisks]}"
                         IsEnabled="{Binding Session.IsStartupReady}" />
-                    <MenuItem Command="{Binding Session.OpenLogFileCommand}" Header="Open Log File" />
+                    <MenuItem Command="{Binding Session.OpenLogFileCommand}" Header="{Binding Strings[Common.OpenLogFile]}" />
                 </MenuItem>
                 <!--  About  -->
-                <MenuItem Command="{Binding ShowAboutCommand}" Header="_About" />
+                <MenuItem Command="{Binding ShowAboutCommand}" Header="{Binding Strings[Menu.About]}" />
             </Menu>
 
             <TextBlock
@@ -68,7 +73,7 @@
 
                 <!--  Wizard header and context  -->
                 <StackPanel Grid.Row="0" Margin="0,0,0,16">
-                    <TextBlock Style="{StaticResource TitleLargeTextBlockStyle}" Text="Foundry.Deploy Wizard" />
+                    <TextBlock Style="{StaticResource TitleLargeTextBlockStyle}" Text="{Binding Strings[Wizard.Title]}" />
                     <Border
                         Margin="0,8,0,0"
                         Padding="8"
@@ -77,13 +82,13 @@
                         BorderThickness="1"
                         CornerRadius="4"
                         Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="DEBUG SAFE MODE ACTIVE: all deployment actions are simulated, no disk/image write is executed." />
+                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Wizard.DebugSafeModeBanner]}" />
                     </Border>
                     <TextBlock
                         Margin="0,8,0,0"
                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="Task-sequence orchestrator for OS deployment in WinPE." />
+                        Text="{Binding Strings[Wizard.Description]}" />
                     <TextBlock
                         Margin="0,8,0,0"
                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
@@ -97,7 +102,7 @@
                     PreviewMouseDown="WizardTabControl_PreviewMouseDown"
                     SelectedIndex="{Binding WizardStepIndex}">
                     <!--  Step 1: Target disk and runtime options  -->
-                    <TabItem Header="1. Target">
+                    <TabItem Header="{Binding Strings[Wizard.StepTarget]}">
                         <Grid Margin="16">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
@@ -106,7 +111,7 @@
                             <!--  Step 1 details and toggles  -->
                             <StackPanel Grid.Row="0">
                                 <StackPanel DataContext="{Binding Preparation}">
-                                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Computer Name" />
+                                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.ComputerName], ElementName=RootWindow}" />
                                     <TextBox
                                         x:Name="TargetComputerNameTextBox"
                                         Margin="0,8,0,0"
@@ -118,7 +123,7 @@
                                         Margin="0,8,0,0"
                                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                         Style="{StaticResource CaptionTextBlockStyle}"
-                                        Text="1-15 characters. A-Z, a-z, 0-9, and hyphen only." />
+                                        Text="{Binding DataContext.Strings[Preparation.ComputerNameHint], ElementName=RootWindow}" />
                                     <TextBlock
                                         Margin="0,4,0,0"
                                         Foreground="#FFC42B1C"
@@ -128,7 +133,7 @@
                                     <TextBlock
                                         Margin="0,12,0,0"
                                         Style="{StaticResource BodyStrongTextBlockStyle}"
-                                        Text="Target Disk" />
+                                        Text="{Binding DataContext.Strings[Preparation.TargetDisk], ElementName=RootWindow}" />
                                     <DockPanel Margin="0,8,0,0">
                                         <ComboBox
                                             Width="640"
@@ -139,26 +144,26 @@
                                             Width="140"
                                             Margin="8,0,0,0"
                                             Command="{Binding RefreshTargetDisksCommand}"
-                                            Content="Refresh Disks" />
+                                            Content="{Binding DataContext.Strings[Preparation.RefreshDisks], ElementName=RootWindow}" />
                                     </DockPanel>
                                     <TextBlock
                                         Margin="0,8,0,0"
                                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                         Style="{StaticResource CaptionTextBlockStyle}"
-                                        Text="{Binding SelectedTargetDisk.SelectionWarning, TargetNullValue=Select a target disk. Non-eligible disks are blocked.}" />
+                                        Text="{Binding TargetDiskSelectionHint}" />
                                     <CheckBox
                                         Margin="0,8,0,0"
                                         IsChecked="{Binding ApplyFirmwareUpdates}"
                                         IsEnabled="{Binding IsFirmwareUpdatesOptionEnabled}">
-                                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="Firmware: Microsoft Update Catalog update enabled." />
+                                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.FirmwareUpdates], ElementName=RootWindow}" />
                                     </CheckBox>
                                     <CheckBox Margin="0,8,0,0" IsChecked="{Binding IsAutopilotEnabled}">
-                                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="Autopilot: Enable offline profile staging." />
+                                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.AutopilotEnable], ElementName=RootWindow}" />
                                     </CheckBox>
                                     <TextBlock
                                         Margin="0,12,0,0"
                                         Style="{StaticResource BodyStrongTextBlockStyle}"
-                                        Text="Autopilot Profile" />
+                                        Text="{Binding DataContext.Strings[Preparation.AutopilotProfile], ElementName=RootWindow}" />
                                     <ComboBox
                                         Margin="0,8,0,0"
                                         DisplayMemberPath="DisplayName"
@@ -176,7 +181,7 @@
                     </TabItem>
 
                     <!--  Step 2: Operating system catalog filters  -->
-                    <TabItem Header="2. Operating System Catalog">
+                    <TabItem Header="{Binding Strings[Wizard.StepOperatingSystemCatalog]}">
                         <Grid Margin="16">
                             <StackPanel Margin="0,0,0,12">
                                 <DockPanel Margin="0,0,0,12">
@@ -184,12 +189,12 @@
                                     <Button
                                         Width="140"
                                         Command="{Binding RefreshCatalogsCommand}"
-                                        Content="Refresh Catalogs" />
+                                        Content="{Binding Strings[Tools.RefreshCatalogs]}" />
                                     <TextBlock
                                         Margin="12,0,0,0"
                                         VerticalAlignment="Center"
                                         Style="{StaticResource BodyStrongTextBlockStyle}"
-                                        Text="{Binding OperatingSystemCatalog.EffectiveOsArchitecture, StringFormat=Architecture: {0}}" />
+                                        Text="{Binding OperatingSystemArchitectureDisplay}" />
                                 </DockPanel>
 
                                 <Grid>
@@ -205,16 +210,16 @@
 
                                     <!--  OS family  -->
                                     <StackPanel Margin="0,0,8,8">
-                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Operating System" />
+                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.OperatingSystem]}" />
                                         <TextBox
                                             Margin="0,8,0,0"
                                             IsReadOnly="True"
-                                            Text="Windows 11" />
+                                            Text="{Binding Strings[OperatingSystem.Windows11]}" />
                                     </StackPanel>
 
                                     <!--  Release identifier  -->
                                     <StackPanel Grid.Column="1" Margin="8,0,0,8">
-                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Version" />
+                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.Version]}" />
                                         <ComboBox
                                             Margin="0,8,0,0"
                                             ItemsSource="{Binding OperatingSystemCatalog.ReleaseIdFilters}"
@@ -223,7 +228,7 @@
 
                                     <!--  Language and licensing  -->
                                     <StackPanel Grid.Row="1" Margin="0,0,8,0">
-                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Language" />
+                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.Language]}" />
                                         <ComboBox
                                             Margin="0,8,0,0"
                                             IsEnabled="{Binding OperatingSystemCatalog.IsLanguageSelectionEnabled}"
@@ -235,7 +240,7 @@
                                         Grid.Row="1"
                                         Grid.Column="1"
                                         Margin="8,0,0,0">
-                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="License Channel" />
+                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.LicenseChannel]}" />
                                         <ComboBox
                                             Margin="0,8,0,0"
                                             ItemsSource="{Binding OperatingSystemCatalog.LicenseChannelFilters}"
@@ -253,7 +258,7 @@
                                         Grid.Row="2"
                                         Grid.ColumnSpan="2"
                                         Margin="0,8,0,0">
-                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Edition (Target)" />
+                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.EditionTarget]}" />
                                         <ComboBox
                                             Margin="0,8,0,0"
                                             ItemsSource="{Binding OperatingSystemCatalog.EditionFilters}"
@@ -271,7 +276,7 @@
                     </TabItem>
 
                     <!--  Step 3: Driver pack selection  -->
-                    <TabItem Header="3. Driver Pack">
+                    <TabItem Header="{Binding Strings[Wizard.StepDriverPack]}">
                         <Grid Margin="16">
                             <StackPanel Margin="0,0,0,12">
                                 <DockPanel Margin="0,0,0,12">
@@ -279,16 +284,16 @@
                                     <Button
                                         Width="140"
                                         Command="{Binding RefreshCatalogsCommand}"
-                                        Content="Refresh Catalogs" />
+                                        Content="{Binding Strings[Tools.RefreshCatalogs]}" />
                                     <TextBlock
                                         Margin="12,0,0,0"
                                         VerticalAlignment="Center"
                                         Style="{StaticResource BodyStrongTextBlockStyle}"
-                                        Text="{Binding EffectiveOsArchitecture, StringFormat=Architecture: {0}}" />
+                                        Text="{Binding DriverPackArchitectureDisplay}" />
                                 </DockPanel>
 
                                 <StackPanel DataContext="{Binding DriverPackSelection}">
-                                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Driver Source" />
+                                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[DriverPack.Source]}" />
                                     <ComboBox
                                         Margin="0,8,0,0"
                                         DisplayMemberPath="DisplayName"
@@ -303,7 +308,7 @@
                                         </Grid.ColumnDefinitions>
 
                                         <StackPanel Grid.Column="0">
-                                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Model" />
+                                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[DriverPack.Model], ElementName=RootWindow}" />
                                             <ComboBox
                                                 Margin="0,8,0,0"
                                                 IsEnabled="{Binding IsDriverPackModelSelectionEnabled}"
@@ -312,7 +317,7 @@
                                         </StackPanel>
 
                                         <StackPanel Grid.Column="2">
-                                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Version" />
+                                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[DriverPack.Version], ElementName=RootWindow}" />
                                             <ComboBox
                                                 Margin="0,8,0,0"
                                                 IsEnabled="{Binding IsDriverPackVersionSelectionEnabled}"
@@ -324,50 +329,50 @@
                                         Margin="0,8,0,0"
                                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                         Style="{StaticResource CaptionTextBlockStyle}"
-                                        Text="{Binding DriverPackModeDisplay, StringFormat=Selected mode: {0}}" />
+                                        Text="{Binding DriverPackModeDisplayText}" />
                                 </StackPanel>
                             </StackPanel>
                         </Grid>
                     </TabItem>
 
                     <!--  Step 4: Deployment summary before execution  -->
-                    <TabItem Header="4. Summary">
+                    <TabItem Header="{Binding Strings[Wizard.StepSummary]}">
                         <StackPanel Margin="16">
                             <TextBlock
                                 Margin="0,0,0,12"
                                 Style="{StaticResource TitleTextBlockStyle}"
-                                Text="Deployment Summary" />
+                                Text="{Binding Strings[Summary.Title]}" />
 
-                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Target Disk" />
-                            <TextBlock Margin="0,0,0,8" Text="{Binding Preparation.SelectedTargetDisk.DisplayLabel, TargetNullValue=No disk selected}" />
+                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.TargetDisk]}" />
+                            <TextBlock Margin="0,0,0,8" Text="{Binding SummaryTargetDiskText}" />
 
-                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Selected Operating System" />
-                            <TextBlock Margin="0,0,0,8" Text="{Binding SelectedOperatingSystem, Converter={StaticResource OperatingSystemSummaryConverter}, TargetNullValue=No selection}" />
+                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.SelectedOperatingSystem]}" />
+                            <TextBlock Margin="0,0,0,8" Text="{Binding SummaryOperatingSystemText}" />
 
-                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Selected Driver Pack" />
-                            <TextBlock Margin="0,0,0,8" Text="{Binding DriverPackSelection.SelectedDriverPackSelectionDisplay, TargetNullValue=None}" />
+                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.SelectedDriverPack]}" />
+                            <TextBlock Margin="0,0,0,8" Text="{Binding DriverPackSelection.SelectedDriverPackSelectionDisplay}" />
 
-                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Driver Pack Mode" />
+                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.DriverPackMode]}" />
                             <TextBlock Margin="0,0,0,8" Text="{Binding DriverPackSelection.DriverPackModeDisplay}" />
 
-                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Firmware" />
-                            <TextBlock Margin="0,0,0,8" Text="{Binding Preparation.ApplyFirmwareUpdates, StringFormat=Firmware updates enabled: {0}}" />
+                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.Firmware]}" />
+                            <TextBlock Margin="0,0,0,8" Text="{Binding SummaryFirmwareText}" />
 
-                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Autopilot" />
-                            <TextBlock Margin="0,0,0,4" Text="{Binding Preparation.IsAutopilotEnabled, StringFormat=Enabled: {0}}" />
-                            <TextBlock Margin="0,0,0,8" Text="{Binding Preparation.SelectedAutopilotProfile.DisplayName, StringFormat=Selected profile: {0}, TargetNullValue=Selected profile: none}" />
+                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.Autopilot]}" />
+                            <TextBlock Margin="0,0,0,4" Text="{Binding SummaryAutopilotEnabledText}" />
+                            <TextBlock Margin="0,0,0,8" Text="{Binding SummaryAutopilotProfileText}" />
 
                             <!--  Execution notes and mode hints  -->
                             <TextBlock
                                 Margin="0,8,0,0"
                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                 Style="{StaticResource CaptionTextBlockStyle}"
-                                Text="Start launches the deployment task sequence orchestrator with real WinPE actions (diskpart, DISM, BCDBoot, driver injection, offline Autopilot profile staging)." />
+                                Text="{Binding Strings[Summary.StartExplanation]}" />
                             <TextBlock
                                 Margin="0,4,0,0"
                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                 Style="{StaticResource CaptionTextBlockStyle}"
-                                Text="Debug Safe Mode: task sequence runs in dry-run simulation."
+                                Text="{Binding Strings[Summary.DebugSafeModeExplanation]}"
                                 Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         </StackPanel>
                     </TabItem>
@@ -389,16 +394,16 @@
                             Width="140"
                             Margin="0,0,8,0"
                             Command="{Binding ShowDebugProgressPageCommand}"
-                            Content="Debug: Progress" />
+                            Content="{Binding Strings[Debug.ProgressButton]}" />
                         <Button
                             Width="140"
                             Margin="0,0,8,0"
                             Command="{Binding ShowDebugSuccessPageCommand}"
-                            Content="Debug: Success" />
+                            Content="{Binding Strings[Debug.SuccessButton]}" />
                         <Button
                             Width="140"
                             Command="{Binding ShowDebugErrorPageCommand}"
-                            Content="Debug: Error" />
+                            Content="{Binding Strings[Debug.ErrorButton]}" />
                     </StackPanel>
 
                     <StackPanel
@@ -409,16 +414,16 @@
                             Width="120"
                             Margin="0,0,8,0"
                             Command="{Binding PreviousWizardStepCommand}"
-                            Content="Previous" />
+                            Content="{Binding Strings[Common.Previous]}" />
                         <Button
                             Width="120"
                             Margin="0,0,8,0"
                             Command="{Binding NextWizardStepCommand}"
-                            Content="Next" />
+                            Content="{Binding Strings[Common.Next]}" />
                         <Button
                             Width="160"
                             Command="{Binding StartDeploymentCommand}"
-                            Content="Start Deployment"
+                            Content="{Binding Strings[Common.StartDeployment]}"
                             Style="{DynamicResource AccentButtonStyle}" />
                     </StackPanel>
                 </Grid>
@@ -451,7 +456,7 @@
                             Margin="0,0,0,4"
                             Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
                             Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="Networking" />
+                            Text="{Binding DataContext.Strings[Progress.Networking], ElementName=RootWindow}" />
                         <TextBlock
                             Margin="0,0,0,2"
                             Style="{StaticResource BodyTextBlockStyle}"
@@ -474,7 +479,7 @@
                             Margin="0,0,0,4"
                             Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
                             Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="Start time" />
+                            Text="{Binding DataContext.Strings[Progress.StartTime], ElementName=RootWindow}" />
                         <TextBlock
                             Margin="0,0,0,20"
                             Style="{StaticResource BodyTextBlockStyle}"
@@ -485,7 +490,7 @@
                             Margin="0,0,0,4"
                             Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
                             Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="Elapsed time" />
+                            Text="{Binding DataContext.Strings[Progress.ElapsedTime], ElementName=RootWindow}" />
                         <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding ElapsedTimeText}" />
                     </StackPanel>
 
@@ -556,7 +561,7 @@
                         Width="140"
                         HorizontalAlignment="Right"
                         Command="{Binding OpenLogFileCommand}"
-                        Content="Open Log File" />
+                        Content="{Binding DataContext.Strings[Common.OpenLogFile], ElementName=RootWindow}" />
                 </Grid>
             </Grid>
 
@@ -583,7 +588,7 @@
                             Margin="0,0,0,4"
                             Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
                             Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="Networking" />
+                            Text="{Binding DataContext.Strings[Progress.Networking], ElementName=RootWindow}" />
                         <TextBlock
                             Margin="0,0,0,2"
                             Style="{StaticResource BodyTextBlockStyle}"
@@ -606,7 +611,7 @@
                             Margin="0,0,0,4"
                             Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
                             Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="Start time" />
+                            Text="{Binding DataContext.Strings[Progress.StartTime], ElementName=RootWindow}" />
                         <TextBlock
                             Margin="0,0,0,20"
                             Style="{StaticResource BodyTextBlockStyle}"
@@ -617,7 +622,7 @@
                             Margin="0,0,0,4"
                             Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
                             Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="Elapsed time" />
+                            Text="{Binding DataContext.Strings[Progress.ElapsedTime], ElementName=RootWindow}" />
                         <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding ElapsedTimeText}" />
                     </StackPanel>
 
@@ -625,21 +630,21 @@
                         <TextBlock
                             HorizontalAlignment="Center"
                             Style="{StaticResource TitleTextBlockStyle}"
-                            Text="Deployment completed successfully."
+                            Text="{Binding DataContext.Strings[Success.Completed], ElementName=RootWindow}"
                             TextAlignment="Center" />
                         <TextBlock
                             Margin="0,16,0,24"
                             HorizontalAlignment="Center"
                             Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                             Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding RebootCountdownSeconds, StringFormat=This computer will reboot in {0} seconds...}"
+                            Text="{Binding RebootCountdownText}"
                             TextAlignment="Center" />
                         <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
                             <Button
                                 Width="140"
                                 Margin="0,0,8,0"
                                 Command="{Binding RebootNowCommand}"
-                                Content="Reboot now" />
+                                Content="{Binding DataContext.Strings[Success.RebootNow], ElementName=RootWindow}" />
                         </StackPanel>
                     </StackPanel>
                 </Grid>
@@ -668,7 +673,7 @@
                             Margin="0,0,0,4"
                             Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
                             Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="Networking" />
+                            Text="{Binding DataContext.Strings[Progress.Networking], ElementName=RootWindow}" />
                         <TextBlock
                             Margin="0,0,0,2"
                             Style="{StaticResource BodyTextBlockStyle}"
@@ -691,7 +696,7 @@
                             Margin="0,0,0,4"
                             Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
                             Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="Start time" />
+                            Text="{Binding DataContext.Strings[Progress.StartTime], ElementName=RootWindow}" />
                         <TextBlock
                             Margin="0,0,0,20"
                             Style="{StaticResource BodyTextBlockStyle}"
@@ -702,7 +707,7 @@
                             Margin="0,0,0,4"
                             Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
                             Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="Elapsed time" />
+                            Text="{Binding DataContext.Strings[Progress.ElapsedTime], ElementName=RootWindow}" />
                         <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding ElapsedTimeText}" />
                     </StackPanel>
 
@@ -714,12 +719,12 @@
                         <TextBlock
                             HorizontalAlignment="Center"
                             Style="{StaticResource TitleTextBlockStyle}"
-                            Text="Deployment failed"
+                            Text="{Binding DataContext.Strings[Error.Title], ElementName=RootWindow}"
                             TextAlignment="Center" />
                         <TextBlock
                             Margin="0,16,0,4"
                             Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="Failed step" />
+                            Text="{Binding DataContext.Strings[Error.FailedStep], ElementName=RootWindow}" />
                         <TextBlock
                             Margin="0,0,0,16"
                             Style="{StaticResource BodyTextBlockStyle}"
@@ -727,7 +732,7 @@
                         <TextBlock
                             Margin="0,0,0,4"
                             Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="Error message" />
+                            Text="{Binding DataContext.Strings[Error.Message], ElementName=RootWindow}" />
                         <Border
                             Height="220"
                             Padding="10"
@@ -746,7 +751,7 @@
                             Margin="0,16,0,0"
                             HorizontalAlignment="Right"
                             Command="{Binding OpenLogFileCommand}"
-                            Content="Open Log File" />
+                            Content="{Binding DataContext.Strings[Common.OpenLogFile], ElementName=RootWindow}" />
                     </StackPanel>
                 </Grid>
             </Grid>
@@ -767,7 +772,7 @@
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     Style="{StaticResource DisplayTextBlockStyle}"
-                    Text="Welcome"
+                    Text="{Binding Strings[Splash.Welcome]}"
                     TextAlignment="Center" />
 
                 <StackPanel
@@ -782,7 +787,7 @@
                         HorizontalAlignment="Center"
                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource BodyTextBlockStyle}"
-                        Text="Initializing components..."
+                        Text="{Binding Strings[Splash.InitializingComponents]}"
                         TextAlignment="Center" />
                 </StackPanel>
 
@@ -792,7 +797,7 @@
                     HorizontalAlignment="Center"
                     VerticalAlignment="Bottom"
                     Command="{Binding BeginWizardCommand}"
-                    Content="Begin"
+                    Content="{Binding Strings[Splash.Begin]}"
                     Style="{DynamicResource AccentButtonStyle}"
                     Visibility="{Binding Session.IsStartupInitializing, Converter={StaticResource InverseBooleanConverter}}" />
             </Grid>

--- a/src/Foundry.Deploy/Models/OperatingSystemCatalogItem.cs
+++ b/src/Foundry.Deploy/Models/OperatingSystemCatalogItem.cs
@@ -21,5 +21,5 @@ public sealed record OperatingSystemCatalogItem
     public string Sha256 { get; init; } = string.Empty;
 
     public string DisplayLabel =>
-        $"Windows {WindowsRelease} {ReleaseId} | {Architecture} | {LanguageCode} | {Edition} | {LicenseChannel} | {Build}";
+        $"{Foundry.Deploy.Converters.OperatingSystemDisplayFormatter.FormatWindowsRelease(WindowsRelease)} {ReleaseId} | {Architecture} | {LanguageCode} | {Foundry.Deploy.Converters.OperatingSystemDisplayFormatter.FormatEdition(Edition)} | {Foundry.Deploy.Converters.OperatingSystemDisplayFormatter.FormatLicenseChannel(LicenseChannel)} | {Build}";
 }

--- a/src/Foundry.Deploy/Models/TargetDiskInfo.cs
+++ b/src/Foundry.Deploy/Models/TargetDiskInfo.cs
@@ -22,13 +22,19 @@ public sealed record TargetDiskInfo
         {
             string sizeGiB = SizeBytes > 0
                 ? $"{(SizeBytes / 1024d / 1024d / 1024d):0.0} GiB"
-                : "Unknown size";
+                : Foundry.Deploy.Services.Localization.LocalizationText.GetString("Disk.UnknownSize");
 
             string warningSuffix = string.IsNullOrWhiteSpace(SelectionWarning)
                 ? string.Empty
-                : $" | {SelectionWarning}";
+                : Foundry.Deploy.Services.Localization.LocalizationText.Format("Disk.WarningSuffixFormat", SelectionWarning);
 
-            return $"Disk {DiskNumber} | {FriendlyName} | {sizeGiB} | {BusType}{warningSuffix}";
+            return Foundry.Deploy.Services.Localization.LocalizationText.Format(
+                "Disk.DisplayLabelFormat",
+                DiskNumber,
+                FriendlyName,
+                sizeGiB,
+                BusType,
+                warningSuffix);
         }
     }
 }

--- a/src/Foundry.Deploy/Models/TargetDiskInfoFactory.cs
+++ b/src/Foundry.Deploy/Models/TargetDiskInfoFactory.cs
@@ -7,7 +7,7 @@ public static class TargetDiskInfoFactory
         return new TargetDiskInfo
         {
             DiskNumber = 999,
-            FriendlyName = "DEBUG VIRTUAL TARGET",
+            FriendlyName = Foundry.Deploy.Services.Localization.LocalizationText.GetString("Disk.DebugVirtualTarget"),
             SerialNumber = "DEBUG-ONLY",
             BusType = "Virtual",
             PartitionStyle = "GPT",

--- a/src/Foundry.Deploy/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry.Deploy/Resources/AppStrings.fr-FR.resx
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="App.Name" xml:space="preserve"><value>Foundry Deploy</value></data>
+  <data name="App.WindowTitle" xml:space="preserve"><value>Foundry.Deploy</value></data>
+  <data name="About.Title" xml:space="preserve"><value>À propos de Foundry Deploy</value></data>
+  <data name="About.DescriptionLine1" xml:space="preserve"><value>Foundry Deploy est l’expérience de déploiement WinPE de Foundry.</value></data>
+  <data name="About.DescriptionLine2" xml:space="preserve"><value>Ce logiciel est fourni tel quel. Vérifiez vos paramètres de déploiement avant utilisation.</value></data>
+  <data name="About.Footer" xml:space="preserve"><value>Copyright (c) 2026 Contributeurs Foundry. Distribué sous licence MIT.</value></data>
+  <data name="Menu.Theme" xml:space="preserve"><value>_Thème</value></data>
+  <data name="Menu.Language" xml:space="preserve"><value>_Langue</value></data>
+  <data name="Menu.Tools" xml:space="preserve"><value>_Outils</value></data>
+  <data name="Menu.About" xml:space="preserve"><value>_À propos</value></data>
+  <data name="Theme.System" xml:space="preserve"><value>Système</value></data>
+  <data name="Theme.Light" xml:space="preserve"><value>Clair</value></data>
+  <data name="Theme.Dark" xml:space="preserve"><value>Sombre</value></data>
+  <data name="Language.English" xml:space="preserve"><value>Anglais</value></data>
+  <data name="Language.French" xml:space="preserve"><value>Français</value></data>
+  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Actualiser les catalogues</value></data>
+  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Actualiser les disques cibles</value></data>
+  <data name="Wizard.Title" xml:space="preserve"><value>Assistant Foundry.Deploy</value></data>
+  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>MODE DEBUG SAFE ACTIF : toutes les actions de déploiement sont simulées, aucune écriture disque/image n’est effectuée.</value></data>
+  <data name="Wizard.Description" xml:space="preserve"><value>Orchestrateur de séquence de tâches pour le déploiement d’OS dans WinPE.</value></data>
+  <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Cible</value></data>
+  <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Catalogue système</value></data>
+  <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Driver Pack</value></data>
+  <data name="Wizard.StepSummary" xml:space="preserve"><value>4. Résumé</value></data>
+  <data name="Preparation.ComputerName" xml:space="preserve"><value>Nom de l’ordinateur</value></data>
+  <data name="Preparation.ComputerNameHint" xml:space="preserve"><value>1 à 15 caractères. A-Z, a-z, 0-9 et tiret uniquement.</value></data>
+  <data name="Preparation.ComputerNameValidationMessage" xml:space="preserve"><value>Le nom de l’ordinateur doit contenir 1 à 15 caractères valides (lettres, chiffres ou tiret).</value></data>
+  <data name="Preparation.TargetDisk" xml:space="preserve"><value>Disque cible</value></data>
+  <data name="Preparation.RefreshDisks" xml:space="preserve"><value>Actualiser les disques</value></data>
+  <data name="Preparation.TargetDiskHint" xml:space="preserve"><value>Sélectionnez un disque cible. Les disques non éligibles sont bloqués.</value></data>
+  <data name="Preparation.FirmwareUpdates" xml:space="preserve"><value>Firmware : activer les mises à jour via Microsoft Update Catalog.</value></data>
+  <data name="Preparation.AutopilotEnable" xml:space="preserve"><value>Autopilot : activer le staging hors ligne du profil.</value></data>
+  <data name="Preparation.AutopilotProfile" xml:space="preserve"><value>Profil Autopilot</value></data>
+  <data name="Preparation.AutopilotProfilesAvailableFormat" xml:space="preserve"><value>Profils disponibles : {0}</value></data>
+  <data name="Preparation.AutopilotProfilesMissing" xml:space="preserve"><value>Aucun profil Autopilot importé n’a été trouvé dans X:\Foundry\Config\Autopilot.</value></data>
+  <data name="Preparation.DetectingHardware" xml:space="preserve"><value>Détection du matériel...</value></data>
+  <data name="Preparation.HardwareDetectionFailed" xml:space="preserve"><value>Échec de la détection matérielle.</value></data>
+  <data name="Preparation.HardwareDetectionFailedFormat" xml:space="preserve"><value>Échec de la détection matérielle : {0}</value></data>
+  <data name="Preparation.HardwareSummaryFormat" xml:space="preserve"><value>{0} | TPM : {1} | Alimentation : {2} | Firmware : {3}</value></data>
+  <data name="Preparation.PowerBattery" xml:space="preserve"><value>Batterie</value></data>
+  <data name="Preparation.PowerAc" xml:space="preserve"><value>Secteur</value></data>
+  <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Chargement des disques cibles...</value></data>
+  <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Échec de la détection des disques cibles : {0}</value></data>
+  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Aucun disque détecté.</value></data>
+  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Disques cibles chargés : {0} détecté(s).</value></data>
+  <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Système d’exploitation</value></data>
+  <data name="Catalog.Version" xml:space="preserve"><value>Version</value></data>
+  <data name="Catalog.Language" xml:space="preserve"><value>Langue</value></data>
+  <data name="Catalog.LicenseChannel" xml:space="preserve"><value>Canal de licence</value></data>
+  <data name="Catalog.EditionTarget" xml:space="preserve"><value>Édition (cible)</value></data>
+  <data name="Catalog.ArchitectureFormat" xml:space="preserve"><value>Architecture : {0}</value></data>
+  <data name="Catalog.Loading" xml:space="preserve"><value>Chargement des catalogues...</value></data>
+  <data name="Catalog.LoadedFormat" xml:space="preserve"><value>Catalogues chargés : {0} entrée(s) OS, {1} driver pack(s).</value></data>
+  <data name="Catalog.LoadFailedFormat" xml:space="preserve"><value>Échec du chargement du catalogue : {0}</value></data>
+  <data name="OperatingSystem.Windows" xml:space="preserve"><value>Windows</value></data>
+  <data name="OperatingSystem.Windows11" xml:space="preserve"><value>Windows 11</value></data>
+  <data name="OperatingSystem.Retail" xml:space="preserve"><value>Retail</value></data>
+  <data name="OperatingSystem.Volume" xml:space="preserve"><value>Volume</value></data>
+  <data name="OperatingSystem.Professional" xml:space="preserve"><value>Professionnel</value></data>
+  <data name="OperatingSystem.ProfessionalN" xml:space="preserve"><value>Professionnel N</value></data>
+  <data name="DriverPack.Source" xml:space="preserve"><value>Source des pilotes</value></data>
+  <data name="DriverPack.Model" xml:space="preserve"><value>Modèle</value></data>
+  <data name="DriverPack.Version" xml:space="preserve"><value>Version</value></data>
+  <data name="DriverPack.SelectedModeFormat" xml:space="preserve"><value>Mode sélectionné : {0}</value></data>
+  <data name="DriverPack.MicrosoftUpdateCatalog" xml:space="preserve"><value>Microsoft Update Catalog</value></data>
+  <data name="DriverPack.OemDriverPack" xml:space="preserve"><value>Driver Pack OEM</value></data>
+  <data name="DriverPack.Oem" xml:space="preserve"><value>OEM</value></data>
+  <data name="DriverPack.NoMatchingModelVersionFormat" xml:space="preserve"><value>{0} | Aucun modèle/version correspondant</value></data>
+  <data name="DriverPack.MultiModelFormat" xml:space="preserve"><value>{0} (+{1} modèles)</value></data>
+  <data name="Summary.Title" xml:space="preserve"><value>Résumé du déploiement</value></data>
+  <data name="Summary.TargetDisk" xml:space="preserve"><value>Disque cible</value></data>
+  <data name="Summary.NoDiskSelected" xml:space="preserve"><value>Aucun disque sélectionné</value></data>
+  <data name="Summary.SelectedOperatingSystem" xml:space="preserve"><value>Système sélectionné</value></data>
+  <data name="Summary.NoSelection" xml:space="preserve"><value>Aucune sélection</value></data>
+  <data name="Summary.SelectedDriverPack" xml:space="preserve"><value>Driver Pack sélectionné</value></data>
+  <data name="Summary.DriverPackMode" xml:space="preserve"><value>Mode du Driver Pack</value></data>
+  <data name="Summary.Firmware" xml:space="preserve"><value>Firmware</value></data>
+  <data name="Summary.FirmwareEnabledFormat" xml:space="preserve"><value>Mises à jour du firmware activées : {0}</value></data>
+  <data name="Summary.Autopilot" xml:space="preserve"><value>Autopilot</value></data>
+  <data name="Summary.EnabledFormat" xml:space="preserve"><value>Activé : {0}</value></data>
+  <data name="Summary.SelectedProfileFormat" xml:space="preserve"><value>Profil sélectionné : {0}</value></data>
+  <data name="Summary.StartExplanation" xml:space="preserve"><value>Démarrer lance l’orchestrateur de séquence de tâches avec les actions WinPE réelles (diskpart, DISM, BCDBoot, injection de pilotes, staging hors ligne du profil Autopilot).</value></data>
+  <data name="Summary.DebugSafeModeExplanation" xml:space="preserve"><value>Debug Safe Mode : la séquence de tâches s’exécute en simulation dry-run.</value></data>
+  <data name="Debug.ProgressButton" xml:space="preserve"><value>Debug : progression</value></data>
+  <data name="Debug.SuccessButton" xml:space="preserve"><value>Debug : succès</value></data>
+  <data name="Debug.ErrorButton" xml:space="preserve"><value>Debug : erreur</value></data>
+  <data name="Debug.ProgressPage" xml:space="preserve"><value>Aperçu debug : page de progression.</value></data>
+  <data name="Debug.SuccessPage" xml:space="preserve"><value>Aperçu debug : page de succès.</value></data>
+  <data name="Debug.ErrorPage" xml:space="preserve"><value>Aperçu debug : page d’erreur.</value></data>
+  <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Aperçu debug : l’application DISM a échoué car la partition cible est en lecture seule.
+
+ErrorCode=0x80070005
+Détails : accès refusé lors du montage de l’image sur le chemin cible.
+Action : vérifiez les attributs du disque puis relancez le déploiement.</value></data>
+  <data name="Debug.ApplyingImageProgressFormat" xml:space="preserve"><value>Application de l’image : {0}%</value></data>
+  <data name="Common.VersionFormat" xml:space="preserve"><value>Version : {0}</value></data>
+  <data name="Common.Previous" xml:space="preserve"><value>Précédent</value></data>
+  <data name="Common.Next" xml:space="preserve"><value>Suivant</value></data>
+  <data name="Common.StartDeployment" xml:space="preserve"><value>Démarrer le déploiement</value></data>
+  <data name="Common.OpenLogFile" xml:space="preserve"><value>Ouvrir le fichier journal</value></data>
+  <data name="Common.NotAvailable" xml:space="preserve"><value>N/D</value></data>
+  <data name="Common.Unavailable" xml:space="preserve"><value>Indisponible</value></data>
+  <data name="Common.None" xml:space="preserve"><value>Aucun</value></data>
+  <data name="Common.Unknown" xml:space="preserve"><value>Inconnu</value></data>
+  <data name="Common.Detected" xml:space="preserve"><value>Détecté</value></data>
+  <data name="Common.Yes" xml:space="preserve"><value>Oui</value></data>
+  <data name="Common.No" xml:space="preserve"><value>Non</value></data>
+  <data name="Common.Enabled" xml:space="preserve"><value>Activé</value></data>
+  <data name="Common.Disabled" xml:space="preserve"><value>Désactivé</value></data>
+  <data name="Progress.Networking" xml:space="preserve"><value>Réseau</value></data>
+  <data name="Progress.StartTime" xml:space="preserve"><value>Heure de début</value></data>
+  <data name="Progress.ElapsedTime" xml:space="preserve"><value>Temps écoulé</value></data>
+  <data name="Success.Completed" xml:space="preserve"><value>Déploiement terminé avec succès.</value></data>
+  <data name="Success.RebootCountdownFormat" xml:space="preserve"><value>Cet ordinateur redémarrera dans {0} secondes...</value></data>
+  <data name="Success.RebootNow" xml:space="preserve"><value>Redémarrer maintenant</value></data>
+  <data name="Error.Title" xml:space="preserve"><value>Le déploiement a échoué</value></data>
+  <data name="Error.FailedStep" xml:space="preserve"><value>Étape en échec</value></data>
+  <data name="Error.Message" xml:space="preserve"><value>Message d’erreur</value></data>
+  <data name="Splash.Welcome" xml:space="preserve"><value>Bienvenue</value></data>
+  <data name="Splash.InitializingComponents" xml:space="preserve"><value>Initialisation des composants...</value></data>
+  <data name="Splash.Begin" xml:space="preserve"><value>Commencer</value></data>
+  <data name="Disk.DisplayLabelFormat" xml:space="preserve"><value>Disque {0} | {1} | {2} | {3}{4}</value></data>
+  <data name="Disk.WarningSuffixFormat" xml:space="preserve"><value> | {0}</value></data>
+  <data name="Disk.UnknownSize" xml:space="preserve"><value>Taille inconnue</value></data>
+  <data name="Disk.BlockedSystemDisk" xml:space="preserve"><value>Bloqué : disque système</value></data>
+  <data name="Disk.BlockedBootDisk" xml:space="preserve"><value>Bloqué : disque de démarrage</value></data>
+  <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Bloqué : lecture seule</value></data>
+  <data name="Disk.BlockedOffline" xml:space="preserve"><value>Bloqué : hors ligne</value></data>
+  <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>CIBLE VIRTUELLE DEBUG</value></data>
+  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Disque sélectionné bloqué : {0}</value></data>
+  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Sélectionnez un système d’exploitation.</value></data>
+  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Saisissez un nom d’ordinateur valide.</value></data>
+  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Sélectionnez un disque cible.</value></data>
+  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Sélectionnez un modèle/version OEM valide avant de démarrer le déploiement.</value></data>
+  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Sélectionnez un profil Autopilot ou désactivez Autopilot avant de démarrer le déploiement.</value></data>
+  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Déploiement annulé par l’utilisateur.</value></data>
+  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Préparation du déploiement terminée.</value></data>
+  <data name="Status.Ready" xml:space="preserve"><value>Prêt</value></data>
+  <data name="Status.WaitingForDeployment" xml:space="preserve"><value>En attente du déploiement...</value></data>
+  <data name="Status.WaitingForProgress" xml:space="preserve"><value>En attente de progression...</value></data>
+  <data name="Status.PreparingDeployment" xml:space="preserve"><value>Préparation du déploiement...</value></data>
+  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Déploiement démarré.</value></data>
+  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Déploiement terminé.</value></data>
+  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Orchestration du déploiement terminée.</value></data>
+  <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Déploiement annulé.</value></data>
+  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Le déploiement a échoué.</value></data>
+  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Le déploiement a échoué : {0}</value></data>
+  <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Une autre opération est déjà en cours.</value></data>
+  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Démarrage de l’orchestration Foundry.Deploy.</value></data>
+  <data name="Status.StartingStep" xml:space="preserve"><value>Démarrage de l’étape...</value></data>
+  <data name="Status.StartingStepFormat" xml:space="preserve"><value>Démarrage de {0}.</value></data>
+  <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Démarrage de {0}...</value></data>
+  <data name="Status.StepCompleted" xml:space="preserve"><value>Étape terminée.</value></data>
+  <data name="Status.StepFailed" xml:space="preserve"><value>Étape en échec.</value></data>
+  <data name="Status.StepSkipped" xml:space="preserve"><value>Étape ignorée.</value></data>
+  <data name="Status.InProgress" xml:space="preserve"><value>En cours...</value></data>
+  <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Étape : ? sur ?</value></data>
+  <data name="Status.StepCounterFormat" xml:space="preserve"><value>Étape : {0} sur {1}</value></data>
+  <data name="Status.RebootingNow" xml:space="preserve"><value>Redémarrage en cours...</value></data>
+  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>La commande de redémarrage a échoué.</value></data>
+  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>La commande de redémarrage a échoué : {0}</value></data>
+  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Impossible d’ouvrir le fichier journal : {0}</value></data>
+  <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe a échoué avec le code de sortie {0}. {1}</value></data>
+  <data name="Status.UnknownStep" xml:space="preserve"><value>Étape inconnue</value></data>
+  <data name="Status.NoErrorDetails" xml:space="preserve"><value>Aucun détail d’erreur n’a été fourni.</value></data>
+  <data name="Step.GatherDeploymentVariables" xml:space="preserve"><value>Collecte des variables de déploiement</value></data>
+  <data name="Step.InitializeDeploymentWorkspace" xml:space="preserve"><value>Initialisation de l’espace de travail</value></data>
+  <data name="Step.ValidateTargetConfiguration" xml:space="preserve"><value>Validation de la configuration cible</value></data>
+  <data name="Step.ResolveCacheStrategy" xml:space="preserve"><value>Résolution de la stratégie de cache</value></data>
+  <data name="Step.PrepareTargetDiskLayout" xml:space="preserve"><value>Préparation du partitionnement cible</value></data>
+  <data name="Step.DownloadOperatingSystemImage" xml:space="preserve"><value>Téléchargement de l’image système</value></data>
+  <data name="Step.ApplyOperatingSystemImage" xml:space="preserve"><value>Application de l’image système</value></data>
+  <data name="Step.ConfigureTargetComputerName" xml:space="preserve"><value>Configuration du nom cible</value></data>
+  <data name="Step.ConfigureRecoveryEnvironment" xml:space="preserve"><value>Configuration de l’environnement de récupération</value></data>
+  <data name="Step.DownloadDriverPack" xml:space="preserve"><value>Téléchargement du Driver Pack</value></data>
+  <data name="Step.ExtractDriverPack" xml:space="preserve"><value>Extraction du Driver Pack</value></data>
+  <data name="Step.ApplyDriverPack" xml:space="preserve"><value>Application du Driver Pack</value></data>
+  <data name="Step.DownloadFirmwareUpdate" xml:space="preserve"><value>Téléchargement de la mise à jour firmware</value></data>
+  <data name="Step.ApplyFirmwareUpdate" xml:space="preserve"><value>Application de la mise à jour firmware</value></data>
+  <data name="Step.SealRecoveryPartition" xml:space="preserve"><value>Masquage de la partition de récupération</value></data>
+  <data name="Step.StageAutopilotConfiguration" xml:space="preserve"><value>Staging de la configuration Autopilot</value></data>
+  <data name="Step.FinalizeDeploymentAndWriteLogs" xml:space="preserve"><value>Finalisation du déploiement et écriture des journaux</value></data>
+  <data name="StepMessage.GatheringDeploymentVariables" xml:space="preserve"><value>Collecte des variables de déploiement...</value></data>
+  <data name="StepMessage.CollectingDeploymentContext" xml:space="preserve"><value>Collecte du contexte de déploiement...</value></data>
+  <data name="StepResult.DeploymentVariablesGathered" xml:space="preserve"><value>Variables de déploiement collectées.</value></data>
+  <data name="StepResult.DeploymentVariablesGatheredSimulation" xml:space="preserve"><value>Variables de déploiement collectées (simulation).</value></data>
+  <data name="StepMessage.InitializingDeploymentWorkspace" xml:space="preserve"><value>Initialisation de l’espace de travail de déploiement...</value></data>
+  <data name="StepMessage.CreatingWorkspaceFolders" xml:space="preserve"><value>Création des dossiers de travail...</value></data>
+  <data name="StepMessage.FinalizingDeployment" xml:space="preserve"><value>Finalisation du déploiement...</value></data>
+  <data name="StepMessage.CleaningTemporaryWorkspace" xml:space="preserve"><value>Nettoyage de l’espace de travail temporaire...</value></data>
+  <data name="StepMessage.WritingDeploymentSummary" xml:space="preserve"><value>Écriture du résumé de déploiement...</value></data>
+  <data name="StepMessage.WritingCompletionLogs" xml:space="preserve"><value>Écriture des journaux de fin...</value></data>
+  <data name="StepResult.WorkspaceInitialized" xml:space="preserve"><value>Espace de travail initialisé.</value></data>
+  <data name="StepResult.WorkspaceInitializedSimulation" xml:space="preserve"><value>Espace de travail initialisé (simulation).</value></data>
+  <data name="StepMessage.ValidatingTargetConfiguration" xml:space="preserve"><value>Validation de la configuration cible...</value></data>
+  <data name="StepMessage.RevalidatingTargetDisk" xml:space="preserve"><value>Revalidation du disque cible...</value></data>
+  <data name="StepMessage.DetectingHardwareProfile" xml:space="preserve"><value>Détection du profil matériel...</value></data>
+  <data name="StepResult.OperatingSystemUrlMissing" xml:space="preserve"><value>L’URL du système d’exploitation est manquante.</value></data>
+  <data name="StepResult.TargetDiskNumberRequired" xml:space="preserve"><value>Le numéro du disque cible est requis.</value></data>
+  <data name="StepResult.TargetConfigurationValidated" xml:space="preserve"><value>Configuration cible validée.</value></data>
+  <data name="StepResult.TargetConfigurationValidatedSimulation" xml:space="preserve"><value>Configuration cible validée (simulation).</value></data>
+  <data name="StepMessage.ResolvingCacheStrategy" xml:space="preserve"><value>Résolution de la stratégie de cache...</value></data>
+  <data name="StepMessage.CheckingCacheDiskConflict" xml:space="preserve"><value>Vérification des conflits disque/cache...</value></data>
+  <data name="StepMessage.PreparingTargetDiskLayout" xml:space="preserve"><value>Préparation du partitionnement cible...</value></data>
+  <data name="StepMessage.PartitioningTargetDisk" xml:space="preserve"><value>Partitionnement du disque cible...</value></data>
+  <data name="StepMessage.PreparingTargetWorkspace" xml:space="preserve"><value>Préparation de l’espace de travail cible...</value></data>
+  <data name="StepMessage.CreatingSimulatedPartitions" xml:space="preserve"><value>Création des partitions simulées...</value></data>
+  <data name="StepResult.TargetDiskLayoutPrepared" xml:space="preserve"><value>Partitionnement cible prêt.</value></data>
+  <data name="StepResult.TargetDiskLayoutPreparedSimulation" xml:space="preserve"><value>Partitionnement cible prêt (simulation).</value></data>
+  <data name="StepResult.TargetDiskLayoutNotPrepared" xml:space="preserve"><value>Le partitionnement cible n’a pas été préparé.</value></data>
+  <data name="StepMessage.DownloadingOperatingSystemImage" xml:space="preserve"><value>Téléchargement de l’image système...</value></data>
+  <data name="StepMessage.CheckingCache" xml:space="preserve"><value>Vérification du cache...</value></data>
+  <data name="StepResult.OperatingSystemImageReadySimulation" xml:space="preserve"><value>Image système prête (simulation).</value></data>
+  <data name="StepResult.OperatingSystemImageNotDownloaded" xml:space="preserve"><value>L’image système n’a pas été téléchargée.</value></data>
+  <data name="StepMessage.ApplyingOperatingSystemImage" xml:space="preserve"><value>Application de l’image OS...</value></data>
+  <data name="StepMessage.InspectingImage" xml:space="preserve"><value>Inspection de l’image...</value></data>
+  <data name="StepMessage.ApplyingImage" xml:space="preserve"><value>Application de l’image...</value></data>
+  <data name="StepMessage.ConfiguringBoot" xml:space="preserve"><value>Configuration du démarrage...</value></data>
+  <data name="StepMessage.VerifyingImage" xml:space="preserve"><value>Vérification de l’image...</value></data>
+  <data name="StepResult.OperatingSystemImageApplied" xml:space="preserve"><value>Image système appliquée.</value></data>
+  <data name="StepResult.OperatingSystemImageAppliedSimulation" xml:space="preserve"><value>Image système appliquée (simulation).</value></data>
+  <data name="StepMessage.ConfiguringTargetComputerName" xml:space="preserve"><value>Configuration du nom de l’ordinateur cible...</value></data>
+  <data name="StepMessage.WritingOfflineComputerName" xml:space="preserve"><value>Écriture du nom hors ligne de l’ordinateur...</value></data>
+  <data name="StepResult.TargetWindowsPartitionUnavailable" xml:space="preserve"><value>La partition Windows cible est indisponible.</value></data>
+  <data name="StepResult.TargetComputerNameConfigured" xml:space="preserve"><value>Nom de l’ordinateur cible configuré.</value></data>
+  <data name="StepResult.TargetComputerNameConfiguredSimulation" xml:space="preserve"><value>Nom de l’ordinateur cible configuré (simulation).</value></data>
+  <data name="StepMessage.ConfiguringRecoveryEnvironment" xml:space="preserve"><value>Configuration de l’environnement de récupération...</value></data>
+  <data name="StepMessage.PreparingWindowsRecoveryEnvironment" xml:space="preserve"><value>Préparation de l’environnement de récupération Windows...</value></data>
+  <data name="StepResult.RecoveryPartitionUnavailable" xml:space="preserve"><value>La partition de récupération est indisponible.</value></data>
+  <data name="StepResult.RecoveryEnvironmentConfigured" xml:space="preserve"><value>Environnement de récupération configuré.</value></data>
+  <data name="StepResult.RecoveryEnvironmentConfiguredSimulation" xml:space="preserve"><value>Environnement de récupération configuré (simulation).</value></data>
+  <data name="StepResult.DriverPackDisabled" xml:space="preserve"><value>Driver Pack désactivé (Aucun sélectionné).</value></data>
+  <data name="StepResult.NoDriverPackDownloadRequired" xml:space="preserve"><value>Aucun téléchargement de Driver Pack requis.</value></data>
+  <data name="StepMessage.DownloadingDriverPack" xml:space="preserve"><value>Téléchargement du Driver Pack...</value></data>
+  <data name="StepMessage.PreparingDownload" xml:space="preserve"><value>Préparation du téléchargement...</value></data>
+  <data name="StepResult.OemDriverPackMissing" xml:space="preserve"><value>Le mode Driver Pack OEM est sélectionné mais aucun Driver Pack n’a été fourni.</value></data>
+  <data name="StepResult.DriverPackDownloaded" xml:space="preserve"><value>Driver Pack téléchargé.</value></data>
+  <data name="StepResult.DriverPackDownloadedSimulation" xml:space="preserve"><value>Driver Pack téléchargé (simulation).</value></data>
+  <data name="StepMessage.ExtractingDriverPack" xml:space="preserve"><value>Extraction du Driver Pack...</value></data>
+  <data name="StepResult.DriverPackNotDownloaded" xml:space="preserve"><value>Le Driver Pack n’a pas été téléchargé.</value></data>
+  <data name="StepResult.DriverPackExtracted" xml:space="preserve"><value>Driver Pack extrait.</value></data>
+  <data name="StepResult.DriverPackExtractedSimulation" xml:space="preserve"><value>Driver Pack extrait (simulation).</value></data>
+  <data name="StepResult.NoDriverPackOperationRequired" xml:space="preserve"><value>Aucune opération Driver Pack requise.</value></data>
+  <data name="StepResult.UnsupportedDriverPackInstallMode" xml:space="preserve"><value>Mode d’installation du Driver Pack non pris en charge.</value></data>
+  <data name="StepResult.NoExtractedInfDriverPayload" xml:space="preserve"><value>Aucune charge utile INF extraite n’est disponible.</value></data>
+  <data name="StepMessage.ApplyingDriverPack" xml:space="preserve"><value>Application du Driver Pack...</value></data>
+  <data name="StepMessage.ApplyingWindowsDrivers" xml:space="preserve"><value>Application des pilotes Windows...</value></data>
+  <data name="StepMessage.MountingWinRe" xml:space="preserve"><value>Montage de WinRE...</value></data>
+  <data name="StepMessage.ApplyingWinReDrivers" xml:space="preserve"><value>Application des pilotes WinRE...</value></data>
+  <data name="StepMessage.UnmountingWinRe" xml:space="preserve"><value>Démontage de WinRE...</value></data>
+  <data name="StepMessage.StagingPackage" xml:space="preserve"><value>Staging du package...</value></data>
+  <data name="StepMessage.UpdatingSetupCompleteHook" xml:space="preserve"><value>Mise à jour du hook SetupComplete...</value></data>
+  <data name="StepResult.DriverPackApplied" xml:space="preserve"><value>Driver Pack appliqué.</value></data>
+  <data name="StepResult.DriverPackStagedForFirstBoot" xml:space="preserve"><value>Driver Pack préparé pour le premier démarrage.</value></data>
+  <data name="StepResult.DriverPackAppliedSimulation" xml:space="preserve"><value>Driver Pack appliqué (simulation).</value></data>
+  <data name="StepMessage.DownloadingFirmwareUpdate" xml:space="preserve"><value>Téléchargement de la mise à jour firmware...</value></data>
+  <data name="StepMessage.PreparingMicrosoftUpdateCatalogLookup" xml:space="preserve"><value>Préparation de la recherche Microsoft Update Catalog...</value></data>
+  <data name="StepResult.FirmwareUpdatesDisabled" xml:space="preserve"><value>Les mises à jour firmware sont désactivées.</value></data>
+  <data name="StepResult.FirmwareUpdatesDisabledForVirtualMachines" xml:space="preserve"><value>Les mises à jour firmware sont désactivées pour les machines virtuelles.</value></data>
+  <data name="StepResult.FirmwareUpdatesSkippedOnBattery" xml:space="preserve"><value>Les mises à jour firmware sont ignorées lorsque l’appareil fonctionne sur batterie.</value></data>
+  <data name="StepResult.SystemFirmwareHardwareIdentifierUnavailable" xml:space="preserve"><value>L’identifiant matériel du firmware système est indisponible.</value></data>
+  <data name="StepResult.FirmwareUpdateDownloaded" xml:space="preserve"><value>Mise à jour firmware téléchargée.</value></data>
+  <data name="StepResult.FirmwareUpdateDownloadedSimulation" xml:space="preserve"><value>Mise à jour firmware téléchargée (simulation).</value></data>
+  <data name="StepResult.NoExtractedFirmwarePayload" xml:space="preserve"><value>Aucune charge utile firmware extraite n’est disponible.</value></data>
+  <data name="StepResult.NoFirmwareInfFiles" xml:space="preserve"><value>La charge utile firmware extraite ne contient aucun fichier INF.</value></data>
+  <data name="StepMessage.ApplyingFirmwareUpdate" xml:space="preserve"><value>Application de la mise à jour firmware...</value></data>
+  <data name="StepMessage.InjectingFirmwarePayload" xml:space="preserve"><value>Injection de la charge utile firmware dans Windows hors ligne...</value></data>
+  <data name="StepResult.FirmwareUpdateApplied" xml:space="preserve"><value>Mise à jour firmware appliquée.</value></data>
+  <data name="StepResult.FirmwareUpdateAppliedSimulation" xml:space="preserve"><value>Mise à jour firmware appliquée (simulation).</value></data>
+  <data name="StepMessage.SealingRecoveryPartition" xml:space="preserve"><value>Masquage de la partition de récupération...</value></data>
+  <data name="StepMessage.RemovingRecoveryDriveLetter" xml:space="preserve"><value>Suppression de la lettre du lecteur de récupération...</value></data>
+  <data name="StepResult.RecoveryPartitionSealed" xml:space="preserve"><value>Partition de récupération masquée.</value></data>
+  <data name="StepResult.RecoveryPartitionSealedSimulation" xml:space="preserve"><value>Partition de récupération masquée (simulation).</value></data>
+  <data name="StepResult.AutopilotDisabled" xml:space="preserve"><value>Autopilot est désactivé.</value></data>
+  <data name="StepResult.AutopilotProfileMissing" xml:space="preserve"><value>Autopilot est activé mais aucun profil n’a été sélectionné.</value></data>
+  <data name="StepResult.TargetWindowsPartitionUnavailableForAutopilot" xml:space="preserve"><value>La partition Windows cible est indisponible pour le staging Autopilot.</value></data>
+  <data name="StepResult.TargetAutopilotDirectoryUnavailable" xml:space="preserve"><value>Impossible de résoudre le répertoire Autopilot cible.</value></data>
+  <data name="StepMessage.StagingAutopilotProfile" xml:space="preserve"><value>Staging du profil Autopilot...</value></data>
+  <data name="StepMessage.CopyingAutopilotConfiguration" xml:space="preserve"><value>Copie de AutopilotConfigurationFile.json...</value></data>
+  <data name="StepMessage.WritingDryRunAutopilotManifest" xml:space="preserve"><value>Écriture du manifeste Autopilot dry-run...</value></data>
+  <data name="StepResult.AutopilotProfileStaged" xml:space="preserve"><value>Profil Autopilot préparé.</value></data>
+  <data name="StepResult.AutopilotProfileStagedSimulation" xml:space="preserve"><value>Profil Autopilot préparé (simulation).</value></data>
+</root>

--- a/src/Foundry.Deploy/Resources/AppStrings.resx
+++ b/src/Foundry.Deploy/Resources/AppStrings.resx
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="App.Name" xml:space="preserve"><value>Foundry Deploy</value></data>
+  <data name="App.WindowTitle" xml:space="preserve"><value>Foundry.Deploy</value></data>
+  <data name="About.Title" xml:space="preserve"><value>About Foundry Deploy</value></data>
+  <data name="About.DescriptionLine1" xml:space="preserve"><value>Foundry Deploy is the WinPE deployment experience for Foundry.</value></data>
+  <data name="About.DescriptionLine2" xml:space="preserve"><value>This software is provided as-is. Review your deployment settings before use.</value></data>
+  <data name="About.Footer" xml:space="preserve"><value>Copyright (c) 2026 Foundry Contributors. Licensed under the MIT License.</value></data>
+  <data name="Menu.Theme" xml:space="preserve"><value>_Theme</value></data>
+  <data name="Menu.Language" xml:space="preserve"><value>_Language</value></data>
+  <data name="Menu.Tools" xml:space="preserve"><value>_Tools</value></data>
+  <data name="Menu.About" xml:space="preserve"><value>_About</value></data>
+  <data name="Theme.System" xml:space="preserve"><value>System</value></data>
+  <data name="Theme.Light" xml:space="preserve"><value>Light</value></data>
+  <data name="Theme.Dark" xml:space="preserve"><value>Dark</value></data>
+  <data name="Language.English" xml:space="preserve"><value>English</value></data>
+  <data name="Language.French" xml:space="preserve"><value>French</value></data>
+  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Refresh Catalogs</value></data>
+  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Refresh Target Disks</value></data>
+  <data name="Wizard.Title" xml:space="preserve"><value>Foundry.Deploy Wizard</value></data>
+  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>DEBUG SAFE MODE ACTIVE: all deployment actions are simulated, no disk/image write is executed.</value></data>
+  <data name="Wizard.Description" xml:space="preserve"><value>Task-sequence orchestrator for OS deployment in WinPE.</value></data>
+  <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Target</value></data>
+  <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operating System Catalog</value></data>
+  <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Driver Pack</value></data>
+  <data name="Wizard.StepSummary" xml:space="preserve"><value>4. Summary</value></data>
+  <data name="Preparation.ComputerName" xml:space="preserve"><value>Computer Name</value></data>
+  <data name="Preparation.ComputerNameHint" xml:space="preserve"><value>1-15 characters. A-Z, a-z, 0-9, and hyphen only.</value></data>
+  <data name="Preparation.ComputerNameValidationMessage" xml:space="preserve"><value>Computer name must contain 1 to 15 valid characters (letters, numbers, or hyphen).</value></data>
+  <data name="Preparation.TargetDisk" xml:space="preserve"><value>Target Disk</value></data>
+  <data name="Preparation.RefreshDisks" xml:space="preserve"><value>Refresh Disks</value></data>
+  <data name="Preparation.TargetDiskHint" xml:space="preserve"><value>Select a target disk. Non-eligible disks are blocked.</value></data>
+  <data name="Preparation.FirmwareUpdates" xml:space="preserve"><value>Firmware: Microsoft Update Catalog update enabled.</value></data>
+  <data name="Preparation.AutopilotEnable" xml:space="preserve"><value>Autopilot: Enable offline profile staging.</value></data>
+  <data name="Preparation.AutopilotProfile" xml:space="preserve"><value>Autopilot Profile</value></data>
+  <data name="Preparation.AutopilotProfilesAvailableFormat" xml:space="preserve"><value>Profiles available: {0}</value></data>
+  <data name="Preparation.AutopilotProfilesMissing" xml:space="preserve"><value>No imported Autopilot profiles were found in X:\Foundry\Config\Autopilot.</value></data>
+  <data name="Preparation.DetectingHardware" xml:space="preserve"><value>Detecting hardware...</value></data>
+  <data name="Preparation.HardwareDetectionFailed" xml:space="preserve"><value>Hardware detection failed.</value></data>
+  <data name="Preparation.HardwareDetectionFailedFormat" xml:space="preserve"><value>Hardware detection failed: {0}</value></data>
+  <data name="Preparation.HardwareSummaryFormat" xml:space="preserve"><value>{0} | TPM: {1} | Power: {2} | Firmware: {3}</value></data>
+  <data name="Preparation.PowerBattery" xml:space="preserve"><value>Battery</value></data>
+  <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
+  <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Loading target disks...</value></data>
+  <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Target disk discovery failed: {0}</value></data>
+  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>No disks detected.</value></data>
+  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Target disks loaded: {0} detected.</value></data>
+  <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Operating System</value></data>
+  <data name="Catalog.Version" xml:space="preserve"><value>Version</value></data>
+  <data name="Catalog.Language" xml:space="preserve"><value>Language</value></data>
+  <data name="Catalog.LicenseChannel" xml:space="preserve"><value>License Channel</value></data>
+  <data name="Catalog.EditionTarget" xml:space="preserve"><value>Edition (Target)</value></data>
+  <data name="Catalog.ArchitectureFormat" xml:space="preserve"><value>Architecture: {0}</value></data>
+  <data name="Catalog.Loading" xml:space="preserve"><value>Loading catalogs...</value></data>
+  <data name="Catalog.LoadedFormat" xml:space="preserve"><value>Catalogs loaded: {0} OS entries, {1} driver packs.</value></data>
+  <data name="Catalog.LoadFailedFormat" xml:space="preserve"><value>Catalog load failed: {0}</value></data>
+  <data name="OperatingSystem.Windows" xml:space="preserve"><value>Windows</value></data>
+  <data name="OperatingSystem.Windows11" xml:space="preserve"><value>Windows 11</value></data>
+  <data name="OperatingSystem.Retail" xml:space="preserve"><value>Retail</value></data>
+  <data name="OperatingSystem.Volume" xml:space="preserve"><value>Volume</value></data>
+  <data name="OperatingSystem.Professional" xml:space="preserve"><value>Professional</value></data>
+  <data name="OperatingSystem.ProfessionalN" xml:space="preserve"><value>Professional N</value></data>
+  <data name="DriverPack.Source" xml:space="preserve"><value>Driver Source</value></data>
+  <data name="DriverPack.Model" xml:space="preserve"><value>Model</value></data>
+  <data name="DriverPack.Version" xml:space="preserve"><value>Version</value></data>
+  <data name="DriverPack.SelectedModeFormat" xml:space="preserve"><value>Selected mode: {0}</value></data>
+  <data name="DriverPack.MicrosoftUpdateCatalog" xml:space="preserve"><value>Microsoft Update Catalog</value></data>
+  <data name="DriverPack.OemDriverPack" xml:space="preserve"><value>OEM Driver Pack</value></data>
+  <data name="DriverPack.Oem" xml:space="preserve"><value>OEM</value></data>
+  <data name="DriverPack.NoMatchingModelVersionFormat" xml:space="preserve"><value>{0} | No matching model/version</value></data>
+  <data name="DriverPack.MultiModelFormat" xml:space="preserve"><value>{0} (+{1} models)</value></data>
+  <data name="Summary.Title" xml:space="preserve"><value>Deployment Summary</value></data>
+  <data name="Summary.TargetDisk" xml:space="preserve"><value>Target Disk</value></data>
+  <data name="Summary.NoDiskSelected" xml:space="preserve"><value>No disk selected</value></data>
+  <data name="Summary.SelectedOperatingSystem" xml:space="preserve"><value>Selected Operating System</value></data>
+  <data name="Summary.NoSelection" xml:space="preserve"><value>No selection</value></data>
+  <data name="Summary.SelectedDriverPack" xml:space="preserve"><value>Selected Driver Pack</value></data>
+  <data name="Summary.DriverPackMode" xml:space="preserve"><value>Driver Pack Mode</value></data>
+  <data name="Summary.Firmware" xml:space="preserve"><value>Firmware</value></data>
+  <data name="Summary.FirmwareEnabledFormat" xml:space="preserve"><value>Firmware updates enabled: {0}</value></data>
+  <data name="Summary.Autopilot" xml:space="preserve"><value>Autopilot</value></data>
+  <data name="Summary.EnabledFormat" xml:space="preserve"><value>Enabled: {0}</value></data>
+  <data name="Summary.SelectedProfileFormat" xml:space="preserve"><value>Selected profile: {0}</value></data>
+  <data name="Summary.StartExplanation" xml:space="preserve"><value>Start launches the deployment task sequence orchestrator with real WinPE actions (diskpart, DISM, BCDBoot, driver injection, offline Autopilot profile staging).</value></data>
+  <data name="Summary.DebugSafeModeExplanation" xml:space="preserve"><value>Debug Safe Mode: task sequence runs in dry-run simulation.</value></data>
+  <data name="Debug.ProgressButton" xml:space="preserve"><value>Debug: Progress</value></data>
+  <data name="Debug.SuccessButton" xml:space="preserve"><value>Debug: Success</value></data>
+  <data name="Debug.ErrorButton" xml:space="preserve"><value>Debug: Error</value></data>
+  <data name="Debug.ProgressPage" xml:space="preserve"><value>Debug preview: progress page.</value></data>
+  <data name="Debug.SuccessPage" xml:space="preserve"><value>Debug preview: success page.</value></data>
+  <data name="Debug.ErrorPage" xml:space="preserve"><value>Debug preview: error page.</value></data>
+  <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Debug preview: DISM apply failed because the target partition is read-only.
+
+ErrorCode=0x80070005
+Details: Access denied while mounting image to target path.
+Action: Verify disk attributes and retry deployment.</value></data>
+  <data name="Debug.ApplyingImageProgressFormat" xml:space="preserve"><value>Applying image: {0}%</value></data>
+  <data name="Common.VersionFormat" xml:space="preserve"><value>Version: {0}</value></data>
+  <data name="Common.Previous" xml:space="preserve"><value>Previous</value></data>
+  <data name="Common.Next" xml:space="preserve"><value>Next</value></data>
+  <data name="Common.StartDeployment" xml:space="preserve"><value>Start Deployment</value></data>
+  <data name="Common.OpenLogFile" xml:space="preserve"><value>Open Log File</value></data>
+  <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
+  <data name="Common.Unavailable" xml:space="preserve"><value>Unavailable</value></data>
+  <data name="Common.None" xml:space="preserve"><value>None</value></data>
+  <data name="Common.Unknown" xml:space="preserve"><value>Unknown</value></data>
+  <data name="Common.Detected" xml:space="preserve"><value>Detected</value></data>
+  <data name="Common.Yes" xml:space="preserve"><value>Yes</value></data>
+  <data name="Common.No" xml:space="preserve"><value>No</value></data>
+  <data name="Common.Enabled" xml:space="preserve"><value>Enabled</value></data>
+  <data name="Common.Disabled" xml:space="preserve"><value>Disabled</value></data>
+  <data name="Progress.Networking" xml:space="preserve"><value>Networking</value></data>
+  <data name="Progress.StartTime" xml:space="preserve"><value>Start time</value></data>
+  <data name="Progress.ElapsedTime" xml:space="preserve"><value>Elapsed time</value></data>
+  <data name="Success.Completed" xml:space="preserve"><value>Deployment completed successfully.</value></data>
+  <data name="Success.RebootCountdownFormat" xml:space="preserve"><value>This computer will reboot in {0} seconds...</value></data>
+  <data name="Success.RebootNow" xml:space="preserve"><value>Reboot now</value></data>
+  <data name="Error.Title" xml:space="preserve"><value>Deployment failed</value></data>
+  <data name="Error.FailedStep" xml:space="preserve"><value>Failed step</value></data>
+  <data name="Error.Message" xml:space="preserve"><value>Error message</value></data>
+  <data name="Splash.Welcome" xml:space="preserve"><value>Welcome</value></data>
+  <data name="Splash.InitializingComponents" xml:space="preserve"><value>Initializing components...</value></data>
+  <data name="Splash.Begin" xml:space="preserve"><value>Begin</value></data>
+  <data name="Disk.DisplayLabelFormat" xml:space="preserve"><value>Disk {0} | {1} | {2} | {3}{4}</value></data>
+  <data name="Disk.WarningSuffixFormat" xml:space="preserve"><value> | {0}</value></data>
+  <data name="Disk.UnknownSize" xml:space="preserve"><value>Unknown size</value></data>
+  <data name="Disk.BlockedSystemDisk" xml:space="preserve"><value>Blocked: system disk</value></data>
+  <data name="Disk.BlockedBootDisk" xml:space="preserve"><value>Blocked: boot disk</value></data>
+  <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Blocked: read-only</value></data>
+  <data name="Disk.BlockedOffline" xml:space="preserve"><value>Blocked: offline</value></data>
+  <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>DEBUG VIRTUAL TARGET</value></data>
+  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Selected disk blocked: {0}</value></data>
+  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Select an operating system.</value></data>
+  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Enter a valid computer name.</value></data>
+  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Select a target disk.</value></data>
+  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Select a valid OEM model/version before starting deployment.</value></data>
+  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Select an Autopilot profile or disable Autopilot before starting deployment.</value></data>
+  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Deployment cancelled by user.</value></data>
+  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Deployment preparation completed.</value></data>
+  <data name="Status.Ready" xml:space="preserve"><value>Ready</value></data>
+  <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Waiting for deployment...</value></data>
+  <data name="Status.WaitingForProgress" xml:space="preserve"><value>Waiting for progress...</value></data>
+  <data name="Status.PreparingDeployment" xml:space="preserve"><value>Preparing deployment...</value></data>
+  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Deployment started.</value></data>
+  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Deployment completed.</value></data>
+  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Deployment orchestration completed.</value></data>
+  <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Deployment cancelled.</value></data>
+  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Deployment failed.</value></data>
+  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Deployment failed: {0}</value></data>
+  <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Another operation is already running.</value></data>
+  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Starting Foundry.Deploy orchestration.</value></data>
+  <data name="Status.StartingStep" xml:space="preserve"><value>Starting step...</value></data>
+  <data name="Status.StartingStepFormat" xml:space="preserve"><value>Starting {0}.</value></data>
+  <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Starting {0}...</value></data>
+  <data name="Status.StepCompleted" xml:space="preserve"><value>Step completed.</value></data>
+  <data name="Status.StepFailed" xml:space="preserve"><value>Step failed.</value></data>
+  <data name="Status.StepSkipped" xml:space="preserve"><value>Step skipped.</value></data>
+  <data name="Status.InProgress" xml:space="preserve"><value>In progress...</value></data>
+  <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Step: ? of ?</value></data>
+  <data name="Status.StepCounterFormat" xml:space="preserve"><value>Step: {0} of {1}</value></data>
+  <data name="Status.RebootingNow" xml:space="preserve"><value>Rebooting now...</value></data>
+  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Reboot command failed.</value></data>
+  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Reboot command failed: {0}</value></data>
+  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Unable to open log file: {0}</value></data>
+  <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe failed with exit code {0}. {1}</value></data>
+  <data name="Status.UnknownStep" xml:space="preserve"><value>Unknown step</value></data>
+  <data name="Status.NoErrorDetails" xml:space="preserve"><value>No error details were provided.</value></data>
+  <data name="Step.GatherDeploymentVariables" xml:space="preserve"><value>Gather deployment variables</value></data>
+  <data name="Step.InitializeDeploymentWorkspace" xml:space="preserve"><value>Initialize deployment workspace</value></data>
+  <data name="Step.ValidateTargetConfiguration" xml:space="preserve"><value>Validate target configuration</value></data>
+  <data name="Step.ResolveCacheStrategy" xml:space="preserve"><value>Resolve cache strategy</value></data>
+  <data name="Step.PrepareTargetDiskLayout" xml:space="preserve"><value>Prepare target disk layout</value></data>
+  <data name="Step.DownloadOperatingSystemImage" xml:space="preserve"><value>Download operating system image</value></data>
+  <data name="Step.ApplyOperatingSystemImage" xml:space="preserve"><value>Apply operating system image</value></data>
+  <data name="Step.ConfigureTargetComputerName" xml:space="preserve"><value>Configure target computer name</value></data>
+  <data name="Step.ConfigureRecoveryEnvironment" xml:space="preserve"><value>Configure recovery environment</value></data>
+  <data name="Step.DownloadDriverPack" xml:space="preserve"><value>Download driver pack</value></data>
+  <data name="Step.ExtractDriverPack" xml:space="preserve"><value>Extract driver pack</value></data>
+  <data name="Step.ApplyDriverPack" xml:space="preserve"><value>Apply driver pack</value></data>
+  <data name="Step.DownloadFirmwareUpdate" xml:space="preserve"><value>Download firmware update</value></data>
+  <data name="Step.ApplyFirmwareUpdate" xml:space="preserve"><value>Apply firmware update</value></data>
+  <data name="Step.SealRecoveryPartition" xml:space="preserve"><value>Seal recovery partition</value></data>
+  <data name="Step.StageAutopilotConfiguration" xml:space="preserve"><value>Stage Autopilot configuration</value></data>
+  <data name="Step.FinalizeDeploymentAndWriteLogs" xml:space="preserve"><value>Finalize deployment and write logs</value></data>
+  <data name="StepMessage.GatheringDeploymentVariables" xml:space="preserve"><value>Gathering deployment variables...</value></data>
+  <data name="StepMessage.CollectingDeploymentContext" xml:space="preserve"><value>Collecting deployment context...</value></data>
+  <data name="StepResult.DeploymentVariablesGathered" xml:space="preserve"><value>Deployment variables gathered.</value></data>
+  <data name="StepResult.DeploymentVariablesGatheredSimulation" xml:space="preserve"><value>Deployment variables gathered (simulation).</value></data>
+  <data name="StepMessage.InitializingDeploymentWorkspace" xml:space="preserve"><value>Initializing deployment workspace...</value></data>
+  <data name="StepMessage.CreatingWorkspaceFolders" xml:space="preserve"><value>Creating workspace folders...</value></data>
+  <data name="StepMessage.FinalizingDeployment" xml:space="preserve"><value>Finalizing deployment...</value></data>
+  <data name="StepMessage.CleaningTemporaryWorkspace" xml:space="preserve"><value>Cleaning temporary workspace...</value></data>
+  <data name="StepMessage.WritingDeploymentSummary" xml:space="preserve"><value>Writing deployment summary...</value></data>
+  <data name="StepMessage.WritingCompletionLogs" xml:space="preserve"><value>Writing completion logs...</value></data>
+  <data name="StepResult.WorkspaceInitialized" xml:space="preserve"><value>Workspace initialized.</value></data>
+  <data name="StepResult.WorkspaceInitializedSimulation" xml:space="preserve"><value>Workspace initialized (simulation).</value></data>
+  <data name="StepMessage.ValidatingTargetConfiguration" xml:space="preserve"><value>Validating target configuration...</value></data>
+  <data name="StepMessage.RevalidatingTargetDisk" xml:space="preserve"><value>Revalidating target disk...</value></data>
+  <data name="StepMessage.DetectingHardwareProfile" xml:space="preserve"><value>Detecting hardware profile...</value></data>
+  <data name="StepResult.OperatingSystemUrlMissing" xml:space="preserve"><value>Operating system URL is missing.</value></data>
+  <data name="StepResult.TargetDiskNumberRequired" xml:space="preserve"><value>Target disk number is required.</value></data>
+  <data name="StepResult.TargetConfigurationValidated" xml:space="preserve"><value>Target configuration validated.</value></data>
+  <data name="StepResult.TargetConfigurationValidatedSimulation" xml:space="preserve"><value>Target configuration validated (simulation).</value></data>
+  <data name="StepMessage.ResolvingCacheStrategy" xml:space="preserve"><value>Resolving cache strategy...</value></data>
+  <data name="StepMessage.CheckingCacheDiskConflict" xml:space="preserve"><value>Checking cache disk conflict...</value></data>
+  <data name="StepMessage.PreparingTargetDiskLayout" xml:space="preserve"><value>Preparing target disk layout...</value></data>
+  <data name="StepMessage.PartitioningTargetDisk" xml:space="preserve"><value>Partitioning target disk...</value></data>
+  <data name="StepMessage.PreparingTargetWorkspace" xml:space="preserve"><value>Preparing target workspace...</value></data>
+  <data name="StepMessage.CreatingSimulatedPartitions" xml:space="preserve"><value>Creating simulated partitions...</value></data>
+  <data name="StepResult.TargetDiskLayoutPrepared" xml:space="preserve"><value>Target disk layout prepared.</value></data>
+  <data name="StepResult.TargetDiskLayoutPreparedSimulation" xml:space="preserve"><value>Target disk layout prepared (simulation).</value></data>
+  <data name="StepResult.TargetDiskLayoutNotPrepared" xml:space="preserve"><value>Target disk layout was not prepared.</value></data>
+  <data name="StepMessage.DownloadingOperatingSystemImage" xml:space="preserve"><value>Downloading OS image...</value></data>
+  <data name="StepMessage.CheckingCache" xml:space="preserve"><value>Checking cache...</value></data>
+  <data name="StepResult.OperatingSystemImageReadySimulation" xml:space="preserve"><value>Operating system image ready (simulation).</value></data>
+  <data name="StepResult.OperatingSystemImageNotDownloaded" xml:space="preserve"><value>Operating system image was not downloaded.</value></data>
+  <data name="StepMessage.ApplyingOperatingSystemImage" xml:space="preserve"><value>Applying OS image...</value></data>
+  <data name="StepMessage.InspectingImage" xml:space="preserve"><value>Inspecting image...</value></data>
+  <data name="StepMessage.ApplyingImage" xml:space="preserve"><value>Applying image...</value></data>
+  <data name="StepMessage.ConfiguringBoot" xml:space="preserve"><value>Configuring boot...</value></data>
+  <data name="StepMessage.VerifyingImage" xml:space="preserve"><value>Verifying image...</value></data>
+  <data name="StepResult.OperatingSystemImageApplied" xml:space="preserve"><value>Operating system image applied.</value></data>
+  <data name="StepResult.OperatingSystemImageAppliedSimulation" xml:space="preserve"><value>Operating system image applied (simulation).</value></data>
+  <data name="StepMessage.ConfiguringTargetComputerName" xml:space="preserve"><value>Configuring target computer name...</value></data>
+  <data name="StepMessage.WritingOfflineComputerName" xml:space="preserve"><value>Writing offline computer name...</value></data>
+  <data name="StepResult.TargetWindowsPartitionUnavailable" xml:space="preserve"><value>Target Windows partition is unavailable.</value></data>
+  <data name="StepResult.TargetComputerNameConfigured" xml:space="preserve"><value>Target computer name configured.</value></data>
+  <data name="StepResult.TargetComputerNameConfiguredSimulation" xml:space="preserve"><value>Target computer name configured (simulation).</value></data>
+  <data name="StepMessage.ConfiguringRecoveryEnvironment" xml:space="preserve"><value>Configuring recovery environment...</value></data>
+  <data name="StepMessage.PreparingWindowsRecoveryEnvironment" xml:space="preserve"><value>Preparing Windows Recovery Environment...</value></data>
+  <data name="StepResult.RecoveryPartitionUnavailable" xml:space="preserve"><value>Recovery partition is unavailable.</value></data>
+  <data name="StepResult.RecoveryEnvironmentConfigured" xml:space="preserve"><value>Recovery environment configured.</value></data>
+  <data name="StepResult.RecoveryEnvironmentConfiguredSimulation" xml:space="preserve"><value>Recovery environment configured (simulation).</value></data>
+  <data name="StepResult.DriverPackDisabled" xml:space="preserve"><value>Driver pack disabled (None selected).</value></data>
+  <data name="StepResult.NoDriverPackDownloadRequired" xml:space="preserve"><value>No driver pack download required.</value></data>
+  <data name="StepMessage.DownloadingDriverPack" xml:space="preserve"><value>Downloading driver pack...</value></data>
+  <data name="StepMessage.PreparingDownload" xml:space="preserve"><value>Preparing download...</value></data>
+  <data name="StepResult.OemDriverPackMissing" xml:space="preserve"><value>OEM driver pack mode selected but no driver pack was provided.</value></data>
+  <data name="StepResult.DriverPackDownloaded" xml:space="preserve"><value>Driver pack downloaded.</value></data>
+  <data name="StepResult.DriverPackDownloadedSimulation" xml:space="preserve"><value>Driver pack downloaded (simulation).</value></data>
+  <data name="StepMessage.ExtractingDriverPack" xml:space="preserve"><value>Extracting driver pack...</value></data>
+  <data name="StepResult.DriverPackNotDownloaded" xml:space="preserve"><value>Driver pack was not downloaded.</value></data>
+  <data name="StepResult.DriverPackExtracted" xml:space="preserve"><value>Driver pack extracted.</value></data>
+  <data name="StepResult.DriverPackExtractedSimulation" xml:space="preserve"><value>Driver pack extracted (simulation).</value></data>
+  <data name="StepResult.NoDriverPackOperationRequired" xml:space="preserve"><value>No driver pack operation is required.</value></data>
+  <data name="StepResult.UnsupportedDriverPackInstallMode" xml:space="preserve"><value>Unsupported driver pack install mode.</value></data>
+  <data name="StepResult.NoExtractedInfDriverPayload" xml:space="preserve"><value>No extracted INF driver payload is available.</value></data>
+  <data name="StepMessage.ApplyingDriverPack" xml:space="preserve"><value>Applying driver pack...</value></data>
+  <data name="StepMessage.ApplyingWindowsDrivers" xml:space="preserve"><value>Applying Windows drivers...</value></data>
+  <data name="StepMessage.MountingWinRe" xml:space="preserve"><value>Mounting WinRE...</value></data>
+  <data name="StepMessage.ApplyingWinReDrivers" xml:space="preserve"><value>Applying WinRE drivers...</value></data>
+  <data name="StepMessage.UnmountingWinRe" xml:space="preserve"><value>Unmounting WinRE...</value></data>
+  <data name="StepMessage.StagingPackage" xml:space="preserve"><value>Staging package...</value></data>
+  <data name="StepMessage.UpdatingSetupCompleteHook" xml:space="preserve"><value>Updating SetupComplete hook...</value></data>
+  <data name="StepResult.DriverPackApplied" xml:space="preserve"><value>Driver pack applied.</value></data>
+  <data name="StepResult.DriverPackStagedForFirstBoot" xml:space="preserve"><value>Driver pack staged for first boot.</value></data>
+  <data name="StepResult.DriverPackAppliedSimulation" xml:space="preserve"><value>Driver pack applied (simulation).</value></data>
+  <data name="StepMessage.DownloadingFirmwareUpdate" xml:space="preserve"><value>Downloading firmware update...</value></data>
+  <data name="StepMessage.PreparingMicrosoftUpdateCatalogLookup" xml:space="preserve"><value>Preparing Microsoft Update Catalog lookup...</value></data>
+  <data name="StepResult.FirmwareUpdatesDisabled" xml:space="preserve"><value>Firmware updates are disabled.</value></data>
+  <data name="StepResult.FirmwareUpdatesDisabledForVirtualMachines" xml:space="preserve"><value>Firmware updates are disabled for virtual machines.</value></data>
+  <data name="StepResult.FirmwareUpdatesSkippedOnBattery" xml:space="preserve"><value>Firmware updates are skipped while the device is running on battery power.</value></data>
+  <data name="StepResult.SystemFirmwareHardwareIdentifierUnavailable" xml:space="preserve"><value>System firmware hardware identifier is unavailable.</value></data>
+  <data name="StepResult.FirmwareUpdateDownloaded" xml:space="preserve"><value>Firmware update downloaded.</value></data>
+  <data name="StepResult.FirmwareUpdateDownloadedSimulation" xml:space="preserve"><value>Firmware update downloaded (simulation).</value></data>
+  <data name="StepResult.NoExtractedFirmwarePayload" xml:space="preserve"><value>No extracted firmware payload is available.</value></data>
+  <data name="StepResult.NoFirmwareInfFiles" xml:space="preserve"><value>The extracted firmware payload does not contain any INF files.</value></data>
+  <data name="StepMessage.ApplyingFirmwareUpdate" xml:space="preserve"><value>Applying firmware update...</value></data>
+  <data name="StepMessage.InjectingFirmwarePayload" xml:space="preserve"><value>Injecting firmware payload into offline Windows...</value></data>
+  <data name="StepResult.FirmwareUpdateApplied" xml:space="preserve"><value>Firmware update applied.</value></data>
+  <data name="StepResult.FirmwareUpdateAppliedSimulation" xml:space="preserve"><value>Firmware update applied (simulation).</value></data>
+  <data name="StepMessage.SealingRecoveryPartition" xml:space="preserve"><value>Sealing recovery partition...</value></data>
+  <data name="StepMessage.RemovingRecoveryDriveLetter" xml:space="preserve"><value>Removing recovery drive letter...</value></data>
+  <data name="StepResult.RecoveryPartitionSealed" xml:space="preserve"><value>Recovery partition sealed.</value></data>
+  <data name="StepResult.RecoveryPartitionSealedSimulation" xml:space="preserve"><value>Recovery partition sealed (simulation).</value></data>
+  <data name="StepResult.AutopilotDisabled" xml:space="preserve"><value>Autopilot is disabled.</value></data>
+  <data name="StepResult.AutopilotProfileMissing" xml:space="preserve"><value>Autopilot is enabled but no profile was selected.</value></data>
+  <data name="StepResult.TargetWindowsPartitionUnavailableForAutopilot" xml:space="preserve"><value>Target Windows partition is unavailable for Autopilot staging.</value></data>
+  <data name="StepResult.TargetAutopilotDirectoryUnavailable" xml:space="preserve"><value>Failed to resolve the target Autopilot directory.</value></data>
+  <data name="StepMessage.StagingAutopilotProfile" xml:space="preserve"><value>Staging Autopilot profile...</value></data>
+  <data name="StepMessage.CopyingAutopilotConfiguration" xml:space="preserve"><value>Copying AutopilotConfigurationFile.json...</value></data>
+  <data name="StepMessage.WritingDryRunAutopilotManifest" xml:space="preserve"><value>Writing dry-run Autopilot manifest...</value></data>
+  <data name="StepResult.AutopilotProfileStaged" xml:space="preserve"><value>Autopilot profile staged.</value></data>
+  <data name="StepResult.AutopilotProfileStagedSimulation" xml:space="preserve"><value>Autopilot profile staged (simulation).</value></data>
+</root>

--- a/src/Foundry.Deploy/Services/ApplicationShell/ApplicationShellService.cs
+++ b/src/Foundry.Deploy/Services/ApplicationShell/ApplicationShellService.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using Foundry.Deploy.Services.Localization;
 using Foundry.Deploy.ViewModels;
 using Foundry.Deploy.Views;
 
@@ -6,15 +7,22 @@ namespace Foundry.Deploy.Services.ApplicationShell;
 
 public sealed class ApplicationShellService : IApplicationShellService
 {
+    private readonly ILocalizationService _localizationService;
+
+    public ApplicationShellService(ILocalizationService localizationService)
+    {
+        _localizationService = localizationService;
+    }
+
     public void ShowAbout()
     {
         var viewModel = new AboutDialogViewModel(
-            FoundryDeployApplicationInfo.AboutTitle,
-            FoundryDeployApplicationInfo.AppName,
+            _localizationService.Strings["About.Title"],
+            _localizationService.Strings["App.Name"],
             FoundryDeployApplicationInfo.Version,
-            FoundryDeployApplicationInfo.DescriptionLine1,
-            FoundryDeployApplicationInfo.DescriptionLine2,
-            FoundryDeployApplicationInfo.Footer);
+            _localizationService.Strings["About.DescriptionLine1"],
+            _localizationService.Strings["About.DescriptionLine2"],
+            _localizationService.Strings["About.Footer"]);
         var dialog = new AboutDialog
         {
             DataContext = viewModel,

--- a/src/Foundry.Deploy/Services/Hardware/TargetDiskService.cs
+++ b/src/Foundry.Deploy/Services/Hardware/TargetDiskService.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Text;
 using System.Text.Json;
 using Foundry.Deploy.Models;
+using Foundry.Deploy.Services.Localization;
 using Foundry.Deploy.Services.System;
 using Microsoft.Extensions.Logging;
 
@@ -178,10 +179,10 @@ if ($null -eq $partition) {{
     private static TargetDiskInfo ParseDisk(JsonElement element)
     {
         int diskNumber = ReadInt(element, "Number");
-        string friendlyName = NormalizeValue(ReadString(element, "FriendlyName"), fallback: "Unknown");
-        string serial = NormalizeValue(ReadString(element, "SerialNumber"), fallback: "Unknown");
-        string busType = NormalizeValue(ReadString(element, "BusType"), fallback: "Unknown");
-        string partitionStyle = NormalizeValue(ReadString(element, "PartitionStyle"), fallback: "Unknown");
+        string friendlyName = NormalizeValue(ReadString(element, "FriendlyName"), fallback: LocalizationText.GetString("Common.Unknown"));
+        string serial = NormalizeValue(ReadString(element, "SerialNumber"), fallback: LocalizationText.GetString("Common.Unknown"));
+        string busType = NormalizeValue(ReadString(element, "BusType"), fallback: LocalizationText.GetString("Common.Unknown"));
+        string partitionStyle = NormalizeValue(ReadString(element, "PartitionStyle"), fallback: LocalizationText.GetString("Common.Unknown"));
         ulong sizeBytes = ReadUInt64(element, "Size");
         bool isSystem = ReadBool(element, "IsSystem");
         bool isBoot = ReadBool(element, "IsBoot");
@@ -213,22 +214,22 @@ if ($null -eq $partition) {{
     {
         if (isSystem)
         {
-            return "Blocked: system disk";
+            return LocalizationText.GetString("Disk.BlockedSystemDisk");
         }
 
         if (isBoot)
         {
-            return "Blocked: boot disk";
+            return LocalizationText.GetString("Disk.BlockedBootDisk");
         }
 
         if (isReadOnly)
         {
-            return "Blocked: read-only";
+            return LocalizationText.GetString("Disk.BlockedReadOnly");
         }
 
         if (isOffline)
         {
-            return "Blocked: offline";
+            return LocalizationText.GetString("Disk.BlockedOffline");
         }
 
         return string.Empty;

--- a/src/Foundry.Deploy/Services/Localization/DeploymentUiTextLocalizer.cs
+++ b/src/Foundry.Deploy/Services/Localization/DeploymentUiTextLocalizer.cs
@@ -1,0 +1,322 @@
+using System.Text.RegularExpressions;
+
+namespace Foundry.Deploy.Services.Localization;
+
+public static partial class DeploymentUiTextLocalizer
+{
+    public static string LocalizeStepName(string value)
+    {
+        return value switch
+        {
+            "Gather deployment variables" => LocalizationText.GetString("Step.GatherDeploymentVariables"),
+            "Initialize deployment workspace" => LocalizationText.GetString("Step.InitializeDeploymentWorkspace"),
+            "Validate target configuration" => LocalizationText.GetString("Step.ValidateTargetConfiguration"),
+            "Resolve cache strategy" => LocalizationText.GetString("Step.ResolveCacheStrategy"),
+            "Prepare target disk layout" => LocalizationText.GetString("Step.PrepareTargetDiskLayout"),
+            "Download operating system image" => LocalizationText.GetString("Step.DownloadOperatingSystemImage"),
+            "Apply operating system image" => LocalizationText.GetString("Step.ApplyOperatingSystemImage"),
+            "Configure target computer name" => LocalizationText.GetString("Step.ConfigureTargetComputerName"),
+            "Configure recovery environment" => LocalizationText.GetString("Step.ConfigureRecoveryEnvironment"),
+            "Download driver pack" => LocalizationText.GetString("Step.DownloadDriverPack"),
+            "Extract driver pack" => LocalizationText.GetString("Step.ExtractDriverPack"),
+            "Apply driver pack" => LocalizationText.GetString("Step.ApplyDriverPack"),
+            "Download firmware update" => LocalizationText.GetString("Step.DownloadFirmwareUpdate"),
+            "Apply firmware update" => LocalizationText.GetString("Step.ApplyFirmwareUpdate"),
+            "Seal recovery partition" => LocalizationText.GetString("Step.SealRecoveryPartition"),
+            "Stage Autopilot configuration" => LocalizationText.GetString("Step.StageAutopilotConfiguration"),
+            "Finalize deployment and write logs" => LocalizationText.GetString("Step.FinalizeDeploymentAndWriteLogs"),
+            _ => LocalizeMessage(value)
+        };
+    }
+
+    public static string LocalizeMessage(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        return value switch
+        {
+            "Ready" => LocalizationText.GetString("Status.Ready"),
+            "Waiting for deployment..." => LocalizationText.GetString("Status.WaitingForDeployment"),
+            "Waiting for progress..." => LocalizationText.GetString("Status.WaitingForProgress"),
+            "Preparing deployment..." => LocalizationText.GetString("Status.PreparingDeployment"),
+            "Deployment started." => LocalizationText.GetString("Status.DeploymentStarted"),
+            "Deployment completed." => LocalizationText.GetString("Status.DeploymentCompleted"),
+            "Deployment orchestration completed." => LocalizationText.GetString("Status.DeploymentOrchestrationCompleted"),
+            "Deployment cancelled." => LocalizationText.GetString("Status.DeploymentCancelled"),
+            "Deployment failed." => LocalizationText.GetString("Status.DeploymentFailed"),
+            "Debug preview: progress page." => LocalizationText.GetString("Debug.ProgressPage"),
+            "Debug preview: success page." => LocalizationText.GetString("Debug.SuccessPage"),
+            "Debug preview: error page." => LocalizationText.GetString("Debug.ErrorPage"),
+            "Starting step..." => LocalizationText.GetString("Status.StartingStep"),
+            "Step completed." => LocalizationText.GetString("Status.StepCompleted"),
+            "Step failed." => LocalizationText.GetString("Status.StepFailed"),
+            "Step skipped." => LocalizationText.GetString("Status.StepSkipped"),
+            "In progress..." => LocalizationText.GetString("Status.InProgress"),
+            "Loading catalogs..." => LocalizationText.GetString("Catalog.Loading"),
+            "Loading target disks..." => LocalizationText.GetString("Preparation.LoadingTargetDisks"),
+            "No disks detected." => LocalizationText.GetString("Preparation.NoDisksDetected"),
+            "Select an operating system." => LocalizationText.GetString("Launch.SelectOperatingSystem"),
+            "Enter a valid computer name." => LocalizationText.GetString("Launch.EnterValidComputerName"),
+            "Select a target disk." => LocalizationText.GetString("Launch.SelectTargetDisk"),
+            "Select a valid OEM model/version before starting deployment." => LocalizationText.GetString("Launch.SelectValidOemDriverPack"),
+            "Select an Autopilot profile or disable Autopilot before starting deployment." => LocalizationText.GetString("Launch.SelectAutopilotProfile"),
+            "Deployment cancelled by user." => LocalizationText.GetString("Launch.CancelledByUser"),
+            "Deployment preparation completed." => LocalizationText.GetString("Launch.PreparationCompleted"),
+            "Another operation is already running." => LocalizationText.GetString("Status.AnotherOperationRunning"),
+            "Starting Foundry.Deploy orchestration." => LocalizationText.GetString("Status.StartingOrchestration"),
+            "Gathering deployment variables..." => LocalizationText.GetString("StepMessage.GatheringDeploymentVariables"),
+            "Collecting deployment context..." => LocalizationText.GetString("StepMessage.CollectingDeploymentContext"),
+            "Deployment variables gathered." => LocalizationText.GetString("StepResult.DeploymentVariablesGathered"),
+            "Deployment variables gathered (simulation)." => LocalizationText.GetString("StepResult.DeploymentVariablesGatheredSimulation"),
+            "Initializing deployment workspace..." => LocalizationText.GetString("StepMessage.InitializingDeploymentWorkspace"),
+            "Creating workspace folders..." => LocalizationText.GetString("StepMessage.CreatingWorkspaceFolders"),
+            "Finalizing deployment..." => LocalizationText.GetString("StepMessage.FinalizingDeployment"),
+            "Cleaning temporary workspace..." => LocalizationText.GetString("StepMessage.CleaningTemporaryWorkspace"),
+            "Writing deployment summary..." => LocalizationText.GetString("StepMessage.WritingDeploymentSummary"),
+            "Writing completion logs..." => LocalizationText.GetString("StepMessage.WritingCompletionLogs"),
+            "Workspace initialized." => LocalizationText.GetString("StepResult.WorkspaceInitialized"),
+            "Workspace initialized (simulation)." => LocalizationText.GetString("StepResult.WorkspaceInitializedSimulation"),
+            "Validating target configuration..." => LocalizationText.GetString("StepMessage.ValidatingTargetConfiguration"),
+            "Revalidating target disk..." => LocalizationText.GetString("StepMessage.RevalidatingTargetDisk"),
+            "Detecting hardware profile..." => LocalizationText.GetString("StepMessage.DetectingHardwareProfile"),
+            "Operating system URL is missing." => LocalizationText.GetString("StepResult.OperatingSystemUrlMissing"),
+            "Target disk number is required." => LocalizationText.GetString("StepResult.TargetDiskNumberRequired"),
+            "Target configuration validated." => LocalizationText.GetString("StepResult.TargetConfigurationValidated"),
+            "Target configuration validated (simulation)." => LocalizationText.GetString("StepResult.TargetConfigurationValidatedSimulation"),
+            "Resolving cache strategy..." => LocalizationText.GetString("StepMessage.ResolvingCacheStrategy"),
+            "Checking cache disk conflict..." => LocalizationText.GetString("StepMessage.CheckingCacheDiskConflict"),
+            "Preparing target disk layout..." => LocalizationText.GetString("StepMessage.PreparingTargetDiskLayout"),
+            "Partitioning target disk..." => LocalizationText.GetString("StepMessage.PartitioningTargetDisk"),
+            "Preparing target workspace..." => LocalizationText.GetString("StepMessage.PreparingTargetWorkspace"),
+            "Creating simulated partitions..." => LocalizationText.GetString("StepMessage.CreatingSimulatedPartitions"),
+            "Target disk layout prepared." => LocalizationText.GetString("StepResult.TargetDiskLayoutPrepared"),
+            "Target disk layout prepared (simulation)." => LocalizationText.GetString("StepResult.TargetDiskLayoutPreparedSimulation"),
+            "Target disk layout was not prepared." => LocalizationText.GetString("StepResult.TargetDiskLayoutNotPrepared"),
+            "Downloading OS image..." => LocalizationText.GetString("StepMessage.DownloadingOperatingSystemImage"),
+            "Checking cache..." => LocalizationText.GetString("StepMessage.CheckingCache"),
+            "Operating system image ready (simulation)." => LocalizationText.GetString("StepResult.OperatingSystemImageReadySimulation"),
+            "Operating system image was not downloaded." => LocalizationText.GetString("StepResult.OperatingSystemImageNotDownloaded"),
+            "Applying OS image..." => LocalizationText.GetString("StepMessage.ApplyingOperatingSystemImage"),
+            "Inspecting image..." => LocalizationText.GetString("StepMessage.InspectingImage"),
+            "Applying image..." => LocalizationText.GetString("StepMessage.ApplyingImage"),
+            "Configuring boot..." => LocalizationText.GetString("StepMessage.ConfiguringBoot"),
+            "Verifying image..." => LocalizationText.GetString("StepMessage.VerifyingImage"),
+            "Operating system image applied." => LocalizationText.GetString("StepResult.OperatingSystemImageApplied"),
+            "Operating system image applied (simulation)." => LocalizationText.GetString("StepResult.OperatingSystemImageAppliedSimulation"),
+            "Configuring target computer name..." => LocalizationText.GetString("StepMessage.ConfiguringTargetComputerName"),
+            "Writing offline computer name..." => LocalizationText.GetString("StepMessage.WritingOfflineComputerName"),
+            "Target Windows partition is unavailable." => LocalizationText.GetString("StepResult.TargetWindowsPartitionUnavailable"),
+            "Target computer name configured." => LocalizationText.GetString("StepResult.TargetComputerNameConfigured"),
+            "Target computer name configured (simulation)." => LocalizationText.GetString("StepResult.TargetComputerNameConfiguredSimulation"),
+            "Configuring recovery environment..." => LocalizationText.GetString("StepMessage.ConfiguringRecoveryEnvironment"),
+            "Preparing Windows Recovery Environment..." => LocalizationText.GetString("StepMessage.PreparingWindowsRecoveryEnvironment"),
+            "Recovery partition is unavailable." => LocalizationText.GetString("StepResult.RecoveryPartitionUnavailable"),
+            "Recovery environment configured." => LocalizationText.GetString("StepResult.RecoveryEnvironmentConfigured"),
+            "Recovery environment configured (simulation)." => LocalizationText.GetString("StepResult.RecoveryEnvironmentConfiguredSimulation"),
+            "Driver pack disabled (None selected)." => LocalizationText.GetString("StepResult.DriverPackDisabled"),
+            "No driver pack download required." => LocalizationText.GetString("StepResult.NoDriverPackDownloadRequired"),
+            "Downloading driver pack..." => LocalizationText.GetString("StepMessage.DownloadingDriverPack"),
+            "Preparing download..." => LocalizationText.GetString("StepMessage.PreparingDownload"),
+            "OEM driver pack mode selected but no driver pack was provided." => LocalizationText.GetString("StepResult.OemDriverPackMissing"),
+            "Driver pack downloaded." => LocalizationText.GetString("StepResult.DriverPackDownloaded"),
+            "Driver pack downloaded (simulation)." => LocalizationText.GetString("StepResult.DriverPackDownloadedSimulation"),
+            "Extracting driver pack..." => LocalizationText.GetString("StepMessage.ExtractingDriverPack"),
+            "Driver pack was not downloaded." => LocalizationText.GetString("StepResult.DriverPackNotDownloaded"),
+            "Driver pack extracted." => LocalizationText.GetString("StepResult.DriverPackExtracted"),
+            "Driver pack extracted (simulation)." => LocalizationText.GetString("StepResult.DriverPackExtractedSimulation"),
+            "No driver pack operation is required." => LocalizationText.GetString("StepResult.NoDriverPackOperationRequired"),
+            "Unsupported driver pack install mode." => LocalizationText.GetString("StepResult.UnsupportedDriverPackInstallMode"),
+            "No extracted INF driver payload is available." => LocalizationText.GetString("StepResult.NoExtractedInfDriverPayload"),
+            "Applying driver pack..." => LocalizationText.GetString("StepMessage.ApplyingDriverPack"),
+            "Applying Windows drivers..." => LocalizationText.GetString("StepMessage.ApplyingWindowsDrivers"),
+            "Mounting WinRE..." => LocalizationText.GetString("StepMessage.MountingWinRe"),
+            "Applying WinRE drivers..." => LocalizationText.GetString("StepMessage.ApplyingWinReDrivers"),
+            "Unmounting WinRE..." => LocalizationText.GetString("StepMessage.UnmountingWinRe"),
+            "Staging package..." => LocalizationText.GetString("StepMessage.StagingPackage"),
+            "Updating SetupComplete hook..." => LocalizationText.GetString("StepMessage.UpdatingSetupCompleteHook"),
+            "Driver pack applied." => LocalizationText.GetString("StepResult.DriverPackApplied"),
+            "Driver pack staged for first boot." => LocalizationText.GetString("StepResult.DriverPackStagedForFirstBoot"),
+            "Driver pack applied (simulation)." => LocalizationText.GetString("StepResult.DriverPackAppliedSimulation"),
+            "Downloading firmware update..." => LocalizationText.GetString("StepMessage.DownloadingFirmwareUpdate"),
+            "Preparing Microsoft Update Catalog lookup..." => LocalizationText.GetString("StepMessage.PreparingMicrosoftUpdateCatalogLookup"),
+            "Firmware updates are disabled." => LocalizationText.GetString("StepResult.FirmwareUpdatesDisabled"),
+            "Firmware updates are disabled for virtual machines." => LocalizationText.GetString("StepResult.FirmwareUpdatesDisabledForVirtualMachines"),
+            "Firmware updates are skipped while the device is running on battery power." => LocalizationText.GetString("StepResult.FirmwareUpdatesSkippedOnBattery"),
+            "System firmware hardware identifier is unavailable." => LocalizationText.GetString("StepResult.SystemFirmwareHardwareIdentifierUnavailable"),
+            "Firmware update downloaded." => LocalizationText.GetString("StepResult.FirmwareUpdateDownloaded"),
+            "Firmware update downloaded (simulation)." => LocalizationText.GetString("StepResult.FirmwareUpdateDownloadedSimulation"),
+            "No extracted firmware payload is available." => LocalizationText.GetString("StepResult.NoExtractedFirmwarePayload"),
+            "The extracted firmware payload does not contain any INF files." => LocalizationText.GetString("StepResult.NoFirmwareInfFiles"),
+            "Applying firmware update..." => LocalizationText.GetString("StepMessage.ApplyingFirmwareUpdate"),
+            "Injecting firmware payload into offline Windows..." => LocalizationText.GetString("StepMessage.InjectingFirmwarePayload"),
+            "Firmware update applied." => LocalizationText.GetString("StepResult.FirmwareUpdateApplied"),
+            "Firmware update applied (simulation)." => LocalizationText.GetString("StepResult.FirmwareUpdateAppliedSimulation"),
+            "Sealing recovery partition..." => LocalizationText.GetString("StepMessage.SealingRecoveryPartition"),
+            "Removing recovery drive letter..." => LocalizationText.GetString("StepMessage.RemovingRecoveryDriveLetter"),
+            "Recovery partition sealed." => LocalizationText.GetString("StepResult.RecoveryPartitionSealed"),
+            "Recovery partition sealed (simulation)." => LocalizationText.GetString("StepResult.RecoveryPartitionSealedSimulation"),
+            "Autopilot is disabled." => LocalizationText.GetString("StepResult.AutopilotDisabled"),
+            "Autopilot is enabled but no profile was selected." => LocalizationText.GetString("StepResult.AutopilotProfileMissing"),
+            "Target Windows partition is unavailable for Autopilot staging." => LocalizationText.GetString("StepResult.TargetWindowsPartitionUnavailableForAutopilot"),
+            "Failed to resolve the target Autopilot directory." => LocalizationText.GetString("StepResult.TargetAutopilotDirectoryUnavailable"),
+            "Staging Autopilot profile..." => LocalizationText.GetString("StepMessage.StagingAutopilotProfile"),
+            "Copying AutopilotConfigurationFile.json..." => LocalizationText.GetString("StepMessage.CopyingAutopilotConfiguration"),
+            "Writing dry-run Autopilot manifest..." => LocalizationText.GetString("StepMessage.WritingDryRunAutopilotManifest"),
+            "Autopilot profile staged." => LocalizationText.GetString("StepResult.AutopilotProfileStaged"),
+            "Autopilot profile staged (simulation)." => LocalizationText.GetString("StepResult.AutopilotProfileStagedSimulation"),
+            "Rebooting now..." => LocalizationText.GetString("Status.RebootingNow"),
+            "Reboot command failed." => LocalizationText.GetString("Status.RebootCommandFailed"),
+            "Unknown step" => LocalizationText.GetString("Status.UnknownStep"),
+            "No error details were provided." => LocalizationText.GetString("Status.NoErrorDetails"),
+            "N/A" => LocalizationText.GetString("Common.NotAvailable"),
+            "Unavailable" => LocalizationText.GetString("Common.Unavailable"),
+            "None" => LocalizationText.GetString("Common.None"),
+            "Microsoft Update Catalog" => LocalizationText.GetString("DriverPack.MicrosoftUpdateCatalog"),
+            "OEM Driver Pack" => LocalizationText.GetString("DriverPack.OemDriverPack"),
+            _ => LocalizeDynamicMessage(value)
+        };
+    }
+
+    private static string LocalizeDynamicMessage(string value)
+    {
+        Match match = CatalogLoadedRegex().Match(value);
+        if (match.Success)
+        {
+            return LocalizationText.Format(
+                "Catalog.LoadedFormat",
+                int.Parse(match.Groups["os"].Value),
+                int.Parse(match.Groups["drivers"].Value));
+        }
+
+        if (TryLocalizeSingleSuffix(value, "Catalog load failed: ", "Catalog.LoadFailedFormat", out string localized))
+        {
+            return localized;
+        }
+
+        if (TryLocalizeSingleSuffix(value, "Target disk discovery failed: ", "Preparation.TargetDiskDiscoveryFailedFormat", out localized))
+        {
+            return localized;
+        }
+
+        if (TryLocalizeSingleSuffix(value, "Hardware detection failed: ", "Preparation.HardwareDetectionFailedFormat", out localized))
+        {
+            return localized;
+        }
+
+        if (TryLocalizeSingleSuffix(value, "Selected disk blocked: ", "Disk.SelectedBlockedFormat", out localized))
+        {
+            return localized;
+        }
+
+        if (TryLocalizeSingleSuffix(value, "Selected disk is blocked: ", "Disk.SelectedBlockedFormat", out localized))
+        {
+            return localized;
+        }
+
+        if (TryLocalizeSingleSuffix(value, "Deployment failed: ", "Status.DeploymentFailedFormat", out localized))
+        {
+            return localized;
+        }
+
+        if (TryLocalizeSingleSuffix(value, "Unable to open log file: ", "Status.UnableToOpenLogFileFormat", out localized))
+        {
+            return localized;
+        }
+
+        if (TryLocalizeSingleSuffix(value, "Reboot command failed: ", "Status.RebootCommandFailedFormat", out localized))
+        {
+            return localized;
+        }
+
+        if (value.StartsWith("Debug preview: DISM apply failed because the target partition is read-only.", StringComparison.Ordinal))
+        {
+            return LocalizationText.GetString("Debug.ErrorPreviewMessage");
+        }
+
+        match = ProfilesAvailableRegex().Match(value);
+        if (match.Success)
+        {
+            return LocalizationText.Format("Preparation.AutopilotProfilesAvailableFormat", int.Parse(match.Groups["count"].Value));
+        }
+
+        match = TargetDisksLoadedRegex().Match(value);
+        if (match.Success)
+        {
+            return LocalizationText.Format("Preparation.TargetDisksLoadedFormat", int.Parse(match.Groups["count"].Value));
+        }
+
+        match = StepCounterRegex().Match(value);
+        if (match.Success)
+        {
+            return LocalizationText.Format(
+                "Status.StepCounterFormat",
+                int.Parse(match.Groups["current"].Value),
+                int.Parse(match.Groups["total"].Value));
+        }
+
+        match = StartingStepRegex().Match(value);
+        if (match.Success)
+        {
+            return LocalizationText.Format("Status.StartingStepFormat", LocalizeStepName(match.Groups["step"].Value));
+        }
+
+        match = StartingStepSubProgressRegex().Match(value);
+        if (match.Success)
+        {
+            return LocalizationText.Format("Status.StartingStepSubProgressFormat", LocalizeStepName(match.Groups["step"].Value));
+        }
+
+        match = ApplyingImageProgressRegex().Match(value);
+        if (match.Success)
+        {
+            return LocalizationText.Format("Debug.ApplyingImageProgressFormat", match.Groups["percent"].Value);
+        }
+
+        match = WpeUtilFailureRegex().Match(value);
+        if (match.Success)
+        {
+            return LocalizationText.Format("Status.WpeUtilFailureFormat", match.Groups["code"].Value, match.Groups["diagnostic"].Value.Trim());
+        }
+
+        return value;
+    }
+
+    private static bool TryLocalizeSingleSuffix(string value, string prefix, string key, out string localized)
+    {
+        if (value.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            localized = LocalizationText.Format(key, value[prefix.Length..].Trim());
+            return true;
+        }
+
+        localized = string.Empty;
+        return false;
+    }
+
+    [GeneratedRegex(@"^Catalogs loaded: (?<os>\d+) OS entries, (?<drivers>\d+) driver packs\.$")]
+    private static partial Regex CatalogLoadedRegex();
+
+    [GeneratedRegex(@"^Profiles available: (?<count>\d+)$")]
+    private static partial Regex ProfilesAvailableRegex();
+
+    [GeneratedRegex(@"^Target disks loaded: (?<count>\d+) detected\.$")]
+    private static partial Regex TargetDisksLoadedRegex();
+
+    [GeneratedRegex(@"^Step: (?<current>\d+) of (?<total>\d+)$")]
+    private static partial Regex StepCounterRegex();
+
+    [GeneratedRegex(@"^Starting (?<step>.+)\.$")]
+    private static partial Regex StartingStepRegex();
+
+    [GeneratedRegex(@"^Starting (?<step>.+)\.\.\.$")]
+    private static partial Regex StartingStepSubProgressRegex();
+
+    [GeneratedRegex(@"^Applying image: (?<percent>\d+(?:[.,]\d+)?)%$")]
+    private static partial Regex ApplyingImageProgressRegex();
+
+    [GeneratedRegex(@"^wpeutil\.exe failed with exit code (?<code>\d+)\. (?<diagnostic>.+)$")]
+    private static partial Regex WpeUtilFailureRegex();
+}

--- a/src/Foundry.Deploy/Services/Localization/ILocalizationService.cs
+++ b/src/Foundry.Deploy/Services/Localization/ILocalizationService.cs
@@ -1,0 +1,11 @@
+using System.Globalization;
+
+namespace Foundry.Deploy.Services.Localization;
+
+public interface ILocalizationService
+{
+    CultureInfo CurrentCulture { get; }
+    StringsWrapper Strings { get; }
+    event EventHandler? LanguageChanged;
+    void SetCulture(CultureInfo culture);
+}

--- a/src/Foundry.Deploy/Services/Localization/LocalizationService.cs
+++ b/src/Foundry.Deploy/Services/Localization/LocalizationService.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Resources;
+
+namespace Foundry.Deploy.Services.Localization;
+
+public sealed class LocalizationService : ILocalizationService, INotifyPropertyChanged
+{
+    private readonly ResourceManager _resourceManager;
+    private readonly StringsWrapper _stringsWrapper;
+    private CultureInfo _currentCulture;
+
+    public LocalizationService()
+    {
+        _resourceManager = LocalizationText.ResourceManager;
+        _currentCulture = CultureInfo.CurrentUICulture;
+        _stringsWrapper = new StringsWrapper(_resourceManager, _currentCulture);
+    }
+
+    public CultureInfo CurrentCulture
+    {
+        get => _currentCulture;
+        private set
+        {
+            if (_currentCulture != value)
+            {
+                _currentCulture = value;
+                CultureInfo.CurrentUICulture = _currentCulture;
+                _stringsWrapper.SetCulture(_currentCulture);
+                OnPropertyChanged(nameof(CurrentCulture));
+            }
+        }
+    }
+
+    public StringsWrapper Strings => _stringsWrapper;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    public event EventHandler? LanguageChanged;
+
+    public void SetCulture(CultureInfo culture)
+    {
+        CurrentCulture = culture;
+        LanguageChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/Foundry.Deploy/Services/Localization/LocalizationText.cs
+++ b/src/Foundry.Deploy/Services/Localization/LocalizationText.cs
@@ -1,0 +1,20 @@
+using System.Globalization;
+using System.Resources;
+
+namespace Foundry.Deploy.Services.Localization;
+
+public static class LocalizationText
+{
+    public static readonly ResourceManager ResourceManager =
+        new("Foundry.Deploy.Resources.AppStrings", typeof(LocalizationText).Assembly);
+
+    public static string GetString(string key)
+    {
+        return ResourceManager.GetString(key, CultureInfo.CurrentUICulture) ?? key;
+    }
+
+    public static string Format(string key, params object[] args)
+    {
+        return string.Format(CultureInfo.CurrentUICulture, GetString(key), args);
+    }
+}

--- a/src/Foundry.Deploy/Services/Localization/StringsWrapper.cs
+++ b/src/Foundry.Deploy/Services/Localization/StringsWrapper.cs
@@ -17,7 +17,11 @@ public sealed class StringsWrapper : INotifyPropertyChanged
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    public string this[string key] => _resourceManager.GetString(key, _currentCulture) ?? key;
+    public string this[string key]
+    {
+        get => _resourceManager.GetString(key, _currentCulture) ?? key;
+        set { /* No-op to support WPF controls that default to TwoWay/OneWayToSource binding */ }
+    }
 
     public void SetCulture(CultureInfo culture)
     {

--- a/src/Foundry.Deploy/Services/Localization/StringsWrapper.cs
+++ b/src/Foundry.Deploy/Services/Localization/StringsWrapper.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Resources;
+
+namespace Foundry.Deploy.Services.Localization;
+
+public sealed class StringsWrapper : INotifyPropertyChanged
+{
+    private readonly ResourceManager _resourceManager;
+    private CultureInfo _currentCulture;
+
+    public StringsWrapper(ResourceManager resourceManager, CultureInfo currentCulture)
+    {
+        _resourceManager = resourceManager;
+        _currentCulture = currentCulture;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public string this[string key] => _resourceManager.GetString(key, _currentCulture) ?? key;
+
+    public void SetCulture(CultureInfo culture)
+    {
+        if (_currentCulture != culture)
+        {
+            _currentCulture = culture;
+            OnPropertyChanged("Item[]");
+        }
+    }
+
+    private void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/Foundry.Deploy/Services/Wizard/DeploymentWizardContext.cs
+++ b/src/Foundry.Deploy/Services/Wizard/DeploymentWizardContext.cs
@@ -95,6 +95,8 @@ public sealed class DeploymentWizardContext : IDisposable
         Preparation.StatusMessageGenerated -= OnPreparationStatusMessageGenerated;
         OperatingSystemCatalog.StateChanged -= OnOperatingSystemCatalogStateChanged;
         DriverPackSelection.StateChanged -= OnDriverPackSelectionStateChanged;
+        Preparation.Dispose();
+        DriverPackSelection.Dispose();
         _isDisposed = true;
     }
 

--- a/src/Foundry.Deploy/Services/Wizard/DeploymentWizardContextFactory.cs
+++ b/src/Foundry.Deploy/Services/Wizard/DeploymentWizardContextFactory.cs
@@ -1,5 +1,6 @@
 using Foundry.Deploy.Services.DriverPacks;
 using Foundry.Deploy.Services.Hardware;
+using Foundry.Deploy.Services.Localization;
 using Foundry.Deploy.ViewModels;
 using Microsoft.Extensions.Logging;
 
@@ -11,6 +12,7 @@ public sealed class DeploymentWizardContextFactory : IDeploymentWizardContextFac
     private readonly IHardwareProfileService _hardwareProfileService;
     private readonly IOfflineWindowsComputerNameService _offlineWindowsComputerNameService;
     private readonly IDriverPackSelectionService _driverPackSelectionService;
+    private readonly ILocalizationService _localizationService;
     private readonly ILoggerFactory _loggerFactory;
 
     public DeploymentWizardContextFactory(
@@ -18,12 +20,14 @@ public sealed class DeploymentWizardContextFactory : IDeploymentWizardContextFac
         IHardwareProfileService hardwareProfileService,
         IOfflineWindowsComputerNameService offlineWindowsComputerNameService,
         IDriverPackSelectionService driverPackSelectionService,
+        ILocalizationService localizationService,
         ILoggerFactory loggerFactory)
     {
         _targetDiskService = targetDiskService;
         _hardwareProfileService = hardwareProfileService;
         _offlineWindowsComputerNameService = offlineWindowsComputerNameService;
         _driverPackSelectionService = driverPackSelectionService;
+        _localizationService = localizationService;
         _loggerFactory = loggerFactory;
     }
 
@@ -33,6 +37,7 @@ public sealed class DeploymentWizardContextFactory : IDeploymentWizardContextFac
             _targetDiskService,
             _hardwareProfileService,
             _offlineWindowsComputerNameService,
+            _localizationService,
             _loggerFactory.CreateLogger<DeploymentPreparationViewModel>(),
             isDebugSafeMode);
         OperatingSystemCatalogViewModel operatingSystemCatalog = new(
@@ -40,6 +45,7 @@ public sealed class DeploymentWizardContextFactory : IDeploymentWizardContextFac
             Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") ?? string.Empty);
         DriverPackSelectionViewModel driverPackSelection = new(
             _driverPackSelectionService,
+            _localizationService,
             operatingSystemCatalog.EffectiveOsArchitecture);
 
         return new DeploymentWizardContext(

--- a/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
@@ -4,13 +4,14 @@ using CommunityToolkit.Mvvm.Input;
 using Foundry.Deploy.Models;
 using Foundry.Deploy.Models.Configuration;
 using Foundry.Deploy.Services.Hardware;
+using Foundry.Deploy.Services.Localization;
 using Foundry.Deploy.Services.System;
 using Foundry.Deploy.Validation;
 using Microsoft.Extensions.Logging;
 
 namespace Foundry.Deploy.ViewModels;
 
-public sealed partial class DeploymentPreparationViewModel : ObservableObject
+public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelBase
 {
     private readonly ITargetDiskService _targetDiskService;
     private readonly IHardwareProfileService _hardwareProfileService;
@@ -20,6 +21,7 @@ public sealed partial class DeploymentPreparationViewModel : ObservableObject
     private HardwareProfile? _detectedHardware;
     private DeployMachineNamingSettings _machineNamingConfiguration = new();
     private string _lockedComputerNamePrefix = string.Empty;
+    private string _detectedHardwareSummaryRaw = LocalizationText.GetString("Preparation.DetectingHardware");
     private bool _isApplyingManagedComputerName;
     private bool _isUpdatingFirmwareOptionSelection;
     private bool _hasUserSelectedFirmwareOption;
@@ -29,14 +31,17 @@ public sealed partial class DeploymentPreparationViewModel : ObservableObject
         ITargetDiskService targetDiskService,
         IHardwareProfileService hardwareProfileService,
         IOfflineWindowsComputerNameService offlineWindowsComputerNameService,
+        ILocalizationService localizationService,
         ILogger logger,
         bool isDebugSafeMode)
+        : base(localizationService)
     {
         _targetDiskService = targetDiskService;
         _hardwareProfileService = hardwareProfileService;
         _offlineWindowsComputerNameService = offlineWindowsComputerNameService;
         _logger = logger;
         _isDebugSafeMode = isDebugSafeMode;
+        LocalizationService.LanguageChanged += OnLocalizationLanguageChanged;
     }
 
     public event EventHandler? StateChanged;
@@ -67,7 +72,7 @@ public sealed partial class DeploymentPreparationViewModel : ObservableObject
     private AutopilotProfileCatalogItem? selectedAutopilotProfile;
 
     [ObservableProperty]
-    private string detectedHardwareSummary = "Detecting hardware...";
+    private string detectedHardwareSummary = LocalizationText.GetString("Preparation.DetectingHardware");
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RefreshTargetDisksCommand))]
@@ -79,10 +84,13 @@ public sealed partial class DeploymentPreparationViewModel : ObservableObject
     public bool IsFirmwareUpdatesOptionEnabled => _detectedHardware?.IsVirtualMachine != true;
     public bool HasAutopilotProfiles => AutopilotProfiles.Count > 0;
     public bool IsAutopilotProfileSelectionEnabled => IsAutopilotEnabled && HasAutopilotProfiles;
+    public string TargetDiskSelectionHint => !string.IsNullOrWhiteSpace(SelectedTargetDisk?.SelectionWarning)
+        ? SelectedTargetDisk.SelectionWarning
+        : GetString("Preparation.TargetDiskHint");
     public string AutopilotProfileHint =>
         HasAutopilotProfiles
-            ? $"Profiles available: {AutopilotProfiles.Count}"
-            : "No imported Autopilot profiles were found in X:\\Foundry\\Config\\Autopilot.";
+            ? Format("Preparation.AutopilotProfilesAvailableFormat", AutopilotProfiles.Count)
+            : GetString("Preparation.AutopilotProfilesMissing");
 
     public bool HasTargetComputerNameValidationError => !string.IsNullOrWhiteSpace(TargetComputerNameValidationMessage);
 
@@ -98,7 +106,7 @@ public sealed partial class DeploymentPreparationViewModel : ObservableObject
         }
 
         IsTargetDiskLoading = true;
-        PublishStatus("Loading target disks...");
+        PublishStatus(GetString("Preparation.LoadingTargetDisks"));
 
         try
         {
@@ -109,7 +117,7 @@ public sealed partial class DeploymentPreparationViewModel : ObservableObject
         catch (Exception ex)
         {
             _logger.LogError(ex, "Target disk discovery failed.");
-            PublishStatus($"Target disk discovery failed: {ex.Message}");
+            PublishStatus(Format("Preparation.TargetDiskDiscoveryFailedFormat", ex.Message));
         }
         finally
         {
@@ -129,7 +137,7 @@ public sealed partial class DeploymentPreparationViewModel : ObservableObject
         catch (Exception ex)
         {
             _logger.LogError(ex, "Hardware profile loading failed in preparation view model.");
-            SetHardwareDetectionFailure($"Hardware detection failed: {ex.Message}");
+            SetHardwareDetectionFailure(Format("Preparation.HardwareDetectionFailedFormat", ex.Message));
         }
     }
 
@@ -197,22 +205,29 @@ public sealed partial class DeploymentPreparationViewModel : ObservableObject
 
         if (profile is null)
         {
-            DetectedHardwareSummary = "Hardware detection failed.";
+            _detectedHardwareSummaryRaw = GetString("Preparation.HardwareDetectionFailed");
+            DetectedHardwareSummary = _detectedHardwareSummaryRaw;
             OnPropertyChanged(nameof(IsFirmwareUpdatesOptionEnabled));
             RaiseStateChanged();
             return;
         }
 
         SyncFirmwareOptionFromHardware(profile);
-        DetectedHardwareSummary =
-            $"{profile.DisplayLabel} | TPM: {(profile.IsTpmPresent ? "Yes" : "No")} | Power: {(profile.IsOnBattery ? "Battery" : "AC")} | Firmware: {(profile.SystemFirmwareHardwareId.Length > 0 ? "Detected" : "Unavailable")}";
+        _detectedHardwareSummaryRaw = Format(
+            "Preparation.HardwareSummaryFormat",
+            profile.DisplayLabel,
+            profile.IsTpmPresent ? GetString("Common.Yes") : GetString("Common.No"),
+            profile.IsOnBattery ? GetString("Preparation.PowerBattery") : GetString("Preparation.PowerAc"),
+            profile.SystemFirmwareHardwareId.Length > 0 ? GetString("Common.Detected") : GetString("Common.Unavailable"));
+        DetectedHardwareSummary = _detectedHardwareSummaryRaw;
         OnPropertyChanged(nameof(IsFirmwareUpdatesOptionEnabled));
         RaiseStateChanged();
     }
 
     public void SetHardwareDetectionFailure(string message)
     {
-        DetectedHardwareSummary = message;
+        _detectedHardwareSummaryRaw = DeploymentUiTextLocalizer.LocalizeMessage(message);
+        DetectedHardwareSummary = _detectedHardwareSummaryRaw;
         RaiseStateChanged();
     }
 
@@ -247,7 +262,7 @@ public sealed partial class DeploymentPreparationViewModel : ObservableObject
         {
             SelectedTargetDisk = null;
             RaiseStateChanged();
-            return "No disks detected.";
+            return GetString("Preparation.NoDisksDetected");
         }
 
         TargetDiskInfo? currentSelection = SelectedTargetDisk is null
@@ -260,7 +275,7 @@ public sealed partial class DeploymentPreparationViewModel : ObservableObject
             ?? TargetDisks.FirstOrDefault();
 
         RaiseStateChanged();
-        return $"Target disks loaded: {TargetDisks.Count} detected.";
+        return Format("Preparation.TargetDisksLoadedFormat", TargetDisks.Count);
     }
 
     partial void OnTargetComputerNameChanged(string value)
@@ -271,7 +286,7 @@ public sealed partial class DeploymentPreparationViewModel : ObservableObject
             return;
         }
 
-        TargetComputerNameValidationMessage = ComputerNameRules.GetValidationMessage(value);
+        TargetComputerNameValidationMessage = ResolveComputerNameValidationMessage(value);
         if (string.IsNullOrWhiteSpace(value))
         {
             RaiseStateChanged();
@@ -285,7 +300,7 @@ public sealed partial class DeploymentPreparationViewModel : ObservableObject
             return;
         }
 
-        TargetComputerNameValidationMessage = ComputerNameRules.GetValidationMessage(normalized);
+        TargetComputerNameValidationMessage = ResolveComputerNameValidationMessage(normalized);
         RaiseStateChanged();
     }
 
@@ -316,6 +331,7 @@ public sealed partial class DeploymentPreparationViewModel : ObservableObject
 
     partial void OnSelectedTargetDiskChanged(TargetDiskInfo? value)
     {
+        OnPropertyChanged(nameof(TargetDiskSelectionHint));
         RaiseStateChanged();
     }
 
@@ -376,7 +392,7 @@ public sealed partial class DeploymentPreparationViewModel : ObservableObject
         try
         {
             TargetComputerName = value;
-            TargetComputerNameValidationMessage = ComputerNameRules.GetValidationMessage(value);
+            TargetComputerNameValidationMessage = ResolveComputerNameValidationMessage(value);
         }
         finally
         {
@@ -472,6 +488,50 @@ public sealed partial class DeploymentPreparationViewModel : ObservableObject
     private void PublishStatus(string message)
     {
         StatusMessageGenerated?.Invoke(message);
+    }
+
+    public override void Dispose()
+    {
+        LocalizationService.LanguageChanged -= OnLocalizationLanguageChanged;
+        base.Dispose();
+    }
+
+    private void OnLocalizationLanguageChanged(object? sender, EventArgs e)
+    {
+        RunOnUiThread(() =>
+        {
+            if (_detectedHardware is not null)
+            {
+                SetDetectedHardware(_detectedHardware);
+            }
+            else
+            {
+                DetectedHardwareSummary = _detectedHardwareSummaryRaw;
+            }
+
+            TargetComputerNameValidationMessage = ResolveComputerNameValidationMessage(TargetComputerName);
+            OnPropertyChanged(nameof(AutopilotProfileHint));
+            OnPropertyChanged(nameof(TargetDiskSelectionHint));
+            OnPropertyChanged(nameof(TargetDisks));
+            OnPropertyChanged(nameof(SelectedTargetDisk));
+        });
+    }
+
+    private string ResolveComputerNameValidationMessage(string? value)
+    {
+        return ComputerNameRules.IsValid(value)
+            ? string.Empty
+            : GetString("Preparation.ComputerNameValidationMessage");
+    }
+
+    private string GetString(string key)
+    {
+        return Strings[key];
+    }
+
+    private string Format(string key, params object[] args)
+    {
+        return string.Format(LocalizationService.CurrentCulture, GetString(key), args);
     }
 
     private bool CanRefreshTargetDisks()

--- a/src/Foundry.Deploy/ViewModels/DeploymentSessionViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentSessionViewModel.cs
@@ -6,6 +6,7 @@ using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Foundry.Deploy.Services.Deployment;
+using Foundry.Deploy.Services.Localization;
 using Foundry.Deploy.Services.Logging;
 using Foundry.Deploy.Services.Operations;
 using Foundry.Deploy.Services.System;
@@ -13,7 +14,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Foundry.Deploy.ViewModels;
 
-public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisposable
+public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
 {
     private readonly Dispatcher _dispatcher;
     private readonly ILogger _logger;
@@ -21,6 +22,11 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
     private readonly IDeploymentOrchestrator _deploymentOrchestrator;
     private readonly IProcessRunner _processRunner;
     private readonly bool _isDebugSafeMode;
+    private string _rawDeploymentStatus = "Ready";
+    private string _rawCurrentStepName = "Waiting for deployment...";
+    private string _rawCurrentStepProgressText = "Waiting for progress...";
+    private string _rawFailedStepName = string.Empty;
+    private string _rawFailedStepErrorMessage = string.Empty;
     private DispatcherTimer? _elapsedTimeTimer;
     private DispatcherTimer? _rebootCountdownTimer;
     private DateTimeOffset? _deploymentStartTimeUtc;
@@ -37,7 +43,9 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
         IOperationProgressService operationProgressService,
         IDeploymentOrchestrator deploymentOrchestrator,
         IProcessRunner processRunner,
+        ILocalizationService localizationService,
         bool isDebugSafeMode)
+        : base(localizationService)
     {
         _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -48,6 +56,7 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
 
         _operationProgressService.ProgressChanged += OnOperationProgressChanged;
         _deploymentOrchestrator.StepProgressChanged += OnStepProgressChanged;
+        LocalizationService.LanguageChanged += OnLocalizationLanguageChanged;
     }
 
     [ObservableProperty]
@@ -63,7 +72,7 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
     private DeploymentPage currentPage = DeploymentPage.Splash;
 
     [ObservableProperty]
-    private string deploymentStatus = "Ready";
+    private string deploymentStatus = LocalizationText.GetString("Status.Ready");
 
     [ObservableProperty]
     private int deploymentProgress;
@@ -75,10 +84,10 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
     private string globalProgressPercentText = "0%";
 
     [ObservableProperty]
-    private string currentStepName = "Waiting for deployment...";
+    private string currentStepName = LocalizationText.GetString("Status.WaitingForDeployment");
 
     [ObservableProperty]
-    private string stepCounterText = "Step: ? of ?";
+    private string stepCounterText = LocalizationText.GetString("Status.StepCounterUnknown");
 
     [ObservableProperty]
     private double currentStepProgress;
@@ -87,31 +96,32 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
     private bool isCurrentStepProgressIndeterminate = true;
 
     [ObservableProperty]
-    private string currentStepProgressText = "Waiting for progress...";
+    private string currentStepProgressText = LocalizationText.GetString("Status.WaitingForProgress");
 
     [ObservableProperty]
     private string computerNameText = string.Empty;
 
     [ObservableProperty]
-    private string ipAddress = "N/A";
+    private string ipAddress = LocalizationText.GetString("Common.NotAvailable");
 
     [ObservableProperty]
-    private string subnetMask = "N/A";
+    private string subnetMask = LocalizationText.GetString("Common.NotAvailable");
 
     [ObservableProperty]
-    private string gatewayAddress = "N/A";
+    private string gatewayAddress = LocalizationText.GetString("Common.NotAvailable");
 
     [ObservableProperty]
-    private string macAddress = "N/A";
+    private string macAddress = LocalizationText.GetString("Common.NotAvailable");
 
     [ObservableProperty]
-    private string startTimeText = "N/A";
+    private string startTimeText = LocalizationText.GetString("Common.NotAvailable");
 
     [ObservableProperty]
     private string elapsedTimeText = "00:00:00";
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RebootNowCommand))]
+    [NotifyPropertyChangedFor(nameof(RebootCountdownText))]
     private int rebootCountdownSeconds = 10;
 
     [ObservableProperty]
@@ -133,10 +143,12 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
     public bool IsStartupReady => !IsStartupInitializing;
 
     public int PlannedStepCount => _deploymentOrchestrator.PlannedSteps.Count;
+    public string RebootCountdownText => Format("Success.RebootCountdownFormat", RebootCountdownSeconds);
 
     public void SetStatus(string status)
     {
-        DeploymentStatus = status;
+        _rawDeploymentStatus = status;
+        DeploymentStatus = DeploymentUiTextLocalizer.LocalizeMessage(status);
     }
 
     public void SetComputerName(string computerName)
@@ -170,10 +182,10 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
 
         DeploymentProgress = 0;
         UpdateGlobalProgressVisuals(0);
-        CurrentStepName = "Preparing deployment...";
+        SetCurrentStepName("Preparing deployment...");
         CurrentStepProgress = 0;
         IsCurrentStepProgressIndeterminate = true;
-        CurrentStepProgressText = "Waiting for progress...";
+        SetCurrentStepProgressText("Waiting for progress...");
         StepCounterText = BuildStepCounterText(0);
         ComputerNameText = computerName;
         CaptureNetworkSnapshot();
@@ -183,7 +195,7 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
         ElapsedTimeText = "00:00:00";
         StartElapsedTimeTracking();
 
-        DeploymentStatus = "Deployment started.";
+        SetStatus("Deployment started.");
         CurrentPage = DeploymentPage.Progress;
     }
 
@@ -191,7 +203,7 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
     {
         _isDeploymentInProgress = false;
         _lastLogsDirectoryPath = logsDirectoryPath ?? string.Empty;
-        DeploymentStatus = status;
+        SetStatus(status);
         CurrentPage = DeploymentPage.Success;
     }
 
@@ -200,7 +212,7 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
         _isDeploymentInProgress = false;
         _lastLogsDirectoryPath = logsDirectoryPath ?? _lastLogsDirectoryPath;
         SetFailureDetails(stepName, errorMessage);
-        DeploymentStatus = status;
+        SetStatus(status);
         CurrentPage = DeploymentPage.Error;
     }
 
@@ -237,17 +249,17 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
         DeploymentProgress = progressPercent;
         UpdateGlobalProgressVisuals(progressPercent);
         ComputerNameText = computerName;
-        CurrentStepName = currentStepName;
+        SetCurrentStepName(currentStepName);
         StepCounterText = BuildStepCounterText(currentStepIndex);
         CurrentStepProgress = 65;
         IsCurrentStepProgressIndeterminate = false;
-        CurrentStepProgressText = "Applying image: 65%";
+        SetCurrentStepProgressText("Applying image: 65%");
         CaptureNetworkSnapshot();
         _deploymentStartTimeUtc = DateTimeOffset.Now;
         StartTimeText = _deploymentStartTimeUtc.Value.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
         ElapsedTimeText = "00:00:00";
         StartElapsedTimeTracking();
-        DeploymentStatus = "Debug preview: progress page.";
+        SetStatus("Debug preview: progress page.");
         CurrentPage = DeploymentPage.Progress;
     }
 
@@ -260,12 +272,12 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
         DeploymentProgress = 100;
         UpdateGlobalProgressVisuals(100);
         ComputerNameText = computerName;
-        CurrentStepName = finalStepName;
+        SetCurrentStepName(finalStepName);
         StepCounterText = BuildStepCounterText(plannedStepCount);
         CurrentStepProgress = 100;
         IsCurrentStepProgressIndeterminate = false;
-        CurrentStepProgressText = "Step completed.";
-        DeploymentStatus = "Debug preview: success page.";
+        SetCurrentStepProgressText("Step completed.");
+        SetStatus("Debug preview: success page.");
         CurrentPage = DeploymentPage.Success;
     }
 
@@ -276,7 +288,7 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
         ComputerNameText = computerName;
         StepCounterText = BuildStepCounterText(currentStepIndex);
         SetFailureDetails(failedStepName, failedStepErrorMessage);
-        DeploymentStatus = "Debug preview: error page.";
+        SetStatus("Debug preview: error page.");
         CurrentPage = DeploymentPage.Error;
     }
 
@@ -297,7 +309,7 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to open log file.");
-            DeploymentStatus = $"Unable to open log file: {ex.Message}";
+            SetStatus($"Unable to open log file: {ex.Message}");
         }
     }
 
@@ -324,7 +336,7 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
 
             if (!string.IsNullOrWhiteSpace(_operationProgressService.Status))
             {
-                DeploymentStatus = _operationProgressService.Status!;
+                SetStatus(_operationProgressService.Status!);
             }
         });
     }
@@ -338,11 +350,11 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
                 _activeStepIndex = stepProgress.StepIndex;
                 CurrentStepProgress = 0;
                 IsCurrentStepProgressIndeterminate = true;
-                CurrentStepProgressText = "Starting step...";
+                SetCurrentStepProgressText("Starting step...");
             }
 
-            CurrentStepName = stepProgress.StepName;
-            StepCounterText = $"Step: {stepProgress.StepIndex} of {stepProgress.StepCount}";
+            SetCurrentStepName(stepProgress.StepName);
+            StepCounterText = BuildStepCounterText(stepProgress.StepIndex);
 
             DeploymentProgress = Math.Max(DeploymentProgress, stepProgress.ProgressPercent);
             UpdateGlobalProgressVisuals(DeploymentProgress);
@@ -350,7 +362,7 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
 
             if (!string.IsNullOrWhiteSpace(stepProgress.Message))
             {
-                DeploymentStatus = stepProgress.Message;
+                SetStatus(stepProgress.Message);
             }
 
             if (stepProgress.State == DeploymentStepState.Failed)
@@ -360,7 +372,7 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
         });
     }
 
-    public void Dispose()
+    public override void Dispose()
     {
         if (_isDisposed)
         {
@@ -369,9 +381,11 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
 
         _operationProgressService.ProgressChanged -= OnOperationProgressChanged;
         _deploymentOrchestrator.StepProgressChanged -= OnStepProgressChanged;
+        LocalizationService.LanguageChanged -= OnLocalizationLanguageChanged;
         StopElapsedTimeTracking();
         StopRebootCountdown(resetSeconds: false);
         _isDisposed = true;
+        base.Dispose();
     }
 
     partial void OnCurrentPageChanged(DeploymentPage value)
@@ -406,21 +420,21 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
         {
             CurrentStepProgress = 100;
             IsCurrentStepProgressIndeterminate = false;
-            CurrentStepProgressText = stepProgress.StepSubProgressLabel ?? "Step completed.";
+            SetCurrentStepProgressText(stepProgress.StepSubProgressLabel ?? "Step completed.");
             return;
         }
 
         if (stepProgress.State == DeploymentStepState.Failed)
         {
             IsCurrentStepProgressIndeterminate = false;
-            CurrentStepProgressText = stepProgress.Message ?? "Step failed.";
+            SetCurrentStepProgressText(stepProgress.Message ?? "Step failed.");
             return;
         }
 
         if (stepProgress.State == DeploymentStepState.Skipped)
         {
             IsCurrentStepProgressIndeterminate = false;
-            CurrentStepProgressText = stepProgress.Message ?? "Step skipped.";
+            SetCurrentStepProgressText(stepProgress.Message ?? "Step skipped.");
             return;
         }
 
@@ -429,16 +443,16 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
             double normalized = Math.Clamp(stepProgress.StepSubProgressPercent.Value, 0d, 100d);
             CurrentStepProgress = normalized;
             IsCurrentStepProgressIndeterminate = false;
-            CurrentStepProgressText = string.IsNullOrWhiteSpace(stepProgress.StepSubProgressLabel)
+            SetCurrentStepProgressText(string.IsNullOrWhiteSpace(stepProgress.StepSubProgressLabel)
                 ? $"{normalized:0.#}%"
-                : stepProgress.StepSubProgressLabel!;
+                : stepProgress.StepSubProgressLabel!);
             return;
         }
 
         if (stepProgress.StepSubProgressIndeterminate)
         {
             IsCurrentStepProgressIndeterminate = true;
-            CurrentStepProgressText = stepProgress.StepSubProgressLabel ?? "In progress...";
+            SetCurrentStepProgressText(stepProgress.StepSubProgressLabel ?? "In progress...");
         }
     }
 
@@ -546,7 +560,7 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
                 throw new FileNotFoundException("Required reboot executable 'wpeutil.exe' was not found.", rebootExecutablePath);
             }
 
-            DeploymentStatus = "Rebooting now...";
+            SetStatus("Rebooting now...");
 
             ProcessExecutionResult result = await _processRunner
                 .RunAsync(rebootExecutablePath, "Reboot", Path.GetTempPath())
@@ -563,7 +577,7 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
                     ? result.StandardOutput
                     : result.StandardError;
                 SetFailureDetails("System reboot", $"wpeutil.exe failed with exit code {result.ExitCode}. {diagnostic}".Trim());
-                DeploymentStatus = "Reboot command failed.";
+                SetStatus("Reboot command failed.");
                 CurrentPage = DeploymentPage.Error;
             });
         }
@@ -572,7 +586,7 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
             RunOnUi(() =>
             {
                 SetFailureDetails("System reboot", ex.Message);
-                DeploymentStatus = $"Reboot command failed: {ex.Message}";
+                SetStatus($"Reboot command failed: {ex.Message}");
                 CurrentPage = DeploymentPage.Error;
             });
         }
@@ -588,22 +602,27 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
 
     private void SetFailureDetails(string? stepName, string? errorMessage)
     {
-        FailedStepName = string.IsNullOrWhiteSpace(stepName) ? "Unknown step" : stepName;
-        FailedStepErrorMessage = string.IsNullOrWhiteSpace(errorMessage) ? "No error details were provided." : errorMessage;
+        _rawFailedStepName = string.IsNullOrWhiteSpace(stepName) ? "Unknown step" : stepName;
+        _rawFailedStepErrorMessage = string.IsNullOrWhiteSpace(errorMessage) ? "No error details were provided." : errorMessage;
+        FailedStepName = DeploymentUiTextLocalizer.LocalizeStepName(_rawFailedStepName);
+        FailedStepErrorMessage = DeploymentUiTextLocalizer.LocalizeMessage(_rawFailedStepErrorMessage);
     }
 
     private void ClearFailureDetails()
     {
+        _rawFailedStepName = string.Empty;
+        _rawFailedStepErrorMessage = string.Empty;
         FailedStepName = string.Empty;
         FailedStepErrorMessage = string.Empty;
     }
 
     private void CaptureNetworkSnapshot()
     {
-        IpAddress = "N/A";
-        SubnetMask = "N/A";
-        GatewayAddress = "N/A";
-        MacAddress = "N/A";
+        string notAvailable = GetString("Common.NotAvailable");
+        IpAddress = notAvailable;
+        SubnetMask = notAvailable;
+        GatewayAddress = notAvailable;
+        MacAddress = notAvailable;
 
         try
         {
@@ -632,10 +651,10 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
                 byte[] macBytes = networkInterface.GetPhysicalAddress().GetAddressBytes();
 
                 IpAddress = ipv4AddressInfo.Address.ToString();
-                SubnetMask = ipv4AddressInfo.IPv4Mask?.ToString() ?? "N/A";
-                GatewayAddress = gatewayInfo?.Address.ToString() ?? "N/A";
+                SubnetMask = ipv4AddressInfo.IPv4Mask?.ToString() ?? notAvailable;
+                GatewayAddress = gatewayInfo?.Address.ToString() ?? notAvailable;
                 MacAddress = macBytes.Length == 0
-                    ? "N/A"
+                    ? notAvailable
                     : string.Join("-", macBytes.Select(value => value.ToString("X2", CultureInfo.InvariantCulture)));
                 return;
             }
@@ -650,11 +669,11 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
     {
         if (_plannedStepCount <= 0)
         {
-            return "Step: ? of ?";
+            return GetString("Status.StepCounterUnknown");
         }
 
         int normalizedStep = Math.Clamp(currentStep, 0, _plannedStepCount);
-        return $"Step: {normalizedStep} of {_plannedStepCount}";
+        return Format("Status.StepCounterFormat", normalizedStep, _plannedStepCount);
     }
 
     private string ResolveEffectiveLogFilePath()
@@ -676,5 +695,46 @@ public sealed partial class DeploymentSessionViewModel : ObservableObject, IDisp
         }
 
         _dispatcher.Invoke(action);
+    }
+
+    private void SetCurrentStepName(string value)
+    {
+        _rawCurrentStepName = value;
+        CurrentStepName = DeploymentUiTextLocalizer.LocalizeStepName(value);
+    }
+
+    private void SetCurrentStepProgressText(string value)
+    {
+        _rawCurrentStepProgressText = value;
+        CurrentStepProgressText = DeploymentUiTextLocalizer.LocalizeMessage(value);
+    }
+
+    private void OnLocalizationLanguageChanged(object? sender, EventArgs e)
+    {
+        RunOnUiThread(() =>
+        {
+            DeploymentStatus = DeploymentUiTextLocalizer.LocalizeMessage(_rawDeploymentStatus);
+            CurrentStepName = DeploymentUiTextLocalizer.LocalizeStepName(_rawCurrentStepName);
+            CurrentStepProgressText = DeploymentUiTextLocalizer.LocalizeMessage(_rawCurrentStepProgressText);
+            FailedStepName = string.IsNullOrWhiteSpace(_rawFailedStepName)
+                ? string.Empty
+                : DeploymentUiTextLocalizer.LocalizeStepName(_rawFailedStepName);
+            FailedStepErrorMessage = string.IsNullOrWhiteSpace(_rawFailedStepErrorMessage)
+                ? string.Empty
+                : DeploymentUiTextLocalizer.LocalizeMessage(_rawFailedStepErrorMessage);
+            StepCounterText = BuildStepCounterText(_activeStepIndex);
+            OnPropertyChanged(nameof(RebootCountdownText));
+            CaptureNetworkSnapshot();
+        });
+    }
+
+    private string GetString(string key)
+    {
+        return Strings[key];
+    }
+
+    private string Format(string key, params object[] args)
+    {
+        return string.Format(LocalizationService.CurrentCulture, GetString(key), args);
     }
 }

--- a/src/Foundry.Deploy/ViewModels/DriverPackSelectionViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DriverPackSelectionViewModel.cs
@@ -4,10 +4,11 @@ using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Foundry.Deploy.Models;
 using Foundry.Deploy.Services.DriverPacks;
+using Foundry.Deploy.Services.Localization;
 
 namespace Foundry.Deploy.ViewModels;
 
-public sealed partial class DriverPackSelectionViewModel : ObservableObject
+public sealed partial class DriverPackSelectionViewModel : LocalizedViewModelBase
 {
     private const string NoneDriverPackOptionKey = "none";
     private const string MicrosoftUpdateCatalogDriverPackOptionKey = "microsoft-update-catalog";
@@ -23,15 +24,22 @@ public sealed partial class DriverPackSelectionViewModel : ObservableObject
     private bool _isUpdatingDriverPackOptionSelection;
     private bool _hasUserSelectedDriverPackOption;
 
-    public DriverPackSelectionViewModel(IDriverPackSelectionService driverPackSelectionService)
-        : this(driverPackSelectionService, string.Empty)
+    public DriverPackSelectionViewModel(
+        IDriverPackSelectionService driverPackSelectionService,
+        ILocalizationService localizationService)
+        : this(driverPackSelectionService, localizationService, string.Empty)
     {
     }
 
-    public DriverPackSelectionViewModel(IDriverPackSelectionService driverPackSelectionService, string initialArchitecture)
+    public DriverPackSelectionViewModel(
+        IDriverPackSelectionService driverPackSelectionService,
+        ILocalizationService localizationService,
+        string initialArchitecture)
+        : base(localizationService)
     {
         _driverPackSelectionService = driverPackSelectionService ?? throw new ArgumentNullException(nameof(driverPackSelectionService));
         _effectiveArchitecture = NormalizeArchitecture(initialArchitecture);
+        LocalizationService.LanguageChanged += OnLocalizationLanguageChanged;
     }
 
     public event EventHandler? StateChanged;
@@ -66,9 +74,9 @@ public sealed partial class DriverPackSelectionViewModel : ObservableObject
 
     public string DriverPackModeDisplay => SelectedDriverPackOption?.Kind switch
     {
-        DriverPackSelectionKind.MicrosoftUpdateCatalog => "Microsoft Update Catalog",
-        DriverPackSelectionKind.OemCatalog => "OEM Driver Pack",
-        _ => "None"
+        DriverPackSelectionKind.MicrosoftUpdateCatalog => GetString("DriverPack.MicrosoftUpdateCatalog"),
+        DriverPackSelectionKind.OemCatalog => GetString("DriverPack.OemDriverPack"),
+        _ => GetString("Common.None")
     };
 
     public bool IsOemDriverSourceSelected => SelectedDriverPackOption?.Kind == DriverPackSelectionKind.OemCatalog;
@@ -476,23 +484,23 @@ public sealed partial class DriverPackSelectionViewModel : ObservableObject
                ?? options[0];
     }
 
-    private static DriverPackOptionItem CreateNoneDriverPackOption()
+    private DriverPackOptionItem CreateNoneDriverPackOption()
     {
         return new DriverPackOptionItem
         {
             Key = NoneDriverPackOptionKey,
-            DisplayName = "None",
+            DisplayName = GetString("Common.None"),
             Kind = DriverPackSelectionKind.None,
             DriverPack = null
         };
     }
 
-    private static DriverPackOptionItem CreateMicrosoftUpdateCatalogOption()
+    private DriverPackOptionItem CreateMicrosoftUpdateCatalogOption()
     {
         return new DriverPackOptionItem
         {
             Key = MicrosoftUpdateCatalogDriverPackOptionKey,
-            DisplayName = "Microsoft Update Catalog",
+            DisplayName = GetString("DriverPack.MicrosoftUpdateCatalog"),
             Kind = DriverPackSelectionKind.MicrosoftUpdateCatalog,
             DriverPack = null
         };
@@ -514,19 +522,19 @@ public sealed partial class DriverPackSelectionViewModel : ObservableObject
         DriverPackSelectionKind selectionKind = GetEffectiveSelectionKind();
         if (selectionKind == DriverPackSelectionKind.None)
         {
-            return "None";
+            return GetString("Common.None");
         }
 
         if (selectionKind == DriverPackSelectionKind.MicrosoftUpdateCatalog)
         {
-            return "Microsoft Update Catalog";
+            return GetString("DriverPack.MicrosoftUpdateCatalog");
         }
 
         DriverPackCatalogItem? selectedPack = ResolveEffectiveDriverPackSelection();
         if (selectedPack is null)
         {
-            string sourceName = SelectedDriverPackOption?.DisplayName ?? "OEM";
-            return $"{sourceName} | No matching model/version";
+            string sourceName = SelectedDriverPackOption?.DisplayName ?? GetString("DriverPack.Oem");
+            return Format("DriverPack.NoMatchingModelVersionFormat", sourceName);
         }
 
         string modelName = string.IsNullOrWhiteSpace(SelectedDriverPackModel)
@@ -617,7 +625,7 @@ public sealed partial class DriverPackSelectionViewModel : ObservableObject
             return Path.GetFileNameWithoutExtension(driverPack.FileName.Trim());
         }
 
-        return "Unknown";
+        return LocalizationText.GetString("Common.Unknown");
     }
 
     private static string ResolveDriverPackFriendlyName(DriverPackCatalogItem driverPack)
@@ -631,7 +639,7 @@ public sealed partial class DriverPackSelectionViewModel : ObservableObject
         {
             return models.Length == 1
                 ? models[0]
-                : $"{models[0]} (+{models.Length - 1} models)";
+                : LocalizationText.Format("DriverPack.MultiModelFormat", models[0], models.Length - 1);
         }
 
         if (!LooksLikeArchiveOrInstallerName(driverPack.Name))
@@ -739,5 +747,31 @@ public sealed partial class DriverPackSelectionViewModel : ObservableObject
         }
 
         return normalized;
+    }
+
+    public override void Dispose()
+    {
+        LocalizationService.LanguageChanged -= OnLocalizationLanguageChanged;
+        base.Dispose();
+    }
+
+    private void OnLocalizationLanguageChanged(object? sender, EventArgs e)
+    {
+        RunOnUiThread(() =>
+        {
+            RefreshDriverPackOptions();
+            OnPropertyChanged(nameof(DriverPackModeDisplay));
+            OnPropertyChanged(nameof(SelectedDriverPackSelectionDisplay));
+        });
+    }
+
+    private string GetString(string key)
+    {
+        return Strings[key];
+    }
+
+    private string Format(string key, params object[] args)
+    {
+        return string.Format(LocalizationService.CurrentCulture, GetString(key), args);
     }
 }

--- a/src/Foundry.Deploy/ViewModels/LocalizedViewModelBase.cs
+++ b/src/Foundry.Deploy/ViewModels/LocalizedViewModelBase.cs
@@ -1,0 +1,53 @@
+using System.Windows;
+using System.Windows.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Foundry.Deploy.Services.Localization;
+
+namespace Foundry.Deploy.ViewModels;
+
+public abstract class LocalizedViewModelBase : ObservableObject, IDisposable
+{
+    private readonly ILocalizationService _localizationService;
+    private readonly Dispatcher _dispatcher;
+    private bool _isDisposed;
+
+    protected LocalizedViewModelBase(ILocalizationService localizationService)
+    {
+        _localizationService = localizationService ?? throw new ArgumentNullException(nameof(localizationService));
+        _dispatcher = Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
+        _localizationService.LanguageChanged += OnLanguageChanged;
+    }
+
+    public StringsWrapper Strings => _localizationService.Strings;
+
+    protected ILocalizationService LocalizationService => _localizationService;
+
+    public virtual void Dispose()
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        _localizationService.LanguageChanged -= OnLanguageChanged;
+        _isDisposed = true;
+    }
+
+    protected void RunOnUiThread(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (_dispatcher.CheckAccess())
+        {
+            action();
+            return;
+        }
+
+        _dispatcher.Invoke(action);
+    }
+
+    private void OnLanguageChanged(object? sender, EventArgs e)
+    {
+        RunOnUiThread(() => OnPropertyChanged(nameof(Strings)));
+    }
+}

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -13,6 +14,7 @@ using Foundry.Deploy.Services.Operations;
 using Foundry.Deploy.Services.Runtime;
 using Foundry.Deploy.Services.Startup;
 using Foundry.Deploy.Services.ApplicationShell;
+using Foundry.Deploy.Services.Localization;
 using Foundry.Deploy.Services.System;
 using Foundry.Deploy.Services.Theme;
 using Foundry.Deploy.Services.Wizard;
@@ -22,7 +24,7 @@ using DeployThemeMode = Foundry.Deploy.Services.Theme.ThemeMode;
 
 namespace Foundry.Deploy.ViewModels;
 
-public partial class MainWindowViewModel : ObservableObject, IDisposable
+public partial class MainWindowViewModel : LocalizedViewModelBase
 {
     private readonly IThemeService _themeService;
     private readonly IDeploymentStartupCoordinator _deploymentStartupCoordinator;
@@ -65,13 +67,32 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     public OperatingSystemCatalogViewModel OperatingSystemCatalog { get; }
     public DriverPackSelectionViewModel DriverPackSelection { get; }
 
+    public CultureInfo CurrentCulture => LocalizationService.CurrentCulture;
     public DeployThemeMode CurrentTheme => _themeService.CurrentTheme;
     public bool IsDebugSafeMode => DebugSafetyMode.IsEnabled;
     public string EffectiveOsArchitecture => OperatingSystemCatalog.EffectiveOsArchitecture;
     public OperatingSystemCatalogItem? SelectedOperatingSystem => OperatingSystemCatalog.SelectedOperatingSystem;
-    public string VersionDisplay => $"Version: {FoundryDeployApplicationInfo.Version}";
+    public string WindowTitle => GetString("App.WindowTitle");
+    public string VersionDisplay => Format("Common.VersionFormat", FoundryDeployApplicationInfo.Version);
+    public string OperatingSystemArchitectureDisplay => Format("Catalog.ArchitectureFormat", OperatingSystemCatalog.EffectiveOsArchitecture);
+    public string DriverPackArchitectureDisplay => Format("Catalog.ArchitectureFormat", EffectiveOsArchitecture);
+    public string DriverPackModeDisplayText => Format("DriverPack.SelectedModeFormat", DriverPackSelection.DriverPackModeDisplay);
+    public string SummaryTargetDiskText => Preparation.SelectedTargetDisk?.DisplayLabel ?? GetString("Summary.NoDiskSelected");
+    public string SummaryOperatingSystemText => SelectedOperatingSystem is null
+        ? GetString("Summary.NoSelection")
+        : new Converters.OperatingSystemSummaryConverter().Convert(SelectedOperatingSystem, typeof(string), string.Empty, LocalizationService.CurrentCulture)?.ToString() ?? GetString("Summary.NoSelection");
+    public string SummaryFirmwareText => Format(
+        "Summary.FirmwareEnabledFormat",
+        Preparation.ApplyFirmwareUpdates ? GetString("Common.Enabled") : GetString("Common.Disabled"));
+    public string SummaryAutopilotEnabledText => Format(
+        "Summary.EnabledFormat",
+        Preparation.IsAutopilotEnabled ? GetString("Common.Yes") : GetString("Common.No"));
+    public string SummaryAutopilotProfileText => Format(
+        "Summary.SelectedProfileFormat",
+        Preparation.SelectedAutopilotProfile?.DisplayName ?? GetString("Common.None"));
 
     public MainWindowViewModel(
+        ILocalizationService localizationService,
         IThemeService themeService,
         IOperationProgressService operationProgressService,
         IDeploymentStartupCoordinator deploymentStartupCoordinator,
@@ -85,6 +106,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         IDeploymentWizardContextFactory deploymentWizardContextFactory,
         IProcessRunner processRunner,
         ILogger<MainWindowViewModel> logger)
+        : base(localizationService)
     {
         _themeService = themeService;
         _deploymentStartupCoordinator = deploymentStartupCoordinator;
@@ -109,8 +131,10 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             operationProgressService,
             _deploymentOrchestrator,
             processRunner,
+            localizationService,
             IsDebugSafeMode);
         Session.PropertyChanged += OnSessionPropertyChanged;
+        LocalizationService.LanguageChanged += OnLocalizationLanguageChanged;
     }
 
     public Task InitializeAsync()
@@ -137,6 +161,12 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         RunOnUi(() => ApplyStartupSnapshot(startupSnapshot));
 
         _isInitialized = true;
+    }
+
+    [RelayCommand]
+    private void SetCulture(string cultureName)
+    {
+        LocalizationService.SetCulture(new CultureInfo(cultureName));
     }
 
     [RelayCommand]
@@ -317,6 +347,14 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     {
         OnPropertyChanged(nameof(EffectiveOsArchitecture));
         OnPropertyChanged(nameof(SelectedOperatingSystem));
+        OnPropertyChanged(nameof(OperatingSystemArchitectureDisplay));
+        OnPropertyChanged(nameof(DriverPackArchitectureDisplay));
+        OnPropertyChanged(nameof(DriverPackModeDisplayText));
+        OnPropertyChanged(nameof(SummaryTargetDiskText));
+        OnPropertyChanged(nameof(SummaryOperatingSystemText));
+        OnPropertyChanged(nameof(SummaryFirmwareText));
+        OnPropertyChanged(nameof(SummaryAutopilotEnabledText));
+        OnPropertyChanged(nameof(SummaryAutopilotProfileText));
         NextWizardStepCommand.NotifyCanExecuteChanged();
         StartDeploymentCommand.NotifyCanExecuteChanged();
     }
@@ -426,7 +464,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         _dispatcher.Invoke(action);
     }
 
-    public void Dispose()
+    public override void Dispose()
     {
         if (_isDisposed)
         {
@@ -436,9 +474,38 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         _wizardContext.StatusMessageGenerated -= OnWizardContextStatusMessageGenerated;
         _wizardContext.StateChanged -= OnWizardContextStateChanged;
         Session.PropertyChanged -= OnSessionPropertyChanged;
+        LocalizationService.LanguageChanged -= OnLocalizationLanguageChanged;
         _wizardContext.Dispose();
         Session.Dispose();
         _isDisposed = true;
+        base.Dispose();
     }
 
+    private void OnLocalizationLanguageChanged(object? sender, EventArgs e)
+    {
+        RunOnUiThread(() =>
+        {
+            OnPropertyChanged(nameof(CurrentCulture));
+            OnPropertyChanged(nameof(WindowTitle));
+            OnPropertyChanged(nameof(VersionDisplay));
+            OnPropertyChanged(nameof(OperatingSystemArchitectureDisplay));
+            OnPropertyChanged(nameof(DriverPackArchitectureDisplay));
+            OnPropertyChanged(nameof(DriverPackModeDisplayText));
+            OnPropertyChanged(nameof(SummaryTargetDiskText));
+            OnPropertyChanged(nameof(SummaryOperatingSystemText));
+            OnPropertyChanged(nameof(SummaryFirmwareText));
+            OnPropertyChanged(nameof(SummaryAutopilotEnabledText));
+            OnPropertyChanged(nameof(SummaryAutopilotProfileText));
+        });
+    }
+
+    private string GetString(string key)
+    {
+        return Strings[key];
+    }
+
+    private string Format(string key, params object[] args)
+    {
+        return string.Format(LocalizationService.CurrentCulture, GetString(key), args);
+    }
 }


### PR DESCRIPTION
## Summary
Add Foundry-style localization infrastructure to Foundry.Deploy and migrate the main user-facing Deploy UI onto resource-backed strings.

## Why
Foundry.Deploy had no localization service layer, no resource files, and a large amount of hardcoded UI and surfaced deployment text. Matching the existing Foundry localization architecture keeps the solution coherent and maintainable.

## Changes
- add `ILocalizationService`, `LocalizationService`, `StringsWrapper`, `LocalizationText`, and a localized base view model
- add `AppStrings.resx` and `AppStrings.fr-FR.resx` for Deploy-local resources
- register localization in DI and route about-dialog content through resources
- localize `MainWindow.xaml`, preparation and driver-pack view models, disk and OS display formatting, and summary/progress/success/error/splash labels
- localize the deployment session surface by translating the existing internal English orchestration messages at the UI boundary

## Testing
- `dotnet build src/Foundry.Deploy/Foundry.Deploy.csproj`

## Notes
- scope is limited to `src/Foundry.Deploy`
- the deployment engine keeps its existing internal English message contract; localization is applied where those messages surface in the UI
