### PR TITLE
refactor(deploy): improve summary wizard layout

### DIFF
--- a/src/Foundry.Deploy/Converters/OperatingSystemSummaryConverter.cs
+++ b/src/Foundry.Deploy/Converters/OperatingSystemSummaryConverter.cs
@@ -17,8 +17,9 @@ public sealed class OperatingSystemSummaryConverter : IValueConverter
         string edition = OperatingSystemDisplayFormatter.FormatEdition(item.Edition);
         string channel = OperatingSystemDisplayFormatter.FormatLicenseChannel(item.LicenseChannel);
         string windowsRelease = OperatingSystemDisplayFormatter.FormatWindowsRelease(item.WindowsRelease);
+        string operatingSystemLabel = string.IsNullOrWhiteSpace(windowsRelease) ? "Windows" : $"Windows {windowsRelease}";
 
-        return $"{windowsRelease} {item.ReleaseId} | {item.Architecture} | {language} | {edition} | {channel} | {item.Build}";
+        return $"{operatingSystemLabel} {item.ReleaseId} | {item.Architecture} | {language} | {edition} | {channel} | {item.Build}";
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/Foundry.Deploy/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry.Deploy/Resources/AppStrings.fr-FR.resx
@@ -79,17 +79,15 @@
   <data name="Summary.Title" xml:space="preserve"><value>Résumé du déploiement</value></data>
   <data name="Summary.TargetDisk" xml:space="preserve"><value>Disque cible</value></data>
   <data name="Summary.NoDiskSelected" xml:space="preserve"><value>Aucun disque sélectionné</value></data>
-  <data name="Summary.SelectedOperatingSystem" xml:space="preserve"><value>Système sélectionné</value></data>
+  <data name="Summary.SelectedOperatingSystem" xml:space="preserve"><value>Système d’exploitation</value></data>
   <data name="Summary.NoSelection" xml:space="preserve"><value>Aucune sélection</value></data>
   <data name="Summary.SelectedDriverPack" xml:space="preserve"><value>Pack de pilotes sélectionné</value></data>
-  <data name="Summary.DriverPackMode" xml:space="preserve"><value>Mode du pack de pilotes</value></data>
   <data name="Summary.Firmware" xml:space="preserve"><value>Firmware</value></data>
-  <data name="Summary.FirmwareEnabledFormat" xml:space="preserve"><value>Mises à jour du firmware activées : {0}</value></data>
   <data name="Summary.Autopilot" xml:space="preserve"><value>Autopilot</value></data>
-  <data name="Summary.EnabledFormat" xml:space="preserve"><value>Activé : {0}</value></data>
-  <data name="Summary.SelectedProfileFormat" xml:space="preserve"><value>Profil sélectionné : {0}</value></data>
-  <data name="Summary.DeployExplanation" xml:space="preserve"><value>Déployer lance l’orchestrateur de séquence de tâches avec les actions WinPE réelles (diskpart, DISM, BCDBoot, injection de pilotes, préparation hors ligne du profil Autopilot).</value></data>
-  <data name="Summary.DebugSafeModeExplanation" xml:space="preserve"><value>Mode debug sécurisé : la séquence de tâches s’exécute en simulation.</value></data>
+  <data name="Summary.AutopilotProfile" xml:space="preserve"><value>Profil Autopilot</value></data>
+  <data name="Summary.SectionTarget" xml:space="preserve"><value>Cible</value></data>
+  <data name="Summary.SectionSystem" xml:space="preserve"><value>Système</value></data>
+  <data name="Summary.SectionDeployment" xml:space="preserve"><value>Options de déploiement</value></data>
   <data name="Debug.ProgressButton" xml:space="preserve"><value>DBG: Progrès</value></data>
   <data name="Debug.SuccessButton" xml:space="preserve"><value>DBG: Succès</value></data>
   <data name="Debug.ErrorButton" xml:space="preserve"><value>DBG: Erreur</value></data>

--- a/src/Foundry.Deploy/Resources/AppStrings.resx
+++ b/src/Foundry.Deploy/Resources/AppStrings.resx
@@ -79,17 +79,15 @@
   <data name="Summary.Title" xml:space="preserve"><value>Deployment Summary</value></data>
   <data name="Summary.TargetDisk" xml:space="preserve"><value>Target Disk</value></data>
   <data name="Summary.NoDiskSelected" xml:space="preserve"><value>No disk selected</value></data>
