### PR TITLE
refactor(localization): simplify localized bindings by adding a no-op setter in StringsWrapper

### DIFF
--- a/src/Foundry/MainWindow.xaml
+++ b/src/Foundry/MainWindow.xaml
@@ -1,4 +1,4 @@
-<Window
+﻿<Window
     x:Class="Foundry.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -65,29 +65,29 @@
                         Command="{Binding SetStandardModeCommand}"
                         Header="{Binding Strings[Mode.Standard]}"
                         IsCheckable="True"
-                        IsChecked="{Binding IsExpertMode, Converter={StaticResource InverseBooleanConverter}}" />
+                        IsChecked="{Binding IsExpertMode, Converter={StaticResource InverseBooleanConverter}, Mode=OneWay}" />
                     <MenuItem
                         Command="{Binding SetExpertModeCommand}"
                         Header="{Binding Strings[Mode.Expert]}"
                         IsCheckable="True"
-                        IsChecked="{Binding IsExpertMode}" />
+                        IsChecked="{Binding IsExpertMode, Mode=OneWay}" />
                 </MenuItem>
                 <MenuItem Header="{Binding Strings[Menu.Theme]}">
                     <MenuItem
                         Command="{Binding SetSystemThemeCommand}"
                         Header="{Binding Strings[Theme.System]}"
                         IsCheckable="True"
-                        IsChecked="{Binding CurrentTheme, Converter={StaticResource ThemeModeToBooleanConverter}, ConverterParameter=System}" />
+                        IsChecked="{Binding CurrentTheme, Converter={StaticResource ThemeModeToBooleanConverter}, ConverterParameter=System, Mode=OneWay}" />
                     <MenuItem
                         Command="{Binding SetLightThemeCommand}"
                         Header="{Binding Strings[Theme.Light]}"
                         IsCheckable="True"
-                        IsChecked="{Binding CurrentTheme, Converter={StaticResource ThemeModeToBooleanConverter}, ConverterParameter=Light}" />
+                        IsChecked="{Binding CurrentTheme, Converter={StaticResource ThemeModeToBooleanConverter}, ConverterParameter=Light, Mode=OneWay}" />
                     <MenuItem
                         Command="{Binding SetDarkThemeCommand}"
                         Header="{Binding Strings[Theme.Dark]}"
                         IsCheckable="True"
-                        IsChecked="{Binding CurrentTheme, Converter={StaticResource ThemeModeToBooleanConverter}, ConverterParameter=Dark}" />
+                        IsChecked="{Binding CurrentTheme, Converter={StaticResource ThemeModeToBooleanConverter}, ConverterParameter=Dark, Mode=OneWay}" />
                 </MenuItem>
                 <MenuItem Header="{Binding Strings[Menu.Language]}">
                     <MenuItem
@@ -95,13 +95,13 @@
                         CommandParameter="en-US"
                         Header="{Binding Strings[Language.English]}"
                         IsCheckable="True"
-                        IsChecked="{Binding CurrentCulture, Converter={StaticResource CultureToBooleanConverter}, ConverterParameter=en-US}" />
+                        IsChecked="{Binding CurrentCulture, Converter={StaticResource CultureToBooleanConverter}, ConverterParameter=en-US, Mode=OneWay}" />
                     <MenuItem
                         Command="{Binding SetCultureCommand}"
                         CommandParameter="fr-FR"
                         Header="{Binding Strings[Language.French]}"
                         IsCheckable="True"
-                        IsChecked="{Binding CurrentCulture, Converter={StaticResource CultureToBooleanConverter}, ConverterParameter=fr-FR}" />
+                        IsChecked="{Binding CurrentCulture, Converter={StaticResource CultureToBooleanConverter}, ConverterParameter=fr-FR, Mode=OneWay}" />
                 </MenuItem>
                 <MenuItem Header="{Binding Strings[Menu.Tools]}">
                     <MenuItem Command="{Binding OpenLogFolderCommand}" Header="{Binding Strings[Menu.Logs]}" />
@@ -266,7 +266,7 @@
                         Height="14"
                         Maximum="100"
                         Minimum="0"
