### PR TITLE
refactor(deploy): improve os catalog wizard layout

### DIFF
--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -75,7 +75,6 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     public OperatingSystemCatalogItem? SelectedOperatingSystem => OperatingSystemCatalog.SelectedOperatingSystem;
     public string WindowTitle => GetString("App.WindowTitle");
     public string VersionDisplay => Format("Common.VersionFormat", FoundryDeployApplicationInfo.Version);
-    public string OperatingSystemArchitectureDisplay => Format("Catalog.ArchitectureFormat", OperatingSystemCatalog.EffectiveOsArchitecture);
     public string DriverPackArchitectureDisplay => Format("Catalog.ArchitectureFormat", EffectiveOsArchitecture);
     public string DriverPackModeDisplayText => Format("DriverPack.SelectedModeFormat", DriverPackSelection.DriverPackModeDisplay);
     public string SummaryTargetDiskText => Preparation.SelectedTargetDisk?.DisplayLabel ?? GetString("Summary.NoDiskSelected");
@@ -362,7 +361,6 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     {
         OnPropertyChanged(nameof(EffectiveOsArchitecture));
         OnPropertyChanged(nameof(SelectedOperatingSystem));
-        OnPropertyChanged(nameof(OperatingSystemArchitectureDisplay));
         OnPropertyChanged(nameof(DriverPackArchitectureDisplay));
         OnPropertyChanged(nameof(DriverPackModeDisplayText));
         OnPropertyChanged(nameof(SummaryTargetDiskText));
@@ -504,7 +502,6 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
             OnPropertyChanged(nameof(CurrentCulture));
             OnPropertyChanged(nameof(WindowTitle));
             OnPropertyChanged(nameof(VersionDisplay));
-            OnPropertyChanged(nameof(OperatingSystemArchitectureDisplay));
             OnPropertyChanged(nameof(DriverPackArchitectureDisplay));
             OnPropertyChanged(nameof(DriverPackModeDisplayText));
             OnPropertyChanged(nameof(SummaryTargetDiskText));

--- a/src/Foundry.Deploy/Views/Wizard/OperatingSystemCatalogStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/OperatingSystemCatalogStepView.xaml
@@ -5,87 +5,84 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <Border Style="{StaticResource ScrollViewerContentGutterBorderStyle}">
-            <StackPanel Margin="0,0,0,12">
-                <TextBlock
-                    Margin="0,0,0,16"
-                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                    Style="{StaticResource CaptionTextBlockStyle}"
-                    Text="{Binding OperatingSystemArchitectureDisplay}" />
+    <ScrollViewer x:Name="OperatingSystemCatalogScrollViewer" VerticalScrollBarVisibility="Auto">
+        <Border
+            MinHeight="{Binding ViewportHeight, ElementName=OperatingSystemCatalogScrollViewer}"
+            Style="{StaticResource ScrollViewerContentGutterBorderStyle}">
+            <Grid>
+                <Border
+                    Width="600"
+                    Margin="0"
+                    Padding="24"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Stretch"
+                    Style="{StaticResource SectionCardBorderStyle}">
+                    <Grid>
+                        <StackPanel VerticalAlignment="Center">
+                            <TextBlock
+                                Margin="0,0,0,20"
+                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Text="{Binding OperatingSystemArchitectureDisplay}" />
 
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="16" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="16" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="12" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
+                            <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding Strings[Catalog.OperatingSystem]}" />
+                            <TextBox
+                                Margin="0,8,0,0"
+                                IsReadOnly="True"
+                                Text="{Binding Strings[OperatingSystem.Windows11]}" />
 
-                    <StackPanel Grid.Column="0">
-                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.OperatingSystem]}" />
-                        <TextBox
-                            Margin="0,8,0,0"
-                            IsReadOnly="True"
-                            Text="{Binding Strings[OperatingSystem.Windows11]}" />
-                    </StackPanel>
+                            <TextBlock
+                                Margin="0,20,0,0"
+                                Style="{StaticResource BodyTextBlockStyle}"
+                                Text="{Binding Strings[Catalog.Version]}" />
+                            <ComboBox
+                                Margin="0,8,0,0"
+                                ItemsSource="{Binding OperatingSystemCatalog.ReleaseIdFilters}"
+                                SelectedItem="{Binding OperatingSystemCatalog.SelectedReleaseId}" />
 
