### PR TITLE
chore: pause scheduled releases during winui migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - feat/winui-migration
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: Release
 
 on:
-  schedule:
-    - cron: '0 3 * * 0'
+  # Scheduled Sunday releases are disabled during the WinUI migration.
+  # Restore the schedule during the final cutover once the WinUI app is release-ready.
+  # schedule:
+  #   - cron: '0 3 * * 0'
   workflow_dispatch:
     inputs:
       force:
@@ -22,6 +24,7 @@ jobs:
   prepare-release:
     name: Prepare Release
     runs-on: ubuntu-slim
+    if: github.ref == 'refs/heads/main'
     outputs:
       should_release: ${{ steps.compute.outputs.should_release }}
       release_tag: ${{ steps.compute.outputs.release_tag }}

--- a/docs/migration/phases/01-foundation.md
+++ b/docs/migration/phases/01-foundation.md
@@ -7,17 +7,20 @@
 **Goal:** prevent automatic releases and establish a stable migration lane before moving projects.
 
 - [x] **1.1** Create branch `feat/winui-migration` from `main`.
-- [ ] **1.2** Disable the Sunday automatic release in `.github\workflows\release.yml`.
-- [ ] **1.3** Keep `workflow_dispatch` release capability available for manual emergency releases.
-- [ ] **1.4** Add a clear workflow comment explaining the schedule is disabled during the WinUI migration.
-- [ ] **1.5** Keep CI on `main` and PRs to `main`.
-- [ ] **1.6** Run the full CI matrix for PRs targeting `feat/winui-migration`.
-- [ ] **1.7** Record the last known good release tag before migration starts.
-- [ ] **1.8** Record current release asset names and consumers.
-- [ ] **1.9** Confirm branch protection on `main`.
-- [ ] **1.10** Confirm `feat/winui-migration` is not used for production releases.
-- [ ] **1.11** Create a GitHub milestone or issue set for the migration phases.
-- [ ] **1.12** Commit:
+- [x] **1.2** Disable the Sunday automatic release in `.github\workflows\release.yml`.
+- [x] **1.3** Keep `workflow_dispatch` release capability available for manual emergency releases.
+- [x] **1.4** Add a clear workflow comment explaining the schedule is disabled during the WinUI migration.
+- [x] **1.5** Keep CI on `main` and PRs to `main`.
+- [x] **1.6** Run the full CI matrix for PRs targeting `feat/winui-migration`.
+- [x] **1.7** Record the last known good release tag before migration starts: `v26.4.26.1`.
+- [x] **1.8** Record current release asset names and consumers:
+  - [x] Main app release assets: `Foundry-x64.exe`, `Foundry-arm64.exe`.
+  - [x] Runtime release assets: `Foundry.Connect-win-x64.zip`, `Foundry.Connect-win-arm64.zip`, `Foundry.Deploy-win-x64.zip`, `Foundry.Deploy-win-arm64.zip`.
+  - [x] Current consumers: README download badges consume the main app assets; WinPE bootstrap/local embedding consumes Connect and Deploy zip assets.
+- [x] **1.9** Confirm branch protection state on `main`: branch protection is currently not configured.
+- [x] **1.10** Confirm `feat/winui-migration` is not used for production releases: release jobs are restricted to `refs/heads/main`.
+- [x] **1.11** Create a GitHub milestone or issue set for the migration phases: issue `#107`.
+- [x] **1.12** Commit:
 
 ```powershell
 git commit -m "chore: pause scheduled releases during winui migration"
@@ -25,9 +28,9 @@ git commit -m "chore: pause scheduled releases during winui migration"
 
 **Validation**
 
-- [ ] **1.13** `git diff -- .github\workflows\release.yml`.
-- [ ] **1.14** Confirm no scheduled release can run automatically.
-- [ ] **1.15** Confirm manual release dispatch still exists.
+- [x] **1.13** `git diff -- .github\workflows\release.yml`.
+- [x] **1.14** Confirm no scheduled release can run automatically.
+- [x] **1.15** Confirm manual release dispatch still exists.
 
 ## Phase 2: Repository Shape And Project Boundary Decision
 


### PR DESCRIPTION
## Summary

- Pauses the scheduled Sunday release while the WinUI migration is in progress.
- Keeps manual `workflow_dispatch` releases available.
- Runs CI for pull requests targeting `feat/winui-migration`.
- Records Phase 1 migration progress in the migration plan.

## Reason

The migration needs a stable integration branch without accidental production releases while the WPF app is progressively replaced by the WinUI app.

## Main Changes

- Comments out the Sunday release schedule in `.github/workflows/release.yml`.
- Restricts release jobs to `refs/heads/main`.
- Adds `feat/winui-migration` to CI pull request targets.
- Records the latest known release tag, current release assets, branch protection state, and tracking issue.

## Testing Notes

- Verified release workflow diff.
- Verified no active `schedule:` trigger remains in the release workflow.
- Verified `workflow_dispatch` remains present.
- Verified CI pull request targets include both `main` and `feat/winui-migration`.
- Ran `git diff --check`.