### PR TITLE
refactor(deploy): split main window into shell views

### DIFF
--- a/src/Foundry.Deploy/App.xaml
+++ b/src/Foundry.Deploy/App.xaml
@@ -20,6 +20,17 @@
                 <Setter Property="Background" Value="{DynamicResource CardBackgroundFillColorDefaultBrush}" />
                 <Setter Property="BorderBrush" Value="{DynamicResource CardStrokeColorDefaultBrush}" />
             </Style>
+
+            <Style x:Key="ScrollViewerContentGutterBorderStyle" TargetType="Border">
+                <Setter Property="Padding" Value="0" />
+                <Style.Triggers>
+                    <DataTrigger
+                        Binding="{Binding ComputedVerticalScrollBarVisibility, RelativeSource={RelativeSource AncestorType={x:Type ScrollViewer}}}"
+                        Value="Visible">
+                        <Setter Property="Padding" Value="0,0,24,0" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/Foundry.Deploy/App.xaml
+++ b/src/Foundry.Deploy/App.xaml
@@ -11,7 +11,6 @@
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
             <converters:InverseBooleanConverter x:Key="InverseBooleanConverter" />
             <converters:OsCatalogFilterDisplayConverter x:Key="OsCatalogFilterDisplayConverter" />
-            <converters:OperatingSystemSummaryConverter x:Key="OperatingSystemSummaryConverter" />
 
             <Style x:Key="SectionCardBorderStyle" TargetType="Border">
                 <Setter Property="Padding" Value="16" />

--- a/src/Foundry.Deploy/App.xaml
+++ b/src/Foundry.Deploy/App.xaml
@@ -12,6 +12,15 @@
             <converters:InverseBooleanConverter x:Key="InverseBooleanConverter" />
             <converters:OsCatalogFilterDisplayConverter x:Key="OsCatalogFilterDisplayConverter" />
             <converters:OperatingSystemSummaryConverter x:Key="OperatingSystemSummaryConverter" />
+
+            <Style x:Key="SectionCardBorderStyle" TargetType="Border">
+                <Setter Property="Padding" Value="16" />
+                <Setter Property="Margin" Value="0,0,0,16" />
+                <Setter Property="CornerRadius" Value="8" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="Background" Value="{DynamicResource CardBackgroundFillColorDefaultBrush}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource CardStrokeColorDefaultBrush}" />
+            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/Foundry.Deploy/MainWindow.xaml
+++ b/src/Foundry.Deploy/MainWindow.xaml
@@ -1,35 +1,53 @@
 <Window
-    x:Name="RootWindow"
     x:Class="Foundry.Deploy.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="clr-namespace:Foundry.Deploy.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:Foundry.Deploy"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:rules="clr-namespace:Foundry.Deploy.Validation"
+    xmlns:views="clr-namespace:Foundry.Deploy.Views"
     Title="{Binding WindowTitle}"
     Icon="/Assets/Icons/app.ico"
     ResizeMode="NoResize"
     WindowState="Maximized"
     WindowStyle="None"
     mc:Ignorable="d">
+    <Window.Resources>
+        <DataTemplate x:Key="SplashPageTemplate">
+            <views:SplashView />
+        </DataTemplate>
+
+        <DataTemplate x:Key="WizardPageTemplate">
+            <views:WizardView />
+        </DataTemplate>
+
+        <DataTemplate x:Key="ProgressPageTemplate">
+            <views:ProgressView />
+        </DataTemplate>
+
+        <DataTemplate x:Key="SuccessPageTemplate">
+            <views:SuccessView />
+        </DataTemplate>
+
+        <DataTemplate x:Key="ErrorPageTemplate">
+            <views:ErrorView />
+        </DataTemplate>
+    </Window.Resources>
+
     <Grid>
-        <!--  Main vertical window layout  -->
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <!--  Row 0: Top menu and app version  -->
-        <Grid Grid.Row="0">
+        <Grid Grid.Row="0" Panel.ZIndex="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
             <Menu Grid.Column="0">
-                <!--  Theme  -->
                 <MenuItem Header="{Binding Strings[Menu.Theme]}">
                     <MenuItem Command="{Binding SetSystemThemeCommand}" Header="{Binding Strings[Theme.System]}" />
                     <MenuItem Command="{Binding SetLightThemeCommand}" Header="{Binding Strings[Theme.Light]}" />
@@ -46,7 +64,6 @@
                         </Style>
                     </MenuItem.ItemContainerStyle>
                 </MenuItem>
-                <!--  Tools  -->
                 <MenuItem Header="{Binding Strings[Menu.Tools]}">
                     <MenuItem Command="{Binding RefreshCatalogsCommand}" Header="{Binding Strings[Tools.RefreshCatalogs]}" />
                     <MenuItem
@@ -55,7 +72,6 @@
                         IsEnabled="{Binding Session.IsStartupReady}" />
                     <MenuItem Command="{Binding Session.OpenLogFileCommand}" Header="{Binding Strings[Tools.OpenLogFile]}" />
                 </MenuItem>
-                <!--  About  -->
                 <MenuItem Command="{Binding ShowAboutCommand}" Header="{Binding Strings[Menu.About]}" />
             </Menu>
 
@@ -68,745 +84,82 @@
                 Text="{Binding VersionDisplay}" />
         </Grid>
 
