### PR TITLE
refactor: migrate foundry logging for winui

### DIFF
--- a/docs/migration/phases/04-localization-logging-shell.md
+++ b/docs/migration/phases/04-localization-logging-shell.md
@@ -94,6 +94,7 @@ git commit -m "feat: migrate foundry localization to winui"
 - [ ] **10.1** Use the approved ProgramData log directory:
   - [ ] `C:\ProgramData\Foundry\Logs`.
   - [ ] Do not use `%LocalAppData%\Foundry\Logs` for the WinUI `Foundry` app.
+  - [ ] Validate the existing `Constants.LogDirectoryPath` and `Constants.LogFilePath` implementation before changing it.
 - [ ] **10.2** Use a single active host log file for the initial WinUI migration:
   - [ ] `C:\ProgramData\Foundry\Logs\Foundry.log`.
   - [ ] Add rolling only if implementation or test evidence shows the active log can grow too large.
@@ -104,17 +105,38 @@ git commit -m "feat: migrate foundry localization to winui"
   - [ ] Process architecture.
   - [ ] Update/install context.
   - [ ] Source context.
-- [ ] **10.5** Configure Serilog before app startup work.
+- [ ] **10.5** Configure bootstrap Serilog before app startup work:
+  - [ ] Initialize logging in `Program.Main` before `VelopackApp.Build().Run()`.
+  - [ ] Log Velopack startup/update hook entry and completion.
+  - [ ] Log WinRT COM wrapper initialization start and completion.
+  - [ ] Keep final app logger configuration consistent after DI/settings are available.
+- [ ] **10.5.1** Register unhandled exception handlers as early as possible:
+  - [ ] Cover failures before `App` host creation where feasible.
+  - [ ] Preserve AppDomain, WinUI, and unobserved task exception logging.
+- [ ] **10.5.2** Implement source-context logging:
+  - [ ] Do not inject the same untyped global `Serilog.ILogger` when class-level source context is expected.
+  - [ ] Use contextual loggers such as `Log.ForContext<T>()`, a typed logger factory, or a Serilog-backed Microsoft logging integration.
+  - [ ] Confirm `SourceContext` is visible in log output.
+- [ ] **10.5.3** Implement runtime log-level policy:
+  - [ ] Use a Serilog `LoggingLevelSwitch` or equivalent logger reconfiguration.
+  - [ ] Default mode writes `Information`, `Warning`, `Error`, and `Fatal`.
+  - [ ] Developer mode adds `Debug`.
+  - [ ] Switching `diagnostics.developerMode` in Settings updates the active logging level without restarting when feasible.
+  - [ ] Do not use `Verbose` unless a future subsystem proves it needs trace-level diagnostics.
 - [ ] **10.6** Add logging for:
   - [ ] App startup.
   - [ ] Windows App SDK runtime initialization.
   - [ ] Velopack first run/update flow.
   - [x] Startup and manual update check elapsed time.
-  - [ ] ADK detection.
-  - [ ] ISO/USB build start and completion.
-  - [ ] Bootstrap payload resolution.
+  - [ ] Debug-level diagnostic details where useful, emitted only when `diagnostics.developerMode` is enabled in Settings.
+- [ ] **10.6.1** Define future workflow logging contracts without blocking Phase 10 on unimplemented workflows:
+  - [ ] ADK detection logs required when ADK service/page work is implemented.
+  - [ ] ISO/USB build start, progress, completion, cancellation, and failure logs required when media creation work is implemented.
+  - [ ] Bootstrap payload resolution logs required when payload resolution work is implemented.
 - [ ] **10.7** Keep log folder command in UI.
 - [ ] **10.7.1** Log folder command opens `C:\ProgramData\Foundry\Logs`.
