### PR TITLE
fix(foundry-deploy): add catalog refresh success log

### DIFF
--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -211,6 +211,10 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         try
         {
             DeploymentCatalogSnapshot snapshot = await _deploymentCatalogLoadService.LoadAsync().ConfigureAwait(false);
+            _logger.LogInformation(
+                "Deployment catalogs refreshed successfully. OperatingSystemCount={OperatingSystemCount}, DriverPackCount={DriverPackCount}",
+                snapshot.OperatingSystems.Count,
+                snapshot.DriverPacks.Count);
 
             RunOnUi(() =>
             {


### PR DESCRIPTION
## Summary
Add a completion log for successful deployment catalog refreshes in Foundry.Deploy.

## Reason
The catalog refresh flow already logged start and failure states, but it did not log successful completion with the loaded counts.

## Main Changes
- Log successful catalog refresh completion in MainWindowViewModel
- Include operating system and driver pack counts in the structured log

## Testing Notes
- dotnet build src/Foundry.Deploy/Foundry.Deploy.csproj