### PR TITLE
fix(release): infer ARM64 platform for arm64 runtime

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,6 +30,7 @@
 
   <!-- Common Build Settings -->
   <PropertyGroup>
+    <Platform Condition="'$(Platform)' == '' and '$(RuntimeIdentifier)' == 'win-arm64'">ARM64</Platform>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
Fix arm64 release publishing by deriving the correct MSBuild platform from the arm64 runtime identifier.

## Why
The scheduled release workflow failed while publishing `win-arm64` assets because `Directory.Build.props` defaulted `Platform` to `x64`, which made `PlatformTarget` incompatible with `RuntimeIdentifier=win-arm64`.

## Changes
- Set `Platform=ARM64` when `RuntimeIdentifier` is `win-arm64` and no platform was explicitly provided.
- Keep the existing default `Platform=x64` for all other builds.
- Keep the release workflow unchanged so runtime/platform compatibility remains centralized in shared build props.

## Testing
- Reproduced the original `NETSDK1032` failure locally with `dotnet publish src\Foundry\Foundry.csproj -c Release -r win-arm64 --self-contained true` before the fix.
- Verified arm64 self-contained single-file publish succeeds for `Foundry`.
- Verified arm64 self-contained single-file publish succeeds for `Foundry.Deploy`.
- Verified arm64 self-contained single-file publish succeeds for `Foundry.Connect`.
- Ran `git diff --check`.

## Notes
The local planning files from the investigation were intentionally not included in this PR.