-                    <StackPanel Grid.Column="2">
-                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.Version]}" />
-                        <ComboBox
-                            Margin="0,8,0,0"
-                            ItemsSource="{Binding OperatingSystemCatalog.ReleaseIdFilters}"
-                            SelectedItem="{Binding OperatingSystemCatalog.SelectedReleaseId}" />
-                    </StackPanel>
+                            <TextBlock
+                                Margin="0,20,0,0"
+                                Style="{StaticResource BodyTextBlockStyle}"
+                                Text="{Binding Strings[Catalog.Language]}" />
+                            <ComboBox
+                                Margin="0,8,0,0"
+                                IsEnabled="{Binding OperatingSystemCatalog.IsLanguageSelectionEnabled}"
+                                ItemsSource="{Binding OperatingSystemCatalog.LanguageFilters}"
+                                SelectedItem="{Binding OperatingSystemCatalog.SelectedLanguageCode}" />
 
-                    <StackPanel Grid.Row="2" Grid.Column="0">
-                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.Language]}" />
-                        <ComboBox
-                            Margin="0,8,0,0"
-                            IsEnabled="{Binding OperatingSystemCatalog.IsLanguageSelectionEnabled}"
-                            ItemsSource="{Binding OperatingSystemCatalog.LanguageFilters}"
-                            SelectedItem="{Binding OperatingSystemCatalog.SelectedLanguageCode}" />
-                    </StackPanel>
+                            <TextBlock
+                                Margin="0,20,0,0"
+                                Style="{StaticResource BodyTextBlockStyle}"
+                                Text="{Binding Strings[Catalog.LicenseChannel]}" />
+                            <ComboBox
+                                Margin="0,8,0,0"
+                                ItemsSource="{Binding OperatingSystemCatalog.LicenseChannelFilters}"
+                                SelectedItem="{Binding OperatingSystemCatalog.SelectedLicenseChannel}">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding ., Converter={StaticResource OsCatalogFilterDisplayConverter}, ConverterParameter=LicenseChannel}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
 
-                    <StackPanel
-                        Grid.Row="2"
-                        Grid.Column="2">
-                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.LicenseChannel]}" />
-                        <ComboBox
-                            Margin="0,8,0,0"
-                            ItemsSource="{Binding OperatingSystemCatalog.LicenseChannelFilters}"
-                            SelectedItem="{Binding OperatingSystemCatalog.SelectedLicenseChannel}">
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding ., Converter={StaticResource OsCatalogFilterDisplayConverter}, ConverterParameter=LicenseChannel}" />
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                        </ComboBox>
-                    </StackPanel>
-
-                    <StackPanel
-                        Grid.Row="4"
-                        Grid.ColumnSpan="3">
-                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.EditionTarget]}" />
-                        <ComboBox
-                            Margin="0,8,0,0"
-                            ItemsSource="{Binding OperatingSystemCatalog.EditionFilters}"
-                            SelectedItem="{Binding OperatingSystemCatalog.SelectedEdition}">
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding ., Converter={StaticResource OsCatalogFilterDisplayConverter}, ConverterParameter=Edition}" />
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                        </ComboBox>
-                    </StackPanel>
-                </Grid>
-            </StackPanel>
+                            <TextBlock
+                                Margin="0,20,0,0"
+                                Style="{StaticResource BodyTextBlockStyle}"
+                                Text="{Binding Strings[Catalog.EditionTarget]}" />
+                            <ComboBox
+                                Margin="0,8,0,0"
+                                ItemsSource="{Binding OperatingSystemCatalog.EditionFilters}"
+                                SelectedItem="{Binding OperatingSystemCatalog.SelectedEdition}">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding ., Converter={StaticResource OsCatalogFilterDisplayConverter}, ConverterParameter=Edition}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+            </Grid>
         </Border>
     </ScrollViewer>
 </UserControl>

