### PR TITLE
feat(adk): add adk status and page integration

### DIFF
--- a/docs/migration/01-workflow.md
+++ b/docs/migration/01-workflow.md
@@ -149,7 +149,7 @@ Use the numeric phase IDs for stable prompts, but execute the work in dependency
 - [x] PR 8: WinUI `.resw` localization foundation.
 - [x] PR 9: production logging contract.
 - [x] PR 10: DevWinUI shell navigation, settings, update banner, and blocking operation overlay.
-- [ ] PR 11: ADK status, ADK page, and navigation readiness integration.
+- [x] PR 11: ADK status, ADK page, and navigation readiness integration.
 - [ ] PR 12: WinPE service foundations.
 - [ ] PR 13: Connect/Deploy runtime layout normalization.
 - [ ] PR 14: new `ProgramData`, ISO, USB, and WinPE media layout enforcement.

--- a/docs/migration/architecture/page-map.md
+++ b/docs/migration/architecture/page-map.md
@@ -258,7 +258,7 @@ Used while ADK installation, ADK upgrade, ISO creation, USB creation, Autopilot 
 - [ ] Revalidate the official Microsoft download URLs and supported ADK version before implementing the WinUI migration.
 - [ ] Treat the WPF `10.1.26100.*` compatibility policy as a starting point, not as a permanent assumption.
 - [ ] Require `10.1.26100.2454+` for the general Windows 11 24H2/25H2 ADK track.
-- [ ] Allow `10.1.28000.1+` for the Windows 11 26H1 Arm64 ADK track.
+- [ ] Do not allow the Windows 11 26H1 Arm64 `10.1.28000.x` ADK track in Foundry.
 - [ ] Display that Microsoft recommends applying the latest ADK servicing patch for the detected target track.
 
 ## Shell Implementation Boundary

--- a/docs/migration/architecture/page-map.md
+++ b/docs/migration/architecture/page-map.md
@@ -256,7 +256,10 @@ Used while ADK installation, ADK upgrade, ISO creation, USB creation, Autopilot 
 - [ ] Keep `/norestart` behavior unless a future ADK version requires a different policy.
 - [ ] Keep the WinPE Add-on as a separate installer step.
 - [ ] Revalidate the official Microsoft download URLs and supported ADK version before implementing the WinUI migration.
-- [ ] Treat the current WPF `10.1.26100.*` compatibility policy as the starting point, not as a permanent assumption.
+- [ ] Treat the WPF `10.1.26100.*` compatibility policy as a starting point, not as a permanent assumption.
+- [ ] Require `10.1.26100.2454+` for the general Windows 11 24H2/25H2 ADK track.
+- [ ] Allow `10.1.28000.1+` for the Windows 11 26H1 Arm64 ADK track.
+- [ ] Display that Microsoft recommends applying the latest ADK servicing patch for the detected target track.
 
 ## Shell Implementation Boundary
 

--- a/docs/migration/phases/03-startup-distribution-ci.md
+++ b/docs/migration/phases/03-startup-distribution-ci.md
@@ -36,13 +36,13 @@
 - [x] **6.8** Remove DevWinUI placeholder update metadata.
 - [ ] **6.8.1** Implement the startup readiness sequence:
   - [x] Initialize logging, dependency injection, and Velopack startup hooks.
-  - [ ] Detect ADK and WinPE Add-on readiness.
+  - [x] Detect ADK and WinPE Add-on readiness.
   - [x] Apply `AdkBlocked` or `Ready` shell navigation state.
   - [ ] Refresh USB targets only after ADK is compatible.
-  - Note: update checks are implemented. USB target refresh remains deferred to Phase 13 after Phase 12 provides ADK-compatible readiness and WinPE service foundations.
+  - Note: ADK readiness and update checks are implemented. USB target refresh remains deferred to Phase 13 after Phase 12 provides WinPE service foundations.
   - [x] Run update checks after readiness initialization.
   - [x] Ensure startup update checks do not block app usage.
-  - Note: ADK detection is deferred to Phase 12; USB refresh is deferred to Phase 13; Velopack update checks are implemented.
+  - Note: USB refresh is deferred to Phase 13.
 - [x] **6.9** Commit:
 
 ```powershell

--- a/docs/migration/phases/04-localization-logging-shell.md
+++ b/docs/migration/phases/04-localization-logging-shell.md
@@ -140,7 +140,7 @@ git commit -m "feat(localization): migrate foundry localization to winui"
   - [x] Do not use `Verbose` unless a future approved subsystem proves it needs trace-level diagnostics.
   - [x] Do not log noisy UI interactions, obvious control flow, secrets, tokens, passwords, encrypted secret payloads, media keys, or sensitive user data.
 - [ ] **10.6.1** Define future workflow logging contracts without blocking Phase 10 on unimplemented workflows:
-  - [ ] ADK detection logs required when ADK service/page work is implemented in Phase 12.
+  - [x] ADK detection logs required when ADK service/page work is implemented in Phase 12.
   - [ ] ISO/USB build start, progress, completion, cancellation, and failure logs required when media creation work is implemented.
   - [ ] Bootstrap payload resolution logs required when payload resolution work is implemented in Phase 12.
   - [ ] Complete the ADK/WinPE portion through Phase 12 implementation and validation.

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -99,7 +99,7 @@ The `12.A` to `12.D` labels are implementation slices, not extra phase numbers. 
   - [x] **12.1.10** Treat the current WPF `10.1.26100.*` compatibility policy as the starting point.
   - [x] **12.1.11** Update compatibility if the target official ADK version changes before implementation.
     - [x] Require `10.1.26100.2454+` for the general Windows 11 24H2/25H2 ADK track.
-    - [x] Allow `10.1.28000.1+` for the Windows 11 26H1 Arm64 ADK track.
+    - [x] Do not allow the Windows 11 26H1 Arm64 `10.1.28000.x` ADK track in Foundry.
     - [x] Display that Microsoft recommends applying the latest ADK servicing patch for the detected target track.
   - [x] **12.1.12** Version ADK installer cache files and write downloads atomically so interrupted downloads are not reused.
 - [ ] **12.2** Port WinPE services in dependency order:

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -279,7 +279,7 @@ git commit -m "feat(winpe): apply programdata media layout"
 - [ ] **12.23** New host-side `ProgramData` layout is used without old-folder fallback.
 - [x] **12.24** ADK page shows missing state when ADK is absent.
 - [x] **12.25** ADK page shows installed version when ADK is present.
-- [ ] **12.26** ADK page shows incompatible state when the version is unsupported.
+- [x] **12.26** ADK page shows incompatible state when the version is unsupported.
 - [x] **12.27** ADK install overlay blocks navigation until completion.
 - [ ] **12.28** ADK upgrade overlay blocks navigation until completion.
 - [x] **12.29** ADK-compatible state unlocks `General`, `Start`, and `Expert` pages.

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -280,9 +280,9 @@ git commit -m "feat(winpe): apply programdata media layout"
 - [x] **12.24** ADK page shows missing state when ADK is absent.
 - [x] **12.25** ADK page shows installed version when ADK is present.
 - [ ] **12.26** ADK page shows incompatible state when the version is unsupported.
-- [ ] **12.27** ADK install overlay blocks navigation until completion.
+- [x] **12.27** ADK install overlay blocks navigation until completion.
 - [ ] **12.28** ADK upgrade overlay blocks navigation until completion.
-- [ ] **12.29** ADK-compatible state unlocks `General`, `Start`, and `Expert` pages.
+- [x] **12.29** ADK-compatible state unlocks `General`, `Start`, and `Expert` pages.
 - [ ] **12.30** PCA2023 media validation covers both supported and unsupported `/bootex` paths.
 - [ ] **12.31** Non-ASCII ISO output path validation confirms the temporary ASCII-safe workaround produces the requested final ISO.
 - [ ] **12.32** USB disk safety validation rejects:

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -281,7 +281,7 @@ git commit -m "feat(winpe): apply programdata media layout"
 - [x] **12.25** ADK page shows installed version when ADK is present.
 - [x] **12.26** ADK page shows incompatible state when the version is unsupported.
 - [x] **12.27** ADK install overlay blocks navigation until completion.
-- [ ] **12.28** ADK upgrade overlay blocks navigation until completion.
+- [x] **12.28** ADK upgrade overlay blocks navigation until completion.
 - [x] **12.29** ADK-compatible state unlocks `General`, `Start`, and `Expert` pages.
 - [ ] **12.30** PCA2023 media validation covers both supported and unsupported `/bootex` paths.
 - [ ] **12.31** Non-ASCII ISO output path validation confirms the temporary ASCII-safe workaround produces the requested final ISO.

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -277,8 +277,8 @@ git commit -m "feat(winpe): apply programdata media layout"
 - [ ] **12.21** USB creation works on a disposable test drive.
 - [ ] **12.22** Generated ISO/USB media matches the documented layout.
 - [ ] **12.23** New host-side `ProgramData` layout is used without old-folder fallback.
-- [ ] **12.24** ADK page shows missing state when ADK is absent.
-- [ ] **12.25** ADK page shows installed version when ADK is present.
+- [x] **12.24** ADK page shows missing state when ADK is absent.
+- [x] **12.25** ADK page shows installed version when ADK is present.
 - [ ] **12.26** ADK page shows incompatible state when the version is unsupported.
 - [ ] **12.27** ADK install overlay blocks navigation until completion.
 - [ ] **12.28** ADK upgrade overlay blocks navigation until completion.

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -12,15 +12,15 @@
 
 The `12.A` to `12.D` labels are implementation slices, not extra phase numbers. They are determined by dependency boundaries:
 
-- [ ] `12.A` owns user-visible ADK readiness and navigation gating.
+- [x] `12.A` owns user-visible ADK readiness and navigation gating.
 - [ ] `12.B` owns pure WinPE service foundations that can be tested without final UI commands.
 - [ ] `12.C` owns Connect/Deploy runtime payload layout and bootstrap resolution.
 - [ ] `12.D` owns final host/media filesystem layout enforcement after services and runtime paths are stable.
 
-- [ ] **12.A** `feat(adk): add adk status and page integration`.
-  - [ ] Scope: ADK/WinPE Add-on detection, installed version, compatibility policy, ADK page state/actions, ADK operation progress, ADK install/upgrade overlay entry points, and shell guard readiness.
-  - [ ] Boundary: answer whether Foundry is ready to unlock `General`, `Start`, and `Expert`; do not wire final ISO/USB creation commands here.
-  - [ ] Reason: Phase 13 and expert workflows need a reliable ADK readiness state before they can safely expose media or configuration workflows.
+- [x] **12.A** `feat(adk): add adk status and page integration`.
+  - [x] Scope: ADK/WinPE Add-on detection, installed version, compatibility policy, ADK page state/actions, ADK operation progress, ADK install/upgrade overlay entry points, and shell guard readiness.
+  - [x] Boundary: answer whether Foundry is ready to unlock `General`, `Start`, and `Expert`; do not wire final ISO/USB creation commands here.
+  - [x] Reason: Phase 13 and expert workflows need a reliable ADK readiness state before they can safely expose media or configuration workflows.
 - [ ] **12.B** `feat(winpe): port winpe service foundations`.
   - [ ] Scope: tool resolution, process runner, build workspace, boot image source strategy, driver catalog/resolution/injection, image internationalization, WinRE boot image preparation, mounted image asset provisioning/customization, workspace preparation, and media output service foundations.
   - [ ] Boundary: port service and Core orchestration building blocks; keep final `Start` page command wiring in Phase 13.
@@ -36,7 +36,7 @@ The `12.A` to `12.D` labels are implementation slices, not extra phase numbers. 
 
 **Deferred infrastructure completion:** Phase 12 is also responsible for completing the ADK/WinPE portions of earlier deferred infrastructure work:
 
-- [ ] Complete Phase 6 readiness item **6.8.1** for ADK detection, WinPE Add-on readiness, and ADK-gated startup readiness.
+- [x] Complete Phase 6 readiness item **6.8.1** for ADK detection, WinPE Add-on readiness, and ADK-gated startup readiness.
 - [ ] Complete Phase 6 readiness item **6.8.1** for USB target service readiness after ADK compatibility is known; keep the final `Start` page refresh command wiring in Phase 13.
 - [ ] Complete Phase 10 logging contract item **10.6.1** for ADK detection and bootstrap payload resolution logs.
 
@@ -72,32 +72,36 @@ The `12.A` to `12.D` labels are implementation slices, not extra phase numbers. 
   - [ ] Preserve required optional component ordering and non-fatal handling for already-installed or not-applicable packages.
   - [ ] Preserve `dism /Set-AllIntl` and `dism /Set-InputLocale` behavior.
 
-- [ ] **12.1** Port `AdkService`.
-  - [ ] **12.1.1** Create the `ADK` page view model with:
-    - [ ] ADK installed state.
-    - [ ] ADK compatible state.
-    - [ ] Installed ADK version.
-    - [ ] Required ADK version policy.
-    - [ ] WinPE Add-on status.
-    - [ ] ISO/USB capability state.
-    - [ ] Current ADK operation progress.
-    - [ ] Current ADK operation status.
-  - [ ] **12.1.2** Keep the `ADK` page actions simple:
-    - [ ] Install ADK.
-    - [ ] Upgrade ADK.
-    - [ ] Refresh status.
-    - [ ] Open logs from the ADK page diagnostics/action area, not from a dedicated footer navigation item.
-  - [ ] **12.1.3** Do not expose a primary uninstall action on the `ADK` page.
-  - [ ] **12.1.4** Keep ADK uninstall only as an internal upgrade implementation detail unless a future advanced diagnostics requirement is approved.
-  - [ ] **12.1.5** Run Foundry-managed ADK installation with Foundry's own blocking progress overlay.
-  - [ ] **12.1.6** Run Foundry-managed ADK upgrade with Foundry's own blocking progress overlay.
-  - [ ] **12.1.7** Run ADK and WinPE Add-on setup in silent mode:
-    - [ ] `adksetup.exe`.
-    - [ ] `adkwinpesetup.exe`.
-  - [ ] **12.1.8** Do not show the native Microsoft ADK setup wizard during normal Foundry-managed installation.
-  - [ ] **12.1.9** Revalidate official Microsoft ADK download URLs and supported ADK version before implementation.
-  - [ ] **12.1.10** Treat the current WPF `10.1.26100.*` compatibility policy as the starting point.
-  - [ ] **12.1.11** Update compatibility if the target official ADK version changes before implementation.
+- [x] **12.1** Port `AdkService`.
+  - [x] **12.1.1** Create the `ADK` page view model with:
+    - [x] ADK installed state.
+    - [x] ADK compatible state.
+    - [x] Installed ADK version.
+    - [x] Required ADK version policy.
+    - [x] WinPE Add-on status.
+    - [x] ISO/USB capability state.
+    - [x] Current ADK operation progress.
+    - [x] Current ADK operation status.
+  - [x] **12.1.2** Keep the `ADK` page actions simple:
+    - [x] Install ADK.
+    - [x] Upgrade ADK.
+    - [x] Refresh status.
+    - [x] Open logs from the ADK page diagnostics/action area, not from a dedicated footer navigation item.
+  - [x] **12.1.3** Do not expose a primary uninstall action on the `ADK` page.
+  - [x] **12.1.4** Keep ADK uninstall only as an internal upgrade implementation detail unless a future advanced diagnostics requirement is approved.
+  - [x] **12.1.5** Run Foundry-managed ADK installation with Foundry's own blocking progress overlay.
+  - [x] **12.1.6** Run Foundry-managed ADK upgrade with Foundry's own blocking progress overlay.
+  - [x] **12.1.7** Run ADK and WinPE Add-on setup in silent mode:
+    - [x] `adksetup.exe`.
+    - [x] `adkwinpesetup.exe`.
+  - [x] **12.1.8** Do not show the native Microsoft ADK setup wizard during normal Foundry-managed installation.
+  - [x] **12.1.9** Revalidate official Microsoft ADK download URLs and supported ADK version before implementation.
+  - [x] **12.1.10** Treat the current WPF `10.1.26100.*` compatibility policy as the starting point.
+  - [x] **12.1.11** Update compatibility if the target official ADK version changes before implementation.
+    - [x] Require `10.1.26100.2454+` for the general Windows 11 24H2/25H2 ADK track.
+    - [x] Allow `10.1.28000.1+` for the Windows 11 26H1 Arm64 ADK track.
+    - [x] Display that Microsoft recommends applying the latest ADK servicing patch for the detected target track.
+  - [x] **12.1.12** Version ADK installer cache files and write downloads atomically so interrupted downloads are not reused.
 - [ ] **12.2** Port WinPE services in dependency order:
   - [ ] Tool resolution.
   - [ ] Process runner.
@@ -240,7 +244,7 @@ The `12.A` to `12.D` labels are implementation slices, not extra phase numbers. 
   - [ ] Deployment session logs under the active workspace.
   - [ ] Target logs under `Windows\Temp\Foundry\Logs`.
 - [ ] **12.16** Commit each Phase 12 slice independently when its validation is complete:
-  - [ ] **12.16.1** Commit Phase 12.A:
+  - [x] **12.16.1** Commit Phase 12.A:
 
 ```powershell
 git commit -m "feat(adk): add adk status and page integration"