-        <!--  Row 1: Main content area  -->
-        <Grid Grid.Row="1" Margin="16">
-            <!--  Wizard page (configuration flow)  -->
-            <Grid Visibility="{Binding Session.IsWizardPage, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-
-                <!--  Wizard header and context  -->
-                <StackPanel Grid.Row="0" Margin="0,0,0,16">
-                    <TextBlock Style="{StaticResource TitleLargeTextBlockStyle}" Text="{Binding Strings[Wizard.Title]}" />
-                    <Border
-                        Margin="0,8,0,0"
-                        Padding="8"
-                        Background="#33FFAA00"
-                        BorderBrush="#FFFFAA00"
-                        BorderThickness="1"
-                        CornerRadius="4"
-                        Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Wizard.DebugSafeModeBanner]}" />
-                    </Border>
-                    <TextBlock
-                        Margin="0,8,0,0"
-                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding Strings[Wizard.Description]}" />
-                    <TextBlock
-                        Margin="0,8,0,0"
-                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding Preparation.DetectedHardwareSummary}" />
-                </StackPanel>
-
-                <!--  Wizard steps  -->
-                <TabControl
-                    Grid.Row="1"
-                    PreviewMouseDown="WizardTabControl_PreviewMouseDown"
-                    SelectedIndex="{Binding WizardStepIndex}">
-                    <!--  Step 1: Target disk and runtime options  -->
-                    <TabItem Header="{Binding Strings[Wizard.StepTarget]}">
-                        <Grid Margin="16">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                            </Grid.RowDefinitions>
-
-                            <!--  Step 1 details and toggles  -->
-                            <StackPanel Grid.Row="0">
-                                <StackPanel DataContext="{Binding Preparation}">
-                                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.ComputerName], ElementName=RootWindow}" />
-                                    <TextBox
-                                        x:Name="TargetComputerNameTextBox"
-                                        Margin="0,8,0,0"
-                                        IsReadOnly="{Binding IsTargetComputerNameReadOnly}"
-                                        MaxLength="{x:Static rules:ComputerNameRules.MaxLength}"
-                                        PreviewTextInput="TargetComputerNameTextBox_PreviewTextInput"
-                                        Text="{Binding TargetComputerName, UpdateSourceTrigger=PropertyChanged}" />
-                                    <TextBlock
-                                        Margin="0,8,0,0"
-                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                        Style="{StaticResource CaptionTextBlockStyle}"
-                                        Text="{Binding DataContext.Strings[Preparation.ComputerNameHint], ElementName=RootWindow}" />
-                                    <TextBlock
-                                        Margin="0,4,0,0"
-                                        Foreground="#FFC42B1C"
-                                        Style="{StaticResource CaptionTextBlockStyle}"
-                                        Text="{Binding TargetComputerNameValidationMessage}"
-                                        Visibility="{Binding HasTargetComputerNameValidationError, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                                    <TextBlock
-                                        Margin="0,12,0,0"
-                                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                                        Text="{Binding DataContext.Strings[Preparation.TargetDisk], ElementName=RootWindow}" />
-                                    <DockPanel Margin="0,8,0,0">
-                                        <ComboBox
-                                            Width="640"
-                                            DisplayMemberPath="DisplayLabel"
-                                            ItemsSource="{Binding TargetDisks}"
-                                            SelectedItem="{Binding SelectedTargetDisk}" />
-                                        <Button
-                                            Width="140"
-                                            Margin="8,0,0,0"
-                                            Command="{Binding RefreshTargetDisksCommand}"
-                                            Content="{Binding DataContext.Strings[Common.Refresh], ElementName=RootWindow}" />
-                                    </DockPanel>
-                                    <TextBlock
-                                        Margin="0,8,0,0"
-                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                        Style="{StaticResource CaptionTextBlockStyle}"
-                                        Text="{Binding TargetDiskSelectionHint}" />
-                                    <CheckBox
-                                        Margin="0,8,0,0"
-                                        IsChecked="{Binding ApplyFirmwareUpdates}"
-                                        IsEnabled="{Binding IsFirmwareUpdatesOptionEnabled}">
-                                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.FirmwareUpdates], ElementName=RootWindow}" />
-                                    </CheckBox>
-                                    <CheckBox Margin="0,8,0,0" IsChecked="{Binding IsAutopilotEnabled}">
-                                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.AutopilotEnable], ElementName=RootWindow}" />
-                                    </CheckBox>
-                                    <TextBlock
-                                        Margin="0,12,0,0"
-                                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                                        Text="{Binding DataContext.Strings[Preparation.AutopilotProfile], ElementName=RootWindow}" />
-                                    <ComboBox
-                                        Margin="0,8,0,0"
-                                        DisplayMemberPath="DisplayName"
-                                        IsEnabled="{Binding IsAutopilotProfileSelectionEnabled}"
-                                        ItemsSource="{Binding AutopilotProfiles}"
-                                        SelectedItem="{Binding SelectedAutopilotProfile}" />
-                                    <TextBlock
-                                        Margin="0,8,0,0"
-                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                        Style="{StaticResource CaptionTextBlockStyle}"
-                                        Text="{Binding AutopilotProfileHint}" />
-                                </StackPanel>
-                            </StackPanel>
-                        </Grid>
-                    </TabItem>
-
-                    <!--  Step 2: Operating system catalog filters  -->
-                    <TabItem Header="{Binding Strings[Wizard.StepOperatingSystemCatalog]}">
-                        <Grid Margin="16">
-                            <StackPanel Margin="0,0,0,12">
-                                <DockPanel Margin="0,0,0,12">
-                                    <!--  Reload catalog sources  -->
-                                    <Button
-                                        Width="140"
-                                        Command="{Binding RefreshCatalogsCommand}"
-                                        Content="{Binding Strings[Common.Refresh]}" />
-                                    <TextBlock
-                                        Margin="12,0,0,0"
-                                        VerticalAlignment="Center"
-                                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                                        Text="{Binding OperatingSystemArchitectureDisplay}" />
-                                </DockPanel>
-
-                                <Grid>
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto" />
-                                        <RowDefinition Height="Auto" />
-                                        <RowDefinition Height="Auto" />
-                                    </Grid.RowDefinitions>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="*" />
-                                    </Grid.ColumnDefinitions>
-
-                                    <!--  OS family  -->
-                                    <StackPanel Margin="0,0,8,8">
-                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.OperatingSystem]}" />
-                                        <TextBox
-                                            Margin="0,8,0,0"
-                                            IsReadOnly="True"
-                                            Text="{Binding Strings[OperatingSystem.Windows11]}" />
-                                    </StackPanel>
-
-                                    <!--  Release identifier  -->
-                                    <StackPanel Grid.Column="1" Margin="8,0,0,8">
-                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.Version]}" />
-                                        <ComboBox
-                                            Margin="0,8,0,0"
-                                            ItemsSource="{Binding OperatingSystemCatalog.ReleaseIdFilters}"
-                                            SelectedItem="{Binding OperatingSystemCatalog.SelectedReleaseId}" />
-                                    </StackPanel>
-
-                                    <!--  Language and licensing  -->
-                                    <StackPanel Grid.Row="1" Margin="0,0,8,0">
-                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.Language]}" />
-                                        <ComboBox
-                                            Margin="0,8,0,0"
-                                            IsEnabled="{Binding OperatingSystemCatalog.IsLanguageSelectionEnabled}"
-                                            ItemsSource="{Binding OperatingSystemCatalog.LanguageFilters}"
-                                            SelectedItem="{Binding OperatingSystemCatalog.SelectedLanguageCode}" />
-                                    </StackPanel>
-
-                                    <StackPanel
-                                        Grid.Row="1"
-                                        Grid.Column="1"
-                                        Margin="8,0,0,0">
-                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.LicenseChannel]}" />
-                                        <ComboBox
-                                            Margin="0,8,0,0"
-                                            ItemsSource="{Binding OperatingSystemCatalog.LicenseChannelFilters}"
-                                            SelectedItem="{Binding OperatingSystemCatalog.SelectedLicenseChannel}">
-                                            <ComboBox.ItemTemplate>
-                                                <DataTemplate>
-                                                    <TextBlock Text="{Binding ., Converter={StaticResource OsCatalogFilterDisplayConverter}, ConverterParameter=LicenseChannel}" />
-                                                </DataTemplate>
-                                            </ComboBox.ItemTemplate>
-                                        </ComboBox>
-                                    </StackPanel>
-
-                                    <!--  Target edition  -->
-                                    <StackPanel
-                                        Grid.Row="2"
-                                        Grid.ColumnSpan="2"
-                                        Margin="0,8,0,0">
-                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.EditionTarget]}" />
-                                        <ComboBox
-                                            Margin="0,8,0,0"
-                                            ItemsSource="{Binding OperatingSystemCatalog.EditionFilters}"
-                                            SelectedItem="{Binding OperatingSystemCatalog.SelectedEdition}">
-                                            <ComboBox.ItemTemplate>
-                                                <DataTemplate>
-                                                    <TextBlock Text="{Binding ., Converter={StaticResource OsCatalogFilterDisplayConverter}, ConverterParameter=Edition}" />
-                                                </DataTemplate>
-                                            </ComboBox.ItemTemplate>
-                                        </ComboBox>
-                                    </StackPanel>
-                                </Grid>
-                            </StackPanel>
-                        </Grid>
-                    </TabItem>
-
-                    <!--  Step 3: Driver pack selection  -->
-                    <TabItem Header="{Binding Strings[Wizard.StepDriverPack]}">
-                        <Grid Margin="16">
-                            <StackPanel Margin="0,0,0,12">
-                                <DockPanel Margin="0,0,0,12">
-                                    <!--  Reload catalog sources  -->
-                                    <Button
-                                        Width="140"
-                                        Command="{Binding RefreshCatalogsCommand}"
-                                        Content="{Binding Strings[Common.Refresh]}" />
-                                    <TextBlock
-                                        Margin="12,0,0,0"
-                                        VerticalAlignment="Center"
-                                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                                        Text="{Binding DriverPackArchitectureDisplay}" />
-                                </DockPanel>
-
-                                <StackPanel DataContext="{Binding DriverPackSelection}">
-                                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[DriverPack.Source]}" />
-                                    <ComboBox
-                                        Margin="0,8,0,0"
-                                        DisplayMemberPath="DisplayName"
-                                        ItemsSource="{Binding DriverPackOptions}"
-                                        SelectedItem="{Binding SelectedDriverPackOption}" />
-                                    <!--  Driver model/version refinement  -->
-                                    <Grid Margin="0,8,0,0">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="12" />
-                                            <ColumnDefinition Width="*" />
-                                        </Grid.ColumnDefinitions>
-
-                                        <StackPanel Grid.Column="0">
-                                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[DriverPack.Model], ElementName=RootWindow}" />
-                                            <ComboBox
-                                                Margin="0,8,0,0"
-                                                IsEnabled="{Binding IsDriverPackModelSelectionEnabled}"
-                                                ItemsSource="{Binding DriverPackModelOptions}"
-                                                SelectedItem="{Binding SelectedDriverPackModel}" />
-                                        </StackPanel>
-
-                                        <StackPanel Grid.Column="2">
-                                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[DriverPack.Version], ElementName=RootWindow}" />
-                                            <ComboBox
-                                                Margin="0,8,0,0"
-                                                IsEnabled="{Binding IsDriverPackVersionSelectionEnabled}"
-                                                ItemsSource="{Binding DriverPackVersionOptions}"
-                                                SelectedItem="{Binding SelectedDriverPackVersion}" />
-                                        </StackPanel>
-                                    </Grid>
-                                    <TextBlock
-                                        Margin="0,8,0,0"
-                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                        Style="{StaticResource CaptionTextBlockStyle}"
-                                        Text="{Binding DriverPackModeDisplayText}" />
-                                </StackPanel>
-                            </StackPanel>
-                        </Grid>
-                    </TabItem>
-
-                    <!--  Step 4: Deployment summary before execution  -->
-                    <TabItem Header="{Binding Strings[Wizard.StepSummary]}">
-                        <StackPanel Margin="16">
-                            <TextBlock
-                                Margin="0,0,0,12"
-                                Style="{StaticResource TitleTextBlockStyle}"
-                                Text="{Binding Strings[Summary.Title]}" />
-
-                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.TargetDisk]}" />
-                            <TextBlock Margin="0,0,0,8" Text="{Binding SummaryTargetDiskText}" />
-
-                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.SelectedOperatingSystem]}" />
-                            <TextBlock Margin="0,0,0,8" Text="{Binding SummaryOperatingSystemText}" />
-
-                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.SelectedDriverPack]}" />
-                            <TextBlock Margin="0,0,0,8" Text="{Binding DriverPackSelection.SelectedDriverPackSelectionDisplay}" />
-
-                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.DriverPackMode]}" />
-                            <TextBlock Margin="0,0,0,8" Text="{Binding DriverPackSelection.DriverPackModeDisplay}" />
-
-                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.Firmware]}" />
-                            <TextBlock Margin="0,0,0,8" Text="{Binding SummaryFirmwareText}" />
-
-                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.Autopilot]}" />
-                            <TextBlock Margin="0,0,0,4" Text="{Binding SummaryAutopilotEnabledText}" />
-                            <TextBlock Margin="0,0,0,8" Text="{Binding SummaryAutopilotProfileText}" />
-
-                            <!--  Execution notes and mode hints  -->
-                            <TextBlock
-                                Margin="0,8,0,0"
-                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                Style="{StaticResource CaptionTextBlockStyle}"
-                                Text="{Binding Strings[Summary.DeployExplanation]}" />
-                            <TextBlock
-                                Margin="0,4,0,0"
-                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                Style="{StaticResource CaptionTextBlockStyle}"
-                                Text="{Binding Strings[Summary.DebugSafeModeExplanation]}"
-                                Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                        </StackPanel>
-                    </TabItem>
-                </TabControl>
-
-                <!--  Wizard navigation actions  -->
-                <Grid Grid.Row="2" Margin="0,12,0,0">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-
-                    <StackPanel
-                        Grid.Column="0"
-                        HorizontalAlignment="Left"
-                        Orientation="Horizontal"
-                        Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <Button
-                            Width="140"
-                            Margin="0,0,8,0"
-                            Command="{Binding ShowDebugProgressPageCommand}"
-                            Content="{Binding Strings[Debug.ProgressButton]}" />
-                        <Button
-                            Width="140"
-                            Margin="0,0,8,0"
-                            Command="{Binding ShowDebugSuccessPageCommand}"
-                            Content="{Binding Strings[Debug.SuccessButton]}" />
-                        <Button
-                            Width="140"
-                            Command="{Binding ShowDebugErrorPageCommand}"
-                            Content="{Binding Strings[Debug.ErrorButton]}" />
-                    </StackPanel>
-
-                    <StackPanel
-                        Grid.Column="1"
-                        HorizontalAlignment="Right"
-                        Orientation="Horizontal">
-                        <Button
-                            Width="120"
-                            Margin="0,0,8,0"
-                            Command="{Binding PreviousWizardStepCommand}"
-                            Content="{Binding Strings[Common.Previous]}" />
-                        <Button
-                            Width="120"
-                            Margin="0,0,8,0"
-                            Command="{Binding NextWizardStepCommand}"
-                            Content="{Binding Strings[Common.Next]}" />
-                        <Button
-                            Width="160"
-                            Command="{Binding StartDeploymentCommand}"
-                            Content="{Binding Strings[Common.Deploy]}"
-                            Style="{DynamicResource AccentButtonStyle}" />
-                    </StackPanel>
-                </Grid>
-            </Grid>
-
-            <!--  Progress page (execution flow)  -->
-            <Grid DataContext="{Binding Session}" Visibility="{Binding IsProgressPage, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-
-                <!--  Progress header: machine name  -->
-                <TextBlock
-                    Grid.Row="0"
-                    Margin="0,0,0,16"
-                    HorizontalAlignment="Center"
-                    Style="{StaticResource TitleLargeTextBlockStyle}"
-                    Text="{Binding ComputerNameText}" />
-
-                <!--  Main content  -->
-                <Grid Grid.Row="1">
-
-                    <!--  Left panel: computer info  -->
-                    <StackPanel HorizontalAlignment="Left" VerticalAlignment="Center">
-
-                        <!--  Networking  -->
-                        <TextBlock
-                            Margin="0,0,0,4"
-                            Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Progress.Networking], ElementName=RootWindow}" />
-                        <TextBlock
-                            Margin="0,0,0,2"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding IpAddress}" />
-                        <TextBlock
-                            Margin="0,0,0,2"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding MacAddress}" />
-                        <TextBlock
-                            Margin="0,0,0,2"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding SubnetMask}" />
-                        <TextBlock
-                            Margin="0,0,0,20"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding GatewayAddress}" />
-
-                        <!--  Start Time  -->
-                        <TextBlock
-                            Margin="0,0,0,4"
-                            Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Progress.StartTime], ElementName=RootWindow}" />
-                        <TextBlock
-                            Margin="0,0,0,20"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding StartTimeText}" />
-
-                        <!--  Elapsed Time  -->
-                        <TextBlock
-                            Margin="0,0,0,4"
-                            Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Progress.ElapsedTime], ElementName=RootWindow}" />
-                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding ElapsedTimeText}" />
-                    </StackPanel>
-
-                    <!--  Center panel: ring + step name + sub-progress  -->
-                    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-
-                        <!--  Progress ring  -->
-                        <Grid
-                            Width="180"
-                            Height="180"
-                            Margin="0,0,0,24"
-                            HorizontalAlignment="Center">
-                            <controls:CustomProgressRing
-                                IsIndeterminate="{Binding IsGlobalProgressIndeterminate}"
-                                ProgressBrush="{DynamicResource AccentFillColorDefaultBrush}"
-                                Thickness="14"
-                                TrackBrush="{DynamicResource ControlStrongFillColorDefaultBrush}"
-                                Value="{Binding DeploymentProgress}" />
-                            <TextBlock
-                                HorizontalAlignment="Center"
-                                VerticalAlignment="Center"
-                                Style="{StaticResource TitleLargeTextBlockStyle}"
-                                Text="{Binding GlobalProgressPercentText}" />
-                        </Grid>
-
-                        <!--  Current step name  -->
-                        <TextBlock
-                            Margin="0,0,0,20"
-                            HorizontalAlignment="Center"
-                            Style="{StaticResource SubtitleTextBlockStyle}"
-                            Text="{Binding CurrentStepName}"
-                            TextAlignment="Center" />
-
-                        <!--  Sub-step progress  -->
-                        <ProgressBar
-                            Width="320"
-                            Height="4"
-                            Margin="0,0,0,8"
-                            HorizontalAlignment="Center"
-                            IsIndeterminate="{Binding IsCurrentStepProgressIndeterminate}"
-                            Maximum="100"
-                            Value="{Binding CurrentStepProgress}" />
-                        <TextBlock
-                            HorizontalAlignment="Center"
-                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                            Style="{StaticResource CaptionTextBlockStyle}"
-                            Text="{Binding CurrentStepProgressText}" />
-                    </StackPanel>
-                </Grid>
-
-                <!--  Bottom: step counter + log button  -->
-                <Grid Grid.Row="2" Margin="0,12,0,0">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock
-                        Grid.Column="1"
-                        VerticalAlignment="Center"
-                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                        Style="{StaticResource BodyTextBlockStyle}"
-                        Text="{Binding StepCounterText}" />
-
-                    <Button
-                        Grid.Column="2"
-                        Width="140"
-                        HorizontalAlignment="Right"
-                        Command="{Binding OpenLogFileCommand}"
-                        Content="{Binding DataContext.Strings[Common.OpenLog], ElementName=RootWindow}" />
-                </Grid>
-            </Grid>
-
-            <!--  Success page (completion flow)  -->
-            <Grid DataContext="{Binding Session}" Visibility="{Binding IsSuccessPage, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
-
-                <TextBlock
-                    Grid.Row="0"
-                    Margin="0,0,0,16"
-                    HorizontalAlignment="Center"
-                    Style="{StaticResource TitleLargeTextBlockStyle}"
-                    Text="{Binding ComputerNameText}" />
-
-                <Grid Grid.Row="1">
-                    <!--  Left panel: computer info  -->
-                    <StackPanel HorizontalAlignment="Left" VerticalAlignment="Center">
-
-                        <!--  Networking  -->
-                        <TextBlock
-                            Margin="0,0,0,4"
-                            Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Progress.Networking], ElementName=RootWindow}" />
-                        <TextBlock
-                            Margin="0,0,0,2"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding IpAddress}" />
-                        <TextBlock
-                            Margin="0,0,0,2"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding MacAddress}" />
-                        <TextBlock
-                            Margin="0,0,0,2"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding SubnetMask}" />
-                        <TextBlock
-                            Margin="0,0,0,20"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding GatewayAddress}" />
-
-                        <!--  Start Time  -->
-                        <TextBlock
-                            Margin="0,0,0,4"
-                            Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Progress.StartTime], ElementName=RootWindow}" />
-                        <TextBlock
-                            Margin="0,0,0,20"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding StartTimeText}" />
-
-                        <!--  Elapsed Time  -->
-                        <TextBlock
-                            Margin="0,0,0,4"
-                            Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Progress.ElapsedTime], ElementName=RootWindow}" />
-                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding ElapsedTimeText}" />
-                    </StackPanel>
-
-                    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                        <TextBlock
-                            HorizontalAlignment="Center"
-                            Style="{StaticResource TitleTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Success.Completed], ElementName=RootWindow}"
-                            TextAlignment="Center" />
-                        <TextBlock
-                            Margin="0,16,0,24"
-                            HorizontalAlignment="Center"
-                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding RebootCountdownText}"
-                            TextAlignment="Center" />
-                        <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
-                            <Button
-                                Width="140"
-                                Margin="0,0,8,0"
-                                Command="{Binding RebootNowCommand}"
-                                Content="{Binding DataContext.Strings[Success.RebootNow], ElementName=RootWindow}" />
-                        </StackPanel>
-                    </StackPanel>
-                </Grid>
-            </Grid>
-
-            <!--  Error page (failure flow)  -->
-            <Grid DataContext="{Binding Session}" Visibility="{Binding IsErrorPage, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
-
-                <TextBlock
-                    Grid.Row="0"
-                    Margin="0,0,0,16"
-                    HorizontalAlignment="Center"
-                    Style="{StaticResource TitleLargeTextBlockStyle}"
-                    Text="{Binding ComputerNameText}" />
-
-                <Grid Grid.Row="1">
-                    <!--  Left panel: computer info  -->
-                    <StackPanel HorizontalAlignment="Left" VerticalAlignment="Center">
-
-                        <!--  Networking  -->
-                        <TextBlock
-                            Margin="0,0,0,4"
-                            Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Progress.Networking], ElementName=RootWindow}" />
-                        <TextBlock
-                            Margin="0,0,0,2"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding IpAddress}" />
-                        <TextBlock
-                            Margin="0,0,0,2"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding MacAddress}" />
-                        <TextBlock
-                            Margin="0,0,0,2"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding SubnetMask}" />
-                        <TextBlock
-                            Margin="0,0,0,20"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding GatewayAddress}" />
-
-                        <!--  Start Time  -->
-                        <TextBlock
-                            Margin="0,0,0,4"
-                            Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Progress.StartTime], ElementName=RootWindow}" />
-                        <TextBlock
-                            Margin="0,0,0,20"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding StartTimeText}" />
-
-                        <!--  Elapsed Time  -->
-                        <TextBlock
-                            Margin="0,0,0,4"
-                            Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Progress.ElapsedTime], ElementName=RootWindow}" />
-                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding ElapsedTimeText}" />
-                    </StackPanel>
-
-                    <StackPanel
-                        Width="900"
-                        MaxWidth="900"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center">
-                        <TextBlock
-                            HorizontalAlignment="Center"
-                            Style="{StaticResource TitleTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Error.Title], ElementName=RootWindow}"
-                            TextAlignment="Center" />
-                        <TextBlock
-                            Margin="0,16,0,4"
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Error.FailedStep], ElementName=RootWindow}" />
-                        <TextBlock
-                            Margin="0,0,0,16"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding FailedStepName}" />
-                        <TextBlock
-                            Margin="0,0,0,4"
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Error.Message], ElementName=RootWindow}" />
-                        <Border
-                            Height="220"
-                            Padding="10"
-                            BorderBrush="{DynamicResource ControlStrongFillColorDefaultBrush}"
-                            BorderThickness="1"
-                            CornerRadius="4">
-                            <ScrollViewer VerticalScrollBarVisibility="Auto">
-                                <TextBlock
-                                    Style="{StaticResource BodyTextBlockStyle}"
-                                    Text="{Binding FailedStepErrorMessage}"
-                                    TextWrapping="Wrap" />
-                            </ScrollViewer>
-                        </Border>
-                        <Button
-                            Width="140"
-                            Margin="0,16,0,0"
-                            HorizontalAlignment="Right"
-                            Command="{Binding OpenLogFileCommand}"
-                            Content="{Binding DataContext.Strings[Common.OpenLog], ElementName=RootWindow}" />
-                    </StackPanel>
-                </Grid>
+        <Grid
+            x:Name="SplashContentHost"
+            Grid.Row="0"
+            Grid.RowSpan="2"
+            Margin="32"
+            Visibility="{Binding Session.IsSplashPage, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Grid
+                Width="{Binding ElementName=SplashContentHost, Path=ActualWidth}"
+                Height="{Binding ElementName=SplashContentHost, Path=ActualHeight}"
+                MaxWidth="1440"
+                MaxHeight="900"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
+                <ContentControl Content="{Binding}" ContentTemplate="{StaticResource SplashPageTemplate}" />
             </Grid>
         </Grid>
 
