### PR TITLE
fix: include winui xaml assets in velopack package

### DIFF
--- a/scripts/Publish-FoundryVelopack.ps1
+++ b/scripts/Publish-FoundryVelopack.ps1
@@ -25,6 +25,8 @@ $releaseNotesPath = Join-Path $artifactsRoot 'release-notes.md'
 $platform = if ($RuntimeIdentifier -eq 'win-x64') { 'x64' } else { 'ARM64' }
 $artifactArchitecture = if ($RuntimeIdentifier -eq 'win-x64') { 'x64' } else { 'arm64' }
 $velopackChannel = $RuntimeIdentifier
+$targetFramework = 'net10.0-windows10.0.26100.0'
+$runtimeBuildDir = Join-Path $repoRoot "src\Foundry\bin\$platform\$Configuration\$targetFramework\$RuntimeIdentifier"
 
 if (-not ($PackVersion -match '^(?<year>\d{2})\.(?<month>\d{1,2})\.(?<day>\d{1,2})-build\.(?<build>\d+)$')) {
     throw "PackVersion '$PackVersion' must use YY.M.D-build.Build."
@@ -91,6 +93,26 @@ if ($LASTEXITCODE -ne 0) {
 $foundryExe = Join-Path $publishDir 'Foundry.exe'
 if (-not (Test-Path -Path $foundryExe -PathType Leaf)) {
     throw "Expected Foundry executable was not published: '$foundryExe'."
+}
+
+$winUiResourceFiles = @('App.xbf', 'Foundry.pri')
+foreach ($file in $winUiResourceFiles) {
+    $source = Join-Path $runtimeBuildDir $file
+    if (-not (Test-Path -Path $source -PathType Leaf)) {
+        throw "Expected WinUI resource file was not built: '$source'."
+    }
+
+    Copy-Item -Path $source -Destination (Join-Path $publishDir $file) -Force
+}
+
+$winUiResourceDirectories = @('Themes', 'Views')
+foreach ($directory in $winUiResourceDirectories) {
+    $source = Join-Path $runtimeBuildDir $directory
+    if (-not (Test-Path -Path $source -PathType Container)) {
+        throw "Expected WinUI resource directory was not built: '$source'."
+    }
+
+    Copy-Item -Path $source -Destination $publishDir -Recurse -Force
 }
 
 & $vpkExe pack `


### PR DESCRIPTION
## Summary
- Copy Foundry WinUI compiled XAML resources into the Velopack packaging directory.
- Fail packaging early if the expected WinUI resource payload is missing.

## Reason
The MSI installed successfully, but the installed app crashed at startup with `Microsoft.UI.Xaml.Markup.XamlParseException` while loading `MainWindow`. The same crash reproduced from the raw publish directory. The publish directory was missing Foundry app XAML resources (`App.xbf`, `Foundry.pri`, `Views/*.xbf`, `Themes/*.xbf`) even though the runtime build output contained them.

## Main changes
- Keep `dotnet publish` as the base packaging source.
- Copy required WinUI XAML resource files and directories from the runtime build output into the Velopack `packDir` before `vpk pack`.
- Validate those files exist before packaging.

## Testing
- `dotnet restore .\src\Foundry.slnx --nologo`
- `dotnet build .\src\Foundry.slnx -c Release -p:Platform=x64 --no-restore --nologo`
- `dotnet build .\src\Foundry.slnx -c Release -p:Platform=ARM64 --no-restore --nologo`
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File .\scripts\Publish-FoundryVelopack.ps1 -RuntimeIdentifier win-x64 -PackVersion 26.4.30-build.2`
- Confirmed generated packDir contains `App.xbf`, `Foundry.pri`, `Views\MainWindow.xbf`, and `Themes\Styles.xbf`.
- Manual validation: generated exe and MSI both launch successfully.