### PR TITLE
refactor(deploy): improve target wizard layout

### DIFF
--- a/src/Foundry.Deploy.Tests/DeploymentPreparationViewModelTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentPreparationViewModelTests.cs
@@ -1,0 +1,122 @@
+using Foundry.Deploy.Models;
+using Foundry.Deploy.Models.Configuration;
+using Foundry.Deploy.Services.Hardware;
+using Foundry.Deploy.Services.Localization;
+using Foundry.Deploy.Services.System;
+using Foundry.Deploy.ViewModels;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class DeploymentPreparationViewModelTests
+{
+    [Fact]
+    public void ApplyAutopilotConfiguration_WhenProfilesExist_EnablesAutopilotByDefault()
+    {
+        using DeploymentPreparationViewModel viewModel = CreateViewModel();
+        AutopilotProfileCatalogItem profile = CreateProfile("default", "Default Profile");
+
+        viewModel.ApplyAutopilotConfiguration(new DeployAutopilotSettings(), [profile]);
+
+        Assert.True(viewModel.HasAutopilotProfiles);
+        Assert.True(viewModel.IsAutopilotEnabled);
+        Assert.True(viewModel.IsAutopilotProfileSelectionEnabled);
+        Assert.Same(profile, viewModel.SelectedAutopilotProfile);
+    }
+
+    [Fact]
+    public void ApplyAutopilotConfiguration_WhenDefaultProfileExists_SelectsDefaultProfile()
+    {
+        using DeploymentPreparationViewModel viewModel = CreateViewModel();
+        AutopilotProfileCatalogItem firstProfile = CreateProfile("first", "First Profile");
+        AutopilotProfileCatalogItem defaultProfile = CreateProfile("default", "Default Profile");
+
+        viewModel.ApplyAutopilotConfiguration(
+            new DeployAutopilotSettings { DefaultProfileFolderName = "default" },
+            [firstProfile, defaultProfile]);
+
+        Assert.True(viewModel.IsAutopilotEnabled);
+        Assert.Same(defaultProfile, viewModel.SelectedAutopilotProfile);
+    }
+
+    [Fact]
+    public void ApplyAutopilotConfiguration_WhenProfilesAreMissing_DisablesAutopilot()
+    {
+        using DeploymentPreparationViewModel viewModel = CreateViewModel();
+
+        viewModel.ApplyAutopilotConfiguration(new DeployAutopilotSettings { IsEnabled = true }, []);
+
+        Assert.False(viewModel.HasAutopilotProfiles);
+        Assert.False(viewModel.IsAutopilotEnabled);
+        Assert.False(viewModel.IsAutopilotProfileSelectionEnabled);
+        Assert.Null(viewModel.SelectedAutopilotProfile);
+        Assert.Equal(string.Empty, viewModel.AutopilotProfileHint);
+    }
+
+    [Fact]
+    public void IsAutopilotProfileSelectionEnabled_FollowsAutopilotToggle()
+    {
+        using DeploymentPreparationViewModel viewModel = CreateViewModel();
+        AutopilotProfileCatalogItem profile = CreateProfile("default", "Default Profile");
+
+        viewModel.ApplyAutopilotConfiguration(new DeployAutopilotSettings(), [profile]);
+        viewModel.IsAutopilotEnabled = false;
+
+        Assert.False(viewModel.IsAutopilotProfileSelectionEnabled);
+
+        viewModel.IsAutopilotEnabled = true;
+
+        Assert.True(viewModel.IsAutopilotProfileSelectionEnabled);
+        Assert.Same(profile, viewModel.SelectedAutopilotProfile);
+    }
+
+    private static DeploymentPreparationViewModel CreateViewModel()
+    {
+        return new DeploymentPreparationViewModel(
+            new FakeTargetDiskService(),
+            new FakeHardwareProfileService(),
+            new FakeOfflineWindowsComputerNameService(),
+            new LocalizationService(),
+            NullLogger.Instance,
+            isDebugSafeMode: false);
+    }
+
+    private static AutopilotProfileCatalogItem CreateProfile(string folderName, string displayName)
+    {
+        return new AutopilotProfileCatalogItem
+        {
+            FolderName = folderName,
+            DisplayName = displayName,
+            ConfigurationFilePath = $@"X:\Foundry\Config\Autopilot\{folderName}\AutopilotConfigurationFile.json"
+        };
+    }
+
+    private sealed class FakeTargetDiskService : ITargetDiskService
+    {
+        public Task<IReadOnlyList<TargetDiskInfo>> GetDisksAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<TargetDiskInfo>>([]);
+        }
+
+        public Task<int?> GetDiskNumberForPathAsync(string path, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<int?>(null);
+        }
+    }
+
+    private sealed class FakeHardwareProfileService : IHardwareProfileService
+    {
+        public Task<HardwareProfile> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new HardwareProfile());
+        }
+    }
+
+    private sealed class FakeOfflineWindowsComputerNameService : IOfflineWindowsComputerNameService
+    {
+        public Task<string?> TryGetOfflineComputerNameAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<string?>(null);
+        }
+    }
+}

--- a/src/Foundry.Deploy/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry.Deploy/Resources/AppStrings.fr-FR.resx
@@ -38,13 +38,16 @@
   <data name="Preparation.ComputerName" xml:space="preserve"><value>Nom de l’ordinateur</value></data>
   <data name="Preparation.ComputerNameHint" xml:space="preserve"><value>1 à 15 caractères. A-Z, a-z, 0-9 et tiret uniquement.</value></data>
   <data name="Preparation.ComputerNameValidationMessage" xml:space="preserve"><value>Le nom de l’ordinateur doit contenir 1 à 15 caractères valides (lettres, chiffres ou tiret).</value></data>
