### PR TITLE
fix(foundry-deploy): refine deploy localization

### DIFF
--- a/src/Foundry.Deploy/Converters/OperatingSystemDisplayFormatter.cs
+++ b/src/Foundry.Deploy/Converters/OperatingSystemDisplayFormatter.cs
@@ -9,7 +9,12 @@ internal static class OperatingSystemDisplayFormatter
 
     public static string FormatLicenseChannel(string channel)
     {
-        return channel.Trim();
+        return channel.Trim().ToUpperInvariant() switch
+        {
+            "RET" => "Retail",
+            "VOL" => "Volume",
+            _ => channel.Trim()
+        };
     }
 
     public static string FormatEdition(string edition)

--- a/src/Foundry.Deploy/Converters/OperatingSystemDisplayFormatter.cs
+++ b/src/Foundry.Deploy/Converters/OperatingSystemDisplayFormatter.cs
@@ -4,34 +4,16 @@ internal static class OperatingSystemDisplayFormatter
 {
     public static string FormatWindowsRelease(string value)
     {
-        string normalized = value.Trim();
-        if (normalized.StartsWith("Windows ", StringComparison.OrdinalIgnoreCase))
-        {
-            return normalized;
-        }
-
-        return int.TryParse(normalized, out _)
-            ? $"{Foundry.Deploy.Services.Localization.LocalizationText.GetString("OperatingSystem.Windows")} {normalized}"
-            : normalized;
+        return value.Trim();
     }
 
     public static string FormatLicenseChannel(string channel)
     {
-        return channel.Trim().ToUpperInvariant() switch
-        {
-            "RET" => Foundry.Deploy.Services.Localization.LocalizationText.GetString("OperatingSystem.Retail"),
-            "VOL" => Foundry.Deploy.Services.Localization.LocalizationText.GetString("OperatingSystem.Volume"),
-            _ => channel
-        };
+        return channel.Trim();
     }
 
     public static string FormatEdition(string edition)
     {
-        return edition.Trim().ToUpperInvariant() switch
-        {
-            "PRO" => Foundry.Deploy.Services.Localization.LocalizationText.GetString("OperatingSystem.Professional"),
-            "PRO N" => Foundry.Deploy.Services.Localization.LocalizationText.GetString("OperatingSystem.ProfessionalN"),
-            _ => edition
-        };
+        return edition.Trim();
     }
 }