-        <!--  Row 2: Bottom status bar  -->
-        <StatusBar Grid.Row="2" Visibility="{Binding Session.IsWizardPage, Converter={StaticResource BooleanToVisibilityConverter}}">
-            <StatusBarItem Content="{Binding Session.DeploymentStatus}" />
-        </StatusBar>
-
-        <!--  Splash page (startup flow)  -->
         <Grid
-            Grid.RowSpan="3"
-            Panel.ZIndex="1"
-            Visibility="{Binding Session.IsSplashPage, Converter={StaticResource BooleanToVisibilityConverter}}">
-            <Grid Margin="16">
+            x:Name="MainContentHost"
+            Grid.Row="1"
+            Margin="32"
+            Visibility="{Binding Session.IsSplashPage, Converter={StaticResource InverseBooleanConverter}}">
+            <Grid
+                Width="{Binding ElementName=MainContentHost, Path=ActualWidth}"
+                Height="{Binding ElementName=MainContentHost, Path=ActualHeight}"
+                MaxWidth="1440"
+                MaxHeight="900"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
+                <ContentControl Content="{Binding}">
+                    <ContentControl.Style>
+                        <Style TargetType="ContentControl">
+                            <Setter Property="ContentTemplate" Value="{StaticResource WizardPageTemplate}" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Session.CurrentPage}" Value="{x:Static local:DeploymentPage.Wizard}">
+                                    <Setter Property="ContentTemplate" Value="{StaticResource WizardPageTemplate}" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Session.CurrentPage}" Value="{x:Static local:DeploymentPage.Progress}">
+                                    <Setter Property="ContentTemplate" Value="{StaticResource ProgressPageTemplate}" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Session.CurrentPage}" Value="{x:Static local:DeploymentPage.Success}">
+                                    <Setter Property="ContentTemplate" Value="{StaticResource SuccessPageTemplate}" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Session.CurrentPage}" Value="{x:Static local:DeploymentPage.Error}">
+                                    <Setter Property="ContentTemplate" Value="{StaticResource ErrorPageTemplate}" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ContentControl.Style>
+                </ContentControl>
+            </Grid>
+        </Grid>
+
+        <Grid
+            Grid.Row="2"
+            Height="52"
+            Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
+            Visibility="{Binding Session.IsSplashPage, Converter={StaticResource InverseBooleanConverter}}">
+            <Grid Margin="12,8,12,8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
                 <TextBlock
-                    HorizontalAlignment="Center"
+                    Grid.Column="0"
+                    Margin="0,0,8,0"
                     VerticalAlignment="Center"
-                    Style="{StaticResource DisplayTextBlockStyle}"
-                    Text="{Binding Strings[Splash.Welcome]}"
-                    TextAlignment="Center" />
-
-                <StackPanel
-                    Width="360"
-                    Margin="0,160,0,0"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center"
-                    Visibility="{Binding Session.IsStartupInitializing, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <ProgressBar Height="6" IsIndeterminate="True" />
-                    <TextBlock
-                        Margin="0,12,0,0"
-                        HorizontalAlignment="Center"
-                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                        Style="{StaticResource BodyTextBlockStyle}"
-                        Text="{Binding Strings[Splash.InitializingComponents]}"
-                        TextAlignment="Center" />
-                </StackPanel>
-
+                    Text="{Binding Session.DeploymentStatus}"
+                    TextTrimming="CharacterEllipsis" />
                 <Button
-                    Width="160"
-                    Margin="0,0,0,24"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Bottom"
-                    Command="{Binding BeginWizardCommand}"
-                    Content="{Binding Strings[Splash.Start]}"
-                    Style="{DynamicResource AccentButtonStyle}"
-                    Visibility="{Binding Session.IsStartupInitializing, Converter={StaticResource InverseBooleanConverter}}" />
+                    Grid.Column="1"
+                    Width="200"
+                    VerticalAlignment="Center"
+                    Command="{Binding Session.OpenLogFileCommand}"
+                    Content="{Binding Strings[Common.OpenLog]}" />
             </Grid>
         </Grid>
     </Grid>

--- a/src/Foundry.Deploy/MainWindow.xaml
+++ b/src/Foundry.Deploy/MainWindow.xaml
@@ -140,8 +140,18 @@
         <Grid
             Grid.Row="2"
             Height="52"
-            Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
-            Visibility="{Binding Session.IsSplashPage, Converter={StaticResource InverseBooleanConverter}}">
+            Background="{DynamicResource CardBackgroundFillColorDefaultBrush}">
+            <Grid.Style>
+                <Style TargetType="Grid">
+                    <Setter Property="Visibility" Value="Collapsed" />
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding Session.CurrentPage}" Value="{x:Static local:DeploymentPage.Wizard}">
+                            <Setter Property="Visibility" Value="Visible" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Grid.Style>
+
             <Grid Margin="12,8,12,8">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />

--- a/src/Foundry.Deploy/MainWindow.xaml.cs
+++ b/src/Foundry.Deploy/MainWindow.xaml.cs
@@ -1,7 +1,4 @@
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
-using Foundry.Deploy.Validation;
 using Foundry.Deploy.ViewModels;
 
 namespace Foundry.Deploy;
@@ -11,79 +8,12 @@ public partial class MainWindow : Window
     public MainWindow(MainWindowViewModel viewModel)
     {
         InitializeComponent();
-        DataObject.AddPastingHandler(TargetComputerNameTextBox, TargetComputerNameTextBox_OnPaste);
         DataContext = viewModel;
         Loaded += async (_, _) => await viewModel.InitializeAsync();
     }
 