+  <data name="Preparation.SectionTargetMachine" xml:space="preserve"><value>Machine cible</value></data>
+  <data name="Preparation.SectionDestinationDisk" xml:space="preserve"><value>Disque de destination</value></data>
+  <data name="Preparation.SectionDeploymentOptions" xml:space="preserve"><value>Options de déploiement</value></data>
+  <data name="Preparation.SectionAutopilot" xml:space="preserve"><value>Autopilot</value></data>
   <data name="Preparation.TargetDisk" xml:space="preserve"><value>Disque cible</value></data>
   <data name="Preparation.TargetDiskHint" xml:space="preserve"><value>Sélectionnez un disque cible. Les disques non éligibles sont bloqués.</value></data>
   <data name="Preparation.FirmwareUpdates" xml:space="preserve"><value>Firmware : activer les mises à jour via Microsoft Update Catalog.</value></data>
   <data name="Preparation.AutopilotEnable" xml:space="preserve"><value>Autopilot : activer la préparation hors ligne du profil.</value></data>
   <data name="Preparation.AutopilotProfile" xml:space="preserve"><value>Profil Autopilot</value></data>
   <data name="Preparation.AutopilotProfilesAvailableFormat" xml:space="preserve"><value>Profils disponibles : {0}</value></data>
-  <data name="Preparation.AutopilotProfilesMissing" xml:space="preserve"><value>Aucun profil Autopilot importé n’a été trouvé dans X:\Foundry\Config\Autopilot.</value></data>
   <data name="Preparation.DetectingHardware" xml:space="preserve"><value>Détection du matériel...</value></data>
   <data name="Preparation.HardwareDetectionFailed" xml:space="preserve"><value>Échec de la détection matérielle.</value></data>
   <data name="Preparation.HardwareDetectionFailedFormat" xml:space="preserve"><value>Échec de la détection matérielle : {0}</value></data>

--- a/src/Foundry.Deploy/Resources/AppStrings.resx
+++ b/src/Foundry.Deploy/Resources/AppStrings.resx
@@ -38,13 +38,16 @@
   <data name="Preparation.ComputerName" xml:space="preserve"><value>Computer Name</value></data>
   <data name="Preparation.ComputerNameHint" xml:space="preserve"><value>1-15 characters. A-Z, a-z, 0-9, and hyphen only.</value></data>
   <data name="Preparation.ComputerNameValidationMessage" xml:space="preserve"><value>Computer name must contain 1 to 15 valid characters (letters, numbers, or hyphen).</value></data>
+  <data name="Preparation.SectionTargetMachine" xml:space="preserve"><value>Target Machine</value></data>
+  <data name="Preparation.SectionDestinationDisk" xml:space="preserve"><value>Destination Disk</value></data>
+  <data name="Preparation.SectionDeploymentOptions" xml:space="preserve"><value>Deployment Options</value></data>
+  <data name="Preparation.SectionAutopilot" xml:space="preserve"><value>Autopilot</value></data>
   <data name="Preparation.TargetDisk" xml:space="preserve"><value>Target Disk</value></data>
   <data name="Preparation.TargetDiskHint" xml:space="preserve"><value>Select a target disk. Non-eligible disks are blocked.</value></data>
   <data name="Preparation.FirmwareUpdates" xml:space="preserve"><value>Firmware: Microsoft Update Catalog update enabled.</value></data>
   <data name="Preparation.AutopilotEnable" xml:space="preserve"><value>Autopilot: Enable offline profile staging.</value></data>
   <data name="Preparation.AutopilotProfile" xml:space="preserve"><value>Autopilot Profile</value></data>
   <data name="Preparation.AutopilotProfilesAvailableFormat" xml:space="preserve"><value>Profiles available: {0}</value></data>
-  <data name="Preparation.AutopilotProfilesMissing" xml:space="preserve"><value>No imported Autopilot profiles were found in X:\Foundry\Config\Autopilot.</value></data>
   <data name="Preparation.DetectingHardware" xml:space="preserve"><value>Detecting hardware...</value></data>
   <data name="Preparation.HardwareDetectionFailed" xml:space="preserve"><value>Hardware detection failed.</value></data>
   <data name="Preparation.HardwareDetectionFailedFormat" xml:space="preserve"><value>Hardware detection failed: {0}</value></data>

--- a/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
@@ -90,7 +90,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
     public string AutopilotProfileHint =>
         HasAutopilotProfiles
             ? Format("Preparation.AutopilotProfilesAvailableFormat", AutopilotProfiles.Count)
-            : GetString("Preparation.AutopilotProfilesMissing");
+            : string.Empty;
 
     public bool HasTargetComputerNameValidationError => !string.IsNullOrWhiteSpace(TargetComputerNameValidationMessage);
 
@@ -194,7 +194,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         OnPropertyChanged(nameof(AutopilotProfileHint));
 
         SelectedAutopilotProfile = ResolveDefaultAutopilotProfile(settings.DefaultProfileFolderName);
-        IsAutopilotEnabled = settings.IsEnabled && SelectedAutopilotProfile is not null;
+        IsAutopilotEnabled = SelectedAutopilotProfile is not null;
 
         RaiseStateChanged();
     }

--- a/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
@@ -7,109 +7,156 @@
     xmlns:rules="clr-namespace:Foundry.Deploy.Validation"
     x:Name="ViewRoot"
     mc:Ignorable="d">
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <Border Style="{StaticResource ScrollViewerContentGutterBorderStyle}">
-            <StackPanel DataContext="{Binding Preparation}">
+    <ScrollViewer x:Name="TargetStepScrollViewer" VerticalScrollBarVisibility="Auto">
+        <Border
+            MinHeight="{Binding ViewportHeight, ElementName=TargetStepScrollViewer}"
+            Style="{StaticResource ScrollViewerContentGutterBorderStyle}">
+            <Grid DataContext="{Binding Preparation}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="24" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
                 <TextBlock