--- a/src/Foundry.Core.Tests/Adk/AdkInstallationDetectorTests.cs
+++ b/src/Foundry.Core.Tests/Adk/AdkInstallationDetectorTests.cs
@@ -1,0 +1,128 @@
+using Foundry.Core.Services.Adk;
+
+namespace Foundry.Core.Tests.Adk;
+
+public sealed class AdkInstallationDetectorTests
+{
+    [Fact]
+    public void Detect_WhenRequiredFoldersAreMissing_ReturnsNotInstalled()
+    {
+        FakeAdkInstallationProbe probe = new()
+        {
+            KitsRootPath = @"C:\Program Files (x86)\Windows Kits\10\"
+        };
+
+        AdkInstallationStatus status = new AdkInstallationDetector(probe).Detect();
+
+        Assert.False(status.IsInstalled);
+        Assert.False(status.IsCompatible);
+        Assert.False(status.IsWinPeAddonInstalled);
+        Assert.False(status.CanCreateMedia);
+    }
+
+    [Fact]
+    public void Detect_WhenDeploymentToolsAndWinPeAddonArePresent_ReturnsInstalled()
+    {
+        FakeAdkInstallationProbe probe = CreateInstalledProbe("10.1.26100.2454");
+
+        AdkInstallationStatus status = new AdkInstallationDetector(probe).Detect();
+
+        Assert.True(status.IsInstalled);
+        Assert.True(status.IsWinPeAddonInstalled);
+        Assert.Equal("10.1.26100.2454", status.InstalledVersion);
+    }
+
+    [Fact]
+    public void Detect_WhenDeploymentToolsArePresentAndWinPeAddonIsMissing_ReturnsAdkInstalledButMediaBlocked()
+    {
+        string kitsRootPath = @"C:\Program Files (x86)\Windows Kits\10\";
+        FakeAdkInstallationProbe probe = new()
+        {
+            KitsRootPath = kitsRootPath,
+            ExistingDirectories =
+            [
+                Path.Combine(kitsRootPath, AdkInstallationDetector.DeploymentToolsRelativePath)
+            ],
+            Products = [new("Windows Assessment and Deployment Kit", "10.1.26100.2454")]
+        };
+
+        AdkInstallationStatus status = new AdkInstallationDetector(probe).Detect();
+
+        Assert.True(status.IsInstalled);
+        Assert.True(status.IsCompatible);
+        Assert.False(status.IsWinPeAddonInstalled);
+        Assert.False(status.CanCreateMedia);
+    }
+
+    [Theory]
+    [InlineData("10.1.26100.1", false)]
+    [InlineData("10.1.26100.2453", false)]
+    [InlineData("10.1.26100.2454", true)]
+    [InlineData("10.1.26100.3000", true)]
+    [InlineData("10.1.28000.1", true)]
+    [InlineData("10.1.28000.2", true)]
+    [InlineData("10.1.22621.1", false)]
+    [InlineData("11.0.26100.1", false)]
+    public void Detect_EvaluatesCompatibilityFromSupportedAdkBuildLines(string installedVersion, bool expectedCompatible)
+    {
+        FakeAdkInstallationProbe probe = CreateInstalledProbe(installedVersion);
+
+        AdkInstallationStatus status = new AdkInstallationDetector(probe).Detect();
+
+        Assert.Equal(expectedCompatible, status.IsCompatible);
+        Assert.Equal(expectedCompatible, status.CanCreateMedia);
+    }
+
+    [Fact]
+    public void Detect_WhenStrictAdkVersionIsMissing_UsesComponentVersionFallback()
+    {
+        FakeAdkInstallationProbe probe = CreateInstalledProbe(null);
+        probe.Products =
+        [
+            new("Windows Deployment Tools", "10.1.26100.2454"),
+            new("Windows PE x64 x86 Add-ons", "10.1.26100.2454")
+        ];
+
+        AdkInstallationStatus status = new AdkInstallationDetector(probe).Detect();
+
+        Assert.Equal("10.1.26100.2454", status.InstalledVersion);
+        Assert.True(status.IsCompatible);
+    }
+
+    private static FakeAdkInstallationProbe CreateInstalledProbe(string? adkVersion)
+    {
+        string kitsRootPath = @"C:\Program Files (x86)\Windows Kits\10\";
+        FakeAdkInstallationProbe probe = new()
+        {
+            KitsRootPath = kitsRootPath,
+            ExistingDirectories =
+            [
+                Path.Combine(kitsRootPath, AdkInstallationDetector.DeploymentToolsRelativePath),
+                Path.Combine(kitsRootPath, AdkInstallationDetector.WinPeRelativePath)
+            ]
+        };
+
+        if (!string.IsNullOrWhiteSpace(adkVersion))
+        {
+            probe.Products = [new("Windows Assessment and Deployment Kit", adkVersion)];
+        }
+
+        return probe;
+    }
+
+    private sealed class FakeAdkInstallationProbe : IAdkInstallationProbe
+    {
+        public string? KitsRootPath { get; init; }
+        public IReadOnlyCollection<string> ExistingDirectories { get; init; } = [];
+        public IReadOnlyList<AdkInstalledProduct> Products { get; set; } = [];
+
+        public string? GetKitsRootPath() => KitsRootPath;
+
+        public bool DirectoryExists(string path)
+        {
+            return ExistingDirectories.Contains(path, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public IReadOnlyList<AdkInstalledProduct> GetInstalledProducts() => Products;
+    }
+}

--- a/src/Foundry.Core.Tests/Adk/AdkInstallationDetectorTests.cs
+++ b/src/Foundry.Core.Tests/Adk/AdkInstallationDetectorTests.cs
@@ -59,8 +59,8 @@ public sealed class AdkInstallationDetectorTests
     [InlineData("10.1.26100.2453", false)]
     [InlineData("10.1.26100.2454", true)]
     [InlineData("10.1.26100.3000", true)]
-    [InlineData("10.1.28000.1", true)]
-    [InlineData("10.1.28000.2", true)]
+    [InlineData("10.1.28000.1", false)]
+    [InlineData("10.1.28000.2", false)]
     [InlineData("10.1.22621.1", false)]
     [InlineData("11.0.26100.1", false)]
     public void Detect_EvaluatesCompatibilityFromSupportedAdkBuildLines(string installedVersion, bool expectedCompatible)

--- a/src/Foundry.Core.Tests/Adk/AdkUninstallCommandSelectorTests.cs
+++ b/src/Foundry.Core.Tests/Adk/AdkUninstallCommandSelectorTests.cs
@@ -56,9 +56,9 @@ public sealed class AdkUninstallCommandSelectorTests
     public void SelectBundleUninstallCommands_IgnoresComponentMsiEntries()
     {
         AdkInstalledProduct componentProduct = new(
-            "Windows Deployment Tools",
+            "Windows PE Boot Files (OnecoreUAP)",
             "10.1.22621.5337",
-            "MsiExec.exe /I{5FF0DAC0-CFB1-D753-B247-F41472C28246}");
+            "MsiExec.exe /I{0C141632-B69C-A38F-0639-743F6F0A8D03}");
 
         IReadOnlyList<AdkUninstallCommand> commands = AdkUninstallCommandSelector.SelectBundleUninstallCommands([componentProduct]);
 

--- a/src/Foundry.Core.Tests/Adk/AdkUninstallCommandSelectorTests.cs
+++ b/src/Foundry.Core.Tests/Adk/AdkUninstallCommandSelectorTests.cs
@@ -1,0 +1,67 @@
+using Foundry.Core.Services.Adk;
+
+namespace Foundry.Core.Tests.Adk;
+
+public sealed class AdkUninstallCommandSelectorTests
+{
+    [Fact]
+    public void SelectBundleUninstallCommands_ReturnsWinPeBeforeAdk()
+    {
+        AdkInstalledProduct adkProduct = new(
+            "Localized Windows ADK bundle",
+            "10.1.22621.5337",
+            null,
+            "\"C:\\ProgramData\\Package Cache\\{adk}\\adksetup.exe\" /uninstall /quiet");
+        AdkInstalledProduct winPeProduct = new(
+            "Localized Windows PE add-on bundle",
+            "10.1.22621.5337",
+            null,
+            "\"C:\\ProgramData\\Package Cache\\{winpe}\\adkwinpesetup.exe\" /uninstall /quiet");
+
+        IReadOnlyList<AdkUninstallCommand> commands = AdkUninstallCommandSelector.SelectBundleUninstallCommands(
+            [adkProduct, winPeProduct]);
+
+        Assert.Collection(
+            commands,
+            command =>
+            {
+                Assert.Equal(winPeProduct.DisplayName, command.DisplayName);
+                Assert.Equal(@"C:\ProgramData\Package Cache\{winpe}\adkwinpesetup.exe", command.FileName);
+                Assert.Equal("/uninstall /quiet /norestart", command.Arguments);
+            },
+            command =>
+            {
+                Assert.Equal(adkProduct.DisplayName, command.DisplayName);
+                Assert.Equal(@"C:\ProgramData\Package Cache\{adk}\adksetup.exe", command.FileName);
+                Assert.Equal("/uninstall /quiet /norestart", command.Arguments);
+            });
+    }
+
+    [Fact]
+    public void SelectBundleUninstallCommands_AddsQuietAndNoRestartArgumentsWhenOnlyInteractiveUninstallExists()
+    {
+        AdkInstalledProduct adkProduct = new(
+            "Windows Assessment and Deployment Kit",
+            "10.1.22621.5337",
+            "\"C:\\ProgramData\\Package Cache\\{adk}\\adksetup.exe\" /uninstall");
+
+        IReadOnlyList<AdkUninstallCommand> commands = AdkUninstallCommandSelector.SelectBundleUninstallCommands([adkProduct]);
+
+        AdkUninstallCommand command = Assert.Single(commands);
+        Assert.Equal(@"C:\ProgramData\Package Cache\{adk}\adksetup.exe", command.FileName);
+        Assert.Equal("/uninstall /quiet /norestart", command.Arguments);
+    }
+
+    [Fact]
+    public void SelectBundleUninstallCommands_IgnoresComponentMsiEntries()
+    {
+        AdkInstalledProduct componentProduct = new(
+            "Windows Deployment Tools",
+            "10.1.22621.5337",
+            "MsiExec.exe /I{5FF0DAC0-CFB1-D753-B247-F41472C28246}");
+
+        IReadOnlyList<AdkUninstallCommand> commands = AdkUninstallCommandSelector.SelectBundleUninstallCommands([componentProduct]);
+
+        Assert.Empty(commands);
+    }
+}

--- a/src/Foundry.Core/Services/Adk/AdkInstallationDetector.cs
+++ b/src/Foundry.Core/Services/Adk/AdkInstallationDetector.cs
@@ -5,9 +5,8 @@ public sealed class AdkInstallationDetector(IAdkInstallationProbe probe)
     public const string DeploymentToolsRelativePath = @"Assessment and Deployment Kit\Deployment Tools";
     public const string WinPeRelativePath = @"Assessment and Deployment Kit\Windows Preinstallation Environment";
 
-    private const string RequiredVersionPolicyText = "Windows ADK 10.1.26100.2454+ or 10.1.28000.1+ with the latest ADK servicing patch";
+    private const string RequiredVersionPolicyText = "Windows ADK 10.1.26100.2454+ with the latest ADK servicing patch";
     private static readonly Version MinimumWindows11AdkVersion = new(10, 1, 26100, 2454);
-    private static readonly Version MinimumWindows11Arm64AdkVersion = new(10, 1, 28000, 1);
 
     public AdkInstallationStatus Detect()
     {
@@ -39,8 +38,7 @@ public sealed class AdkInstallationDetector(IAdkInstallationProbe probe)
 
         if (Version.TryParse(versionText, out Version? version))
         {
-            return IsVersionAtLeast(version, MinimumWindows11AdkVersion)
-                || IsVersionAtLeast(version, MinimumWindows11Arm64AdkVersion);
+            return IsVersionAtLeast(version, MinimumWindows11AdkVersion);
         }
 
         return false;

--- a/src/Foundry.Core/Services/Adk/AdkInstallationDetector.cs
+++ b/src/Foundry.Core/Services/Adk/AdkInstallationDetector.cs
@@ -1,0 +1,96 @@
+namespace Foundry.Core.Services.Adk;
+
+public sealed class AdkInstallationDetector(IAdkInstallationProbe probe)
+{
+    public const string DeploymentToolsRelativePath = @"Assessment and Deployment Kit\Deployment Tools";
+    public const string WinPeRelativePath = @"Assessment and Deployment Kit\Windows Preinstallation Environment";
+
+    private const string RequiredVersionPolicyText = "Windows ADK 10.1.26100.2454+ or 10.1.28000.1+ with the latest ADK servicing patch";
+    private static readonly Version MinimumWindows11AdkVersion = new(10, 1, 26100, 2454);
+    private static readonly Version MinimumWindows11Arm64AdkVersion = new(10, 1, 28000, 1);
+
+    public AdkInstallationStatus Detect()
+    {
+        string? kitsRootPath = probe.GetKitsRootPath();
+        bool hasKitsRoot = !string.IsNullOrWhiteSpace(kitsRootPath);
+        bool hasDeploymentTools = hasKitsRoot
+            && probe.DirectoryExists(Path.Combine(kitsRootPath!, DeploymentToolsRelativePath));
+        bool hasWinPeAddon = hasKitsRoot
+            && probe.DirectoryExists(Path.Combine(kitsRootPath!, WinPeRelativePath));
+        string? installedVersion = ResolveInstalledVersion(probe.GetInstalledProducts());
+        bool isInstalled = hasDeploymentTools;
+        bool isCompatible = isInstalled && IsCompatibleVersion(installedVersion);
+
+        return new(
+            isInstalled,
+            isCompatible,
+            hasWinPeAddon,
+            installedVersion,
+            kitsRootPath,
+            RequiredVersionPolicyText);
+    }
+
+    public static bool IsCompatibleVersion(string? versionText)
+    {
+        if (string.IsNullOrWhiteSpace(versionText))
+        {
+            return false;
+        }
+
+        if (Version.TryParse(versionText, out Version? version))
+        {
+            return IsVersionAtLeast(version, MinimumWindows11AdkVersion)
+                || IsVersionAtLeast(version, MinimumWindows11Arm64AdkVersion);
+        }
+
+        return false;
+    }
+
+    private static string? ResolveInstalledVersion(IReadOnlyList<AdkInstalledProduct> products)
+    {
+        string? strictAdkVersion = products
+            .Where(product => string.Equals(
+                product.DisplayName,
+                "Windows Assessment and Deployment Kit",
+                StringComparison.OrdinalIgnoreCase))
+            .Select(product => product.DisplayVersion)
+            .FirstOrDefault(version => !string.IsNullOrWhiteSpace(version));
+
+        if (!string.IsNullOrWhiteSpace(strictAdkVersion))
+        {
+            return strictAdkVersion;
+        }
+
+        return products
+            .Where(IsAdkComponentProduct)
+            .Select(product => product.DisplayVersion)
+            .Where(version => !string.IsNullOrWhiteSpace(version))
+            .GroupBy(version => version!, StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(group => group.Count())
+            .ThenByDescending(group => ParseVersionOrDefault(group.Key))
+            .Select(group => group.Key)
+            .FirstOrDefault();
+    }
+
+    private static bool IsAdkComponentProduct(AdkInstalledProduct product)
+    {
+        return product.DisplayName.Equals("Windows Deployment Tools", StringComparison.OrdinalIgnoreCase)
+            || product.DisplayName.Contains("WinPE", StringComparison.OrdinalIgnoreCase)
+            || (product.DisplayName.Contains("Windows PE", StringComparison.OrdinalIgnoreCase)
+                && (product.DisplayName.Contains("Deployment", StringComparison.OrdinalIgnoreCase)
+                    || product.DisplayName.Contains("deploiement", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    private static Version ParseVersionOrDefault(string versionText)
+    {
+        return Version.TryParse(versionText, out Version? version) ? version : new Version();
+    }
+
+    private static bool IsVersionAtLeast(Version version, Version minimumVersion)
+    {
+        return version.Major == minimumVersion.Major
+            && version.Minor == minimumVersion.Minor
+            && version.Build == minimumVersion.Build
+            && version.Revision >= minimumVersion.Revision;
+    }
+}

--- a/src/Foundry.Core/Services/Adk/AdkInstallationStatus.cs
+++ b/src/Foundry.Core/Services/Adk/AdkInstallationStatus.cs
@@ -1,0 +1,12 @@
+namespace Foundry.Core.Services.Adk;
+
+public sealed record AdkInstallationStatus(
+    bool IsInstalled,
+    bool IsCompatible,
+    bool IsWinPeAddonInstalled,
+    string? InstalledVersion,
+    string? KitsRootPath,
+    string RequiredVersionPolicy)
+{
+    public bool CanCreateMedia => IsInstalled && IsCompatible && IsWinPeAddonInstalled;
+}

--- a/src/Foundry.Core/Services/Adk/AdkInstalledProduct.cs
+++ b/src/Foundry.Core/Services/Adk/AdkInstalledProduct.cs
@@ -1,0 +1,3 @@
+namespace Foundry.Core.Services.Adk;
+
+public sealed record AdkInstalledProduct(string DisplayName, string? DisplayVersion);

--- a/src/Foundry.Core/Services/Adk/AdkInstalledProduct.cs
+++ b/src/Foundry.Core/Services/Adk/AdkInstalledProduct.cs
@@ -1,3 +1,7 @@
 namespace Foundry.Core.Services.Adk;
 
-public sealed record AdkInstalledProduct(string DisplayName, string? DisplayVersion);
+public sealed record AdkInstalledProduct(
+    string DisplayName,
+    string? DisplayVersion,
+    string? UninstallString = null,
+    string? QuietUninstallString = null);

--- a/src/Foundry.Core/Services/Adk/AdkUninstallCommand.cs
+++ b/src/Foundry.Core/Services/Adk/AdkUninstallCommand.cs
@@ -1,0 +1,3 @@
+namespace Foundry.Core.Services.Adk;
+
+public sealed record AdkUninstallCommand(string DisplayName, string FileName, string Arguments);

--- a/src/Foundry.Core/Services/Adk/AdkUninstallCommandSelector.cs
+++ b/src/Foundry.Core/Services/Adk/AdkUninstallCommandSelector.cs
@@ -31,17 +31,12 @@ public static class AdkUninstallCommandSelector
 
     private static bool IsAdkBundle(AdkInstalledProduct product)
     {
-        return ContainsSetupExecutable(product, "adksetup.exe")
-            || product.DisplayName.Equals("Windows Assessment and Deployment Kit", StringComparison.OrdinalIgnoreCase)
-            || product.DisplayName.Contains("Deployment Kit", StringComparison.OrdinalIgnoreCase);
+        return ContainsSetupExecutable(product, "adksetup.exe");
     }
 
     private static bool IsWinPeBundle(AdkInstalledProduct product)
     {
-        return ContainsSetupExecutable(product, "adkwinpesetup.exe")
-            || product.DisplayName.Contains("Windows Preinstallation Environment", StringComparison.OrdinalIgnoreCase)
-            || product.DisplayName.Contains("Windows PE", StringComparison.OrdinalIgnoreCase)
-            || product.DisplayName.Contains("WinPE", StringComparison.OrdinalIgnoreCase);
+        return ContainsSetupExecutable(product, "adkwinpesetup.exe");
     }
 
     private static bool ContainsSetupExecutable(AdkInstalledProduct product, string setupFileName)

--- a/src/Foundry.Core/Services/Adk/AdkUninstallCommandSelector.cs
+++ b/src/Foundry.Core/Services/Adk/AdkUninstallCommandSelector.cs
@@ -1,0 +1,127 @@
+namespace Foundry.Core.Services.Adk;
+
+public static class AdkUninstallCommandSelector
+{
+    public static IReadOnlyList<AdkUninstallCommand> SelectBundleUninstallCommands(IReadOnlyList<AdkInstalledProduct> products)
+    {
+        List<AdkUninstallCommand> commands = [];
+
+        AdkUninstallCommand? winPeCommand = products
+            .Where(IsWinPeBundle)
+            .Select(TryCreateCommand)
+            .FirstOrDefault(command => command is not null);
+
+        if (winPeCommand is not null)
+        {
+            commands.Add(winPeCommand);
+        }
+
+        AdkUninstallCommand? adkCommand = products
+            .Where(IsAdkBundle)
+            .Select(TryCreateCommand)
+            .FirstOrDefault(command => command is not null);
+
+        if (adkCommand is not null)
+        {
+            commands.Add(adkCommand);
+        }
+
+        return commands;
+    }
+
+    private static bool IsAdkBundle(AdkInstalledProduct product)
+    {
+        return ContainsSetupExecutable(product, "adksetup.exe")
+            || product.DisplayName.Equals("Windows Assessment and Deployment Kit", StringComparison.OrdinalIgnoreCase)
+            || product.DisplayName.Contains("Deployment Kit", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsWinPeBundle(AdkInstalledProduct product)
+    {
+        return ContainsSetupExecutable(product, "adkwinpesetup.exe")
+            || product.DisplayName.Contains("Windows Preinstallation Environment", StringComparison.OrdinalIgnoreCase)
+            || product.DisplayName.Contains("Windows PE", StringComparison.OrdinalIgnoreCase)
+            || product.DisplayName.Contains("WinPE", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool ContainsSetupExecutable(AdkInstalledProduct product, string setupFileName)
+    {
+        return (product.QuietUninstallString?.Contains(setupFileName, StringComparison.OrdinalIgnoreCase) ?? false)
+            || (product.UninstallString?.Contains(setupFileName, StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+
+    private static AdkUninstallCommand? TryCreateCommand(AdkInstalledProduct product)
+    {
+        string? commandLine = !string.IsNullOrWhiteSpace(product.QuietUninstallString)
+            ? product.QuietUninstallString
+            : product.UninstallString;
+
+        if (string.IsNullOrWhiteSpace(commandLine) || !TrySplitCommandLine(commandLine, out string fileName, out string arguments))
+        {
+            return null;
+        }
+
+        arguments = EnsureUninstallArgument(arguments);
+        arguments = EnsureQuietArgument(arguments);
+        arguments = EnsureNoRestartArgument(arguments);
+
+        return new(product.DisplayName, fileName, arguments);
+    }
+
+    private static string EnsureUninstallArgument(string arguments)
+    {
+        return arguments.Contains("/uninstall", StringComparison.OrdinalIgnoreCase)
+            ? arguments
+            : $"{arguments} /uninstall".Trim();
+    }
+
+    private static string EnsureQuietArgument(string arguments)
+    {
+        return arguments.Contains("/quiet", StringComparison.OrdinalIgnoreCase)
+            ? arguments
+            : $"{arguments} /quiet".Trim();
+    }
+
+    private static string EnsureNoRestartArgument(string arguments)
+    {
+        return arguments.Contains("/norestart", StringComparison.OrdinalIgnoreCase)
+            ? arguments
+            : $"{arguments} /norestart".Trim();
+    }
+
+    private static bool TrySplitCommandLine(string commandLine, out string fileName, out string arguments)
+    {
+        commandLine = commandLine.Trim();
+        fileName = string.Empty;
+        arguments = string.Empty;
+
+        if (commandLine.Length == 0)
+        {
+            return false;
+        }
+
+        if (commandLine[0] == '"')
+        {
+            int closingQuoteIndex = commandLine.IndexOf('"', 1);
+            if (closingQuoteIndex <= 1)
+            {
+                return false;
+            }
+
+            fileName = commandLine[1..closingQuoteIndex];
+            arguments = commandLine[(closingQuoteIndex + 1)..].Trim();
+            return true;
+        }
+
+        int firstSpaceIndex = commandLine.IndexOf(' ');
+        if (firstSpaceIndex < 0)
+        {
+            fileName = commandLine;
+            return true;
+        }
+
+        fileName = commandLine[..firstSpaceIndex];
+        arguments = commandLine[(firstSpaceIndex + 1)..].Trim();
+        return true;
+    }
+}

--- a/src/Foundry.Core/Services/Adk/IAdkInstallationProbe.cs
+++ b/src/Foundry.Core/Services/Adk/IAdkInstallationProbe.cs
@@ -1,0 +1,8 @@
+namespace Foundry.Core.Services.Adk;
+
+public interface IAdkInstallationProbe
+{
+    string? GetKitsRootPath();
+    bool DirectoryExists(string path);
+    IReadOnlyList<AdkInstalledProduct> GetInstalledProducts();
+}

--- a/src/Foundry.Core/Services/Adk/WindowsAdkInstallationProbe.cs
+++ b/src/Foundry.Core/Services/Adk/WindowsAdkInstallationProbe.cs
@@ -1,0 +1,53 @@
+using Microsoft.Win32;
+
+namespace Foundry.Core.Services.Adk;
+
+public sealed class WindowsAdkInstallationProbe : IAdkInstallationProbe
+{
+    private const string InstalledRootsKeyPath = @"SOFTWARE\WOW6432Node\Microsoft\Windows Kits\Installed Roots";
+    private const string KitsRootValueName = "KitsRoot10";
+    private static readonly string[] UninstallKeyPaths =
+    [
+        @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+        @"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
+    ];
+
+    public string? GetKitsRootPath()
+    {
+        using RegistryKey? key = Registry.LocalMachine.OpenSubKey(InstalledRootsKeyPath);
+        return key?.GetValue(KitsRootValueName) as string;
+    }
+
+    public bool DirectoryExists(string path)
+    {
+        return Directory.Exists(path);
+    }
+
+    public IReadOnlyList<AdkInstalledProduct> GetInstalledProducts()
+    {
+        List<AdkInstalledProduct> products = [];
+
+        foreach (string keyPath in UninstallKeyPaths)
+        {
+            using RegistryKey? uninstallKey = Registry.LocalMachine.OpenSubKey(keyPath);
+            if (uninstallKey is null)
+            {
+                continue;
+            }
+
+            foreach (string subKeyName in uninstallKey.GetSubKeyNames())
+            {
+                using RegistryKey? productKey = uninstallKey.OpenSubKey(subKeyName);
+                string? displayName = productKey?.GetValue("DisplayName") as string;
+                if (string.IsNullOrWhiteSpace(displayName))
+                {
+                    continue;
+                }
+
+                products.Add(new(displayName, productKey?.GetValue("DisplayVersion") as string));
+            }
+        }
+
+        return products;
+    }
+}

--- a/src/Foundry.Core/Services/Adk/WindowsAdkInstallationProbe.cs
+++ b/src/Foundry.Core/Services/Adk/WindowsAdkInstallationProbe.cs
@@ -44,7 +44,11 @@ public sealed class WindowsAdkInstallationProbe : IAdkInstallationProbe
                     continue;
                 }
 
-                products.Add(new(displayName, productKey?.GetValue("DisplayVersion") as string));
+                products.Add(new(
+                    displayName,
+                    productKey?.GetValue("DisplayVersion") as string,
+                    productKey?.GetValue("UninstallString") as string,
+                    productKey?.GetValue("QuietUninstallString") as string));
             }
         }
 

--- a/src/Foundry/Common/Constants.cs
+++ b/src/Foundry/Common/Constants.cs
@@ -12,6 +12,7 @@ namespace Foundry.Common
         public static readonly string SettingsDirectoryPath = Path.Combine(RootDirectoryPath, "Settings");
         public static readonly string LogDirectoryPath = Path.Combine(RootDirectoryPath, "Logs");
         public static readonly string CacheDirectoryPath = Path.Combine(RootDirectoryPath, "Cache");
+        public static readonly string InstallerCacheDirectoryPath = Path.Combine(CacheDirectoryPath, "Installers");
         public static readonly string WorkspacesDirectoryPath = Path.Combine(RootDirectoryPath, "Workspaces");
         public static readonly string TempDirectoryPath = Path.Combine(RootDirectoryPath, "Temp");
         public static readonly string LogFilePath = Path.Combine(LogDirectoryPath, "Foundry.log");
@@ -26,6 +27,7 @@ namespace Foundry.Common
             Directory.CreateDirectory(SettingsDirectoryPath);
             Directory.CreateDirectory(LogDirectoryPath);
             Directory.CreateDirectory(CacheDirectoryPath);
+            Directory.CreateDirectory(InstallerCacheDirectoryPath);
             Directory.CreateDirectory(WorkspacesDirectoryPath);
             Directory.CreateDirectory(TempDirectoryPath);
         }

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,6 +1,9 @@
 using Foundry.Core.Services.Application;
+using Foundry.Core.Services.Adk;
 using Foundry.Services.Application;
+using Foundry.Services.Adk;
 using Foundry.Services.Localization;
+using Foundry.Services.Operations;
 using Foundry.Services.Settings;
 using Foundry.Services.Shell;
 using Foundry.Services.Startup;
@@ -18,6 +21,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<MainWindow>();
 
         services.AddSingleton<IAppSettingsService, JsonAppSettingsService>();
+        services.AddSingleton<IAdkInstallationProbe, WindowsAdkInstallationProbe>();
+        services.AddSingleton<IOperationProgressService, OperationProgressService>();
+        services.AddSingleton<IAdkService, AdkService>();
         services.AddSingleton<IShellNavigationGuardService, ShellNavigationGuardService>();
         services.AddSingleton<IApplicationLocalizationService, ApplicationLocalizationService>();
         services.AddSingleton<IApplicationUpdateStateService, ApplicationUpdateStateService>();
@@ -35,6 +41,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<MainViewModel>();
         services.AddSingleton<ContextMenuService>();
         services.AddTransient<GeneralSettingViewModel>();
+        services.AddTransient<AdkPageViewModel>();
         services.AddTransient<AppUpdateSettingViewModel>();
         services.AddTransient<AboutUsSettingViewModel>();
 

--- a/src/Foundry/Services/Adk/AdkService.cs
+++ b/src/Foundry/Services/Adk/AdkService.cs
@@ -1,0 +1,201 @@
+using System.Diagnostics;
+using Foundry.Core.Services.Adk;
+using Foundry.Services.Localization;
+using Foundry.Services.Operations;
+using Serilog;
+
+namespace Foundry.Services.Adk;
+
+internal sealed class AdkService(
+    IAdkInstallationProbe installationProbe,
+    IOperationProgressService operationProgressService,
+    IApplicationLocalizationService localizationService,
+    ILogger logger) : IAdkService
+{
+    private const string TargetAdkVersion = "10.1.26100.2454";
+    private const string AdkSetupFileName = $"adksetup-{TargetAdkVersion}.exe";
+    private const string WinPeSetupFileName = $"adkwinpesetup-{TargetAdkVersion}.exe";
+    private const string AdkSetupUrl = "https://go.microsoft.com/fwlink/?linkid=2289980";
+    private const string WinPeSetupUrl = "https://go.microsoft.com/fwlink/?linkid=2289981";
+    private const string AdkInstallArguments = "/quiet /norestart /features OptionId.DeploymentTools";
+    private const string WinPeInstallArguments = "/quiet /norestart";
+    private const string UninstallArguments = "/uninstall /quiet /norestart";
+    private static readonly HttpClient HttpClient = new();
+
+    private readonly ILogger logger = logger.ForContext<AdkService>();
+    private readonly SemaphoreSlim operationLock = new(1, 1);
+
+    public event EventHandler<AdkStatusChangedEventArgs>? StatusChanged;
+
+    public AdkInstallationStatus CurrentStatus { get; private set; } = new(
+        false,
+        false,
+        false,
+        null,
+        null,
+        "Windows ADK 10.1.26100.*");
+
+    public Task<AdkInstallationStatus> RefreshStatusAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        AdkInstallationStatus status = new AdkInstallationDetector(installationProbe).Detect();
+        ApplyStatus(status);
+
+        logger.Information(
+            "ADK status refreshed. IsInstalled={IsInstalled}, IsCompatible={IsCompatible}, IsWinPeAddonInstalled={IsWinPeAddonInstalled}, InstalledVersion={InstalledVersion}",
+            status.IsInstalled,
+            status.IsCompatible,
+            status.IsWinPeAddonInstalled,
+            status.InstalledVersion);
+
+        return Task.FromResult(status);
+    }
+
+    public Task<AdkInstallationStatus> InstallAsync(CancellationToken cancellationToken = default)
+    {
+        return RunInstallOperationAsync(OperationKind.AdkInstall, uninstallFirst: false, cancellationToken);
+    }
+
+    public Task<AdkInstallationStatus> UpgradeAsync(CancellationToken cancellationToken = default)
+    {
+        return RunInstallOperationAsync(OperationKind.AdkUpgrade, uninstallFirst: true, cancellationToken);
+    }
+
+    private async Task<AdkInstallationStatus> RunInstallOperationAsync(
+        OperationKind operationKind,
+        bool uninstallFirst,
+        CancellationToken cancellationToken)
+    {
+        await operationLock.WaitAsync(cancellationToken);
+        string terminalStatus = string.Empty;
+
+        try
+        {
+            operationProgressService.Start(operationKind, GetOperationStartText(operationKind));
+            Directory.CreateDirectory(Constants.InstallerCacheDirectoryPath);
+
+            string adkSetupPath = Path.Combine(Constants.InstallerCacheDirectoryPath, AdkSetupFileName);
+            string winPeSetupPath = Path.Combine(Constants.InstallerCacheDirectoryPath, WinPeSetupFileName);
+
+            await DownloadInstallerAsync(AdkSetupUrl, adkSetupPath, uninstallFirst ? 35 : 20, cancellationToken);
+            await DownloadInstallerAsync(WinPeSetupUrl, winPeSetupPath, uninstallFirst ? 45 : 40, cancellationToken);
+
+            if (uninstallFirst)
+            {
+                operationProgressService.Report(45, localizationService.GetString("Adk.Operation.UninstallingWinPe"));
+                await RunSetupAsync(winPeSetupPath, UninstallArguments, cancellationToken);
+                operationProgressService.Report(55, localizationService.GetString("Adk.Operation.UninstallingAdk"));
+                await RunSetupAsync(adkSetupPath, UninstallArguments, cancellationToken);
+            }
+
+            operationProgressService.Report(uninstallFirst ? 70 : 55, localizationService.GetString("Adk.Operation.InstallingAdk"));
+            await RunSetupAsync(adkSetupPath, AdkInstallArguments, cancellationToken);
+
+            operationProgressService.Report(uninstallFirst ? 88 : 80, localizationService.GetString("Adk.Operation.InstallingWinPe"));
+            await RunSetupAsync(winPeSetupPath, WinPeInstallArguments, cancellationToken);
+
+            operationProgressService.Report(95, localizationService.GetString("Adk.Operation.Verifying"));
+            AdkInstallationStatus status = await RefreshStatusAsync(cancellationToken);
+            terminalStatus = localizationService.GetString("Adk.Operation.Completed");
+            operationProgressService.Complete(terminalStatus);
+            logger.Information(
+                "ADK operation completed. OperationKind={OperationKind}, IsCompatible={IsCompatible}, InstalledVersion={InstalledVersion}",
+                operationKind,
+                status.IsCompatible,
+                status.InstalledVersion);
+
+            return status;
+        }
+        catch (Exception ex)
+        {
+            logger.Error(ex, "ADK operation failed. OperationKind={OperationKind}", operationKind);
+            terminalStatus = localizationService.GetString("Adk.Operation.Failed");
+            operationProgressService.Report(100, terminalStatus);
+            throw;
+        }
+        finally
+        {
+            operationProgressService.Reset(terminalStatus);
+            operationLock.Release();
+        }
+    }
+
+    private async Task DownloadInstallerAsync(
+        string url,
+        string outputPath,
+        int completedProgress,
+        CancellationToken cancellationToken)
+    {
+        if (File.Exists(outputPath))
+        {
+            FileInfo cachedInstaller = new(outputPath);
+            if (cachedInstaller.Length == 0)
+            {
+                File.Delete(outputPath);
+            }
+            else
+            {
+                operationProgressService.Report(completedProgress, localizationService.GetString("Adk.Operation.DownloadCached"));
+                logger.Debug("ADK installer cache hit. Url={Url}, OutputPath={OutputPath}", url, outputPath);
+                return;
+            }
+        }
+
+        operationProgressService.Report(Math.Max(0, completedProgress - 10), localizationService.GetString("Adk.Operation.Downloading"));
+        logger.Information("Downloading ADK installer. Url={Url}, OutputPath={OutputPath}", url, outputPath);
+        string temporaryOutputPath = $"{outputPath}.download";
+        if (File.Exists(temporaryOutputPath))
+        {
+            File.Delete(temporaryOutputPath);
+        }
+
+        using HttpResponseMessage response = await HttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        await using Stream input = await response.Content.ReadAsStreamAsync(cancellationToken);
+        await using (FileStream output = File.Create(temporaryOutputPath))
+        {
+            await input.CopyToAsync(output, cancellationToken);
+            await output.FlushAsync(cancellationToken);
+        }
+
+        File.Move(temporaryOutputPath, outputPath, overwrite: true);
+
+        operationProgressService.Report(completedProgress, localizationService.GetString("Adk.Operation.Downloaded"));
+    }
+
+    private static async Task RunSetupAsync(string setupPath, string arguments, CancellationToken cancellationToken)
+    {
+        if (!File.Exists(setupPath))
+        {
+            throw new FileNotFoundException("ADK setup executable was not found.", setupPath);
+        }
+
+        using Process process = Process.Start(new ProcessStartInfo
+        {
+            FileName = setupPath,
+            Arguments = arguments,
+            UseShellExecute = true,
+            Verb = "runas"
+        }) ?? throw new InvalidOperationException($"Unable to start '{setupPath}'.");
+
+        await process.WaitForExitAsync(cancellationToken);
+        if (process.ExitCode is not 0 and not 3010)
+        {
+            throw new InvalidOperationException($"'{Path.GetFileName(setupPath)}' exited with code {process.ExitCode}.");
+        }
+    }
+
+    private string GetOperationStartText(OperationKind operationKind)
+    {
+        return operationKind == OperationKind.AdkUpgrade
+            ? localizationService.GetString("Adk.Operation.UpgradeStarted")
+            : localizationService.GetString("Adk.Operation.InstallStarted");
+    }
+
+    private void ApplyStatus(AdkInstallationStatus status)
+    {
+        CurrentStatus = status;
+        StatusChanged?.Invoke(this, new(status));
+    }
+}

--- a/src/Foundry/Services/Adk/AdkService.cs
+++ b/src/Foundry/Services/Adk/AdkService.cs
@@ -19,7 +19,6 @@ internal sealed class AdkService(
     private const string WinPeSetupUrl = "https://go.microsoft.com/fwlink/?linkid=2289981";
     private const string AdkInstallArguments = "/quiet /norestart /features OptionId.DeploymentTools";
     private const string WinPeInstallArguments = "/quiet /norestart";
-    private const string UninstallArguments = "/uninstall /quiet /norestart";
     private static readonly HttpClient HttpClient = new();
 
     private readonly ILogger logger = logger.ForContext<AdkService>();
@@ -82,17 +81,14 @@ internal sealed class AdkService(
 
             if (uninstallFirst)
             {
-                operationProgressService.Report(45, localizationService.GetString("Adk.Operation.UninstallingWinPe"));
-                await RunSetupAsync(winPeSetupPath, UninstallArguments, cancellationToken);
-                operationProgressService.Report(55, localizationService.GetString("Adk.Operation.UninstallingAdk"));
-                await RunSetupAsync(adkSetupPath, UninstallArguments, cancellationToken);
+                await UninstallExistingBundlesAsync(cancellationToken);
             }
 
             operationProgressService.Report(uninstallFirst ? 70 : 55, localizationService.GetString("Adk.Operation.InstallingAdk"));
-            await RunSetupAsync(adkSetupPath, AdkInstallArguments, cancellationToken);
+            await RunElevatedProcessAsync(adkSetupPath, AdkInstallArguments, cancellationToken);
 
             operationProgressService.Report(uninstallFirst ? 88 : 80, localizationService.GetString("Adk.Operation.InstallingWinPe"));
-            await RunSetupAsync(winPeSetupPath, WinPeInstallArguments, cancellationToken);
+            await RunElevatedProcessAsync(winPeSetupPath, WinPeInstallArguments, cancellationToken);
 
             operationProgressService.Report(95, localizationService.GetString("Adk.Operation.Verifying"));
             AdkInstallationStatus status = await RefreshStatusAsync(cancellationToken);
@@ -164,7 +160,33 @@ internal sealed class AdkService(
         operationProgressService.Report(completedProgress, localizationService.GetString("Adk.Operation.Downloaded"));
     }
 
-    private static async Task RunSetupAsync(string setupPath, string arguments, CancellationToken cancellationToken)
+    private async Task UninstallExistingBundlesAsync(CancellationToken cancellationToken)
+    {
+        IReadOnlyList<AdkUninstallCommand> uninstallCommands = AdkUninstallCommandSelector.SelectBundleUninstallCommands(
+            installationProbe.GetInstalledProducts());
+
+        if (uninstallCommands.Count == 0)
+        {
+            throw new InvalidOperationException("Windows ADK uninstall commands were not found in the Windows uninstall registry.");
+        }
+
+        foreach (AdkUninstallCommand command in uninstallCommands)
+        {
+            operationProgressService.Report(
+                command.FileName.EndsWith("adkwinpesetup.exe", StringComparison.OrdinalIgnoreCase) ? 45 : 55,
+                command.FileName.EndsWith("adkwinpesetup.exe", StringComparison.OrdinalIgnoreCase)
+                    ? localizationService.GetString("Adk.Operation.UninstallingWinPe")
+                    : localizationService.GetString("Adk.Operation.UninstallingAdk"));
+
+            logger.Information(
+                "Uninstalling existing ADK bundle. DisplayName={DisplayName}, FileName={FileName}",
+                command.DisplayName,
+                Path.GetFileName(command.FileName));
+            await RunElevatedProcessAsync(command.FileName, command.Arguments, cancellationToken);
+        }
+    }
+
+    private static async Task RunElevatedProcessAsync(string setupPath, string arguments, CancellationToken cancellationToken)
     {
         if (!File.Exists(setupPath))
         {

--- a/src/Foundry/Services/Adk/AdkStatusChangedEventArgs.cs
+++ b/src/Foundry/Services/Adk/AdkStatusChangedEventArgs.cs
@@ -1,0 +1,8 @@
+using Foundry.Core.Services.Adk;
+
+namespace Foundry.Services.Adk;
+
+public sealed class AdkStatusChangedEventArgs(AdkInstallationStatus status) : EventArgs
+{
+    public AdkInstallationStatus Status { get; } = status;
+}

--- a/src/Foundry/Services/Adk/IAdkService.cs
+++ b/src/Foundry/Services/Adk/IAdkService.cs
@@ -1,0 +1,12 @@
+using Foundry.Core.Services.Adk;
+
+namespace Foundry.Services.Adk;
+
+public interface IAdkService
+{
+    event EventHandler<AdkStatusChangedEventArgs>? StatusChanged;
+    AdkInstallationStatus CurrentStatus { get; }
+    Task<AdkInstallationStatus> RefreshStatusAsync(CancellationToken cancellationToken = default);
+    Task<AdkInstallationStatus> InstallAsync(CancellationToken cancellationToken = default);
+    Task<AdkInstallationStatus> UpgradeAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Foundry/Services/Operations/IOperationProgressService.cs
+++ b/src/Foundry/Services/Operations/IOperationProgressService.cs
@@ -1,0 +1,11 @@
+namespace Foundry.Services.Operations;
+
+public interface IOperationProgressService
+{
+    event EventHandler<OperationProgressChangedEventArgs>? StateChanged;
+    OperationProgressState State { get; }
+    void Start(OperationKind kind, string status);
+    void Report(int progress, string status);
+    void Complete(string status);
+    void Reset(string status = "");
+}

--- a/src/Foundry/Services/Operations/OperationKind.cs
+++ b/src/Foundry/Services/Operations/OperationKind.cs
@@ -1,0 +1,8 @@
+namespace Foundry.Services.Operations;
+
+public enum OperationKind
+{
+    None,
+    AdkInstall,
+    AdkUpgrade
+}

--- a/src/Foundry/Services/Operations/OperationProgressChangedEventArgs.cs
+++ b/src/Foundry/Services/Operations/OperationProgressChangedEventArgs.cs
@@ -1,0 +1,6 @@
+namespace Foundry.Services.Operations;
+
+public sealed class OperationProgressChangedEventArgs(OperationProgressState state) : EventArgs
+{
+    public OperationProgressState State { get; } = state;
+}

--- a/src/Foundry/Services/Operations/OperationProgressService.cs
+++ b/src/Foundry/Services/Operations/OperationProgressService.cs
@@ -1,0 +1,49 @@
+namespace Foundry.Services.Operations;
+
+internal sealed class OperationProgressService : IOperationProgressService
+{
+    public event EventHandler<OperationProgressChangedEventArgs>? StateChanged;
+
+    public OperationProgressState State { get; private set; } = OperationProgressState.Idle;
+
+    public void Start(OperationKind kind, string status)
+    {
+        if (kind == OperationKind.None)
+        {
+            throw new ArgumentOutOfRangeException(nameof(kind), kind, "An operation kind is required.");
+        }
+
+        SetState(new(kind, 0, status));
+    }
+
+    public void Report(int progress, string status)
+    {
+        if (!State.IsRunning)
+        {
+            return;
+        }
+
+        SetState(State with { Progress = Math.Clamp(progress, 0, 100), Status = status });
+    }
+
+    public void Complete(string status)
+    {
+        if (!State.IsRunning)
+        {
+            return;
+        }
+
+        SetState(State with { Progress = 100, Status = status });
+    }
+
+    public void Reset(string status = "")
+    {
+        SetState(OperationProgressState.Idle with { Status = status });
+    }
+
+    private void SetState(OperationProgressState state)
+    {
+        State = state;
+        StateChanged?.Invoke(this, new(State));
+    }
+}

--- a/src/Foundry/Services/Operations/OperationProgressState.cs
+++ b/src/Foundry/Services/Operations/OperationProgressState.cs
@@ -1,0 +1,7 @@
+namespace Foundry.Services.Operations;
+
+public sealed record OperationProgressState(OperationKind Kind, int Progress, string Status)
+{
+    public static OperationProgressState Idle { get; } = new(OperationKind.None, 0, string.Empty);
+    public bool IsRunning => Kind != OperationKind.None;
+}

--- a/src/Foundry/Services/Startup/StartupReadinessService.cs
+++ b/src/Foundry/Services/Startup/StartupReadinessService.cs
@@ -1,3 +1,4 @@
+using Foundry.Services.Adk;
 using Foundry.Services.Settings;
 using Foundry.Services.Shell;
 using Foundry.Services.Updates;
@@ -8,6 +9,7 @@ namespace Foundry.Services.Startup;
 internal sealed class StartupReadinessService(
     IAppSettingsService appSettingsService,
     IApplicationUpdateService updateService,
+    IAdkService adkService,
     IShellNavigationGuardService shellNavigationGuardService,
     ILogger logger) : IStartupReadinessService
 {
@@ -29,7 +31,8 @@ internal sealed class StartupReadinessService(
                 Constants.AppSettingsPath,
                 appSettingsService.Current.Updates.Channel);
 
-            shellNavigationGuardService.SetState(ShellNavigationState.Ready);
+            var adkStatus = await adkService.RefreshStatusAsync(cancellationToken);
+            shellNavigationGuardService.SetState(adkStatus.CanCreateMedia ? ShellNavigationState.Ready : ShellNavigationState.AdkBlocked);
 
             await updateService.InitializeAsync(cancellationToken);
 

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -81,9 +81,6 @@
   <data name="MainWindow.ThemeButton.ToolTip" xml:space="preserve">
     <value>Toggle theme</value>
   </data>
-  <data name="AdkPage_Title.Text" xml:space="preserve">
-    <value>ADK</value>
-  </data>
   <data name="AutopilotPage_Title.Text" xml:space="preserve">
     <value>Autopilot</value>
   </data>
@@ -341,5 +338,101 @@
   </data>
   <data name="Update.Status.UpdateAvailableWithVersion" xml:space="preserve">
     <value>Foundry {0} is available.</value>
+  </data>
+  <data name="Adk.PageTitle" xml:space="preserve">
+    <value>Windows ADK</value>
+  </data>
+  <data name="Adk.Status.ReadyTitle" xml:space="preserve">
+    <value>ADK is ready</value>
+  </data>
+  <data name="Adk.Status.ReadyDescription" xml:space="preserve">
+    <value>Foundry can create ISO and USB media.</value>
+  </data>
+  <data name="Adk.Status.MissingTitle" xml:space="preserve">
+    <value>ADK is not installed</value>
+  </data>
+  <data name="Adk.Status.MissingDescription" xml:space="preserve">
+    <value>Install the Windows ADK Deployment Tools and the Windows PE Add-on before configuring media creation.</value>
+  </data>
+  <data name="Adk.Status.IncompatibleTitle" xml:space="preserve">
+    <value>ADK version is unsupported</value>
+  </data>
+  <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
+    <value>Upgrade the Windows ADK to a supported 10.1.26100 build.</value>
+  </data>
+  <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
+    <value>Windows PE Add-on is missing</value>
+  </data>
+  <data name="Adk.Status.WinPeMissingDescription" xml:space="preserve">
+    <value>Install the Windows PE Add-on for the installed Windows ADK.</value>
+  </data>
+  <data name="Adk.Version.NotDetected" xml:space="preserve">
+    <value>Version not detected</value>
+  </data>
+  <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
+    <value>Requires Windows ADK 10.1.26100.2454+ or 10.1.28000.1+ with the latest ADK servicing patch.</value>
+  </data>
+  <data name="Adk.WinPeAddon.Installed" xml:space="preserve">
+    <value>Windows PE Add-on installed</value>
+  </data>
+  <data name="Adk.WinPeAddon.Missing" xml:space="preserve">
+    <value>Windows PE Add-on missing</value>
+  </data>
+  <data name="Adk.MediaCapability.Ready" xml:space="preserve">
+    <value>ISO and USB creation can be unlocked.</value>
+  </data>
+  <data name="Adk.MediaCapability.Blocked" xml:space="preserve">
+    <value>ISO and USB creation remain blocked.</value>
+  </data>
+  <data name="Adk.Operation.Ready" xml:space="preserve">
+    <value>No ADK operation is running.</value>
+  </data>
+  <data name="Adk.Operation.InstallStarted" xml:space="preserve">
+    <value>Installing Windows ADK</value>
+  </data>
+  <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
+    <value>Upgrading Windows ADK</value>
+  </data>
+  <data name="Adk.Operation.Downloading" xml:space="preserve">
+    <value>Downloading ADK installer</value>
+  </data>
+  <data name="Adk.Operation.Downloaded" xml:space="preserve">
+    <value>ADK installer downloaded</value>
+  </data>
+  <data name="Adk.Operation.DownloadCached" xml:space="preserve">
+    <value>Using cached ADK installer</value>
+  </data>
+  <data name="Adk.Operation.UninstallingWinPe" xml:space="preserve">
+    <value>Removing existing Windows PE Add-on</value>
+  </data>
+  <data name="Adk.Operation.UninstallingAdk" xml:space="preserve">
+    <value>Removing existing Windows ADK</value>
+  </data>
+  <data name="Adk.Operation.InstallingAdk" xml:space="preserve">
+    <value>Installing Windows ADK Deployment Tools</value>
+  </data>
+  <data name="Adk.Operation.InstallingWinPe" xml:space="preserve">
+    <value>Installing Windows PE Add-on</value>
+  </data>
+  <data name="Adk.Operation.Verifying" xml:space="preserve">
+    <value>Verifying ADK installation</value>
+  </data>
+  <data name="Adk.Operation.Completed" xml:space="preserve">
+    <value>ADK operation completed</value>
+  </data>
+  <data name="Adk.Operation.Failed" xml:space="preserve">
+    <value>ADK operation failed</value>
+  </data>
+  <data name="AdkPage_RefreshButton.Content" xml:space="preserve">
+    <value>Refresh status</value>
+  </data>
+  <data name="AdkPage_InstallButton.Content" xml:space="preserve">
+    <value>Install ADK</value>
+  </data>
+  <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
+    <value>Upgrade ADK</value>
+  </data>
+  <data name="AdkPage_OpenLogsButton.Content" xml:space="preserve">
+    <value>Open logs</value>
   </data>
 </root>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -370,7 +370,7 @@
     <value>Version not detected</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 10.1.26100.2454+ or 10.1.28000.1+ with the latest ADK servicing patch.</value>
+    <value>Requires Windows ADK 10.1.26100.2454+ with the latest ADK servicing patch.</value>
   </data>
   <data name="Adk.WinPeAddon.Installed" xml:space="preserve">
     <value>Windows PE Add-on installed</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -370,7 +370,7 @@
     <value>Version non détectée</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Nécessite Windows ADK 10.1.26100.2454+ ou 10.1.28000.1+ avec le dernier correctif de maintenance ADK.</value>
+    <value>Nécessite Windows ADK 10.1.26100.2454+ avec le dernier correctif de maintenance ADK.</value>
   </data>
   <data name="Adk.WinPeAddon.Installed" xml:space="preserve">
     <value>Module complémentaire Windows PE installé</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -81,9 +81,6 @@
   <data name="MainWindow.ThemeButton.ToolTip" xml:space="preserve">
     <value>Changer le thème</value>
   </data>
-  <data name="AdkPage_Title.Text" xml:space="preserve">
-    <value>ADK</value>
-  </data>
   <data name="AutopilotPage_Title.Text" xml:space="preserve">
     <value>Autopilot</value>
   </data>
@@ -341,5 +338,101 @@
   </data>
   <data name="Update.Status.UpdateAvailableWithVersion" xml:space="preserve">
     <value>Foundry {0} est disponible.</value>
+  </data>
+  <data name="Adk.PageTitle" xml:space="preserve">
+    <value>Windows ADK</value>
+  </data>
+  <data name="Adk.Status.ReadyTitle" xml:space="preserve">
+    <value>L'ADK est prêt</value>
+  </data>
+  <data name="Adk.Status.ReadyDescription" xml:space="preserve">
+    <value>Foundry peut créer des médias ISO et USB.</value>
+  </data>
+  <data name="Adk.Status.MissingTitle" xml:space="preserve">
+    <value>L'ADK n'est pas installé</value>
+  </data>
+  <data name="Adk.Status.MissingDescription" xml:space="preserve">
+    <value>Installez les outils de déploiement Windows ADK et le module complémentaire Windows PE avant de configurer la création de médias.</value>
+  </data>
+  <data name="Adk.Status.IncompatibleTitle" xml:space="preserve">
+    <value>La version de l'ADK n'est pas prise en charge</value>
+  </data>
+  <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
+    <value>Mettez à niveau Windows ADK vers une version 10.1.26100 prise en charge.</value>
+  </data>
+  <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
+    <value>Le module complémentaire Windows PE est manquant</value>
+  </data>
+  <data name="Adk.Status.WinPeMissingDescription" xml:space="preserve">
+    <value>Installez le module complémentaire Windows PE correspondant au Windows ADK installé.</value>
+  </data>
+  <data name="Adk.Version.NotDetected" xml:space="preserve">
+    <value>Version non détectée</value>
+  </data>
+  <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
+    <value>Nécessite Windows ADK 10.1.26100.2454+ ou 10.1.28000.1+ avec le dernier correctif de maintenance ADK.</value>
+  </data>
+  <data name="Adk.WinPeAddon.Installed" xml:space="preserve">
+    <value>Module complémentaire Windows PE installé</value>
+  </data>
+  <data name="Adk.WinPeAddon.Missing" xml:space="preserve">
+    <value>Module complémentaire Windows PE manquant</value>
+  </data>
+  <data name="Adk.MediaCapability.Ready" xml:space="preserve">
+    <value>La création ISO et USB peut être déverrouillée.</value>
+  </data>
+  <data name="Adk.MediaCapability.Blocked" xml:space="preserve">
+    <value>La création ISO et USB reste bloquée.</value>
+  </data>
+  <data name="Adk.Operation.Ready" xml:space="preserve">
+    <value>Aucune opération ADK n'est en cours.</value>
+  </data>
+  <data name="Adk.Operation.InstallStarted" xml:space="preserve">
+    <value>Installation de Windows ADK</value>
+  </data>
+  <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
+    <value>Mise à niveau de Windows ADK</value>
+  </data>
+  <data name="Adk.Operation.Downloading" xml:space="preserve">
+    <value>Téléchargement du programme d'installation ADK</value>
+  </data>
+  <data name="Adk.Operation.Downloaded" xml:space="preserve">
+    <value>Programme d'installation ADK téléchargé</value>
+  </data>
+  <data name="Adk.Operation.DownloadCached" xml:space="preserve">
+    <value>Utilisation du programme d'installation ADK en cache</value>
+  </data>
+  <data name="Adk.Operation.UninstallingWinPe" xml:space="preserve">
+    <value>Suppression du module complémentaire Windows PE existant</value>
+  </data>
+  <data name="Adk.Operation.UninstallingAdk" xml:space="preserve">
+    <value>Suppression du Windows ADK existant</value>
+  </data>
+  <data name="Adk.Operation.InstallingAdk" xml:space="preserve">
+    <value>Installation des outils de déploiement Windows ADK</value>
+  </data>
+  <data name="Adk.Operation.InstallingWinPe" xml:space="preserve">
+    <value>Installation du module complémentaire Windows PE</value>
+  </data>
+  <data name="Adk.Operation.Verifying" xml:space="preserve">
+    <value>Vérification de l'installation ADK</value>
+  </data>
+  <data name="Adk.Operation.Completed" xml:space="preserve">
+    <value>Opération ADK terminée</value>
+  </data>
+  <data name="Adk.Operation.Failed" xml:space="preserve">
+    <value>Échec de l'opération ADK</value>
+  </data>
+  <data name="AdkPage_RefreshButton.Content" xml:space="preserve">
+    <value>Actualiser l'état</value>
+  </data>
+  <data name="AdkPage_InstallButton.Content" xml:space="preserve">
+    <value>Installer l'ADK</value>
+  </data>
+  <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
+    <value>Mettre à niveau l'ADK</value>
+  </data>
+  <data name="AdkPage_OpenLogsButton.Content" xml:space="preserve">
+    <value>Ouvrir les journaux</value>
   </data>
 </root>

--- a/src/Foundry/ViewModels/AdkPageViewModel.cs
+++ b/src/Foundry/ViewModels/AdkPageViewModel.cs
@@ -1,0 +1,254 @@
+using Foundry.Core.Services.Adk;
+using Foundry.Core.Services.Application;
+using Foundry.Services.Adk;
+using Foundry.Services.Localization;
+using Foundry.Services.Operations;
+using Foundry.Services.Shell;
+using Serilog;
+
+namespace Foundry.ViewModels;
+
+public sealed partial class AdkPageViewModel : ObservableObject, IDisposable
+{
+    private readonly IAdkService adkService;
+    private readonly IOperationProgressService operationProgressService;
+    private readonly IShellNavigationGuardService shellNavigationGuardService;
+    private readonly IApplicationLocalizationService localizationService;
+    private readonly IExternalProcessLauncher externalProcessLauncher;
+    private readonly IAppDispatcher appDispatcher;
+    private readonly ILogger logger;
+
+    [ObservableProperty]
+    public partial string PageTitle { get; set; }
+
+    [ObservableProperty]
+    public partial string StatusTitle { get; set; }
+
+    [ObservableProperty]
+    public partial string StatusDescription { get; set; }
+
+    [ObservableProperty]
+    public partial string InstalledVersion { get; set; }
+
+    [ObservableProperty]
+    public partial string RequiredVersionPolicy { get; set; }
+
+    [ObservableProperty]
+    public partial string WinPeAddonStatus { get; set; }
+
+    [ObservableProperty]
+    public partial string MediaCapabilityStatus { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsBusy { get; set; }
+
+    [ObservableProperty]
+    public partial int OperationProgress { get; set; }
+
+    [ObservableProperty]
+    public partial string OperationStatus { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsInstallButtonVisible { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsUpgradeButtonVisible { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsActionEnabled { get; set; }
+
+    public AdkPageViewModel(
+        IAdkService adkService,
+        IOperationProgressService operationProgressService,
+        IShellNavigationGuardService shellNavigationGuardService,
+        IApplicationLocalizationService localizationService,
+        IExternalProcessLauncher externalProcessLauncher,
+        IAppDispatcher appDispatcher,
+        ILogger logger)
+    {
+        this.adkService = adkService;
+        this.operationProgressService = operationProgressService;
+        this.shellNavigationGuardService = shellNavigationGuardService;
+        this.localizationService = localizationService;
+        this.externalProcessLauncher = externalProcessLauncher;
+        this.appDispatcher = appDispatcher;
+        this.logger = logger.ForContext<AdkPageViewModel>();
+
+        PageTitle = localizationService.GetString("Adk.PageTitle");
+        StatusTitle = string.Empty;
+        StatusDescription = string.Empty;
+        InstalledVersion = string.Empty;
+        RequiredVersionPolicy = string.Empty;
+        WinPeAddonStatus = string.Empty;
+        MediaCapabilityStatus = string.Empty;
+        OperationStatus = localizationService.GetString("Adk.Operation.Ready");
+        IsActionEnabled = true;
+
+        adkService.StatusChanged += OnAdkStatusChanged;
+        operationProgressService.StateChanged += OnOperationProgressChanged;
+        localizationService.LanguageChanged += OnLanguageChanged;
+
+        ApplyStatus(adkService.CurrentStatus);
+        ApplyOperationState(operationProgressService.State);
+    }
+
+    public void Dispose()
+    {
+        adkService.StatusChanged -= OnAdkStatusChanged;
+        operationProgressService.StateChanged -= OnOperationProgressChanged;
+        localizationService.LanguageChanged -= OnLanguageChanged;
+    }
+
+    [RelayCommand]
+    private async Task RefreshStatusAsync()
+    {
+        AdkInstallationStatus status = await adkService.RefreshStatusAsync();
+        ApplyShellState(status);
+    }
+
+    [RelayCommand]
+    private Task InstallAdkAsync()
+    {
+        return RunBlockingAdkOperationAsync(adkService.InstallAsync);
+    }
+
+    [RelayCommand]
+    private Task UpgradeAdkAsync()
+    {
+        return RunBlockingAdkOperationAsync(adkService.UpgradeAsync);
+    }
+
+    [RelayCommand]
+    private Task OpenLogsAsync()
+    {
+        return externalProcessLauncher.OpenFolderAsync(Constants.LogDirectoryPath);
+    }
+
+    private async Task RunBlockingAdkOperationAsync(Func<CancellationToken, Task<AdkInstallationStatus>> operation)
+    {
+        shellNavigationGuardService.SetState(ShellNavigationState.OperationRunning);
+
+        try
+        {
+            AdkInstallationStatus status = await operation(CancellationToken.None);
+            ApplyShellState(status);
+        }
+        catch (Exception ex)
+        {
+            logger.Warning("ADK page operation failed. ErrorMessage={ErrorMessage}", ex.Message);
+            OperationStatus = localizationService.GetString("Adk.Operation.Failed");
+            shellNavigationGuardService.SetState(ShellNavigationState.AdkBlocked);
+        }
+    }
+
+    private void ApplyShellState(AdkInstallationStatus status)
+    {
+        shellNavigationGuardService.SetState(status.CanCreateMedia ? ShellNavigationState.Ready : ShellNavigationState.AdkBlocked);
+    }
+
+    private void OnAdkStatusChanged(object? sender, AdkStatusChangedEventArgs e)
+    {
+        if (!appDispatcher.TryEnqueue(() => ApplyStatus(e.Status)))
+        {
+            logger.Warning(
+                "Failed to enqueue ADK page status refresh. IsInstalled={IsInstalled}, IsCompatible={IsCompatible}, IsWinPeAddonInstalled={IsWinPeAddonInstalled}",
+                e.Status.IsInstalled,
+                e.Status.IsCompatible,
+                e.Status.IsWinPeAddonInstalled);
+        }
+    }
+
+    private void OnOperationProgressChanged(object? sender, OperationProgressChangedEventArgs e)
+    {
+        if (!appDispatcher.TryEnqueue(() => ApplyOperationState(e.State)))
+        {
+            logger.Warning(
+                "Failed to enqueue ADK page operation refresh. OperationKind={OperationKind}, Progress={Progress}",
+                e.State.Kind,
+                e.State.Progress);
+        }
+    }
+
+    private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
+    {
+        if (!appDispatcher.TryEnqueue(() =>
+        {
+            PageTitle = localizationService.GetString("Adk.PageTitle");
+            ApplyStatus(adkService.CurrentStatus);
+            ApplyOperationState(operationProgressService.State);
+        }))
+        {
+            logger.Warning(
+                "Failed to enqueue ADK page localization refresh. OldLanguage={OldLanguage}, NewLanguage={NewLanguage}",
+                e.OldLanguage,
+                e.NewLanguage);
+        }
+    }
+
+    private void ApplyStatus(AdkInstallationStatus status)
+    {
+        StatusTitle = GetStatusTitle(status);
+        StatusDescription = GetStatusDescription(status);
+        InstalledVersion = status.InstalledVersion ?? localizationService.GetString("Adk.Version.NotDetected");
+        RequiredVersionPolicy = localizationService.GetString("Adk.Version.RequiredPolicy");
+        WinPeAddonStatus = status.IsWinPeAddonInstalled
+            ? localizationService.GetString("Adk.WinPeAddon.Installed")
+            : localizationService.GetString("Adk.WinPeAddon.Missing");
+        MediaCapabilityStatus = status.CanCreateMedia
+            ? localizationService.GetString("Adk.MediaCapability.Ready")
+            : localizationService.GetString("Adk.MediaCapability.Blocked");
+        IsUpgradeButtonVisible = status.IsInstalled && !status.IsCompatible;
+        IsInstallButtonVisible = !IsUpgradeButtonVisible && (!status.IsInstalled || !status.IsWinPeAddonInstalled);
+        IsActionEnabled = !IsBusy;
+    }
+
+    private void ApplyOperationState(OperationProgressState state)
+    {
+        IsBusy = state.IsRunning;
+        OperationProgress = state.Progress;
+        OperationStatus = !string.IsNullOrWhiteSpace(state.Status)
+            ? state.Status
+            : localizationService.GetString("Adk.Operation.Ready");
+        IsActionEnabled = !IsBusy;
+    }
+
+    private string GetStatusTitle(AdkInstallationStatus status)
+    {
+        if (status.CanCreateMedia)
+        {
+            return localizationService.GetString("Adk.Status.ReadyTitle");
+        }
+
+        if (!status.IsInstalled)
+        {
+            return localizationService.GetString("Adk.Status.MissingTitle");
+        }
+
+        if (!status.IsCompatible)
+        {
+            return localizationService.GetString("Adk.Status.IncompatibleTitle");
+        }
+
+        return localizationService.GetString("Adk.Status.WinPeMissingTitle");
+    }
+
+    private string GetStatusDescription(AdkInstallationStatus status)
+    {
+        if (status.CanCreateMedia)
+        {
+            return localizationService.GetString("Adk.Status.ReadyDescription");
+        }
+
+        if (!status.IsInstalled)
+        {
+            return localizationService.GetString("Adk.Status.MissingDescription");
+        }
+
+        if (!status.IsCompatible)
+        {
+            return localizationService.GetString("Adk.Status.IncompatibleDescription");
+        }
+
+        return localizationService.GetString("Adk.Status.WinPeMissingDescription");
+    }
+}

--- a/src/Foundry/Views/AdkPage.xaml
+++ b/src/Foundry/Views/AdkPage.xaml
@@ -1,13 +1,62 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Page x:Class="Foundry.Views.AdkPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:dev="using:DevWinUI">
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
                 Padding="{ThemeResource ContentPagePadding}">
         <StackPanel Margin="10"
-                    Spacing="5">
-            <TextBlock x:Uid="AdkPage_Title"
+                    dev:PanelAttach.ChildrenTransitions="Default"
+                    Spacing="8">
+            <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
                        Style="{ThemeResource TitleTextBlockStyle}" />
+
+            <dev:SettingsCard Description="{x:Bind ViewModel.StatusDescription, Mode=OneWay}"
+                              Header="{x:Bind ViewModel.StatusTitle, Mode=OneWay}"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E946}">
+                <StackPanel Orientation="Horizontal"
+                            Spacing="10">
+                    <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            x:Uid="AdkPage_RefreshButton"
+                            Command="{x:Bind ViewModel.RefreshStatusCommand}"
+                            IsEnabled="{x:Bind ViewModel.IsActionEnabled, Mode=OneWay}" />
+                    <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            x:Uid="AdkPage_InstallButton"
+                            Command="{x:Bind ViewModel.InstallAdkCommand}"
+                            IsEnabled="{x:Bind ViewModel.IsActionEnabled, Mode=OneWay}"
+                            Style="{ThemeResource AccentButtonStyle}"
+                            Visibility="{x:Bind ViewModel.IsInstallButtonVisible, Mode=OneWay}" />
+                    <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            x:Uid="AdkPage_UpgradeButton"
+                            Command="{x:Bind ViewModel.UpgradeAdkCommand}"
+                            IsEnabled="{x:Bind ViewModel.IsActionEnabled, Mode=OneWay}"
+                            Style="{ThemeResource AccentButtonStyle}"
+                            Visibility="{x:Bind ViewModel.IsUpgradeButtonVisible, Mode=OneWay}" />
+                </StackPanel>
+            </dev:SettingsCard>
+
+            <dev:SettingsCard Description="{x:Bind ViewModel.RequiredVersionPolicy, Mode=OneWay}"
+                              Header="{x:Bind ViewModel.InstalledVersion, Mode=OneWay}"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E946}" />
+
+            <dev:SettingsCard Description="{x:Bind ViewModel.MediaCapabilityStatus, Mode=OneWay}"
+                              Header="{x:Bind ViewModel.WinPeAddonStatus, Mode=OneWay}"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E7C1}" />
+
+            <dev:SettingsCard Description="{x:Bind ViewModel.OperationStatus, Mode=OneWay}"
+                              Header="{x:Bind ViewModel.OperationStatus, Mode=OneWay}"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E9F5}">
+                <StackPanel Orientation="Horizontal"
+                            Spacing="10">
+                    <ProgressBar Width="180"
+                                 Maximum="100"
+                                 Value="{x:Bind ViewModel.OperationProgress, Mode=OneWay}"
+                                 Visibility="{x:Bind ViewModel.IsBusy, Mode=OneWay}" />
+                    <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            x:Uid="AdkPage_OpenLogsButton"
+                            Command="{x:Bind ViewModel.OpenLogsCommand}" />
+                </StackPanel>
+            </dev:SettingsCard>
         </StackPanel>
     </ScrollView>
 </Page>

--- a/src/Foundry/Views/AdkPage.xaml.cs
+++ b/src/Foundry/Views/AdkPage.xaml.cs
@@ -2,8 +2,18 @@ namespace Foundry.Views;
 
 public sealed partial class AdkPage : Page
 {
+    public AdkPageViewModel ViewModel { get; }
+
     public AdkPage()
     {
+        ViewModel = App.GetService<AdkPageViewModel>();
         InitializeComponent();
+        Unloaded += OnUnloaded;
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        ViewModel.Dispose();
+        Unloaded -= OnUnloaded;
     }
 }

--- a/src/Foundry/Views/MainWindow.xaml.cs
+++ b/src/Foundry/Views/MainWindow.xaml.cs
@@ -253,12 +253,11 @@ namespace Foundry.Views
         {
             ShellNavigationState state = shellNavigationGuardService.State;
             bool isOperationRunning = state == ShellNavigationState.OperationRunning;
-            SearchBox.IsEnabled = state != ShellNavigationState.AdkBlocked;
+            SearchBox.IsEnabled = state == ShellNavigationState.Ready;
             UpdateOperationDialog(isOperationRunning);
 
-            ShellNavigationState visualNavigationState = isOperationRunning ? ShellNavigationState.Ready : state;
-            ApplyNavigationItemsState(NavView.MenuItems, isFooter: false, visualNavigationState);
-            ApplyNavigationItemsState(NavView.FooterMenuItems, isFooter: true, visualNavigationState);
+            ApplyNavigationItemsState(NavView.MenuItems, isFooter: false, state);
+            ApplyNavigationItemsState(NavView.FooterMenuItems, isFooter: true, state);
 
             NavView.IsBackEnabled = !isOperationRunning && NavFrame.CanGoBack;
             AppTitleBar.IsBackButtonVisible = !isOperationRunning && NavFrame.CanGoBack;

--- a/src/Foundry/Views/MainWindow.xaml.cs
+++ b/src/Foundry/Views/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 using Foundry.Services.Localization;
+using Foundry.Services.Operations;
 using Foundry.Services.Shell;
 using Microsoft.UI.Windowing;
 using Serilog;
@@ -8,17 +9,21 @@ namespace Foundry.Views
     public sealed partial class MainWindow : Window
     {
         private readonly IApplicationLocalizationService localizationService;
+        private readonly IOperationProgressService operationProgressService;
         private readonly IShellNavigationGuardService shellNavigationGuardService;
         private readonly ILogger logger = Log.ForContext<MainWindow>();
         private ContentDialog? operationDialog;
         private bool isClosingOperationDialog;
         private JsonNavigationService? jsonNavigationService;
+        private TextBlock? operationStatusText;
+        private ProgressBar? operationProgressBar;
 
         public MainViewModel ViewModel { get; }
 
         public MainWindow()
         {
             localizationService = App.GetService<IApplicationLocalizationService>();
+            operationProgressService = App.GetService<IOperationProgressService>();
             shellNavigationGuardService = App.GetService<IShellNavigationGuardService>();
             ViewModel = App.GetService<MainViewModel>();
             this.InitializeComponent();
@@ -30,6 +35,7 @@ namespace Foundry.Views
             ApplyShellNavigationState();
 
             localizationService.LanguageChanged += OnLanguageChanged;
+            operationProgressService.StateChanged += OnOperationProgressChanged;
             shellNavigationGuardService.StateChanged += OnShellNavigationStateChanged;
             NavFrame.Navigated += OnNavFrameNavigated;
             AppTitleBar.BackRequested += OnTitleBarBackRequested;
@@ -139,6 +145,7 @@ namespace Foundry.Views
         private void OnClosed(object sender, WindowEventArgs args)
         {
             localizationService.LanguageChanged -= OnLanguageChanged;
+            operationProgressService.StateChanged -= OnOperationProgressChanged;
             shellNavigationGuardService.StateChanged -= OnShellNavigationStateChanged;
             NavFrame.Navigated -= OnNavFrameNavigated;
             AppTitleBar.BackRequested -= OnTitleBarBackRequested;
@@ -188,6 +195,17 @@ namespace Foundry.Views
             }
 
             ApplyShellNavigationState();
+        }
+
+        private void OnOperationProgressChanged(object? sender, OperationProgressChangedEventArgs e)
+        {
+            if (!DispatcherQueue.HasThreadAccess)
+            {
+                DispatcherQueue.TryEnqueue(() => ApplyOperationState(e.State));
+                return;
+            }
+
+            ApplyOperationState(e.State);
         }
 
         private void OnNavFrameNavigated(object sender, NavigationEventArgs e)
@@ -294,6 +312,21 @@ namespace Foundry.Views
 
         private FrameworkElement CreateOperationDialogContent()
         {
+            operationStatusText = new TextBlock
+            {
+                Text = GetOperationDialogStatusText(),
+                TextWrapping = TextWrapping.Wrap,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                TextAlignment = TextAlignment.Center
+            };
+
+            operationProgressBar = new ProgressBar
+            {
+                Minimum = 0,
+                Maximum = 100,
+                Value = operationProgressService.State.Progress
+            };
+
             return new StackPanel
             {
                 MinWidth = 360,
@@ -307,12 +340,8 @@ namespace Foundry.Views
                         IsActive = true,
                         HorizontalAlignment = HorizontalAlignment.Center
                     },
-                    new TextBlock
-                    {
-                        Text = localizationService.GetString("Shell.OperationRunning"),
-                        TextWrapping = TextWrapping.Wrap,
-                        HorizontalAlignment = HorizontalAlignment.Center
-                    }
+                    operationStatusText,
+                    operationProgressBar
                 }
             };
         }
@@ -324,6 +353,8 @@ namespace Foundry.Views
                 return;
             }
 
+            operationStatusText = null;
+            operationProgressBar = null;
             isClosingOperationDialog = true;
             operationDialog.Hide();
         }
@@ -370,6 +401,26 @@ namespace Foundry.Views
                     || string.Equals(uniqueId, typeof(AdkPage).FullName, StringComparison.Ordinal),
                 _ => false
             };
+        }
+
+        private void ApplyOperationState(OperationProgressState state)
+        {
+            if (operationStatusText is not null)
+            {
+                operationStatusText.Text = GetOperationDialogStatusText();
+            }
+
+            if (operationProgressBar is not null)
+            {
+                operationProgressBar.Value = state.Progress;
+            }
+        }
+
+        private string GetOperationDialogStatusText()
+        {
+            return !string.IsNullOrWhiteSpace(operationProgressService.State.Status)
+                ? operationProgressService.State.Status
+                : localizationService.GetString("Shell.OperationRunning");
         }
     }
 


### PR DESCRIPTION
## Summary
- Add Windows ADK/WinPE Add-on detection in Foundry.Core with non-UI tests.
- Add the WinUI ADK page view model, actions, localized status text, and blocking operation progress.
- Gate shell navigation from startup based on ADK compatibility and update the migration plan for Phase 12.A.

## Reason
Phase 13 media creation and later expert workflows need a reliable ADK readiness state before ISO/USB actions can be exposed safely.

## Main changes
- Detect Deployment Tools, WinPE Add-on, installed ADK version, and the supported ADK 24H2 track.
- Require `10.1.26100.2454+`, with UI wording that calls out Microsoft ADK servicing patches.
- Explicitly reject the Windows 11 26H1 Arm64 `10.1.28000.x` ADK track in Foundry.
- Add Foundry-managed ADK install/upgrade operations using versioned installer cache files and atomic downloads.
- Add operation progress plumbing for the existing blocking overlay.

## Testing
- `dotnet test .\src\Foundry.Core.Tests\Foundry.Core.Tests.csproj -c Release --no-restore --nologo --filter FullyQualifiedName~AdkInstallationDetectorTests`
- `dotnet build .\src\Foundry.slnx -c Release -p:Platform=x64 --no-restore --nologo`
- `dotnet test .\src\Foundry.slnx -c Release --no-build --nologo`
- `dotnet build .\src\Foundry.slnx -c Release -p:Platform=ARM64 --no-restore --nologo`
- `git diff --check`