### PR TITLE
fix(runtime): block non-WinPE startup

### DIFF
--- a/src/Foundry.Connect.Tests/RuntimeStartupGuardTests.cs
+++ b/src/Foundry.Connect.Tests/RuntimeStartupGuardTests.cs
@@ -1,0 +1,17 @@
+using Foundry.Connect.Services.Runtime;
+
+namespace Foundry.Connect.Tests;
+
+public sealed class RuntimeStartupGuardTests
+{
+    [Theory]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(false, false, false)]
+    public void CanRun_ReturnsExpectedPolicy(bool isWinPeRuntime, bool isDebuggerBypassEnabled, bool expected)
+    {
+        bool canRun = RuntimeStartupGuard.CanRun(isWinPeRuntime, isDebuggerBypassEnabled);
+
+        Assert.Equal(expected, canRun);
+    }
+}

--- a/src/Foundry.Connect.Tests/WinPeRuntimeDetectorTests.cs
+++ b/src/Foundry.Connect.Tests/WinPeRuntimeDetectorTests.cs
@@ -1,0 +1,55 @@
+using Foundry.Connect.Services.Runtime;
+
+namespace Foundry.Connect.Tests;
+
+public sealed class WinPeRuntimeDetectorTests
+{
+    private const string WinPeVersionRegistryKey = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\WinPE";
+    private const string MiniNtRegistryKey = @"SYSTEM\CurrentControlSet\Control\MiniNT";
+
+    [Theory]
+    [InlineData(WinPeVersionRegistryKey)]
+    [InlineData(MiniNtRegistryKey)]
+    public void IsWinPeRuntime_WhenRegistryMarkerExists_ReturnsTrue(string registryMarker)
+    {
+        bool isWinPe = WinPeRuntimeDetector.IsWinPeRuntime(
+            systemDrive: "C:",
+            windowsDirectory: @"C:\Windows",
+            registryKeyExists: key => string.Equals(key, registryMarker, StringComparison.OrdinalIgnoreCase));
+
+        Assert.True(isWinPe);
+    }
+
+    [Fact]
+    public void IsWinPeRuntime_WhenSystemDriveIsX_ReturnsTrue()
+    {
+        bool isWinPe = WinPeRuntimeDetector.IsWinPeRuntime(
+            systemDrive: "X:",
+            windowsDirectory: @"C:\Windows",
+            registryKeyExists: _ => false);
+
+        Assert.True(isWinPe);
+    }
+
+    [Fact]
+    public void IsWinPeRuntime_WhenWindowsDirectoryIsOnXDrive_ReturnsTrue()
+    {
+        bool isWinPe = WinPeRuntimeDetector.IsWinPeRuntime(
+            systemDrive: "C:",
+            windowsDirectory: @"X:\Windows",
+            registryKeyExists: _ => false);
+
+        Assert.True(isWinPe);
+    }
+
+    [Fact]
+    public void IsWinPeRuntime_WhenNoMarkerExists_ReturnsFalse()
+    {
+        bool isWinPe = WinPeRuntimeDetector.IsWinPeRuntime(
+            systemDrive: "C:",
+            windowsDirectory: @"C:\Windows",
+            registryKeyExists: _ => false);
+
+        Assert.False(isWinPe);
+    }
+}