-                    Margin="0,0,0,24"
                     Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                     Style="{StaticResource CaptionTextBlockStyle}"
                     Text="{Binding DetectedHardwareSummary}" />
 
-                <Grid>
+                <Grid Grid.Row="2">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="3*" />
-                        <ColumnDefinition Width="32" />
-                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="24" />
+                        <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
 
-                    <StackPanel Grid.Column="0" MaxWidth="760">
-                        <TextBlock
-                            Margin="0,0,0,12"
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Preparation.SectionTargetMachine], ElementName=ViewRoot}" />
-
-                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.ComputerName], ElementName=ViewRoot}" />
-                        <TextBox
-                            x:Name="TargetComputerNameTextBox"
-                            Margin="0,8,0,0"
-                            MaxWidth="680"
-                            HorizontalAlignment="Stretch"
-                            IsReadOnly="{Binding IsTargetComputerNameReadOnly}"
-                            MaxLength="{x:Static rules:ComputerNameRules.MaxLength}"
-                            PreviewTextInput="TargetComputerNameTextBox_PreviewTextInput"
-                            Text="{Binding TargetComputerName, UpdateSourceTrigger=PropertyChanged}" />
-                        <TextBlock
-                            Margin="0,8,0,0"
-                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                            Style="{StaticResource CaptionTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Preparation.ComputerNameHint], ElementName=ViewRoot}" />
-                        <TextBlock
-                            Margin="0,4,0,0"
-                            Foreground="#FFC42B1C"
-                            Style="{StaticResource CaptionTextBlockStyle}"
-                            Text="{Binding TargetComputerNameValidationMessage}"
-                            Visibility="{Binding HasTargetComputerNameValidationError, Converter={StaticResource BooleanToVisibilityConverter}}" />
-
-                        <TextBlock
-                            Margin="0,24,0,0"
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Preparation.TargetDisk], ElementName=ViewRoot}" />
-                        <ComboBox
-                            Margin="0,8,0,0"
-                            MaxWidth="680"
-                            HorizontalAlignment="Stretch"
-                            DisplayMemberPath="DisplayLabel"
-                            ItemsSource="{Binding TargetDisks}"
-                            SelectedItem="{Binding SelectedTargetDisk}" />
-                        <TextBlock
-                            Margin="0,8,0,0"
-                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                            Style="{StaticResource CaptionTextBlockStyle}"
-                            Text="{Binding TargetDiskSelectionHint}" />
-                    </StackPanel>
-
-                    <StackPanel Grid.Column="2">
-                        <TextBlock
-                            Margin="0,0,0,12"
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Preparation.SectionDeploymentOptions], ElementName=ViewRoot}" />
-                        <CheckBox
-                            IsChecked="{Binding ApplyFirmwareUpdates}"
-                            IsEnabled="{Binding IsFirmwareUpdatesOptionEnabled}">
-                            <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.FirmwareUpdates], ElementName=ViewRoot}" />
-                        </CheckBox>
-
-                        <StackPanel
-                            Margin="0,24,0,0"
-                            Visibility="{Binding HasAutopilotProfiles, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <!-- Target Machine Card (Left, Stretched Vertically) -->
+                    <Border
+                        Grid.Column="0"
+                        Margin="0"
+                        Padding="16"
+                        Style="{StaticResource SectionCardBorderStyle}"
+                        VerticalAlignment="Stretch">
+                        <StackPanel>
                             <TextBlock
-                                Margin="0,0,0,12"
-                                Style="{StaticResource BodyStrongTextBlockStyle}"
-                                Text="{Binding DataContext.Strings[Preparation.SectionAutopilot], ElementName=ViewRoot}" />
-                            <CheckBox IsChecked="{Binding IsAutopilotEnabled}">
-                                <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.AutopilotEnable], ElementName=ViewRoot}" />
-                            </CheckBox>
+                                Margin="0,0,0,16"
+                                Style="{StaticResource SubtitleTextBlockStyle}"
+                                Text="{Binding DataContext.Strings[Preparation.SectionTargetMachine], ElementName=ViewRoot}" />
 
                             <TextBlock
-                                Margin="0,12,0,0"
-                                Style="{StaticResource BodyStrongTextBlockStyle}"
-                                Text="{Binding DataContext.Strings[Preparation.AutopilotProfile], ElementName=ViewRoot}" />
-                            <ComboBox
-                                Margin="0,8,0,0"
-                                DisplayMemberPath="DisplayName"
-                                IsEnabled="{Binding IsAutopilotProfileSelectionEnabled}"
-                                ItemsSource="{Binding AutopilotProfiles}"
-                                SelectedItem="{Binding SelectedAutopilotProfile}" />
+                                Margin="0,0,0,8"
+                                Style="{StaticResource BodyTextBlockStyle}"
+                                Text="{Binding DataContext.Strings[Preparation.ComputerName], ElementName=ViewRoot}" />
+                            <TextBox
+                                x:Name="TargetComputerNameTextBox"
+                                HorizontalAlignment="Stretch"
+                                IsReadOnly="{Binding IsTargetComputerNameReadOnly}"
+                                MaxLength="{x:Static rules:ComputerNameRules.MaxLength}"
+                                PreviewTextInput="TargetComputerNameTextBox_PreviewTextInput"
+                                Text="{Binding TargetComputerName, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBlock
-                                Margin="0,8,0,0"
+                                Margin="0,4,0,0"
                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                 Style="{StaticResource CaptionTextBlockStyle}"