-    private void WizardTabControl_PreviewMouseDown(object sender, MouseButtonEventArgs e)
-    {
-        if (sender is not TabControl tabControl || e.OriginalSource is not DependencyObject source)
-        {
-            return;
-        }
-
-        if (ItemsControl.ContainerFromElement(tabControl, source) is TabItem)
-        {
-            e.Handled = true;
-        }
-    }
-
-    private void TargetComputerNameTextBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
-    {
-        if (sender is TextBox { IsReadOnly: true })
-        {
-            e.Handled = true;
-            return;
-        }
-
-        if (!ComputerNameRules.IsAllowedText(e.Text))
-        {
-            e.Handled = true;
-        }
-    }
-
-    private void TargetComputerNameTextBox_OnPaste(object sender, DataObjectPastingEventArgs e)
-    {
-        if (sender is not TextBox textBox)
-        {
-            e.CancelCommand();
-            return;
-        }
-
-        if (textBox.IsReadOnly)
-        {
-            e.CancelCommand();
-            return;
-        }
-
-        string? pastedText = e.DataObject.GetDataPresent(DataFormats.UnicodeText)
-            ? e.DataObject.GetData(DataFormats.UnicodeText) as string
-            : e.DataObject.GetDataPresent(DataFormats.Text)
-                ? e.DataObject.GetData(DataFormats.Text) as string
-                : null;
-
-        if (pastedText is null || !ComputerNameRules.IsAllowedText(pastedText))
-        {
-            e.CancelCommand();
-            return;
-        }
-
-        string currentText = textBox.Text ?? string.Empty;
-        int selectionStart = Math.Clamp(textBox.SelectionStart, 0, currentText.Length);
-        int selectionLength = Math.Clamp(textBox.SelectionLength, 0, currentText.Length - selectionStart);
-        string nextText = currentText.Remove(selectionStart, selectionLength).Insert(selectionStart, pastedText);
-
-        if (textBox.MaxLength > 0 && nextText.Length > textBox.MaxLength)
-        {
-            e.CancelCommand();
-        }
-    }
-
     protected override void OnClosed(EventArgs e)
     {
-        DataObject.RemovePastingHandler(TargetComputerNameTextBox, TargetComputerNameTextBox_OnPaste);
-
         if (DataContext is MainWindowViewModel viewModel)
         {
             viewModel.Dispose();

--- a/src/Foundry.Deploy/Services/Localization/DeploymentUiTextLocalizer.cs
+++ b/src/Foundry.Deploy/Services/Localization/DeploymentUiTextLocalizer.cs
@@ -56,6 +56,8 @@ public static partial class DeploymentUiTextLocalizer
             "Step skipped." => LocalizationText.GetString("Status.StepSkipped"),
             "In progress..." => LocalizationText.GetString("Status.InProgress"),
             "Loading catalogs..." => LocalizationText.GetString("Catalog.Loading"),
+            "Detecting hardware..." => LocalizationText.GetString("Preparation.DetectingHardware"),
+            "Hardware detection failed." => LocalizationText.GetString("Preparation.HardwareDetectionFailed"),
             "Loading target disks..." => LocalizationText.GetString("Preparation.LoadingTargetDisks"),
             "No disks detected." => LocalizationText.GetString("Preparation.NoDisksDetected"),
             "Select an operating system." => LocalizationText.GetString("Launch.SelectOperatingSystem"),

--- a/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
@@ -21,7 +21,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
     private HardwareProfile? _detectedHardware;
     private DeployMachineNamingSettings _machineNamingConfiguration = new();
     private string _lockedComputerNamePrefix = string.Empty;
-    private string _detectedHardwareSummaryRaw = LocalizationText.GetString("Preparation.DetectingHardware");
+    private string _detectedHardwareSummaryRaw = "Detecting hardware...";
     private bool _isApplyingManagedComputerName;
     private bool _isUpdatingFirmwareOptionSelection;
     private bool _hasUserSelectedFirmwareOption;
@@ -106,7 +106,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         }
 
         IsTargetDiskLoading = true;
-        PublishStatus(GetString("Preparation.LoadingTargetDisks"));
+        PublishStatus("Loading target disks...");
 
         try
         {
@@ -117,7 +117,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         catch (Exception ex)
         {
             _logger.LogError(ex, "Target disk discovery failed.");
-            PublishStatus(Format("Preparation.TargetDiskDiscoveryFailedFormat", ex.Message));
+            PublishStatus($"Target disk discovery failed: {ex.Message}");
         }
         finally
         {
@@ -137,7 +137,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         catch (Exception ex)
         {
             _logger.LogError(ex, "Hardware profile loading failed in preparation view model.");
-            SetHardwareDetectionFailure(Format("Preparation.HardwareDetectionFailedFormat", ex.Message));
+            SetHardwareDetectionFailure($"Hardware detection failed: {ex.Message}");
         }
     }
 
@@ -205,8 +205,8 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
 
         if (profile is null)
         {
-            _detectedHardwareSummaryRaw = GetString("Preparation.HardwareDetectionFailed");
-            DetectedHardwareSummary = _detectedHardwareSummaryRaw;
+            _detectedHardwareSummaryRaw = "Hardware detection failed.";
+            DetectedHardwareSummary = DeploymentUiTextLocalizer.LocalizeMessage(_detectedHardwareSummaryRaw);
             OnPropertyChanged(nameof(IsFirmwareUpdatesOptionEnabled));
             RaiseStateChanged();
             return;
@@ -226,8 +226,8 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
 
     public void SetHardwareDetectionFailure(string message)
     {
-        _detectedHardwareSummaryRaw = DeploymentUiTextLocalizer.LocalizeMessage(message);
-        DetectedHardwareSummary = _detectedHardwareSummaryRaw;
+        _detectedHardwareSummaryRaw = message;
+        DetectedHardwareSummary = DeploymentUiTextLocalizer.LocalizeMessage(message);
         RaiseStateChanged();
     }
 
@@ -262,7 +262,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         {
             SelectedTargetDisk = null;
             RaiseStateChanged();
-            return GetString("Preparation.NoDisksDetected");
+            return "No disks detected.";
         }
 
         TargetDiskInfo? currentSelection = SelectedTargetDisk is null
@@ -275,7 +275,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
             ?? TargetDisks.FirstOrDefault();
 
         RaiseStateChanged();
-        return Format("Preparation.TargetDisksLoadedFormat", TargetDisks.Count);
+        return $"Target disks loaded: {TargetDisks.Count} detected.";
     }
 
     partial void OnTargetComputerNameChanged(string value)
@@ -506,7 +506,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
             }
             else
             {
-                DetectedHardwareSummary = _detectedHardwareSummaryRaw;
+                DetectedHardwareSummary = DeploymentUiTextLocalizer.LocalizeMessage(_detectedHardwareSummaryRaw);
             }
 
             TargetComputerNameValidationMessage = ResolveComputerNameValidationMessage(TargetComputerName);

--- a/src/Foundry.Deploy/ViewModels/DeploymentSessionViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentSessionViewModel.cs
@@ -65,10 +65,7 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsSplashPage))]
-    [NotifyPropertyChangedFor(nameof(IsWizardPage))]
-    [NotifyPropertyChangedFor(nameof(IsProgressPage))]
     [NotifyPropertyChangedFor(nameof(IsSuccessPage))]
-    [NotifyPropertyChangedFor(nameof(IsErrorPage))]
     private DeploymentPage currentPage = DeploymentPage.Splash;
 
     [ObservableProperty]
@@ -132,13 +129,7 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
 
     public bool IsSplashPage => CurrentPage == DeploymentPage.Splash;
 
-    public bool IsWizardPage => CurrentPage == DeploymentPage.Wizard;
-
-    public bool IsProgressPage => CurrentPage == DeploymentPage.Progress;
-
     public bool IsSuccessPage => CurrentPage == DeploymentPage.Success;
-
-    public bool IsErrorPage => CurrentPage == DeploymentPage.Error;
 
     public bool IsStartupReady => !IsStartupInitializing;
 

--- a/src/Foundry.Deploy/Views/DeploymentSessionSummaryView.xaml
+++ b/src/Foundry.Deploy/Views/DeploymentSessionSummaryView.xaml
@@ -1,0 +1,48 @@
+<UserControl
+    x:Class="Foundry.Deploy.Views.DeploymentSessionSummaryView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <StackPanel HorizontalAlignment="Left" VerticalAlignment="Center">
+        <TextBlock
+            Margin="0,0,0,4"
+            Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
+            Style="{StaticResource BodyStrongTextBlockStyle}"
+            Text="{Binding Strings[Progress.Networking]}" />
+        <TextBlock
+            Margin="0,0,0,2"
+            Style="{StaticResource BodyTextBlockStyle}"
+            Text="{Binding IpAddress}" />
+        <TextBlock
+            Margin="0,0,0,2"
+            Style="{StaticResource BodyTextBlockStyle}"
+            Text="{Binding MacAddress}" />
+        <TextBlock
+            Margin="0,0,0,2"
+            Style="{StaticResource BodyTextBlockStyle}"
+            Text="{Binding SubnetMask}" />
+        <TextBlock
+            Margin="0,0,0,20"
+            Style="{StaticResource BodyTextBlockStyle}"
+            Text="{Binding GatewayAddress}" />
+
+        <TextBlock
+            Margin="0,0,0,4"
+            Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
+            Style="{StaticResource BodyStrongTextBlockStyle}"
+            Text="{Binding Strings[Progress.StartTime]}" />
+        <TextBlock
+            Margin="0,0,0,20"
+            Style="{StaticResource BodyTextBlockStyle}"
+            Text="{Binding StartTimeText}" />
+
+        <TextBlock
+            Margin="0,0,0,4"
+            Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
+            Style="{StaticResource BodyStrongTextBlockStyle}"
+            Text="{Binding Strings[Progress.ElapsedTime]}" />
+        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding ElapsedTimeText}" />
+    </StackPanel>
+</UserControl>

--- a/src/Foundry.Deploy/Views/DeploymentSessionSummaryView.xaml.cs
+++ b/src/Foundry.Deploy/Views/DeploymentSessionSummaryView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Foundry.Deploy.Views;
+
+public partial class DeploymentSessionSummaryView : UserControl
+{
+    public DeploymentSessionSummaryView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Foundry.Deploy/Views/ErrorView.xaml
+++ b/src/Foundry.Deploy/Views/ErrorView.xaml
@@ -1,0 +1,63 @@
+<UserControl
+    x:Class="Foundry.Deploy.Views.ErrorView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:views="clr-namespace:Foundry.Deploy.Views"
+    mc:Ignorable="d">
+    <Grid DataContext="{Binding Session}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock
+            Grid.Row="0"
+            Margin="0,0,0,16"
+            HorizontalAlignment="Center"
+            Style="{StaticResource TitleLargeTextBlockStyle}"
+            Text="{Binding ComputerNameText}" />
+
+        <Grid Grid.Row="1">
+            <views:DeploymentSessionSummaryView />
+
+            <StackPanel
+                Width="900"
+                MaxWidth="900"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
+                <TextBlock
+                    HorizontalAlignment="Center"
+                    Style="{StaticResource TitleTextBlockStyle}"
+                    Text="{Binding Strings[Error.Title]}"
+                    TextAlignment="Center" />
+                <TextBlock
+                    Margin="0,16,0,4"
+                    Style="{StaticResource BodyStrongTextBlockStyle}"
+                    Text="{Binding Strings[Error.FailedStep]}" />
+                <TextBlock
+                    Margin="0,0,0,16"
+                    Style="{StaticResource BodyTextBlockStyle}"
+                    Text="{Binding FailedStepName}" />
+                <TextBlock
+                    Margin="0,0,0,4"
+                    Style="{StaticResource BodyStrongTextBlockStyle}"
+                    Text="{Binding Strings[Error.Message]}" />
+                <Border
+                    Height="220"
+                    Padding="10"
+                    BorderBrush="{DynamicResource ControlStrongFillColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="4">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <TextBlock
+                            Style="{StaticResource BodyTextBlockStyle}"
+                            Text="{Binding FailedStepErrorMessage}"
+                            TextWrapping="Wrap" />
+                    </ScrollViewer>
+                </Border>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/Foundry.Deploy/Views/ErrorView.xaml
+++ b/src/Foundry.Deploy/Views/ErrorView.xaml
@@ -51,10 +51,12 @@
                     BorderThickness="1"
                     CornerRadius="4">
                     <ScrollViewer VerticalScrollBarVisibility="Auto">
-                        <TextBlock
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding FailedStepErrorMessage}"
-                            TextWrapping="Wrap" />
+                        <Border Style="{StaticResource ScrollViewerContentGutterBorderStyle}">
+                            <TextBlock
+                                Style="{StaticResource BodyTextBlockStyle}"
+                                Text="{Binding FailedStepErrorMessage}"
+                                TextWrapping="Wrap" />
+                        </Border>
                     </ScrollViewer>
                 </Border>
             </StackPanel>

