### PR TITLE
feat(shell): add foundry winui navigation

### DIFF
--- a/docs/migration/phases/03-startup-distribution-ci.md
+++ b/docs/migration/phases/03-startup-distribution-ci.md
@@ -110,12 +110,12 @@ Note: manual launch validation is kept unchecked until a local Visual Studio run
   - [x] Keep manual checks unthrottled.
   - [x] Keep startup failures non-blocking and visible in logs.
   - Note: GitHub Releases is the correct Velopack source for the default feed URL; the elapsed-time logs identify whether startup/manual delay is in source creation or the remote `CheckForUpdatesAsync` request.
-- [ ] **7.7.2** Add startup update notification UX:
-  - [ ] When a startup check finds an update, show a non-blocking shell notification/banner.
-  - [ ] Do not show a modal dialog automatically on startup.
-  - [ ] Provide an action that opens the update settings surface or dedicated update view.
-  - [ ] Use a confirmation dialog only before download/restart.
-  - [ ] Reuse the same latest update state in the shell banner and update settings page, so a startup-detected update is visible in settings without another manual check.
+- [x] **7.7.2** Add startup update notification UX:
+  - [x] When a startup check finds an update, show a non-blocking shell notification/banner.
+  - [x] Do not show a modal dialog automatically on startup.
+  - [x] Provide an action that opens the update settings surface or dedicated update view.
+  - [x] Use a confirmation dialog only before download/restart.
+  - [x] Reuse the same latest update state in the shell banner and update settings page, so a startup-detected update is visible in settings without another manual check.
   - Note: this is intentionally implemented with Phase 11 shell work in **11.7.1**.
 - [x] **7.8** Add release artifact naming contract:
   - [x] `FoundrySetup-x64.msi`.

--- a/docs/migration/phases/04-localization-logging-shell.md
+++ b/docs/migration/phases/04-localization-logging-shell.md
@@ -163,127 +163,127 @@ git commit -m "refactor: migrate foundry logging for winui"
 
 **Goal:** keep DevWinUI as the long-term shell baseline and progressively plug real Foundry workflows into it.
 
