### PR TITLE
refactor: define winui application service boundaries

### DIFF
--- a/docs/migration/phases/02-core-extraction.md
+++ b/docs/migration/phases/02-core-extraction.md
@@ -81,33 +81,33 @@ git commit -m "refactor: extract foundry core project"
 
 **Goal:** reduce `MainWindowViewModel` risk before translating it into WinUI pages.
 
-- [ ] **5.1** Read archived `MainWindowViewModel.cs` as reference only.
-- [ ] **5.2** Identify all responsibilities:
-  - [ ] App menu commands.
-  - [ ] Theme selection.
-  - [ ] Language selection.
-  - [ ] ADK status and install/upgrade.
-  - [ ] ISO output selection.
-  - [ ] USB candidate refresh.
-  - [ ] ISO creation.
-  - [ ] USB creation.
-  - [ ] Expert configuration import/export.
-  - [ ] Deploy configuration export.
-  - [ ] Progress/status display.
-  - [ ] Update check.
-  - [ ] About/help links.
-- [ ] **5.3** Create thin service contracts for UI-facing operations:
-  - [ ] `IFilePickerService`.
-  - [ ] `IDialogService`.
-  - [ ] `IApplicationLifetimeService`.
-  - [ ] `IExternalProcessLauncher`.
-  - [ ] `IAppDispatcher`.
-- [ ] **5.4** Keep service interfaces platform-neutral where possible.
-- [ ] **5.5** Implement WinUI versions in the `Foundry` app project, not in `Foundry.Core`.
-- [ ] **5.6** Identify duplicated or awkward logic that can be simplified during extraction without changing runtime behavior.
-- [ ] **5.7** Record any targeted `Foundry.Connect` or `Foundry.Deploy` changes needed to simplify shared contracts.
-- [ ] **5.8** Keep WPF reference unchanged.
-- [ ] **5.9** Commit:
+- [x] **5.1** Read archived `MainWindowViewModel.cs` as reference only.
+- [x] **5.2** Identify all responsibilities:
+  - [x] App menu commands.
+  - [x] Theme selection.
+  - [x] Language selection.
+  - [x] ADK status and install/upgrade.
+  - [x] ISO output selection.
+  - [x] USB candidate refresh.
+  - [x] ISO creation.
+  - [x] USB creation.
+  - [x] Expert configuration import/export.
+  - [x] Deploy configuration export.
+  - [x] Progress/status display.
+  - [x] Update check.
+  - [x] About/help links.
+- [x] **5.3** Create thin service contracts for UI-facing operations:
+  - [x] `IFilePickerService`.
+  - [x] `IDialogService`.
+  - [x] `IApplicationLifetimeService`.
+  - [x] `IExternalProcessLauncher`.
+  - [x] `IAppDispatcher`.
+- [x] **5.4** Keep service interfaces platform-neutral where possible.
+- [x] **5.5** Implement WinUI versions in the `Foundry` app project, not in `Foundry.Core`.
+- [x] **5.6** Identify duplicated or awkward logic that can be simplified during extraction without changing runtime behavior.
+- [x] **5.7** Record any targeted `Foundry.Connect` or `Foundry.Deploy` changes needed to simplify shared contracts.
+- [x] **5.8** Keep WPF reference unchanged.
+- [x] **5.9** Commit:
 
 ```powershell
 git commit -m "refactor: define winui application service boundaries"
@@ -115,6 +115,24 @@ git commit -m "refactor: define winui application service boundaries"
 
 **Validation**
 
-- [ ] **5.10** Confirm `Foundry.Core` has no dependency on `Microsoft.UI.Xaml`.
-- [ ] **5.11** Confirm `Foundry.Core` has no dependency on `System.Windows`.
-- [ ] **5.12** Confirm app project owns all WinUI-specific service implementations.
+- [x] **5.10** Confirm `Foundry.Core` has no dependency on `Microsoft.UI.Xaml`.
+- [x] **5.11** Confirm `Foundry.Core` has no dependency on `System.Windows`.
+- [x] **5.12** Confirm app project owns all WinUI-specific service implementations.
+
+**Phase 5 notes**
+
+- [x] `Foundry.Core` owns neutral contracts only:
+  - [x] Picker request/choice DTOs.
+  - [x] Dialog request DTOs.
+  - [x] `IFilePickerService`, `IDialogService`, `IApplicationLifetimeService`, `IExternalProcessLauncher`, `IAppDispatcher`.
+- [x] `Foundry` owns WinUI implementations:
+  - [x] `WinUiFilePickerService` using Windows App SDK pickers tied to the main `AppWindow.Id`.
+  - [x] `WinUiDialogService` using WinUI `ContentDialog`.
+  - [x] `WinUiAppDispatcher` using WinUI `DispatcherQueue`.
+  - [x] `WinUiApplicationLifetimeService` using WinUI application lifetime.
+  - [x] `WinUiExternalProcessLauncher` using shell execution for URLs, files, and folders.
+- [x] Future simplification candidates:
+  - [x] Replace broad WPF `ApplicationShellService` usage with focused picker, dialog, launcher, lifetime, and dispatcher contracts.
+  - [x] Keep file/folder picking asynchronous in WinUI instead of preserving synchronous WPF dialog calls.
+  - [x] Keep `MainWindowViewModel` port split by navigation page rather than recreating one large shell view model.
+- [x] No targeted `Foundry.Connect` or `Foundry.Deploy` changes are needed for these service-boundary contracts.

--- a/src/Foundry.Core/Services/Application/ConfirmationDialogRequest.cs
+++ b/src/Foundry.Core/Services/Application/ConfirmationDialogRequest.cs
@@ -1,0 +1,7 @@
+namespace Foundry.Core.Services.Application;
+
+public sealed record ConfirmationDialogRequest(
+    string Title,
+    string Message,
+    string PrimaryButtonText,
+    string CancelButtonText);

--- a/src/Foundry.Core/Services/Application/DialogRequest.cs
+++ b/src/Foundry.Core/Services/Application/DialogRequest.cs
@@ -1,0 +1,6 @@
+namespace Foundry.Core.Services.Application;
+
+public sealed record DialogRequest(
+    string Title,
+    string Message,
+    string CloseButtonText = "OK");

--- a/src/Foundry.Core/Services/Application/FileOpenPickerRequest.cs
+++ b/src/Foundry.Core/Services/Application/FileOpenPickerRequest.cs
@@ -1,0 +1,6 @@
+namespace Foundry.Core.Services.Application;
+
+public sealed record FileOpenPickerRequest(
+    string Title,
+    IReadOnlyList<string> FileTypeFilters,
+    string? SuggestedFolderPath = null);

--- a/src/Foundry.Core/Services/Application/FilePickerTypeChoice.cs
+++ b/src/Foundry.Core/Services/Application/FilePickerTypeChoice.cs
@@ -1,0 +1,3 @@
+namespace Foundry.Core.Services.Application;
+
+public sealed record FilePickerTypeChoice(string Name, IReadOnlyList<string> Extensions);

--- a/src/Foundry.Core/Services/Application/FileSavePickerRequest.cs
+++ b/src/Foundry.Core/Services/Application/FileSavePickerRequest.cs
@@ -1,0 +1,8 @@
+namespace Foundry.Core.Services.Application;
+
+public sealed record FileSavePickerRequest(
+    string Title,
+    string SuggestedFileName,
+    IReadOnlyList<FilePickerTypeChoice> FileTypeChoices,
+    string? DefaultFileExtension = null,
+    string? SuggestedFolderPath = null);

--- a/src/Foundry.Core/Services/Application/FolderPickerRequest.cs
+++ b/src/Foundry.Core/Services/Application/FolderPickerRequest.cs
@@ -1,0 +1,5 @@
+namespace Foundry.Core.Services.Application;
+
+public sealed record FolderPickerRequest(
+    string Title,
+    string? SuggestedFolderPath = null);

--- a/src/Foundry.Core/Services/Application/IAppDispatcher.cs
+++ b/src/Foundry.Core/Services/Application/IAppDispatcher.cs
@@ -1,0 +1,8 @@
+namespace Foundry.Core.Services.Application;
+
+public interface IAppDispatcher
+{
+    bool HasThreadAccess { get; }
+    bool TryEnqueue(Action action);
+    Task EnqueueAsync(Action action);
+}

--- a/src/Foundry.Core/Services/Application/IApplicationLifetimeService.cs
+++ b/src/Foundry.Core/Services/Application/IApplicationLifetimeService.cs
@@ -1,0 +1,6 @@
+namespace Foundry.Core.Services.Application;
+
+public interface IApplicationLifetimeService
+{
+    void Shutdown();
+}

--- a/src/Foundry.Core/Services/Application/IDialogService.cs
+++ b/src/Foundry.Core/Services/Application/IDialogService.cs
@@ -1,0 +1,7 @@
+namespace Foundry.Core.Services.Application;
+
+public interface IDialogService
+{
+    Task ShowMessageAsync(DialogRequest request);
+    Task<bool> ConfirmAsync(ConfirmationDialogRequest request);
+}

--- a/src/Foundry.Core/Services/Application/IExternalProcessLauncher.cs
+++ b/src/Foundry.Core/Services/Application/IExternalProcessLauncher.cs
@@ -1,0 +1,8 @@
+namespace Foundry.Core.Services.Application;
+
+public interface IExternalProcessLauncher
+{
+    Task OpenUriAsync(Uri uri);
+    Task OpenFolderAsync(string folderPath);
+    Task OpenFileAsync(string filePath);
+}

--- a/src/Foundry.Core/Services/Application/IFilePickerService.cs
+++ b/src/Foundry.Core/Services/Application/IFilePickerService.cs
@@ -1,0 +1,8 @@
+namespace Foundry.Core.Services.Application;
+
+public interface IFilePickerService
+{
+    Task<string?> PickOpenFileAsync(FileOpenPickerRequest request);
+    Task<string?> PickSaveFileAsync(FileSavePickerRequest request);
+    Task<string?> PickFolderAsync(FolderPickerRequest request);
+}

--- a/src/Foundry/App.xaml.cs
+++ b/src/Foundry/App.xaml.cs
@@ -30,6 +30,11 @@
             var services = new ServiceCollection();
             services.AddSingleton<IThemeService, ThemeService>();
             services.AddSingleton<IJsonNavigationService, JsonNavigationService>();
+            services.AddSingleton<Foundry.Core.Services.Application.IApplicationLifetimeService, Services.Application.WinUiApplicationLifetimeService>();
+            services.AddSingleton<Foundry.Core.Services.Application.IAppDispatcher, Services.Application.WinUiAppDispatcher>();
+            services.AddSingleton<Foundry.Core.Services.Application.IDialogService, Services.Application.WinUiDialogService>();
+            services.AddSingleton<Foundry.Core.Services.Application.IExternalProcessLauncher, Services.Application.WinUiExternalProcessLauncher>();
+            services.AddSingleton<Foundry.Core.Services.Application.IFilePickerService, Services.Application.WinUiFilePickerService>();
 
             services.AddTransient<MainViewModel>();
             services.AddSingleton<ContextMenuService>();

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -65,4 +65,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Velopack" Version="0.0.1589-ga2c5a97" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Foundry.Core\Foundry.Core.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Foundry/Services/Application/WinUiAppDispatcher.cs
+++ b/src/Foundry/Services/Application/WinUiAppDispatcher.cs
@@ -1,0 +1,59 @@
+using Foundry.Core.Services.Application;
+using Microsoft.UI.Dispatching;
+
+namespace Foundry.Services.Application;
+
+public sealed class WinUiAppDispatcher : IAppDispatcher
+{
+    public bool HasThreadAccess => GetDispatcherQueue().HasThreadAccess;
+
+    public bool TryEnqueue(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        DispatcherQueue dispatcherQueue = GetDispatcherQueue();
+        if (dispatcherQueue.HasThreadAccess)
+        {
+            action();
+            return true;
+        }
+
+        return dispatcherQueue.TryEnqueue(() => action());
+    }
+
+    public Task EnqueueAsync(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        DispatcherQueue dispatcherQueue = GetDispatcherQueue();
+        if (dispatcherQueue.HasThreadAccess)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!dispatcherQueue.TryEnqueue(() =>
+            {
+                try
+                {
+                    action();
+                    completion.SetResult();
+                }
+                catch (Exception ex)
+                {
+                    completion.SetException(ex);
+                }
+            }))
+        {
+            completion.SetException(new InvalidOperationException("Unable to enqueue work on the WinUI dispatcher."));
+        }
+
+        return completion.Task;
+    }
+
+    private static DispatcherQueue GetDispatcherQueue()
+    {
+        return App.MainWindow.DispatcherQueue ?? DispatcherQueue.GetForCurrentThread();
+    }
+}

--- a/src/Foundry/Services/Application/WinUiApplicationLifetimeService.cs
+++ b/src/Foundry/Services/Application/WinUiApplicationLifetimeService.cs
@@ -1,0 +1,11 @@
+using Foundry.Core.Services.Application;
+
+namespace Foundry.Services.Application;
+
+public sealed class WinUiApplicationLifetimeService : IApplicationLifetimeService
+{
+    public void Shutdown()
+    {
+        Microsoft.UI.Xaml.Application.Current.Exit();
+    }
+}

--- a/src/Foundry/Services/Application/WinUiDialogService.cs
+++ b/src/Foundry/Services/Application/WinUiDialogService.cs
@@ -1,0 +1,43 @@
+using Foundry.Core.Services.Application;
+
+namespace Foundry.Services.Application;
+
+public sealed class WinUiDialogService : IDialogService
+{
+    public async Task ShowMessageAsync(DialogRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var dialog = new ContentDialog
+        {
+            Title = request.Title,
+            Content = request.Message,
+            CloseButtonText = request.CloseButtonText,
+            XamlRoot = GetXamlRoot()
+        };
+
+        await dialog.ShowAsync();
+    }
+
+    public async Task<bool> ConfirmAsync(ConfirmationDialogRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var dialog = new ContentDialog
+        {
+            Title = request.Title,
+            Content = request.Message,
+            PrimaryButtonText = request.PrimaryButtonText,
+            CloseButtonText = request.CancelButtonText,
+            XamlRoot = GetXamlRoot()
+        };
+
+        ContentDialogResult result = await dialog.ShowAsync();
+        return result == ContentDialogResult.Primary;
+    }
+
+    private static XamlRoot GetXamlRoot()
+    {
+        return App.MainWindow.Content.XamlRoot;
+    }
+}

--- a/src/Foundry/Services/Application/WinUiExternalProcessLauncher.cs
+++ b/src/Foundry/Services/Application/WinUiExternalProcessLauncher.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics;
+using Foundry.Core.Services.Application;
+
+namespace Foundry.Services.Application;
+
+public sealed class WinUiExternalProcessLauncher : IExternalProcessLauncher
+{
+    public Task OpenUriAsync(Uri uri)
+    {
+        ArgumentNullException.ThrowIfNull(uri);
+        Open(uri.AbsoluteUri);
+        return Task.CompletedTask;
+    }
+
+    public Task OpenFolderAsync(string folderPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(folderPath);
+        Directory.CreateDirectory(folderPath);
+        Open(folderPath);
+        return Task.CompletedTask;
+    }
+
+    public Task OpenFileAsync(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        Open(filePath);
+        return Task.CompletedTask;
+    }
+
+    private static void Open(string target)
+    {
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = target,
+            UseShellExecute = true
+        });
+    }
+}

--- a/src/Foundry/Services/Application/WinUiFilePickerService.cs
+++ b/src/Foundry/Services/Application/WinUiFilePickerService.cs
@@ -1,0 +1,86 @@
+using Foundry.Core.Services.Application;
+using Microsoft.Windows.Storage.Pickers;
+
+namespace Foundry.Services.Application;
+
+public sealed class WinUiFilePickerService : IFilePickerService
+{
+    public async Task<string?> PickOpenFileAsync(FileOpenPickerRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var picker = new FileOpenPicker(App.MainWindow.AppWindow.Id)
+        {
+            Title = request.Title
+        };
+
+        foreach (string filter in NormalizeFileTypeFilters(request.FileTypeFilters))
+        {
+            picker.FileTypeFilter.Add(filter);
+        }
+
+        PickFileResult? result = await picker.PickSingleFileAsync();
+        return result?.Path;
+    }
+
+    public async Task<string?> PickSaveFileAsync(FileSavePickerRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var picker = new FileSavePicker(App.MainWindow.AppWindow.Id)
+        {
+            Title = request.Title,
+            SuggestedFileName = request.SuggestedFileName,
+            DefaultFileExtension = request.DefaultFileExtension ?? ResolveDefaultExtension(request.FileTypeChoices)
+        };
+
+        foreach (FilePickerTypeChoice choice in request.FileTypeChoices)
+        {
+            picker.FileTypeChoices.Add(choice.Name, choice.Extensions.Select(NormalizeExtension).ToList());
+        }
+
+        PickFileResult? result = await picker.PickSaveFileAsync();
+        return result?.Path;
+    }
+
+    public async Task<string?> PickFolderAsync(FolderPickerRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var picker = new FolderPicker(App.MainWindow.AppWindow.Id)
+        {
+            Title = request.Title
+        };
+
+        PickFolderResult? result = await picker.PickSingleFolderAsync();
+        return result?.Path;
+    }
+
+    private static IReadOnlyList<string> NormalizeFileTypeFilters(IReadOnlyList<string> filters)
+    {
+        if (filters.Count == 0)
+        {
+            return ["*"];
+        }
+
+        return filters.Select(NormalizeExtension).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+    }
+
+    private static string NormalizeExtension(string extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension) || extension.Trim() == "*")
+        {
+            return "*";
+        }
+
+        string trimmed = extension.Trim();
+        return trimmed.StartsWith(".", StringComparison.Ordinal) ? trimmed : $".{trimmed}";
+    }
+
+    private static string? ResolveDefaultExtension(IReadOnlyList<FilePickerTypeChoice> choices)
+    {
+        return choices.FirstOrDefault()?.Extensions.FirstOrDefault() is { } extension
+            ? NormalizeExtension(extension)
+            : null;
+    }
+}


### PR DESCRIPTION
Summary:
- Add platform-neutral application service contracts in Foundry.Core.
- Add WinUI implementations for picker, dialog, dispatcher, lifetime, and external launching services in Foundry.
- Register the new service boundaries in the WinUI app DI container and update Phase 5 migration plan notes.

Reason:
This reduces the risk of porting the archived WPF MainWindowViewModel by separating UI-facing operations from future page and view model logic.

Main changes:
- Introduce IFilePickerService, IDialogService, IApplicationLifetimeService, IExternalProcessLauncher, and IAppDispatcher.
- Use Windows App SDK pickers through the Foundry WinUI app implementation.
- Keep Foundry.Core free of WinUI and WPF framework references.
- Record future simplification candidates and confirm no Foundry.Connect or Foundry.Deploy changes are required in this phase.

Testing:
- dotnet test .\src\Foundry.Core.Tests\Foundry.Core.Tests.csproj -c Release --no-restore --nologo
- dotnet build .\src\Foundry.slnx -c Release -p:Platform=x64 --no-restore --nologo
- dotnet build .\src\Foundry.slnx -c Release -p:Platform=ARM64 --no-restore --nologo

Known warnings are from the existing WinUI template project and remain outside this phase scope.