--- a/src/Foundry.Deploy/Views/ErrorView.xaml.cs
+++ b/src/Foundry.Deploy/Views/ErrorView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Foundry.Deploy.Views;
+
+public partial class ErrorView : UserControl
+{
+    public ErrorView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Foundry.Deploy/Views/ProgressView.xaml
+++ b/src/Foundry.Deploy/Views/ProgressView.xaml
@@ -1,0 +1,77 @@
+<UserControl
+    x:Class="Foundry.Deploy.Views.ProgressView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:Foundry.Deploy.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:views="clr-namespace:Foundry.Deploy.Views"
+    mc:Ignorable="d">
+    <Grid DataContext="{Binding Session}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock
+            Grid.Row="0"
+            Margin="0,0,0,16"
+            HorizontalAlignment="Center"
+            Style="{StaticResource TitleLargeTextBlockStyle}"
+            Text="{Binding ComputerNameText}" />
+
+        <Grid Grid.Row="1">
+            <views:DeploymentSessionSummaryView />
+
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                <Grid
+                    Width="180"
+                    Height="180"
+                    Margin="0,0,0,24"
+                    HorizontalAlignment="Center">
+                    <controls:CustomProgressRing
+                        IsIndeterminate="{Binding IsGlobalProgressIndeterminate}"
+                        ProgressBrush="{DynamicResource AccentFillColorDefaultBrush}"
+                        Thickness="14"
+                        TrackBrush="{DynamicResource ControlStrongFillColorDefaultBrush}"
+                        Value="{Binding DeploymentProgress}" />
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource TitleLargeTextBlockStyle}"
+                        Text="{Binding GlobalProgressPercentText}" />
+                </Grid>
+
+                <TextBlock
+                    Margin="0,0,0,20"
+                    HorizontalAlignment="Center"
+                    Style="{StaticResource SubtitleTextBlockStyle}"
+                    Text="{Binding CurrentStepName}"
+                    TextAlignment="Center" />
+
+                <ProgressBar
+                    Width="320"
+                    Height="4"
+                    Margin="0,0,0,8"
+                    HorizontalAlignment="Center"
+                    IsIndeterminate="{Binding IsCurrentStepProgressIndeterminate}"
+                    Maximum="100"
+                    Value="{Binding CurrentStepProgress}" />
+                <TextBlock
+                    HorizontalAlignment="Center"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{Binding CurrentStepProgressText}" />
+            </StackPanel>
+        </Grid>
+
+        <TextBlock
+            Grid.Row="2"
+            Margin="0,12,0,0"
+            HorizontalAlignment="Center"
+            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+            Style="{StaticResource BodyTextBlockStyle}"
+            Text="{Binding StepCounterText}" />
+    </Grid>
+</UserControl>

--- a/src/Foundry.Deploy/Views/ProgressView.xaml.cs
+++ b/src/Foundry.Deploy/Views/ProgressView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Foundry.Deploy.Views;
+
+public partial class ProgressView : UserControl
+{
+    public ProgressView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Foundry.Deploy/Views/SplashView.xaml
+++ b/src/Foundry.Deploy/Views/SplashView.xaml
@@ -1,0 +1,42 @@
+<UserControl
+    x:Class="Foundry.Deploy.Views.SplashView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <Grid>
+        <TextBlock
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Style="{StaticResource DisplayTextBlockStyle}"
+            Text="{Binding Strings[Splash.Welcome]}"
+            TextAlignment="Center" />
+
+        <StackPanel
+            Width="360"
+            Margin="0,160,0,0"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Visibility="{Binding Session.IsStartupInitializing, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <ProgressBar Height="6" IsIndeterminate="True" />
+            <TextBlock
+                Margin="0,12,0,0"
+                HorizontalAlignment="Center"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Style="{StaticResource BodyTextBlockStyle}"
+                Text="{Binding Strings[Splash.InitializingComponents]}"
+                TextAlignment="Center" />
+        </StackPanel>
+
+        <Button
+            Width="160"
+            Margin="0,0,0,24"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Bottom"
+            Command="{Binding BeginWizardCommand}"
+            Content="{Binding Strings[Splash.Start]}"
+            Style="{DynamicResource AccentButtonStyle}"
+            Visibility="{Binding Session.IsStartupInitializing, Converter={StaticResource InverseBooleanConverter}}" />
+    </Grid>
+</UserControl>

--- a/src/Foundry.Deploy/Views/SplashView.xaml.cs
+++ b/src/Foundry.Deploy/Views/SplashView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Foundry.Deploy.Views;
+
+public partial class SplashView : UserControl
+{
+    public SplashView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Foundry.Deploy/Views/SuccessView.xaml
+++ b/src/Foundry.Deploy/Views/SuccessView.xaml
@@ -1,0 +1,46 @@
+<UserControl
+    x:Class="Foundry.Deploy.Views.SuccessView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:views="clr-namespace:Foundry.Deploy.Views"
+    mc:Ignorable="d">
+    <Grid DataContext="{Binding Session}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock
+            Grid.Row="0"
+            Margin="0,0,0,16"
+            HorizontalAlignment="Center"
+            Style="{StaticResource TitleLargeTextBlockStyle}"
+            Text="{Binding ComputerNameText}" />
+
+        <Grid Grid.Row="1">
+            <views:DeploymentSessionSummaryView />
+
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock
+                    HorizontalAlignment="Center"
+                    Style="{StaticResource TitleTextBlockStyle}"
+                    Text="{Binding Strings[Success.Completed]}"
+                    TextAlignment="Center" />
+                <TextBlock
+                    Margin="0,16,0,24"
+                    HorizontalAlignment="Center"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource BodyTextBlockStyle}"
+                    Text="{Binding RebootCountdownText}"
+                    TextAlignment="Center" />
+                <Button
+                    Width="140"
+                    HorizontalAlignment="Center"
+                    Command="{Binding RebootNowCommand}"
+                    Content="{Binding Strings[Success.RebootNow]}" />
+            </StackPanel>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/Foundry.Deploy/Views/SuccessView.xaml.cs
+++ b/src/Foundry.Deploy/Views/SuccessView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Foundry.Deploy.Views;
+
+public partial class SuccessView : UserControl
+{
+    public SuccessView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Foundry.Deploy/Views/Wizard/DriverPackStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/DriverPackStepView.xaml
@@ -1,0 +1,64 @@
+<UserControl
+    x:Class="Foundry.Deploy.Views.Wizard.DriverPackStepView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    x:Name="ViewRoot"
+    mc:Ignorable="d">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="0,0,0,12">
+            <DockPanel Margin="0,0,0,12">
+                <Button
+                    Width="140"
+                    Command="{Binding RefreshCatalogsCommand}"
+                    Content="{Binding Strings[Common.Refresh]}" />
+                <TextBlock
+                    Margin="12,0,0,0"
+                    VerticalAlignment="Center"
+                    Style="{StaticResource BodyStrongTextBlockStyle}"
+                    Text="{Binding DriverPackArchitectureDisplay}" />
+            </DockPanel>
+
+            <StackPanel DataContext="{Binding DriverPackSelection}">
+                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[DriverPack.Source]}" />
+                <ComboBox
+                    Margin="0,8,0,0"
+                    DisplayMemberPath="DisplayName"
+                    ItemsSource="{Binding DriverPackOptions}"
+                    SelectedItem="{Binding SelectedDriverPackOption}" />
+
+                <Grid Margin="0,8,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="12" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0">
+                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[DriverPack.Model], ElementName=ViewRoot}" />
+                        <ComboBox
+                            Margin="0,8,0,0"
+                            IsEnabled="{Binding IsDriverPackModelSelectionEnabled}"
+                            ItemsSource="{Binding DriverPackModelOptions}"
+                            SelectedItem="{Binding SelectedDriverPackModel}" />
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="2">
+                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[DriverPack.Version], ElementName=ViewRoot}" />
+                        <ComboBox
+                            Margin="0,8,0,0"
+                            IsEnabled="{Binding IsDriverPackVersionSelectionEnabled}"
+                            ItemsSource="{Binding DriverPackVersionOptions}"
+                            SelectedItem="{Binding SelectedDriverPackVersion}" />
+                    </StackPanel>
+                </Grid>
+                <TextBlock
+                    Margin="0,8,0,0"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{Binding DataContext.DriverPackModeDisplayText, ElementName=ViewRoot}" />
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/Foundry.Deploy/Views/Wizard/DriverPackStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/DriverPackStepView.xaml
@@ -7,58 +7,60 @@
     x:Name="ViewRoot"
     mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="0,0,0,12">
-            <DockPanel Margin="0,0,0,12">
-                <Button
-                    Width="140"
-                    Command="{Binding RefreshCatalogsCommand}"
-                    Content="{Binding Strings[Common.Refresh]}" />
-                <TextBlock
-                    Margin="12,0,0,0"
-                    VerticalAlignment="Center"
-                    Style="{StaticResource BodyStrongTextBlockStyle}"
-                    Text="{Binding DriverPackArchitectureDisplay}" />
-            </DockPanel>
+        <Border Style="{StaticResource ScrollViewerContentGutterBorderStyle}">
+            <StackPanel Margin="0,0,0,12">
+                <DockPanel Margin="0,0,0,12">
+                    <Button
+                        Width="140"
+                        Command="{Binding RefreshCatalogsCommand}"
+                        Content="{Binding Strings[Common.Refresh]}" />
+                    <TextBlock
+                        Margin="12,0,0,0"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{Binding DriverPackArchitectureDisplay}" />
+                </DockPanel>
 
-            <StackPanel DataContext="{Binding DriverPackSelection}">
-                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[DriverPack.Source]}" />
-                <ComboBox
-                    Margin="0,8,0,0"
-                    DisplayMemberPath="DisplayName"
-                    ItemsSource="{Binding DriverPackOptions}"
-                    SelectedItem="{Binding SelectedDriverPackOption}" />
+                <StackPanel DataContext="{Binding DriverPackSelection}">
+                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[DriverPack.Source]}" />
+                    <ComboBox
+                        Margin="0,8,0,0"
+                        DisplayMemberPath="DisplayName"
+                        ItemsSource="{Binding DriverPackOptions}"
+                        SelectedItem="{Binding SelectedDriverPackOption}" />
 
-                <Grid Margin="0,8,0,0">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="12" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
+                    <Grid Margin="0,8,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="12" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
 
-                    <StackPanel Grid.Column="0">
-                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[DriverPack.Model], ElementName=ViewRoot}" />
-                        <ComboBox
-                            Margin="0,8,0,0"
-                            IsEnabled="{Binding IsDriverPackModelSelectionEnabled}"
-                            ItemsSource="{Binding DriverPackModelOptions}"
-                            SelectedItem="{Binding SelectedDriverPackModel}" />
-                    </StackPanel>
+                        <StackPanel Grid.Column="0">
+                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[DriverPack.Model], ElementName=ViewRoot}" />
+                            <ComboBox
+                                Margin="0,8,0,0"
+                                IsEnabled="{Binding IsDriverPackModelSelectionEnabled}"
+                                ItemsSource="{Binding DriverPackModelOptions}"
+                                SelectedItem="{Binding SelectedDriverPackModel}" />
+                        </StackPanel>
 
-                    <StackPanel Grid.Column="2">
-                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[DriverPack.Version], ElementName=ViewRoot}" />
-                        <ComboBox
-                            Margin="0,8,0,0"
-                            IsEnabled="{Binding IsDriverPackVersionSelectionEnabled}"
-                            ItemsSource="{Binding DriverPackVersionOptions}"
-                            SelectedItem="{Binding SelectedDriverPackVersion}" />
-                    </StackPanel>
-                </Grid>
-                <TextBlock
-                    Margin="0,8,0,0"
-                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                    Style="{StaticResource CaptionTextBlockStyle}"
-                    Text="{Binding DataContext.DriverPackModeDisplayText, ElementName=ViewRoot}" />
+                        <StackPanel Grid.Column="2">
+                            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[DriverPack.Version], ElementName=ViewRoot}" />
+                            <ComboBox
+                                Margin="0,8,0,0"
+                                IsEnabled="{Binding IsDriverPackVersionSelectionEnabled}"
+                                ItemsSource="{Binding DriverPackVersionOptions}"
+                                SelectedItem="{Binding SelectedDriverPackVersion}" />
+                        </StackPanel>
+                    </Grid>
+                    <TextBlock
+                        Margin="0,8,0,0"
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{Binding DataContext.DriverPackModeDisplayText, ElementName=ViewRoot}" />
+                </StackPanel>
             </StackPanel>
