### PR TITLE
ci(workflows): cache NuGet packages in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Cache NuGet packages
         uses: actions/cache@v4
         with:
-          path: ${{ env.USERPROFILE }}\.nuget\packages
+          path: ~/.nuget/packages
           key: ${{ runner.os }}-${{ runner.arch }}-nuget-${{ hashFiles('src/**/*.csproj', 'src/Directory.Build.props', 'global.json', 'NuGet.config', 'nuget.config') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-nuget-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,14 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.USERPROFILE }}\.nuget\packages
+          key: ${{ runner.os }}-${{ runner.arch }}-nuget-${{ hashFiles('src/**/*.csproj', 'src/Directory.Build.props', 'global.json', 'NuGet.config', 'nuget.config') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-nuget-
+
       - name: Restore solution
         run: dotnet restore .\src\Foundry.slnx --nologo
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Cache NuGet packages
         uses: actions/cache@v4
         with:
-          path: ${{ env.USERPROFILE }}\.nuget\packages
+          path: ~/.nuget/packages
           key: ${{ runner.os }}-${{ runner.arch }}-nuget-${{ hashFiles('src/**/*.csproj', 'src/Directory.Build.props', 'global.json', 'NuGet.config', 'nuget.config') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-nuget-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,14 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.USERPROFILE }}\.nuget\packages
+          key: ${{ runner.os }}-${{ runner.arch }}-nuget-${{ hashFiles('src/**/*.csproj', 'src/Directory.Build.props', 'global.json', 'NuGet.config', 'nuget.config') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-nuget-
+
       - name: Validate release tag and apply version
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
Add NuGet package caching to the CI and release GitHub Actions workflows.

## Why
The workflows were restoring NuGet dependencies from scratch on each run. Caching the global NuGet package folder should reduce repeated downloads and make runs less dependent on network latency.

## Changes
- add `actions/cache@v4` to `.github/workflows/ci.yml`
- add `actions/cache@v4` to `.github/workflows/release.yml`
- key the cache by OS, architecture, and dependency-related project files
- keep cache buckets separated for x64 and ARM64 runners

## Testing
- reviewed the workflow diff locally
- ran `git diff --check`
- did not run a live GitHub Actions workflow from this environment

## Notes
This change uses an explicit cache step instead of `actions/setup-dotnet` built-in caching because the repository does not currently use `packages.lock.json`.