-                                Text="{Binding AutopilotProfileHint}" />
+                                Text="{Binding DataContext.Strings[Preparation.ComputerNameHint], ElementName=ViewRoot}" />
+                            <TextBlock
+                                Margin="0,4,0,0"
+                                Foreground="#FFC42B1C"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Text="{Binding TargetComputerNameValidationMessage}"
+                                Visibility="{Binding HasTargetComputerNameValidationError, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                            <TextBlock
+                                Margin="0,24,0,8"
+                                Style="{StaticResource BodyTextBlockStyle}"
+                                Text="{Binding DataContext.Strings[Preparation.TargetDisk], ElementName=ViewRoot}" />
+                            <ComboBox
+                                HorizontalAlignment="Stretch"
+                                DisplayMemberPath="DisplayLabel"
+                                ItemsSource="{Binding TargetDisks}"
+                                SelectedItem="{Binding SelectedTargetDisk}" />
+                            <TextBlock
+                                Margin="0,4,0,0"
+                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Text="{Binding TargetDiskSelectionHint}" />
                         </StackPanel>
-                    </StackPanel>
+                    </Border>
+
+                    <Grid Grid.Column="2">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="24" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+
+                        <!-- Deployment Options Card -->
+                        <Border
+                            Grid.Row="0"
+                            Margin="0"
+                            Padding="16">
+                            <Border.Style>
+                                <Style BasedOn="{StaticResource SectionCardBorderStyle}" TargetType="Border">
+                                    <Setter Property="Margin" Value="0" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding HasAutopilotProfiles}" Value="False">
+                                            <Setter Property="Grid.RowSpan" Value="3" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
+
+                            <StackPanel>
+                                <TextBlock
+                                    Margin="0,0,0,16"
+                                    Style="{StaticResource SubtitleTextBlockStyle}"
+                                    Text="{Binding DataContext.Strings[Preparation.SectionDeploymentOptions], ElementName=ViewRoot}" />
+                                <CheckBox
+                                    IsChecked="{Binding ApplyFirmwareUpdates}"
+                                    IsEnabled="{Binding IsFirmwareUpdatesOptionEnabled}">
+                                    <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.FirmwareUpdates], ElementName=ViewRoot}" />
+                                </CheckBox>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Windows Autopilot Card -->
+                        <Border
+                            Grid.Row="2"
+                            Margin="0"
+                            Padding="16"
+                            Style="{StaticResource SectionCardBorderStyle}"
+                            Visibility="{Binding HasAutopilotProfiles, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <StackPanel>
+                                <TextBlock
+                                    Margin="0,0,0,16"
+                                    Style="{StaticResource SubtitleTextBlockStyle}"
+                                    Text="{Binding DataContext.Strings[Preparation.SectionAutopilot], ElementName=ViewRoot}" />
+                                <CheckBox Margin="0,0,0,16" IsChecked="{Binding IsAutopilotEnabled}">
+                                    <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.AutopilotEnable], ElementName=ViewRoot}" />
+                                </CheckBox>
+
+                                <StackPanel IsEnabled="{Binding IsAutopilotEnabled}">
+                                    <TextBlock
+                                        Margin="0,0,0,8"
+                                        Style="{StaticResource BodyTextBlockStyle}"
+                                        Text="{Binding DataContext.Strings[Preparation.AutopilotProfile], ElementName=ViewRoot}" />
+                                    <ComboBox
+                                        HorizontalAlignment="Stretch"
+                                        DisplayMemberPath="DisplayName"
+                                        IsEnabled="{Binding IsAutopilotProfileSelectionEnabled}"
+                                        ItemsSource="{Binding AutopilotProfiles}"
+                                        SelectedItem="{Binding SelectedAutopilotProfile}" />
+                                    <TextBlock
+                                        Margin="0,4,0,0"
+                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                        Style="{StaticResource CaptionTextBlockStyle}"
+                                        Text="{Binding AutopilotProfileHint}" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+                    </Grid>
                 </Grid>
-            </StackPanel>
+            </Grid>
         </Border>
     </ScrollViewer>
 </UserControl>

--- a/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
@@ -10,115 +10,93 @@
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Border Style="{StaticResource ScrollViewerContentGutterBorderStyle}">
             <StackPanel DataContext="{Binding Preparation}">
-                <StackPanel Margin="0,0,0,24">
-                    <TextBlock
-                        Margin="0,0,0,12"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding DataContext.Strings[Preparation.SectionTargetMachine], ElementName=ViewRoot}" />
-                    <TextBlock
-                        Margin="0,0,0,16"
-                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding DetectedHardwareSummary}" />
+                <TextBlock
+                    Margin="0,0,0,24"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{Binding DetectedHardwareSummary}" />
 
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="180" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition Width="32" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
 
+                    <StackPanel Grid.Column="0" MaxWidth="900">
                         <TextBlock
-                            Margin="0,0,12,0"
-                            VerticalAlignment="Center"
+                            Margin="0,0,0,12"
                             Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Preparation.ComputerName], ElementName=ViewRoot}" />
-                        <StackPanel Grid.Column="1">
-                            <TextBox
-                                x:Name="TargetComputerNameTextBox"
-                                IsReadOnly="{Binding IsTargetComputerNameReadOnly}"
-                                MaxLength="{x:Static rules:ComputerNameRules.MaxLength}"
-                                PreviewTextInput="TargetComputerNameTextBox_PreviewTextInput"
-                                Text="{Binding TargetComputerName, UpdateSourceTrigger=PropertyChanged}" />
-                            <TextBlock
-                                Margin="0,8,0,0"
-                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                Style="{StaticResource CaptionTextBlockStyle}"
-                                Text="{Binding DataContext.Strings[Preparation.ComputerNameHint], ElementName=ViewRoot}" />
-                            <TextBlock
-                                Margin="0,4,0,0"
-                                Foreground="#FFC42B1C"
-                                Style="{StaticResource CaptionTextBlockStyle}"
-                                Text="{Binding TargetComputerNameValidationMessage}"
-                                Visibility="{Binding HasTargetComputerNameValidationError, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                        </StackPanel>
-                    </Grid>
-                </StackPanel>
+                            Text="{Binding DataContext.Strings[Preparation.SectionTargetMachine], ElementName=ViewRoot}" />
 