--- a/src/Foundry.Deploy/Views/Wizard/OperatingSystemCatalogStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/OperatingSystemCatalogStepView.xaml
@@ -19,12 +19,6 @@
                     Style="{StaticResource SectionCardBorderStyle}">
                     <Grid>
                         <StackPanel VerticalAlignment="Center">
-                            <TextBlock
-                                Margin="0,0,0,20"
-                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                Style="{StaticResource CaptionTextBlockStyle}"
-                                Text="{Binding OperatingSystemArchitectureDisplay}" />
-
                             <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{Binding Strings[Catalog.OperatingSystem]}" />
                             <TextBox
                                 Margin="0,8,0,0"

--- a/src/Foundry.Deploy/Views/Wizard/OperatingSystemCatalogStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/OperatingSystemCatalogStepView.xaml
@@ -8,30 +8,27 @@
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Border Style="{StaticResource ScrollViewerContentGutterBorderStyle}">
             <StackPanel Margin="0,0,0,12">
-                <DockPanel Margin="0,0,0,12">
-                    <Button
-                        Width="140"
-                        Command="{Binding RefreshCatalogsCommand}"
-                        Content="{Binding Strings[Common.Refresh]}" />
-                    <TextBlock
-                        Margin="12,0,0,0"
-                        VerticalAlignment="Center"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding OperatingSystemArchitectureDisplay}" />
-                </DockPanel>
+                <TextBlock
+                    Margin="0,0,0,16"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{Binding OperatingSystemArchitectureDisplay}" />
 
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="16" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="16" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="12" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
 
-                    <StackPanel Margin="0,0,8,8">
+                    <StackPanel Grid.Column="0">
                         <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.OperatingSystem]}" />
                         <TextBox
                             Margin="0,8,0,0"
@@ -39,7 +36,7 @@
                             Text="{Binding Strings[OperatingSystem.Windows11]}" />
                     </StackPanel>
 
-                    <StackPanel Grid.Column="1" Margin="8,0,0,8">
+                    <StackPanel Grid.Column="2">
                         <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.Version]}" />
                         <ComboBox
                             Margin="0,8,0,0"
@@ -47,7 +44,7 @@
                             SelectedItem="{Binding OperatingSystemCatalog.SelectedReleaseId}" />
                     </StackPanel>
 
-                    <StackPanel Grid.Row="1" Margin="0,0,8,0">
+                    <StackPanel Grid.Row="2" Grid.Column="0">
                         <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.Language]}" />
                         <ComboBox
                             Margin="0,8,0,0"
@@ -57,9 +54,8 @@
                     </StackPanel>
 
                     <StackPanel
-                        Grid.Row="1"
-                        Grid.Column="1"
-                        Margin="8,0,0,0">
+                        Grid.Row="2"
+                        Grid.Column="2">
                         <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.LicenseChannel]}" />
                         <ComboBox
                             Margin="0,8,0,0"
@@ -74,9 +70,8 @@
                     </StackPanel>
 
                     <StackPanel
-                        Grid.Row="2"
-                        Grid.ColumnSpan="2"
-                        Margin="0,8,0,0">
+                        Grid.Row="4"
+                        Grid.ColumnSpan="3">
                         <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Catalog.EditionTarget]}" />
                         <ComboBox
                             Margin="0,8,0,0"


### PR DESCRIPTION
## Summary
Clean up the Operating System Catalog wizard step layout.

## Why
The refresh button duplicated the Tools menu and the selector grid needed more consistent spacing.

## Changes
- Removed the local catalog refresh button.
- Kept architecture information as compact status text.
- Reworked the selector grid spacing.
- Kept the edition selector full width for longer catalog values.

## Testing
- Ran `dotnet build src/Foundry.Deploy/Foundry.Deploy.csproj` successfully.
- Checked live catalog value lengths before choosing the layout.

## Notes
- Catalog refresh remains available from the Tools menu.