-                        Value="{Binding GlobalOperationProgress}" />
+                        Value="{Binding GlobalOperationProgress, Mode=OneWay}" />
 
                     <TextBlock
                         Grid.Row="2"

--- a/src/Foundry/MainWindow.xaml
+++ b/src/Foundry/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window
+<Window
     x:Class="Foundry.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Foundry/MainWindow.xaml
+++ b/src/Foundry/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window
+<Window
     x:Class="Foundry.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -65,29 +65,29 @@
                         Command="{Binding SetStandardModeCommand}"
                         Header="{Binding Strings[Mode.Standard]}"
                         IsCheckable="True"
-                        IsChecked="{Binding IsExpertMode, Converter={StaticResource InverseBooleanConverter}, Mode=OneWay}" />
+                        IsChecked="{Binding IsExpertMode, Converter={StaticResource InverseBooleanConverter}}" />
                     <MenuItem
                         Command="{Binding SetExpertModeCommand}"
                         Header="{Binding Strings[Mode.Expert]}"
                         IsCheckable="True"
-                        IsChecked="{Binding IsExpertMode, Mode=OneWay}" />
+                        IsChecked="{Binding IsExpertMode}" />
                 </MenuItem>
                 <MenuItem Header="{Binding Strings[Menu.Theme]}">
                     <MenuItem
                         Command="{Binding SetSystemThemeCommand}"
                         Header="{Binding Strings[Theme.System]}"
                         IsCheckable="True"
-                        IsChecked="{Binding CurrentTheme, Converter={StaticResource ThemeModeToBooleanConverter}, ConverterParameter=System, Mode=OneWay}" />
+                        IsChecked="{Binding CurrentTheme, Converter={StaticResource ThemeModeToBooleanConverter}, ConverterParameter=System}" />
                     <MenuItem
                         Command="{Binding SetLightThemeCommand}"
                         Header="{Binding Strings[Theme.Light]}"
                         IsCheckable="True"
-                        IsChecked="{Binding CurrentTheme, Converter={StaticResource ThemeModeToBooleanConverter}, ConverterParameter=Light, Mode=OneWay}" />
+                        IsChecked="{Binding CurrentTheme, Converter={StaticResource ThemeModeToBooleanConverter}, ConverterParameter=Light}" />
                     <MenuItem
                         Command="{Binding SetDarkThemeCommand}"
                         Header="{Binding Strings[Theme.Dark]}"
                         IsCheckable="True"
-                        IsChecked="{Binding CurrentTheme, Converter={StaticResource ThemeModeToBooleanConverter}, ConverterParameter=Dark, Mode=OneWay}" />
+                        IsChecked="{Binding CurrentTheme, Converter={StaticResource ThemeModeToBooleanConverter}, ConverterParameter=Dark}" />
                 </MenuItem>
                 <MenuItem Header="{Binding Strings[Menu.Language]}">
                     <MenuItem
@@ -95,13 +95,13 @@
                         CommandParameter="en-US"
                         Header="{Binding Strings[Language.English]}"
                         IsCheckable="True"
-                        IsChecked="{Binding CurrentCulture, Converter={StaticResource CultureToBooleanConverter}, ConverterParameter=en-US, Mode=OneWay}" />
+                        IsChecked="{Binding CurrentCulture, Converter={StaticResource CultureToBooleanConverter}, ConverterParameter=en-US}" />
                     <MenuItem
                         Command="{Binding SetCultureCommand}"
                         CommandParameter="fr-FR"
                         Header="{Binding Strings[Language.French]}"
                         IsCheckable="True"
-                        IsChecked="{Binding CurrentCulture, Converter={StaticResource CultureToBooleanConverter}, ConverterParameter=fr-FR, Mode=OneWay}" />
+                        IsChecked="{Binding CurrentCulture, Converter={StaticResource CultureToBooleanConverter}, ConverterParameter=fr-FR}" />
                 </MenuItem>
                 <MenuItem Header="{Binding Strings[Menu.Tools]}">
                     <MenuItem Command="{Binding OpenLogFolderCommand}" Header="{Binding Strings[Menu.Logs]}" />