+- [ ] **10.7.2** Remove unused logging dependencies unless they serve a configured sink:
+  - [ ] Remove `Serilog.Sinks.Console` from the WinUI project if no console sink is intentionally configured.
 - [ ] **10.8** Commit:
 
 ```powershell
@@ -127,6 +149,9 @@ git commit -m "refactor: migrate foundry logging for winui"
 - [ ] **10.10** Confirm startup failures are logged.
 - [ ] **10.11** Confirm update failures are logged.
 - [ ] **10.12** Confirm media creation logs remain readable.
+- [ ] **10.13** Confirm `Debug` events are absent when `diagnostics.developerMode=false`.
+- [ ] **10.14** Confirm `Debug` events are written when `diagnostics.developerMode=true`.
+- [ ] **10.15** Confirm source context appears for app services.
 
 ## Phase 11: Shell, Navigation, And App Settings
 

--- a/docs/migration/phases/04-localization-logging-shell.md
+++ b/docs/migration/phases/04-localization-logging-shell.md
@@ -91,53 +91,55 @@ git commit -m "feat: migrate foundry localization to winui"
 
 **Goal:** preserve production diagnostics across the WinUI startup and update model.
 
-- [ ] **10.1** Use the approved ProgramData log directory:
-  - [ ] `C:\ProgramData\Foundry\Logs`.
-  - [ ] Do not use `%LocalAppData%\Foundry\Logs` for the WinUI `Foundry` app.
-  - [ ] Validate the existing `Constants.LogDirectoryPath` and `Constants.LogFilePath` implementation before changing it.
-- [ ] **10.2** Use a single active host log file for the initial WinUI migration:
-  - [ ] `C:\ProgramData\Foundry\Logs\Foundry.log`.
-  - [ ] Add rolling only if implementation or test evidence shows the active log can grow too large.
-- [ ] **10.3** Preserve UTC timestamp enrichment.
-- [ ] **10.4** Include:
-  - [ ] App version.
-  - [ ] Runtime identifier.
-  - [ ] Process architecture.
-  - [ ] Update/install context.
-  - [ ] Source context.
-- [ ] **10.5** Configure bootstrap Serilog before app startup work:
-  - [ ] Initialize logging in `Program.Main` before `VelopackApp.Build().Run()`.
-  - [ ] Log Velopack startup/update hook entry and completion.
-  - [ ] Log WinRT COM wrapper initialization start and completion.
-  - [ ] Keep final app logger configuration consistent after DI/settings are available.
-- [ ] **10.5.1** Register unhandled exception handlers as early as possible:
-  - [ ] Cover failures before `App` host creation where feasible.
-  - [ ] Preserve AppDomain, WinUI, and unobserved task exception logging.
-- [ ] **10.5.2** Implement source-context logging:
-  - [ ] Do not inject the same untyped global `Serilog.ILogger` when class-level source context is expected.
-  - [ ] Use contextual loggers such as `Log.ForContext<T>()`, a typed logger factory, or a Serilog-backed Microsoft logging integration.
-  - [ ] Confirm `SourceContext` is visible in log output.
-- [ ] **10.5.3** Implement runtime log-level policy:
-  - [ ] Use a Serilog `LoggingLevelSwitch` or equivalent logger reconfiguration.
-  - [ ] Default mode writes `Information`, `Warning`, `Error`, and `Fatal`.
-  - [ ] Developer mode adds `Debug`.
-  - [ ] Switching `diagnostics.developerMode` in Settings updates the active logging level without restarting when feasible.
-  - [ ] Do not use `Verbose` unless a future subsystem proves it needs trace-level diagnostics.
-- [ ] **10.6** Add logging for:
-  - [ ] App startup.
-  - [ ] Windows App SDK runtime initialization.
-  - [ ] Velopack first run/update flow.
+- [x] **10.1** Use the approved ProgramData log directory:
+  - [x] `C:\ProgramData\Foundry\Logs`.
+  - [x] Do not use `%LocalAppData%\Foundry\Logs` for the WinUI `Foundry` app.
+  - [x] Validate the existing `Constants.LogDirectoryPath` and `Constants.LogFilePath` implementation before changing it.
+- [x] **10.2** Use a single active host log file for the initial WinUI migration:
+  - [x] `C:\ProgramData\Foundry\Logs\Foundry.log`.
+  - [x] Add rolling only if implementation or test evidence shows the active log can grow too large.
+- [x] **10.3** Use a readable timestamp in the human log:
+  - [x] Keep local timestamp with offset in `Foundry.log`.
+  - [x] Do not duplicate UTC metadata on every line.
+- [x] **10.4** Include:
+  - [x] App version in startup metadata.
+  - [x] Runtime identifier in startup metadata.
+  - [x] Process architecture in startup metadata.
+  - [x] Update/install context in relevant update and Velopack events.
+  - [x] Concise source context.
+- [x] **10.5** Configure bootstrap Serilog before app startup work:
+  - [x] Initialize logging in `Program.Main` before `VelopackApp.Build().Run()`.
+  - [x] Log Velopack startup/update hook entry and completion.
+  - [x] Log WinRT COM wrapper initialization start and completion.
+  - [x] Keep final app logger configuration consistent after DI/settings are available.
+- [x] **10.5.1** Register unhandled exception handlers as early as possible:
+  - [x] Cover failures before `App` host creation where feasible.
+  - [x] Preserve AppDomain, WinUI, and unobserved task exception logging.
+- [x] **10.5.2** Implement source-context logging:
+  - [x] Do not inject the same untyped global `Serilog.ILogger` when class-level source context is expected.
+  - [x] Use contextual loggers such as `Log.ForContext<T>()`, a typed logger factory, or a Serilog-backed Microsoft logging integration.
+  - [x] Confirm a concise source context/component is visible in log output.
+- [x] **10.5.3** Implement runtime log-level policy:
+  - [x] Use a Serilog `LoggingLevelSwitch` or equivalent logger reconfiguration.
+  - [x] Default mode writes `Information`, `Warning`, `Error`, and `Fatal`.
+  - [x] Developer mode adds `Debug`.
+  - [x] Switching `diagnostics.developerMode` in Settings updates the active logging level without restarting when feasible.
+  - [x] Do not use `Verbose` unless a future subsystem proves it needs trace-level diagnostics.
+- [x] **10.6** Add logging for:
+  - [x] App startup.
+  - [x] Windows App SDK runtime initialization.
+  - [x] Velopack first run/update flow.
   - [x] Startup and manual update check elapsed time.
-  - [ ] Debug-level diagnostic details where useful, emitted only when `diagnostics.developerMode` is enabled in Settings.
+  - [x] Debug-level diagnostic details where useful, emitted only when `diagnostics.developerMode` is enabled in Settings.
 - [ ] **10.6.1** Define future workflow logging contracts without blocking Phase 10 on unimplemented workflows:
   - [ ] ADK detection logs required when ADK service/page work is implemented.
   - [ ] ISO/USB build start, progress, completion, cancellation, and failure logs required when media creation work is implemented.
   - [ ] Bootstrap payload resolution logs required when payload resolution work is implemented.
-- [ ] **10.7** Keep log folder command in UI.
-- [ ] **10.7.1** Log folder command opens `C:\ProgramData\Foundry\Logs`.
-- [ ] **10.7.2** Remove unused logging dependencies unless they serve a configured sink:
-  - [ ] Remove `Serilog.Sinks.Console` from the WinUI project if no console sink is intentionally configured.
-- [ ] **10.8** Commit:
+- [x] **10.7** Keep log folder command in UI.
+- [x] **10.7.1** Log folder command opens `C:\ProgramData\Foundry\Logs`.
+- [x] **10.7.2** Remove unused logging dependencies unless they serve a configured sink:
+  - [x] Remove `Serilog.Sinks.Console` from the WinUI project if no console sink is intentionally configured.
+- [x] **10.8** Commit:
 
 ```powershell
 git commit -m "refactor: migrate foundry logging for winui"
