### PR TITLE
fix(deploy): remove wizard header title

### DIFF
--- a/src/Foundry.Deploy/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry.Deploy/Resources/AppStrings.fr-FR.resx
@@ -30,9 +30,7 @@
   <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Actualiser les catalogues</value></data>
   <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Actualiser les disques cibles</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Ouvrir le fichier journal</value></data>
-  <data name="Wizard.Title" xml:space="preserve"><value>Assistant Foundry.Deploy</value></data>
   <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>MODE DEBUG SÉCURISÉ ACTIF : toutes les actions de déploiement sont simulées, aucune écriture disque/image n’est effectuée.</value></data>
-  <data name="Wizard.Description" xml:space="preserve"><value>Orchestrateur de séquence de tâches pour le déploiement d’OS dans WinPE.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Cible</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Catalogue système</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Pack de pilotes</value></data>

--- a/src/Foundry.Deploy/Resources/AppStrings.resx
+++ b/src/Foundry.Deploy/Resources/AppStrings.resx
@@ -30,9 +30,7 @@
   <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Refresh Catalogs</value></data>
   <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Refresh Target Disks</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Open Log File</value></data>
-  <data name="Wizard.Title" xml:space="preserve"><value>Foundry.Deploy Wizard</value></data>
   <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>DEBUG SAFE MODE ACTIVE: all deployment actions are simulated; no disk/image write is performed.</value></data>
-  <data name="Wizard.Description" xml:space="preserve"><value>Task-sequence orchestrator for OS deployment in WinPE.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Target</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operating System Catalog</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Driver Pack</value></data>

--- a/src/Foundry.Deploy/Views/WizardView.xaml
+++ b/src/Foundry.Deploy/Views/WizardView.xaml
@@ -49,10 +49,9 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <StackPanel Grid.Row="0" Margin="0,0,0,16">
-            <TextBlock Style="{StaticResource TitleLargeTextBlockStyle}" Text="{Binding Strings[Wizard.Title]}" />
+        <StackPanel Grid.Row="0" Margin="0,0,0,12">
             <Border
-                Margin="0,8,0,0"
+                Margin="0,0,0,8"
                 Padding="8"
                 Background="#33FFAA00"
                 BorderBrush="#FFFFAA00"
@@ -62,12 +61,6 @@
                 <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Wizard.DebugSafeModeBanner]}" />
             </Border>
             <TextBlock
-                Margin="0,8,0,0"
-                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{Binding Strings[Wizard.Description]}" />
-            <TextBlock
-                Margin="0,8,0,0"
                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                 Style="{StaticResource CaptionTextBlockStyle}"
                 Text="{Binding Preparation.DetectedHardwareSummary}" />


### PR DESCRIPTION
## Summary
Remove the redundant Foundry.Deploy wizard title and description from the wizard shell.

## Why
The header consumed vertical space without adding useful context to each wizard step.

## Changes
- Removed the wizard title and description TextBlocks from `WizardView.xaml`.
- Tightened the remaining header spacing.
- Removed obsolete English and French localization keys.

## Testing
- Ran `dotnet build src/Foundry.Deploy/Foundry.Deploy.csproj` successfully.

## Notes
- The debug safe mode banner and detected hardware summary remain available in this branch.