-  <data name="Summary.SelectedOperatingSystem" xml:space="preserve"><value>Selected Operating System</value></data>
+  <data name="Summary.SelectedOperatingSystem" xml:space="preserve"><value>Operating System</value></data>
   <data name="Summary.NoSelection" xml:space="preserve"><value>No selection</value></data>
   <data name="Summary.SelectedDriverPack" xml:space="preserve"><value>Selected Driver Pack</value></data>
-  <data name="Summary.DriverPackMode" xml:space="preserve"><value>Driver Pack Mode</value></data>
   <data name="Summary.Firmware" xml:space="preserve"><value>Firmware</value></data>
-  <data name="Summary.FirmwareEnabledFormat" xml:space="preserve"><value>Firmware updates enabled: {0}</value></data>
   <data name="Summary.Autopilot" xml:space="preserve"><value>Autopilot</value></data>
-  <data name="Summary.EnabledFormat" xml:space="preserve"><value>Enabled: {0}</value></data>
-  <data name="Summary.SelectedProfileFormat" xml:space="preserve"><value>Selected profile: {0}</value></data>
-  <data name="Summary.DeployExplanation" xml:space="preserve"><value>Deploy launches the deployment task sequence orchestrator with real WinPE actions (diskpart, DISM, BCDBoot, driver injection, offline Autopilot profile staging).</value></data>
-  <data name="Summary.DebugSafeModeExplanation" xml:space="preserve"><value>Debug safe mode: the task sequence runs in simulation.</value></data>
+  <data name="Summary.AutopilotProfile" xml:space="preserve"><value>Autopilot Profile</value></data>
+  <data name="Summary.SectionTarget" xml:space="preserve"><value>Target</value></data>
+  <data name="Summary.SectionSystem" xml:space="preserve"><value>System</value></data>
+  <data name="Summary.SectionDeployment" xml:space="preserve"><value>Deployment Options</value></data>
   <data name="Debug.ProgressButton" xml:space="preserve"><value>DBG: Progress</value></data>
   <data name="Debug.SuccessButton" xml:space="preserve"><value>DBG: Success</value></data>
   <data name="Debug.ErrorButton" xml:space="preserve"><value>DBG: Error</value></data>

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -82,15 +82,9 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     public string SummaryOperatingSystemText => SelectedOperatingSystem is null
         ? GetString("Summary.NoSelection")
         : new Converters.OperatingSystemSummaryConverter().Convert(SelectedOperatingSystem, typeof(string), string.Empty, LocalizationService.CurrentCulture)?.ToString() ?? GetString("Summary.NoSelection");
-    public string SummaryFirmwareText => Format(
-        "Summary.FirmwareEnabledFormat",
-        Preparation.ApplyFirmwareUpdates ? GetString("Common.Enabled") : GetString("Common.Disabled"));
-    public string SummaryAutopilotEnabledText => Format(
-        "Summary.EnabledFormat",
-        Preparation.IsAutopilotEnabled ? GetString("Common.Yes") : GetString("Common.No"));
-    public string SummaryAutopilotProfileText => Format(
-        "Summary.SelectedProfileFormat",
-        Preparation.SelectedAutopilotProfile?.DisplayName ?? GetString("Common.None"));
+    public string SummaryFirmwareText => Preparation.ApplyFirmwareUpdates ? GetString("Common.Enabled") : GetString("Common.Disabled");
+    public string SummaryAutopilotEnabledText => Preparation.IsAutopilotEnabled ? GetString("Common.Yes") : GetString("Common.No");
+    public string SummaryAutopilotProfileText => Preparation.SelectedAutopilotProfile?.DisplayName ?? GetString("Common.None");
 
     public MainWindowViewModel(
         ILocalizationService localizationService,

--- a/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
@@ -9,31 +9,98 @@
         <Border Style="{StaticResource ScrollViewerContentGutterBorderStyle}">
             <StackPanel>
                 <TextBlock
-                    Margin="0,0,0,12"
+                    Margin="0,0,0,16"
                     Style="{StaticResource TitleTextBlockStyle}"
                     Text="{Binding Strings[Summary.Title]}" />
 
-                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.TargetDisk]}" />
-                <TextBlock Margin="0,0,0,8" Text="{Binding SummaryTargetDiskText}" />
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="12" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="12" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="12" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="12" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="12" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="220" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
 