-        </StackPanel>
+        </Border>
     </ScrollViewer>
 </UserControl>

--- a/src/Foundry.Deploy/Views/Wizard/DriverPackStepView.xaml.cs
+++ b/src/Foundry.Deploy/Views/Wizard/DriverPackStepView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Foundry.Deploy.Views.Wizard;
+
+public partial class DriverPackStepView : UserControl
+{
+    public DriverPackStepView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Foundry.Deploy/Views/Wizard/OperatingSystemCatalogStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/OperatingSystemCatalogStepView.xaml
@@ -1,0 +1,94 @@
+<UserControl
+    x:Class="Foundry.Deploy.Views.Wizard.OperatingSystemCatalogStepView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="0,0,0,12">
+            <DockPanel Margin="0,0,0,12">
+                <Button
+                    Width="140"
+                    Command="{Binding RefreshCatalogsCommand}"
+                    Content="{Binding Strings[Common.Refresh]}" />
+                <TextBlock
+                    Margin="12,0,0,0"
+                    VerticalAlignment="Center"
+                    Style="{StaticResource BodyStrongTextBlockStyle}"
+                    Text="{Binding OperatingSystemArchitectureDisplay}" />
+            </DockPanel>
+
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Margin="0,0,8,8">
+                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.OperatingSystem]}" />
+                    <TextBox
+                        Margin="0,8,0,0"
+                        IsReadOnly="True"
+                        Text="{Binding Strings[OperatingSystem.Windows11]}" />
+                </StackPanel>
+
+                <StackPanel Grid.Column="1" Margin="8,0,0,8">
+                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.Version]}" />
+                    <ComboBox
+                        Margin="0,8,0,0"
+                        ItemsSource="{Binding OperatingSystemCatalog.ReleaseIdFilters}"
+                        SelectedItem="{Binding OperatingSystemCatalog.SelectedReleaseId}" />
+                </StackPanel>
+
+                <StackPanel Grid.Row="1" Margin="0,0,8,0">
+                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.Language]}" />
+                    <ComboBox
+                        Margin="0,8,0,0"
+                        IsEnabled="{Binding OperatingSystemCatalog.IsLanguageSelectionEnabled}"
+                        ItemsSource="{Binding OperatingSystemCatalog.LanguageFilters}"
+                        SelectedItem="{Binding OperatingSystemCatalog.SelectedLanguageCode}" />
+                </StackPanel>
+
+                <StackPanel
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    Margin="8,0,0,0">
+                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.LicenseChannel]}" />
+                    <ComboBox
+                        Margin="0,8,0,0"
+                        ItemsSource="{Binding OperatingSystemCatalog.LicenseChannelFilters}"
+                        SelectedItem="{Binding OperatingSystemCatalog.SelectedLicenseChannel}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding ., Converter={StaticResource OsCatalogFilterDisplayConverter}, ConverterParameter=LicenseChannel}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </StackPanel>
+
+                <StackPanel
+                    Grid.Row="2"
+                    Grid.ColumnSpan="2"
+                    Margin="0,8,0,0">
+                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.EditionTarget]}" />
+                    <ComboBox
+                        Margin="0,8,0,0"
+                        ItemsSource="{Binding OperatingSystemCatalog.EditionFilters}"
+                        SelectedItem="{Binding OperatingSystemCatalog.SelectedEdition}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding ., Converter={StaticResource OsCatalogFilterDisplayConverter}, ConverterParameter=Edition}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </StackPanel>
+            </Grid>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/Foundry.Deploy/Views/Wizard/OperatingSystemCatalogStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/OperatingSystemCatalogStepView.xaml
@@ -6,89 +6,91 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="0,0,0,12">
-            <DockPanel Margin="0,0,0,12">
-                <Button
-                    Width="140"
-                    Command="{Binding RefreshCatalogsCommand}"
-                    Content="{Binding Strings[Common.Refresh]}" />
-                <TextBlock
-                    Margin="12,0,0,0"
-                    VerticalAlignment="Center"
-                    Style="{StaticResource BodyStrongTextBlockStyle}"
-                    Text="{Binding OperatingSystemArchitectureDisplay}" />
-            </DockPanel>
+        <Border Style="{StaticResource ScrollViewerContentGutterBorderStyle}">
+            <StackPanel Margin="0,0,0,12">
+                <DockPanel Margin="0,0,0,12">
+                    <Button
+                        Width="140"
+                        Command="{Binding RefreshCatalogsCommand}"
+                        Content="{Binding Strings[Common.Refresh]}" />
+                    <TextBlock
+                        Margin="12,0,0,0"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{Binding OperatingSystemArchitectureDisplay}" />
+                </DockPanel>
 
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
 
-                <StackPanel Margin="0,0,8,8">
-                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.OperatingSystem]}" />
-                    <TextBox
-                        Margin="0,8,0,0"
-                        IsReadOnly="True"
-                        Text="{Binding Strings[OperatingSystem.Windows11]}" />
-                </StackPanel>
+                    <StackPanel Margin="0,0,8,8">
+                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.OperatingSystem]}" />
+                        <TextBox
+                            Margin="0,8,0,0"
+                            IsReadOnly="True"
+                            Text="{Binding Strings[OperatingSystem.Windows11]}" />
+                    </StackPanel>
 
-                <StackPanel Grid.Column="1" Margin="8,0,0,8">
-                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.Version]}" />
-                    <ComboBox
-                        Margin="0,8,0,0"
-                        ItemsSource="{Binding OperatingSystemCatalog.ReleaseIdFilters}"
-                        SelectedItem="{Binding OperatingSystemCatalog.SelectedReleaseId}" />
-                </StackPanel>
+                    <StackPanel Grid.Column="1" Margin="8,0,0,8">
+                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.Version]}" />
+                        <ComboBox
+                            Margin="0,8,0,0"
+                            ItemsSource="{Binding OperatingSystemCatalog.ReleaseIdFilters}"
+                            SelectedItem="{Binding OperatingSystemCatalog.SelectedReleaseId}" />
+                    </StackPanel>
 
-                <StackPanel Grid.Row="1" Margin="0,0,8,0">
-                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.Language]}" />
-                    <ComboBox
-                        Margin="0,8,0,0"
-                        IsEnabled="{Binding OperatingSystemCatalog.IsLanguageSelectionEnabled}"
-                        ItemsSource="{Binding OperatingSystemCatalog.LanguageFilters}"
-                        SelectedItem="{Binding OperatingSystemCatalog.SelectedLanguageCode}" />
-                </StackPanel>
+                    <StackPanel Grid.Row="1" Margin="0,0,8,0">
+                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.Language]}" />
+                        <ComboBox
+                            Margin="0,8,0,0"
+                            IsEnabled="{Binding OperatingSystemCatalog.IsLanguageSelectionEnabled}"
+                            ItemsSource="{Binding OperatingSystemCatalog.LanguageFilters}"
+                            SelectedItem="{Binding OperatingSystemCatalog.SelectedLanguageCode}" />
+                    </StackPanel>
 
-                <StackPanel
-                    Grid.Row="1"
-                    Grid.Column="1"
-                    Margin="8,0,0,0">
-                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.LicenseChannel]}" />
-                    <ComboBox
-                        Margin="0,8,0,0"
-                        ItemsSource="{Binding OperatingSystemCatalog.LicenseChannelFilters}"
-                        SelectedItem="{Binding OperatingSystemCatalog.SelectedLicenseChannel}">
-                        <ComboBox.ItemTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding ., Converter={StaticResource OsCatalogFilterDisplayConverter}, ConverterParameter=LicenseChannel}" />
-                            </DataTemplate>
-                        </ComboBox.ItemTemplate>
-                    </ComboBox>
-                </StackPanel>
+                    <StackPanel
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        Margin="8,0,0,0">
+                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.LicenseChannel]}" />
+                        <ComboBox
+                            Margin="0,8,0,0"
+                            ItemsSource="{Binding OperatingSystemCatalog.LicenseChannelFilters}"
+                            SelectedItem="{Binding OperatingSystemCatalog.SelectedLicenseChannel}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding ., Converter={StaticResource OsCatalogFilterDisplayConverter}, ConverterParameter=LicenseChannel}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                    </StackPanel>
 
-                <StackPanel
-                    Grid.Row="2"
-                    Grid.ColumnSpan="2"
-                    Margin="0,8,0,0">
-                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.EditionTarget]}" />
-                    <ComboBox
-                        Margin="0,8,0,0"
-                        ItemsSource="{Binding OperatingSystemCatalog.EditionFilters}"
-                        SelectedItem="{Binding OperatingSystemCatalog.SelectedEdition}">
-                        <ComboBox.ItemTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding ., Converter={StaticResource OsCatalogFilterDisplayConverter}, ConverterParameter=Edition}" />
-                            </DataTemplate>
-                        </ComboBox.ItemTemplate>
-                    </ComboBox>
-                </StackPanel>
-            </Grid>
-        </StackPanel>
+                    <StackPanel
+                        Grid.Row="2"
+                        Grid.ColumnSpan="2"
+                        Margin="0,8,0,0">
+                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.EditionTarget]}" />
+                        <ComboBox
+                            Margin="0,8,0,0"
+                            ItemsSource="{Binding OperatingSystemCatalog.EditionFilters}"
+                            SelectedItem="{Binding OperatingSystemCatalog.SelectedEdition}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding ., Converter={StaticResource OsCatalogFilterDisplayConverter}, ConverterParameter=Edition}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                    </StackPanel>
+                </Grid>
+            </StackPanel>
+        </Border>
     </ScrollViewer>
 </UserControl>

--- a/src/Foundry.Deploy/Views/Wizard/OperatingSystemCatalogStepView.xaml.cs
+++ b/src/Foundry.Deploy/Views/Wizard/OperatingSystemCatalogStepView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Foundry.Deploy.Views.Wizard;
+
+public partial class OperatingSystemCatalogStepView : UserControl
+{
+    public OperatingSystemCatalogStepView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
@@ -1,0 +1,47 @@
+<UserControl
+    x:Class="Foundry.Deploy.Views.Wizard.SummaryStepView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel>
+            <TextBlock
+                Margin="0,0,0,12"
+                Style="{StaticResource TitleTextBlockStyle}"
+                Text="{Binding Strings[Summary.Title]}" />
+
+            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.TargetDisk]}" />
+            <TextBlock Margin="0,0,0,8" Text="{Binding SummaryTargetDiskText}" />
+
+            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.SelectedOperatingSystem]}" />
+            <TextBlock Margin="0,0,0,8" Text="{Binding SummaryOperatingSystemText}" />
+
+            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.SelectedDriverPack]}" />
+            <TextBlock Margin="0,0,0,8" Text="{Binding DriverPackSelection.SelectedDriverPackSelectionDisplay}" />
+
+            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.DriverPackMode]}" />
+            <TextBlock Margin="0,0,0,8" Text="{Binding DriverPackSelection.DriverPackModeDisplay}" />
+
+            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.Firmware]}" />
+            <TextBlock Margin="0,0,0,8" Text="{Binding SummaryFirmwareText}" />
+
+            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.Autopilot]}" />
+            <TextBlock Margin="0,0,0,4" Text="{Binding SummaryAutopilotEnabledText}" />
+            <TextBlock Margin="0,0,0,8" Text="{Binding SummaryAutopilotProfileText}" />
+
+            <TextBlock
+                Margin="0,8,0,0"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Style="{StaticResource CaptionTextBlockStyle}"
+                Text="{Binding Strings[Summary.DeployExplanation]}" />
+            <TextBlock
+                Margin="0,4,0,0"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Style="{StaticResource CaptionTextBlockStyle}"
+                Text="{Binding Strings[Summary.DebugSafeModeExplanation]}"
+                Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
@@ -6,42 +6,44 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel>
-            <TextBlock
-                Margin="0,0,0,12"
-                Style="{StaticResource TitleTextBlockStyle}"
-                Text="{Binding Strings[Summary.Title]}" />
+        <Border Style="{StaticResource ScrollViewerContentGutterBorderStyle}">
+            <StackPanel>
+                <TextBlock
+                    Margin="0,0,0,12"
+                    Style="{StaticResource TitleTextBlockStyle}"
+                    Text="{Binding Strings[Summary.Title]}" />
 
