### PR TITLE
fix(foundry): add configuration operation success logs

### DIFF
--- a/src/Foundry/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry/ViewModels/MainWindowViewModel.cs
@@ -283,6 +283,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         try
         {
             FoundryExpertConfigurationDocument document = await _expertConfigurationService.LoadAsync(path).ConfigureAwait(false);
+            _logger.LogInformation("Expert configuration imported successfully. Path={Path}", path);
             RunOnUiThread(() =>
             {
                 ApplyExpertConfigurationDocument(document);
@@ -313,6 +314,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         try
         {
             await _expertConfigurationService.SaveAsync(path, BuildExpertConfigurationDocument()).ConfigureAwait(false);
+            _logger.LogInformation("Expert configuration exported successfully. Path={Path}", path);
             RunOnUiThread(() => MediaActionMessage = string.Format(CurrentCulture, Strings["Expert.ConfigExportedFormat"], Path.GetFileName(path)));
         }
         catch (Exception ex)
@@ -338,6 +340,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
         {
             string json = BuildDeployConfigurationJsonForCurrentMode() ?? string.Empty;
             await File.WriteAllTextAsync(path, json).ConfigureAwait(false);
+            _logger.LogInformation("Deploy configuration exported successfully. Path={Path}", path);
             RunOnUiThread(() => MediaActionMessage = string.Format(CurrentCulture, Strings["DeployConfig.ExportedFormat"], Path.GetFileName(path)));
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
Add success-path logs for expert and deploy configuration file operations in the Foundry desktop app.

## Reason
These user-triggered file operations already logged failures, but successful completion was not recorded, which reduced traceability when validating import/export behavior.

## Main Changes
- Log successful expert configuration imports
- Log successful expert configuration exports
- Log successful deploy configuration exports

## Testing Notes
- dotnet build src/Foundry/Foundry.csproj