-                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.SelectedOperatingSystem]}" />
-                <TextBlock Margin="0,0,0,8" Text="{Binding SummaryOperatingSystemText}" />
+                    <TextBlock
+                        Margin="0,0,12,0"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{Binding Strings[Summary.TargetDisk]}" />
+                    <TextBlock
+                        Grid.Column="1"
+                        Text="{Binding SummaryTargetDiskText}"
+                        TextWrapping="Wrap" />
 
-                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.SelectedDriverPack]}" />
-                <TextBlock Margin="0,0,0,8" Text="{Binding DriverPackSelection.SelectedDriverPackSelectionDisplay}" />
+                    <TextBlock
+                        Grid.Row="2"
+                        Margin="0,0,12,0"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{Binding Strings[Summary.SelectedOperatingSystem]}" />
+                    <TextBlock
+                        Grid.Row="2"
+                        Grid.Column="1"
+                        Text="{Binding SummaryOperatingSystemText}"
+                        TextWrapping="Wrap" />
 
-                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.DriverPackMode]}" />
-                <TextBlock Margin="0,0,0,8" Text="{Binding DriverPackSelection.DriverPackModeDisplay}" />
+                    <TextBlock
+                        Grid.Row="4"
+                        Margin="0,0,12,0"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{Binding Strings[Summary.SelectedDriverPack]}" />
+                    <TextBlock
+                        Grid.Row="4"
+                        Grid.Column="1"
+                        Text="{Binding DriverPackSelection.SelectedDriverPackSelectionDisplay}"
+                        TextWrapping="Wrap" />
 
-                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.Firmware]}" />
-                <TextBlock Margin="0,0,0,8" Text="{Binding SummaryFirmwareText}" />
+                    <TextBlock
+                        Grid.Row="6"
+                        Margin="0,0,12,0"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{Binding Strings[Summary.DriverPackMode]}" />
+                    <TextBlock
+                        Grid.Row="6"
+                        Grid.Column="1"
+                        Text="{Binding DriverPackSelection.DriverPackModeDisplay}"
+                        TextWrapping="Wrap" />
 
-                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Summary.Autopilot]}" />
-                <TextBlock Margin="0,0,0,4" Text="{Binding SummaryAutopilotEnabledText}" />
-                <TextBlock Margin="0,0,0,8" Text="{Binding SummaryAutopilotProfileText}" />
+                    <TextBlock
+                        Grid.Row="8"
+                        Margin="0,0,12,0"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{Binding Strings[Summary.Firmware]}" />
+                    <TextBlock
+                        Grid.Row="8"
+                        Grid.Column="1"
+                        Text="{Binding SummaryFirmwareText}"
+                        TextWrapping="Wrap" />
+
+                    <TextBlock
+                        Grid.Row="10"
+                        Margin="0,0,12,0"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{Binding Strings[Summary.Autopilot]}" />
+                    <StackPanel Grid.Row="10" Grid.Column="1">
+                        <TextBlock Text="{Binding SummaryAutopilotEnabledText}" TextWrapping="Wrap" />
+                        <TextBlock
+                            Margin="0,4,0,0"
+                            Text="{Binding SummaryAutopilotProfileText}"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
+                </Grid>
 
                 <TextBlock
-                    Margin="0,8,0,0"
+                    Margin="0,16,0,0"
                     Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                     Style="{StaticResource CaptionTextBlockStyle}"
                     Text="{Binding Strings[Summary.DeployExplanation]}" />

--- a/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
@@ -12,7 +12,7 @@
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
-                    <RowDefinition Height="24" />
+                    <RowDefinition Height="16" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
 
@@ -24,28 +24,22 @@
                     Grid.Row="2"
                     Width="760"
                     Margin="0"
-                    Padding="24"
+                    Padding="20"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Stretch"
                     Style="{StaticResource SectionCardBorderStyle}">
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="*" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
+                    <StackPanel VerticalAlignment="Center">
+                        <TextBlock
+                            Margin="0,0,0,12"
+                            Style="{StaticResource SubtitleTextBlockStyle}"
+                            Text="{Binding Strings[Summary.SectionTarget]}" />
 