@@ -266,7 +266,7 @@
                         Height="14"
                         Maximum="100"
                         Minimum="0"
-                        Value="{Binding GlobalOperationProgress, Mode=OneWay}" />
+                        Value="{Binding GlobalOperationProgress}" />
 
                     <TextBlock
                         Grid.Row="2"

--- a/src/Foundry/Services/Localization/StringsWrapper.cs
+++ b/src/Foundry/Services/Localization/StringsWrapper.cs
@@ -23,6 +23,7 @@ public sealed class StringsWrapper : INotifyPropertyChanged
         {
             return _resourceManager.GetString(key, _currentCulture) ?? key;
         }
+        set { /* No-op to support WPF controls that default to TwoWay/OneWayToSource binding */ }
     }
 
     public void SetCulture(CultureInfo culture)

--- a/src/Foundry/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry/ViewModels/MainWindowViewModel.cs
@@ -119,7 +119,11 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
     public ILocalizationService LocalizationService => _localizationService;
     public CultureInfo CurrentCulture => _localizationService.CurrentCulture;
-    public ThemeMode CurrentTheme => _themeService.CurrentTheme;
+    public ThemeMode CurrentTheme
+    {
+        get => _themeService.CurrentTheme;
+        set { /* No-op to support TwoWay bindings in XAML */ }
+    }
     public StringsWrapper Strings => _localizationService.Strings;
     public int GlobalOperationProgress => _operationProgressService.Progress;
     public bool IsGlobalOperationInProgress => _operationProgressService.IsOperationInProgress;

--- a/src/Foundry/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry/ViewModels/MainWindowViewModel.cs
@@ -118,16 +118,8 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     public IReadOnlyList<UsbPartitionStyle> AvailablePartitionStyles { get; } = Enum.GetValues<UsbPartitionStyle>();
 
     public ILocalizationService LocalizationService => _localizationService;
-    public CultureInfo CurrentCulture
-    {
-        get => _localizationService.CurrentCulture;
-        set { /* No-op to support TwoWay bindings in XAML */ }
-    }
-    public ThemeMode CurrentTheme
-    {
-        get => _themeService.CurrentTheme;
-        set { /* No-op to support TwoWay bindings in XAML */ }
-    }
+    public CultureInfo CurrentCulture => _localizationService.CurrentCulture;
+    public ThemeMode CurrentTheme => _themeService.CurrentTheme;
     public StringsWrapper Strings => _localizationService.Strings;
     public int GlobalOperationProgress => _operationProgressService.Progress;
     public bool IsGlobalOperationInProgress => _operationProgressService.IsOperationInProgress;

--- a/src/Foundry/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry/ViewModels/MainWindowViewModel.cs
@@ -118,7 +118,11 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
     public IReadOnlyList<UsbPartitionStyle> AvailablePartitionStyles { get; } = Enum.GetValues<UsbPartitionStyle>();
 
     public ILocalizationService LocalizationService => _localizationService;