--- a/src/Foundry.Connect/Program.cs
+++ b/src/Foundry.Connect/Program.cs
@@ -26,6 +26,12 @@ public static class Program
         try
         {
             Log.Information("Starting Foundry.Connect bootstrap.");
+            if (!RuntimeStartupGuard.CanRun())
+            {
+                Log.Error("Foundry.Connect can only run in WinPE outside a DEBUG debugger session.");
+                return (int)FoundryConnectExitCode.StartupFailure;
+            }
+
             ConfigureRuntimeCompatibility();
             Log.Information("Runtime compatibility configuration completed.");
 

--- a/src/Foundry.Connect/Services/Runtime/ConnectWorkspacePaths.cs
+++ b/src/Foundry.Connect/Services/Runtime/ConnectWorkspacePaths.cs
@@ -8,16 +8,7 @@ internal static class ConnectWorkspacePaths
 
     public static bool IsWinPeRuntime()
     {
-        string? systemDrive = Environment.GetEnvironmentVariable("SystemDrive");
-        if (!string.IsNullOrWhiteSpace(systemDrive) &&
-            systemDrive.Equals("X:", StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        string windowsDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
-        return !string.IsNullOrWhiteSpace(windowsDirectory) &&
-               windowsDirectory.StartsWith(@"X:\", StringComparison.OrdinalIgnoreCase);
+        return WinPeRuntimeDetector.IsWinPeRuntime();
     }
 
     public static string GetConfigFilePath(string fileName)

--- a/src/Foundry.Connect/Services/Runtime/RuntimeStartupGuard.cs
+++ b/src/Foundry.Connect/Services/Runtime/RuntimeStartupGuard.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics;
+
+namespace Foundry.Connect.Services.Runtime;
+
+internal static class RuntimeStartupGuard
+{
+    public static bool CanRun()
+    {
+        return CanRun(WinPeRuntimeDetector.IsWinPeRuntime(), IsDebuggerBypassEnabled());
+    }
+
+    internal static bool CanRun(bool isWinPeRuntime, bool isDebuggerBypassEnabled)
+    {
+        return isWinPeRuntime || isDebuggerBypassEnabled;
+    }
+
+    private static bool IsDebuggerBypassEnabled()
+    {
+#if DEBUG
+        return Debugger.IsAttached;
+#else
+        return false;
+#endif
+    }
+}

--- a/src/Foundry.Connect/Services/Runtime/WinPeRuntimeDetector.cs
+++ b/src/Foundry.Connect/Services/Runtime/WinPeRuntimeDetector.cs
@@ -1,0 +1,52 @@
+using Microsoft.Win32;
+
+namespace Foundry.Connect.Services.Runtime;
+
+internal static class WinPeRuntimeDetector
+{
+    private const string WinPeVersionRegistryKey = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\WinPE";
+    private const string MiniNtRegistryKey = @"SYSTEM\CurrentControlSet\Control\MiniNT";
+
+    public static bool IsWinPeRuntime()
+    {
+        return IsWinPeRuntime(
+            Environment.GetEnvironmentVariable("SystemDrive"),
+            Environment.GetFolderPath(Environment.SpecialFolder.Windows),
+            RegistryKeyExists);
+    }
+
+    internal static bool IsWinPeRuntime(
+        string? systemDrive,
+        string? windowsDirectory,
+        Func<string, bool> registryKeyExists)
+    {
+        ArgumentNullException.ThrowIfNull(registryKeyExists);
+
+        if (registryKeyExists(WinPeVersionRegistryKey) || registryKeyExists(MiniNtRegistryKey))
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(systemDrive) &&
+            systemDrive.Equals("X:", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return !string.IsNullOrWhiteSpace(windowsDirectory) &&
+               windowsDirectory.StartsWith(@"X:\", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool RegistryKeyExists(string subKeyPath)
+    {
+        try
+        {
+            using RegistryKey? key = Registry.LocalMachine.OpenSubKey(subKeyPath);
+            return key is not null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/Foundry.Deploy.Tests/RuntimeStartupGuardTests.cs
+++ b/src/Foundry.Deploy.Tests/RuntimeStartupGuardTests.cs
@@ -1,0 +1,17 @@
+using Foundry.Deploy.Services.Runtime;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class RuntimeStartupGuardTests
+{
+    [Theory]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(false, false, false)]
+    public void CanRun_ReturnsExpectedPolicy(bool isWinPeRuntime, bool isDebuggerBypassEnabled, bool expected)
+    {
+        bool canRun = RuntimeStartupGuard.CanRun(isWinPeRuntime, isDebuggerBypassEnabled);
+
+        Assert.Equal(expected, canRun);
+    }
+}

--- a/src/Foundry.Deploy.Tests/WinPeRuntimeDetectorTests.cs
+++ b/src/Foundry.Deploy.Tests/WinPeRuntimeDetectorTests.cs
@@ -1,0 +1,55 @@
+using Foundry.Deploy.Services.Runtime;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class WinPeRuntimeDetectorTests
+{
+    private const string WinPeVersionRegistryKey = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\WinPE";
+    private const string MiniNtRegistryKey = @"SYSTEM\CurrentControlSet\Control\MiniNT";
+
+    [Theory]
+    [InlineData(WinPeVersionRegistryKey)]
+    [InlineData(MiniNtRegistryKey)]
+    public void IsWinPeRuntime_WhenRegistryMarkerExists_ReturnsTrue(string registryMarker)
+    {
+        bool isWinPe = WinPeRuntimeDetector.IsWinPeRuntime(
+            systemDrive: "C:",
+            windowsDirectory: @"C:\Windows",
+            registryKeyExists: key => string.Equals(key, registryMarker, StringComparison.OrdinalIgnoreCase));
+
+        Assert.True(isWinPe);
+    }
+
+    [Fact]
+    public void IsWinPeRuntime_WhenSystemDriveIsX_ReturnsTrue()
+    {
+        bool isWinPe = WinPeRuntimeDetector.IsWinPeRuntime(
+            systemDrive: "X:",
+            windowsDirectory: @"C:\Windows",
+            registryKeyExists: _ => false);
+
+        Assert.True(isWinPe);
+    }
+
+    [Fact]
+    public void IsWinPeRuntime_WhenWindowsDirectoryIsOnXDrive_ReturnsTrue()
+    {
+        bool isWinPe = WinPeRuntimeDetector.IsWinPeRuntime(
+            systemDrive: "C:",
+            windowsDirectory: @"X:\Windows",
+            registryKeyExists: _ => false);
+
+        Assert.True(isWinPe);
+    }
+
+    [Fact]
+    public void IsWinPeRuntime_WhenNoMarkerExists_ReturnsFalse()
+    {
+        bool isWinPe = WinPeRuntimeDetector.IsWinPeRuntime(
+            systemDrive: "C:",
+            windowsDirectory: @"C:\Windows",
+            registryKeyExists: _ => false);
+
+        Assert.False(isWinPe);
+    }
+}

--- a/src/Foundry.Deploy/Program.cs
+++ b/src/Foundry.Deploy/Program.cs
@@ -11,13 +11,13 @@ using Foundry.Deploy.Services.DriverPacks;
 using Foundry.Deploy.Services.Hardware;
 using Foundry.Deploy.Services.Logging;
 using Foundry.Deploy.Services.Operations;
+using Foundry.Deploy.Services.Runtime;
 using Foundry.Deploy.Services.System;
 using Foundry.Deploy.Services.Theme;
 using Foundry.Deploy.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Win32;
 using Serilog;
 
 namespace Foundry.Deploy;
@@ -36,6 +36,12 @@ public static class Program
         try
         {
             Log.Information("Starting Foundry.Deploy bootstrap.");
+            if (!RuntimeStartupGuard.CanRun())
+            {
+                Log.Error("Foundry.Deploy can only run in WinPE outside a DEBUG debugger session.");
+                return 1;
+            }
+
             ConfigureRuntimeCompatibility();
 
             using IHost host = BuildHost(args);
@@ -80,38 +86,7 @@ public static class Program
             return IsTruthy(overrideValue);
         }
 
-        return IsRunningInWinPe();
-    }
-
-    private static bool IsRunningInWinPe()
-    {
-        string? systemDrive = Environment.GetEnvironmentVariable("SystemDrive");
-        if (systemDrive is not null && systemDrive.Equals("X:", StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        string windowsDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
-        if (!string.IsNullOrWhiteSpace(windowsDirectory) &&
-            windowsDirectory.StartsWith(@"X:\", StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        try
-        {
-            using RegistryKey? miniNt = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Control\MiniNT");
-            if (miniNt is not null)
-            {
-                return true;
-            }
-        }
-        catch
-        {
-            // Ignore registry access errors and continue with fallback checks.
-        }
-
-        return false;
+        return WinPeRuntimeDetector.IsWinPeRuntime();
     }
 
     private static bool IsTruthy(string value)

--- a/src/Foundry.Deploy/Services/Runtime/RuntimeStartupGuard.cs
+++ b/src/Foundry.Deploy/Services/Runtime/RuntimeStartupGuard.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics;
+
+namespace Foundry.Deploy.Services.Runtime;
+
+internal static class RuntimeStartupGuard
+{
+    public static bool CanRun()
+    {
+        return CanRun(WinPeRuntimeDetector.IsWinPeRuntime(), IsDebuggerBypassEnabled());
+    }
+
+    internal static bool CanRun(bool isWinPeRuntime, bool isDebuggerBypassEnabled)
+    {
+        return isWinPeRuntime || isDebuggerBypassEnabled;
+    }
+
+    private static bool IsDebuggerBypassEnabled()
+    {
+#if DEBUG
+        return Debugger.IsAttached;
+#else
+        return false;
+#endif
+    }
+}

--- a/src/Foundry.Deploy/Services/Runtime/WinPeRuntimeDetector.cs
+++ b/src/Foundry.Deploy/Services/Runtime/WinPeRuntimeDetector.cs
@@ -1,0 +1,52 @@
+using Microsoft.Win32;
+
+namespace Foundry.Deploy.Services.Runtime;
+
+internal static class WinPeRuntimeDetector
+{
+    private const string WinPeVersionRegistryKey = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\WinPE";
+    private const string MiniNtRegistryKey = @"SYSTEM\CurrentControlSet\Control\MiniNT";
+
+    public static bool IsWinPeRuntime()
+    {
+        return IsWinPeRuntime(
+            Environment.GetEnvironmentVariable("SystemDrive"),
+            Environment.GetFolderPath(Environment.SpecialFolder.Windows),
+            RegistryKeyExists);
+    }
+
+    internal static bool IsWinPeRuntime(
+        string? systemDrive,
+        string? windowsDirectory,
+        Func<string, bool> registryKeyExists)
+    {
+        ArgumentNullException.ThrowIfNull(registryKeyExists);
+
+        if (registryKeyExists(WinPeVersionRegistryKey) || registryKeyExists(MiniNtRegistryKey))
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(systemDrive) &&
+            systemDrive.Equals("X:", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return !string.IsNullOrWhiteSpace(windowsDirectory) &&
+               windowsDirectory.StartsWith(@"X:\", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool RegistryKeyExists(string subKeyPath)
+    {
+        try
+        {
+            using RegistryKey? key = Registry.LocalMachine.OpenSubKey(subKeyPath);
+            return key is not null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Block Foundry.Deploy and Foundry.Connect from starting outside WinPE unless they are running as DEBUG builds with an attached debugger.

## Why
The deployment payloads are intended to run from the WinPE bootstrap. Before this change, both WPF executables could start on a normal Windows host, which made real deployment actions possible outside the intended runtime.

## Changes
- Add startup guards to Foundry.Deploy and Foundry.Connect before WPF host creation.
- Add WinPE detection based on registry markers, with `X:` drive checks retained as fallback.
- Reuse the stronger detector for Foundry.Connect runtime path decisions.
- Add focused unit tests for guard policy and WinPE detection markers/fallbacks.

## Testing
- `dotnet test src\Foundry.slnx --nologo`
- `dotnet test src\Foundry.slnx -c Release --nologo`

## Notes
The runtime guard implementation is intentionally duplicated per executable to keep Foundry.Deploy and Foundry.Connect independent.