-            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.TargetDisk]}" />
-            <TextBlock Margin="0,0,0,8" Text="{Binding SummaryTargetDiskText}" />
+                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.TargetDisk]}" />
+                <TextBlock Margin="0,0,0,8" Text="{Binding SummaryTargetDiskText}" />
 
-            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.SelectedOperatingSystem]}" />
-            <TextBlock Margin="0,0,0,8" Text="{Binding SummaryOperatingSystemText}" />
+                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.SelectedOperatingSystem]}" />
+                <TextBlock Margin="0,0,0,8" Text="{Binding SummaryOperatingSystemText}" />
 
-            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.SelectedDriverPack]}" />
-            <TextBlock Margin="0,0,0,8" Text="{Binding DriverPackSelection.SelectedDriverPackSelectionDisplay}" />
+                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.SelectedDriverPack]}" />
+                <TextBlock Margin="0,0,0,8" Text="{Binding DriverPackSelection.SelectedDriverPackSelectionDisplay}" />
 
-            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.DriverPackMode]}" />
-            <TextBlock Margin="0,0,0,8" Text="{Binding DriverPackSelection.DriverPackModeDisplay}" />
+                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.DriverPackMode]}" />
+                <TextBlock Margin="0,0,0,8" Text="{Binding DriverPackSelection.DriverPackModeDisplay}" />
 
-            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.Firmware]}" />
-            <TextBlock Margin="0,0,0,8" Text="{Binding SummaryFirmwareText}" />
+                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.Firmware]}" />
+                <TextBlock Margin="0,0,0,8" Text="{Binding SummaryFirmwareText}" />
 
-            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.Autopilot]}" />
-            <TextBlock Margin="0,0,0,4" Text="{Binding SummaryAutopilotEnabledText}" />
-            <TextBlock Margin="0,0,0,8" Text="{Binding SummaryAutopilotProfileText}" />
+                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.Autopilot]}" />
+                <TextBlock Margin="0,0,0,4" Text="{Binding SummaryAutopilotEnabledText}" />
+                <TextBlock Margin="0,0,0,8" Text="{Binding SummaryAutopilotProfileText}" />
 
-            <TextBlock
-                Margin="0,8,0,0"
-                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{Binding Strings[Summary.DeployExplanation]}" />
-            <TextBlock
-                Margin="0,4,0,0"
-                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{Binding Strings[Summary.DebugSafeModeExplanation]}"
-                Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
-        </StackPanel>
+                <TextBlock
+                    Margin="0,8,0,0"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{Binding Strings[Summary.DeployExplanation]}" />
+                <TextBlock
+                    Margin="0,4,0,0"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{Binding Strings[Summary.DebugSafeModeExplanation]}"
+                    Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
+            </StackPanel>
+        </Border>
     </ScrollViewer>
 </UserControl>

--- a/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml.cs
+++ b/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Foundry.Deploy.Views.Wizard;
+
+public partial class SummaryStepView : UserControl
+{
+    public SummaryStepView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
@@ -1,0 +1,81 @@
+<UserControl
+    x:Class="Foundry.Deploy.Views.Wizard.TargetStepView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:rules="clr-namespace:Foundry.Deploy.Validation"
+    x:Name="ViewRoot"
+    mc:Ignorable="d">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel DataContext="{Binding Preparation}">
+            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.ComputerName], ElementName=ViewRoot}" />
+            <TextBox
+                x:Name="TargetComputerNameTextBox"
+                Margin="0,8,0,0"
+                IsReadOnly="{Binding IsTargetComputerNameReadOnly}"
+                MaxLength="{x:Static rules:ComputerNameRules.MaxLength}"
+                PreviewTextInput="TargetComputerNameTextBox_PreviewTextInput"
+                Text="{Binding TargetComputerName, UpdateSourceTrigger=PropertyChanged}" />
+            <TextBlock
+                Margin="0,8,0,0"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Style="{StaticResource CaptionTextBlockStyle}"
+                Text="{Binding DataContext.Strings[Preparation.ComputerNameHint], ElementName=ViewRoot}" />
+            <TextBlock
+                Margin="0,4,0,0"
+                Foreground="#FFC42B1C"
+                Style="{StaticResource CaptionTextBlockStyle}"
+                Text="{Binding TargetComputerNameValidationMessage}"
+                Visibility="{Binding HasTargetComputerNameValidationError, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+            <TextBlock
+                Margin="0,12,0,0"
+                Style="{StaticResource BodyStrongTextBlockStyle}"
+                Text="{Binding DataContext.Strings[Preparation.TargetDisk], ElementName=ViewRoot}" />
+            <DockPanel Margin="0,8,0,0">
+                <ComboBox
+                    Width="640"
+                    DisplayMemberPath="DisplayLabel"
+                    ItemsSource="{Binding TargetDisks}"
+                    SelectedItem="{Binding SelectedTargetDisk}" />
+                <Button
+                    Width="140"
+                    Margin="8,0,0,0"
+                    Command="{Binding RefreshTargetDisksCommand}"
+                    Content="{Binding DataContext.Strings[Common.Refresh], ElementName=ViewRoot}" />
+            </DockPanel>
+            <TextBlock
+                Margin="0,8,0,0"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Style="{StaticResource CaptionTextBlockStyle}"
+                Text="{Binding TargetDiskSelectionHint}" />
+
+            <CheckBox
+                Margin="0,8,0,0"
+                IsChecked="{Binding ApplyFirmwareUpdates}"
+                IsEnabled="{Binding IsFirmwareUpdatesOptionEnabled}">
+                <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.FirmwareUpdates], ElementName=ViewRoot}" />
+            </CheckBox>
+            <CheckBox Margin="0,8,0,0" IsChecked="{Binding IsAutopilotEnabled}">
+                <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.AutopilotEnable], ElementName=ViewRoot}" />
+            </CheckBox>
+
+            <TextBlock
+                Margin="0,12,0,0"
+                Style="{StaticResource BodyStrongTextBlockStyle}"
+                Text="{Binding DataContext.Strings[Preparation.AutopilotProfile], ElementName=ViewRoot}" />
+            <ComboBox
+                Margin="0,8,0,0"
+                DisplayMemberPath="DisplayName"
+                IsEnabled="{Binding IsAutopilotProfileSelectionEnabled}"
+                ItemsSource="{Binding AutopilotProfiles}"
+                SelectedItem="{Binding SelectedAutopilotProfile}" />
+            <TextBlock
+                Margin="0,8,0,0"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Style="{StaticResource CaptionTextBlockStyle}"
+                Text="{Binding AutopilotProfileHint}" />
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
@@ -8,74 +8,76 @@
     x:Name="ViewRoot"
     mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel DataContext="{Binding Preparation}">
-            <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.ComputerName], ElementName=ViewRoot}" />
-            <TextBox
-                x:Name="TargetComputerNameTextBox"
-                Margin="0,8,0,0"
-                IsReadOnly="{Binding IsTargetComputerNameReadOnly}"
-                MaxLength="{x:Static rules:ComputerNameRules.MaxLength}"
-                PreviewTextInput="TargetComputerNameTextBox_PreviewTextInput"
-                Text="{Binding TargetComputerName, UpdateSourceTrigger=PropertyChanged}" />
-            <TextBlock
-                Margin="0,8,0,0"
-                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{Binding DataContext.Strings[Preparation.ComputerNameHint], ElementName=ViewRoot}" />
-            <TextBlock
-                Margin="0,4,0,0"
-                Foreground="#FFC42B1C"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{Binding TargetComputerNameValidationMessage}"
-                Visibility="{Binding HasTargetComputerNameValidationError, Converter={StaticResource BooleanToVisibilityConverter}}" />
+        <Border Style="{StaticResource ScrollViewerContentGutterBorderStyle}">
+            <StackPanel DataContext="{Binding Preparation}">
+                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.ComputerName], ElementName=ViewRoot}" />
+                <TextBox
+                    x:Name="TargetComputerNameTextBox"
+                    Margin="0,8,0,0"
+                    IsReadOnly="{Binding IsTargetComputerNameReadOnly}"
+                    MaxLength="{x:Static rules:ComputerNameRules.MaxLength}"
+                    PreviewTextInput="TargetComputerNameTextBox_PreviewTextInput"
+                    Text="{Binding TargetComputerName, UpdateSourceTrigger=PropertyChanged}" />
+                <TextBlock
+                    Margin="0,8,0,0"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{Binding DataContext.Strings[Preparation.ComputerNameHint], ElementName=ViewRoot}" />
+                <TextBlock
+                    Margin="0,4,0,0"
+                    Foreground="#FFC42B1C"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{Binding TargetComputerNameValidationMessage}"
+                    Visibility="{Binding HasTargetComputerNameValidationError, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-            <TextBlock
-                Margin="0,12,0,0"
-                Style="{StaticResource BodyStrongTextBlockStyle}"
-                Text="{Binding DataContext.Strings[Preparation.TargetDisk], ElementName=ViewRoot}" />
-            <DockPanel Margin="0,8,0,0">
+                <TextBlock
+                    Margin="0,12,0,0"
+                    Style="{StaticResource BodyStrongTextBlockStyle}"
+                    Text="{Binding DataContext.Strings[Preparation.TargetDisk], ElementName=ViewRoot}" />
+                <DockPanel Margin="0,8,0,0">
+                    <ComboBox
+                        Width="640"
+                        DisplayMemberPath="DisplayLabel"
+                        ItemsSource="{Binding TargetDisks}"
+                        SelectedItem="{Binding SelectedTargetDisk}" />
+                    <Button
+                        Width="140"
+                        Margin="8,0,0,0"
+                        Command="{Binding RefreshTargetDisksCommand}"
+                        Content="{Binding DataContext.Strings[Common.Refresh], ElementName=ViewRoot}" />
+                </DockPanel>
+                <TextBlock
+                    Margin="0,8,0,0"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{Binding TargetDiskSelectionHint}" />
+
+                <CheckBox
+                    Margin="0,8,0,0"
+                    IsChecked="{Binding ApplyFirmwareUpdates}"
+                    IsEnabled="{Binding IsFirmwareUpdatesOptionEnabled}">
+                    <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.FirmwareUpdates], ElementName=ViewRoot}" />
+                </CheckBox>
+                <CheckBox Margin="0,8,0,0" IsChecked="{Binding IsAutopilotEnabled}">
+                    <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.AutopilotEnable], ElementName=ViewRoot}" />
+                </CheckBox>
+
+                <TextBlock
+                    Margin="0,12,0,0"
+                    Style="{StaticResource BodyStrongTextBlockStyle}"
+                    Text="{Binding DataContext.Strings[Preparation.AutopilotProfile], ElementName=ViewRoot}" />
                 <ComboBox
-                    Width="640"
-                    DisplayMemberPath="DisplayLabel"
-                    ItemsSource="{Binding TargetDisks}"
-                    SelectedItem="{Binding SelectedTargetDisk}" />
-                <Button
-                    Width="140"
-                    Margin="8,0,0,0"
-                    Command="{Binding RefreshTargetDisksCommand}"
-                    Content="{Binding DataContext.Strings[Common.Refresh], ElementName=ViewRoot}" />
-            </DockPanel>
-            <TextBlock
-                Margin="0,8,0,0"
-                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{Binding TargetDiskSelectionHint}" />
-
-            <CheckBox
-                Margin="0,8,0,0"
-                IsChecked="{Binding ApplyFirmwareUpdates}"
-                IsEnabled="{Binding IsFirmwareUpdatesOptionEnabled}">
-                <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.FirmwareUpdates], ElementName=ViewRoot}" />
-            </CheckBox>
-            <CheckBox Margin="0,8,0,0" IsChecked="{Binding IsAutopilotEnabled}">
-                <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.AutopilotEnable], ElementName=ViewRoot}" />
-            </CheckBox>
-
-            <TextBlock
-                Margin="0,12,0,0"
-                Style="{StaticResource BodyStrongTextBlockStyle}"
-                Text="{Binding DataContext.Strings[Preparation.AutopilotProfile], ElementName=ViewRoot}" />
-            <ComboBox
-                Margin="0,8,0,0"
-                DisplayMemberPath="DisplayName"
-                IsEnabled="{Binding IsAutopilotProfileSelectionEnabled}"
-                ItemsSource="{Binding AutopilotProfiles}"
-                SelectedItem="{Binding SelectedAutopilotProfile}" />
-            <TextBlock
-                Margin="0,8,0,0"
-                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{Binding AutopilotProfileHint}" />
-        </StackPanel>
+                    Margin="0,8,0,0"
+                    DisplayMemberPath="DisplayName"
+                    IsEnabled="{Binding IsAutopilotProfileSelectionEnabled}"
+                    ItemsSource="{Binding AutopilotProfiles}"
+                    SelectedItem="{Binding SelectedAutopilotProfile}" />
+                <TextBlock
+                    Margin="0,8,0,0"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{Binding AutopilotProfileHint}" />
+            </StackPanel>
+        </Border>
     </ScrollViewer>
 </UserControl>