-    public CultureInfo CurrentCulture => _localizationService.CurrentCulture;
+    public CultureInfo CurrentCulture
+    {
+        get => _localizationService.CurrentCulture;
+        set { /* No-op to support TwoWay bindings in XAML */ }
+    }
     public ThemeMode CurrentTheme
     {
         get => _themeService.CurrentTheme;

--- a/src/Foundry/Views/AboutDialog.xaml
+++ b/src/Foundry/Views/AboutDialog.xaml
@@ -1,8 +1,8 @@
-<Window
+﻿<Window
     x:Class="Foundry.Views.AboutDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Title="{Binding Strings[About.Title]}"
+    Title="{Binding Strings[About.Title], Mode=OneWay}"
     MinWidth="640"
     MinHeight="380"
     Icon="/Assets/Icons/app.ico"
@@ -49,10 +49,10 @@
                     Margin="0,24,0,0"
                     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                     Style="{DynamicResource BodyTextBlockStyle}">
-                    <Run Text="{Binding Strings[About.CheckForUpdatesLabel]}" />
+                    <Run Text="{Binding Strings[About.CheckForUpdatesLabel], Mode=OneWay}" />
                     <Run Text=" " />
                     <Hyperlink Command="{Binding CheckForUpdatesCommand}">
-                        <Run Text="{Binding CheckForUpdatesLinkText}" />
+                        <Run Text="{Binding CheckForUpdatesLinkText, Mode=OneWay}" />
                     </Hyperlink>
                 </TextBlock>
 
@@ -60,14 +60,14 @@
                     Margin="0,24,0,0"
                     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                     Style="{DynamicResource BodyTextBlockStyle}"
-                    Text="{Binding Strings[About.DescriptionLine1]}"
+                    Text="{Binding Strings[About.DescriptionLine1], Mode=OneWay}"
                     TextWrapping="Wrap" />
 
                 <TextBlock
                     Margin="0,0,0,0"
                     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                     Style="{DynamicResource BodyTextBlockStyle}"
-                    Text="{Binding Strings[About.DescriptionLine2]}"
+                    Text="{Binding Strings[About.DescriptionLine2], Mode=OneWay}"
                     TextWrapping="Wrap" />
 
                 <TextBlock
@@ -75,15 +75,15 @@
                     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                     Style="{DynamicResource BodyTextBlockStyle}">
                     <Hyperlink Command="{Binding OpenLicenseCommand}">
-                        <Run Text="{Binding Strings[About.LicenseLink]}" />
+                        <Run Text="{Binding Strings[About.LicenseLink], Mode=OneWay}" />
                     </Hyperlink>
                     <Run Text=" | " />
                     <Hyperlink Command="{Binding OpenAuthorsCommand}">
-                        <Run Text="{Binding Strings[About.AuthorsLink]}" />
+                        <Run Text="{Binding Strings[About.AuthorsLink], Mode=OneWay}" />
                     </Hyperlink>
                     <Run Text=" | " />
                     <Hyperlink Command="{Binding OpenSupportCommand}">
-                        <Run Text="{Binding Strings[About.SupportLink]}" />
+                        <Run Text="{Binding Strings[About.SupportLink], Mode=OneWay}" />
                     </Hyperlink>
                 </TextBlock>
             </StackPanel>
@@ -94,7 +94,7 @@
             HorizontalAlignment="Center"
             Foreground="{DynamicResource TextFillColorSecondaryBrush}"
             Style="{StaticResource CaptionTextBlockStyle}"
-            Text="{Binding Strings[About.Footer]}"
+            Text="{Binding Strings[About.Footer], Mode=OneWay}"
             TextWrapping="Wrap" />
     </Grid>
 </Window>

--- a/src/Foundry/Views/AboutDialog.xaml
+++ b/src/Foundry/Views/AboutDialog.xaml
@@ -1,8 +1,8 @@
-﻿<Window
+<Window
     x:Class="Foundry.Views.AboutDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Title="{Binding Strings[About.Title], Mode=OneWay}"
+    Title="{Binding Strings[About.Title]}"
     MinWidth="640"
     MinHeight="380"
     Icon="/Assets/Icons/app.ico"
@@ -49,7 +49,7 @@
                     Margin="0,24,0,0"
                     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                     Style="{DynamicResource BodyTextBlockStyle}">
-                    <Run Text="{Binding Strings[About.CheckForUpdatesLabel], Mode=OneWay}" />
+                    <Run Text="{Binding Strings[About.CheckForUpdatesLabel]}" />
                     <Run Text=" " />
                     <Hyperlink Command="{Binding CheckForUpdatesCommand}">
                         <Run Text="{Binding CheckForUpdatesLinkText, Mode=OneWay}" />
@@ -60,14 +60,14 @@
                     Margin="0,24,0,0"
                     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                     Style="{DynamicResource BodyTextBlockStyle}"
-                    Text="{Binding Strings[About.DescriptionLine1], Mode=OneWay}"
+                    Text="{Binding Strings[About.DescriptionLine1]}"
                     TextWrapping="Wrap" />
 
                 <TextBlock
                     Margin="0,0,0,0"
                     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                     Style="{DynamicResource BodyTextBlockStyle}"
-                    Text="{Binding Strings[About.DescriptionLine2], Mode=OneWay}"
+                    Text="{Binding Strings[About.DescriptionLine2]}"
                     TextWrapping="Wrap" />
 
                 <TextBlock
@@ -75,15 +75,15 @@
                     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                     Style="{DynamicResource BodyTextBlockStyle}">
                     <Hyperlink Command="{Binding OpenLicenseCommand}">
-                        <Run Text="{Binding Strings[About.LicenseLink], Mode=OneWay}" />
+                        <Run Text="{Binding Strings[About.LicenseLink]}" />
                     </Hyperlink>
                     <Run Text=" | " />
                     <Hyperlink Command="{Binding OpenAuthorsCommand}">
-                        <Run Text="{Binding Strings[About.AuthorsLink], Mode=OneWay}" />
+                        <Run Text="{Binding Strings[About.AuthorsLink]}" />
                     </Hyperlink>
                     <Run Text=" | " />
                     <Hyperlink Command="{Binding OpenSupportCommand}">
-                        <Run Text="{Binding Strings[About.SupportLink], Mode=OneWay}" />
+                        <Run Text="{Binding Strings[About.SupportLink]}" />
                     </Hyperlink>
                 </TextBlock>
             </StackPanel>
@@ -94,7 +94,7 @@
             HorizontalAlignment="Center"
             Foreground="{DynamicResource TextFillColorSecondaryBrush}"
             Style="{StaticResource CaptionTextBlockStyle}"
-            Text="{Binding Strings[About.Footer], Mode=OneWay}"
+            Text="{Binding Strings[About.Footer]}"
             TextWrapping="Wrap" />
     </Grid>
 </Window>

--- a/src/Foundry/Views/AboutDialog.xaml
+++ b/src/Foundry/Views/AboutDialog.xaml
@@ -1,8 +1,8 @@
-﻿<Window
+<Window
     x:Class="Foundry.Views.AboutDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Title="{Binding Strings[About.Title], Mode=OneWay}"
+    Title="{Binding Strings[About.Title]}"
     MinWidth="640"
     MinHeight="380"
     Icon="/Assets/Icons/app.ico"
@@ -49,10 +49,10 @@
                     Margin="0,24,0,0"
                     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                     Style="{DynamicResource BodyTextBlockStyle}">
-                    <Run Text="{Binding Strings[About.CheckForUpdatesLabel], Mode=OneWay}" />
+                    <Run Text="{Binding Strings[About.CheckForUpdatesLabel]}" />
                     <Run Text=" " />
                     <Hyperlink Command="{Binding CheckForUpdatesCommand}">
-                        <Run Text="{Binding CheckForUpdatesLinkText, Mode=OneWay}" />
+                        <Run Text="{Binding CheckForUpdatesLinkText}" />
                     </Hyperlink>
                 </TextBlock>
 
@@ -60,14 +60,14 @@
                     Margin="0,24,0,0"
                     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                     Style="{DynamicResource BodyTextBlockStyle}"
-                    Text="{Binding Strings[About.DescriptionLine1], Mode=OneWay}"
+                    Text="{Binding Strings[About.DescriptionLine1]}"
                     TextWrapping="Wrap" />
 
                 <TextBlock
                     Margin="0,0,0,0"
                     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                     Style="{DynamicResource BodyTextBlockStyle}"
-                    Text="{Binding Strings[About.DescriptionLine2], Mode=OneWay}"
+                    Text="{Binding Strings[About.DescriptionLine2]}"
                     TextWrapping="Wrap" />
 
                 <TextBlock
@@ -75,15 +75,15 @@
                     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                     Style="{DynamicResource BodyTextBlockStyle}">
                     <Hyperlink Command="{Binding OpenLicenseCommand}">
-                        <Run Text="{Binding Strings[About.LicenseLink], Mode=OneWay}" />
+                        <Run Text="{Binding Strings[About.LicenseLink]}" />
                     </Hyperlink>
                     <Run Text=" | " />
                     <Hyperlink Command="{Binding OpenAuthorsCommand}">
-                        <Run Text="{Binding Strings[About.AuthorsLink], Mode=OneWay}" />
+                        <Run Text="{Binding Strings[About.AuthorsLink]}" />
                     </Hyperlink>
                     <Run Text=" | " />
                     <Hyperlink Command="{Binding OpenSupportCommand}">
-                        <Run Text="{Binding Strings[About.SupportLink], Mode=OneWay}" />
+                        <Run Text="{Binding Strings[About.SupportLink]}" />
                     </Hyperlink>
                 </TextBlock>
             </StackPanel>
@@ -94,7 +94,7 @@
             HorizontalAlignment="Center"
             Foreground="{DynamicResource TextFillColorSecondaryBrush}"
             Style="{StaticResource CaptionTextBlockStyle}"
-            Text="{Binding Strings[About.Footer], Mode=OneWay}"
+            Text="{Binding Strings[About.Footer]}"
             TextWrapping="Wrap" />
     </Grid>
 </Window>

--- a/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml
+++ b/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml
@@ -1,4 +1,4 @@
-<Window
+﻿<Window
     x:Class="Foundry.Views.AutopilotProfileSelectionDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml
+++ b/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml
@@ -1,4 +1,4 @@
-﻿<Window
+<Window
     x:Class="Foundry.Views.AutopilotProfileSelectionDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Foundry/Views/AutopilotSettingsView.xaml
+++ b/src/Foundry/Views/AutopilotSettingsView.xaml
@@ -1,4 +1,4 @@
-<UserControl
+﻿<UserControl
     x:Class="Foundry.Views.AutopilotSettingsView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">

--- a/src/Foundry/Views/AutopilotSettingsView.xaml
+++ b/src/Foundry/Views/AutopilotSettingsView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="Foundry.Views.AutopilotSettingsView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">

--- a/src/Foundry/Views/CustomizationSettingsView.xaml
+++ b/src/Foundry/Views/CustomizationSettingsView.xaml
@@ -1,4 +1,4 @@
-<UserControl
+﻿<UserControl
     x:Class="Foundry.Views.CustomizationSettingsView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">

--- a/src/Foundry/Views/CustomizationSettingsView.xaml
+++ b/src/Foundry/Views/CustomizationSettingsView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="Foundry.Views.CustomizationSettingsView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">

--- a/src/Foundry/Views/GeneralSettingsView.xaml
+++ b/src/Foundry/Views/GeneralSettingsView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="Foundry.Views.GeneralSettingsView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Foundry/Views/GeneralSettingsView.xaml
+++ b/src/Foundry/Views/GeneralSettingsView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="Foundry.Views.GeneralSettingsView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -32,7 +32,7 @@
                 Grid.Column="1"
                 Margin="0,0,8,0"
                 IsReadOnly="True"
-                Text="{Binding IsoOutputPath, Mode=OneWay}" />
+                Text="{Binding IsoOutputPath}" />
 
             <Button
                 Grid.Column="2"

--- a/src/Foundry/Views/GeneralSettingsView.xaml
+++ b/src/Foundry/Views/GeneralSettingsView.xaml
@@ -1,4 +1,4 @@
-<UserControl
+﻿<UserControl
     x:Class="Foundry.Views.GeneralSettingsView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -32,7 +32,7 @@
                 Grid.Column="1"
                 Margin="0,0,8,0"
                 IsReadOnly="True"
-                Text="{Binding IsoOutputPath}" />
+                Text="{Binding IsoOutputPath, Mode=OneWay}" />
 
             <Button
                 Grid.Column="2"

--- a/src/Foundry/Views/LocalizationSettingsView.xaml
+++ b/src/Foundry/Views/LocalizationSettingsView.xaml
@@ -1,4 +1,4 @@
-<UserControl
+﻿<UserControl
     x:Class="Foundry.Views.LocalizationSettingsView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">

--- a/src/Foundry/Views/LocalizationSettingsView.xaml
+++ b/src/Foundry/Views/LocalizationSettingsView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="Foundry.Views.LocalizationSettingsView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">

--- a/src/Foundry/Views/NetworkSettingsView.xaml
+++ b/src/Foundry/Views/NetworkSettingsView.xaml
@@ -1,4 +1,4 @@
-<UserControl
+﻿<UserControl
     x:Class="Foundry.Views.NetworkSettingsView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Foundry/Views/NetworkSettingsView.xaml
+++ b/src/Foundry/Views/NetworkSettingsView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="Foundry.Views.NetworkSettingsView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Foundry/Views/UpdateAvailableDialog.xaml
+++ b/src/Foundry/Views/UpdateAvailableDialog.xaml
@@ -1,8 +1,8 @@
-﻿<Window
+<Window
     x:Class="Foundry.Views.UpdateAvailableDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Title="{Binding Strings[UpdateAvailable.Title], Mode=OneWay}"
+    Title="{Binding Strings[UpdateAvailable.Title]}"
     Width="960"
     Height="760"
     MinWidth="960"
@@ -29,7 +29,7 @@
             <TextBlock
                 Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                 Style="{DynamicResource TitleLargeTextBlockStyle}"
-                Text="{Binding Strings[UpdateAvailable.Heading], Mode=OneWay}"
+                Text="{Binding Strings[UpdateAvailable.Heading]}"
                 TextWrapping="Wrap" />
             <TextBlock
                 Margin="0,12,0,0"
@@ -60,7 +60,7 @@
                     <TextBlock
                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding Strings[UpdateAvailable.LatestVersionLabel], Mode=OneWay}" />