@@ -145,13 +147,15 @@ git commit -m "refactor: migrate foundry logging for winui"
 
 **Validation**
 
-- [ ] **10.9** Confirm log file exists after normal startup.
-- [ ] **10.10** Confirm startup failures are logged.
-- [ ] **10.11** Confirm update failures are logged.
+- [x] **10.9** Confirm log file exists after normal startup.
+- [x] **10.10** Confirm startup failures are logged.
+- [x] **10.11** Confirm update failures are logged.
 - [ ] **10.12** Confirm media creation logs remain readable.
-- [ ] **10.13** Confirm `Debug` events are absent when `diagnostics.developerMode=false`.
-- [ ] **10.14** Confirm `Debug` events are written when `diagnostics.developerMode=true`.
-- [ ] **10.15** Confirm source context appears for app services.
+  - Deferred until Phase 12 implements ISO/USB media creation in WinUI.
+  - Complete this through Phase 12 validation item **12.16**.
+- [x] **10.13** Confirm `Debug` events are absent when `diagnostics.developerMode=false`.
+- [x] **10.14** Confirm `Debug` events are written when `diagnostics.developerMode=true`.
+- [x] **10.15** Confirm concise source context appears for app services.
 
 ## Phase 11: Shell, Navigation, And App Settings
 

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -57,6 +57,10 @@ git commit -m "feat: port media creation workflow to winui"
 - [ ] **12.13** ADK missing state disables `Start` navigation through the shell guard.
 - [ ] **12.14** ISO creation overlay blocks navigation until completion.
 - [ ] **12.15** USB creation overlay blocks navigation until completion.
+- [ ] **12.16** Confirm media creation logs remain readable and complete deferred Phase 10 validation **10.12**:
+  - [ ] ISO creation logs include start, progress, completion, cancellation, and failure details.
+  - [ ] USB creation logs include start, progress, completion, cancellation, and failure details.
+  - [ ] Logs are readable in `C:\ProgramData\Foundry\Logs\Foundry.log` without enabling `Verbose`.
 
 ## Phase 13: ADK And WinPE Service Integration
 

--- a/src/Foundry/App.xaml.cs
+++ b/src/Foundry/App.xaml.cs
@@ -1,5 +1,6 @@
 using Foundry.DependencyInjection;
 using Foundry.Services.Localization;
+using Foundry.Services.Settings;
 using Foundry.Services.Startup;
 using Microsoft.Extensions.Hosting;
 using Serilog;
@@ -8,6 +9,7 @@ namespace Foundry
 {
     public partial class App : Application
     {
+        private static readonly ILogger AppLogger = Log.ForContext<App>();
         private bool isShuttingDown;
 
         public new static App Current => (App)Application.Current;
@@ -30,14 +32,12 @@ namespace Foundry
 
         public App()
         {
-            Constants.EnsureDataDirectories();
-            ConfigureLogger();
-
             Host = FoundryHost.Create();
+            SetDeveloperModeEnabled(Host.Services.GetRequiredService<IAppSettingsService>().Current.Diagnostics.DeveloperMode);
             Host.Services.GetRequiredService<IApplicationLocalizationService>().InitializeAsync().GetAwaiter().GetResult();
-            RegisterExceptionHandlers();
+            RegisterWinUiExceptionHandler();
 
-            Logger.Information("Foundry WinUI startup initialized.");
+            AppLogger.Information("Foundry WinUI host initialized.");
             this.InitializeComponent();
         }
 
@@ -59,7 +59,7 @@ namespace Foundry
             }
             catch (Exception ex)
             {
-                Logger.Fatal(ex, "Foundry failed during WinUI launch.");
+                AppLogger.Error(ex, "Foundry WinUI launch failed.");
                 throw;
             }
         }
@@ -69,52 +69,41 @@ namespace Foundry
             ContextMenuService menuService = GetService<ContextMenuService>();
             if (RuntimeHelper.IsPackaged())
             {
-                ContextMenuItem menu = new()
+                try
                 {
-                    Title = "Open Foundry Here",
-                    Param = @"""{path}""",
-                    AcceptFileFlag = (int)FileMatchFlagEnum.All,
-                    AcceptDirectoryFlag = (int)(DirectoryMatchFlagEnum.Directory | DirectoryMatchFlagEnum.Background | DirectoryMatchFlagEnum.Desktop),
-                    AcceptMultipleFilesFlag = (int)FilesMatchFlagEnum.Each,
-                    Index = 0,
-                    Enabled = true,
-                    Icon = ProcessInfoHelper.GetFileVersionInfo().FileName,
-                    Exe = "Foundry.exe"
-                };
+                    ContextMenuItem menu = new()
+                    {
+                        Title = "Open Foundry Here",
+                        Param = @"""{path}""",
+                        AcceptFileFlag = (int)FileMatchFlagEnum.All,
+                        AcceptDirectoryFlag = (int)(DirectoryMatchFlagEnum.Directory | DirectoryMatchFlagEnum.Background | DirectoryMatchFlagEnum.Desktop),
+                        AcceptMultipleFilesFlag = (int)FilesMatchFlagEnum.Each,
+                        Index = 0,
+                        Enabled = true,
+                        Icon = ProcessInfoHelper.GetFileVersionInfo().FileName,
+                        Exe = "Foundry.exe"
+                    };
 
-                await menuService.SaveAsync(menu);
+                    await menuService.SaveAsync(menu);
+                }
+                catch (Exception ex)
+                {
+                    AppLogger.Warning(ex, "Failed to register packaged shell context menu.");
+                }
             }
 
             await GetService<IStartupReadinessService>().InitializeAsync();
+            AppLogger.Information("Foundry WinUI startup completed.");
         }
 