--- a/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml.cs
+++ b/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml.cs
@@ -1,0 +1,91 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Foundry.Deploy.Validation;
+
+namespace Foundry.Deploy.Views.Wizard;
+
+public partial class TargetStepView : UserControl
+{
+    private bool _isPasteHandlerAttached;
+
+    public TargetStepView()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        if (_isPasteHandlerAttached)
+        {
+            return;
+        }
+
+        DataObject.AddPastingHandler(TargetComputerNameTextBox, TargetComputerNameTextBox_OnPaste);
+        _isPasteHandlerAttached = true;
+    }
+
+    private void TargetComputerNameTextBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
+    {
+        if (sender is TextBox { IsReadOnly: true })
+        {
+            e.Handled = true;
+            return;
+        }
+
+        if (!ComputerNameRules.IsAllowedText(e.Text))
+        {
+            e.Handled = true;
+        }
+    }
+
+    private void TargetComputerNameTextBox_OnPaste(object sender, DataObjectPastingEventArgs e)
+    {
+        if (sender is not TextBox textBox)
+        {
+            e.CancelCommand();
+            return;
+        }
+
+        if (textBox.IsReadOnly)
+        {
+            e.CancelCommand();
+            return;
+        }
+
+        string? pastedText = e.DataObject.GetDataPresent(DataFormats.UnicodeText)
+            ? e.DataObject.GetData(DataFormats.UnicodeText) as string
+            : e.DataObject.GetDataPresent(DataFormats.Text)
+                ? e.DataObject.GetData(DataFormats.Text) as string
+                : null;
+
+        if (pastedText is null || !ComputerNameRules.IsAllowedText(pastedText))
+        {
+            e.CancelCommand();
+            return;
+        }
+
+        string currentText = textBox.Text ?? string.Empty;
+        int selectionStart = Math.Clamp(textBox.SelectionStart, 0, currentText.Length);
+        int selectionLength = Math.Clamp(textBox.SelectionLength, 0, currentText.Length - selectionStart);
+        string nextText = currentText.Remove(selectionStart, selectionLength).Insert(selectionStart, pastedText);
+
+        if (textBox.MaxLength > 0 && nextText.Length > textBox.MaxLength)
+        {
+            e.CancelCommand();
+        }
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (!_isPasteHandlerAttached)
+        {
+            return;
+        }
+
+        DataObject.RemovePastingHandler(TargetComputerNameTextBox, TargetComputerNameTextBox_OnPaste);
+        _isPasteHandlerAttached = false;
+    }
+}

--- a/src/Foundry.Deploy/Views/WizardView.xaml
+++ b/src/Foundry.Deploy/Views/WizardView.xaml
@@ -1,0 +1,235 @@
+<UserControl
+    x:Class="Foundry.Deploy.Views.WizardView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:sys="clr-namespace:System;assembly=mscorlib"
+    xmlns:wizardViews="clr-namespace:Foundry.Deploy.Views.Wizard"
+    mc:Ignorable="d">
+    <UserControl.Resources>
+        <DataTemplate x:Key="TargetStepTemplate">
+            <wizardViews:TargetStepView />
+        </DataTemplate>
+
+        <DataTemplate x:Key="OperatingSystemCatalogStepTemplate">
+            <wizardViews:OperatingSystemCatalogStepView />
+        </DataTemplate>
+
+        <DataTemplate x:Key="DriverPackStepTemplate">
+            <wizardViews:DriverPackStepView />
+        </DataTemplate>
+
+        <DataTemplate x:Key="SummaryStepTemplate">
+            <wizardViews:SummaryStepView />
+        </DataTemplate>
+
+        <Style x:Key="WizardStepBorderBaseStyle" TargetType="Border">
+            <Setter Property="Padding" Value="12" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="6" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CardStrokeColorDefaultBrush}" />
+            <Setter Property="Background" Value="{DynamicResource CardBackgroundFillColorDefaultBrush}" />
+        </Style>
+
+        <Style
+            x:Key="WizardStepTextStyle"
+            BasedOn="{StaticResource BodyStrongTextBlockStyle}"
+            TargetType="TextBlock">
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+        </Style>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Style="{StaticResource TitleLargeTextBlockStyle}" Text="{Binding Strings[Wizard.Title]}" />
+            <Border
+                Margin="0,8,0,0"
+                Padding="8"
+                Background="#33FFAA00"
+                BorderBrush="#FFFFAA00"
+                BorderThickness="1"
+                CornerRadius="4"
+                Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Wizard.DebugSafeModeBanner]}" />
+            </Border>
+            <TextBlock
+                Margin="0,8,0,0"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Style="{StaticResource CaptionTextBlockStyle}"
+                Text="{Binding Strings[Wizard.Description]}" />
+            <TextBlock
+                Margin="0,8,0,0"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Style="{StaticResource CaptionTextBlockStyle}"
+                Text="{Binding Preparation.DetectedHardwareSummary}" />
+        </StackPanel>
+
+        <Grid Grid.Row="1" Margin="0,0,0,16">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="8" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="8" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="8" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0">
+                <Border.Style>
+                    <Style BasedOn="{StaticResource WizardStepBorderBaseStyle}" TargetType="Border">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding WizardStepIndex}">
+                                <DataTrigger.Value>
+                                    <sys:Int32>0</sys:Int32>
+                                </DataTrigger.Value>
+                                <Setter Property="BorderBrush" Value="{DynamicResource AccentFillColorDefaultBrush}" />
+                                <Setter Property="BorderThickness" Value="2" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+                <TextBlock Style="{StaticResource WizardStepTextStyle}" Text="{Binding Strings[Wizard.StepTarget]}" />
+            </Border>
+
+            <Border Grid.Column="2">
+                <Border.Style>
+                    <Style BasedOn="{StaticResource WizardStepBorderBaseStyle}" TargetType="Border">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding WizardStepIndex}">
+                                <DataTrigger.Value>
+                                    <sys:Int32>1</sys:Int32>
+                                </DataTrigger.Value>
+                                <Setter Property="BorderBrush" Value="{DynamicResource AccentFillColorDefaultBrush}" />
+                                <Setter Property="BorderThickness" Value="2" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+                <TextBlock Style="{StaticResource WizardStepTextStyle}" Text="{Binding Strings[Wizard.StepOperatingSystemCatalog]}" />
+            </Border>
+
+            <Border Grid.Column="4">
+                <Border.Style>
+                    <Style BasedOn="{StaticResource WizardStepBorderBaseStyle}" TargetType="Border">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding WizardStepIndex}">
+                                <DataTrigger.Value>
+                                    <sys:Int32>2</sys:Int32>
+                                </DataTrigger.Value>
+                                <Setter Property="BorderBrush" Value="{DynamicResource AccentFillColorDefaultBrush}" />
+                                <Setter Property="BorderThickness" Value="2" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+                <TextBlock Style="{StaticResource WizardStepTextStyle}" Text="{Binding Strings[Wizard.StepDriverPack]}" />
+            </Border>
+
+            <Border Grid.Column="6">
+                <Border.Style>
+                    <Style BasedOn="{StaticResource WizardStepBorderBaseStyle}" TargetType="Border">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding WizardStepIndex}">
+                                <DataTrigger.Value>
+                                    <sys:Int32>3</sys:Int32>
+                                </DataTrigger.Value>
+                                <Setter Property="BorderBrush" Value="{DynamicResource AccentFillColorDefaultBrush}" />
+                                <Setter Property="BorderThickness" Value="2" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+                <TextBlock Style="{StaticResource WizardStepTextStyle}" Text="{Binding Strings[Wizard.StepSummary]}" />
+            </Border>
+        </Grid>
+
+        <Border Grid.Row="2" Style="{StaticResource SectionCardBorderStyle}">
+            <ContentControl Content="{Binding}">
+                <ContentControl.Style>
+                    <Style TargetType="ContentControl">
+                        <Setter Property="ContentTemplate" Value="{StaticResource TargetStepTemplate}" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding WizardStepIndex}">
+                                <DataTrigger.Value>
+                                    <sys:Int32>1</sys:Int32>
+                                </DataTrigger.Value>
+                                <Setter Property="ContentTemplate" Value="{StaticResource OperatingSystemCatalogStepTemplate}" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding WizardStepIndex}">
+                                <DataTrigger.Value>
+                                    <sys:Int32>2</sys:Int32>
+                                </DataTrigger.Value>
+                                <Setter Property="ContentTemplate" Value="{StaticResource DriverPackStepTemplate}" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding WizardStepIndex}">
+                                <DataTrigger.Value>
+                                    <sys:Int32>3</sys:Int32>
+                                </DataTrigger.Value>
+                                <Setter Property="ContentTemplate" Value="{StaticResource SummaryStepTemplate}" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </ContentControl.Style>
+            </ContentControl>
+        </Border>
+
+        <Grid Grid.Row="3" Margin="0,12,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <StackPanel
+                Grid.Column="0"
+                HorizontalAlignment="Left"
+                Orientation="Horizontal"
+                Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Button
+                    Width="140"
+                    Margin="0,0,8,0"
+                    Command="{Binding ShowDebugProgressPageCommand}"
+                    Content="{Binding Strings[Debug.ProgressButton]}" />
+                <Button
+                    Width="140"
+                    Margin="0,0,8,0"
+                    Command="{Binding ShowDebugSuccessPageCommand}"
+                    Content="{Binding Strings[Debug.SuccessButton]}" />
+                <Button
+                    Width="140"
+                    Command="{Binding ShowDebugErrorPageCommand}"
+                    Content="{Binding Strings[Debug.ErrorButton]}" />
+            </StackPanel>
+
+            <StackPanel
+                Grid.Column="1"
+                HorizontalAlignment="Right"
+                Orientation="Horizontal">
+                <Button
+                    Width="120"
+                    Margin="0,0,8,0"
+                    Command="{Binding PreviousWizardStepCommand}"
+                    Content="{Binding Strings[Common.Previous]}" />
+                <Button
+                    Width="120"
+                    Margin="0,0,8,0"
+                    Command="{Binding NextWizardStepCommand}"
+                    Content="{Binding Strings[Common.Next]}" />
+                <Button
+                    Width="160"
+                    Command="{Binding StartDeploymentCommand}"
+                    Content="{Binding Strings[Common.Deploy]}"
+                    Style="{DynamicResource AccentButtonStyle}" />
+            </StackPanel>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/Foundry.Deploy/Views/WizardView.xaml.cs
+++ b/src/Foundry.Deploy/Views/WizardView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Foundry.Deploy.Views;
+
+public partial class WizardView : UserControl
+{
+    public WizardView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
Refactor Foundry.Deploy MainWindow into a shell layout with extracted page and wizard views.

## Why
The previous MainWindow XAML owned every deployment page and wizard step in one file, making the UI difficult to maintain and diverging from the Foundry.Connect shell pattern.

## Changes
- Add a shell-style MainWindow with top menu, centered content host, and bottom status area.
- Extract Splash, Wizard, Progress, Success, and Error pages into dedicated views.
- Replace the wizard TabControl with a display-only stepper and extracted step views.
- Extract the repeated deployment session summary used by runtime result pages.
- Move target computer name input validation out of MainWindow code-behind.
- Align the log action on the right side of the bottom status area and improve spacing.
- Preserve invariant status messages so deployment status can re-localize after language changes.
- Remove obsolete MainWindow XAML and code-behind handlers.

## Testing
- `dotnet build src\Foundry.Deploy\Foundry.Deploy.csproj`
- `dotnet test src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj`
- `git diff --check`

## Notes
- Created as a draft PR for visual review of the WPF screens.
- Planning scratch files from the local planning workflow were not included in this PR.