+                        Text="{Binding Strings[UpdateAvailable.LatestVersionLabel]}" />
                     <TextBlock
                         Margin="0,8,0,0"
                         Foreground="{DynamicResource SystemFillColorSuccessBrush}"
@@ -71,7 +71,7 @@
                         <TextBlock
                             Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                             Style="{StaticResource CaptionTextBlockStyle}"
-                            Text="{Binding Strings[UpdateAvailable.ReleaseLabel], Mode=OneWay}" />
+                            Text="{Binding Strings[UpdateAvailable.ReleaseLabel]}" />
                         <TextBlock
                             Margin="0,4,0,0"
                             Foreground="{DynamicResource TextFillColorPrimaryBrush}"
@@ -85,7 +85,7 @@
                     <TextBlock
                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding Strings[UpdateAvailable.CurrentVersionLabel], Mode=OneWay}" />
+                        Text="{Binding Strings[UpdateAvailable.CurrentVersionLabel]}" />
                     <TextBlock
                         Margin="0,8,0,0"
                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
@@ -97,7 +97,7 @@
                     <TextBlock
                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding Strings[UpdateAvailable.PublishedLabel], Mode=OneWay}" />
+                        Text="{Binding Strings[UpdateAvailable.PublishedLabel]}" />
                     <TextBlock
                         Margin="0,8,0,0"
                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