-        private void RegisterExceptionHandlers()
+        private void RegisterWinUiExceptionHandler()
         {
-            AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
-            TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
             UnhandledException += OnWinUiUnhandledException;
-        }
-
-        private static void OnUnhandledException(object sender, System.UnhandledExceptionEventArgs e)
-        {
-            if (e.ExceptionObject is Exception ex)
-            {
-                Logger.Fatal(ex, "Unhandled AppDomain exception. IsTerminating={IsTerminating}", e.IsTerminating);
-                return;
-            }
-
-            Logger.Fatal("Unhandled AppDomain exception. IsTerminating={IsTerminating}, ExceptionObject={ExceptionObject}", e.IsTerminating, e.ExceptionObject);
-        }
-
-        private static void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
-        {
-            Logger.Error(e.Exception, "Unobserved task exception.");
-            e.SetObserved();
         }
 
         private static void OnWinUiUnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
         {
-            Logger.Fatal(e.Exception, "Unhandled WinUI exception.");
+            AppLogger.Fatal(e.Exception, "Unhandled WinUI exception.");
         }
 
         private void OnMainWindowClosed(object sender, WindowEventArgs args)
@@ -125,7 +114,7 @@ namespace Foundry
             }
 
             isShuttingDown = true;
-            Logger.Information("Foundry WinUI shutdown started.");
+            AppLogger.Information("Foundry WinUI shutdown started.");
             Host.Dispose();
             Log.CloseAndFlush();
         }

--- a/src/Foundry/Common/LoggerSetup.cs
+++ b/src/Foundry/Common/LoggerSetup.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
@@ -7,33 +6,84 @@ namespace Foundry.Common
 {
     public static partial class LoggerSetup
     {
+        private static readonly LoggingLevelSwitch MinimumLevelSwitch = new(LogEventLevel.Information);
+        private static bool globalExceptionHandlersRegistered;
+
         public static ILogger Logger { get; private set; } = Serilog.Core.Logger.None;
+        private static ILogger SetupLogger => Log.ForContext("SourceContext", typeof(LoggerSetup).FullName);
 
         public static void ConfigureLogger()
         {
             Directory.CreateDirectory(Constants.LogDirectoryPath);
 
             Logger = new LoggerConfiguration()
-                .MinimumLevel.Information()
+                .MinimumLevel.ControlledBy(MinimumLevelSwitch)
                 .Enrich.FromLogContext()
-                .Enrich.With<UtcTimestampEnricher>()
-                .Enrich.WithProperty("Application", Constants.ApplicationName)
-                .Enrich.WithProperty("Version", FoundryApplicationInfo.Version)
-                .Enrich.WithProperty("RuntimeIdentifier", RuntimeInformation.RuntimeIdentifier)
-                .Enrich.WithProperty("ProcessArchitecture", RuntimeInformation.ProcessArchitecture.ToString())
-                .Enrich.WithProperty("UpdateContext", "Startup")
-                .WriteTo.File(Constants.LogFilePath, shared: true)
+                .Enrich.With<LogComponentEnricher>()
+                .WriteTo.File(
+                    Constants.LogFilePath,
+                    outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] [{Component}] {Message:lj}{NewLine}{Exception}",
+                    shared: true)
                 .WriteTo.Debug()
                 .CreateLogger();
 
             Log.Logger = Logger;
         }
 
-        private sealed class UtcTimestampEnricher : ILogEventEnricher
+        public static void SetDeveloperModeEnabled(bool isEnabled)
+        {
+            LogEventLevel targetLevel = isEnabled ? LogEventLevel.Debug : LogEventLevel.Information;
+            if (MinimumLevelSwitch.MinimumLevel == targetLevel)
+            {
+                return;
+            }
+
+            MinimumLevelSwitch.MinimumLevel = targetLevel;
+            SetupLogger.Information("Developer diagnostics logging level changed. DeveloperMode={DeveloperMode}, MinimumLevel={MinimumLevel}", isEnabled, targetLevel);
+        }
+
+        public static void RegisterGlobalExceptionHandlers()
+        {
+            if (globalExceptionHandlersRegistered)
+            {
+                return;
+            }
+
+            AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+            TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
+            globalExceptionHandlersRegistered = true;
+        }
+
+        private static void OnUnhandledException(object sender, System.UnhandledExceptionEventArgs e)
+        {
+            if (e.ExceptionObject is Exception ex)
+            {
+                SetupLogger.Fatal(ex, "Unhandled AppDomain exception. IsTerminating={IsTerminating}", e.IsTerminating);
+                return;
+            }
+
+            SetupLogger.Fatal("Unhandled AppDomain exception. IsTerminating={IsTerminating}, ExceptionObject={ExceptionObject}", e.IsTerminating, e.ExceptionObject);
+        }
+
+        private static void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+        {
+            SetupLogger.Error(e.Exception, "Unobserved task exception.");
+            e.SetObserved();
+        }
+
+        private sealed class LogComponentEnricher : ILogEventEnricher
         {
             public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
             {
-                logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("UtcTimestamp", DateTimeOffset.UtcNow));
+                string component = Constants.ApplicationName;
+                if (logEvent.Properties.TryGetValue("SourceContext", out LogEventPropertyValue? sourceContextValue) &&
+                    sourceContextValue is ScalarValue { Value: string sourceContext } &&
+                    !string.IsNullOrWhiteSpace(sourceContext))
+                {
+                    component = sourceContext[(sourceContext.LastIndexOf('.') + 1)..];
+                }
+
+                logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("Component", component));
             }
         }
     }

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -67,7 +67,6 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Serilog" Version="4.3.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Velopack" Version="0.0.1589-ga2c5a97" />

--- a/src/Foundry/Program.cs
+++ b/src/Foundry/Program.cs
@@ -1,5 +1,7 @@
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
+using Serilog;
+using System.Runtime.InteropServices;
 using Velopack;
 
 namespace Foundry;