-                        <Grid VerticalAlignment="Center">
+                        <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
-                                <RowDefinition Height="12" />
+                                <RowDefinition Height="8" />
                                 <RowDefinition Height="Auto" />
-                                <RowDefinition Height="12" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="12" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="12" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="12" />
+                                <RowDefinition Height="8" />
                                 <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
@@ -56,78 +50,115 @@
 
                             <TextBlock
                                 Style="{StaticResource BodyStrongTextBlockStyle}"
-                                Text="{Binding Strings[Summary.TargetDisk]}" />
+                                Text="{Binding Strings[Preparation.ComputerName]}" />
                             <TextBlock
                                 Grid.Column="2"
-                                Text="{Binding SummaryTargetDiskText}"
+                                Text="{Binding Preparation.TargetComputerName}"
                                 TextWrapping="Wrap" />
 
                             <TextBlock
                                 Grid.Row="2"
                                 Style="{StaticResource BodyStrongTextBlockStyle}"
-                                Text="{Binding Strings[Summary.SelectedOperatingSystem]}" />
+                                Text="{Binding Strings[Summary.TargetDisk]}" />
                             <TextBlock
                                 Grid.Row="2"
+                                Grid.Column="2"
+                                Text="{Binding SummaryTargetDiskText}"
+                                TextWrapping="Wrap" />
+                        </Grid>
+
+                        <Separator Margin="0,16,0,16" />
+
+                        <TextBlock
+                            Margin="0,0,0,12"
+                            Style="{StaticResource SubtitleTextBlockStyle}"
+                            Text="{Binding Strings[Summary.SectionSystem]}" />
+
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="8" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="8" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="220" />
+                                <ColumnDefinition Width="24" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+
+                            <TextBlock
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="{Binding Strings[Summary.SelectedOperatingSystem]}" />
+                            <TextBlock
                                 Grid.Column="2"
                                 Text="{Binding SummaryOperatingSystemText}"
                                 TextWrapping="Wrap" />
 
                             <TextBlock
-                                Grid.Row="4"
+                                Grid.Row="2"
                                 Style="{StaticResource BodyStrongTextBlockStyle}"
                                 Text="{Binding Strings[Summary.SelectedDriverPack]}" />
                             <TextBlock
-                                Grid.Row="4"
+                                Grid.Row="2"
                                 Grid.Column="2"
                                 Text="{Binding DriverPackSelection.SelectedDriverPackSelectionDisplay}"
                                 TextWrapping="Wrap" />
+                        </Grid>
+
+                        <Separator Margin="0,16,0,16" />
+
+                        <TextBlock
+                            Margin="0,0,0,12"
+                            Style="{StaticResource SubtitleTextBlockStyle}"
+                            Text="{Binding Strings[Summary.SectionDeployment]}" />
+
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="8" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="8" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="220" />
+                                <ColumnDefinition Width="24" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
 
                             <TextBlock
-                                Grid.Row="6"
-                                Style="{StaticResource BodyStrongTextBlockStyle}"
-                                Text="{Binding Strings[Summary.DriverPackMode]}" />
-                            <TextBlock
-                                Grid.Row="6"
-                                Grid.Column="2"
-                                Text="{Binding DriverPackSelection.DriverPackModeDisplay}"
-                                TextWrapping="Wrap" />
-
-                            <TextBlock
-                                Grid.Row="8"
                                 Style="{StaticResource BodyStrongTextBlockStyle}"
                                 Text="{Binding Strings[Summary.Firmware]}" />
                             <TextBlock
-                                Grid.Row="8"
                                 Grid.Column="2"
                                 Text="{Binding SummaryFirmwareText}"
                                 TextWrapping="Wrap" />
 
                             <TextBlock
-                                Grid.Row="10"
+                                Grid.Row="2"
                                 Style="{StaticResource BodyStrongTextBlockStyle}"
                                 Text="{Binding Strings[Summary.Autopilot]}" />