@@ -117,7 +117,7 @@
             <TextBlock
                 Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                 Style="{DynamicResource BodyStrongTextBlockStyle}"
-                Text="{Binding Strings[UpdateAvailable.ReleaseNotes], Mode=OneWay}" />
+                Text="{Binding Strings[UpdateAvailable.ReleaseNotes]}" />
 
             <Border
                 Grid.Row="1"
@@ -146,12 +146,12 @@
                 Width="140"
                 Margin="0,0,10,0"
                 Command="{Binding CloseCommand}"
-                Content="{Binding Strings[UpdateAvailable.Later], Mode=OneWay}"
+                Content="{Binding Strings[UpdateAvailable.Later]}"
                 IsCancel="True" />
             <Button
                 Width="170"
                 Command="{Binding OpenReleaseCommand}"
-                Content="{Binding Strings[UpdateAvailable.OpenRelease], Mode=OneWay}"
+                Content="{Binding Strings[UpdateAvailable.OpenRelease]}"
                 IsDefault="True"
                 Style="{DynamicResource AccentButtonStyle}" />
         </StackPanel>

--- a/src/Foundry/Views/UpdateAvailableDialog.xaml
+++ b/src/Foundry/Views/UpdateAvailableDialog.xaml
@@ -1,8 +1,8 @@
-<Window
+﻿<Window
     x:Class="Foundry.Views.UpdateAvailableDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Title="{Binding Strings[UpdateAvailable.Title]}"
