### PR TITLE
fix(connect): correct Wi-Fi card list layout

### DIFF
--- a/src/Foundry.Connect/Views/EthernetWifiView.xaml
+++ b/src/Foundry.Connect/Views/EthernetWifiView.xaml
@@ -9,7 +9,6 @@
     <UserControl.Resources>
         <DataTemplate x:Key="WifiNetworkItemTemplate">
             <Border
-                MaxWidth="{Binding RelativeSource={RelativeSource AncestorType=ListView}, Path=ActualWidth}"
                 Margin="0,0,0,8"
                 Padding="10"
                 HorizontalAlignment="Stretch">
@@ -61,7 +60,6 @@
                     <Grid
                         x:Name="ConnectActionsPanel"
                         Grid.Row="1"
-                        MaxWidth="{Binding RelativeSource={RelativeSource AncestorType=ListView}, Path=ActualWidth}"
                         Margin="0,12,0,0"
                         HorizontalAlignment="Stretch"
                         Visibility="Collapsed">
@@ -527,38 +525,37 @@
                 </Grid>
 
                 <Grid Grid.Row="1" Margin="0,16,0,0">
-                    <Grid Margin="0,8,0,0">
-                        <TextBlock
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                            Text="{Binding WifiDiscoveryEmptyStateText}"
-                            TextWrapping="Wrap">
-                            <TextBlock.Style>
-                                <Style BasedOn="{StaticResource BodyTextBlockStyle}" TargetType="TextBlock">
-                                    <Setter Property="Visibility" Value="Collapsed" />
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding HasWifiNetworks}" Value="False">
-                                            <Setter Property="Visibility" Value="Visible" />
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </TextBlock.Style>
-                        </TextBlock>
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Text="{Binding WifiDiscoveryEmptyStateText}"
+                        TextWrapping="Wrap">
+                        <TextBlock.Style>
+                            <Style BasedOn="{StaticResource BodyTextBlockStyle}" TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasWifiNetworks}" Value="False">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
 
+                    <Border Padding="0,8,24,0">
                         <ListView
                             x:Name="WifiNetworksListView"
                             MinHeight="160"
-                            MaxHeight="320"
-                            VerticalAlignment="Top"
                             HorizontalContentAlignment="Stretch"
                             ItemTemplate="{StaticResource WifiNetworkItemTemplate}"
                             ItemsSource="{Binding WifiNetworks}"
+                            Padding="0,0,8,0"
                             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                             ScrollViewer.VerticalScrollBarVisibility="Auto"
                             SelectedItem="{Binding SelectedWifiNetwork, Mode=TwoWay}"
                             Visibility="{Binding HasWifiNetworks, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                    </Grid>
+                    </Border>
                 </Grid>
             </Grid>
         </Border>


### PR DESCRIPTION
## Summary
Correct the Wi-Fi card list layout in Foundry.Connect so the list uses the full card height and the scrollbar no longer crowds item content.

## Reason
The Wi-Fi list stopped around the middle of the card because the `ListView` height was capped, and the selected item content visually collided with the vertical scrollbar.

## Main Changes
- removed the fixed list height cap so the Wi-Fi list can stretch to the bottom of the card
- removed item width constraints tied to the full `ListView` width
- added right-side spacing around the scrollable area to match the existing Foundry layout pattern

## Testing Notes
- `dotnet build src/Foundry.Connect/Foundry.Connect.csproj`