-                            <StackPanel Grid.Row="10" Grid.Column="2">
-                                <TextBlock Text="{Binding SummaryAutopilotEnabledText}" TextWrapping="Wrap" />
-                                <TextBlock
-                                    Margin="0,4,0,0"
-                                    Text="{Binding SummaryAutopilotProfileText}"
-                                    TextWrapping="Wrap" />
-                            </StackPanel>
-                        </Grid>
+                            <TextBlock
+                                Grid.Row="2"
+                                Grid.Column="2"
+                                Text="{Binding SummaryAutopilotEnabledText}"
+                                TextWrapping="Wrap" />
 
-                        <StackPanel Grid.Row="1" Margin="0,24,0,0">
                             <TextBlock
-                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                Style="{StaticResource CaptionTextBlockStyle}"
-                                Text="{Binding Strings[Summary.DeployExplanation]}" />
+                                Grid.Row="4"
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="{Binding Strings[Summary.AutopilotProfile]}"
+                                Visibility="{Binding Preparation.IsAutopilotEnabled, Converter={StaticResource BooleanToVisibilityConverter}}" />
                             <TextBlock
-                                Margin="0,4,0,0"
-                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                Style="{StaticResource CaptionTextBlockStyle}"
-                                Text="{Binding Strings[Summary.DebugSafeModeExplanation]}"
-                                Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                        </StackPanel>
-                    </Grid>
+                                Grid.Row="4"
+                                Grid.Column="2"
+                                Text="{Binding SummaryAutopilotProfileText}"
+                                TextWrapping="Wrap"
+                                Visibility="{Binding Preparation.IsAutopilotEnabled, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                        </Grid>
+                    </StackPanel>
                 </Border>
             </Grid>
         </Border>

--- a/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
@@ -5,112 +5,131 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <Border Style="{StaticResource ScrollViewerContentGutterBorderStyle}">
-            <StackPanel>
+    <ScrollViewer x:Name="SummaryScrollViewer" VerticalScrollBarVisibility="Auto">
+        <Border
+            MinHeight="{Binding ViewportHeight, ElementName=SummaryScrollViewer}"
+            Style="{StaticResource ScrollViewerContentGutterBorderStyle}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="24" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
                 <TextBlock
-                    Margin="0,0,0,16"
                     Style="{StaticResource TitleTextBlockStyle}"
                     Text="{Binding Strings[Summary.Title]}" />
 
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="12" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="12" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="12" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="12" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="12" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="220" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
+                <Border
+                    Grid.Row="2"
+                    Width="760"
+                    Margin="0"
+                    Padding="24"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Stretch"
+                    Style="{StaticResource SectionCardBorderStyle}">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
 
-                    <TextBlock
-                        Margin="0,0,12,0"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding Strings[Summary.TargetDisk]}" />
-                    <TextBlock
-                        Grid.Column="1"
-                        Text="{Binding SummaryTargetDiskText}"
-                        TextWrapping="Wrap" />
+                        <Grid VerticalAlignment="Center">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="12" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="12" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="12" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="12" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="12" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="220" />
+                                <ColumnDefinition Width="24" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
 
-                    <TextBlock
-                        Grid.Row="2"
-                        Margin="0,0,12,0"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding Strings[Summary.SelectedOperatingSystem]}" />
-                    <TextBlock
-                        Grid.Row="2"
-                        Grid.Column="1"
-                        Text="{Binding SummaryOperatingSystemText}"
-                        TextWrapping="Wrap" />
+                            <TextBlock
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="{Binding Strings[Summary.TargetDisk]}" />
+                            <TextBlock
+                                Grid.Column="2"
+                                Text="{Binding SummaryTargetDiskText}"
+                                TextWrapping="Wrap" />
 
-                    <TextBlock
-                        Grid.Row="4"
-                        Margin="0,0,12,0"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding Strings[Summary.SelectedDriverPack]}" />
-                    <TextBlock
-                        Grid.Row="4"
-                        Grid.Column="1"
-                        Text="{Binding DriverPackSelection.SelectedDriverPackSelectionDisplay}"
-                        TextWrapping="Wrap" />
+                            <TextBlock
+                                Grid.Row="2"
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="{Binding Strings[Summary.SelectedOperatingSystem]}" />
+                            <TextBlock
+                                Grid.Row="2"
+                                Grid.Column="2"
+                                Text="{Binding SummaryOperatingSystemText}"
+                                TextWrapping="Wrap" />
 