-                <StackPanel Margin="0,0,0,24">
-                    <TextBlock
-                        Margin="0,0,0,12"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding DataContext.Strings[Preparation.SectionDestinationDisk], ElementName=ViewRoot}" />
-
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="180" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
+                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.ComputerName], ElementName=ViewRoot}" />
+                        <TextBox
+                            x:Name="TargetComputerNameTextBox"
+                            Margin="0,8,0,0"
+                            MaxWidth="760"
+                            HorizontalAlignment="Stretch"
+                            IsReadOnly="{Binding IsTargetComputerNameReadOnly}"
+                            MaxLength="{x:Static rules:ComputerNameRules.MaxLength}"
+                            PreviewTextInput="TargetComputerNameTextBox_PreviewTextInput"
+                            Text="{Binding TargetComputerName, UpdateSourceTrigger=PropertyChanged}" />
+                        <TextBlock
+                            Margin="0,8,0,0"
+                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                            Style="{StaticResource CaptionTextBlockStyle}"
+                            Text="{Binding DataContext.Strings[Preparation.ComputerNameHint], ElementName=ViewRoot}" />
+                        <TextBlock
+                            Margin="0,4,0,0"
+                            Foreground="#FFC42B1C"
+                            Style="{StaticResource CaptionTextBlockStyle}"
+                            Text="{Binding TargetComputerNameValidationMessage}"
+                            Visibility="{Binding HasTargetComputerNameValidationError, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
                         <TextBlock
-                            Margin="0,0,12,0"
-                            VerticalAlignment="Center"
+                            Margin="0,24,0,0"
                             Style="{StaticResource BodyStrongTextBlockStyle}"
                             Text="{Binding DataContext.Strings[Preparation.TargetDisk], ElementName=ViewRoot}" />
-                        <StackPanel Grid.Column="1">
-                            <ComboBox
-                                DisplayMemberPath="DisplayLabel"
-                                ItemsSource="{Binding TargetDisks}"
-                                SelectedItem="{Binding SelectedTargetDisk}" />
-                            <TextBlock
-                                Margin="0,8,0,0"
-                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                Style="{StaticResource CaptionTextBlockStyle}"
-                                Text="{Binding TargetDiskSelectionHint}" />
-                        </StackPanel>
-                    </Grid>
-                </StackPanel>
-
-                <StackPanel Margin="0,0,0,24">
-                    <TextBlock
-                        Margin="0,0,0,12"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding DataContext.Strings[Preparation.SectionDeploymentOptions], ElementName=ViewRoot}" />
-                    <CheckBox
-                        IsChecked="{Binding ApplyFirmwareUpdates}"
-                        IsEnabled="{Binding IsFirmwareUpdatesOptionEnabled}">
-                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.FirmwareUpdates], ElementName=ViewRoot}" />
-                    </CheckBox>
-                </StackPanel>
-
-                <StackPanel Visibility="{Binding HasAutopilotProfiles, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <TextBlock
-                        Margin="0,0,0,12"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding DataContext.Strings[Preparation.SectionAutopilot], ElementName=ViewRoot}" />
-                    <CheckBox IsChecked="{Binding IsAutopilotEnabled}">
-                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.AutopilotEnable], ElementName=ViewRoot}" />
-                    </CheckBox>
-
-                    <Grid Margin="0,12,0,0">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="180" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-
+                        <ComboBox
+                            Margin="0,8,0,0"
+                            MaxWidth="760"
+                            HorizontalAlignment="Stretch"
+                            DisplayMemberPath="DisplayLabel"
+                            ItemsSource="{Binding TargetDisks}"
+                            SelectedItem="{Binding SelectedTargetDisk}" />
                         <TextBlock
-                            Margin="0,0,12,0"
-                            VerticalAlignment="Center"
+                            Margin="0,8,0,0"
+                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                            Style="{StaticResource CaptionTextBlockStyle}"
+                            Text="{Binding TargetDiskSelectionHint}" />
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="2">
+                        <TextBlock
+                            Margin="0,0,0,12"
                             Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding DataContext.Strings[Preparation.AutopilotProfile], ElementName=ViewRoot}" />
-                        <StackPanel Grid.Column="1">
+                            Text="{Binding DataContext.Strings[Preparation.SectionDeploymentOptions], ElementName=ViewRoot}" />
+                        <CheckBox
+                            IsChecked="{Binding ApplyFirmwareUpdates}"
+                            IsEnabled="{Binding IsFirmwareUpdatesOptionEnabled}">
+                            <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.FirmwareUpdates], ElementName=ViewRoot}" />
+                        </CheckBox>
+
+                        <StackPanel
+                            Margin="0,24,0,0"
+                            Visibility="{Binding HasAutopilotProfiles, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <TextBlock
+                                Margin="0,0,0,12"
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="{Binding DataContext.Strings[Preparation.SectionAutopilot], ElementName=ViewRoot}" />
+                            <CheckBox IsChecked="{Binding IsAutopilotEnabled}">
+                                <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.AutopilotEnable], ElementName=ViewRoot}" />
+                            </CheckBox>
+
+                            <TextBlock
+                                Margin="0,12,0,0"
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="{Binding DataContext.Strings[Preparation.AutopilotProfile], ElementName=ViewRoot}" />
                             <ComboBox
+                                Margin="0,8,0,0"
                                 DisplayMemberPath="DisplayName"
                                 IsEnabled="{Binding IsAutopilotProfileSelectionEnabled}"
                                 ItemsSource="{Binding AutopilotProfiles}"
@@ -129,8 +107,8 @@
                                 Style="{StaticResource CaptionTextBlockStyle}"
                                 Text="{Binding AutopilotProfileHint}" />
                         </StackPanel>