-- [ ] **11.1** Keep DevWinUI navigation, settings, title bar, breadcrumb, and shell conventions as the long-term Foundry shell baseline.
-  - [ ] DevWinUI remains responsible for JSON-driven `NavigationView` item creation through `JsonNavigationService`.
-  - [ ] DevWinUI remains responsible for `TitleBar`, `BreadcrumbNavigator`, `Settings` item integration, search suggestions, and page navigation glue where the existing service supports it.
-  - [ ] Foundry owns runtime business state decisions that DevWinUI JSON does not model, including ADK readiness, operation locks, update banners, and command eligibility.
-- [ ] **11.2** Do not port the old WPF main window layout 1:1.
-- [ ] **11.3** Replace prototype menu JSON with Foundry-specific entries.
-  - [ ] Use `Assets\NavViewMenu\AppData.json` as the source for DevWinUI top-level navigation.
-  - [ ] Use section headers plus direct page items for the main navigation:
-    - [ ] `General` and `Expert` are visual section headers.
-    - [ ] `General` and `Expert` are not clickable parent pages.
-    - [ ] `General` and `Expert` are not expandable/collapsible groups.
-    - [ ] Pages remain directly visible under their section header.
-  - [ ] Use DevWinUI-supported schema fields:
-    - [ ] `Groups`.
-    - [ ] `Items`.
-    - [ ] `UniqueId`.
-    - [ ] `Title` as fallback text.
-    - [ ] `LocalizeId`.
-    - [ ] `UsexUid=true`.
-    - [ ] `ImagePath` or `IconGlyph`.
-    - [ ] `IsFooterNavigationViewItem`.
-    - [ ] `ShowItemsWithoutGroup`.
-    - [ ] `IsExpanded`.
-    - [ ] `HideGroup`.
-    - [ ] `HideNavigationViewItem`.
-    - [ ] `IncludedInBuild` only for compile/build availability, not runtime business blocking.
-  - [ ] Do not depend on unsupported JSON-only runtime state such as `RequiresAdk`, `OperationLocked`, or per-state enabled rules.
-  - [ ] Keep runtime navigation state in Foundry services instead of inventing custom DevWinUI JSON schema fields.
-- [ ] **11.4** Confirm generated page mappings are deterministic.
-  - [ ] Confirm `NavigationPageMappings.PageDictionary` contains every `UniqueId` referenced by `AppData.json`.
-  - [ ] Confirm `BreadcrumbPageMappings.PageDictionary` contains every shell page and settings page that can appear in breadcrumbs.
-  - [ ] Confirm each page has one stable `UniqueId`; use DevWinUI `Parameter` only when the same page type intentionally represents multiple logical pages.
-- [ ] **11.5** Add Foundry pages incrementally without blocking unrelated business logic extraction.
-- [ ] **11.6** Define first-level pages:
-  - [ ] General section header with direct items: `Home`, `ADK`, `General`, `Start`.
-  - [ ] Expert section header with direct items: `Network`, `Localization`, `Autopilot`, `Customization`.
-  - [ ] Footer section in this order: `Documentation`, `About`, `Settings`.
-  - [ ] Do not add a `Logs` footer navigation item.
-  - [ ] Keep log-folder access inside diagnostics/settings surfaces instead of exposing a dedicated navigation page.
-  - [ ] **11.6.1** Use the target page map from [Page Map And Navigation Contract](../architecture/page-map.md).
-  - [ ] **11.6.2** Implement shell-level navigation guard states:
-    - [ ] `AdkBlocked`.
-    - [ ] `Ready`.
-    - [ ] `OperationRunning`.
-  - [ ] **11.6.3** When ADK is missing or incompatible, allow only:
-    - [ ] `Home`.
-    - [ ] `ADK`.
-    - [ ] Footer pages.
-  - [ ] **11.6.4** When ADK is missing or incompatible, disable:
-    - [ ] `General`.
-    - [ ] `Start`.
-    - [ ] All `Expert` pages.
-  - [ ] **11.6.5** When a global operation is running, disable:
-    - [ ] All `NavigationView` items.
-    - [ ] Back navigation.
-    - [ ] Settings navigation.
-    - [ ] Title bar back navigation.
-    - [ ] Search-driven navigation.
-  - [ ] **11.6.6** Add blocking operation overlay support:
-    - [ ] ADK install.
-    - [ ] ADK upgrade.
-    - [ ] ISO creation.
-    - [ ] USB creation.
-  - [ ] **11.6.7** Ensure the operation overlay remains visible and blocks navigation until the operation fully completes.
-  - [ ] **11.6.8** Apply navigation guards after every DevWinUI navigation refresh:
-    - [ ] Initial `JsonNavigationService.ConfigureJsonFile(...)`.
-    - [ ] Runtime localization refresh through `JsonNavigationService.ReInitialize()`.
-    - [ ] Any future AppData/menu rebuild.
-  - [ ] **11.6.9** Do not rely only on `NavigationViewItem.IsEnabled` for operation blocking:
-    - [ ] Prevent programmatic navigation through a Foundry-owned navigation facade or guard check.
-    - [ ] Prevent search result navigation when `OperationRunning`.
-    - [ ] Prevent back navigation when `OperationRunning`.
-    - [ ] Keep the active operation page/overlay visible until completion.
-- [ ] **11.7** Do not migrate the old WPF menu bar.
-  - [ ] Remove any expectation of a 1:1 WPF menu command port.
-  - [ ] Add only WinUI shell entry points that still make product sense in the DevWinUI shell:
-    - [ ] Documentation.
-    - [ ] GitHub repository.
-    - [ ] GitHub issues.
-    - [ ] Check for updates.
-    - [ ] About.
-  - [ ] Do not add a dedicated Logs navigation button; use the existing settings diagnostics/log-folder command.
-  - [ ] Keep import/export configuration actions for later workflow phases instead of adding them as menu-bar equivalents:
-    - [ ] Import expert configuration is handled by Phase 14.
-    - [ ] Export expert configuration is handled by Phase 14.
-    - [ ] Export deploy configuration is handled by Phase 14.
-- [ ] **11.7.1** Add shell update notification behavior:
-  - [ ] Use a global top-shell WinUI `InfoBar` banner pattern inspired by UniGetUI's `UpdatesBanner`.
-  - [ ] Host the banner in the shell, above the page content and shared across pages.
-  - [ ] Show a non-blocking update available banner when startup update check returns `UpdateAvailable`.
-  - [ ] Do not interrupt startup with a modal `ContentDialog`.
-  - [ ] Banner action opens the update settings page or dedicated update view.
-  - [ ] Download/restart remains an explicit user action with confirmation.
-  - [ ] Keep the banner outside DevWinUI `AppData.json`; it is runtime state, not static navigation metadata.
-  - [ ] Keep the banner persistent until the user dismisses it, opens update details, or the update state changes.
-  - [ ] Do not add Windows toast activation in Phase 11; revisit only if background update notifications become a product requirement.
-  - [ ] Share update state between startup checks, shell banner, and settings UI:
-    - [ ] Startup check publishes the latest `ApplicationUpdateCheckResult`.
-    - [ ] Manual check publishes the latest `ApplicationUpdateCheckResult`.
-    - [ ] Settings update page reads the latest published state when it loads.
-    - [ ] Settings update page updates automatically when startup check completes while the page is open.
-    - [ ] The shell banner and settings page use the same pending update state, so the user does not need to click `Check for updates` again after a startup check found an update.
-- [ ] **11.8** Keep code-behind limited to WinUI events and navigation glue.
-- [ ] **11.8.1** Replace DevWinUI prototype AppData paths with Foundry ProgramData paths:
-  - [ ] `C:\ProgramData\Foundry\Settings\appsettings.json`.
-  - [ ] `C:\ProgramData\Foundry\Logs`.
-  - [ ] `C:\ProgramData\Foundry\Cache`.
-  - [ ] `C:\ProgramData\Foundry\Workspaces`.
-  - [ ] `C:\ProgramData\Foundry\Temp`.
-- [ ] **11.8.2** Remove DevWinUI prototype `nucs.JsonSettings` app settings plumbing from the WinUI `Foundry` app.
-- [ ] **11.8.3** Implement initial `appsettings.json` schema:
-  - [ ] `schemaVersion`.
-  - [ ] `appearance.theme`.
-  - [ ] `localization.language`.
-  - [ ] `updates.checkOnStartup`.
-  - [ ] `updates.channel`.
-  - [ ] `updates.feedUrl`.
-  - [ ] `diagnostics.developerMode`.
-  - [ ] No secrets.
-  - [ ] No workflow or export configuration.
-- [ ] **11.9** Commit:
+- [x] **11.1** Keep DevWinUI navigation, settings, title bar, breadcrumb, and shell conventions as the long-term Foundry shell baseline.
+  - [x] DevWinUI remains responsible for JSON-driven `NavigationView` item creation through `JsonNavigationService`.
+  - [x] DevWinUI remains responsible for `TitleBar`, `BreadcrumbNavigator`, `Settings` item integration, search suggestions, and page navigation glue where the existing service supports it.
+  - [x] Foundry owns runtime business state decisions that DevWinUI JSON does not model, including ADK readiness, operation locks, update banners, and command eligibility.
+- [x] **11.2** Do not port the old WPF main window layout 1:1.
+- [x] **11.3** Replace prototype menu JSON with Foundry-specific entries.
+  - [x] Use `Assets\NavViewMenu\AppData.json` as the source for DevWinUI top-level navigation.
+  - [x] Use section headers plus direct page items for the main navigation:
+    - [x] `General` and `Expert` are visual section headers.
+    - [x] `General` and `Expert` are not clickable parent pages.
+    - [x] `General` and `Expert` are not expandable/collapsible groups.
+    - [x] Pages remain directly visible under their section header.
+  - [x] Use DevWinUI-supported schema fields:
+    - [x] `Groups`.
+    - [x] `Items`.
+    - [x] `UniqueId`.
+    - [x] `Title` as fallback text.
+    - [x] `LocalizeId`.
+    - [x] `UsexUid=true`.
+    - [x] `ImagePath` or `IconGlyph`.
+    - [x] `IsFooterNavigationViewItem`.
+    - [x] `ShowItemsWithoutGroup`.
+    - [x] `IsExpanded`.
+    - [x] `HideGroup`.
+    - [x] `HideNavigationViewItem`.
+    - [x] `IncludedInBuild` only for compile/build availability, not runtime business blocking.
+  - [x] Do not depend on unsupported JSON-only runtime state such as `RequiresAdk`, `OperationLocked`, or per-state enabled rules.
+  - [x] Keep runtime navigation state in Foundry services instead of inventing custom DevWinUI JSON schema fields.
+- [x] **11.4** Confirm generated page mappings are deterministic.
+  - [x] Confirm `NavigationPageMappings.PageDictionary` contains every `UniqueId` referenced by `AppData.json`.
+  - [x] Confirm `BreadcrumbPageMappings.PageDictionary` contains every shell page and settings page that can appear in breadcrumbs.
+  - [x] Confirm each page has one stable `UniqueId`; use DevWinUI `Parameter` only when the same page type intentionally represents multiple logical pages.
+- [x] **11.5** Add Foundry pages incrementally without blocking unrelated business logic extraction.
+- [x] **11.6** Define first-level pages:
+  - [x] General section header with direct items: `Home`, `ADK`, `General`, `Start`.
+  - [x] Expert section header with direct items: `Network`, `Localization`, `Autopilot`, `Customization`.
+  - [x] Footer section in this order: `Documentation`, `About`, `Settings`.
+  - [x] Do not add a `Logs` footer navigation item.
+  - [x] Keep log-folder access inside diagnostics/settings surfaces instead of exposing a dedicated navigation page.
+  - [x] **11.6.1** Use the target page map from [Page Map And Navigation Contract](../architecture/page-map.md).
+  - [x] **11.6.2** Implement shell-level navigation guard states:
+    - [x] `AdkBlocked`.
+    - [x] `Ready`.
+    - [x] `OperationRunning`.
+  - [x] **11.6.3** When ADK is missing or incompatible, allow only:
+    - [x] `Home`.
+    - [x] `ADK`.
+    - [x] Footer pages.
+  - [x] **11.6.4** When ADK is missing or incompatible, disable:
+    - [x] `General`.
+    - [x] `Start`.
+    - [x] All `Expert` pages.
+  - [x] **11.6.5** When a global operation is running, disable:
+    - [x] All `NavigationView` items.
+    - [x] Back navigation.
+    - [x] Settings navigation.
+    - [x] Title bar back navigation.
+    - [x] Search-driven navigation.
+  - [x] **11.6.6** Add blocking operation overlay support:
+    - [x] ADK install.
+    - [x] ADK upgrade.
+    - [x] ISO creation.
+    - [x] USB creation.
+  - [x] **11.6.7** Ensure the operation overlay remains visible and blocks navigation until the operation fully completes.
+  - [x] **11.6.8** Apply navigation guards after every DevWinUI navigation refresh:
+    - [x] Initial `JsonNavigationService.ConfigureJsonFile(...)`.
+    - [x] Runtime localization refresh through `JsonNavigationService.ReInitialize()`.
+    - [x] Any future AppData/menu rebuild.
+  - [x] **11.6.9** Do not rely only on `NavigationViewItem.IsEnabled` for operation blocking:
+    - [x] Prevent programmatic navigation through a Foundry-owned navigation facade or guard check.
+    - [x] Prevent search result navigation when `OperationRunning`.
+    - [x] Prevent back navigation when `OperationRunning`.
+    - [x] Keep the active operation page/overlay visible until completion.
+- [x] **11.7** Do not migrate the old WPF menu bar.
+  - [x] Remove any expectation of a 1:1 WPF menu command port.
+  - [x] Add only WinUI shell entry points that still make product sense in the DevWinUI shell:
+    - [x] Documentation.
+    - [x] GitHub repository.
+    - [x] GitHub issues.
+    - [x] Check for updates.
+    - [x] About.
+  - [x] Do not add a dedicated Logs navigation button; use the existing settings diagnostics/log-folder command.
+  - [x] Keep import/export configuration actions for later workflow phases instead of adding them as menu-bar equivalents:
+    - [x] Import expert configuration is handled by Phase 14.
+    - [x] Export expert configuration is handled by Phase 14.
+    - [x] Export deploy configuration is handled by Phase 14.
+- [x] **11.7.1** Add shell update notification behavior:
+  - [x] Use a global top-shell WinUI `InfoBar` banner pattern inspired by UniGetUI's `UpdatesBanner`.
+  - [x] Host the banner in the shell, above the page content and shared across pages.
+  - [x] Show a non-blocking update available banner when startup update check returns `UpdateAvailable`.
+  - [x] Do not interrupt startup with a modal `ContentDialog`.
+  - [x] Banner action opens the update settings page or dedicated update view.
+  - [x] Download/restart remains an explicit user action with confirmation.
+  - [x] Keep the banner outside DevWinUI `AppData.json`; it is runtime state, not static navigation metadata.
+  - [x] Keep the banner persistent until the user dismisses it, opens update details, or the update state changes.
+  - [x] Do not add Windows toast activation in Phase 11; revisit only if background update notifications become a product requirement.
+  - [x] Share update state between startup checks, shell banner, and settings UI:
+    - [x] Startup check publishes the latest `ApplicationUpdateCheckResult`.
+    - [x] Manual check publishes the latest `ApplicationUpdateCheckResult`.
+    - [x] Settings update page reads the latest published state when it loads.
+    - [x] Settings update page updates automatically when startup check completes while the page is open.
+    - [x] The shell banner and settings page use the same pending update state, so the user does not need to click `Check for updates` again after a startup check found an update.
+- [x] **11.8** Keep code-behind limited to WinUI events and navigation glue.
+- [x] **11.8.1** Replace DevWinUI prototype AppData paths with Foundry ProgramData paths:
+  - [x] `C:\ProgramData\Foundry\Settings\appsettings.json`.
+  - [x] `C:\ProgramData\Foundry\Logs`.
+  - [x] `C:\ProgramData\Foundry\Cache`.
+  - [x] `C:\ProgramData\Foundry\Workspaces`.
+  - [x] `C:\ProgramData\Foundry\Temp`.
+- [x] **11.8.2** Remove DevWinUI prototype `nucs.JsonSettings` app settings plumbing from the WinUI `Foundry` app.
+- [x] **11.8.3** Implement initial `appsettings.json` schema:
+  - [x] `schemaVersion`.
+  - [x] `appearance.theme`.
+  - [x] `localization.language`.
+  - [x] `updates.checkOnStartup`.
+  - [x] `updates.channel`.
+  - [x] `updates.feedUrl`.
+  - [x] `diagnostics.developerMode`.
+  - [x] No secrets.
+  - [x] No workflow or export configuration.
+- [x] **11.9** Commit:
 
 ```powershell
 git commit -m "feat: add foundry winui shell navigation"

--- a/src/Foundry/Assets/NavViewMenu/AppData.json
+++ b/src/Foundry/Assets/NavViewMenu/AppData.json
@@ -1,21 +1,146 @@
-﻿{
+{
   "$schema": "https://raw.githubusercontent.com/Ghost1372/DevWinUI/refs/heads/main/tools/AppData.Schema.json",
   "Groups": [
     {
-      "UniqueId": "Foundry",
-      "LocalizeId": "Nav_HomeKey",
+      "UniqueId": "Foundry.Navigation.GeneralHeader",
+      "Title": "General",
+      "LocalizeId": "Nav_GeneralSection",
       "UsexUid": true,
-      "ImagePath": "ms-appx:///Assets/AppIcon.png",
+      "IsSpecialSection": false,
+      "IsNavigationViewItemHeader": true,
+      "Items": []
+    },
+    {
+      "UniqueId": "Foundry.Navigation.GeneralItems",
+      "Title": "General Items",
       "IsSpecialSection": false,
       "ShowItemsWithoutGroup": true,
-      "IsExpanded": false,
       "Items": [
         {
           "UniqueId": "Foundry.Views.HomeLandingPage",
+          "Title": "Home",
           "LocalizeId": "Nav_HomeKey",
           "UsexUid": true,
           "ImagePath": "ms-appx:///Assets/AppIcon.png",
-          "HideItem": true
+          "HideItem": true,
+          "IsNew": false,
+          "IsUpdated": false
+        },
+        {
+          "UniqueId": "Foundry.Views.AdkPage",
+          "Title": "ADK",
+          "LocalizeId": "Nav_AdkKey",
+          "UsexUid": true,
+          "IconGlyph": "E946",
+          "HideItem": true,
+          "IsNew": false,
+          "IsUpdated": false
+        },
+        {
+          "UniqueId": "Foundry.Views.GeneralConfigurationPage",
+          "Title": "General",
+          "LocalizeId": "Nav_GeneralConfigurationKey",
+          "UsexUid": true,
+          "IconGlyph": "E713",
+          "HideItem": true,
+          "IsNew": false,
+          "IsUpdated": false
+        },
+        {
+          "UniqueId": "Foundry.Views.StartPage",
+          "Title": "Start",
+          "LocalizeId": "Nav_StartKey",
+          "UsexUid": true,
+          "IconGlyph": "E768",
+          "HideItem": true,
+          "IsNew": false,
+          "IsUpdated": false
+        }
+      ]
+    },
+    {
+      "UniqueId": "Foundry.Navigation.ExpertHeader",
+      "Title": "Expert",
+      "LocalizeId": "Nav_ExpertSection",
+      "UsexUid": true,
+      "IsSpecialSection": false,
+      "IsNavigationViewItemHeader": true,
+      "Items": []
+    },
+    {
+      "UniqueId": "Foundry.Navigation.ExpertItems",
+      "Title": "Expert Items",
+      "IsSpecialSection": false,
+      "ShowItemsWithoutGroup": true,
+      "Items": [
+        {
+          "UniqueId": "Foundry.Views.NetworkPage",
+          "Title": "Network",
+          "LocalizeId": "Nav_NetworkKey",
+          "UsexUid": true,
+          "IconGlyph": "E968",
+          "HideItem": true,
+          "IsNew": false,
+          "IsUpdated": false
+        },
+        {
+          "UniqueId": "Foundry.Views.LocalizationPage",
+          "Title": "Localization",
+          "LocalizeId": "Nav_LocalizationKey",
+          "UsexUid": true,
+          "IconGlyph": "E909",
+          "HideItem": true,
+          "IsNew": false,
+          "IsUpdated": false
+        },
+        {
+          "UniqueId": "Foundry.Views.AutopilotPage",
+          "Title": "Autopilot",
+          "LocalizeId": "Nav_AutopilotKey",
+          "UsexUid": true,
+          "IconGlyph": "E7C1",
+          "HideItem": true,
+          "IsNew": false,
+          "IsUpdated": false
+        },
+        {
+          "UniqueId": "Foundry.Views.CustomizationPage",
+          "Title": "Customization",
+          "LocalizeId": "Nav_CustomizationKey",
+          "UsexUid": true,
+          "IconGlyph": "E771",
+          "HideItem": true,
+          "IsNew": false,
+          "IsUpdated": false
+        }
+      ]
+    },
+    {
+      "UniqueId": "Foundry.Navigation.FooterItems",
+      "Title": "Footer",
+      "IsSpecialSection": false,
+      "ShowItemsWithoutGroup": true,
+      "IsFooterNavigationViewItem": true,
+      "Items": [
+        {
+          "UniqueId": "Foundry.Views.DocumentationPage",
+          "Title": "Documentation",
+          "LocalizeId": "Nav_DocumentationKey",
+          "UsexUid": true,
+          "IconGlyph": "E8A5",
+          "HideItem": true,
+          "IsNew": false,
+          "IsUpdated": false
+        },
+        {
+          "UniqueId": "Foundry.Views.AboutUsSettingPage",
+          "Title": "About",
+          "LocalizeId": "Nav_AboutKey",
+          "UsexUid": true,
+          "IconGlyph": "E946",
+          "HideItem": true,
+          "IsNew": false,
+          "IsUpdated": false
         }
       ]
     }

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IAppSettingsService, JsonAppSettingsService>();
         services.AddSingleton<IShellNavigationGuardService, ShellNavigationGuardService>();
         services.AddSingleton<IApplicationLocalizationService, ApplicationLocalizationService>();
+        services.AddSingleton<IApplicationUpdateStateService, ApplicationUpdateStateService>();
         services.AddSingleton<IApplicationUpdateService, ApplicationUpdateService>();
         services.AddSingleton<IStartupReadinessService, StartupReadinessService>();
 

--- a/src/Foundry/Services/Updates/ApplicationUpdateService.cs
+++ b/src/Foundry/Services/Updates/ApplicationUpdateService.cs
@@ -10,6 +10,7 @@ namespace Foundry.Services.Updates;
 internal sealed class ApplicationUpdateService(
     IAppSettingsService appSettingsService,
     IApplicationLifetimeService applicationLifetimeService,
+    IApplicationUpdateStateService updateStateService,
     ILogger logger) : IApplicationUpdateService
 {
     private readonly ILogger logger = logger.ForContext<ApplicationUpdateService>();
@@ -44,7 +45,7 @@ internal sealed class ApplicationUpdateService(
         {
             const string message = "Update check skipped because a debugger is attached.";
             logger.Information(message);
-            return new ApplicationUpdateCheckResult(ApplicationUpdateStatus.SkippedInDebug, message);
+            return PublishCheckResult(new ApplicationUpdateCheckResult(ApplicationUpdateStatus.SkippedInDebug, message));
         }
 
         Stopwatch totalStopwatch = Stopwatch.StartNew();
@@ -81,7 +82,8 @@ internal sealed class ApplicationUpdateService(
                     message,
                     isStartupCheck,
                     totalStopwatch.ElapsedMilliseconds);
-                return new ApplicationUpdateCheckResult(ApplicationUpdateStatus.NotInstalled, message);
+                ClearPendingUpdate();
+                return PublishCheckResult(new ApplicationUpdateCheckResult(ApplicationUpdateStatus.NotInstalled, message));
             }
 
             logger.Information(
@@ -109,7 +111,7 @@ internal sealed class ApplicationUpdateService(
                     isStartupCheck,
                     totalStopwatch.ElapsedMilliseconds);
                 ClearPendingUpdate();
-                return new ApplicationUpdateCheckResult(ApplicationUpdateStatus.NoUpdate, message);
+                return PublishCheckResult(new ApplicationUpdateCheckResult(ApplicationUpdateStatus.NoUpdate, message));
             }
 
             pendingUpdate = updateInfo;
@@ -128,11 +130,11 @@ internal sealed class ApplicationUpdateService(
                 isStartupCheck,
                 totalStopwatch.ElapsedMilliseconds);
 
-            return new ApplicationUpdateCheckResult(
+            return PublishCheckResult(new ApplicationUpdateCheckResult(
                 ApplicationUpdateStatus.UpdateAvailable,
                 updateMessage,
                 version,
-                releaseNotes);
+                releaseNotes));
         }
         catch (Exception ex)
         {
@@ -142,7 +144,7 @@ internal sealed class ApplicationUpdateService(
                 "Foundry update check failed. IsStartupCheck={IsStartupCheck}, ElapsedMilliseconds={ElapsedMilliseconds}",
                 isStartupCheck,
                 totalStopwatch.ElapsedMilliseconds);
-            return new ApplicationUpdateCheckResult(ApplicationUpdateStatus.Failed, ex.Message);
+            return PublishCheckResult(new ApplicationUpdateCheckResult(ApplicationUpdateStatus.Failed, ex.Message));
         }
     }
 
@@ -304,5 +306,11 @@ internal sealed class ApplicationUpdateService(
     {
         pendingUpdate = null;
         pendingUpdateManager = null;
+    }
+
+    private ApplicationUpdateCheckResult PublishCheckResult(ApplicationUpdateCheckResult result)
+    {
+        updateStateService.Publish(result);
+        return result;
     }
 }

--- a/src/Foundry/Services/Updates/ApplicationUpdateStateChangedEventArgs.cs
+++ b/src/Foundry/Services/Updates/ApplicationUpdateStateChangedEventArgs.cs
@@ -1,0 +1,6 @@
+namespace Foundry.Services.Updates;
+
+public sealed class ApplicationUpdateStateChangedEventArgs(ApplicationUpdateCheckResult? currentResult) : EventArgs
+{
+    public ApplicationUpdateCheckResult? CurrentResult { get; } = currentResult;
+}

--- a/src/Foundry/Services/Updates/ApplicationUpdateStateService.cs
+++ b/src/Foundry/Services/Updates/ApplicationUpdateStateService.cs
@@ -1,0 +1,20 @@
+using Serilog;
+
+namespace Foundry.Services.Updates;
+
+internal sealed class ApplicationUpdateStateService(ILogger logger) : IApplicationUpdateStateService
+{
+    private readonly ILogger logger = logger.ForContext<ApplicationUpdateStateService>();
+
+    public event EventHandler<ApplicationUpdateStateChangedEventArgs>? StateChanged;
+
+    public ApplicationUpdateCheckResult? CurrentResult { get; private set; }
+
+    public void Publish(ApplicationUpdateCheckResult result)
+    {
+        CurrentResult = result;
+        logger.Debug("Application update state changed. Status={Status}, Version={Version}", result.Status, result.Version);
+        StateChanged?.Invoke(this, new ApplicationUpdateStateChangedEventArgs(CurrentResult));
+    }
+
+}

--- a/src/Foundry/Services/Updates/IApplicationUpdateStateService.cs
+++ b/src/Foundry/Services/Updates/IApplicationUpdateStateService.cs
@@ -1,0 +1,8 @@
+namespace Foundry.Services.Updates;
+
+public interface IApplicationUpdateStateService
+{
+    event EventHandler<ApplicationUpdateStateChangedEventArgs>? StateChanged;
+    ApplicationUpdateCheckResult? CurrentResult { get; }
+    void Publish(ApplicationUpdateCheckResult result);
+}

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -42,6 +42,9 @@
   <data name="Common.Close" xml:space="preserve">
     <value>Close</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
   <data name="Common.Disabled" xml:space="preserve">
     <value>Disabled</value>
   </data>
@@ -78,6 +81,108 @@
   <data name="MainWindow.ThemeButton.ToolTip" xml:space="preserve">
     <value>Toggle theme</value>
   </data>
+  <data name="AdkPage_Title.Text" xml:space="preserve">
+    <value>ADK</value>
+  </data>
+  <data name="AutopilotPage_Title.Text" xml:space="preserve">
+    <value>Autopilot</value>
+  </data>
+  <data name="CustomizationPage_Title.Text" xml:space="preserve">
+    <value>Customization</value>
+  </data>
+  <data name="DocumentationPage_DocsLink.Content" xml:space="preserve">
+    <value>Documentation</value>
+  </data>
+  <data name="DocumentationPage_IssuesLink.Content" xml:space="preserve">
+    <value>GitHub issues</value>
+  </data>
+  <data name="DocumentationPage_RepositoryLink.Content" xml:space="preserve">
+    <value>GitHub repository</value>
+  </data>
+  <data name="DocumentationPage_Title.Text" xml:space="preserve">
+    <value>Documentation</value>
+  </data>
+  <data name="GeneralConfigurationPage_Title.Text" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="LocalizationPage_Title.Text" xml:space="preserve">
+    <value>Localization</value>
+  </data>
+  <data name="NetworkPage_Title.Text" xml:space="preserve">
+    <value>Network</value>
+  </data>
+  <data name="Shell.OperationRunning" xml:space="preserve">
+    <value>Operation in progress</value>
+  </data>
+  <data name="StartPage_Title.Text" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="UpdateBanner.Action" xml:space="preserve">
+    <value>View update</value>
+  </data>
+  <data name="UpdateBanner.Title" xml:space="preserve">
+    <value>Update available</value>
+  </data>
+  <data name="Nav_AboutKey.Description" xml:space="preserve">
+    <value>Product and version information.</value>
+  </data>
+  <data name="Nav_AboutKey.Subtitle" xml:space="preserve">
+    <value>Foundry information</value>
+  </data>
+  <data name="Nav_AboutKey.Title" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="Nav_AdkKey.Description" xml:space="preserve">
+    <value>ADK readiness and installation.</value>
+  </data>
+  <data name="Nav_AdkKey.Subtitle" xml:space="preserve">
+    <value>Windows ADK</value>
+  </data>
+  <data name="Nav_AdkKey.Title" xml:space="preserve">
+    <value>ADK</value>
+  </data>
+  <data name="Nav_AutopilotKey.Description" xml:space="preserve">
+    <value>Autopilot profile configuration.</value>
+  </data>
+  <data name="Nav_AutopilotKey.Subtitle" xml:space="preserve">
+    <value>Autopilot</value>
+  </data>
+  <data name="Nav_AutopilotKey.Title" xml:space="preserve">
+    <value>Autopilot</value>
+  </data>
+  <data name="Nav_CustomizationKey.Description" xml:space="preserve">
+    <value>Deployment customization options.</value>
+  </data>
+  <data name="Nav_CustomizationKey.Subtitle" xml:space="preserve">
+    <value>Customization</value>
+  </data>
+  <data name="Nav_CustomizationKey.Title" xml:space="preserve">
+    <value>Customization</value>
+  </data>
+  <data name="Nav_DocumentationKey.Description" xml:space="preserve">
+    <value>Foundry documentation and project links.</value>
+  </data>
+  <data name="Nav_DocumentationKey.Subtitle" xml:space="preserve">
+    <value>Documentation</value>
+  </data>
+  <data name="Nav_DocumentationKey.Title" xml:space="preserve">
+    <value>Documentation</value>
+  </data>
+  <data name="Nav_ExpertSection.Title" xml:space="preserve">
+    <value>Expert</value>
+  </data>
+  <data name="Nav_GeneralConfigurationKey.Description" xml:space="preserve">
+    <value>Standard configuration workflow.</value>
+  </data>
+  <data name="Nav_GeneralConfigurationKey.Subtitle" xml:space="preserve">
+    <value>Standard configuration</value>
+  </data>
+  <data name="Nav_GeneralConfigurationKey.Title" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="Nav_GeneralSection.Title" xml:space="preserve">
+    <value>General</value>
+  </data>
   <data name="Nav_HomeKey.Description" xml:space="preserve">
     <value>Foundry home</value>
   </data>
@@ -89,6 +194,33 @@
   </data>
   <data name="Nav_HomeKey.Title" xml:space="preserve">
     <value>Home</value>
+  </data>
+  <data name="Nav_LocalizationKey.Description" xml:space="preserve">
+    <value>WinPE language and localization settings.</value>
+  </data>
+  <data name="Nav_LocalizationKey.Subtitle" xml:space="preserve">
+    <value>Localization</value>
+  </data>
+  <data name="Nav_LocalizationKey.Title" xml:space="preserve">
+    <value>Localization</value>
+  </data>
+  <data name="Nav_NetworkKey.Description" xml:space="preserve">
+    <value>Network and connectivity configuration.</value>
+  </data>
+  <data name="Nav_NetworkKey.Subtitle" xml:space="preserve">
+    <value>Network</value>
+  </data>
+  <data name="Nav_NetworkKey.Title" xml:space="preserve">
+    <value>Network</value>
+  </data>
+  <data name="Nav_StartKey.Description" xml:space="preserve">
+    <value>Review and start media creation.</value>
+  </data>
+  <data name="Nav_StartKey.Subtitle" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="Nav_StartKey.Title" xml:space="preserve">
+    <value>Start</value>
   </data>
   <data name="SettingsPage.PageTitle" xml:space="preserve">
     <value>Settings</value>
@@ -158,6 +290,15 @@
   </data>
   <data name="Update.CurrentVersionFormat" xml:space="preserve">
     <value>Current version {0}</value>
+  </data>
+  <data name="Update.ConfirmDownloadRestart.Message" xml:space="preserve">
+    <value>Foundry will download the update and restart to apply it.</value>
+  </data>
+  <data name="Update.ConfirmDownloadRestart.PrimaryButton" xml:space="preserve">
+    <value>Download and restart</value>
+  </data>
+  <data name="Update.ConfirmDownloadRestart.Title" xml:space="preserve">
+    <value>Apply update</value>
   </data>
   <data name="Update.NoReleaseNotes" xml:space="preserve">
     <value>No release notes were provided for this update.</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -42,6 +42,9 @@
   <data name="Common.Close" xml:space="preserve">
     <value>Fermer</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
   <data name="Common.Disabled" xml:space="preserve">
     <value>Désactivé</value>
   </data>
@@ -78,6 +81,108 @@
   <data name="MainWindow.ThemeButton.ToolTip" xml:space="preserve">
     <value>Changer le thème</value>
   </data>
+  <data name="AdkPage_Title.Text" xml:space="preserve">
+    <value>ADK</value>
+  </data>
+  <data name="AutopilotPage_Title.Text" xml:space="preserve">
+    <value>Autopilot</value>
+  </data>
+  <data name="CustomizationPage_Title.Text" xml:space="preserve">
+    <value>Personnalisation</value>
+  </data>
+  <data name="DocumentationPage_DocsLink.Content" xml:space="preserve">
+    <value>Documentation</value>
+  </data>
+  <data name="DocumentationPage_IssuesLink.Content" xml:space="preserve">
+    <value>Issues GitHub</value>
+  </data>
+  <data name="DocumentationPage_RepositoryLink.Content" xml:space="preserve">
+    <value>Dépôt GitHub</value>
+  </data>
+  <data name="DocumentationPage_Title.Text" xml:space="preserve">
+    <value>Documentation</value>
+  </data>
+  <data name="GeneralConfigurationPage_Title.Text" xml:space="preserve">
+    <value>Général</value>
+  </data>
+  <data name="LocalizationPage_Title.Text" xml:space="preserve">
+    <value>Localisation</value>
+  </data>
+  <data name="NetworkPage_Title.Text" xml:space="preserve">
+    <value>Réseau</value>
+  </data>
+  <data name="Shell.OperationRunning" xml:space="preserve">
+    <value>Opération en cours</value>
+  </data>
+  <data name="StartPage_Title.Text" xml:space="preserve">
+    <value>Démarrer</value>
+  </data>
+  <data name="UpdateBanner.Action" xml:space="preserve">
+    <value>Voir la mise à jour</value>
+  </data>
+  <data name="UpdateBanner.Title" xml:space="preserve">
+    <value>Mise à jour disponible</value>
+  </data>
+  <data name="Nav_AboutKey.Description" xml:space="preserve">
+    <value>Informations de produit et de version.</value>
+  </data>
+  <data name="Nav_AboutKey.Subtitle" xml:space="preserve">
+    <value>Informations Foundry</value>
+  </data>
+  <data name="Nav_AboutKey.Title" xml:space="preserve">
+    <value>À propos</value>
+  </data>
+  <data name="Nav_AdkKey.Description" xml:space="preserve">
+    <value>État et installation de l'ADK.</value>
+  </data>
+  <data name="Nav_AdkKey.Subtitle" xml:space="preserve">
+    <value>Windows ADK</value>
+  </data>
+  <data name="Nav_AdkKey.Title" xml:space="preserve">
+    <value>ADK</value>
+  </data>
+  <data name="Nav_AutopilotKey.Description" xml:space="preserve">
+    <value>Configuration des profils Autopilot.</value>
+  </data>
+  <data name="Nav_AutopilotKey.Subtitle" xml:space="preserve">
+    <value>Autopilot</value>
+  </data>
+  <data name="Nav_AutopilotKey.Title" xml:space="preserve">
+    <value>Autopilot</value>
+  </data>
+  <data name="Nav_CustomizationKey.Description" xml:space="preserve">
+    <value>Options de personnalisation du déploiement.</value>
+  </data>
+  <data name="Nav_CustomizationKey.Subtitle" xml:space="preserve">
+    <value>Personnalisation</value>
+  </data>
+  <data name="Nav_CustomizationKey.Title" xml:space="preserve">
+    <value>Personnalisation</value>
+  </data>
+  <data name="Nav_DocumentationKey.Description" xml:space="preserve">
+    <value>Documentation Foundry et liens du projet.</value>
+  </data>
+  <data name="Nav_DocumentationKey.Subtitle" xml:space="preserve">
+    <value>Documentation</value>
+  </data>
+  <data name="Nav_DocumentationKey.Title" xml:space="preserve">
+    <value>Documentation</value>
+  </data>
+  <data name="Nav_ExpertSection.Title" xml:space="preserve">
+    <value>Expert</value>
+  </data>
+  <data name="Nav_GeneralConfigurationKey.Description" xml:space="preserve">
+    <value>Workflow de configuration standard.</value>
+  </data>
+  <data name="Nav_GeneralConfigurationKey.Subtitle" xml:space="preserve">
+    <value>Configuration standard</value>
+  </data>
+  <data name="Nav_GeneralConfigurationKey.Title" xml:space="preserve">
+    <value>Général</value>
+  </data>
+  <data name="Nav_GeneralSection.Title" xml:space="preserve">
+    <value>Général</value>
+  </data>
   <data name="Nav_HomeKey.Description" xml:space="preserve">
     <value>Accueil Foundry</value>
   </data>
@@ -89,6 +194,33 @@
   </data>
   <data name="Nav_HomeKey.Title" xml:space="preserve">
     <value>Accueil</value>
+  </data>
+  <data name="Nav_LocalizationKey.Description" xml:space="preserve">
+    <value>Langue WinPE et paramètres de localisation.</value>
+  </data>
+  <data name="Nav_LocalizationKey.Subtitle" xml:space="preserve">
+    <value>Localisation</value>
+  </data>
+  <data name="Nav_LocalizationKey.Title" xml:space="preserve">
+    <value>Localisation</value>
+  </data>
+  <data name="Nav_NetworkKey.Description" xml:space="preserve">
+    <value>Configuration réseau et connectivité.</value>
+  </data>
+  <data name="Nav_NetworkKey.Subtitle" xml:space="preserve">
+    <value>Réseau</value>
+  </data>
+  <data name="Nav_NetworkKey.Title" xml:space="preserve">
+    <value>Réseau</value>
+  </data>
+  <data name="Nav_StartKey.Description" xml:space="preserve">
+    <value>Vérifier et lancer la création du média.</value>
+  </data>
+  <data name="Nav_StartKey.Subtitle" xml:space="preserve">
+    <value>Démarrer</value>
+  </data>
+  <data name="Nav_StartKey.Title" xml:space="preserve">
+    <value>Démarrer</value>
   </data>
   <data name="SettingsPage.PageTitle" xml:space="preserve">
     <value>Paramètres</value>
@@ -158,6 +290,15 @@
   </data>
   <data name="Update.CurrentVersionFormat" xml:space="preserve">
     <value>Version actuelle {0}</value>
+  </data>
+  <data name="Update.ConfirmDownloadRestart.Message" xml:space="preserve">
+    <value>Foundry va télécharger la mise à jour et redémarrer pour l'appliquer.</value>
+  </data>
+  <data name="Update.ConfirmDownloadRestart.PrimaryButton" xml:space="preserve">
+    <value>Télécharger et redémarrer</value>
+  </data>
+  <data name="Update.ConfirmDownloadRestart.Title" xml:space="preserve">
+    <value>Appliquer la mise à jour</value>
   </data>
   <data name="Update.NoReleaseNotes" xml:space="preserve">
     <value>Aucune note de version n'a été fournie pour cette mise à jour.</value>

--- a/src/Foundry/ViewModels/MainViewModel.cs
+++ b/src/Foundry/ViewModels/MainViewModel.cs
@@ -1,7 +1,102 @@
-﻿namespace Foundry.ViewModels
-{
-    public partial class MainViewModel : ObservableObject
-    {
+using Foundry.Core.Services.Application;
+using Foundry.Services.Localization;
+using Foundry.Services.Updates;
 
+namespace Foundry.ViewModels
+{
+    public sealed partial class MainViewModel : ObservableObject, IDisposable
+    {
+        private readonly IApplicationUpdateStateService updateStateService;
+        private readonly IApplicationLocalizationService localizationService;
+        private readonly IAppDispatcher appDispatcher;
+        private ApplicationUpdateCheckResult? currentUpdateResult;
+        private bool isUpdateBannerDismissed;
+
+        [ObservableProperty]
+        public partial bool IsUpdateBannerOpen { get; set; }
+
+        [ObservableProperty]
+        public partial string UpdateBannerTitle { get; set; }
+
+        [ObservableProperty]
+        public partial string UpdateBannerMessage { get; set; }
+
+        [ObservableProperty]
+        public partial string UpdateBannerActionText { get; set; }
+
+        public MainViewModel(
+            IApplicationUpdateStateService updateStateService,
+            IApplicationLocalizationService localizationService,
+            IAppDispatcher appDispatcher)
+        {
+            this.updateStateService = updateStateService;
+            this.localizationService = localizationService;
+            this.appDispatcher = appDispatcher;
+
+            UpdateBannerTitle = localizationService.GetString("UpdateBanner.Title");
+            UpdateBannerMessage = localizationService.GetString("Update.Status.UpdateAvailable");
+            UpdateBannerActionText = localizationService.GetString("UpdateBanner.Action");
+
+            updateStateService.StateChanged += OnUpdateStateChanged;
+            localizationService.LanguageChanged += OnLanguageChanged;
+            ApplyUpdateState(updateStateService.CurrentResult);
+        }
+
+        public void DismissUpdateBanner()
+        {
+            isUpdateBannerDismissed = true;
+            IsUpdateBannerOpen = false;
+        }
+
+        public void MarkUpdateBannerActionOpened()
+        {
+            isUpdateBannerDismissed = true;
+            IsUpdateBannerOpen = false;
+        }
+
+        public void Dispose()
+        {
+            updateStateService.StateChanged -= OnUpdateStateChanged;
+            localizationService.LanguageChanged -= OnLanguageChanged;
+        }
+
+        private void OnUpdateStateChanged(object? sender, ApplicationUpdateStateChangedEventArgs e)
+        {
+            _ = appDispatcher.TryEnqueue(() => ApplyUpdateState(e.CurrentResult));
+        }
+
+        private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
+        {
+            _ = appDispatcher.TryEnqueue(() => ApplyUpdateState(currentUpdateResult));
+        }
+
+        private void ApplyUpdateState(ApplicationUpdateCheckResult? result)
+        {
+            bool updateChanged = currentUpdateResult?.Status != result?.Status
+                || !string.Equals(currentUpdateResult?.Version, result?.Version, StringComparison.Ordinal);
+
+            currentUpdateResult = result;
+            UpdateBannerTitle = localizationService.GetString("UpdateBanner.Title");
+            UpdateBannerActionText = localizationService.GetString("UpdateBanner.Action");
+
+            if (result?.IsUpdateAvailable == true)
+            {
+                if (updateChanged)
+                {
+                    isUpdateBannerDismissed = false;
+                }
+
+                UpdateBannerMessage = result.Version is not null
+                    ? localizationService.FormatString("Update.Status.UpdateAvailableWithVersion", result.Version)
+                    : localizationService.GetString("Update.Status.UpdateAvailable");
+
+                IsUpdateBannerOpen = !isUpdateBannerDismissed;
+                return;
+            }
+
+            isUpdateBannerDismissed = false;
+            UpdateBannerMessage = localizationService.GetString("Update.Status.UpdateAvailable");
+            IsUpdateBannerOpen = false;
+        }
     }
 }

--- a/src/Foundry/ViewModels/Settings/AppUpdateSettingViewModel.cs
+++ b/src/Foundry/ViewModels/Settings/AppUpdateSettingViewModel.cs
@@ -5,12 +5,15 @@ using Foundry.Services.Updates;
 
 namespace Foundry.ViewModels
 {
-    public sealed partial class AppUpdateSettingViewModel : ObservableObject
+    public sealed partial class AppUpdateSettingViewModel : ObservableObject, IDisposable
     {
         private readonly IAppSettingsService appSettingsService;
         private readonly IDialogService dialogService;
         private readonly IApplicationUpdateService applicationUpdateService;
+        private readonly IApplicationUpdateStateService updateStateService;
         private readonly IApplicationLocalizationService localizationService;
+        private readonly IAppDispatcher appDispatcher;
+        private ApplicationUpdateCheckResult? currentCheckResult;
         private string releaseNotes;
 
         [ObservableProperty]
@@ -47,18 +50,32 @@ namespace Foundry.ViewModels
             IAppSettingsService appSettingsService,
             IDialogService dialogService,
             IApplicationUpdateService applicationUpdateService,
-            IApplicationLocalizationService localizationService)
+            IApplicationUpdateStateService updateStateService,
+            IApplicationLocalizationService localizationService,
+            IAppDispatcher appDispatcher)
         {
             this.appSettingsService = appSettingsService;
             this.dialogService = dialogService;
             this.applicationUpdateService = applicationUpdateService;
+            this.updateStateService = updateStateService;
             this.localizationService = localizationService;
+            this.appDispatcher = appDispatcher;
             releaseNotes = localizationService.GetString("Update.ReleaseNotesFallback");
 
             CurrentVersion = localizationService.FormatString("Update.CurrentVersionFormat", FoundryApplicationInfo.Version);
             LastUpdateCheck = appSettingsService.Current.Updates.LastCheckedAt?.ToString("yyyy-MM-dd HH:mm") ?? localizationService.GetString("Update.NotChecked");
             IsCheckButtonEnabled = true;
             LoadingStatus = localizationService.GetString("Update.Status.Ready");
+
+            updateStateService.StateChanged += OnUpdateStateChanged;
+            localizationService.LanguageChanged += OnLanguageChanged;
+            ApplyCurrentUpdateState(updateStateService.CurrentResult);
+        }
+
+        public void Dispose()
+        {
+            updateStateService.StateChanged -= OnUpdateStateChanged;
+            localizationService.LanguageChanged -= OnLanguageChanged;
         }
 
         [RelayCommand]
@@ -80,11 +97,7 @@ namespace Foundry.ViewModels
                 appSettingsService.Save();
 
                 LastUpdateCheck = checkedAt.ToString("yyyy-MM-dd HH:mm");
-                LoadingStatus = GetCheckStatusMessage(result);
-                IsUpdateAvailable = result.IsUpdateAvailable;
-                IsInstallButtonVisible = result.IsUpdateAvailable;
-                IsReleaseNotesVisible = result.IsUpdateAvailable && !string.IsNullOrWhiteSpace(result.ReleaseNotes);
-                releaseNotes = result.ReleaseNotes ?? localizationService.GetString("Update.NoReleaseNotes");
+                ApplyCurrentUpdateState(result);
             }
             finally
             {
@@ -104,6 +117,21 @@ namespace Foundry.ViewModels
 
             try
             {
+                bool confirmed = await dialogService.ConfirmAsync(new ConfirmationDialogRequest(
+                    localizationService.GetString("Update.ConfirmDownloadRestart.Title"),
+                    localizationService.GetString("Update.ConfirmDownloadRestart.Message"),
+                    localizationService.GetString("Update.ConfirmDownloadRestart.PrimaryButton"),
+                    localizationService.GetString("Common.Cancel")));
+
+                if (!confirmed)
+                {
+                    LoadingStatus = currentCheckResult is not null
+                        ? GetCheckStatusMessage(currentCheckResult)
+                        : localizationService.GetString("Update.Status.Ready");
+                    IsInstallButtonVisible = IsUpdateAvailable;
+                    return;
+                }
+
                 Progress<int> progress = new(value =>
                 {
                     DownloadProgress = value;
@@ -136,6 +164,43 @@ namespace Foundry.ViewModels
                 localizationService.GetString("Update.ReleaseNotesDialogTitle"),
                 releaseNotes,
                 localizationService.GetString("Common.Close")));
+        }
+
+        private void OnUpdateStateChanged(object? sender, ApplicationUpdateStateChangedEventArgs e)
+        {
+            _ = appDispatcher.TryEnqueue(() => ApplyCurrentUpdateState(e.CurrentResult));
+        }
+
+        private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
+        {
+            _ = appDispatcher.TryEnqueue(() =>
+            {
+                CurrentVersion = localizationService.FormatString("Update.CurrentVersionFormat", FoundryApplicationInfo.Version);
+                LastUpdateCheck = appSettingsService.Current.Updates.LastCheckedAt?.ToString("yyyy-MM-dd HH:mm")
+                    ?? localizationService.GetString("Update.NotChecked");
+                ApplyCurrentUpdateState(currentCheckResult);
+            });
+        }
+
+        private void ApplyCurrentUpdateState(ApplicationUpdateCheckResult? result)
+        {
+            currentCheckResult = result;
+
+            if (result is null)
+            {
+                LoadingStatus = localizationService.GetString("Update.Status.Ready");
+                IsUpdateAvailable = false;
+                IsInstallButtonVisible = false;
+                IsReleaseNotesVisible = false;
+                releaseNotes = localizationService.GetString("Update.ReleaseNotesFallback");
+                return;
+            }
+
+            LoadingStatus = GetCheckStatusMessage(result);
+            IsUpdateAvailable = result.IsUpdateAvailable;
+            IsInstallButtonVisible = result.IsUpdateAvailable;
+            IsReleaseNotesVisible = result.IsUpdateAvailable && !string.IsNullOrWhiteSpace(result.ReleaseNotes);
+            releaseNotes = result.ReleaseNotes ?? localizationService.GetString("Update.NoReleaseNotes");
         }
 
         private string GetCheckStatusMessage(ApplicationUpdateCheckResult result)

--- a/src/Foundry/Views/AdkPage.xaml
+++ b/src/Foundry/Views/AdkPage.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page x:Class="Foundry.Views.AdkPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:dev="using:DevWinUI"
+      dev:BreadcrumbNavigator.IsHeaderVisible="True">
+    <ScrollView Margin="{ThemeResource ContentPageMargin}"
+                Padding="{ThemeResource ContentPagePadding}">
+        <StackPanel Margin="10"
+                    Spacing="5">
+            <TextBlock x:Uid="AdkPage_Title"
+                       Style="{ThemeResource TitleTextBlockStyle}" />
+        </StackPanel>
+    </ScrollView>
+</Page>

--- a/src/Foundry/Views/AdkPage.xaml.cs
+++ b/src/Foundry/Views/AdkPage.xaml.cs
@@ -1,0 +1,12 @@
+using Foundry.Services.Localization;
+
+namespace Foundry.Views;
+
+public sealed partial class AdkPage : Page
+{
+    public AdkPage()
+    {
+        InitializeComponent();
+        BreadcrumbNavigator.SetPageTitle(this, App.GetService<IApplicationLocalizationService>().GetString("Nav_AdkKey.Title"));
+    }
+}

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page x:Class="Foundry.Views.AutopilotPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:dev="using:DevWinUI"
+      dev:BreadcrumbNavigator.IsHeaderVisible="True">
+    <ScrollView Margin="{ThemeResource ContentPageMargin}"
+                Padding="{ThemeResource ContentPagePadding}">
+        <StackPanel Margin="10"
+                    Spacing="5">
+            <TextBlock x:Uid="AutopilotPage_Title"
+                       Style="{ThemeResource TitleTextBlockStyle}" />
+        </StackPanel>
+    </ScrollView>
+</Page>

--- a/src/Foundry/Views/AutopilotPage.xaml.cs
+++ b/src/Foundry/Views/AutopilotPage.xaml.cs
@@ -1,0 +1,12 @@
+using Foundry.Services.Localization;
+
+namespace Foundry.Views;
+
+public sealed partial class AutopilotPage : Page
+{
+    public AutopilotPage()
+    {
+        InitializeComponent();
+        BreadcrumbNavigator.SetPageTitle(this, App.GetService<IApplicationLocalizationService>().GetString("Nav_AutopilotKey.Title"));
+    }
+}

--- a/src/Foundry/Views/CustomizationPage.xaml
+++ b/src/Foundry/Views/CustomizationPage.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page x:Class="Foundry.Views.CustomizationPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:dev="using:DevWinUI"
+      dev:BreadcrumbNavigator.IsHeaderVisible="True">
+    <ScrollView Margin="{ThemeResource ContentPageMargin}"
+                Padding="{ThemeResource ContentPagePadding}">
+        <StackPanel Margin="10"
+                    Spacing="5">
+            <TextBlock x:Uid="CustomizationPage_Title"
+                       Style="{ThemeResource TitleTextBlockStyle}" />
+        </StackPanel>
+    </ScrollView>
+</Page>

--- a/src/Foundry/Views/CustomizationPage.xaml.cs
+++ b/src/Foundry/Views/CustomizationPage.xaml.cs
@@ -1,0 +1,12 @@
+using Foundry.Services.Localization;
+
+namespace Foundry.Views;
+
+public sealed partial class CustomizationPage : Page
+{
+    public CustomizationPage()
+    {
+        InitializeComponent();
+        BreadcrumbNavigator.SetPageTitle(this, App.GetService<IApplicationLocalizationService>().GetString("Nav_CustomizationKey.Title"));
+    }
+}

--- a/src/Foundry/Views/DocumentationPage.xaml
+++ b/src/Foundry/Views/DocumentationPage.xaml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page x:Class="Foundry.Views.DocumentationPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:dev="using:DevWinUI"
+      dev:BreadcrumbNavigator.IsHeaderVisible="True">
+    <ScrollView Margin="{ThemeResource ContentPageMargin}"
+                Padding="{ThemeResource ContentPagePadding}">
+        <StackPanel Margin="10"
+                    Spacing="8">
+            <TextBlock x:Uid="DocumentationPage_Title"
+                       Style="{ThemeResource TitleTextBlockStyle}" />
+            <HyperlinkButton x:Uid="DocumentationPage_DocsLink"
+                             NavigateUri="https://foundry-osd.github.io/" />
+            <HyperlinkButton x:Uid="DocumentationPage_RepositoryLink"
+                             NavigateUri="https://github.com/foundry-osd/foundry" />
+            <HyperlinkButton x:Uid="DocumentationPage_IssuesLink"
+                             NavigateUri="https://github.com/foundry-osd/foundry/issues" />
+        </StackPanel>
+    </ScrollView>
+</Page>

--- a/src/Foundry/Views/DocumentationPage.xaml.cs
+++ b/src/Foundry/Views/DocumentationPage.xaml.cs
@@ -1,0 +1,12 @@
+using Foundry.Services.Localization;
+
+namespace Foundry.Views;
+
+public sealed partial class DocumentationPage : Page
+{
+    public DocumentationPage()
+    {
+        InitializeComponent();
+        BreadcrumbNavigator.SetPageTitle(this, App.GetService<IApplicationLocalizationService>().GetString("Nav_DocumentationKey.Title"));
+    }
+}

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page x:Class="Foundry.Views.GeneralConfigurationPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:dev="using:DevWinUI"
+      dev:BreadcrumbNavigator.IsHeaderVisible="True">
+    <ScrollView Margin="{ThemeResource ContentPageMargin}"
+                Padding="{ThemeResource ContentPagePadding}">
+        <StackPanel Margin="10"
+                    Spacing="5">
+            <TextBlock x:Uid="GeneralConfigurationPage_Title"
+                       Style="{ThemeResource TitleTextBlockStyle}" />
+        </StackPanel>
+    </ScrollView>
+</Page>

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
@@ -1,0 +1,12 @@
+using Foundry.Services.Localization;
+
+namespace Foundry.Views;
+
+public sealed partial class GeneralConfigurationPage : Page
+{
+    public GeneralConfigurationPage()
+    {
+        InitializeComponent();
+        BreadcrumbNavigator.SetPageTitle(this, App.GetService<IApplicationLocalizationService>().GetString("Nav_GeneralConfigurationKey.Title"));
+    }
+}

--- a/src/Foundry/Views/LocalizationPage.xaml
+++ b/src/Foundry/Views/LocalizationPage.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page x:Class="Foundry.Views.LocalizationPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:dev="using:DevWinUI"
+      dev:BreadcrumbNavigator.IsHeaderVisible="True">
+    <ScrollView Margin="{ThemeResource ContentPageMargin}"
+                Padding="{ThemeResource ContentPagePadding}">
+        <StackPanel Margin="10"
+                    Spacing="5">
+            <TextBlock x:Uid="LocalizationPage_Title"
+                       Style="{ThemeResource TitleTextBlockStyle}" />
+        </StackPanel>
+    </ScrollView>
+</Page>

--- a/src/Foundry/Views/LocalizationPage.xaml.cs
+++ b/src/Foundry/Views/LocalizationPage.xaml.cs
@@ -1,0 +1,12 @@
+using Foundry.Services.Localization;
+
+namespace Foundry.Views;
+
+public sealed partial class LocalizationPage : Page
+{
+    public LocalizationPage()
+    {
+        InitializeComponent();
+        BreadcrumbNavigator.SetPageTitle(this, App.GetService<IApplicationLocalizationService>().GetString("Nav_LocalizationKey.Title"));
+    }
+}

--- a/src/Foundry/Views/MainWindow.xaml
+++ b/src/Foundry/Views/MainWindow.xaml
@@ -43,7 +43,43 @@
             <NavigationView.Header>
                 <dev:BreadcrumbNavigator x:Name="BreadCrumbNav" />
             </NavigationView.Header>
-            <Frame x:Name="NavFrame" />
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+                <InfoBar x:Name="UpdateInfoBar"
+                         Margin="16,8,16,0"
+                         IsClosable="True"
+                         IsOpen="{x:Bind ViewModel.IsUpdateBannerOpen, Mode=OneWay}"
+                         Message="{x:Bind ViewModel.UpdateBannerMessage, Mode=OneWay}"
+                         Severity="Informational"
+                         Title="{x:Bind ViewModel.UpdateBannerTitle, Mode=OneWay}"
+                         Closed="UpdateInfoBar_Closed">
+                    <InfoBar.ActionButton>
+                        <Button Content="{x:Bind ViewModel.UpdateBannerActionText, Mode=OneWay}"
+                                Click="UpdateInfoBarActionButton_Click"
+                                Style="{ThemeResource AccentButtonStyle}" />
+                    </InfoBar.ActionButton>
+                </InfoBar>
+                <Grid Grid.Row="1">
+                    <Frame x:Name="NavFrame" />
+                    <Grid x:Name="OperationOverlay"
+                          Background="{ThemeResource SystemControlAcrylicWindowBrush}"
+                          Visibility="Collapsed">
+                        <StackPanel HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Spacing="12">
+                            <ProgressRing Width="48"
+                                          Height="48"
+                                          IsActive="True" />
+                            <TextBlock x:Name="OperationOverlayTitle"
+                                       HorizontalAlignment="Center"
+                                       Style="{ThemeResource SubtitleTextBlockStyle}" />
+                        </StackPanel>
+                    </Grid>
+                </Grid>
+            </Grid>
         </NavigationView>
     </Grid>
 </Window>

--- a/src/Foundry/Views/MainWindow.xaml.cs
+++ b/src/Foundry/Views/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 using Foundry.Services.Localization;
+using Foundry.Services.Shell;
 using Microsoft.UI.Windowing;
 
 namespace Foundry.Views
@@ -6,6 +7,7 @@ namespace Foundry.Views
     public sealed partial class MainWindow : Window
     {
         private readonly IApplicationLocalizationService localizationService;
+        private readonly IShellNavigationGuardService shellNavigationGuardService;
         private JsonNavigationService? jsonNavigationService;
 
         public MainViewModel ViewModel { get; }
@@ -13,6 +15,7 @@ namespace Foundry.Views
         public MainWindow()
         {
             localizationService = App.GetService<IApplicationLocalizationService>();
+            shellNavigationGuardService = App.GetService<IShellNavigationGuardService>();
             ViewModel = App.GetService<MainViewModel>();
             this.InitializeComponent();
             ExtendsContentIntoTitleBar = true;
@@ -20,8 +23,13 @@ namespace Foundry.Views
             AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Tall;
             ApplyLocalizedShellText();
             InitializeNavigation();
+            ApplyShellNavigationState();
 
             localizationService.LanguageChanged += OnLanguageChanged;
+            shellNavigationGuardService.StateChanged += OnShellNavigationStateChanged;
+            NavFrame.Navigated += OnNavFrameNavigated;
+            AppTitleBar.BackRequested += OnTitleBarBackRequested;
+            AppTitleBar.PaneToggleRequested += OnTitleBarPaneToggleRequested;
             Closed += OnClosed;
         }
 
@@ -34,7 +42,6 @@ namespace Foundry.Views
                     .ConfigureDefaultPage(typeof(HomeLandingPage))
                     .ConfigureSettingsPage(typeof(SettingsPage))
                     .ConfigureJsonFile("Assets/NavViewMenu/AppData.json")
-                    .ConfigureTitleBar(AppTitleBar)
                     .ConfigureBreadcrumbBar(BreadCrumbNav, BreadcrumbPageMappings.PageDictionary);
             }
         }
@@ -66,12 +73,14 @@ namespace Foundry.Views
             jsonNavigationService?.ReInitialize();
             ApplyLocalizedShellText();
             RefreshLocalizedBreadcrumbs();
+            ApplyShellNavigationState();
 
             Type? currentPageType = NavFrame.CurrentSourcePageType;
             if (currentPageType is not null)
             {
                 NavFrame.Navigate(currentPageType);
                 RefreshLocalizedBreadcrumbs();
+                ApplyShellNavigationState();
             }
         }
 
@@ -113,13 +122,37 @@ namespace Foundry.Views
                 return localizationService.GetString("SettingsPage_AboutCard.Header");
             }
 
+            string? pageResourceKey = step.Page switch
+            {
+                Type page when page == typeof(HomeLandingPage) => "Nav_HomeKey.Title",
+                Type page when page == typeof(AdkPage) => "Nav_AdkKey.Title",
+                Type page when page == typeof(GeneralConfigurationPage) => "Nav_GeneralConfigurationKey.Title",
+                Type page when page == typeof(StartPage) => "Nav_StartKey.Title",
+                Type page when page == typeof(NetworkPage) => "Nav_NetworkKey.Title",
+                Type page when page == typeof(LocalizationPage) => "Nav_LocalizationKey.Title",
+                Type page when page == typeof(AutopilotPage) => "Nav_AutopilotKey.Title",
+                Type page when page == typeof(CustomizationPage) => "Nav_CustomizationKey.Title",
+                Type page when page == typeof(DocumentationPage) => "Nav_DocumentationKey.Title",
+                _ => null
+            };
+
+            if (pageResourceKey is not null)
+            {
+                return localizationService.GetString(pageResourceKey);
+            }
+
             return step.Label;
         }
 
         private void OnClosed(object sender, WindowEventArgs args)
         {
             localizationService.LanguageChanged -= OnLanguageChanged;
+            shellNavigationGuardService.StateChanged -= OnShellNavigationStateChanged;
+            NavFrame.Navigated -= OnNavFrameNavigated;
+            AppTitleBar.BackRequested -= OnTitleBarBackRequested;
+            AppTitleBar.PaneToggleRequested -= OnTitleBarPaneToggleRequested;
             Closed -= OnClosed;
+            ViewModel.Dispose();
         }
 
         private async void ThemeButton_Click(object sender, RoutedEventArgs e)
@@ -129,12 +162,131 @@ namespace Foundry.Views
 
         private void OnTextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
         {
+            if (shellNavigationGuardService.State != ShellNavigationState.Ready)
+            {
+                sender.ItemsSource = null;
+                return;
+            }
+
             AutoSuggestBoxHelper.OnITitleBarAutoSuggestBoxTextChangedEvent(sender, args, NavFrame);
         }
 
         private void OnQuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
         {
+            if (shellNavigationGuardService.State != ShellNavigationState.Ready)
+            {
+                return;
+            }
+
             AutoSuggestBoxHelper.OnITitleBarAutoSuggestBoxQuerySubmittedEvent(sender, args, NavFrame);
+        }
+
+        private void OnShellNavigationStateChanged(object? sender, EventArgs e)
+        {
+            if (!DispatcherQueue.HasThreadAccess)
+            {
+                _ = DispatcherQueue.TryEnqueue(ApplyShellNavigationState);
+                return;
+            }
+
+            ApplyShellNavigationState();
+        }
+
+        private void OnNavFrameNavigated(object sender, NavigationEventArgs e)
+        {
+            ApplyShellNavigationState();
+        }
+
+        private void OnTitleBarBackRequested(TitleBar sender, object args)
+        {
+            if (shellNavigationGuardService.State == ShellNavigationState.OperationRunning)
+            {
+                return;
+            }
+
+            jsonNavigationService?.GoBack();
+        }
+
+        private void OnTitleBarPaneToggleRequested(TitleBar sender, object args)
+        {
+            NavView.IsPaneOpen = !NavView.IsPaneOpen;
+        }
+
+        private void UpdateInfoBar_Closed(InfoBar sender, InfoBarClosedEventArgs args)
+        {
+            if (args.Reason == InfoBarCloseReason.CloseButton)
+            {
+                ViewModel.DismissUpdateBanner();
+            }
+        }
+
+        private void UpdateInfoBarActionButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (shellNavigationGuardService.State == ShellNavigationState.OperationRunning)
+            {
+                return;
+            }
+
+            ViewModel.MarkUpdateBannerActionOpened();
+            jsonNavigationService?.NavigateTo(
+                typeof(AppUpdateSettingPage),
+                localizationService.GetString("SettingsPage_UpdateCard.Header"));
+        }
+
+        private void ApplyShellNavigationState()
+        {
+            ShellNavigationState state = shellNavigationGuardService.State;
+            bool isOperationRunning = state == ShellNavigationState.OperationRunning;
+            SearchBox.IsEnabled = state == ShellNavigationState.Ready;
+            OperationOverlay.Visibility = isOperationRunning ? Visibility.Visible : Visibility.Collapsed;
+            OperationOverlayTitle.Text = localizationService.GetString("Shell.OperationRunning");
+
+            ApplyNavigationItemsState(NavView.MenuItems, isFooter: false, state);
+            ApplyNavigationItemsState(NavView.FooterMenuItems, isFooter: true, state);
+
+            if (NavView.SettingsItem is NavigationViewItem settingsItem)
+            {
+                settingsItem.IsEnabled = !isOperationRunning;
+            }
+
+            NavView.IsBackEnabled = !isOperationRunning && NavFrame.CanGoBack;
+            AppTitleBar.IsBackButtonVisible = !isOperationRunning && NavFrame.CanGoBack;
+        }
+
+        private static void ApplyNavigationItemsState(IList<object> items, bool isFooter, ShellNavigationState state)
+        {
+            foreach (object item in items)
+            {
+                ApplyNavigationItemState(item, isFooter, state);
+            }
+        }
+
+        private static void ApplyNavigationItemState(object item, bool isFooter, ShellNavigationState state)
+        {
+            if (item is not NavigationViewItem navigationItem)
+            {
+                return;
+            }
+
+            navigationItem.IsEnabled = IsNavigationItemEnabled(navigationItem.Tag as string, isFooter, state);
+
+            foreach (object child in navigationItem.MenuItems)
+            {
+                ApplyNavigationItemState(child, isFooter, state);
+            }
+        }
+
+        private static bool IsNavigationItemEnabled(string? uniqueId, bool isFooter, ShellNavigationState state)
+        {
+            return state switch
+            {
+                ShellNavigationState.Ready => true,
+                ShellNavigationState.OperationRunning => false,
+                ShellNavigationState.AdkBlocked => isFooter
+                    || string.Equals(uniqueId, typeof(HomeLandingPage).FullName, StringComparison.Ordinal)
+                    || string.Equals(uniqueId, typeof(AdkPage).FullName, StringComparison.Ordinal),
+                _ => false
+            };
         }
     }
 

--- a/src/Foundry/Views/NetworkPage.xaml
+++ b/src/Foundry/Views/NetworkPage.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page x:Class="Foundry.Views.NetworkPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:dev="using:DevWinUI"
+      dev:BreadcrumbNavigator.IsHeaderVisible="True">
+    <ScrollView Margin="{ThemeResource ContentPageMargin}"
+                Padding="{ThemeResource ContentPagePadding}">
+        <StackPanel Margin="10"
+                    Spacing="5">
+            <TextBlock x:Uid="NetworkPage_Title"
+                       Style="{ThemeResource TitleTextBlockStyle}" />
+        </StackPanel>
+    </ScrollView>
+</Page>

--- a/src/Foundry/Views/NetworkPage.xaml.cs
+++ b/src/Foundry/Views/NetworkPage.xaml.cs
@@ -1,0 +1,12 @@
+using Foundry.Services.Localization;
+
+namespace Foundry.Views;
+
+public sealed partial class NetworkPage : Page
+{
+    public NetworkPage()
+    {
+        InitializeComponent();
+        BreadcrumbNavigator.SetPageTitle(this, App.GetService<IApplicationLocalizationService>().GetString("Nav_NetworkKey.Title"));
+    }
+}

--- a/src/Foundry/Views/Settings/AppUpdateSettingPage.xaml.cs
+++ b/src/Foundry/Views/Settings/AppUpdateSettingPage.xaml.cs
@@ -8,8 +8,13 @@
         {
             ViewModel = App.GetService<AppUpdateSettingViewModel>();
             this.InitializeComponent();
+            Unloaded += OnUnloaded;
+        }
+
+        private void OnUnloaded(object sender, RoutedEventArgs e)
+        {
+            ViewModel.Dispose();
+            Unloaded -= OnUnloaded;
         }
     }
-
-
 }

--- a/src/Foundry/Views/SettingsPage.xaml.cs
+++ b/src/Foundry/Views/SettingsPage.xaml.cs
@@ -1,17 +1,21 @@
 using Foundry.Services.Localization;
+using Foundry.Services.Shell;
 
 namespace Foundry.Views
 {
     public sealed partial class SettingsPage : Page
     {
         private readonly IApplicationLocalizationService localizationService;
+        private readonly IShellNavigationGuardService shellNavigationGuardService;
 
         public SettingsPage()
         {
             localizationService = App.GetService<IApplicationLocalizationService>();
+            shellNavigationGuardService = App.GetService<IShellNavigationGuardService>();
             this.InitializeComponent();
             ApplyLocalizedText();
             localizationService.LanguageChanged += OnLanguageChanged;
+            shellNavigationGuardService.StateChanged += OnShellNavigationStateChanged;
             Unloaded += OnUnloaded;
         }
 
@@ -29,6 +33,7 @@ namespace Foundry.Views
         private void ApplyLocalizedText()
         {
             ApplyLocalizedNavigationParameters();
+            ApplyNavigationGuardState();
         }
 
         private void ApplyLocalizedNavigationParameters()
@@ -59,7 +64,28 @@ namespace Foundry.Views
         private void OnUnloaded(object sender, RoutedEventArgs e)
         {
             localizationService.LanguageChanged -= OnLanguageChanged;
+            shellNavigationGuardService.StateChanged -= OnShellNavigationStateChanged;
             Unloaded -= OnUnloaded;
+        }
+
+        private void OnShellNavigationStateChanged(object? sender, EventArgs e)
+        {
+            if (!DispatcherQueue.HasThreadAccess)
+            {
+                _ = DispatcherQueue.TryEnqueue(ApplyNavigationGuardState);
+                return;
+            }
+
+            ApplyNavigationGuardState();
+        }
+
+        private void ApplyNavigationGuardState()
+        {
+            bool isOperationRunning = shellNavigationGuardService.State == ShellNavigationState.OperationRunning;
+            GeneralSettingsCard.IsEnabled = !isOperationRunning;
+            ThemeSettingsCard.IsEnabled = !isOperationRunning;
+            UpdateSettingsCard.IsEnabled = !isOperationRunning;
+            AboutSettingsCard.IsEnabled = !isOperationRunning;
         }
     }
 

--- a/src/Foundry/Views/StartPage.xaml
+++ b/src/Foundry/Views/StartPage.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page x:Class="Foundry.Views.StartPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:dev="using:DevWinUI"
+      dev:BreadcrumbNavigator.IsHeaderVisible="True">
+    <ScrollView Margin="{ThemeResource ContentPageMargin}"
+                Padding="{ThemeResource ContentPagePadding}">
+        <StackPanel Margin="10"
+                    Spacing="5">
+            <TextBlock x:Uid="StartPage_Title"
+                       Style="{ThemeResource TitleTextBlockStyle}" />
+        </StackPanel>
+    </ScrollView>
+</Page>

--- a/src/Foundry/Views/StartPage.xaml.cs
+++ b/src/Foundry/Views/StartPage.xaml.cs
@@ -1,0 +1,12 @@
+using Foundry.Services.Localization;
+
+namespace Foundry.Views;
+
+public sealed partial class StartPage : Page
+{
+    public StartPage()
+    {
+        InitializeComponent();
+        BreadcrumbNavigator.SetPageTitle(this, App.GetService<IApplicationLocalizationService>().GetString("Nav_StartKey.Title"));
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the prototype DevWinUI navigation metadata with Foundry sections, footer entries, and initial shell pages.
- Add shell navigation guard application for Ready, ADK-blocked, and operation-running states.
- Add shared update-check state so startup/manual checks drive both the shell update banner and the update settings page.

## Reason
Phase 11 needs the DevWinUI shell to become the long-term Foundry navigation baseline while keeping runtime state outside static AppData metadata.

## Main changes
- Added General, Expert, Documentation, About, and Settings navigation structure without a dedicated Logs footer item.
- Added initial placeholder pages for Phase 11 navigation targets.
- Added a top-shell WinUI InfoBar for update availability, with an action to open the update settings surface.
- Added update download/restart confirmation.
- Updated migration plan checkboxes for completed Phase 11 implementation tasks and Phase 7.7.2.

## Testing
- `dotnet build src\Foundry\Foundry.csproj --configuration Debug --no-restore`
- `dotnet test src\Foundry.slnx --configuration Release --no-restore`
