### PR TITLE
feat: migrate foundry localization to winui

### DIFF
--- a/docs/migration/phases/04-localization-logging-shell.md
+++ b/docs/migration/phases/04-localization-logging-shell.md
@@ -6,70 +6,70 @@
 
 **Goal:** replace WPF `.resx`/indexer binding behavior in the main `Foundry` app with a `.resw` WinUI localization system.
 
-- [ ] **9.1** Inventory current localization keys:
-  - [ ] `archive\Foundry.WpfReference\Resources\AppStrings.resx`.
-  - [ ] `archive\Foundry.WpfReference\Resources\AppStrings.fr-FR.resx`.
-  - [ ] Reuse the proven reference pattern from `E:\Github\Bucket_v2_old`:
-    - [ ] `src\Bucket.Core\Services\LocalizationService.cs`.
-    - [ ] `src\Bucket.App\Assets\NavViewMenu\AppData.json`.
-    - [ ] `src\Bucket.App\Strings\en-US\Resources.resw`.
-    - [ ] `src\Bucket.App\Strings\fr-FR\Resources.resw`.
-    - [ ] `src\Bucket.App\Views\Settings\GeneralSettingPage.xaml.cs`.
-    - [ ] `src\Bucket.App\Views\MainWindow.xaml.cs`.
-  - [ ] DevWinUI prototype shell text:
-    - [ ] `src\Foundry\Assets\NavViewMenu\AppData.json`.
-    - [ ] `dev:BreadcrumbNavigator.PageTitle` and `BreadCrumbHeader` values.
-    - [ ] DevWinUI settings cards, title bar search text, tooltips, badges, and landing page strings.
-- [ ] **9.2** Use the decided target resource format:
-  - [ ] Use `.resw` for all migrated WinUI `Foundry` UI text.
-  - [ ] Use `.resw` for view-model-facing user-visible text in the WinUI `Foundry` app.
-  - [ ] Do not keep `.resx` localization in the migrated WinUI `Foundry` app.
-  - [ ] Keep `.resx` only in WPF `Foundry.Connect` and `Foundry.Deploy`.
-  - [ ] Add `.resw` files as MSBuild `AdditionalFiles` if required by `DevWinUI.SourceGenerator`.
-- [ ] **9.3** Define localization layers:
-  - [ ] UI resources for XAML text.
-  - [ ] ViewModel text service for computed labels/status.
-  - [ ] Core codes, values, or invariant diagnostics that can be mapped to `.resw` text by the WinUI app.
-  - [ ] Use `Microsoft.Windows.ApplicationModel.Resources.ResourceManager` with a language-specific `ResourceContext` for view-model-facing string lookup.
-  - [ ] Do not rely only on `ResourceLoader` for runtime language changes, because the old DevWinUI project used `ResourceManager` + `ResourceContext.QualifierValues["Language"]` successfully for hot switching.
-  - [ ] Keep `Foundry.Core` free of Windows App SDK resource APIs; the WinUI app owns `.resw` lookup and localized display strings.
-  - [ ] DevWinUI navigation metadata:
-    - [ ] Use `LocalizeId` and `UsexUid=true` in `AppData.json` for NavigationView groups/items when supported by DevWinUI.
-    - [ ] Use resource keys shaped like the proven reference pattern, for example `Nav_HomeKey.Title`.
-    - [ ] Keep literal `Title` values only as fallback/default design-time text.
-    - [ ] Do not invent per-language JSON files or per-language `Title` maps unless DevWinUI localization support proves insufficient.
-  - [ ] DevWinUI breadcrumb and settings navigation text:
-    - [ ] Replace hardcoded `BreadCrumbHeader` and settings-card strings with resource-backed values.
-    - [ ] Ensure generated breadcrumb mappings and runtime navigation parameters receive localized text.
-- [ ] **9.4** Implement missing-key behavior:
-  - [ ] Development mode logs missing keys.
-  - [ ] Production mode falls back safely.
-  - [ ] Invalid persisted language values fall back to `en-US` and are rewritten to `appsettings.json`.
-- [ ] **9.5** Implement culture switching:
-  - [ ] Initialize localization before `MainWindow.InitializeComponent()` and before `JsonNavigationService.ConfigureJsonFile(...)`.
-  - [ ] Menu/settings command updates the selected language.
-  - [ ] Persist the selected BCP-47 language tag to `C:\ProgramData\Foundry\Settings\appsettings.json`.
-  - [ ] Set `Microsoft.Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride` during startup before localized resources are loaded.
-  - [ ] Set `ApplicationLanguages.PrimaryLanguageOverride` again when the user changes language at runtime.
-  - [ ] Update the active `ResourceContext.QualifierValues["Language"]` when the user changes language at runtime.
-  - [ ] Expose a language change event from `IApplicationLocalizationService`.
-  - [ ] ViewModels refresh computed strings.
-  - [ ] Pages reload or rebind localized text.
-  - [ ] DevWinUI NavigationView groups/items, breadcrumbs, settings cards, title bar search text, and landing page strings refresh without restarting the app.
-  - [ ] Reinitialize DevWinUI `JsonNavigationService` after runtime language changes, following the old `Bucket_v2_old` pattern that calls `JsonNavigationService.ReInitialize()`.
-  - [ ] Add a controlled Foundry wrapper around DevWinUI navigation refresh if direct `ReInitialize()` is not sufficient or becomes version-sensitive.
-  - [ ] Do not require an application restart for language changes.
-  - [ ] If a WinUI resource was already loaded before the language change, explicitly reload or rebind that UI surface after changing `PrimaryLanguageOverride`.
-- [ ] **9.6** Migrate languages:
-  - [ ] `en-US`.
-  - [ ] `fr-FR`.
-- [ ] **9.7** Migrate supported culture catalog tests.
-- [ ] **9.7.1** Verify DevWinUI localization behavior against current DevWinUI docs/source before implementation:
-  - [ ] Confirm `LocalizeId` resource-key naming requirements.
-  - [ ] Confirm `UsexUid=true` behavior for NavigationView groups and items.
-  - [ ] Confirm whether `JsonNavigationService.ReInitialize()` still refreshes localized navigation items in the current DevWinUI package version.
-  - [ ] Document any DevWinUI limitation that requires an app-owned refresh workaround.
-- [ ] **9.8** Commit:
+- [x] **9.1** Inventory current localization keys:
+  - [x] `archive\Foundry.WpfReference\Resources\AppStrings.resx`.
+  - [x] `archive\Foundry.WpfReference\Resources\AppStrings.fr-FR.resx`.
+  - [x] Reuse the proven reference pattern from `E:\Github\Bucket_v2_old`:
+    - [x] `src\Bucket.Core\Services\LocalizationService.cs`.
+    - [x] `src\Bucket.App\Assets\NavViewMenu\AppData.json`.
+    - [x] `src\Bucket.App\Strings\en-US\Resources.resw`.
+    - [x] `src\Bucket.App\Strings\fr-FR\Resources.resw`.
+    - [x] `src\Bucket.App\Views\Settings\GeneralSettingPage.xaml.cs`.
+    - [x] `src\Bucket.App\Views\MainWindow.xaml.cs`.
+  - [x] DevWinUI prototype shell text:
+    - [x] `src\Foundry\Assets\NavViewMenu\AppData.json`.
+    - [x] `dev:BreadcrumbNavigator.PageTitle` and `BreadCrumbHeader` values.
+    - [x] DevWinUI settings cards, title bar search text, tooltips, badges, and landing page strings.
+- [x] **9.2** Use the decided target resource format:
+  - [x] Use `.resw` for all migrated WinUI `Foundry` UI text.
+  - [x] Use `.resw` for view-model-facing user-visible text in the WinUI `Foundry` app.
+  - [x] Do not keep `.resx` localization in the migrated WinUI `Foundry` app.
+  - [x] Keep `.resx` only in WPF `Foundry.Connect` and `Foundry.Deploy`.
+  - [x] Add `.resw` files as MSBuild `AdditionalFiles` if required by `DevWinUI.SourceGenerator`.
+- [x] **9.3** Define localization layers:
+  - [x] UI resources for XAML text.
+  - [x] ViewModel text service for computed labels/status.
+  - [x] Core codes, values, or invariant diagnostics that can be mapped to `.resw` text by the WinUI app.
+  - [x] Use `Microsoft.Windows.ApplicationModel.Resources.ResourceManager` with a language-specific `ResourceContext` for view-model-facing string lookup.
+  - [x] Do not rely only on `ResourceLoader` for runtime language changes, because the old DevWinUI project used `ResourceManager` + `ResourceContext.QualifierValues["Language"]` successfully for hot switching.
+  - [x] Keep `Foundry.Core` free of Windows App SDK resource APIs; the WinUI app owns `.resw` lookup and localized display strings.
+  - [x] DevWinUI navigation metadata:
+    - [x] Use `LocalizeId` and `UsexUid=true` in `AppData.json` for NavigationView groups/items when supported by DevWinUI.
+    - [x] Use resource keys shaped like the proven reference pattern, for example `Nav_HomeKey.Title`.
+    - [x] Keep literal `Title` values only as fallback/default design-time text.
+    - [x] Do not invent per-language JSON files or per-language `Title` maps unless DevWinUI localization support proves insufficient.
+  - [x] DevWinUI breadcrumb and settings navigation text:
+    - [x] Replace hardcoded `BreadCrumbHeader` and settings-card strings with resource-backed values.
+    - [x] Ensure generated breadcrumb mappings and runtime navigation parameters receive localized text.
+- [x] **9.4** Implement missing-key behavior:
+  - [x] Development mode logs missing keys.
+  - [x] Production mode falls back safely.
+  - [x] Invalid persisted language values fall back to `en-US` and are rewritten to `appsettings.json`.
+- [x] **9.5** Implement culture switching:
+  - [x] Initialize localization before `MainWindow.InitializeComponent()` and before `JsonNavigationService.ConfigureJsonFile(...)`.
+  - [x] Menu/settings command updates the selected language.
+  - [x] Persist the selected BCP-47 language tag to `C:\ProgramData\Foundry\Settings\appsettings.json`.
+  - [x] Set `Microsoft.Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride` during startup before localized resources are loaded.
+  - [x] Set `ApplicationLanguages.PrimaryLanguageOverride` again when the user changes language at runtime.
+  - [x] Update the active `ResourceContext.QualifierValues["Language"]` when the user changes language at runtime.
+  - [x] Expose a language change event from `IApplicationLocalizationService`.
+  - [x] ViewModels refresh computed strings.
+  - [x] Pages reload or rebind localized text.
+  - [x] DevWinUI NavigationView groups/items, breadcrumbs, settings cards, title bar search text, and landing page strings refresh without restarting the app.
+  - [x] Reinitialize DevWinUI `JsonNavigationService` after runtime language changes, following the old `Bucket_v2_old` pattern that calls `JsonNavigationService.ReInitialize()`.
+  - [x] Add a controlled Foundry wrapper around DevWinUI navigation refresh if direct `ReInitialize()` is not sufficient or becomes version-sensitive.
+  - [x] Do not require an application restart for language changes.
+  - [x] If a WinUI resource was already loaded before the language change, explicitly reload or rebind that UI surface after changing `PrimaryLanguageOverride`.
+- [x] **9.6** Migrate languages:
+  - [x] `en-US`.
+  - [x] `fr-FR`.
+- [x] **9.7** Migrate supported culture catalog tests.
+- [x] **9.7.1** Verify DevWinUI localization behavior against current DevWinUI docs/source before implementation:
+  - [x] Confirm `LocalizeId` resource-key naming requirements.
+  - [x] Confirm `UsexUid=true` behavior for NavigationView groups and items.
+  - [x] Confirm whether `JsonNavigationService.ReInitialize()` still refreshes localized navigation items in the current DevWinUI package version.
+  - [x] Document any DevWinUI limitation that requires an app-owned refresh workaround.
+- [x] **9.8** Commit:
 
 ```powershell
 git commit -m "feat: migrate foundry localization to winui"

--- a/docs/migration/phases/04-localization-logging-shell.md
+++ b/docs/migration/phases/04-localization-logging-shell.md
@@ -79,11 +79,11 @@ git commit -m "feat: migrate foundry localization to winui"
 
 - [x] **9.9** Launch app in English.
 - [x] **9.10** Launch app in French.
-- [ ] **9.11** Switch language at runtime.
-- [ ] **9.12** Confirm computed labels update.
-- [ ] **9.13** Confirm missing keys are visible during development.
-- [ ] **9.14** Confirm DevWinUI NavigationView group/item labels update after runtime language switch without restarting.
-- [ ] **9.15** Confirm breadcrumbs, settings cards, title bar search text, and landing page strings update after runtime language switch without restarting.
+- [x] **9.11** Switch language at runtime.
+- [x] **9.12** Confirm computed labels update.
+- [x] **9.13** Confirm missing keys are visible during development.
+- [x] **9.14** Confirm DevWinUI NavigationView group/item labels update after runtime language switch without restarting.
+- [x] **9.15** Confirm breadcrumbs, settings cards, title bar search text, and landing page strings update after runtime language switch without restarting.
 
 ## Phase 10: Logging Migration
 

--- a/docs/migration/phases/04-localization-logging-shell.md
+++ b/docs/migration/phases/04-localization-logging-shell.md
@@ -77,8 +77,8 @@ git commit -m "feat: migrate foundry localization to winui"
 
 **Validation**
 
-- [ ] **9.9** Launch app in English.
-- [ ] **9.10** Launch app in French.
+- [x] **9.9** Launch app in English.
+- [x] **9.10** Launch app in French.
 - [ ] **9.11** Switch language at runtime.
 - [ ] **9.12** Confirm computed labels update.
 - [ ] **9.13** Confirm missing keys are visible during development.

--- a/src/Foundry.Core.Tests/Localization/SupportedCultureCatalogTests.cs
+++ b/src/Foundry.Core.Tests/Localization/SupportedCultureCatalogTests.cs
@@ -34,4 +34,25 @@ public sealed class SupportedCultureCatalogTests
 
         Assert.Equal(expectedCode, result);
     }
+
+    [Theory]
+    [InlineData("fr-FR", "fr-FR")]
+    [InlineData("fr-CA", "fr-FR")]
+    [InlineData("en-GB", "en-US")]
+    [InlineData("de-DE", "en-US")]
+    [InlineData("invalid", "en-US")]
+    public void MatchPreferredCulture_ReturnsBestSupportedCulture(string preferredCultureCode, string expectedCode)
+    {
+        string result = SupportedCultureCatalog.MatchPreferredCulture([preferredCultureCode]);
+
+        Assert.Equal(expectedCode, result);
+    }
+
+    [Fact]
+    public void MatchPreferredCulture_UsesFirstSupportedPreferredCulture()
+    {
+        string result = SupportedCultureCatalog.MatchPreferredCulture(["de-DE", "fr-CA", "en-GB"]);
+
+        Assert.Equal("fr-FR", result);
+    }
 }

--- a/src/Foundry.Core.Tests/Localization/SupportedCultureCatalogTests.cs
+++ b/src/Foundry.Core.Tests/Localization/SupportedCultureCatalogTests.cs
@@ -20,4 +20,18 @@ public sealed class SupportedCultureCatalogTests
         Assert.Single(options, option => option.IsSelected);
         Assert.True(options.Single(option => option.Code == "fr-FR").IsSelected);
     }
+
+    [Theory]
+    [InlineData(null, "en-US")]
+    [InlineData("", "en-US")]
+    [InlineData("invalid", "en-US")]
+    [InlineData("de-DE", "en-US")]
+    [InlineData("fr_fr", "fr-FR")]
+    [InlineData("EN-us", "en-US")]
+    public void ValidateOrDefault_ReturnsSupportedCanonicalCulture(string? cultureCode, string expectedCode)
+    {
+        string result = SupportedCultureCatalog.ValidateOrDefault(cultureCode);
+
+        Assert.Equal(expectedCode, result);
+    }
 }

--- a/src/Foundry.Core/Localization/SupportedCultureCatalog.cs
+++ b/src/Foundry.Core/Localization/SupportedCultureCatalog.cs
@@ -4,6 +4,8 @@ namespace Foundry.Core.Localization;
 
 public static class SupportedCultureCatalog
 {
+    public const string DefaultCultureCode = "en-US";
+
     private static readonly SupportedCultureDefinition[] Definitions =
     [
         new("en-US", "Language.English", 10),
@@ -26,6 +28,29 @@ public static class SupportedCultureCatalog
                 getString(definition.ResourceKey),
                 NormalizeForComparison(definition.Code).Equals(selectedCode, StringComparison.OrdinalIgnoreCase)))
             .ToArray();
+    }
+
+    public static string ValidateOrDefault(string? cultureCode)
+    {
+        if (string.IsNullOrWhiteSpace(cultureCode))
+        {
+            return DefaultCultureCode;
+        }
+
+        try
+        {
+            string canonicalCode = Canonicalize(cultureCode);
+            return Definitions.Any(definition => string.Equals(
+                Canonicalize(definition.Code),
+                canonicalCode,
+                StringComparison.OrdinalIgnoreCase))
+                ? canonicalCode
+                : DefaultCultureCode;
+        }
+        catch (CultureNotFoundException)
+        {
+            return DefaultCultureCode;
+        }
     }
 
     private static string Canonicalize(string cultureCode)

--- a/src/Foundry.Core/Localization/SupportedCultureCatalog.cs
+++ b/src/Foundry.Core/Localization/SupportedCultureCatalog.cs
@@ -53,6 +53,70 @@ public static class SupportedCultureCatalog
         }
     }
 
+    public static string MatchPreferredCulture(IEnumerable<string?> preferredCultureCodes)
+    {
+        ArgumentNullException.ThrowIfNull(preferredCultureCodes);
+
+        foreach (string? cultureCode in preferredCultureCodes)
+        {
+            string? directMatch = TryGetSupportedCultureCode(cultureCode);
+            if (directMatch is not null)
+            {
+                return directMatch;
+            }
+
+            string? languageFamilyMatch = TryGetSupportedLanguageFamilyCode(cultureCode);
+            if (languageFamilyMatch is not null)
+            {
+                return languageFamilyMatch;
+            }
+        }
+
+        return DefaultCultureCode;
+    }
+
+    private static string? TryGetSupportedCultureCode(string? cultureCode)
+    {
+        if (string.IsNullOrWhiteSpace(cultureCode))
+        {
+            return null;
+        }
+
+        try
+        {
+            string canonicalCode = Canonicalize(cultureCode);
+            return Definitions
+                .Select(definition => Canonicalize(definition.Code))
+                .FirstOrDefault(code => string.Equals(code, canonicalCode, StringComparison.OrdinalIgnoreCase));
+        }
+        catch (CultureNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    private static string? TryGetSupportedLanguageFamilyCode(string? cultureCode)
+    {
+        if (string.IsNullOrWhiteSpace(cultureCode))
+        {
+            return null;
+        }
+
+        try
+        {
+            string languageFamily = CultureInfo.GetCultureInfo(cultureCode.Trim().Replace('_', '-')).TwoLetterISOLanguageName;
+            return Definitions
+                .Select(definition => Canonicalize(definition.Code))
+                .FirstOrDefault(code => CultureInfo.GetCultureInfo(code).TwoLetterISOLanguageName.Equals(
+                    languageFamily,
+                    StringComparison.OrdinalIgnoreCase));
+        }
+        catch (CultureNotFoundException)
+        {
+            return null;
+        }
+    }
+
     private static string Canonicalize(string cultureCode)
     {
         return CultureInfo.GetCultureInfo(cultureCode.Trim().Replace('_', '-')).Name;

--- a/src/Foundry/App.xaml.cs
+++ b/src/Foundry/App.xaml.cs
@@ -1,4 +1,5 @@
 using Foundry.DependencyInjection;
+using Foundry.Services.Localization;
 using Foundry.Services.Startup;
 using Microsoft.Extensions.Hosting;
 using Serilog;
@@ -33,6 +34,7 @@ namespace Foundry
             ConfigureLogger();
 
             Host = FoundryHost.Create();
+            Host.Services.GetRequiredService<IApplicationLocalizationService>().InitializeAsync().GetAwaiter().GetResult();
             RegisterExceptionHandlers();
 
             Logger.Information("Foundry WinUI startup initialized.");

--- a/src/Foundry/Assets/NavViewMenu/AppData.json
+++ b/src/Foundry/Assets/NavViewMenu/AppData.json
@@ -3,7 +3,8 @@
   "Groups": [
     {
       "UniqueId": "Foundry",
-      "Title": "Foundry",
+      "LocalizeId": "Nav_HomeKey",
+      "UsexUid": true,
       "ImagePath": "ms-appx:///Assets/AppIcon.png",
       "IsSpecialSection": false,
       "ShowItemsWithoutGroup": true,
@@ -11,8 +12,8 @@
       "Items": [
         {
           "UniqueId": "Foundry.Views.HomeLandingPage",
-          "Title": "Foundry",
-          "Subtitle": "Foundry",
+          "LocalizeId": "Nav_HomeKey",
+          "UsexUid": true,
           "ImagePath": "ms-appx:///Assets/AppIcon.png",
           "HideItem": true
         }

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -32,8 +32,8 @@
   </PropertyGroup>
   <ItemGroup>
     <AdditionalFiles Include="**\*.xaml" Link="%(RecursiveDir)%(Filename)%(Extension)" />
-    <AdditionalFiles Include="Assets\NavViewMenu\AppData.json" Link="%(RecursiveDir)%(Filename)%(Extension)" />
-    <AdditionalFiles Include="Strings\**\*.resw" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <AdditionalFiles Include="Assets\NavViewMenu\AppData.json" Link="Assets\NavViewMenu\%(Filename)%(Extension)" />
+    <AdditionalFiles Include="Strings\**\*.resw" Link="Strings\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\**\*">

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -33,11 +33,19 @@
   <ItemGroup>
     <AdditionalFiles Include="**\*.xaml" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <AdditionalFiles Include="Assets\NavViewMenu\AppData.json" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <AdditionalFiles Include="Strings\**\*.resw" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\**\*">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </None>
+    <Content Include="Assets\NavViewMenu\AppData.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Strings\**\*.resw">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <PRIResource Include="Strings\**\*.resw" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Models\" />

--- a/src/Foundry/Services/Localization/ApplicationLanguageChangedEventArgs.cs
+++ b/src/Foundry/Services/Localization/ApplicationLanguageChangedEventArgs.cs
@@ -1,0 +1,7 @@
+namespace Foundry.Services.Localization;
+
+public sealed class ApplicationLanguageChangedEventArgs(string oldLanguage, string newLanguage) : EventArgs
+{
+    public string OldLanguage { get; } = oldLanguage;
+    public string NewLanguage { get; } = newLanguage;
+}

--- a/src/Foundry/Services/Localization/ApplicationLocalizationService.cs
+++ b/src/Foundry/Services/Localization/ApplicationLocalizationService.cs
@@ -1,4 +1,8 @@
+using System.Globalization;
+using Foundry.Core.Localization;
 using Foundry.Services.Settings;
+using Microsoft.Windows.ApplicationModel.Resources;
+using Microsoft.Windows.Globalization;
 using Serilog;
 
 namespace Foundry.Services.Localization;
@@ -7,12 +11,116 @@ internal sealed class ApplicationLocalizationService(
     IAppSettingsService appSettingsService,
     ILogger logger) : IApplicationLocalizationService
 {
-    public string CurrentLanguage => appSettingsService.Current.Localization.Language;
+    private ResourceManager? resourceManager;
+    private ResourceContext? resourceContext;
+    private string currentLanguage = SupportedCultureCatalog.DefaultCultureCode;
+
+    public string CurrentLanguage => currentLanguage;
+
+    public event EventHandler<ApplicationLanguageChangedEventArgs>? LanguageChanged;
 
     public Task InitializeAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        logger.Information("Localization initialized. Language={Language}", CurrentLanguage);
+
+        string configuredLanguage = appSettingsService.Current.Localization.Language;
+        string validatedLanguage = SupportedCultureCatalog.ValidateOrDefault(configuredLanguage);
+        if (!string.Equals(configuredLanguage, validatedLanguage, StringComparison.OrdinalIgnoreCase))
+        {
+            appSettingsService.Current.Localization.Language = validatedLanguage;
+            appSettingsService.Save();
+        }
+
+        ApplyLanguage(validatedLanguage);
         return Task.CompletedTask;
+    }
+
+    public Task SetLanguageAsync(string languageCode, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string validatedLanguage = SupportedCultureCatalog.ValidateOrDefault(languageCode);
+        if (string.Equals(currentLanguage, validatedLanguage, StringComparison.OrdinalIgnoreCase))
+        {
+            return Task.CompletedTask;
+        }
+
+        string oldLanguage = currentLanguage;
+        ApplyLanguage(validatedLanguage);
+
+        appSettingsService.Current.Localization.Language = validatedLanguage;
+        appSettingsService.Save();
+
+        LanguageChanged?.Invoke(this, new ApplicationLanguageChangedEventArgs(oldLanguage, validatedLanguage));
+        return Task.CompletedTask;
+    }
+
+    public string GetString(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        try
+        {
+            ResourceCandidate? candidate = TryGetResourceCandidate(key);
+            string? value = candidate?.ValueAsString;
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+        catch (Exception ex)
+        {
+            if (appSettingsService.Current.Diagnostics.DeveloperMode)
+            {
+                logger.Warning(ex, "Localized resource lookup failed. Key={Key}, Language={Language}", key, currentLanguage);
+            }
+        }
+
+        if (appSettingsService.Current.Diagnostics.DeveloperMode)
+        {
+            logger.Warning("Localized resource key was not found. Key={Key}, Language={Language}", key, currentLanguage);
+        }
+
+        return key;
+    }
+
+    private ResourceCandidate? TryGetResourceCandidate(string key)
+    {
+        if (resourceManager is null || resourceContext is null)
+        {
+            return null;
+        }
+
+        string resourceKey = key.Replace('.', '/');
+        ResourceMap resourceMap = resourceManager.MainResourceMap.GetSubtree("Resources");
+        return resourceMap.TryGetValue(key, resourceContext)
+            ?? resourceMap.TryGetValue(resourceKey, resourceContext);
+    }
+
+    public string FormatString(string key, params object[] args)
+    {
+        return string.Format(CultureInfo.CurrentCulture, GetString(key), args);
+    }
+
+    public IReadOnlyList<SupportedCultureOption> CreateSupportedLanguageOptions()
+    {
+        CultureInfo currentCulture = CultureInfo.GetCultureInfo(currentLanguage);
+        return SupportedCultureCatalog.CreateOptions(currentCulture, GetString);
+    }
+
+    private void ApplyLanguage(string languageCode)
+    {
+        CultureInfo culture = CultureInfo.GetCultureInfo(languageCode);
+        CultureInfo.DefaultThreadCurrentCulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+
+        ApplicationLanguages.PrimaryLanguageOverride = languageCode;
+
+        resourceManager ??= new ResourceManager();
+        resourceContext ??= resourceManager.CreateResourceContext();
+        resourceContext.QualifierValues["Language"] = languageCode;
+
+        currentLanguage = languageCode;
+        logger.Information("Localization initialized. Language={Language}", CurrentLanguage);
     }
 }

--- a/src/Foundry/Services/Localization/ApplicationLocalizationService.cs
+++ b/src/Foundry/Services/Localization/ApplicationLocalizationService.cs
@@ -4,6 +4,7 @@ using Foundry.Services.Settings;
 using Microsoft.Windows.ApplicationModel.Resources;
 using Microsoft.Windows.Globalization;
 using Serilog;
+using Windows.System.UserProfile;
 
 namespace Foundry.Services.Localization;
 
@@ -24,7 +25,10 @@ internal sealed class ApplicationLocalizationService(
         cancellationToken.ThrowIfCancellationRequested();
 
         string configuredLanguage = appSettingsService.Current.Localization.Language;
-        string validatedLanguage = SupportedCultureCatalog.ValidateOrDefault(configuredLanguage);
+        string validatedLanguage = appSettingsService.IsFirstRun
+            ? SupportedCultureCatalog.MatchPreferredCulture(GetPreferredLanguageCodes())
+            : SupportedCultureCatalog.ValidateOrDefault(configuredLanguage);
+
         if (!string.Equals(configuredLanguage, validatedLanguage, StringComparison.OrdinalIgnoreCase))
         {
             appSettingsService.Current.Localization.Language = validatedLanguage;
@@ -122,5 +126,22 @@ internal sealed class ApplicationLocalizationService(
 
         currentLanguage = languageCode;
         logger.Information("Localization initialized. Language={Language}", CurrentLanguage);
+    }
+
+    private static IReadOnlyList<string?> GetPreferredLanguageCodes()
+    {
+        List<string?> languageCodes = [];
+
+        try
+        {
+            languageCodes.AddRange(GlobalizationPreferences.Languages);
+        }
+        catch
+        {
+            // Fall back to CultureInfo below when WinRT user profile language APIs are unavailable.
+        }
+
+        languageCodes.Add(CultureInfo.CurrentUICulture.Name);
+        return languageCodes;
     }
 }

--- a/src/Foundry/Services/Localization/IApplicationLocalizationService.cs
+++ b/src/Foundry/Services/Localization/IApplicationLocalizationService.cs
@@ -1,7 +1,14 @@
+using Foundry.Core.Localization;
+
 namespace Foundry.Services.Localization;
 
 public interface IApplicationLocalizationService
 {
     string CurrentLanguage { get; }
+    event EventHandler<ApplicationLanguageChangedEventArgs>? LanguageChanged;
     Task InitializeAsync(CancellationToken cancellationToken = default);
+    Task SetLanguageAsync(string languageCode, CancellationToken cancellationToken = default);
+    string GetString(string key);
+    string FormatString(string key, params object[] args);
+    IReadOnlyList<SupportedCultureOption> CreateSupportedLanguageOptions();
 }

--- a/src/Foundry/Services/Settings/IAppSettingsService.cs
+++ b/src/Foundry/Services/Settings/IAppSettingsService.cs
@@ -3,5 +3,6 @@ namespace Foundry.Services.Settings;
 public interface IAppSettingsService
 {
     FoundryAppSettings Current { get; }
+    bool IsFirstRun { get; }
     void Save();
 }

--- a/src/Foundry/Services/Settings/JsonAppSettingsService.cs
+++ b/src/Foundry/Services/Settings/JsonAppSettingsService.cs
@@ -7,11 +7,13 @@ internal sealed partial class JsonAppSettingsService : IAppSettingsService
 {
     public JsonAppSettingsService()
     {
+        IsFirstRun = !File.Exists(Constants.AppSettingsPath);
         Current = Load();
         Save();
     }
 
     public FoundryAppSettings Current { get; }
+    public bool IsFirstRun { get; }
 
     public void Save()
     {

--- a/src/Foundry/Services/Startup/StartupReadinessService.cs
+++ b/src/Foundry/Services/Startup/StartupReadinessService.cs
@@ -1,4 +1,3 @@
-using Foundry.Services.Localization;
 using Foundry.Services.Settings;
 using Foundry.Services.Shell;
 using Foundry.Services.Updates;
@@ -8,7 +7,6 @@ namespace Foundry.Services.Startup;
 
 internal sealed class StartupReadinessService(
     IAppSettingsService appSettingsService,
-    IApplicationLocalizationService localizationService,
     IApplicationUpdateService updateService,
     IShellNavigationGuardService shellNavigationGuardService,
     ILogger logger) : IStartupReadinessService
@@ -21,8 +19,6 @@ internal sealed class StartupReadinessService(
             "Startup readiness initialization started. CheckOnStartup={CheckOnStartup}, UpdateChannel={UpdateChannel}",
             appSettingsService.Current.Updates.CheckOnStartup,
             appSettingsService.Current.Updates.Channel);
-
-        await localizationService.InitializeAsync(cancellationToken);
 
         shellNavigationGuardService.SetState(ShellNavigationState.Ready);
 

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -84,6 +84,9 @@
   <data name="Nav_HomeKey.Title" xml:space="preserve">
     <value>Home</value>
   </data>
+  <data name="SettingsPage.PageTitle" xml:space="preserve">
+    <value>Settings</value>
+  </data>
   <data name="SettingsPage_AboutCard.Description" xml:space="preserve">
     <value>Product, version, repository, and release information.</value>
   </data>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="About_FoundryExpander.Description" xml:space="preserve">
+    <value>Foundry migration shell and deployment media authoring tool.</value>
+  </data>
+  <data name="About_FoundryExpander.Header" xml:space="preserve">
+    <value>Foundry</value>
+  </data>
+  <data name="About_RelatedLinksText.Text" xml:space="preserve">
+    <value>Related links</value>
+  </data>
+  <data name="About_ReleaseNotesLink.Content" xml:space="preserve">
+    <value>Release notes</value>
+  </data>
+  <data name="About_SourceCodeLink.Content" xml:space="preserve">
+    <value>Source code</value>
+  </data>
+  <data name="AppUpdate_CheckButton.Content" xml:space="preserve">
+    <value>Check for new version</value>
+  </data>
+  <data name="AppUpdate_DownloadRestartButton.Content" xml:space="preserve">
+    <value>Download and restart</value>
+  </data>
+  <data name="AppUpdate_LastCheckLabel.Text" xml:space="preserve">
+    <value>Last update check</value>
+  </data>
+  <data name="AppUpdate_ReleaseNotesLink.Content" xml:space="preserve">
+    <value>Release notes</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
+    <value>Enable developer diagnostics and open the Foundry log folder.</value>
+  </data>
+  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
+    <value>Diagnostics and feedback</value>
+  </data>
+  <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
+    <value>Change the application language without restarting Foundry.</value>
+  </data>
+  <data name="GeneralSetting_LanguageCard.Header" xml:space="preserve">
+    <value>Language</value>
+  </data>
+  <data name="GeneralSetting_StartupCard.Description" xml:space="preserve">
+    <value>Automatically launch Foundry when you log in to Windows.</value>
+  </data>
+  <data name="GeneralSetting_StartupCard.Header" xml:space="preserve">
+    <value>Run at startup</value>
+  </data>
+  <data name="Language.English" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="Language.French" xml:space="preserve">
+    <value>French</value>
+  </data>
+  <data name="MainWindow.SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Search</value>
+  </data>
+  <data name="MainWindow.ThemeButton.ToolTip" xml:space="preserve">
+    <value>Toggle theme</value>
+  </data>
+  <data name="Nav_HomeKey.Description" xml:space="preserve">
+    <value>Foundry home</value>
+  </data>
+  <data name="Nav_HomeKey.SecondaryTitle" xml:space="preserve">
+    <value>Foundry</value>
+  </data>
+  <data name="Nav_HomeKey.Subtitle" xml:space="preserve">
+    <value>Foundry</value>
+  </data>
+  <data name="Nav_HomeKey.Title" xml:space="preserve">
+    <value>Home</value>
+  </data>
+  <data name="SettingsPage_AboutCard.Description" xml:space="preserve">
+    <value>Product, version, repository, and release information.</value>
+  </data>
+  <data name="SettingsPage_AboutCard.Header" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="SettingsPage_GeneralCard.Description" xml:space="preserve">
+    <value>Manage startup, language, diagnostics, and application behavior.</value>
+  </data>
+  <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="SettingsPage_ThemeCard.Description" xml:space="preserve">
+    <value>Change theme, backdrop, and accent color preferences.</value>
+  </data>
+  <data name="SettingsPage_ThemeCard.Header" xml:space="preserve">
+    <value>Appearance and behavior</value>
+  </data>
+  <data name="SettingsPage_UpdateCard.Description" xml:space="preserve">
+    <value>Check for Foundry updates and review release notes.</value>
+  </data>
+  <data name="SettingsPage_UpdateCard.Header" xml:space="preserve">
+    <value>Update app</value>
+  </data>
+  <data name="ThemeSetting_AccentCard.Description" xml:space="preserve">
+    <value>Open Windows color settings to change the accent color.</value>
+  </data>
+  <data name="ThemeSetting_AccentCard.Header" xml:space="preserve">
+    <value>Accent color</value>
+  </data>
+  <data name="ThemeSetting_AcrylicItem.Content" xml:space="preserve">
+    <value>Acrylic</value>
+  </data>
+  <data name="ThemeSetting_AcrylicThinItem.Content" xml:space="preserve">
+    <value>Acrylic Thin</value>
+  </data>
+  <data name="ThemeSetting_AppThemeCard.Description" xml:space="preserve">
+    <value>Select the application theme.</value>
+  </data>
+  <data name="ThemeSetting_AppThemeCard.Header" xml:space="preserve">
+    <value>App theme</value>
+  </data>
+  <data name="ThemeSetting_DarkItem.Content" xml:space="preserve">
+    <value>Dark</value>
+  </data>
+  <data name="ThemeSetting_DefaultItem.Content" xml:space="preserve">
+    <value>System</value>
+  </data>
+  <data name="ThemeSetting_LightItem.Content" xml:space="preserve">
+    <value>Light</value>
+  </data>
+  <data name="ThemeSetting_MaterialCard.Description" xml:space="preserve">
+    <value>Choose the backdrop material used behind the app.</value>
+  </data>
+  <data name="ThemeSetting_MaterialCard.Header" xml:space="preserve">
+    <value>Material</value>
+  </data>
+  <data name="ThemeSetting_MicaAltItem.Content" xml:space="preserve">
+    <value>Mica Alt</value>
+  </data>
+  <data name="ThemeSetting_MicaItem.Content" xml:space="preserve">
+    <value>Mica</value>
+  </data>
+  <data name="Update.CurrentVersionFormat" xml:space="preserve">
+    <value>Current version {0}</value>
+  </data>
+  <data name="Update.NoReleaseNotes" xml:space="preserve">
+    <value>No release notes were provided for this update.</value>
+  </data>
+  <data name="Update.NotChecked" xml:space="preserve">
+    <value>Not checked</value>
+  </data>
+  <data name="Update.ReleaseNotesDialogTitle" xml:space="preserve">
+    <value>Release notes</value>
+  </data>
+  <data name="Update.ReleaseNotesFallback" xml:space="preserve">
+    <value>Release notes will be available from the configured Velopack update feed.</value>
+  </data>
+  <data name="Update.Status.Checking" xml:space="preserve">
+    <value>Checking for updates</value>
+  </data>
+  <data name="Update.Status.Downloading" xml:space="preserve">
+    <value>Downloading update</value>
+  </data>
+  <data name="Update.Status.DownloadingProgressFormat" xml:space="preserve">
+    <value>Downloading update ({0}%)</value>
+  </data>
+  <data name="Update.Status.FailedFormat" xml:space="preserve">
+    <value>Update check failed: {0}</value>
+  </data>
+  <data name="Update.Status.NoUpdate" xml:space="preserve">
+    <value>Foundry is up to date.</value>
+  </data>
+  <data name="Update.Status.NotInstalled" xml:space="preserve">
+    <value>Update check skipped because Foundry is not running from a Velopack installation.</value>
+  </data>
+  <data name="Update.Status.Ready" xml:space="preserve">
+    <value>Ready</value>
+  </data>
+  <data name="Update.Status.SkippedInDebug" xml:space="preserve">
+    <value>Update check skipped because a debugger is attached.</value>
+  </data>
+  <data name="Update.Status.UpdateAvailable" xml:space="preserve">
+    <value>A Foundry update is available.</value>
+  </data>
+  <data name="Update.Status.UpdateAvailableWithVersion" xml:space="preserve">
+    <value>Foundry {0} is available.</value>
+  </data>
+</root>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -42,6 +42,12 @@
   <data name="Common.Close" xml:space="preserve">
     <value>Close</value>
   </data>
+  <data name="Common.Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="Common.Enabled" xml:space="preserve">
+    <value>Enabled</value>
+  </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
     <value>Enable developer diagnostics and open the Foundry log folder.</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="About_FoundryExpander.Description" xml:space="preserve">
+    <value>Shell de migration Foundry et outil de création de médias de déploiement.</value>
+  </data>
+  <data name="About_FoundryExpander.Header" xml:space="preserve">
+    <value>Foundry</value>
+  </data>
+  <data name="About_RelatedLinksText.Text" xml:space="preserve">
+    <value>Liens associés</value>
+  </data>
+  <data name="About_ReleaseNotesLink.Content" xml:space="preserve">
+    <value>Notes de version</value>
+  </data>
+  <data name="About_SourceCodeLink.Content" xml:space="preserve">
+    <value>Code source</value>
+  </data>
+  <data name="AppUpdate_CheckButton.Content" xml:space="preserve">
+    <value>Rechercher une nouvelle version</value>
+  </data>
+  <data name="AppUpdate_DownloadRestartButton.Content" xml:space="preserve">
+    <value>Télécharger et redémarrer</value>
+  </data>
+  <data name="AppUpdate_LastCheckLabel.Text" xml:space="preserve">
+    <value>Dernière vérification</value>
+  </data>
+  <data name="AppUpdate_ReleaseNotesLink.Content" xml:space="preserve">
+    <value>Notes de version</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Fermer</value>
+  </data>
+  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
+    <value>Activer les diagnostics développeur et ouvrir le dossier des journaux Foundry.</value>
+  </data>
+  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
+    <value>Diagnostics et commentaires</value>
+  </data>
+  <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
+    <value>Changer la langue de l'application sans redémarrer Foundry.</value>
+  </data>
+  <data name="GeneralSetting_LanguageCard.Header" xml:space="preserve">
+    <value>Langue</value>
+  </data>
+  <data name="GeneralSetting_StartupCard.Description" xml:space="preserve">
+    <value>Lancer automatiquement Foundry lorsque vous ouvrez une session Windows.</value>
+  </data>
+  <data name="GeneralSetting_StartupCard.Header" xml:space="preserve">
+    <value>Lancer au démarrage</value>
+  </data>
+  <data name="Language.English" xml:space="preserve">
+    <value>Anglais</value>
+  </data>
+  <data name="Language.French" xml:space="preserve">
+    <value>Français</value>
+  </data>
+  <data name="MainWindow.SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Rechercher</value>
+  </data>
+  <data name="MainWindow.ThemeButton.ToolTip" xml:space="preserve">
+    <value>Changer le thème</value>
+  </data>
+  <data name="Nav_HomeKey.Description" xml:space="preserve">
+    <value>Accueil Foundry</value>
+  </data>
+  <data name="Nav_HomeKey.SecondaryTitle" xml:space="preserve">
+    <value>Foundry</value>
+  </data>
+  <data name="Nav_HomeKey.Subtitle" xml:space="preserve">
+    <value>Foundry</value>
+  </data>
+  <data name="Nav_HomeKey.Title" xml:space="preserve">
+    <value>Accueil</value>
+  </data>
+  <data name="SettingsPage_AboutCard.Description" xml:space="preserve">
+    <value>Produit, version, dépôt et informations de publication.</value>
+  </data>
+  <data name="SettingsPage_AboutCard.Header" xml:space="preserve">
+    <value>À propos</value>
+  </data>
+  <data name="SettingsPage_GeneralCard.Description" xml:space="preserve">
+    <value>Gérer le démarrage, la langue, les diagnostics et le comportement de l'application.</value>
+  </data>
+  <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
+    <value>Général</value>
+  </data>
+  <data name="SettingsPage_ThemeCard.Description" xml:space="preserve">
+    <value>Modifier le thème, l'arrière-plan et la couleur d'accentuation.</value>
+  </data>
+  <data name="SettingsPage_ThemeCard.Header" xml:space="preserve">
+    <value>Apparence et comportement</value>
+  </data>
+  <data name="SettingsPage_UpdateCard.Description" xml:space="preserve">
+    <value>Rechercher les mises à jour Foundry et consulter les notes de version.</value>
+  </data>
+  <data name="SettingsPage_UpdateCard.Header" xml:space="preserve">
+    <value>Mettre à jour l'application</value>
+  </data>
+  <data name="ThemeSetting_AccentCard.Description" xml:space="preserve">
+    <value>Ouvrir les paramètres de couleur Windows pour changer la couleur d'accentuation.</value>
+  </data>
+  <data name="ThemeSetting_AccentCard.Header" xml:space="preserve">
+    <value>Couleur d'accentuation</value>
+  </data>
+  <data name="ThemeSetting_AcrylicItem.Content" xml:space="preserve">
+    <value>Acrylique</value>
+  </data>
+  <data name="ThemeSetting_AcrylicThinItem.Content" xml:space="preserve">
+    <value>Acrylique fin</value>
+  </data>
+  <data name="ThemeSetting_AppThemeCard.Description" xml:space="preserve">
+    <value>Sélectionner le thème de l'application.</value>
+  </data>
+  <data name="ThemeSetting_AppThemeCard.Header" xml:space="preserve">
+    <value>Thème de l'application</value>
+  </data>
+  <data name="ThemeSetting_DarkItem.Content" xml:space="preserve">
+    <value>Sombre</value>
+  </data>
+  <data name="ThemeSetting_DefaultItem.Content" xml:space="preserve">
+    <value>Système</value>
+  </data>
+  <data name="ThemeSetting_LightItem.Content" xml:space="preserve">
+    <value>Clair</value>
+  </data>
+  <data name="ThemeSetting_MaterialCard.Description" xml:space="preserve">
+    <value>Choisir le matériau utilisé derrière l'application.</value>
+  </data>
+  <data name="ThemeSetting_MaterialCard.Header" xml:space="preserve">
+    <value>Matériau</value>
+  </data>
+  <data name="ThemeSetting_MicaAltItem.Content" xml:space="preserve">
+    <value>Mica Alt</value>
+  </data>
+  <data name="ThemeSetting_MicaItem.Content" xml:space="preserve">
+    <value>Mica</value>
+  </data>
+  <data name="Update.CurrentVersionFormat" xml:space="preserve">
+    <value>Version actuelle {0}</value>
+  </data>
+  <data name="Update.NoReleaseNotes" xml:space="preserve">
+    <value>Aucune note de version n'a été fournie pour cette mise à jour.</value>
+  </data>
+  <data name="Update.NotChecked" xml:space="preserve">
+    <value>Jamais vérifié</value>
+  </data>
+  <data name="Update.ReleaseNotesDialogTitle" xml:space="preserve">
+    <value>Notes de version</value>
+  </data>
+  <data name="Update.ReleaseNotesFallback" xml:space="preserve">
+    <value>Les notes de version seront disponibles depuis le flux de mise à jour Velopack configuré.</value>
+  </data>
+  <data name="Update.Status.Checking" xml:space="preserve">
+    <value>Recherche de mises à jour</value>
+  </data>
+  <data name="Update.Status.Downloading" xml:space="preserve">
+    <value>Téléchargement de la mise à jour</value>
+  </data>
+  <data name="Update.Status.DownloadingProgressFormat" xml:space="preserve">
+    <value>Téléchargement de la mise à jour ({0} %)</value>
+  </data>
+  <data name="Update.Status.FailedFormat" xml:space="preserve">
+    <value>Échec de la recherche de mise à jour : {0}</value>
+  </data>
+  <data name="Update.Status.NoUpdate" xml:space="preserve">
+    <value>Foundry est à jour.</value>
+  </data>
+  <data name="Update.Status.NotInstalled" xml:space="preserve">
+    <value>Recherche de mise à jour ignorée car Foundry ne s'exécute pas depuis une installation Velopack.</value>
+  </data>
+  <data name="Update.Status.Ready" xml:space="preserve">
+    <value>Prêt</value>
+  </data>
+  <data name="Update.Status.SkippedInDebug" xml:space="preserve">
+    <value>Recherche de mise à jour ignorée car un débogueur est attaché.</value>
+  </data>
+  <data name="Update.Status.UpdateAvailable" xml:space="preserve">
+    <value>Une mise à jour Foundry est disponible.</value>
+  </data>
+  <data name="Update.Status.UpdateAvailableWithVersion" xml:space="preserve">
+    <value>Foundry {0} est disponible.</value>
+  </data>
+</root>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -42,6 +42,12 @@
   <data name="Common.Close" xml:space="preserve">
     <value>Fermer</value>
   </data>
+  <data name="Common.Disabled" xml:space="preserve">
+    <value>Désactivé</value>
+  </data>
+  <data name="Common.Enabled" xml:space="preserve">
+    <value>Activé</value>
+  </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
     <value>Activer les diagnostics développeur et ouvrir le dossier des journaux Foundry.</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -84,6 +84,9 @@
   <data name="Nav_HomeKey.Title" xml:space="preserve">
     <value>Accueil</value>
   </data>
+  <data name="SettingsPage.PageTitle" xml:space="preserve">
+    <value>Paramètres</value>
+  </data>
   <data name="SettingsPage_AboutCard.Description" xml:space="preserve">
     <value>Produit, version, dépôt et informations de publication.</value>
   </data>

--- a/src/Foundry/ViewModels/Settings/AppUpdateSettingViewModel.cs
+++ b/src/Foundry/ViewModels/Settings/AppUpdateSettingViewModel.cs
@@ -1,4 +1,5 @@
 using Foundry.Core.Services.Application;
+using Foundry.Services.Localization;
 using Foundry.Services.Settings;
 using Foundry.Services.Updates;
 
@@ -9,7 +10,8 @@ namespace Foundry.ViewModels
         private readonly IAppSettingsService appSettingsService;
         private readonly IDialogService dialogService;
         private readonly IApplicationUpdateService applicationUpdateService;
-        private string releaseNotes = "Release notes will be available from the configured Velopack update feed.";
+        private readonly IApplicationLocalizationService localizationService;
+        private string releaseNotes;
 
         [ObservableProperty]
         public partial string CurrentVersion { get; set; }
@@ -44,16 +46,19 @@ namespace Foundry.ViewModels
         public AppUpdateSettingViewModel(
             IAppSettingsService appSettingsService,
             IDialogService dialogService,
-            IApplicationUpdateService applicationUpdateService)
+            IApplicationUpdateService applicationUpdateService,
+            IApplicationLocalizationService localizationService)
         {
             this.appSettingsService = appSettingsService;
             this.dialogService = dialogService;
             this.applicationUpdateService = applicationUpdateService;
+            this.localizationService = localizationService;
+            releaseNotes = localizationService.GetString("Update.ReleaseNotesFallback");
 
-            CurrentVersion = $"Current Version {FoundryApplicationInfo.Version}";
-            LastUpdateCheck = appSettingsService.Current.Updates.LastCheckedAt?.ToString("yyyy-MM-dd HH:mm") ?? "Not checked";
+            CurrentVersion = localizationService.FormatString("Update.CurrentVersionFormat", FoundryApplicationInfo.Version);
+            LastUpdateCheck = appSettingsService.Current.Updates.LastCheckedAt?.ToString("yyyy-MM-dd HH:mm") ?? localizationService.GetString("Update.NotChecked");
             IsCheckButtonEnabled = true;
-            LoadingStatus = "Ready";
+            LoadingStatus = localizationService.GetString("Update.Status.Ready");
         }
 
         [RelayCommand]
@@ -65,7 +70,7 @@ namespace Foundry.ViewModels
             IsReleaseNotesVisible = false;
             IsCheckButtonEnabled = false;
             DownloadProgress = 0;
-            LoadingStatus = "Checking for updates";
+            LoadingStatus = localizationService.GetString("Update.Status.Checking");
 
             try
             {
@@ -75,16 +80,11 @@ namespace Foundry.ViewModels
                 appSettingsService.Save();
 
                 LastUpdateCheck = checkedAt.ToString("yyyy-MM-dd HH:mm");
-                LoadingStatus = result.Message;
+                LoadingStatus = GetCheckStatusMessage(result);
                 IsUpdateAvailable = result.IsUpdateAvailable;
                 IsInstallButtonVisible = result.IsUpdateAvailable;
                 IsReleaseNotesVisible = result.IsUpdateAvailable && !string.IsNullOrWhiteSpace(result.ReleaseNotes);
-                releaseNotes = result.ReleaseNotes ?? "No release notes were provided for this update.";
-
-                if (result.Version is not null)
-                {
-                    LoadingStatus = $"{result.Message} Version {result.Version}.";
-                }
+                releaseNotes = result.ReleaseNotes ?? localizationService.GetString("Update.NoReleaseNotes");
             }
             finally
             {
@@ -99,7 +99,7 @@ namespace Foundry.ViewModels
             IsLoading = true;
             IsCheckButtonEnabled = false;
             IsInstallButtonVisible = false;
-            LoadingStatus = "Downloading update";
+            LoadingStatus = localizationService.GetString("Update.Status.Downloading");
             DownloadProgress = 0;
 
             try
@@ -107,7 +107,7 @@ namespace Foundry.ViewModels
                 Progress<int> progress = new(value =>
                 {
                     DownloadProgress = value;
-                    LoadingStatus = $"Downloading update ({value}%)";
+                    LoadingStatus = localizationService.FormatString("Update.Status.DownloadingProgressFormat", value);
                 });
 
                 ApplicationUpdateDownloadResult result = await applicationUpdateService.DownloadUpdateAsync(progress);
@@ -132,7 +132,25 @@ namespace Foundry.ViewModels
         [RelayCommand]
         private Task GetReleaseNotesAsync()
         {
-            return dialogService.ShowMessageAsync(new DialogRequest("Release Note", releaseNotes, "Close"));
+            return dialogService.ShowMessageAsync(new DialogRequest(
+                localizationService.GetString("Update.ReleaseNotesDialogTitle"),
+                releaseNotes,
+                localizationService.GetString("Common.Close")));
+        }
+
+        private string GetCheckStatusMessage(ApplicationUpdateCheckResult result)
+        {
+            return result.Status switch
+            {
+                ApplicationUpdateStatus.NoUpdate => localizationService.GetString("Update.Status.NoUpdate"),
+                ApplicationUpdateStatus.UpdateAvailable => result.Version is not null
+                    ? localizationService.FormatString("Update.Status.UpdateAvailableWithVersion", result.Version)
+                    : localizationService.GetString("Update.Status.UpdateAvailable"),
+                ApplicationUpdateStatus.Failed => localizationService.FormatString("Update.Status.FailedFormat", result.Message),
+                ApplicationUpdateStatus.SkippedInDebug => localizationService.GetString("Update.Status.SkippedInDebug"),
+                ApplicationUpdateStatus.NotInstalled => localizationService.GetString("Update.Status.NotInstalled"),
+                _ => result.Message
+            };
         }
     }
 }

--- a/src/Foundry/ViewModels/Settings/GeneralSettingViewModel.cs
+++ b/src/Foundry/ViewModels/Settings/GeneralSettingViewModel.cs
@@ -42,7 +42,6 @@ namespace Foundry.ViewModels
             }
 
             await localizationService.SetLanguageAsync(selectedLanguage.Code);
-            RefreshSupportedLanguages();
         }
 
         partial void OnIsDeveloperModeChanged(bool value)

--- a/src/Foundry/ViewModels/Settings/GeneralSettingViewModel.cs
+++ b/src/Foundry/ViewModels/Settings/GeneralSettingViewModel.cs
@@ -56,7 +56,7 @@ namespace Foundry.ViewModels
             return externalProcessLauncher.OpenFolderAsync(Constants.LogDirectoryPath);
         }
 
-        private void RefreshSupportedLanguages()
+        public void RefreshSupportedLanguages()
         {
             SupportedLanguages.Clear();
 

--- a/src/Foundry/ViewModels/Settings/GeneralSettingViewModel.cs
+++ b/src/Foundry/ViewModels/Settings/GeneralSettingViewModel.cs
@@ -1,4 +1,7 @@
+using System.Collections.ObjectModel;
+using Foundry.Core.Localization;
 using Foundry.Core.Services.Application;
+using Foundry.Services.Localization;
 using Foundry.Services.Settings;
 
 namespace Foundry.ViewModels
@@ -7,20 +10,40 @@ namespace Foundry.ViewModels
     {
         private readonly IAppSettingsService appSettingsService;
         private readonly IExternalProcessLauncher externalProcessLauncher;
+        private readonly IApplicationLocalizationService localizationService;
 
         public GeneralSettingViewModel(
             IAppSettingsService appSettingsService,
-            IExternalProcessLauncher externalProcessLauncher)
+            IExternalProcessLauncher externalProcessLauncher,
+            IApplicationLocalizationService localizationService)
         {
             this.appSettingsService = appSettingsService;
             this.externalProcessLauncher = externalProcessLauncher;
+            this.localizationService = localizationService;
             IsDeveloperMode = appSettingsService.Current.Diagnostics.DeveloperMode;
+            RefreshSupportedLanguages();
         }
+
+        public ObservableCollection<SupportedCultureOption> SupportedLanguages { get; } = [];
 
         public string LogDirectoryPath => Constants.LogDirectoryPath;
 
         [ObservableProperty]
         public partial bool IsDeveloperMode { get; set; }
+
+        [ObservableProperty]
+        public partial SupportedCultureOption? SelectedLanguage { get; set; }
+
+        public async Task SetLanguageAsync(SupportedCultureOption? selectedLanguage)
+        {
+            if (selectedLanguage is null)
+            {
+                return;
+            }
+
+            await localizationService.SetLanguageAsync(selectedLanguage.Code);
+            RefreshSupportedLanguages();
+        }
 
         partial void OnIsDeveloperModeChanged(bool value)
         {
@@ -32,6 +55,23 @@ namespace Foundry.ViewModels
         private Task OpenLogFolderAsync()
         {
             return externalProcessLauncher.OpenFolderAsync(Constants.LogDirectoryPath);
+        }
+
+        private void RefreshSupportedLanguages()
+        {
+            SupportedLanguages.Clear();
+
+            SupportedCultureOption? selectedOption = null;
+            foreach (SupportedCultureOption option in localizationService.CreateSupportedLanguageOptions())
+            {
+                SupportedLanguages.Add(option);
+                if (option.IsSelected)
+                {
+                    selectedOption = option;
+                }
+            }
+
+            SelectedLanguage = selectedOption;
         }
     }
 }

--- a/src/Foundry/Views/MainWindow.xaml
+++ b/src/Foundry/Views/MainWindow.xaml
@@ -17,9 +17,9 @@
                   IsBackButtonVisible="True"
                   IsPaneToggleButtonVisible="True"
                   Subtitle="{x:Bind dev:ProcessInfoHelper.VersionWithPrefix}">
-            <AutoSuggestBox MinWidth="320"
+            <AutoSuggestBox x:Name="SearchBox"
+                            MinWidth="320"
                             VerticalAlignment="Center"
-                            PlaceholderText="Search"
                             QueryIcon="Find"
                             QuerySubmitted="OnQuerySubmitted"
                             TextChanged="OnTextChanged" />
@@ -33,8 +33,7 @@
                         Click="ThemeButton_Click"
                         Content="{dev:FontIcon GlyphCode=E793,
                                                FontSize=16}"
-                        Style="{ThemeResource SubtleButtonStyle}"
-                        ToolTipService.ToolTip="Toggle Theme" />
+                        Style="{ThemeResource SubtleButtonStyle}" />
             </TitleBar.RightHeader>
         </TitleBar>
         <NavigationView x:Name="NavView"

--- a/src/Foundry/Views/MainWindow.xaml.cs
+++ b/src/Foundry/Views/MainWindow.xaml.cs
@@ -1,28 +1,77 @@
-﻿using Microsoft.UI.Windowing;
+using Foundry.Services.Localization;
+using Microsoft.UI.Windowing;
 
 namespace Foundry.Views
 {
     public sealed partial class MainWindow : Window
     {
+        private readonly IApplicationLocalizationService localizationService;
+        private JsonNavigationService? jsonNavigationService;
+
         public MainViewModel ViewModel { get; }
+
         public MainWindow()
         {
+            localizationService = App.GetService<IApplicationLocalizationService>();
             ViewModel = App.GetService<MainViewModel>();
             this.InitializeComponent();
             ExtendsContentIntoTitleBar = true;
             SetTitleBar(AppTitleBar);
             AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Tall;
+            ApplyLocalizedShellText();
+            InitializeNavigation();
 
-            var navService = App.GetService<IJsonNavigationService>() as JsonNavigationService;
-            if (navService != null)
+            localizationService.LanguageChanged += OnLanguageChanged;
+            Closed += OnClosed;
+        }
+
+        private void InitializeNavigation()
+        {
+            jsonNavigationService = App.GetService<IJsonNavigationService>() as JsonNavigationService;
+            if (jsonNavigationService != null)
             {
-                navService.Initialize(NavView, NavFrame, NavigationPageMappings.PageDictionary)
+                jsonNavigationService.Initialize(NavView, NavFrame, NavigationPageMappings.PageDictionary)
                     .ConfigureDefaultPage(typeof(HomeLandingPage))
                     .ConfigureSettingsPage(typeof(SettingsPage))
                     .ConfigureJsonFile("Assets/NavViewMenu/AppData.json")
                     .ConfigureTitleBar(AppTitleBar)
                     .ConfigureBreadcrumbBar(BreadCrumbNav, BreadcrumbPageMappings.PageDictionary);
             }
+        }
+
+        private void ApplyLocalizedShellText()
+        {
+            SearchBox.PlaceholderText = localizationService.GetString("MainWindow.SearchBox.PlaceholderText");
+            ToolTipService.SetToolTip(ThemeButton, localizationService.GetString("MainWindow.ThemeButton.ToolTip"));
+        }
+
+        private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
+        {
+            if (!DispatcherQueue.HasThreadAccess)
+            {
+                _ = DispatcherQueue.TryEnqueue(RefreshLocalizedShell);
+                return;
+            }
+
+            RefreshLocalizedShell();
+        }
+
+        private void RefreshLocalizedShell()
+        {
+            ApplyLocalizedShellText();
+            jsonNavigationService?.ReInitialize();
+
+            Type? currentPageType = NavFrame.CurrentSourcePageType;
+            if (currentPageType is not null)
+            {
+                NavFrame.Navigate(currentPageType);
+            }
+        }
+
+        private void OnClosed(object sender, WindowEventArgs args)
+        {
+            localizationService.LanguageChanged -= OnLanguageChanged;
+            Closed -= OnClosed;
         }
 
         private async void ThemeButton_Click(object sender, RoutedEventArgs e)

--- a/src/Foundry/Views/MainWindow.xaml.cs
+++ b/src/Foundry/Views/MainWindow.xaml.cs
@@ -43,6 +43,11 @@ namespace Foundry.Views
         {
             SearchBox.PlaceholderText = localizationService.GetString("MainWindow.SearchBox.PlaceholderText");
             ToolTipService.SetToolTip(ThemeButton, localizationService.GetString("MainWindow.ThemeButton.ToolTip"));
+
+            if (NavView.SettingsItem is NavigationViewItem settingsItem)
+            {
+                settingsItem.Content = localizationService.GetString("SettingsPage.PageTitle");
+            }
         }
 
         private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
@@ -58,14 +63,57 @@ namespace Foundry.Views
 
         private void RefreshLocalizedShell()
         {
-            ApplyLocalizedShellText();
             jsonNavigationService?.ReInitialize();
+            ApplyLocalizedShellText();
+            RefreshLocalizedBreadcrumbs();
 
             Type? currentPageType = NavFrame.CurrentSourcePageType;
             if (currentPageType is not null)
             {
                 NavFrame.Navigate(currentPageType);
+                RefreshLocalizedBreadcrumbs();
             }
+        }
+
+        private void RefreshLocalizedBreadcrumbs()
+        {
+            if (BreadCrumbNav.BreadCrumbs is null || BreadCrumbNav.BreadCrumbs.Count == 0)
+            {
+                return;
+            }
+
+            BreadCrumbNav.BreadCrumbs = new(BreadCrumbNav.BreadCrumbs.Select(step =>
+                new BreadcrumbStep(GetLocalizedBreadcrumbLabel(step), step.Page, step.Parameter)));
+        }
+
+        private string GetLocalizedBreadcrumbLabel(BreadcrumbStep step)
+        {
+            if (step.Page == typeof(SettingsPage))
+            {
+                return localizationService.GetString("SettingsPage.PageTitle");
+            }
+
+            if (step.Page == typeof(GeneralSettingPage))
+            {
+                return localizationService.GetString("SettingsPage_GeneralCard.Header");
+            }
+
+            if (step.Page == typeof(ThemeSettingPage))
+            {
+                return localizationService.GetString("SettingsPage_ThemeCard.Header");
+            }
+
+            if (step.Page == typeof(AppUpdateSettingPage))
+            {
+                return localizationService.GetString("SettingsPage_UpdateCard.Header");
+            }
+
+            if (step.Page == typeof(AboutUsSettingPage))
+            {
+                return localizationService.GetString("SettingsPage_AboutCard.Header");
+            }
+
+            return step.Label;
         }
 
         private void OnClosed(object sender, WindowEventArgs args)

--- a/src/Foundry/Views/Settings/AboutUsSettingPage.xaml
+++ b/src/Foundry/Views/Settings/AboutUsSettingPage.xaml
@@ -15,8 +15,7 @@
         <StackPanel Margin="10"
                     dev:PanelAttach.ChildrenTransitions="Default"
                     Spacing="5">
-            <dev:SettingsExpander Description="Description"
-                                  Header="Foundry"
+            <dev:SettingsExpander x:Uid="About_FoundryExpander"
                                   HeaderIcon="{dev:BitmapIcon Source=Assets/AppIcon.png}"
                                   IsExpanded="True">
 
@@ -28,10 +27,10 @@
                                       ContentAlignment="Left">
                         <StackPanel Orientation="Vertical"
                                     Spacing="5">
-                            <TextBlock Text="Related Links" />
-                            <HyperlinkButton Content="Source Code"
+                            <TextBlock x:Uid="About_RelatedLinksText" />
+                            <HyperlinkButton x:Uid="About_SourceCodeLink"
                                              NavigateUri="{x:Bind ViewModel.RepositoryUri}" />
-                            <HyperlinkButton Content="Release Notes"
+                            <HyperlinkButton x:Uid="About_ReleaseNotesLink"
                                              NavigateUri="{x:Bind ViewModel.LatestReleaseUri}" />
                         </StackPanel>
                     </dev:SettingsCard>

--- a/src/Foundry/Views/Settings/AppUpdateSettingPage.xaml
+++ b/src/Foundry/Views/Settings/AppUpdateSettingPage.xaml
@@ -20,8 +20,8 @@
                 <dev:SettingsCard.Description>
                     <StackPanel Orientation="Horizontal"
                                 Spacing="5">
-                        <TextBlock Style="{StaticResource SecondaryTextStyle}"
-                                   Text="Last Update Check" />
+                        <TextBlock x:Uid="AppUpdate_LastCheckLabel"
+                                   Style="{StaticResource SecondaryTextStyle}" />
                         <TextBlock FlowDirection="LeftToRight"
                                    Style="{StaticResource SecondaryTextStyle}"
                                    Text="{x:Bind ViewModel.LastUpdateCheck}" />
@@ -31,8 +31,8 @@
                             Spacing="10">
                     <ProgressRing IsActive="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
                     <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            x:Uid="AppUpdate_CheckButton"
                             Command="{x:Bind ViewModel.CheckForUpdateCommand}"
-                            Content="Check for New Version"
                             IsEnabled="{x:Bind ViewModel.IsCheckButtonEnabled, Mode=OneWay}"
                             Style="{ThemeResource AccentButtonStyle}" />
                 </StackPanel>
@@ -46,8 +46,8 @@
                               HeaderIcon="{dev:BitmapIcon Source=Assets/Fluent/Info.png}">
                 <dev:SettingsCard.Description>
                     <HyperlinkButton Padding="5,0"
+                                     x:Uid="AppUpdate_ReleaseNotesLink"
                                      Command="{x:Bind ViewModel.GetReleaseNotesCommand}"
-                                     Content="Release Note"
                                      Visibility="{x:Bind ViewModel.IsReleaseNotesVisible, Mode=OneWay}" />
                 </dev:SettingsCard.Description>
                 <StackPanel VerticalAlignment="Center"
@@ -58,8 +58,8 @@
                                  Value="{x:Bind ViewModel.DownloadProgress, Mode=OneWay}"
                                  Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
                     <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            x:Uid="AppUpdate_DownloadRestartButton"
                             Command="{x:Bind ViewModel.DownloadAndRestartUpdateCommand}"
-                            Content="Download and Restart"
                             Visibility="{x:Bind ViewModel.IsInstallButtonVisible, Mode=OneWay}" />
                 </StackPanel>
             </dev:SettingsCard>

--- a/src/Foundry/Views/Settings/GeneralSettingPage.xaml
+++ b/src/Foundry/Views/Settings/GeneralSettingPage.xaml
@@ -16,14 +16,23 @@
                     dev:PanelAttach.ChildrenTransitions="Default"
                     Spacing="5">
 
-            <dev:SettingsCard Description="Automatically launch app when you log in to Windows"
-                              Header="Run at startup"
+            <dev:SettingsCard x:Uid="GeneralSetting_StartupCard"
                               HeaderIcon="{dev:BitmapIcon Source=Assets/Fluent/Startup.png}">
                 <ToggleSwitch IsOn="{x:Bind dev:StartupHelper.IsAppStartupWithWindowsForXamlBindingEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </dev:SettingsCard>
 
-            <dev:SettingsExpander Description="Help us improve this app by sharing optional diagnostics data to inform bug fixes, performance, and feature enhancements"
-                                  Header="Diagnostics &amp; feedback (Restart Required)"
+            <dev:SettingsCard x:Uid="GeneralSetting_LanguageCard">
+                <dev:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xF2B7;" />
+                </dev:SettingsCard.HeaderIcon>
+                <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                          DisplayMemberPath="DisplayName"
+                          ItemsSource="{x:Bind ViewModel.SupportedLanguages, Mode=OneWay}"
+                          SelectedItem="{x:Bind ViewModel.SelectedLanguage, Mode=TwoWay}"
+                          SelectionChanged="LanguageComboBox_SelectionChanged" />
+            </dev:SettingsCard>
+
+            <dev:SettingsExpander x:Uid="GeneralSetting_DiagnosticsCard"
                                   HeaderIcon="{dev:BitmapIcon Source=Assets/Fluent/DevMode.png}">
                 <ToggleSwitch IsOn="{x:Bind ViewModel.IsDeveloperMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 <dev:SettingsExpander.ItemsHeader>

--- a/src/Foundry/Views/Settings/GeneralSettingPage.xaml
+++ b/src/Foundry/Views/Settings/GeneralSettingPage.xaml
@@ -16,16 +16,19 @@
                     dev:PanelAttach.ChildrenTransitions="Default"
                     Spacing="5">
 
-            <dev:SettingsCard x:Uid="GeneralSetting_StartupCard"
+            <dev:SettingsCard x:Name="StartupCard"
+                              x:Uid="GeneralSetting_StartupCard"
                               HeaderIcon="{dev:BitmapIcon Source=Assets/Fluent/Startup.png}">
                 <ToggleSwitch IsOn="{x:Bind dev:StartupHelper.IsAppStartupWithWindowsForXamlBindingEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </dev:SettingsCard>
 
-            <dev:SettingsCard x:Uid="GeneralSetting_LanguageCard">
+            <dev:SettingsCard x:Name="LanguageCard"
+                              x:Uid="GeneralSetting_LanguageCard">
                 <dev:SettingsCard.HeaderIcon>
                     <FontIcon Glyph="&#xF2B7;" />
                 </dev:SettingsCard.HeaderIcon>
-                <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                <ComboBox x:Name="LanguageComboBox"
+                          MinWidth="{StaticResource SettingActionControlMinWidth}"
                           ItemsSource="{x:Bind ViewModel.SupportedLanguages, Mode=OneWay}"
                           SelectedItem="{x:Bind ViewModel.SelectedLanguage, Mode=TwoWay}"
                           SelectionChanged="LanguageComboBox_SelectionChanged">
@@ -37,7 +40,8 @@
                 </ComboBox>
             </dev:SettingsCard>
 
-            <dev:SettingsExpander x:Uid="GeneralSetting_DiagnosticsCard"
+            <dev:SettingsExpander x:Name="DiagnosticsCard"
+                                  x:Uid="GeneralSetting_DiagnosticsCard"
                                   HeaderIcon="{dev:BitmapIcon Source=Assets/Fluent/DevMode.png}">
                 <ToggleSwitch IsOn="{x:Bind ViewModel.IsDeveloperMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 <dev:SettingsExpander.ItemsHeader>

--- a/src/Foundry/Views/Settings/GeneralSettingPage.xaml
+++ b/src/Foundry/Views/Settings/GeneralSettingPage.xaml
@@ -26,10 +26,15 @@
                     <FontIcon Glyph="&#xF2B7;" />
                 </dev:SettingsCard.HeaderIcon>
                 <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
-                          DisplayMemberPath="DisplayName"
                           ItemsSource="{x:Bind ViewModel.SupportedLanguages, Mode=OneWay}"
                           SelectedItem="{x:Bind ViewModel.SelectedLanguage, Mode=TwoWay}"
-                          SelectionChanged="LanguageComboBox_SelectionChanged" />
+                          SelectionChanged="LanguageComboBox_SelectionChanged">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding DisplayName}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
             </dev:SettingsCard>
 
             <dev:SettingsExpander x:Uid="GeneralSetting_DiagnosticsCard"

--- a/src/Foundry/Views/Settings/GeneralSettingPage.xaml
+++ b/src/Foundry/Views/Settings/GeneralSettingPage.xaml
@@ -19,7 +19,8 @@
             <dev:SettingsCard x:Name="StartupCard"
                               x:Uid="GeneralSetting_StartupCard"
                               HeaderIcon="{dev:BitmapIcon Source=Assets/Fluent/Startup.png}">
-                <ToggleSwitch IsOn="{x:Bind dev:StartupHelper.IsAppStartupWithWindowsForXamlBindingEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <ToggleSwitch x:Name="StartupToggle"
+                              IsOn="{x:Bind dev:StartupHelper.IsAppStartupWithWindowsForXamlBindingEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </dev:SettingsCard>
 
             <dev:SettingsCard x:Name="LanguageCard"
@@ -43,7 +44,8 @@
             <dev:SettingsExpander x:Name="DiagnosticsCard"
                                   x:Uid="GeneralSetting_DiagnosticsCard"
                                   HeaderIcon="{dev:BitmapIcon Source=Assets/Fluent/DevMode.png}">
-                <ToggleSwitch IsOn="{x:Bind ViewModel.IsDeveloperMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <ToggleSwitch x:Name="DiagnosticsToggle"
+                              IsOn="{x:Bind ViewModel.IsDeveloperMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 <dev:SettingsExpander.ItemsHeader>
                     <HyperlinkButton HorizontalAlignment="Stretch"
                                      HorizontalContentAlignment="Left"

--- a/src/Foundry/Views/Settings/GeneralSettingPage.xaml.cs
+++ b/src/Foundry/Views/Settings/GeneralSettingPage.xaml.cs
@@ -4,16 +4,24 @@ namespace Foundry.Views;
 
 public sealed partial class GeneralSettingPage : Page
 {
+    private bool isInitializingLanguageSelection = true;
+
     public GeneralSettingViewModel ViewModel { get; }
 
     public GeneralSettingPage()
     {
         ViewModel = App.GetService<GeneralSettingViewModel>();
         InitializeComponent();
+        isInitializingLanguageSelection = false;
     }
 
     private async void LanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
+        if (isInitializingLanguageSelection)
+        {
+            return;
+        }
+
         if (e.AddedItems.FirstOrDefault() is SupportedCultureOption selectedLanguage)
         {
             await ViewModel.SetLanguageAsync(selectedLanguage);

--- a/src/Foundry/Views/Settings/GeneralSettingPage.xaml.cs
+++ b/src/Foundry/Views/Settings/GeneralSettingPage.xaml.cs
@@ -1,12 +1,22 @@
-﻿namespace Foundry.Views
+using Foundry.Core.Localization;
+
+namespace Foundry.Views;
+
+public sealed partial class GeneralSettingPage : Page
 {
-    public sealed partial class GeneralSettingPage : Page
+    public GeneralSettingViewModel ViewModel { get; }
+
+    public GeneralSettingPage()
     {
-        public GeneralSettingViewModel ViewModel { get; }
-        public GeneralSettingPage()
+        ViewModel = App.GetService<GeneralSettingViewModel>();
+        InitializeComponent();
+    }
+
+    private async void LanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (e.AddedItems.FirstOrDefault() is SupportedCultureOption selectedLanguage)
         {
-            ViewModel = App.GetService<GeneralSettingViewModel>();
-            this.InitializeComponent();
+            await ViewModel.SetLanguageAsync(selectedLanguage);
         }
     }
 }

--- a/src/Foundry/Views/Settings/GeneralSettingPage.xaml.cs
+++ b/src/Foundry/Views/Settings/GeneralSettingPage.xaml.cs
@@ -1,17 +1,23 @@
 using Foundry.Core.Localization;
+using Foundry.Services.Localization;
 
 namespace Foundry.Views;
 
 public sealed partial class GeneralSettingPage : Page
 {
     private bool isInitializingLanguageSelection = true;
+    private readonly IApplicationLocalizationService localizationService;
 
     public GeneralSettingViewModel ViewModel { get; }
 
     public GeneralSettingPage()
     {
+        localizationService = App.GetService<IApplicationLocalizationService>();
         ViewModel = App.GetService<GeneralSettingViewModel>();
         InitializeComponent();
+        ApplyLocalizedText();
+        localizationService.LanguageChanged += OnLanguageChanged;
+        Unloaded += OnUnloaded;
         isInitializingLanguageSelection = false;
     }
 
@@ -26,5 +32,40 @@ public sealed partial class GeneralSettingPage : Page
         {
             await ViewModel.SetLanguageAsync(selectedLanguage);
         }
+    }
+
+    private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
+    {
+        if (!DispatcherQueue.HasThreadAccess)
+        {
+            _ = DispatcherQueue.TryEnqueue(ApplyLocalizedText);
+            return;
+        }
+
+        ApplyLocalizedText();
+    }
+
+    private void ApplyLocalizedText()
+    {
+        StartupCard.Header = localizationService.GetString("GeneralSetting_StartupCard.Header");
+        StartupCard.Description = localizationService.GetString("GeneralSetting_StartupCard.Description");
+        LanguageCard.Header = localizationService.GetString("GeneralSetting_LanguageCard.Header");
+        LanguageCard.Description = localizationService.GetString("GeneralSetting_LanguageCard.Description");
+        DiagnosticsCard.Header = localizationService.GetString("GeneralSetting_DiagnosticsCard.Header");
+        DiagnosticsCard.Description = localizationService.GetString("GeneralSetting_DiagnosticsCard.Description");
+
+        BreadcrumbNavigator.SetPageTitle(this, localizationService.GetString("SettingsPage_GeneralCard.Header"));
+
+        bool wasInitializingLanguageSelection = isInitializingLanguageSelection;
+        isInitializingLanguageSelection = true;
+        ViewModel.RefreshSupportedLanguages();
+        LanguageComboBox.SelectedItem = ViewModel.SelectedLanguage;
+        isInitializingLanguageSelection = wasInitializingLanguageSelection;
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        localizationService.LanguageChanged -= OnLanguageChanged;
+        Unloaded -= OnUnloaded;
     }
 }

--- a/src/Foundry/Views/Settings/GeneralSettingPage.xaml.cs
+++ b/src/Foundry/Views/Settings/GeneralSettingPage.xaml.cs
@@ -53,6 +53,10 @@ public sealed partial class GeneralSettingPage : Page
         LanguageCard.Description = localizationService.GetString("GeneralSetting_LanguageCard.Description");
         DiagnosticsCard.Header = localizationService.GetString("GeneralSetting_DiagnosticsCard.Header");
         DiagnosticsCard.Description = localizationService.GetString("GeneralSetting_DiagnosticsCard.Description");
+        StartupToggle.OnContent = localizationService.GetString("Common.Enabled");
+        StartupToggle.OffContent = localizationService.GetString("Common.Disabled");
+        DiagnosticsToggle.OnContent = localizationService.GetString("Common.Enabled");
+        DiagnosticsToggle.OffContent = localizationService.GetString("Common.Disabled");
 
         BreadcrumbNavigator.SetPageTitle(this, localizationService.GetString("SettingsPage_GeneralCard.Header"));
 

--- a/src/Foundry/Views/Settings/ThemeSettingPage.xaml
+++ b/src/Foundry/Views/Settings/ThemeSettingPage.xaml
@@ -15,35 +15,32 @@
         <StackPanel Margin="10"
                     dev:PanelAttach.ChildrenTransitions="Default"
                     Spacing="5">
-            <dev:SettingsCard Description="Select the theme that suits your mood and preference. You can choose from dark, light, or system themes."
-                              Header="App theme"
+            <dev:SettingsCard x:Uid="ThemeSetting_AppThemeCard"
                               HeaderIcon="{dev:BitmapIcon Source=Assets/Fluent/Theme.png}">
                 <ComboBox dev:ThemeServiceAttach.ThemeService="{x:Bind local:App.Current.ThemeService}">
-                    <ComboBoxItem Content="Light"
+                    <ComboBoxItem x:Uid="ThemeSetting_LightItem"
                                   Tag="Light" />
-                    <ComboBoxItem Content="Dark"
+                    <ComboBoxItem x:Uid="ThemeSetting_DarkItem"
                                   Tag="Dark" />
-                    <ComboBoxItem Content="Default"
+                    <ComboBoxItem x:Uid="ThemeSetting_DefaultItem"
                                   Tag="Default" />
                 </ComboBox>
             </dev:SettingsCard>
-            <dev:SettingsCard Description="Change the appearance of the backdrop material behind your app. You can choose from mica, acrylic, or transparent options."
-                              Header="Material"
+            <dev:SettingsCard x:Uid="ThemeSetting_MaterialCard"
                               HeaderIcon="{dev:BitmapIcon Source=Assets/Fluent/Backdrop.png}">
                 <ComboBox dev:ThemeServiceAttach.ThemeService="{x:Bind local:App.Current.ThemeService}">
-                    <ComboBoxItem Content="Mica"
+                    <ComboBoxItem x:Uid="ThemeSetting_MicaItem"
                                   Tag="Mica" />
-                    <ComboBoxItem Content="Mica Alt"
+                    <ComboBoxItem x:Uid="ThemeSetting_MicaAltItem"
                                   Tag="MicaAlt" />
-                    <ComboBoxItem Content="Acrylic"
+                    <ComboBoxItem x:Uid="ThemeSetting_AcrylicItem"
                                   Tag="Acrylic" />
-                    <ComboBoxItem Content="Acrylic Thin"
+                    <ComboBoxItem x:Uid="ThemeSetting_AcrylicThinItem"
                                   Tag="AcrylicThin" />
                 </ComboBox>
             </dev:SettingsCard>
             <dev:SettingsCard ActionIcon="{dev:BitmapIcon Source=Assets/Fluent/External.png}"
-                              Description="Sync your app’s color with your Windows accent color. You can open the Windows accent color setting by clicking this card."
-                              Header="Accent color"
+                              x:Uid="ThemeSetting_AccentCard"
                               HeaderIcon="{dev:BitmapIcon Source=Assets/Fluent/Color.png}"
                               IsClickEnabled="True"
                               LaunchUri="ms-settings:colors" />

--- a/src/Foundry/Views/SettingsPage.xaml
+++ b/src/Foundry/Views/SettingsPage.xaml
@@ -8,6 +8,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:views="using:Foundry.Views"
       dev:BreadcrumbNavigator.IsHeaderVisible="True"
+      dev:BreadcrumbNavigator.PageTitle="Settings"
       mc:Ignorable="d">
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
                 Padding="{ThemeResource ContentPagePadding}"

--- a/src/Foundry/Views/SettingsPage.xaml
+++ b/src/Foundry/Views/SettingsPage.xaml
@@ -16,30 +16,26 @@
         <StackPanel Margin="10"
                     dev:PanelAttach.ChildrenTransitions="Default"
                     Spacing="5">
-            <dev:SettingsCard Description="Change your app Settings"
-                              Header="General"
+            <dev:SettingsCard x:Name="GeneralSettingsCard"
+                              x:Uid="SettingsPage_GeneralCard"
                               HeaderIcon="{dev:BitmapIcon Source=Assets/Fluent/General.png}"
                               IsClickEnabled="True"
-                              Command="{x:Bind local:App.Current.NavService.NavigateToCommand}"
-                              CommandParameter="{dev:NavigationParameter PageType=views:GeneralSettingPage, BreadCrumbHeader='General'}" />
-            <dev:SettingsCard Description="Explore the different ways to customize the appearance and behavior of your app. You can change the material, theme, accent, and more options to suit your style and preference."
-                              Header="Appearance &amp; behavior"
+                              Command="{x:Bind local:App.Current.NavService.NavigateToCommand}" />
+            <dev:SettingsCard x:Name="ThemeSettingsCard"
+                              x:Uid="SettingsPage_ThemeCard"
                               HeaderIcon="{dev:BitmapIcon Source=Assets/Fluent/Theme.png}"
                               IsClickEnabled="True"
-                              Command="{x:Bind local:App.Current.NavService.NavigateToCommand}"
-                              CommandParameter="{dev:NavigationParameter PageType=views:ThemeSettingPage, BreadCrumbHeader='Appearance &amp; behavior'}" />
-            <dev:SettingsCard Description="Check for Updates"
-                              Header="Update App"
+                              Command="{x:Bind local:App.Current.NavService.NavigateToCommand}" />
+            <dev:SettingsCard x:Name="UpdateSettingsCard"
+                              x:Uid="SettingsPage_UpdateCard"
                               HeaderIcon="{dev:BitmapIcon Source=Assets/Fluent/Update.png}"
                               IsClickEnabled="True"
-                              Command="{x:Bind local:App.Current.NavService.NavigateToCommand}"
-                              CommandParameter="{dev:NavigationParameter PageType=views:AppUpdateSettingPage, BreadCrumbHeader='Update App'}" />
-            <dev:SettingsCard Description="About Foundry and Developer"
-                              Header="About us"
+                              Command="{x:Bind local:App.Current.NavService.NavigateToCommand}" />
+            <dev:SettingsCard x:Name="AboutSettingsCard"
+                              x:Uid="SettingsPage_AboutCard"
                               HeaderIcon="{dev:BitmapIcon Source=Assets/Fluent/Info.png}"
                               IsClickEnabled="True"
-                              Command="{x:Bind local:App.Current.NavService.NavigateToCommand}"
-                              CommandParameter="{dev:NavigationParameter PageType=views:AboutUsSettingPage, BreadCrumbHeader='About us'}" />
+                              Command="{x:Bind local:App.Current.NavService.NavigateToCommand}" />
 
         </StackPanel>
     </ScrollView>

--- a/src/Foundry/Views/SettingsPage.xaml
+++ b/src/Foundry/Views/SettingsPage.xaml
@@ -8,7 +8,6 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:views="using:Foundry.Views"
       dev:BreadcrumbNavigator.IsHeaderVisible="True"
-      dev:BreadcrumbNavigator.PageTitle="Settings"
       mc:Ignorable="d">
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
                 Padding="{ThemeResource ContentPagePadding}"

--- a/src/Foundry/Views/SettingsPage.xaml.cs
+++ b/src/Foundry/Views/SettingsPage.xaml.cs
@@ -1,10 +1,41 @@
-﻿namespace Foundry.Views
+using Foundry.Services.Localization;
+
+namespace Foundry.Views
 {
     public sealed partial class SettingsPage : Page
     {
+        private readonly IApplicationLocalizationService localizationService;
+
         public SettingsPage()
         {
+            localizationService = App.GetService<IApplicationLocalizationService>();
             this.InitializeComponent();
+            ApplyLocalizedNavigationParameters();
+        }
+
+        private void ApplyLocalizedNavigationParameters()
+        {
+            GeneralSettingsCard.CommandParameter = CreateNavigationParameter(
+                typeof(GeneralSettingPage),
+                "SettingsPage_GeneralCard.Header");
+            ThemeSettingsCard.CommandParameter = CreateNavigationParameter(
+                typeof(ThemeSettingPage),
+                "SettingsPage_ThemeCard.Header");
+            UpdateSettingsCard.CommandParameter = CreateNavigationParameter(
+                typeof(AppUpdateSettingPage),
+                "SettingsPage_UpdateCard.Header");
+            AboutSettingsCard.CommandParameter = CreateNavigationParameter(
+                typeof(AboutUsSettingPage),
+                "SettingsPage_AboutCard.Header");
+        }
+
+        private NavigationParameterExtension CreateNavigationParameter(Type pageType, string titleResourceKey)
+        {
+            return new NavigationParameterExtension
+            {
+                PageType = pageType,
+                BreadCrumbHeader = localizationService.GetString(titleResourceKey)
+            };
         }
     }
 

--- a/src/Foundry/Views/SettingsPage.xaml.cs
+++ b/src/Foundry/Views/SettingsPage.xaml.cs
@@ -28,7 +28,6 @@ namespace Foundry.Views
 
         private void ApplyLocalizedText()
         {
-            BreadcrumbNavigator.SetPageTitle(this, localizationService.GetString("SettingsPage.PageTitle"));
             ApplyLocalizedNavigationParameters();
         }
 

--- a/src/Foundry/Views/SettingsPage.xaml.cs
+++ b/src/Foundry/Views/SettingsPage.xaml.cs
@@ -10,6 +10,25 @@ namespace Foundry.Views
         {
             localizationService = App.GetService<IApplicationLocalizationService>();
             this.InitializeComponent();
+            ApplyLocalizedText();
+            localizationService.LanguageChanged += OnLanguageChanged;
+            Unloaded += OnUnloaded;
+        }
+
+        private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
+        {
+            if (!DispatcherQueue.HasThreadAccess)
+            {
+                _ = DispatcherQueue.TryEnqueue(ApplyLocalizedText);
+                return;
+            }
+
+            ApplyLocalizedText();
+        }
+
+        private void ApplyLocalizedText()
+        {
+            BreadcrumbNavigator.SetPageTitle(this, localizationService.GetString("SettingsPage.PageTitle"));
             ApplyLocalizedNavigationParameters();
         }
 
@@ -36,6 +55,12 @@ namespace Foundry.Views
                 PageType = pageType,
                 BreadCrumbHeader = localizationService.GetString(titleResourceKey)
             };
+        }
+
+        private void OnUnloaded(object sender, RoutedEventArgs e)
+        {
+            localizationService.LanguageChanged -= OnLanguageChanged;
+            Unloaded -= OnUnloaded;
         }
     }
 


### PR DESCRIPTION
## Summary
- Add WinUI `.resw` resources for English and French shell/settings text.
- Initialize Windows App SDK localization before WinUI resources load.
- Add runtime language switching with DevWinUI navigation refresh and localized breadcrumb parameters.
- Localize update/settings view-model messages and add supported culture validation tests.

## Reason
Phase 9 requires replacing the WPF `.resx` localization model in the WinUI Foundry app while keeping Foundry.Core free of Windows App SDK resource APIs.

## Main changes
- Adds `Strings/en-US/Resources.resw` and `Strings/fr-FR/Resources.resw`.
- Includes `.resw` files as DevWinUI source-generator input and PRI resources.
- Updates `AppData.json` to use DevWinUI `LocalizeId`/`UsexUid` navigation localization.
- Adds `IApplicationLocalizationService` string lookup, formatting, culture persistence, and language-change event support.
- Reloads the active shell page after a language change so already-loaded XAML text refreshes without app restart.

## Testing
- `dotnet build .\src\Foundry.slnx -c Debug -p:Platform=x64 --nologo`
- `dotnet test .\src\Foundry.slnx -c Release -p:Platform=x64 --nologo`
- Controlled Debug launch from the worktree output; startup stayed up and latest log entries no longer report missing shell localization keys.
