### PR TITLE
ci(release): automate scheduled GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,122 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  schedule:
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Create a release even if no commits exist since the latest published release
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
-  publish-release-assets:
-    name: Publish Release Assets
-    runs-on: windows-latest
+  prepare-release:
+    name: Prepare Release
+    runs-on: ubuntu-slim
+    outputs:
+      should_release: ${{ steps.compute.outputs.should_release }}
+      release_tag: ${{ steps.compute.outputs.release_tag }}
+      release_name: ${{ steps.compute.outputs.release_name }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Determine release metadata
+        id: compute
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FORCE_RELEASE: ${{ inputs.force && 'true' || 'false' }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          git fetch --force --tags
+
+          $latestReleaseTag = $null
+          try {
+              $latestReleaseTag = gh api "repos/$env:GITHUB_REPOSITORY/releases/latest" --jq '.tag_name'
+          }
+          catch {
+              Write-Host 'No published release found yet.'
+          }
+
+          $changeCount = if ([string]::IsNullOrWhiteSpace($latestReleaseTag)) {
+              [int](git rev-list --count HEAD)
+          }
+          else {
+              [int](git rev-list --count "$latestReleaseTag..HEAD")
+          }
+
+          $parisNow = [System.TimeZoneInfo]::ConvertTimeBySystemTimeZoneId([DateTimeOffset]::UtcNow, 'Europe/Paris')
+          $datePrefix = 'v{0}.{1}.{2}' -f ($parisNow.Year % 100), $parisNow.Month, $parisNow.Day
+
+          $existingTags = @(git tag -l "$datePrefix.*")
+          $nextBuild = 1
+
+          if ($existingTags.Count -gt 0) {
+              $existingBuilds = $existingTags |
+                  ForEach-Object {
+                      if ($_ -match '^v\d{2}\.\d{1,2}\.\d{1,2}\.(\d+)$') {
+                          [int]$Matches[1]
+                      }
+                  } |
+                  Sort-Object -Descending
+
+              if ($existingBuilds.Count -gt 0) {
+                  $nextBuild = $existingBuilds[0] + 1
+              }
+          }
+
+          $releaseTag = "$datePrefix.$nextBuild"
+          $releaseName = "Foundry $releaseTag"
+          $shouldRelease = $changeCount -gt 0 -or $env:FORCE_RELEASE -eq 'true'
+
+          "should_release=$($shouldRelease.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
+          "release_tag=$releaseTag" >> $env:GITHUB_OUTPUT
+          "release_name=$releaseName" >> $env:GITHUB_OUTPUT
+
+          if ($shouldRelease) {
+              Write-Host "Release will be created with tag '$releaseTag'."
+          }
+          else {
+              Write-Host "No commits found since '$latestReleaseTag'. Skipping release creation."
+          }
+
+      - name: Create GitHub release
+        if: steps.compute.outputs.should_release == 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.compute.outputs.release_tag }}" `
+            --title "${{ steps.compute.outputs.release_name }}" `
+            --target "${{ github.sha }}" `
+            --generate-notes
+
+  publish-release-assets:
+    name: Publish Release Assets
+    runs-on: windows-latest
+    needs: prepare-release
+    if: needs.prepare-release.outputs.should_release == 'true'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up .NET SDK
         uses: actions/setup-dotnet@v5
@@ -32,10 +134,10 @@ jobs:
       - name: Validate release tag and apply version
         shell: pwsh
         run: |
-          $tag = '${{ github.event.release.tag_name }}'
+          $tag = '${{ needs.prepare-release.outputs.release_tag }}'
           $match = [regex]::Match($tag, '^v(?<year>\d{2})\.(?<month>\d{1,2})\.(?<day>\d{1,2})\.(?<build>[1-9]\d*)$')
           if (-not $match.Success) {
-              throw "Release tag '$tag' must use the format vYY.M.D.B."
+              throw "Release tag '$tag' must use the format vYY.M.D.Build."
           }
 
           $year = 2000 + [int]$match.Groups['year'].Value
@@ -169,7 +271,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          $releaseTag = '${{ github.event.release.tag_name }}'
+          $releaseTag = '${{ needs.prepare-release.outputs.release_tag }}'
           $releaseRoot = Join-Path $env:GITHUB_WORKSPACE 'artifacts\release'
           $assets = @(
               (Join-Path $releaseRoot 'Foundry-x64.exe'),


### PR DESCRIPTION
## Summary
Automate GitHub release creation so releases are generated on a weekly schedule or manually, using the existing Foundry tag and title conventions.

## Why
The current release process requires manually drafting a GitHub release, choosing the next tag, generating notes, and publishing it. This change moves that flow into GitHub Actions while avoiding empty releases when nothing changed since the previous published release.

## Changes
- trigger the release workflow on Sundays at 02:00 Europe/Paris and on manual `workflow_dispatch`
- compute the next `vYY.M.D.Build` tag from the current Paris date and existing same-day tags
- skip release creation when there are no commits since the latest published release, unless the manual run is forced
- create the GitHub release with the `Foundry v...` title and autogenerated release notes before uploading assets
- keep the existing asset build and upload logic, now driven by the computed release tag

## Testing
- reviewed the workflow diff locally
- dry-ran the release calculation against the current repository state
- did not run the workflow on GitHub from this branch

## Notes
- untracked local planning files were intentionally left out of this PR to keep the scope limited to the release workflow