+    Title="{Binding Strings[UpdateAvailable.Title], Mode=OneWay}"
     Width="960"
     Height="760"
     MinWidth="960"
@@ -29,7 +29,7 @@
             <TextBlock
                 Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                 Style="{DynamicResource TitleLargeTextBlockStyle}"
-                Text="{Binding Strings[UpdateAvailable.Heading]}"
+                Text="{Binding Strings[UpdateAvailable.Heading], Mode=OneWay}"
                 TextWrapping="Wrap" />
             <TextBlock
                 Margin="0,12,0,0"
@@ -60,7 +60,7 @@
                     <TextBlock
                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding Strings[UpdateAvailable.LatestVersionLabel]}" />
+                        Text="{Binding Strings[UpdateAvailable.LatestVersionLabel], Mode=OneWay}" />
                     <TextBlock
                         Margin="0,8,0,0"
                         Foreground="{DynamicResource SystemFillColorSuccessBrush}"
@@ -71,7 +71,7 @@
                         <TextBlock
                             Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                             Style="{StaticResource CaptionTextBlockStyle}"
-                            Text="{Binding Strings[UpdateAvailable.ReleaseLabel]}" />
+                            Text="{Binding Strings[UpdateAvailable.ReleaseLabel], Mode=OneWay}" />
                         <TextBlock
                             Margin="0,4,0,0"
                             Foreground="{DynamicResource TextFillColorPrimaryBrush}"