-                    <TextBlock
-                        Grid.Row="6"
-                        Margin="0,0,12,0"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding Strings[Summary.DriverPackMode]}" />
-                    <TextBlock
-                        Grid.Row="6"
-                        Grid.Column="1"
-                        Text="{Binding DriverPackSelection.DriverPackModeDisplay}"
-                        TextWrapping="Wrap" />
+                            <TextBlock
+                                Grid.Row="4"
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="{Binding Strings[Summary.SelectedDriverPack]}" />
+                            <TextBlock
+                                Grid.Row="4"
+                                Grid.Column="2"
+                                Text="{Binding DriverPackSelection.SelectedDriverPackSelectionDisplay}"
+                                TextWrapping="Wrap" />
 
-                    <TextBlock
-                        Grid.Row="8"
-                        Margin="0,0,12,0"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding Strings[Summary.Firmware]}" />
-                    <TextBlock
-                        Grid.Row="8"
-                        Grid.Column="1"
-                        Text="{Binding SummaryFirmwareText}"
-                        TextWrapping="Wrap" />
+                            <TextBlock
+                                Grid.Row="6"
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="{Binding Strings[Summary.DriverPackMode]}" />
+                            <TextBlock
+                                Grid.Row="6"
+                                Grid.Column="2"
+                                Text="{Binding DriverPackSelection.DriverPackModeDisplay}"
+                                TextWrapping="Wrap" />
 
-                    <TextBlock
-                        Grid.Row="10"
-                        Margin="0,0,12,0"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{Binding Strings[Summary.Autopilot]}" />
-                    <StackPanel Grid.Row="10" Grid.Column="1">
-                        <TextBlock Text="{Binding SummaryAutopilotEnabledText}" TextWrapping="Wrap" />
-                        <TextBlock
-                            Margin="0,4,0,0"
-                            Text="{Binding SummaryAutopilotProfileText}"
-                            TextWrapping="Wrap" />
-                    </StackPanel>
-                </Grid>
+                            <TextBlock
+                                Grid.Row="8"
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="{Binding Strings[Summary.Firmware]}" />
+                            <TextBlock
+                                Grid.Row="8"
+                                Grid.Column="2"
+                                Text="{Binding SummaryFirmwareText}"
+                                TextWrapping="Wrap" />
 
-                <TextBlock
-                    Margin="0,16,0,0"
-                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                    Style="{StaticResource CaptionTextBlockStyle}"
-                    Text="{Binding Strings[Summary.DeployExplanation]}" />
-                <TextBlock
-                    Margin="0,4,0,0"
-                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                    Style="{StaticResource CaptionTextBlockStyle}"
-                    Text="{Binding Strings[Summary.DebugSafeModeExplanation]}"
-                    Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
-            </StackPanel>
+                            <TextBlock
+                                Grid.Row="10"
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="{Binding Strings[Summary.Autopilot]}" />
+                            <StackPanel Grid.Row="10" Grid.Column="2">
+                                <TextBlock Text="{Binding SummaryAutopilotEnabledText}" TextWrapping="Wrap" />
+                                <TextBlock
+                                    Margin="0,4,0,0"
+                                    Text="{Binding SummaryAutopilotProfileText}"
+                                    TextWrapping="Wrap" />
+                            </StackPanel>
+                        </Grid>
+
+                        <StackPanel Grid.Row="1" Margin="0,24,0,0">
+                            <TextBlock
+                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Text="{Binding Strings[Summary.DeployExplanation]}" />
+                            <TextBlock
+                                Margin="0,4,0,0"
+                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Text="{Binding Strings[Summary.DebugSafeModeExplanation]}"
+                                Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                        </StackPanel>
+                    </Grid>
+                </Border>
+            </Grid>
         </Border>
     </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
## Summary
Improve the Deployment Summary wizard step layout.

## Why
The previous flat label/value stack was harder to scan before starting deployment.

## Changes
- Kept the summary title.
- Reworked summary content into an aligned two-column review grid.
- Added wrapping for longer summary values.
- Preserved the deployment and debug explanations.

## Testing
- Ran `dotnet build src/Foundry.Deploy/Foundry.Deploy.csproj` successfully.

## Notes
- No behavior changes are intended.