--- a/src/Foundry.Deploy/FoundryDeployApplicationInfo.cs
+++ b/src/Foundry.Deploy/FoundryDeployApplicationInfo.cs
@@ -6,12 +6,6 @@ public static class FoundryDeployApplicationInfo
 {
     private static readonly string AppVersion = ResolveVersion();
 
-    public const string AppName = "Foundry Deploy";
-    public const string AboutTitle = "About Foundry Deploy";
-    public const string DescriptionLine1 = "Foundry Deploy is the WinPE deployment experience for Foundry.";
-    public const string DescriptionLine2 = "This software is provided as-is. Review your deployment settings before use.";
-    public const string Footer = "Copyright (c) 2026 Foundry Contributors. Licensed under the MIT License.";
-
     public static string Version => AppVersion;
 
     private static string ResolveVersion()

--- a/src/Foundry.Deploy/MainWindow.xaml
+++ b/src/Foundry.Deploy/MainWindow.xaml
@@ -46,7 +46,7 @@
                         Command="{Binding Preparation.RefreshTargetDisksCommand}"
                         Header="{Binding Strings[Tools.RefreshTargetDisks]}"
                         IsEnabled="{Binding Session.IsStartupReady}" />
-                    <MenuItem Command="{Binding Session.OpenLogFileCommand}" Header="{Binding Strings[Common.OpenLogFile]}" />
+                    <MenuItem Command="{Binding Session.OpenLogFileCommand}" Header="{Binding Strings[Tools.OpenLogFile]}" />
                 </MenuItem>
                 <!--  About  -->
                 <MenuItem Command="{Binding ShowAboutCommand}" Header="{Binding Strings[Menu.About]}" />
@@ -144,7 +144,7 @@
                                             Width="140"
                                             Margin="8,0,0,0"
                                             Command="{Binding RefreshTargetDisksCommand}"
-                                            Content="{Binding DataContext.Strings[Preparation.RefreshDisks], ElementName=RootWindow}" />
+                                            Content="{Binding DataContext.Strings[Common.Refresh], ElementName=RootWindow}" />
                                     </DockPanel>
                                     <TextBlock
                                         Margin="0,8,0,0"
@@ -189,7 +189,7 @@
                                     <Button
                                         Width="140"
                                         Command="{Binding RefreshCatalogsCommand}"
-                                        Content="{Binding Strings[Tools.RefreshCatalogs]}" />
+                                        Content="{Binding Strings[Common.Refresh]}" />
                                     <TextBlock
                                         Margin="12,0,0,0"
                                         VerticalAlignment="Center"
@@ -284,7 +284,7 @@
                                     <Button
                                         Width="140"
                                         Command="{Binding RefreshCatalogsCommand}"
-                                        Content="{Binding Strings[Tools.RefreshCatalogs]}" />
+                                        Content="{Binding Strings[Common.Refresh]}" />
                                     <TextBlock
                                         Margin="12,0,0,0"
                                         VerticalAlignment="Center"
@@ -367,7 +367,7 @@
                                 Margin="0,8,0,0"
                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                 Style="{StaticResource CaptionTextBlockStyle}"
-                                Text="{Binding Strings[Summary.StartExplanation]}" />
+                                Text="{Binding Strings[Summary.DeployExplanation]}" />
                             <TextBlock
                                 Margin="0,4,0,0"
                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
@@ -423,7 +423,7 @@
                         <Button
                             Width="160"
                             Command="{Binding StartDeploymentCommand}"
-                            Content="{Binding Strings[Common.StartDeployment]}"
+                            Content="{Binding Strings[Common.Deploy]}"
                             Style="{DynamicResource AccentButtonStyle}" />
                     </StackPanel>
                 </Grid>
@@ -561,7 +561,7 @@
                         Width="140"
                         HorizontalAlignment="Right"
                         Command="{Binding OpenLogFileCommand}"
-                        Content="{Binding DataContext.Strings[Common.OpenLogFile], ElementName=RootWindow}" />
+                        Content="{Binding DataContext.Strings[Common.OpenLog], ElementName=RootWindow}" />
                 </Grid>
             </Grid>
 
@@ -751,7 +751,7 @@
                             Margin="0,16,0,0"
                             HorizontalAlignment="Right"
                             Command="{Binding OpenLogFileCommand}"
-                            Content="{Binding DataContext.Strings[Common.OpenLogFile], ElementName=RootWindow}" />
+                            Content="{Binding DataContext.Strings[Common.OpenLog], ElementName=RootWindow}" />
                     </StackPanel>
                 </Grid>
             </Grid>
@@ -797,7 +797,7 @@
                     HorizontalAlignment="Center"
                     VerticalAlignment="Bottom"
                     Command="{Binding BeginWizardCommand}"
-                    Content="{Binding Strings[Splash.Begin]}"
+                    Content="{Binding Strings[Splash.Start]}"
                     Style="{DynamicResource AccentButtonStyle}"
                     Visibility="{Binding Session.IsStartupInitializing, Converter={StaticResource InverseBooleanConverter}}" />
             </Grid>

--- a/src/Foundry.Deploy/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry.Deploy/Resources/AppStrings.fr-FR.resx
@@ -12,10 +12,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="App.Name" xml:space="preserve"><value>Foundry Deploy</value></data>
+  <data name="App.Name" xml:space="preserve"><value>Foundry.Deploy</value></data>
   <data name="App.WindowTitle" xml:space="preserve"><value>Foundry.Deploy</value></data>
-  <data name="About.Title" xml:space="preserve"><value>À propos de Foundry Deploy</value></data>
-  <data name="About.DescriptionLine1" xml:space="preserve"><value>Foundry Deploy est l’expérience de déploiement WinPE de Foundry.</value></data>
+  <data name="About.Title" xml:space="preserve"><value>À propos de Foundry.Deploy</value></data>
+  <data name="About.DescriptionLine1" xml:space="preserve"><value>Foundry.Deploy est l’expérience de déploiement WinPE de Foundry.</value></data>
   <data name="About.DescriptionLine2" xml:space="preserve"><value>Ce logiciel est fourni tel quel. Vérifiez vos paramètres de déploiement avant utilisation.</value></data>
   <data name="About.Footer" xml:space="preserve"><value>Copyright (c) 2026 Contributeurs Foundry. Distribué sous licence MIT.</value></data>
   <data name="Menu.Theme" xml:space="preserve"><value>_Thème</value></data>
@@ -29,21 +29,21 @@
   <data name="Language.French" xml:space="preserve"><value>Français</value></data>
   <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Actualiser les catalogues</value></data>
   <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Actualiser les disques cibles</value></data>
+  <data name="Tools.OpenLogFile" xml:space="preserve"><value>Ouvrir le fichier journal</value></data>
   <data name="Wizard.Title" xml:space="preserve"><value>Assistant Foundry.Deploy</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>MODE DEBUG SAFE ACTIF : toutes les actions de déploiement sont simulées, aucune écriture disque/image n’est effectuée.</value></data>
+  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>MODE DEBUG SÉCURISÉ ACTIF : toutes les actions de déploiement sont simulées, aucune écriture disque/image n’est effectuée.</value></data>
   <data name="Wizard.Description" xml:space="preserve"><value>Orchestrateur de séquence de tâches pour le déploiement d’OS dans WinPE.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Cible</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Catalogue système</value></data>
-  <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Driver Pack</value></data>
+  <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Pack de pilotes</value></data>
   <data name="Wizard.StepSummary" xml:space="preserve"><value>4. Résumé</value></data>
   <data name="Preparation.ComputerName" xml:space="preserve"><value>Nom de l’ordinateur</value></data>
   <data name="Preparation.ComputerNameHint" xml:space="preserve"><value>1 à 15 caractères. A-Z, a-z, 0-9 et tiret uniquement.</value></data>
   <data name="Preparation.ComputerNameValidationMessage" xml:space="preserve"><value>Le nom de l’ordinateur doit contenir 1 à 15 caractères valides (lettres, chiffres ou tiret).</value></data>
   <data name="Preparation.TargetDisk" xml:space="preserve"><value>Disque cible</value></data>
-  <data name="Preparation.RefreshDisks" xml:space="preserve"><value>Actualiser les disques</value></data>
   <data name="Preparation.TargetDiskHint" xml:space="preserve"><value>Sélectionnez un disque cible. Les disques non éligibles sont bloqués.</value></data>
   <data name="Preparation.FirmwareUpdates" xml:space="preserve"><value>Firmware : activer les mises à jour via Microsoft Update Catalog.</value></data>
-  <data name="Preparation.AutopilotEnable" xml:space="preserve"><value>Autopilot : activer le staging hors ligne du profil.</value></data>
+  <data name="Preparation.AutopilotEnable" xml:space="preserve"><value>Autopilot : activer la préparation hors ligne du profil.</value></data>
   <data name="Preparation.AutopilotProfile" xml:space="preserve"><value>Profil Autopilot</value></data>
   <data name="Preparation.AutopilotProfilesAvailableFormat" xml:space="preserve"><value>Profils disponibles : {0}</value></data>
   <data name="Preparation.AutopilotProfilesMissing" xml:space="preserve"><value>Aucun profil Autopilot importé n’a été trouvé dans X:\Foundry\Config\Autopilot.</value></data>
@@ -64,20 +64,15 @@
   <data name="Catalog.EditionTarget" xml:space="preserve"><value>Édition (cible)</value></data>
   <data name="Catalog.ArchitectureFormat" xml:space="preserve"><value>Architecture : {0}</value></data>
   <data name="Catalog.Loading" xml:space="preserve"><value>Chargement des catalogues...</value></data>
-  <data name="Catalog.LoadedFormat" xml:space="preserve"><value>Catalogues chargés : {0} entrée(s) OS, {1} driver pack(s).</value></data>
+  <data name="Catalog.LoadedFormat" xml:space="preserve"><value>Catalogues chargés : {0} entrée(s) OS, {1} pack(s) de pilotes.</value></data>
   <data name="Catalog.LoadFailedFormat" xml:space="preserve"><value>Échec du chargement du catalogue : {0}</value></data>
-  <data name="OperatingSystem.Windows" xml:space="preserve"><value>Windows</value></data>
   <data name="OperatingSystem.Windows11" xml:space="preserve"><value>Windows 11</value></data>
-  <data name="OperatingSystem.Retail" xml:space="preserve"><value>Retail</value></data>
-  <data name="OperatingSystem.Volume" xml:space="preserve"><value>Volume</value></data>
-  <data name="OperatingSystem.Professional" xml:space="preserve"><value>Professionnel</value></data>
-  <data name="OperatingSystem.ProfessionalN" xml:space="preserve"><value>Professionnel N</value></data>
   <data name="DriverPack.Source" xml:space="preserve"><value>Source des pilotes</value></data>
   <data name="DriverPack.Model" xml:space="preserve"><value>Modèle</value></data>
   <data name="DriverPack.Version" xml:space="preserve"><value>Version</value></data>
   <data name="DriverPack.SelectedModeFormat" xml:space="preserve"><value>Mode sélectionné : {0}</value></data>
   <data name="DriverPack.MicrosoftUpdateCatalog" xml:space="preserve"><value>Microsoft Update Catalog</value></data>
-  <data name="DriverPack.OemDriverPack" xml:space="preserve"><value>Driver Pack OEM</value></data>
+  <data name="DriverPack.OemDriverPack" xml:space="preserve"><value>Pack de pilotes OEM</value></data>
   <data name="DriverPack.Oem" xml:space="preserve"><value>OEM</value></data>
   <data name="DriverPack.NoMatchingModelVersionFormat" xml:space="preserve"><value>{0} | Aucun modèle/version correspondant</value></data>
   <data name="DriverPack.MultiModelFormat" xml:space="preserve"><value>{0} (+{1} modèles)</value></data>
@@ -86,32 +81,33 @@
   <data name="Summary.NoDiskSelected" xml:space="preserve"><value>Aucun disque sélectionné</value></data>
   <data name="Summary.SelectedOperatingSystem" xml:space="preserve"><value>Système sélectionné</value></data>
   <data name="Summary.NoSelection" xml:space="preserve"><value>Aucune sélection</value></data>
-  <data name="Summary.SelectedDriverPack" xml:space="preserve"><value>Driver Pack sélectionné</value></data>
-  <data name="Summary.DriverPackMode" xml:space="preserve"><value>Mode du Driver Pack</value></data>
+  <data name="Summary.SelectedDriverPack" xml:space="preserve"><value>Pack de pilotes sélectionné</value></data>
+  <data name="Summary.DriverPackMode" xml:space="preserve"><value>Mode du pack de pilotes</value></data>
   <data name="Summary.Firmware" xml:space="preserve"><value>Firmware</value></data>
   <data name="Summary.FirmwareEnabledFormat" xml:space="preserve"><value>Mises à jour du firmware activées : {0}</value></data>
   <data name="Summary.Autopilot" xml:space="preserve"><value>Autopilot</value></data>
   <data name="Summary.EnabledFormat" xml:space="preserve"><value>Activé : {0}</value></data>
   <data name="Summary.SelectedProfileFormat" xml:space="preserve"><value>Profil sélectionné : {0}</value></data>
-  <data name="Summary.StartExplanation" xml:space="preserve"><value>Démarrer lance l’orchestrateur de séquence de tâches avec les actions WinPE réelles (diskpart, DISM, BCDBoot, injection de pilotes, staging hors ligne du profil Autopilot).</value></data>
-  <data name="Summary.DebugSafeModeExplanation" xml:space="preserve"><value>Debug Safe Mode : la séquence de tâches s’exécute en simulation dry-run.</value></data>
-  <data name="Debug.ProgressButton" xml:space="preserve"><value>Debug : progression</value></data>
-  <data name="Debug.SuccessButton" xml:space="preserve"><value>Debug : succès</value></data>
-  <data name="Debug.ErrorButton" xml:space="preserve"><value>Debug : erreur</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Aperçu debug : page de progression.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Aperçu debug : page de succès.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Aperçu debug : page d’erreur.</value></data>
-  <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Aperçu debug : l’application DISM a échoué car la partition cible est en lecture seule.
+  <data name="Summary.DeployExplanation" xml:space="preserve"><value>Déployer lance l’orchestrateur de séquence de tâches avec les actions WinPE réelles (diskpart, DISM, BCDBoot, injection de pilotes, préparation hors ligne du profil Autopilot).</value></data>
+  <data name="Summary.DebugSafeModeExplanation" xml:space="preserve"><value>Mode debug sécurisé : la séquence de tâches s’exécute en simulation.</value></data>
+  <data name="Debug.ProgressButton" xml:space="preserve"><value>DBG: Progrès</value></data>
+  <data name="Debug.SuccessButton" xml:space="preserve"><value>DBG: Succès</value></data>
+  <data name="Debug.ErrorButton" xml:space="preserve"><value>DBG: Erreur</value></data>
+  <data name="Debug.ProgressPage" xml:space="preserve"><value>Aperçu DBG : page de progression.</value></data>
+  <data name="Debug.SuccessPage" xml:space="preserve"><value>Aperçu DBG : page de succès.</value></data>
+  <data name="Debug.ErrorPage" xml:space="preserve"><value>Aperçu DBG : page d’erreur.</value></data>
+  <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Aperçu DBG : l’application DISM a échoué car la partition cible est en lecture seule.
 
 ErrorCode=0x80070005
 Détails : accès refusé lors du montage de l’image sur le chemin cible.
 Action : vérifiez les attributs du disque puis relancez le déploiement.</value></data>
   <data name="Debug.ApplyingImageProgressFormat" xml:space="preserve"><value>Application de l’image : {0}%</value></data>
+  <data name="Common.Refresh" xml:space="preserve"><value>Actualiser</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Version : {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Précédent</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Suivant</value></data>
-  <data name="Common.StartDeployment" xml:space="preserve"><value>Démarrer le déploiement</value></data>
-  <data name="Common.OpenLogFile" xml:space="preserve"><value>Ouvrir le fichier journal</value></data>
+  <data name="Common.Deploy" xml:space="preserve"><value>Déployer</value></data>
+  <data name="Common.OpenLog" xml:space="preserve"><value>Ouvrir journal</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/D</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Indisponible</value></data>
   <data name="Common.None" xml:space="preserve"><value>Aucun</value></data>
@@ -126,13 +122,13 @@ Action : vérifiez les attributs du disque puis relancez le déploiement.</value
   <data name="Progress.ElapsedTime" xml:space="preserve"><value>Temps écoulé</value></data>
   <data name="Success.Completed" xml:space="preserve"><value>Déploiement terminé avec succès.</value></data>
   <data name="Success.RebootCountdownFormat" xml:space="preserve"><value>Cet ordinateur redémarrera dans {0} secondes...</value></data>
-  <data name="Success.RebootNow" xml:space="preserve"><value>Redémarrer maintenant</value></data>
+  <data name="Success.RebootNow" xml:space="preserve"><value>Redémarrer</value></data>
   <data name="Error.Title" xml:space="preserve"><value>Le déploiement a échoué</value></data>
   <data name="Error.FailedStep" xml:space="preserve"><value>Étape en échec</value></data>
   <data name="Error.Message" xml:space="preserve"><value>Message d’erreur</value></data>
   <data name="Splash.Welcome" xml:space="preserve"><value>Bienvenue</value></data>
   <data name="Splash.InitializingComponents" xml:space="preserve"><value>Initialisation des composants...</value></data>
-  <data name="Splash.Begin" xml:space="preserve"><value>Commencer</value></data>
+  <data name="Splash.Start" xml:space="preserve"><value>Démarrer</value></data>
   <data name="Disk.DisplayLabelFormat" xml:space="preserve"><value>Disque {0} | {1} | {2} | {3}{4}</value></data>
   <data name="Disk.WarningSuffixFormat" xml:space="preserve"><value> | {0}</value></data>
   <data name="Disk.UnknownSize" xml:space="preserve"><value>Taille inconnue</value></data>
@@ -140,13 +136,13 @@ Action : vérifiez les attributs du disque puis relancez le déploiement.</value
   <data name="Disk.BlockedBootDisk" xml:space="preserve"><value>Bloqué : disque de démarrage</value></data>
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Bloqué : lecture seule</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Bloqué : hors ligne</value></data>
-  <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>CIBLE VIRTUELLE DEBUG</value></data>
+  <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>CIBLE VIRTUELLE DBG</value></data>
   <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Disque sélectionné bloqué : {0}</value></data>
   <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Sélectionnez un système d’exploitation.</value></data>
   <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Saisissez un nom d’ordinateur valide.</value></data>
   <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Sélectionnez un disque cible.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Sélectionnez un modèle/version OEM valide avant de démarrer le déploiement.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Sélectionnez un profil Autopilot ou désactivez Autopilot avant de démarrer le déploiement.</value></data>
+  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Sélectionnez un modèle/version OEM valide avant de déployer.</value></data>
+  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Sélectionnez un profil Autopilot ou désactivez Autopilot avant de déployer.</value></data>
   <data name="Launch.CancelledByUser" xml:space="preserve"><value>Déploiement annulé par l’utilisateur.</value></data>
   <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Préparation du déploiement terminée.</value></data>
   <data name="Status.Ready" xml:space="preserve"><value>Prêt</value></data>
@@ -160,6 +156,7 @@ Action : vérifiez les attributs du disque puis relancez le déploiement.</value
   <data name="Status.DeploymentFailed" xml:space="preserve"><value>Le déploiement a échoué.</value></data>
   <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Le déploiement a échoué : {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Une autre opération est déjà en cours.</value></data>
+  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Mode debug sécurisé activé : les actions de déploiement sont simulées.</value></data>
   <data name="Status.StartingOrchestration" xml:space="preserve"><value>Démarrage de l’orchestration Foundry.Deploy.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Démarrage de l’étape...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Démarrage de {0}.</value></data>
@@ -186,13 +183,13 @@ Action : vérifiez les attributs du disque puis relancez le déploiement.</value
   <data name="Step.ApplyOperatingSystemImage" xml:space="preserve"><value>Application de l’image système</value></data>
   <data name="Step.ConfigureTargetComputerName" xml:space="preserve"><value>Configuration du nom cible</value></data>
   <data name="Step.ConfigureRecoveryEnvironment" xml:space="preserve"><value>Configuration de l’environnement de récupération</value></data>
-  <data name="Step.DownloadDriverPack" xml:space="preserve"><value>Téléchargement du Driver Pack</value></data>
-  <data name="Step.ExtractDriverPack" xml:space="preserve"><value>Extraction du Driver Pack</value></data>
-  <data name="Step.ApplyDriverPack" xml:space="preserve"><value>Application du Driver Pack</value></data>
+  <data name="Step.DownloadDriverPack" xml:space="preserve"><value>Téléchargement du pack de pilotes</value></data>
+  <data name="Step.ExtractDriverPack" xml:space="preserve"><value>Extraction du pack de pilotes</value></data>
+  <data name="Step.ApplyDriverPack" xml:space="preserve"><value>Application du pack de pilotes</value></data>
   <data name="Step.DownloadFirmwareUpdate" xml:space="preserve"><value>Téléchargement de la mise à jour firmware</value></data>
   <data name="Step.ApplyFirmwareUpdate" xml:space="preserve"><value>Application de la mise à jour firmware</value></data>
   <data name="Step.SealRecoveryPartition" xml:space="preserve"><value>Masquage de la partition de récupération</value></data>
-  <data name="Step.StageAutopilotConfiguration" xml:space="preserve"><value>Staging de la configuration Autopilot</value></data>
+  <data name="Step.StageAutopilotConfiguration" xml:space="preserve"><value>Préparation de la configuration Autopilot</value></data>
   <data name="Step.FinalizeDeploymentAndWriteLogs" xml:space="preserve"><value>Finalisation du déploiement et écriture des journaux</value></data>
   <data name="StepMessage.GatheringDeploymentVariables" xml:space="preserve"><value>Collecte des variables de déploiement...</value></data>
   <data name="StepMessage.CollectingDeploymentContext" xml:space="preserve"><value>Collecte du contexte de déploiement...</value></data>
@@ -243,30 +240,30 @@ Action : vérifiez les attributs du disque puis relancez le déploiement.</value
   <data name="StepResult.RecoveryPartitionUnavailable" xml:space="preserve"><value>La partition de récupération est indisponible.</value></data>
   <data name="StepResult.RecoveryEnvironmentConfigured" xml:space="preserve"><value>Environnement de récupération configuré.</value></data>
   <data name="StepResult.RecoveryEnvironmentConfiguredSimulation" xml:space="preserve"><value>Environnement de récupération configuré (simulation).</value></data>
-  <data name="StepResult.DriverPackDisabled" xml:space="preserve"><value>Driver Pack désactivé (Aucun sélectionné).</value></data>
-  <data name="StepResult.NoDriverPackDownloadRequired" xml:space="preserve"><value>Aucun téléchargement de Driver Pack requis.</value></data>
-  <data name="StepMessage.DownloadingDriverPack" xml:space="preserve"><value>Téléchargement du Driver Pack...</value></data>
+  <data name="StepResult.DriverPackDisabled" xml:space="preserve"><value>Pack de pilotes désactivé (aucun sélectionné).</value></data>
+  <data name="StepResult.NoDriverPackDownloadRequired" xml:space="preserve"><value>Aucun téléchargement de pack de pilotes requis.</value></data>
+  <data name="StepMessage.DownloadingDriverPack" xml:space="preserve"><value>Téléchargement du pack de pilotes...</value></data>
   <data name="StepMessage.PreparingDownload" xml:space="preserve"><value>Préparation du téléchargement...</value></data>
-  <data name="StepResult.OemDriverPackMissing" xml:space="preserve"><value>Le mode Driver Pack OEM est sélectionné mais aucun Driver Pack n’a été fourni.</value></data>
-  <data name="StepResult.DriverPackDownloaded" xml:space="preserve"><value>Driver Pack téléchargé.</value></data>
-  <data name="StepResult.DriverPackDownloadedSimulation" xml:space="preserve"><value>Driver Pack téléchargé (simulation).</value></data>
-  <data name="StepMessage.ExtractingDriverPack" xml:space="preserve"><value>Extraction du Driver Pack...</value></data>
-  <data name="StepResult.DriverPackNotDownloaded" xml:space="preserve"><value>Le Driver Pack n’a pas été téléchargé.</value></data>
-  <data name="StepResult.DriverPackExtracted" xml:space="preserve"><value>Driver Pack extrait.</value></data>
-  <data name="StepResult.DriverPackExtractedSimulation" xml:space="preserve"><value>Driver Pack extrait (simulation).</value></data>
-  <data name="StepResult.NoDriverPackOperationRequired" xml:space="preserve"><value>Aucune opération Driver Pack requise.</value></data>
-  <data name="StepResult.UnsupportedDriverPackInstallMode" xml:space="preserve"><value>Mode d’installation du Driver Pack non pris en charge.</value></data>
+  <data name="StepResult.OemDriverPackMissing" xml:space="preserve"><value>Le mode pack de pilotes OEM est sélectionné mais aucun pack de pilotes n’a été fourni.</value></data>
+  <data name="StepResult.DriverPackDownloaded" xml:space="preserve"><value>Pack de pilotes téléchargé.</value></data>
+  <data name="StepResult.DriverPackDownloadedSimulation" xml:space="preserve"><value>Pack de pilotes téléchargé (simulation).</value></data>
+  <data name="StepMessage.ExtractingDriverPack" xml:space="preserve"><value>Extraction du pack de pilotes...</value></data>
+  <data name="StepResult.DriverPackNotDownloaded" xml:space="preserve"><value>Le pack de pilotes n’a pas été téléchargé.</value></data>
+  <data name="StepResult.DriverPackExtracted" xml:space="preserve"><value>Pack de pilotes extrait.</value></data>
+  <data name="StepResult.DriverPackExtractedSimulation" xml:space="preserve"><value>Pack de pilotes extrait (simulation).</value></data>
+  <data name="StepResult.NoDriverPackOperationRequired" xml:space="preserve"><value>Aucune opération sur le pack de pilotes n’est requise.</value></data>
+  <data name="StepResult.UnsupportedDriverPackInstallMode" xml:space="preserve"><value>Mode d’installation du pack de pilotes non pris en charge.</value></data>
   <data name="StepResult.NoExtractedInfDriverPayload" xml:space="preserve"><value>Aucune charge utile INF extraite n’est disponible.</value></data>
-  <data name="StepMessage.ApplyingDriverPack" xml:space="preserve"><value>Application du Driver Pack...</value></data>
+  <data name="StepMessage.ApplyingDriverPack" xml:space="preserve"><value>Application du pack de pilotes...</value></data>
   <data name="StepMessage.ApplyingWindowsDrivers" xml:space="preserve"><value>Application des pilotes Windows...</value></data>
   <data name="StepMessage.MountingWinRe" xml:space="preserve"><value>Montage de WinRE...</value></data>
   <data name="StepMessage.ApplyingWinReDrivers" xml:space="preserve"><value>Application des pilotes WinRE...</value></data>
   <data name="StepMessage.UnmountingWinRe" xml:space="preserve"><value>Démontage de WinRE...</value></data>
   <data name="StepMessage.StagingPackage" xml:space="preserve"><value>Staging du package...</value></data>
   <data name="StepMessage.UpdatingSetupCompleteHook" xml:space="preserve"><value>Mise à jour du hook SetupComplete...</value></data>
-  <data name="StepResult.DriverPackApplied" xml:space="preserve"><value>Driver Pack appliqué.</value></data>
-  <data name="StepResult.DriverPackStagedForFirstBoot" xml:space="preserve"><value>Driver Pack préparé pour le premier démarrage.</value></data>
-  <data name="StepResult.DriverPackAppliedSimulation" xml:space="preserve"><value>Driver Pack appliqué (simulation).</value></data>
+  <data name="StepResult.DriverPackApplied" xml:space="preserve"><value>Pack de pilotes appliqué.</value></data>
+  <data name="StepResult.DriverPackStagedForFirstBoot" xml:space="preserve"><value>Pack de pilotes préparé pour le premier démarrage.</value></data>
+  <data name="StepResult.DriverPackAppliedSimulation" xml:space="preserve"><value>Pack de pilotes appliqué (simulation).</value></data>
   <data name="StepMessage.DownloadingFirmwareUpdate" xml:space="preserve"><value>Téléchargement de la mise à jour firmware...</value></data>
   <data name="StepMessage.PreparingMicrosoftUpdateCatalogLookup" xml:space="preserve"><value>Préparation de la recherche Microsoft Update Catalog...</value></data>
   <data name="StepResult.FirmwareUpdatesDisabled" xml:space="preserve"><value>Les mises à jour firmware sont désactivées.</value></data>
@@ -287,11 +284,11 @@ Action : vérifiez les attributs du disque puis relancez le déploiement.</value
   <data name="StepResult.RecoveryPartitionSealedSimulation" xml:space="preserve"><value>Partition de récupération masquée (simulation).</value></data>
   <data name="StepResult.AutopilotDisabled" xml:space="preserve"><value>Autopilot est désactivé.</value></data>
   <data name="StepResult.AutopilotProfileMissing" xml:space="preserve"><value>Autopilot est activé mais aucun profil n’a été sélectionné.</value></data>
-  <data name="StepResult.TargetWindowsPartitionUnavailableForAutopilot" xml:space="preserve"><value>La partition Windows cible est indisponible pour le staging Autopilot.</value></data>
+  <data name="StepResult.TargetWindowsPartitionUnavailableForAutopilot" xml:space="preserve"><value>La partition Windows cible est indisponible pour la préparation Autopilot.</value></data>
   <data name="StepResult.TargetAutopilotDirectoryUnavailable" xml:space="preserve"><value>Impossible de résoudre le répertoire Autopilot cible.</value></data>
-  <data name="StepMessage.StagingAutopilotProfile" xml:space="preserve"><value>Staging du profil Autopilot...</value></data>
+  <data name="StepMessage.StagingAutopilotProfile" xml:space="preserve"><value>Préparation du profil Autopilot...</value></data>
   <data name="StepMessage.CopyingAutopilotConfiguration" xml:space="preserve"><value>Copie de AutopilotConfigurationFile.json...</value></data>
-  <data name="StepMessage.WritingDryRunAutopilotManifest" xml:space="preserve"><value>Écriture du manifeste Autopilot dry-run...</value></data>
+  <data name="StepMessage.WritingDryRunAutopilotManifest" xml:space="preserve"><value>Écriture du manifeste Autopilot de simulation...</value></data>
   <data name="StepResult.AutopilotProfileStaged" xml:space="preserve"><value>Profil Autopilot préparé.</value></data>
   <data name="StepResult.AutopilotProfileStagedSimulation" xml:space="preserve"><value>Profil Autopilot préparé (simulation).</value></data>
 </root>

--- a/src/Foundry.Deploy/Resources/AppStrings.resx
+++ b/src/Foundry.Deploy/Resources/AppStrings.resx
@@ -12,10 +12,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="App.Name" xml:space="preserve"><value>Foundry Deploy</value></data>
+  <data name="App.Name" xml:space="preserve"><value>Foundry.Deploy</value></data>
   <data name="App.WindowTitle" xml:space="preserve"><value>Foundry.Deploy</value></data>
-  <data name="About.Title" xml:space="preserve"><value>About Foundry Deploy</value></data>
-  <data name="About.DescriptionLine1" xml:space="preserve"><value>Foundry Deploy is the WinPE deployment experience for Foundry.</value></data>
+  <data name="About.Title" xml:space="preserve"><value>About Foundry.Deploy</value></data>
+  <data name="About.DescriptionLine1" xml:space="preserve"><value>Foundry.Deploy is the WinPE deployment experience for Foundry.</value></data>
   <data name="About.DescriptionLine2" xml:space="preserve"><value>This software is provided as-is. Review your deployment settings before use.</value></data>
   <data name="About.Footer" xml:space="preserve"><value>Copyright (c) 2026 Foundry Contributors. Licensed under the MIT License.</value></data>
   <data name="Menu.Theme" xml:space="preserve"><value>_Theme</value></data>
@@ -29,8 +29,9 @@
   <data name="Language.French" xml:space="preserve"><value>French</value></data>
   <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Refresh Catalogs</value></data>
   <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Refresh Target Disks</value></data>
+  <data name="Tools.OpenLogFile" xml:space="preserve"><value>Open Log File</value></data>
   <data name="Wizard.Title" xml:space="preserve"><value>Foundry.Deploy Wizard</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>DEBUG SAFE MODE ACTIVE: all deployment actions are simulated, no disk/image write is executed.</value></data>
+  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>DEBUG SAFE MODE ACTIVE: all deployment actions are simulated; no disk/image write is performed.</value></data>
   <data name="Wizard.Description" xml:space="preserve"><value>Task-sequence orchestrator for OS deployment in WinPE.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Target</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operating System Catalog</value></data>
@@ -40,7 +41,6 @@
   <data name="Preparation.ComputerNameHint" xml:space="preserve"><value>1-15 characters. A-Z, a-z, 0-9, and hyphen only.</value></data>
   <data name="Preparation.ComputerNameValidationMessage" xml:space="preserve"><value>Computer name must contain 1 to 15 valid characters (letters, numbers, or hyphen).</value></data>
   <data name="Preparation.TargetDisk" xml:space="preserve"><value>Target Disk</value></data>
-  <data name="Preparation.RefreshDisks" xml:space="preserve"><value>Refresh Disks</value></data>
   <data name="Preparation.TargetDiskHint" xml:space="preserve"><value>Select a target disk. Non-eligible disks are blocked.</value></data>
   <data name="Preparation.FirmwareUpdates" xml:space="preserve"><value>Firmware: Microsoft Update Catalog update enabled.</value></data>
   <data name="Preparation.AutopilotEnable" xml:space="preserve"><value>Autopilot: Enable offline profile staging.</value></data>
@@ -66,12 +66,7 @@
   <data name="Catalog.Loading" xml:space="preserve"><value>Loading catalogs...</value></data>
   <data name="Catalog.LoadedFormat" xml:space="preserve"><value>Catalogs loaded: {0} OS entries, {1} driver packs.</value></data>
   <data name="Catalog.LoadFailedFormat" xml:space="preserve"><value>Catalog load failed: {0}</value></data>
-  <data name="OperatingSystem.Windows" xml:space="preserve"><value>Windows</value></data>
   <data name="OperatingSystem.Windows11" xml:space="preserve"><value>Windows 11</value></data>
-  <data name="OperatingSystem.Retail" xml:space="preserve"><value>Retail</value></data>
-  <data name="OperatingSystem.Volume" xml:space="preserve"><value>Volume</value></data>
-  <data name="OperatingSystem.Professional" xml:space="preserve"><value>Professional</value></data>
-  <data name="OperatingSystem.ProfessionalN" xml:space="preserve"><value>Professional N</value></data>
   <data name="DriverPack.Source" xml:space="preserve"><value>Driver Source</value></data>
   <data name="DriverPack.Model" xml:space="preserve"><value>Model</value></data>
   <data name="DriverPack.Version" xml:space="preserve"><value>Version</value></data>
@@ -93,25 +88,26 @@
   <data name="Summary.Autopilot" xml:space="preserve"><value>Autopilot</value></data>
   <data name="Summary.EnabledFormat" xml:space="preserve"><value>Enabled: {0}</value></data>
   <data name="Summary.SelectedProfileFormat" xml:space="preserve"><value>Selected profile: {0}</value></data>
-  <data name="Summary.StartExplanation" xml:space="preserve"><value>Start launches the deployment task sequence orchestrator with real WinPE actions (diskpart, DISM, BCDBoot, driver injection, offline Autopilot profile staging).</value></data>
-  <data name="Summary.DebugSafeModeExplanation" xml:space="preserve"><value>Debug Safe Mode: task sequence runs in dry-run simulation.</value></data>
-  <data name="Debug.ProgressButton" xml:space="preserve"><value>Debug: Progress</value></data>
-  <data name="Debug.SuccessButton" xml:space="preserve"><value>Debug: Success</value></data>
-  <data name="Debug.ErrorButton" xml:space="preserve"><value>Debug: Error</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Debug preview: progress page.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Debug preview: success page.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Debug preview: error page.</value></data>
-  <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Debug preview: DISM apply failed because the target partition is read-only.
+  <data name="Summary.DeployExplanation" xml:space="preserve"><value>Deploy launches the deployment task sequence orchestrator with real WinPE actions (diskpart, DISM, BCDBoot, driver injection, offline Autopilot profile staging).</value></data>
+  <data name="Summary.DebugSafeModeExplanation" xml:space="preserve"><value>Debug safe mode: the task sequence runs in simulation.</value></data>
+  <data name="Debug.ProgressButton" xml:space="preserve"><value>DBG: Progress</value></data>
+  <data name="Debug.SuccessButton" xml:space="preserve"><value>DBG: Success</value></data>
+  <data name="Debug.ErrorButton" xml:space="preserve"><value>DBG: Error</value></data>
+  <data name="Debug.ProgressPage" xml:space="preserve"><value>DBG preview: progress page.</value></data>
+  <data name="Debug.SuccessPage" xml:space="preserve"><value>DBG preview: success page.</value></data>
+  <data name="Debug.ErrorPage" xml:space="preserve"><value>DBG preview: error page.</value></data>
+  <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>DBG preview: DISM apply failed because the target partition is read-only.
 
 ErrorCode=0x80070005
 Details: Access denied while mounting image to target path.
 Action: Verify disk attributes and retry deployment.</value></data>
   <data name="Debug.ApplyingImageProgressFormat" xml:space="preserve"><value>Applying image: {0}%</value></data>
+  <data name="Common.Refresh" xml:space="preserve"><value>Refresh</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Version: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Previous</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Next</value></data>
-  <data name="Common.StartDeployment" xml:space="preserve"><value>Start Deployment</value></data>
-  <data name="Common.OpenLogFile" xml:space="preserve"><value>Open Log File</value></data>
+  <data name="Common.Deploy" xml:space="preserve"><value>Deploy</value></data>
+  <data name="Common.OpenLog" xml:space="preserve"><value>Open Log</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Unavailable</value></data>
   <data name="Common.None" xml:space="preserve"><value>None</value></data>
@@ -126,13 +122,13 @@ Action: Verify disk attributes and retry deployment.</value></data>
   <data name="Progress.ElapsedTime" xml:space="preserve"><value>Elapsed time</value></data>
   <data name="Success.Completed" xml:space="preserve"><value>Deployment completed successfully.</value></data>
   <data name="Success.RebootCountdownFormat" xml:space="preserve"><value>This computer will reboot in {0} seconds...</value></data>
-  <data name="Success.RebootNow" xml:space="preserve"><value>Reboot now</value></data>
+  <data name="Success.RebootNow" xml:space="preserve"><value>Reboot</value></data>
   <data name="Error.Title" xml:space="preserve"><value>Deployment failed</value></data>
   <data name="Error.FailedStep" xml:space="preserve"><value>Failed step</value></data>
   <data name="Error.Message" xml:space="preserve"><value>Error message</value></data>
   <data name="Splash.Welcome" xml:space="preserve"><value>Welcome</value></data>
   <data name="Splash.InitializingComponents" xml:space="preserve"><value>Initializing components...</value></data>
-  <data name="Splash.Begin" xml:space="preserve"><value>Begin</value></data>
+  <data name="Splash.Start" xml:space="preserve"><value>Start</value></data>
   <data name="Disk.DisplayLabelFormat" xml:space="preserve"><value>Disk {0} | {1} | {2} | {3}{4}</value></data>
   <data name="Disk.WarningSuffixFormat" xml:space="preserve"><value> | {0}</value></data>
   <data name="Disk.UnknownSize" xml:space="preserve"><value>Unknown size</value></data>
@@ -145,8 +141,8 @@ Action: Verify disk attributes and retry deployment.</value></data>
   <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Select an operating system.</value></data>
   <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Enter a valid computer name.</value></data>
   <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Select a target disk.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Select a valid OEM model/version before starting deployment.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Select an Autopilot profile or disable Autopilot before starting deployment.</value></data>
+  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Select a valid OEM model/version before deploying.</value></data>
+  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Select an Autopilot profile or disable Autopilot before deploying.</value></data>
   <data name="Launch.CancelledByUser" xml:space="preserve"><value>Deployment cancelled by user.</value></data>
   <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Deployment preparation completed.</value></data>
   <data name="Status.Ready" xml:space="preserve"><value>Ready</value></data>
@@ -160,6 +156,7 @@ Action: Verify disk attributes and retry deployment.</value></data>
   <data name="Status.DeploymentFailed" xml:space="preserve"><value>Deployment failed.</value></data>
   <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Deployment failed: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Another operation is already running.</value></data>
+  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Debug safe mode enabled: deployment actions are simulated.</value></data>
   <data name="Status.StartingOrchestration" xml:space="preserve"><value>Starting Foundry.Deploy orchestration.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Starting step...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Starting {0}.</value></data>

--- a/src/Foundry.Deploy/Services/Localization/DeploymentUiTextLocalizer.cs
+++ b/src/Foundry.Deploy/Services/Localization/DeploymentUiTextLocalizer.cs
@@ -66,6 +66,7 @@ public static partial class DeploymentUiTextLocalizer
             "Deployment cancelled by user." => LocalizationText.GetString("Launch.CancelledByUser"),
             "Deployment preparation completed." => LocalizationText.GetString("Launch.PreparationCompleted"),
             "Another operation is already running." => LocalizationText.GetString("Status.AnotherOperationRunning"),
+            "Debug Safe Mode enabled: deployment actions are simulated." => LocalizationText.GetString("Status.DebugSafeModeEnabled"),
             "Starting Foundry.Deploy orchestration." => LocalizationText.GetString("Status.StartingOrchestration"),
             "Gathering deployment variables..." => LocalizationText.GetString("StepMessage.GatheringDeploymentVariables"),
             "Collecting deployment context..." => LocalizationText.GetString("StepMessage.CollectingDeploymentContext"),


### PR DESCRIPTION
## Summary
Refine `Foundry.Deploy` localization for fixed-width actions and catalog display values.

## Reason
Several French UI labels were too long for the existing button sizes, and catalog display formatting was rewriting raw OS metadata in ways that were not wanted.

## Main Changes
- compacted localized action labels used by fixed-width buttons
- split log labels between menu and button contexts
- normalized visible `Foundry.Deploy` glossary and debug wording
- kept OS catalog edition and other catalog values raw
- expanded `RET` and `VOL` to `Retail` and `Volume`
- removed obsolete application info constants

## Testing Notes
- `dotnet build src/Foundry.Deploy/Foundry.Deploy.csproj`
- build succeeded with 0 warnings and 0 errors