-                    </Grid>
-                </StackPanel>
+                    </StackPanel>
+                </Grid>
             </StackPanel>
         </Border>
     </ScrollViewer>

--- a/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
@@ -9,103 +9,129 @@
     mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Border Style="{StaticResource ScrollViewerContentGutterBorderStyle}">
-            <Grid DataContext="{Binding Preparation}">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="16" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="16" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="16" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="12" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="180" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-
-                <TextBlock
-                    Grid.ColumnSpan="2"
-                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                    Style="{StaticResource CaptionTextBlockStyle}"
-                    Text="{Binding DetectedHardwareSummary}" />
-
-                <TextBlock
-                    Grid.Row="2"
-                    Margin="0,0,12,0"
-                    VerticalAlignment="Center"
-                    Style="{StaticResource BodyStrongTextBlockStyle}"
-                    Text="{Binding DataContext.Strings[Preparation.ComputerName], ElementName=ViewRoot}" />
-                <StackPanel Grid.Row="2" Grid.Column="1">
-                    <TextBox
-                        x:Name="TargetComputerNameTextBox"
-                        IsReadOnly="{Binding IsTargetComputerNameReadOnly}"
-                        MaxLength="{x:Static rules:ComputerNameRules.MaxLength}"
-                        PreviewTextInput="TargetComputerNameTextBox_PreviewTextInput"
-                        Text="{Binding TargetComputerName, UpdateSourceTrigger=PropertyChanged}" />
+            <StackPanel DataContext="{Binding Preparation}">
+                <StackPanel Margin="0,0,0,24">
                     <TextBlock
-                        Margin="0,8,0,0"
+                        Margin="0,0,0,12"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{Binding DataContext.Strings[Preparation.SectionTargetMachine], ElementName=ViewRoot}" />
+                    <TextBlock
+                        Margin="0,0,0,16"
                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding DataContext.Strings[Preparation.ComputerNameHint], ElementName=ViewRoot}" />
-                    <TextBlock
-                        Margin="0,4,0,0"
-                        Foreground="#FFC42B1C"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding TargetComputerNameValidationMessage}"
-                        Visibility="{Binding HasTargetComputerNameValidationError, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                        Text="{Binding DetectedHardwareSummary}" />
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="180" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock
+                            Margin="0,0,12,0"
+                            VerticalAlignment="Center"
+                            Style="{StaticResource BodyStrongTextBlockStyle}"
+                            Text="{Binding DataContext.Strings[Preparation.ComputerName], ElementName=ViewRoot}" />
+                        <StackPanel Grid.Column="1">
+                            <TextBox
+                                x:Name="TargetComputerNameTextBox"
+                                IsReadOnly="{Binding IsTargetComputerNameReadOnly}"
+                                MaxLength="{x:Static rules:ComputerNameRules.MaxLength}"
+                                PreviewTextInput="TargetComputerNameTextBox_PreviewTextInput"
+                                Text="{Binding TargetComputerName, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBlock
+                                Margin="0,8,0,0"
+                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Text="{Binding DataContext.Strings[Preparation.ComputerNameHint], ElementName=ViewRoot}" />
+                            <TextBlock
+                                Margin="0,4,0,0"
+                                Foreground="#FFC42B1C"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Text="{Binding TargetComputerNameValidationMessage}"
+                                Visibility="{Binding HasTargetComputerNameValidationError, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                        </StackPanel>
+                    </Grid>
                 </StackPanel>
 
-                <TextBlock
-                    Grid.Row="4"
-                    Margin="0,0,12,0"
-                    VerticalAlignment="Center"
-                    Style="{StaticResource BodyStrongTextBlockStyle}"
-                    Text="{Binding DataContext.Strings[Preparation.TargetDisk], ElementName=ViewRoot}" />
-                <StackPanel Grid.Row="4" Grid.Column="1">
-                    <ComboBox
-                        DisplayMemberPath="DisplayLabel"
-                        ItemsSource="{Binding TargetDisks}"
-                        SelectedItem="{Binding SelectedTargetDisk}" />
+                <StackPanel Margin="0,0,0,24">
                     <TextBlock
-                        Margin="0,8,0,0"
-                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding TargetDiskSelectionHint}" />
+                        Margin="0,0,0,12"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{Binding DataContext.Strings[Preparation.SectionDestinationDisk], ElementName=ViewRoot}" />
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="180" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock
+                            Margin="0,0,12,0"
+                            VerticalAlignment="Center"
+                            Style="{StaticResource BodyStrongTextBlockStyle}"
+                            Text="{Binding DataContext.Strings[Preparation.TargetDisk], ElementName=ViewRoot}" />
+                        <StackPanel Grid.Column="1">
+                            <ComboBox
+                                DisplayMemberPath="DisplayLabel"
+                                ItemsSource="{Binding TargetDisks}"
+                                SelectedItem="{Binding SelectedTargetDisk}" />
+                            <TextBlock
+                                Margin="0,8,0,0"
+                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Text="{Binding TargetDiskSelectionHint}" />
+                        </StackPanel>
+                    </Grid>
                 </StackPanel>
 
-                <StackPanel Grid.Row="6" Grid.ColumnSpan="2">
+                <StackPanel Margin="0,0,0,24">
+                    <TextBlock
+                        Margin="0,0,0,12"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{Binding DataContext.Strings[Preparation.SectionDeploymentOptions], ElementName=ViewRoot}" />
                     <CheckBox
                         IsChecked="{Binding ApplyFirmwareUpdates}"
                         IsEnabled="{Binding IsFirmwareUpdatesOptionEnabled}">
                         <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.FirmwareUpdates], ElementName=ViewRoot}" />
                     </CheckBox>