@@ -85,7 +85,7 @@
                     <TextBlock
                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding Strings[UpdateAvailable.CurrentVersionLabel]}" />
+                        Text="{Binding Strings[UpdateAvailable.CurrentVersionLabel], Mode=OneWay}" />
                     <TextBlock
                         Margin="0,8,0,0"
                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
@@ -97,7 +97,7 @@
                     <TextBlock
                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding Strings[UpdateAvailable.PublishedLabel]}" />
+                        Text="{Binding Strings[UpdateAvailable.PublishedLabel], Mode=OneWay}" />
                     <TextBlock
                         Margin="0,8,0,0"
                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
@@ -117,7 +117,7 @@
             <TextBlock
                 Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                 Style="{DynamicResource BodyStrongTextBlockStyle}"
-                Text="{Binding Strings[UpdateAvailable.ReleaseNotes]}" />
+                Text="{Binding Strings[UpdateAvailable.ReleaseNotes], Mode=OneWay}" />
 
             <Border
                 Grid.Row="1"
@@ -146,12 +146,12 @@
                 Width="140"
                 Margin="0,0,10,0"
                 Command="{Binding CloseCommand}"
-                Content="{Binding Strings[UpdateAvailable.Later]}"
+                Content="{Binding Strings[UpdateAvailable.Later], Mode=OneWay}"
                 IsCancel="True" />
             <Button
                 Width="170"
                 Command="{Binding OpenReleaseCommand}"
-                Content="{Binding Strings[UpdateAvailable.OpenRelease]}"
+                Content="{Binding Strings[UpdateAvailable.OpenRelease], Mode=OneWay}"
                 IsDefault="True"
                 Style="{DynamicResource AccentButtonStyle}" />
         </StackPanel>


### PR DESCRIPTION
**Summary**
This PR standardizes how localized strings are bound to WPF properties in the `Foundry` project.

**Reason**
Currently, `Foundry` implements a read-only indexer in its `StringsWrapper` class and requires developers to add `, Mode=OneWay` manually wherever WPF attempts to apply a default `TwoWay` or `OneWayToSource` binding (especially on `TextBox` or `Run` elements). Omitting this often leads to a silent `InvalidOperationException` that crashes the app at view load time.

**Main Changes**
- Added an empty `set` (No-Op) to the `StringsWrapper` indexer so it handles `TwoWay` bindings gracefully.
- Removed superfluous `, Mode=OneWay` declarations across all `.xaml` files in `Foundry`.

**Testing**
The application shouldn't crash on start and texts should still be fully localized.