@@ -9,14 +11,53 @@ public static class Program
     [STAThread]
     public static void Main(string[] args)
     {
-        VelopackApp.Build().Run();
+        Constants.EnsureDataDirectories();
+        ConfigureLogger();
+        RegisterGlobalExceptionHandlers();
 
-        WinRT.ComWrappersSupport.InitializeComWrappers();
-        Application.Start(_ =>
+        ILogger logger = Log.ForContext(typeof(Program));
+        logger.Information(
+            "Foundry process bootstrap started. Version={Version}, RuntimeIdentifier={RuntimeIdentifier}, ProcessArchitecture={ProcessArchitecture}, ArgumentsCount={ArgumentsCount}",
+            FoundryApplicationInfo.Version,
+            RuntimeInformation.RuntimeIdentifier,
+            RuntimeInformation.ProcessArchitecture.ToString(),
+            args.Length);
+
+        try
         {
-            DispatcherQueueSynchronizationContext context = new(DispatcherQueue.GetForCurrentThread());
-            SynchronizationContext.SetSynchronizationContext(context);
-            new App();
-        });
+            logger.Information("Velopack startup flow started.");
+            VelopackApp.Build()
+                .OnFirstRun(version => logger.Information("Velopack first run detected. Version={Version}", version))
+                .OnRestarted(version => logger.Information("Velopack restarted Foundry after update. Version={Version}", version))
+                .OnBeforeUpdateFastCallback(version =>
+                {
+                    logger.Information("Velopack before-update fast callback started. Version={Version}", version);
+                    Log.CloseAndFlush();
+                })
+                .OnAfterUpdateFastCallback(version =>
+                {
+                    logger.Information("Velopack after-update fast callback completed. Version={Version}", version);
+                    Log.CloseAndFlush();
+                })
+                .Run();
+            logger.Information("Velopack startup flow completed.");
+
+            logger.Information("WinRT COM wrapper initialization started.");
+            WinRT.ComWrappersSupport.InitializeComWrappers();
+            logger.Information("WinRT COM wrapper initialization completed.");
+
+            Application.Start(_ =>
+            {
+                DispatcherQueueSynchronizationContext context = new(DispatcherQueue.GetForCurrentThread());
+                SynchronizationContext.SetSynchronizationContext(context);
+                new App();
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.Fatal(ex, "Foundry process bootstrap failed.");
+            Log.CloseAndFlush();
+            throw;
+        }
     }
 }

--- a/src/Foundry/Services/Application/WinUiExternalProcessLauncher.cs
+++ b/src/Foundry/Services/Application/WinUiExternalProcessLauncher.cs
@@ -1,38 +1,71 @@
 using System.Diagnostics;
 using Foundry.Core.Services.Application;
+using Serilog;
 
 namespace Foundry.Services.Application;
 
-public sealed class WinUiExternalProcessLauncher : IExternalProcessLauncher
+public sealed class WinUiExternalProcessLauncher(ILogger logger) : IExternalProcessLauncher
 {
+    private readonly ILogger logger = logger.ForContext<WinUiExternalProcessLauncher>();
+
     public Task OpenUriAsync(Uri uri)
     {
         ArgumentNullException.ThrowIfNull(uri);
-        Open(uri.AbsoluteUri);
+        Open(uri.AbsoluteUri, "Uri", GetUriLogValue(uri));
         return Task.CompletedTask;
     }
 
     public Task OpenFolderAsync(string folderPath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(folderPath);
-        Directory.CreateDirectory(folderPath);
-        Open(folderPath);
+        try
+        {
+            Directory.CreateDirectory(folderPath);
+        }
+        catch (Exception ex)
+        {
+            logger.Error(ex, "Failed to prepare external target. TargetKind={TargetKind}, Target={Target}", "Folder", folderPath);
+            throw;
+        }
+
+        Open(folderPath, "Folder", folderPath);
         return Task.CompletedTask;
     }
 
     public Task OpenFileAsync(string filePath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
-        Open(filePath);
+        Open(filePath, "File", filePath);
         return Task.CompletedTask;
     }
 
-    private static void Open(string target)
+    private void Open(string target, string targetKind, string targetLogValue)
     {
-        Process.Start(new ProcessStartInfo
+        try
         {
-            FileName = target,
-            UseShellExecute = true
-        });
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = target,
+                UseShellExecute = true
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.Error(ex, "Failed to open external target. TargetKind={TargetKind}, Target={Target}", targetKind, targetLogValue);
+            throw;
+        }
+    }
+
+    private static string GetUriLogValue(Uri uri)
+    {
+        UriBuilder builder = new(uri)
+        {
+            UserName = string.Empty,
+            Password = string.Empty,
+            Query = string.Empty,
+            Fragment = string.Empty
+        };
+
+        return builder.Uri.ToString().TrimEnd('/');
     }
 }