-                    <CheckBox Margin="0,8,0,0" IsChecked="{Binding IsAutopilotEnabled}">
-                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.AutopilotEnable], ElementName=ViewRoot}" />
-                    </CheckBox>
                 </StackPanel>
 
-                <TextBlock
-                    Grid.Row="8"
-                    Margin="0,0,12,0"
-                    VerticalAlignment="Center"
-                    Style="{StaticResource BodyStrongTextBlockStyle}"
-                    Text="{Binding DataContext.Strings[Preparation.AutopilotProfile], ElementName=ViewRoot}" />
-                <StackPanel Grid.Row="8" Grid.Column="1">
-                    <ComboBox
-                        DisplayMemberPath="DisplayName"
-                        IsEnabled="{Binding IsAutopilotProfileSelectionEnabled}"
-                        ItemsSource="{Binding AutopilotProfiles}"
-                        SelectedItem="{Binding SelectedAutopilotProfile}" />
+                <StackPanel Visibility="{Binding HasAutopilotProfiles, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <TextBlock
-                        Margin="0,8,0,0"
-                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding AutopilotProfileHint}" />
+                        Margin="0,0,0,12"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{Binding DataContext.Strings[Preparation.SectionAutopilot], ElementName=ViewRoot}" />
+                    <CheckBox IsChecked="{Binding IsAutopilotEnabled}">
+                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.AutopilotEnable], ElementName=ViewRoot}" />
+                    </CheckBox>
+
+                    <Grid Margin="0,12,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="180" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock
+                            Margin="0,0,12,0"
+                            VerticalAlignment="Center"
+                            Style="{StaticResource BodyStrongTextBlockStyle}"
+                            Text="{Binding DataContext.Strings[Preparation.AutopilotProfile], ElementName=ViewRoot}" />
+                        <StackPanel Grid.Column="1">
+                            <ComboBox
+                                DisplayMemberPath="DisplayName"
+                                IsEnabled="{Binding IsAutopilotProfileSelectionEnabled}"
+                                ItemsSource="{Binding AutopilotProfiles}"
+                                SelectedItem="{Binding SelectedAutopilotProfile}" />
+                            <TextBlock
+                                Margin="0,8,0,0"
+                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Text="{Binding AutopilotProfileHint}" />
+                        </StackPanel>
+                    </Grid>
                 </StackPanel>
-            </Grid>
+            </StackPanel>
         </Border>
     </ScrollViewer>
 </UserControl>

--- a/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
@@ -18,12 +18,12 @@
 
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition Width="3*" />
                         <ColumnDefinition Width="32" />
-                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="2*" />
                     </Grid.ColumnDefinitions>
 
-                    <StackPanel Grid.Column="0" MaxWidth="900">
+                    <StackPanel Grid.Column="0" MaxWidth="760">
                         <TextBlock
                             Margin="0,0,0,12"
                             Style="{StaticResource BodyStrongTextBlockStyle}"
@@ -33,7 +33,7 @@
                         <TextBox
                             x:Name="TargetComputerNameTextBox"
                             Margin="0,8,0,0"
-                            MaxWidth="760"
+                            MaxWidth="680"
                             HorizontalAlignment="Stretch"
                             IsReadOnly="{Binding IsTargetComputerNameReadOnly}"
                             MaxLength="{x:Static rules:ComputerNameRules.MaxLength}"
@@ -57,7 +57,7 @@
                             Text="{Binding DataContext.Strings[Preparation.TargetDisk], ElementName=ViewRoot}" />
                         <ComboBox
                             Margin="0,8,0,0"
-                            MaxWidth="760"
+                            MaxWidth="680"
                             HorizontalAlignment="Stretch"
                             DisplayMemberPath="DisplayLabel"
                             ItemsSource="{Binding TargetDisks}"

--- a/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
@@ -9,75 +9,103 @@
     mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Border Style="{StaticResource ScrollViewerContentGutterBorderStyle}">
-            <StackPanel DataContext="{Binding Preparation}">
-                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.ComputerName], ElementName=ViewRoot}" />
-                <TextBox
-                    x:Name="TargetComputerNameTextBox"
-                    Margin="0,8,0,0"
-                    IsReadOnly="{Binding IsTargetComputerNameReadOnly}"
-                    MaxLength="{x:Static rules:ComputerNameRules.MaxLength}"
-                    PreviewTextInput="TargetComputerNameTextBox_PreviewTextInput"
-                    Text="{Binding TargetComputerName, UpdateSourceTrigger=PropertyChanged}" />
-                <TextBlock
-                    Margin="0,8,0,0"
-                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                    Style="{StaticResource CaptionTextBlockStyle}"
-                    Text="{Binding DataContext.Strings[Preparation.ComputerNameHint], ElementName=ViewRoot}" />
-                <TextBlock
-                    Margin="0,4,0,0"
-                    Foreground="#FFC42B1C"
-                    Style="{StaticResource CaptionTextBlockStyle}"
-                    Text="{Binding TargetComputerNameValidationMessage}"
-                    Visibility="{Binding HasTargetComputerNameValidationError, Converter={StaticResource BooleanToVisibilityConverter}}" />
+            <Grid DataContext="{Binding Preparation}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="16" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="16" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="16" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="12" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="180" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
 
                 <TextBlock
-                    Margin="0,12,0,0"
+                    Grid.ColumnSpan="2"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{Binding DetectedHardwareSummary}" />
+
+                <TextBlock
+                    Grid.Row="2"
+                    Margin="0,0,12,0"
+                    VerticalAlignment="Center"
+                    Style="{StaticResource BodyStrongTextBlockStyle}"
+                    Text="{Binding DataContext.Strings[Preparation.ComputerName], ElementName=ViewRoot}" />
+                <StackPanel Grid.Row="2" Grid.Column="1">
+                    <TextBox
+                        x:Name="TargetComputerNameTextBox"
+                        IsReadOnly="{Binding IsTargetComputerNameReadOnly}"
+                        MaxLength="{x:Static rules:ComputerNameRules.MaxLength}"
+                        PreviewTextInput="TargetComputerNameTextBox_PreviewTextInput"
+                        Text="{Binding TargetComputerName, UpdateSourceTrigger=PropertyChanged}" />
+                    <TextBlock
+                        Margin="0,8,0,0"
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{Binding DataContext.Strings[Preparation.ComputerNameHint], ElementName=ViewRoot}" />
+                    <TextBlock
+                        Margin="0,4,0,0"
+                        Foreground="#FFC42B1C"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{Binding TargetComputerNameValidationMessage}"
+                        Visibility="{Binding HasTargetComputerNameValidationError, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                </StackPanel>
+
+                <TextBlock
+                    Grid.Row="4"
+                    Margin="0,0,12,0"
+                    VerticalAlignment="Center"
                     Style="{StaticResource BodyStrongTextBlockStyle}"
                     Text="{Binding DataContext.Strings[Preparation.TargetDisk], ElementName=ViewRoot}" />
-                <DockPanel Margin="0,8,0,0">
+                <StackPanel Grid.Row="4" Grid.Column="1">
                     <ComboBox
-                        Width="640"
                         DisplayMemberPath="DisplayLabel"
                         ItemsSource="{Binding TargetDisks}"
                         SelectedItem="{Binding SelectedTargetDisk}" />
-                    <Button
-                        Width="140"
-                        Margin="8,0,0,0"
-                        Command="{Binding RefreshTargetDisksCommand}"
-                        Content="{Binding DataContext.Strings[Common.Refresh], ElementName=ViewRoot}" />
-                </DockPanel>
-                <TextBlock
-                    Margin="0,8,0,0"
-                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                    Style="{StaticResource CaptionTextBlockStyle}"
-                    Text="{Binding TargetDiskSelectionHint}" />
+                    <TextBlock
+                        Margin="0,8,0,0"
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{Binding TargetDiskSelectionHint}" />
+                </StackPanel>
 
-                <CheckBox
-                    Margin="0,8,0,0"
-                    IsChecked="{Binding ApplyFirmwareUpdates}"
-                    IsEnabled="{Binding IsFirmwareUpdatesOptionEnabled}">
-                    <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.FirmwareUpdates], ElementName=ViewRoot}" />
-                </CheckBox>
-                <CheckBox Margin="0,8,0,0" IsChecked="{Binding IsAutopilotEnabled}">
-                    <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.AutopilotEnable], ElementName=ViewRoot}" />
-                </CheckBox>
+                <StackPanel Grid.Row="6" Grid.ColumnSpan="2">
+                    <CheckBox
+                        IsChecked="{Binding ApplyFirmwareUpdates}"
+                        IsEnabled="{Binding IsFirmwareUpdatesOptionEnabled}">
+                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.FirmwareUpdates], ElementName=ViewRoot}" />
+                    </CheckBox>
+                    <CheckBox Margin="0,8,0,0" IsChecked="{Binding IsAutopilotEnabled}">
+                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding DataContext.Strings[Preparation.AutopilotEnable], ElementName=ViewRoot}" />
+                    </CheckBox>
+                </StackPanel>
 
                 <TextBlock
-                    Margin="0,12,0,0"
+                    Grid.Row="8"
+                    Margin="0,0,12,0"
+                    VerticalAlignment="Center"
                     Style="{StaticResource BodyStrongTextBlockStyle}"
                     Text="{Binding DataContext.Strings[Preparation.AutopilotProfile], ElementName=ViewRoot}" />
-                <ComboBox
-                    Margin="0,8,0,0"
-                    DisplayMemberPath="DisplayName"
-                    IsEnabled="{Binding IsAutopilotProfileSelectionEnabled}"
-                    ItemsSource="{Binding AutopilotProfiles}"
-                    SelectedItem="{Binding SelectedAutopilotProfile}" />
-                <TextBlock
-                    Margin="0,8,0,0"
-                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                    Style="{StaticResource CaptionTextBlockStyle}"
-                    Text="{Binding AutopilotProfileHint}" />
-            </StackPanel>
+                <StackPanel Grid.Row="8" Grid.Column="1">
+                    <ComboBox
+                        DisplayMemberPath="DisplayName"
+                        IsEnabled="{Binding IsAutopilotProfileSelectionEnabled}"
+                        ItemsSource="{Binding AutopilotProfiles}"
+                        SelectedItem="{Binding SelectedAutopilotProfile}" />
+                    <TextBlock
+                        Margin="0,8,0,0"
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{Binding AutopilotProfileHint}" />
+                </StackPanel>
+            </Grid>
         </Border>
     </ScrollViewer>
 </UserControl>

--- a/src/Foundry.Deploy/Views/WizardView.xaml
+++ b/src/Foundry.Deploy/Views/WizardView.xaml
@@ -66,11 +66,6 @@
                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                 Style="{StaticResource CaptionTextBlockStyle}"
                 Text="{Binding Strings[Wizard.Description]}" />
-            <TextBlock
-                Margin="0,8,0,0"
-                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{Binding Preparation.DetectedHardwareSummary}" />
         </StackPanel>
 
         <Grid Grid.Row="1" Margin="0,0,0,16">


### PR DESCRIPTION
## Summary
Improve the Target wizard step layout for clearer target configuration.

## Why
The previous flat layout used fixed widths and duplicated refresh actions already available in the Tools menu.

## Changes
- Moved detected hardware context into the Target step.
- Reworked the view into a two-column form layout.
- Removed the local target disk refresh button.
- Let the target disk selector stretch with available space.

## Testing
- Ran `dotnet build src/Foundry.Deploy/Foundry.Deploy.csproj` successfully.

## Notes
- The target disk refresh command remains available from the Tools menu.