--- a/src/Foundry/Services/Localization/ApplicationLocalizationService.cs
+++ b/src/Foundry/Services/Localization/ApplicationLocalizationService.cs
@@ -12,6 +12,7 @@ internal sealed class ApplicationLocalizationService(
     IAppSettingsService appSettingsService,
     ILogger logger) : IApplicationLocalizationService
 {
+    private readonly ILogger logger = logger.ForContext<ApplicationLocalizationService>();
     private ResourceManager? resourceManager;
     private ResourceContext? resourceContext;
     private string currentLanguage = SupportedCultureCatalog.DefaultCultureCode;
@@ -32,10 +33,23 @@ internal sealed class ApplicationLocalizationService(
         if (!string.Equals(configuredLanguage, validatedLanguage, StringComparison.OrdinalIgnoreCase))
         {
             appSettingsService.Current.Localization.Language = validatedLanguage;
-            appSettingsService.Save();
+            try
+            {
+                appSettingsService.Save();
+            }
+            catch (Exception ex)
+            {
+                logger.Error(
+                    ex,
+                    "Failed to persist normalized application language. ConfiguredLanguage={ConfiguredLanguage}, NormalizedLanguage={NormalizedLanguage}",
+                    configuredLanguage,
+                    validatedLanguage);
+                throw;
+            }
         }
 
         ApplyLanguage(validatedLanguage);
+        logger.Information("Localization initialized. Language={Language}", CurrentLanguage);
         return Task.CompletedTask;
     }
 
@@ -44,18 +58,38 @@ internal sealed class ApplicationLocalizationService(
         cancellationToken.ThrowIfCancellationRequested();
 
         string validatedLanguage = SupportedCultureCatalog.ValidateOrDefault(languageCode);
+        if (!string.Equals(languageCode, validatedLanguage, StringComparison.OrdinalIgnoreCase))
+        {
+            logger.Warning(
+                "Unsupported language requested; using fallback. RequestedLanguage={RequestedLanguage}, FallbackLanguage={FallbackLanguage}",
+                languageCode,
+                validatedLanguage);
+        }
+
         if (string.Equals(currentLanguage, validatedLanguage, StringComparison.OrdinalIgnoreCase))
         {
             return Task.CompletedTask;
         }
 
         string oldLanguage = currentLanguage;
-        ApplyLanguage(validatedLanguage);
-
         appSettingsService.Current.Localization.Language = validatedLanguage;
-        appSettingsService.Save();
+        try
+        {
+            appSettingsService.Save();
+        }
+        catch (Exception ex)
+        {
+            logger.Error(
+                ex,
+                "Failed to persist selected language. OldLanguage={OldLanguage}, NewLanguage={NewLanguage}",
+                oldLanguage,
+                validatedLanguage);
+            throw;
+        }
 
+        ApplyLanguage(validatedLanguage);
         LanguageChanged?.Invoke(this, new ApplicationLanguageChangedEventArgs(oldLanguage, validatedLanguage));
+        logger.Information("Application language changed. OldLanguage={OldLanguage}, NewLanguage={NewLanguage}", oldLanguage, validatedLanguage);
         return Task.CompletedTask;
     }
 
@@ -125,7 +159,7 @@ internal sealed class ApplicationLocalizationService(
         resourceContext.QualifierValues["Language"] = languageCode;
 
         currentLanguage = languageCode;
-        logger.Information("Localization initialized. Language={Language}", CurrentLanguage);
+        logger.Debug("Localization language applied. Language={Language}", CurrentLanguage);
     }
 
     private static IReadOnlyList<string?> GetPreferredLanguageCodes()

--- a/src/Foundry/Services/Settings/JsonAppSettingsService.cs
+++ b/src/Foundry/Services/Settings/JsonAppSettingsService.cs
@@ -1,12 +1,16 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Serilog;
 
 namespace Foundry.Services.Settings;
 
 internal sealed partial class JsonAppSettingsService : IAppSettingsService
 {
-    public JsonAppSettingsService()
+    private readonly ILogger logger;
+
+    public JsonAppSettingsService(ILogger logger)
     {
+        this.logger = logger.ForContext<JsonAppSettingsService>();
         IsFirstRun = !File.Exists(Constants.AppSettingsPath);
         Current = Load();
         Save();
@@ -17,12 +21,20 @@ internal sealed partial class JsonAppSettingsService : IAppSettingsService
 
     public void Save()
     {
-        Directory.CreateDirectory(Constants.SettingsDirectoryPath);
-        string json = JsonSerializer.Serialize(Current, FoundryAppSettingsJsonContext.Default.FoundryAppSettings);
-        File.WriteAllText(Constants.AppSettingsPath, json);
+        try
+        {
+            Directory.CreateDirectory(Constants.SettingsDirectoryPath);
+            string json = JsonSerializer.Serialize(Current, FoundryAppSettingsJsonContext.Default.FoundryAppSettings);
+            File.WriteAllText(Constants.AppSettingsPath, json);
+        }
+        catch (Exception ex)
+        {
+            logger.Error(ex, "Failed to save app settings. SettingsPath={SettingsPath}", Constants.AppSettingsPath);
+            throw;
+        }
     }
 
-    private static FoundryAppSettings Load()
+    private FoundryAppSettings Load()
     {
         if (!File.Exists(Constants.AppSettingsPath))
         {
@@ -34,15 +46,34 @@ internal sealed partial class JsonAppSettingsService : IAppSettingsService
             string json = File.ReadAllText(Constants.AppSettingsPath);
             return JsonSerializer.Deserialize(json, FoundryAppSettingsJsonContext.Default.FoundryAppSettings) ?? new FoundryAppSettings();
         }
-        catch
+        catch (Exception ex)
         {
             string backupPath = Constants.AppSettingsPath + ".invalid";
-            if (File.Exists(backupPath))
+            try
             {
-                File.Delete(backupPath);
+                if (File.Exists(backupPath))
+                {
+                    File.Delete(backupPath);
+                }
+
+                File.Move(Constants.AppSettingsPath, backupPath);
+                logger.Warning(
+                    ex,
+                    "App settings file was invalid and defaults were restored. SettingsPath={SettingsPath}, BackupPath={BackupPath}",
+                    Constants.AppSettingsPath,
+                    backupPath);
+            }
+            catch (Exception backupException)
+            {
+                logger.Error(
+                    backupException,
+                    "Failed to back up invalid app settings. SettingsPath={SettingsPath}, BackupPath={BackupPath}, OriginalError={OriginalError}",
+                    Constants.AppSettingsPath,
+                    backupPath,
+                    ex.Message);
+                throw;
             }
 
-            File.Move(Constants.AppSettingsPath, backupPath);
             return new FoundryAppSettings();
         }
     }

--- a/src/Foundry/Services/Shell/ShellNavigationGuardService.cs
+++ b/src/Foundry/Services/Shell/ShellNavigationGuardService.cs
@@ -1,19 +1,31 @@
+using Serilog;
+
 namespace Foundry.Services.Shell;
 
-internal sealed class ShellNavigationGuardService : IShellNavigationGuardService
+internal sealed class ShellNavigationGuardService(ILogger logger) : IShellNavigationGuardService
 {
+    private readonly ILogger logger = logger.ForContext<ShellNavigationGuardService>();
+
     public event EventHandler? StateChanged;
 
     public ShellNavigationState State { get; private set; } = ShellNavigationState.Ready;
 
     public void SetState(ShellNavigationState state)
     {
+        if (!Enum.IsDefined(state))
+        {
+            logger.Warning("Invalid shell navigation state requested. RequestedState={RequestedState}", state);
+            return;
+        }
+
         if (State == state)
         {
             return;
         }
 
+        ShellNavigationState previousState = State;
         State = state;
+        logger.Debug("Shell navigation state changed. PreviousState={PreviousState}, NewState={NewState}", previousState, State);
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/src/Foundry/Services/Startup/StartupReadinessService.cs
+++ b/src/Foundry/Services/Startup/StartupReadinessService.cs
@@ -11,19 +11,34 @@ internal sealed class StartupReadinessService(
     IShellNavigationGuardService shellNavigationGuardService,
     ILogger logger) : IStartupReadinessService
 {
+    private readonly ILogger logger = logger.ForContext<StartupReadinessService>();
+
     public async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        logger.Information(
-            "Startup readiness initialization started. CheckOnStartup={CheckOnStartup}, UpdateChannel={UpdateChannel}",
-            appSettingsService.Current.Updates.CheckOnStartup,
-            appSettingsService.Current.Updates.Channel);
+        try
+        {
+            logger.Information(
+                "Startup readiness initialization started. CheckOnStartup={CheckOnStartup}, UpdateChannel={UpdateChannel}",
+                appSettingsService.Current.Updates.CheckOnStartup,
+                appSettingsService.Current.Updates.Channel);
+            logger.Debug(
+                "Startup readiness diagnostics. LogDirectoryPath={LogDirectoryPath}, SettingsPath={SettingsPath}, UpdateChannel={UpdateChannel}",
+                Constants.LogDirectoryPath,
+                Constants.AppSettingsPath,
+                appSettingsService.Current.Updates.Channel);
 
-        shellNavigationGuardService.SetState(ShellNavigationState.Ready);
+            shellNavigationGuardService.SetState(ShellNavigationState.Ready);
 
-        await updateService.InitializeAsync(cancellationToken);
+            await updateService.InitializeAsync(cancellationToken);
 
-        logger.Information("Startup readiness initialized. ShellNavigationState={ShellNavigationState}", shellNavigationGuardService.State);
+            logger.Information("Startup readiness initialized. ShellNavigationState={ShellNavigationState}", shellNavigationGuardService.State);
+        }
+        catch (Exception ex)
+        {
+            logger.Error(ex, "Startup readiness initialization failed. ShellNavigationState={ShellNavigationState}", shellNavigationGuardService.State);
+            throw;
+        }
     }
 }

--- a/src/Foundry/Services/Updates/ApplicationUpdateService.cs
+++ b/src/Foundry/Services/Updates/ApplicationUpdateService.cs
@@ -12,6 +12,7 @@ internal sealed class ApplicationUpdateService(
     IApplicationLifetimeService applicationLifetimeService,
     ILogger logger) : IApplicationUpdateService
 {
+    private readonly ILogger logger = logger.ForContext<ApplicationUpdateService>();
     private Velopack.UpdateInfo? pendingUpdate;
     private UpdateManager? pendingUpdateManager;
 
@@ -20,10 +21,10 @@ internal sealed class ApplicationUpdateService(
         cancellationToken.ThrowIfCancellationRequested();
 
         logger.Information(
-            "Update service initialized. CheckOnStartup={CheckOnStartup}, Channel={Channel}, FeedUrl={FeedUrl}",
+            "Update service initialized. CheckOnStartup={CheckOnStartup}, Channel={Channel}, FeedSource={FeedSource}",
             appSettingsService.Current.Updates.CheckOnStartup,
             appSettingsService.Current.Updates.Channel,
-            appSettingsService.Current.Updates.FeedUrl);
+            GetFeedUrlLogValue(appSettingsService.Current.Updates.FeedUrl));
 
         if (appSettingsService.Current.Updates.CheckOnStartup)
         {
@@ -52,16 +53,22 @@ internal sealed class ApplicationUpdateService(
         {
             string feedUrl = appSettingsService.Current.Updates.FeedUrl;
             string sourceKind = ResolveUpdateSourceKind(feedUrl);
+            logger.Debug(
+                "Resolved update source. IsStartupCheck={IsStartupCheck}, SourceKind={SourceKind}, FeedSource={FeedSource}, Channel={Channel}",
+                isStartupCheck,
+                sourceKind,
+                GetFeedUrlLogValue(feedUrl),
+                appSettingsService.Current.Updates.Channel);
 
             Stopwatch sourceStopwatch = Stopwatch.StartNew();
             UpdateManager updateManager = CreateUpdateManager();
             sourceStopwatch.Stop();
 
-            logger.Information(
-                "Foundry update source created. IsStartupCheck={IsStartupCheck}, SourceKind={SourceKind}, FeedUrl={FeedUrl}, ConfiguredChannel={ConfiguredChannel}, ElapsedMilliseconds={ElapsedMilliseconds}",
+            logger.Debug(
+                "Foundry update source created. IsStartupCheck={IsStartupCheck}, SourceKind={SourceKind}, FeedSource={FeedSource}, ConfiguredChannel={ConfiguredChannel}, ElapsedMilliseconds={ElapsedMilliseconds}",
                 isStartupCheck,
                 sourceKind,
-                feedUrl,
+                GetFeedUrlLogValue(feedUrl),
                 appSettingsService.Current.Updates.Channel,
                 sourceStopwatch.ElapsedMilliseconds);
 
@@ -78,17 +85,17 @@ internal sealed class ApplicationUpdateService(
             }
 
             logger.Information(
-                "Checking for Foundry updates. IsStartupCheck={IsStartupCheck}, SourceKind={SourceKind}, FeedUrl={FeedUrl}",
+                "Checking for Foundry updates. IsStartupCheck={IsStartupCheck}, SourceKind={SourceKind}, FeedSource={FeedSource}",
                 isStartupCheck,
                 sourceKind,
-                feedUrl);
+                GetFeedUrlLogValue(feedUrl));
 
             Stopwatch checkStopwatch = Stopwatch.StartNew();
             Velopack.UpdateInfo? updateInfo = await updateManager.CheckForUpdatesAsync();
             checkStopwatch.Stop();
             totalStopwatch.Stop();
 
-            logger.Information(
+            logger.Debug(
                 "Foundry update check request completed. IsStartupCheck={IsStartupCheck}, ElapsedMilliseconds={ElapsedMilliseconds}",
                 isStartupCheck,
                 checkStopwatch.ElapsedMilliseconds);
@@ -184,9 +191,18 @@ internal sealed class ApplicationUpdateService(
             return;
         }
 
-        logger.Information("Applying Foundry update and restarting. Version={Version}", pendingUpdate.TargetFullRelease.Version);
-        pendingUpdateManager.WaitExitThenApplyUpdates(pendingUpdate.TargetFullRelease, silent: false, restart: true);
-        applicationLifetimeService.Shutdown();
+        string version = pendingUpdate.TargetFullRelease.Version?.ToString() ?? "unknown";
+        try
+        {
+            logger.Information("Applying Foundry update and restarting. Version={Version}", version);
+            pendingUpdateManager.WaitExitThenApplyUpdates(pendingUpdate.TargetFullRelease, silent: false, restart: true);
+            applicationLifetimeService.Shutdown();
+        }
+        catch (Exception ex)
+        {
+            logger.Error(ex, "Failed to apply Foundry update and restart. Version={Version}", version);
+            throw;
+        }
     }
 
     private async Task RunStartupCheckAsync(CancellationToken cancellationToken)
@@ -209,8 +225,14 @@ internal sealed class ApplicationUpdateService(
         string feedUrl = appSettingsService.Current.Updates.FeedUrl;
         if (!IsGitHubRepositoryUrl(feedUrl))
         {
+            logger.Debug("Creating simple web Velopack update manager. FeedSource={FeedSource}", GetFeedUrlLogValue(feedUrl));
             return new UpdateManager(feedUrl, options, locator: null);
         }
+
+        logger.Debug(
+            "Creating GitHub Velopack update manager. FeedSource={FeedSource}, Channel={Channel}",
+            GetFeedUrlLogValue(feedUrl),
+            appSettingsService.Current.Updates.Channel);
 
         GithubSource source = new(
             feedUrl,
@@ -238,6 +260,29 @@ internal sealed class ApplicationUpdateService(
     private static string ResolveUpdateSourceKind(string feedUrl)
     {
         return IsGitHubRepositoryUrl(feedUrl) ? "GitHubReleases" : "SimpleWeb";
+    }
+
+    private static string GetFeedUrlLogValue(string feedUrl)
+    {
+        if (!Uri.TryCreate(feedUrl, UriKind.Absolute, out Uri? uri))
+        {
+            return feedUrl;
+        }
+
+        if (uri.IsFile)
+        {
+            return uri.LocalPath;
+        }
+
+        UriBuilder builder = new(uri)
+        {
+            UserName = string.Empty,
+            Password = string.Empty,
+            Query = string.Empty,
+            Fragment = string.Empty
+        };
+
+        return builder.Uri.ToString().TrimEnd('/');
     }
 
     private static string ResolveReleaseNotes(VelopackAsset targetRelease)

--- a/src/Foundry/ViewModels/Settings/GeneralSettingViewModel.cs
+++ b/src/Foundry/ViewModels/Settings/GeneralSettingViewModel.cs
@@ -48,6 +48,7 @@ namespace Foundry.ViewModels
         {
             appSettingsService.Current.Diagnostics.DeveloperMode = value;
             appSettingsService.Save();
+            SetDeveloperModeEnabled(value);
         }
 
         [RelayCommand]


### PR DESCRIPTION
## Summary
- Move Foundry WinUI logging bootstrap to `Program.Main` before Velopack and WinUI startup.
- Add contextual Serilog source output, runtime developer-mode log level switching, and early exception handlers.
- Remove the unused console sink package and update the migration plan checklist.

## Reason
Phase 10 needs production diagnostics to survive the WinUI startup and Velopack update model while keeping Debug logs gated behind the Diagnostics developer setting.

## Main changes
- Configure Serilog with `LoggingLevelSwitch`, ProgramData file output, UTC/app/runtime enrichment, and visible `SourceContext`.
- Log Velopack startup/update hooks and WinRT initialization from the process bootstrap path.
- Apply developer-mode logging level from settings at startup and when the setting changes.
- Add targeted Debug diagnostics only when developer mode is enabled.

## Testing
- `dotnet build .\src\Foundry.slnx -c Debug -p:Platform=x64 --nologo`
- `dotnet test .\src\Foundry.slnx -c Release -p:Platform=x64 --nologo`
- Runtime validation against `C:\ProgramData\Foundry\Logs\Foundry.log`: no `[DBG]` with `developerMode=false`, `[DBG]` present with `developerMode=true`, and source context visible.
- `git diff --check`