### PR TITLE
refactor(runtime): normalize connect deploy runtime layout

### DIFF
--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -14,7 +14,7 @@ The `12.A` to `12.D` labels are implementation slices, not extra phase numbers. 
 
 - [x] `12.A` owns user-visible ADK readiness and navigation gating.
 - [x] `12.B` owns pure WinPE service foundations that can be tested without final UI commands.
-- [ ] `12.C` owns Connect/Deploy runtime payload layout and bootstrap resolution.
+- [x] `12.C` owns Connect/Deploy runtime payload layout and bootstrap resolution.
 - [ ] `12.D` owns final host/media filesystem layout enforcement after services and runtime paths are stable.
 
 - [x] **12.A** `feat(adk): add adk status and page integration`.
@@ -25,10 +25,10 @@ The `12.A` to `12.D` labels are implementation slices, not extra phase numbers. 
   - [x] Scope: tool resolution, process runner, build workspace, boot image source strategy, driver catalog/resolution/injection, image internationalization, WinRE boot image preparation, mounted image asset provisioning/customization, workspace preparation, and media output service foundations.
   - [x] Boundary: port service and Core orchestration building blocks; keep final `Start` page command wiring in Phase 13.
   - [x] Reason: these services can be validated independently from the final WinUI media workflow and should be stable before user-facing ISO/USB execution is added.
-- [ ] **12.C** `refactor(runtime): normalize connect deploy runtime layout`.
-  - [ ] Scope: normalize `Runtime\Foundry.Connect\<rid>` and `Runtime\Foundry.Deploy\<rid>`, update bootstrap resolution, update ISO runtime provisioning, update USB cache provisioning, remove unnecessary `Foundry.Connect` USB duplication, preserve local debug Connect/Deploy overrides, and preserve release/download fallback behavior.
-  - [ ] Boundary: touch runtime payload layout and bootstrap assumptions only; do not redesign Connect or Deploy application behavior unless the layout change necessarily flows into them.
-  - [ ] Reason: Connect/Deploy runtime layout affects ISO, USB, bootstrap, and downstream compatibility, so it needs a focused PR with explicit validation.
+- [x] **12.C** `refactor(runtime): normalize connect deploy runtime layout`.
+  - [x] Scope: normalize `Runtime\Foundry.Connect\<rid>` and `Runtime\Foundry.Deploy\<rid>`, update bootstrap resolution, update ISO runtime provisioning, update USB cache provisioning, remove unnecessary `Foundry.Connect` USB duplication, preserve local debug Connect/Deploy overrides, and preserve release/download fallback behavior.
+  - [x] Boundary: touch runtime payload layout and bootstrap assumptions only; do not redesign Connect or Deploy application behavior unless the layout change necessarily flows into them.
+  - [x] Reason: Connect/Deploy runtime layout affects ISO, USB, bootstrap, and downstream compatibility, so it needs a focused PR with explicit validation.
 - [ ] **12.D** `feat(winpe): apply programdata and media layout`.
   - [ ] Scope: enforce the new `C:\ProgramData\Foundry` host layout, `X:\Foundry` boot image layout, USB BOOT/cache layout, cache/temp/log placement, media secret-key placement, no old-folder fallback, failure-path log relocation, and ISO volume-label behavior.
   - [ ] Boundary: make the documented filesystem contract real after ADK readiness, WinPE service foundations, and runtime payload layout are known.
@@ -180,42 +180,42 @@ The `12.A` to `12.D` labels are implementation slices, not extra phase numbers. 
 - [ ] **12.7** Rename or wrap ambiguous path concepts in `Foundry.Core`:
   - [ ] Distinguish `RuntimeRoot` from `CacheRoot`.
   - [ ] Distinguish host build workspace from WinPE runtime workspace.
-  - [ ] Distinguish ISO transient runtime from USB persistent cache.
+  - [x] Distinguish ISO transient runtime from USB persistent cache for Connect/Deploy runtime payload provisioning.
 - [ ] **12.8** Reassess the current `CacheRootPath` behavior where a path ending in `Runtime` writes `OperatingSystem` and `DriverPack` to its parent.
-- [ ] **12.9** Normalize the Connect and Deploy runtime cache layout immediately:
-  - [ ] Use one application-root convention: `Runtime\<ApplicationName>\<rid>`.
-  - [ ] Store Connect at `Runtime\Foundry.Connect\<rid>`.
-  - [ ] Store Deploy at `Runtime\Foundry.Deploy\<rid>`.
-  - [ ] Update `FoundryBootstrap.ps1` to resolve both applications through the normalized convention.
-  - [ ] Correct all Connect and Deploy source retrieval paths after normalization:
-    - [ ] Embedded ISO runtime lookup.
-    - [ ] USB `Foundry Cache` runtime lookup.
-    - [ ] Local debug project publish output lookup.
-    - [ ] Local archive override lookup.
-    - [ ] GitHub release ZIP lookup.
-    - [ ] Existing cache fallback lookup.
-    - [ ] Embedded archive fallback lookup when still intentionally supported.
-  - [ ] Update ISO runtime provisioning to write the normalized layout.
-  - [ ] Update USB cache provisioning to write the normalized layout.
-  - [ ] Update runtime manifest/cache metadata paths if they depend on the old Deploy shape.
-  - [ ] Preserve bootstrap release tag override variables:
-    - [ ] `FOUNDRY_CONNECT_RELEASE_TAG`.
-    - [ ] `FOUNDRY_DEPLOY_RELEASE_TAG`.
-    - [ ] `FOUNDRY_RELEASE_TAG`.
-  - [ ] Preserve bootstrap archive override variables:
-    - [ ] `FOUNDRY_CONNECT_ARCHIVE`.
-    - [ ] `FOUNDRY_DEPLOY_ARCHIVE`.
-    - [ ] `FOUNDRY_CONNECT_ARCHIVE_SHA256`.
-    - [ ] `FOUNDRY_DEPLOY_ARCHIVE_SHA256`.
-  - [ ] Preserve `curl` download with PowerShell/.NET fallback where the bootstrap still needs runtime download support.
+- [x] **12.9** Normalize the Connect and Deploy runtime cache layout immediately:
+  - [x] Use one application-root convention: `Runtime\<ApplicationName>\<rid>`.
+  - [x] Store Connect at `Runtime\Foundry.Connect\<rid>`.
+  - [x] Store Deploy at `Runtime\Foundry.Deploy\<rid>`.
+  - [x] Update `FoundryBootstrap.ps1` to resolve both applications through the normalized convention.
+  - [x] Correct all Connect and Deploy source retrieval paths after normalization:
+    - [x] Embedded ISO runtime lookup.
+    - [x] USB `Foundry Cache` runtime lookup.
+    - [x] Local debug project publish output lookup.
+    - [x] Local archive override lookup.
+    - [x] GitHub release ZIP lookup.
+    - [x] Existing cache fallback lookup.
+    - [x] Embedded archive fallback lookup when still intentionally supported.
+  - [x] Update ISO runtime provisioning to write the normalized layout.
+  - [x] Update USB cache provisioning to write the normalized layout.
+  - [x] Update runtime manifest/cache metadata paths if they depend on the old Deploy shape; no runtime manifest path currently exists in Core.
+  - [x] Preserve bootstrap release tag override variables:
+    - [x] `FOUNDRY_CONNECT_RELEASE_TAG`.
+    - [x] `FOUNDRY_DEPLOY_RELEASE_TAG`.
+    - [x] `FOUNDRY_RELEASE_TAG`.
+  - [x] Preserve bootstrap archive override variables:
+    - [x] `FOUNDRY_CONNECT_ARCHIVE`.
+    - [x] `FOUNDRY_DEPLOY_ARCHIVE`.
+    - [x] `FOUNDRY_CONNECT_ARCHIVE_SHA256`.
+    - [x] `FOUNDRY_DEPLOY_ARCHIVE_SHA256`.
+  - [x] Preserve `curl` download with PowerShell/.NET fallback where the bootstrap still needs runtime download support.
 - [x] **12.9.1** Provision `curl.exe` into WinPE `System32` for architectures where the bootstrap can prefer it before falling back to PowerShell/.NET downloads.
-- [ ] **12.10** Remove the unnecessary `Foundry.Connect` runtime duplication on USB:
-  - [ ] Keep `Foundry.Connect` in the `Foundry Cache` partition.
-  - [ ] Keep only minimal boot/bootstrap files on the BOOT partition.
-  - [ ] Ensure ISO mode still has the required runtime under `X:\Foundry\Runtime`.
-- [ ] **12.11** Remove or explicitly mark obsolete legacy archive contracts:
-  - [ ] `Foundry\Seed\Foundry.Connect.zip` appears unused after extracted Connect runtime provisioning.
-  - [ ] `Foundry\Seed\Foundry.Deploy.zip` remains a valid local Deploy seed package.
+- [x] **12.10** Remove the unnecessary `Foundry.Connect` runtime duplication on USB:
+  - [x] Keep `Foundry.Connect` in the `Foundry Cache` partition.
+  - [x] Keep only minimal boot/bootstrap files on the BOOT partition.
+  - [x] Ensure ISO mode still has the required runtime under `X:\Foundry\Runtime`.
+- [x] **12.11** Remove or explicitly mark obsolete legacy archive contracts:
+  - [x] `Foundry\Seed\Foundry.Connect.zip` appears unused after extracted Connect runtime provisioning.
+  - [x] `Foundry\Seed\Foundry.Deploy.zip` remains a valid local Deploy seed package.
 - [ ] **12.12** Fix or remove unused ISO volume-label intent:
   - [ ] `IsoOutputOptions.VolumeLabel` is currently configured by the app but not passed to `MakeWinPEMedia`.
 - [x] **12.12.1** Preserve MakeWinPEMedia compatibility details:
@@ -256,7 +256,7 @@ git commit -m "feat(adk): add adk status and page integration"
 git commit -m "feat(winpe): port service foundations"
 ```
 
-  - [ ] **12.16.3** Commit Phase 12.C:
+  - [x] **12.16.3** Commit Phase 12.C:
 
 ```powershell
 git commit -m "refactor(runtime): normalize connect deploy layout"

--- a/src/Foundry.Core.Tests/WinPe/WinPeEmbeddedAssetServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeEmbeddedAssetServiceTests.cs
@@ -89,4 +89,35 @@ public sealed class WinPeEmbeddedAssetServiceTests
         Assert.Contains("Timezone map unavailable. Auto-detect skipped.", content, StringComparison.Ordinal);
         Assert.Contains("Timezone update failed. Continuing.", content, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void GetBootstrapScriptContent_UsesNormalizedApplicationRuntimeLayout()
+    {
+        var service = new WinPeEmbeddedAssetService();
+
+        string content = service.GetBootstrapScriptContent();
+
+        Assert.Contains("return Join-Path $BootstrapRoot $ApplicationName", content, StringComparison.Ordinal);
+        Assert.Contains("Get-RuntimeCacheRoot -BootstrapRoot $BootstrapRoot -ApplicationName $ApplicationName -RuntimeIdentifier $RuntimeIdentifier", content, StringComparison.Ordinal);
+        Assert.DoesNotContain("'Foundry.Deploy' { return $BootstrapRoot }", content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetBootstrapScriptContent_PreservesRuntimeDownloadOverrides()
+    {
+        var service = new WinPeEmbeddedAssetService();
+
+        string content = service.GetBootstrapScriptContent();
+
+        Assert.Contains("FOUNDRY_CONNECT_RELEASE_TAG", content, StringComparison.Ordinal);
+        Assert.Contains("FOUNDRY_DEPLOY_RELEASE_TAG", content, StringComparison.Ordinal);
+        Assert.Contains("FOUNDRY_RELEASE_TAG", content, StringComparison.Ordinal);
+        Assert.Contains("FOUNDRY_CONNECT_ARCHIVE", content, StringComparison.Ordinal);
+        Assert.Contains("FOUNDRY_DEPLOY_ARCHIVE", content, StringComparison.Ordinal);
+        Assert.Contains("FOUNDRY_CONNECT_ARCHIVE_SHA256", content, StringComparison.Ordinal);
+        Assert.Contains("FOUNDRY_DEPLOY_ARCHIVE_SHA256", content, StringComparison.Ordinal);
+        Assert.Contains("curl.exe", content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("System.Net.WebClient", content, StringComparison.Ordinal);
+        Assert.Contains("Invoke-WebRequest", content, StringComparison.Ordinal);
+    }
 }

--- a/src/Foundry.Core.Tests/WinPe/WinPeMountedImageCustomizationServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeMountedImageCustomizationServiceTests.cs
@@ -15,13 +15,20 @@ public sealed class WinPeMountedImageCustomizationServiceTests
         var driverInjection = new FakeDriverInjectionService();
         var internationalization = new FakeInternationalizationService();
         var assetProvisioning = new FakeAssetProvisioningService();
+        var runtimePayloadProvisioning = new FakeRuntimePayloadProvisioningService();
         var winRePreparation = new FakeWinRePreparationService();
         var service = new WinPeMountedImageCustomizationService(
             runner,
             driverInjection,
             internationalization,
             assetProvisioning,
+            runtimePayloadProvisioning,
             winRePreparation);
+        var runtimePayloadOptions = new WinPeRuntimePayloadProvisioningOptions
+        {
+            WorkingDirectoryPath = Path.Combine(temp.RootPath, "runtime-work"),
+            Connect = new WinPeRuntimePayloadApplicationOptions { IsEnabled = true }
+        };
 
         WinPeResult result = await service.CustomizeAsync(
             new WinPeMountedImageCustomizationOptions
@@ -37,6 +44,7 @@ public sealed class WinPeMountedImageCustomizationServiceTests
                     CurlExecutableSourcePath = Path.Combine(temp.RootPath, "curl.exe"),
                     IanaWindowsTimeZoneMapJson = "{}"
                 },
+                RuntimePayloadProvisioning = runtimePayloadOptions,
                 WinReCacheDirectoryPath = Path.Combine(temp.RootPath, "cache")
             },
             CancellationToken.None);
@@ -45,6 +53,10 @@ public sealed class WinPeMountedImageCustomizationServiceTests
         Assert.False(winRePreparation.WasCalled);
         Assert.Single(assetProvisioning.Options);
         Assert.Equal(temp.Artifact.MountDirectoryPath, assetProvisioning.Options[0].MountedImagePath);
+        Assert.Single(runtimePayloadProvisioning.Options);
+        Assert.Equal(temp.Artifact.MountDirectoryPath, runtimePayloadProvisioning.Options[0].MountedImagePath);
+        Assert.Equal(temp.Artifact.Architecture, runtimePayloadProvisioning.Options[0].Architecture);
+        Assert.Same(runtimePayloadOptions.Connect, runtimePayloadProvisioning.Options[0].Connect);
         Assert.Single(driverInjection.Options);
         Assert.Equal(driverDirectory, Assert.Single(driverInjection.Options[0].DriverPackagePaths));
         Assert.Single(internationalization.Options);
@@ -63,6 +75,7 @@ public sealed class WinPeMountedImageCustomizationServiceTests
             new FakeDriverInjectionService(),
             new FakeInternationalizationService(WinPeResult.Failure(WinPeErrorCodes.BuildFailed, "intl failed")),
             new FakeAssetProvisioningService(),
+            new FakeRuntimePayloadProvisioningService(),
             new FakeWinRePreparationService());
 
         WinPeResult result = await service.CustomizeAsync(
@@ -108,6 +121,7 @@ public sealed class WinPeMountedImageCustomizationServiceTests
             driverInjection,
             new FakeInternationalizationService(),
             new FakeAssetProvisioningService(),
+            new FakeRuntimePayloadProvisioningService(),
             new FakeWinRePreparationService(new WinReBootImagePreparationResult
             {
                 DependencyFiles =
@@ -264,6 +278,19 @@ public sealed class WinPeMountedImageCustomizationServiceTests
 
         public Task<WinPeResult> ProvisionAsync(
             WinPeMountedImageAssetProvisioningOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            Options.Add(options);
+            return Task.FromResult(result ?? WinPeResult.Success());
+        }
+    }
+
+    private sealed class FakeRuntimePayloadProvisioningService(WinPeResult? result = null) : IWinPeRuntimePayloadProvisioningService
+    {
+        public List<WinPeRuntimePayloadProvisioningOptions> Options { get; } = [];
+
+        public Task<WinPeResult> ProvisionAsync(
+            WinPeRuntimePayloadProvisioningOptions options,
             CancellationToken cancellationToken = default)
         {
             Options.Add(options);

--- a/src/Foundry.Core.Tests/WinPe/WinPeRuntimePayloadProvisioningOptionsTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeRuntimePayloadProvisioningOptionsTests.cs
@@ -1,0 +1,102 @@
+using Foundry.Core.Services.WinPe;
+
+namespace Foundry.Core.Tests.WinPe;
+
+public sealed class WinPeRuntimePayloadProvisioningOptionsTests
+{
+    [Fact]
+    public void CreateDeveloperOptions_WhenDebuggerAttachedAndProjectsExist_EnablesLocalRuntimes()
+    {
+        using TempProjectRoot root = TempProjectRoot.Create();
+        string connectProjectPath = root.CreateProject("Foundry.Connect");
+        string deployProjectPath = root.CreateProject("Foundry.Deploy");
+
+        WinPeRuntimePayloadProvisioningOptions options = WinPeRuntimePayloadProvisioningOptions.CreateDeveloperOptions(
+            WinPeArchitecture.X64,
+            workingDirectoryPath: Path.Combine(root.RootPath, "work"),
+            mountedImagePath: Path.Combine(root.RootPath, "mount"),
+            usbCacheRootPath: Path.Combine(root.RootPath, "usb"),
+            isDebuggerAttached: true,
+            getEnvironmentVariable: _ => null,
+            projectDiscoveryStartPath: root.RootPath);
+
+        Assert.True(options.Connect.IsEnabled);
+        Assert.True(options.Deploy.IsEnabled);
+        Assert.Equal(connectProjectPath, options.Connect.ProjectPath);
+        Assert.Equal(deployProjectPath, options.Deploy.ProjectPath);
+    }
+
+    [Fact]
+    public void CreateDeveloperOptions_WhenDebuggerIsNotAttached_DoesNotAutoEnableLocalRuntimes()
+    {
+        using TempProjectRoot root = TempProjectRoot.Create();
+        root.CreateProject("Foundry.Connect");
+        root.CreateProject("Foundry.Deploy");
+
+        WinPeRuntimePayloadProvisioningOptions options = WinPeRuntimePayloadProvisioningOptions.CreateDeveloperOptions(
+            WinPeArchitecture.X64,
+            workingDirectoryPath: Path.Combine(root.RootPath, "work"),
+            mountedImagePath: Path.Combine(root.RootPath, "mount"),
+            usbCacheRootPath: Path.Combine(root.RootPath, "usb"),
+            isDebuggerAttached: false,
+            getEnvironmentVariable: _ => null,
+            projectDiscoveryStartPath: root.RootPath);
+
+        Assert.False(options.Connect.IsEnabled);
+        Assert.False(options.Deploy.IsEnabled);
+    }
+
+    [Fact]
+    public void CreateDeveloperOptions_WhenArchiveOverrideIsSet_PrefersArchiveOverProject()
+    {
+        using TempProjectRoot root = TempProjectRoot.Create();
+        root.CreateProject("Foundry.Connect");
+        string archivePath = Path.Combine(root.RootPath, "connect.zip");
+
+        WinPeRuntimePayloadProvisioningOptions options = WinPeRuntimePayloadProvisioningOptions.CreateDeveloperOptions(
+            WinPeArchitecture.X64,
+            workingDirectoryPath: Path.Combine(root.RootPath, "work"),
+            mountedImagePath: Path.Combine(root.RootPath, "mount"),
+            usbCacheRootPath: Path.Combine(root.RootPath, "usb"),
+            isDebuggerAttached: true,
+            getEnvironmentVariable: key => key switch
+            {
+                WinPeRuntimePayloadEnvironmentVariables.LocalConnectArchive => archivePath,
+                _ => null
+            },
+            projectDiscoveryStartPath: root.RootPath);
+
+        Assert.True(options.Connect.IsEnabled);
+        Assert.Equal(archivePath, options.Connect.ArchivePath);
+        Assert.Empty(options.Connect.ProjectPath);
+    }
+
+    private sealed class TempProjectRoot : IDisposable
+    {
+        private TempProjectRoot(string rootPath)
+        {
+            RootPath = rootPath;
+            Directory.CreateDirectory(rootPath);
+        }
+
+        public string RootPath { get; }
+
+        public static TempProjectRoot Create()
+        {
+            return new TempProjectRoot(Path.Combine(Path.GetTempPath(), $"foundry-runtime-options-{Guid.NewGuid():N}"));
+        }
+
+        public string CreateProject(string projectName)
+        {
+            string projectPath = Path.Combine(RootPath, "src", projectName, $"{projectName}.csproj");
+            Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
+            File.WriteAllText(projectPath, "<Project />");
+            return projectPath;
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(RootPath, recursive: true);
+        }
+    }
+}

--- a/src/Foundry.Core.Tests/WinPe/WinPeRuntimePayloadProvisioningServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeRuntimePayloadProvisioningServiceTests.cs
@@ -1,0 +1,239 @@
+using System.IO.Compression;
+using Foundry.Core.Services.WinPe;
+
+namespace Foundry.Core.Tests.WinPe;
+
+public sealed class WinPeRuntimePayloadProvisioningServiceTests
+{
+    [Fact]
+    public async Task ProvisionAsync_WhenLocalArchivesAreProvided_ExtractsToNormalizedIsoAndUsbRuntimeRoots()
+    {
+        using TempRuntimeWorkspace workspace = TempRuntimeWorkspace.Create();
+        string connectArchivePath = workspace.CreateArchive("connect.zip", "Foundry.Connect.exe");
+        string deployArchivePath = workspace.CreateArchive("deploy.zip", "Foundry.Deploy.exe");
+        string legacyConnectSeedPath = Path.Combine(workspace.MountedImagePath, "Foundry", "Seed", "Foundry.Connect.zip");
+        Directory.CreateDirectory(Path.GetDirectoryName(legacyConnectSeedPath)!);
+        File.WriteAllText(legacyConnectSeedPath, "legacy");
+
+        var service = new WinPeRuntimePayloadProvisioningService(new FakeRuntimeProcessRunner());
+
+        WinPeResult result = await service.ProvisionAsync(
+            new WinPeRuntimePayloadProvisioningOptions
+            {
+                Architecture = WinPeArchitecture.X64,
+                WorkingDirectoryPath = workspace.WorkingDirectoryPath,
+                MountedImagePath = workspace.MountedImagePath,
+                UsbCacheRootPath = workspace.UsbCacheRootPath,
+                Connect = new WinPeRuntimePayloadApplicationOptions
+                {
+                    IsEnabled = true,
+                    ArchivePath = connectArchivePath
+                },
+                Deploy = new WinPeRuntimePayloadApplicationOptions
+                {
+                    IsEnabled = true,
+                    ArchivePath = deployArchivePath
+                }
+            },
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Error?.Details);
+        Assert.True(File.Exists(Path.Combine(workspace.MountedImagePath, "Foundry", "Runtime", "Foundry.Connect", "win-x64", "Foundry.Connect.exe")));
+        Assert.True(File.Exists(Path.Combine(workspace.MountedImagePath, "Foundry", "Runtime", "Foundry.Deploy", "win-x64", "Foundry.Deploy.exe")));
+        Assert.True(File.Exists(Path.Combine(workspace.UsbCacheRootPath, "Runtime", "Foundry.Connect", "win-x64", "Foundry.Connect.exe")));
+        Assert.True(File.Exists(Path.Combine(workspace.UsbCacheRootPath, "Runtime", "Foundry.Deploy", "win-x64", "Foundry.Deploy.exe")));
+        Assert.False(File.Exists(Path.Combine(workspace.MountedImagePath, "Foundry", "Seed", "Foundry.Connect.zip")));
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_WhenArchiveAndProjectAreProvided_PrefersArchive()
+    {
+        using TempRuntimeWorkspace workspace = TempRuntimeWorkspace.Create();
+        string connectArchivePath = workspace.CreateArchive("connect.zip", "Foundry.Connect.exe");
+        string projectPath = Path.Combine(workspace.RootPath, "src", "Foundry.Connect", "Foundry.Connect.csproj");
+        Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
+        File.WriteAllText(projectPath, "<Project />");
+        var runner = new FakeRuntimeProcessRunner();
+
+        var service = new WinPeRuntimePayloadProvisioningService(runner);
+
+        WinPeResult result = await service.ProvisionAsync(
+            new WinPeRuntimePayloadProvisioningOptions
+            {
+                Architecture = WinPeArchitecture.X64,
+                WorkingDirectoryPath = workspace.WorkingDirectoryPath,
+                MountedImagePath = workspace.MountedImagePath,
+                Connect = new WinPeRuntimePayloadApplicationOptions
+                {
+                    IsEnabled = true,
+                    ArchivePath = connectArchivePath,
+                    ProjectPath = projectPath
+                }
+            },
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Error?.Details);
+        Assert.Empty(runner.Executions);
+        Assert.True(File.Exists(Path.Combine(workspace.MountedImagePath, "Foundry", "Runtime", "Foundry.Connect", "win-x64", "Foundry.Connect.exe")));
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_WhenProjectIsProvided_PublishesSingleFileBeforeProvisioning()
+    {
+        using TempRuntimeWorkspace workspace = TempRuntimeWorkspace.Create();
+        string projectPath = Path.Combine(workspace.RootPath, "src", "Foundry.Deploy", "Foundry.Deploy.csproj");
+        Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
+        File.WriteAllText(projectPath, "<Project />");
+        var runner = new FakeRuntimeProcessRunner();
+
+        var service = new WinPeRuntimePayloadProvisioningService(runner);
+
+        WinPeResult result = await service.ProvisionAsync(
+            new WinPeRuntimePayloadProvisioningOptions
+            {
+                Architecture = WinPeArchitecture.Arm64,
+                WorkingDirectoryPath = workspace.WorkingDirectoryPath,
+                MountedImagePath = workspace.MountedImagePath,
+                Deploy = new WinPeRuntimePayloadApplicationOptions
+                {
+                    IsEnabled = true,
+                    ProjectPath = projectPath
+                }
+            },
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Error?.Details);
+        WinPeProcessExecution execution = Assert.Single(runner.Executions);
+        Assert.Equal("dotnet", execution.FileName);
+        Assert.Contains("publish", execution.Arguments);
+        Assert.Contains("-r win-arm64", execution.Arguments);
+        Assert.Contains("/p:PublishSingleFile=true", execution.Arguments);
+        Assert.True(File.Exists(Path.Combine(workspace.MountedImagePath, "Foundry", "Runtime", "Foundry.Deploy", "win-arm64", "Foundry.Deploy.exe")));
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_WhenApplicationIsDisabled_DoesNotCreateRuntimeRoot()
+    {
+        using TempRuntimeWorkspace workspace = TempRuntimeWorkspace.Create();
+
+        var service = new WinPeRuntimePayloadProvisioningService(new FakeRuntimeProcessRunner());
+
+        WinPeResult result = await service.ProvisionAsync(
+            new WinPeRuntimePayloadProvisioningOptions
+            {
+                Architecture = WinPeArchitecture.X64,
+                WorkingDirectoryPath = workspace.WorkingDirectoryPath,
+                MountedImagePath = workspace.MountedImagePath,
+                UsbCacheRootPath = workspace.UsbCacheRootPath
+            },
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Error?.Details);
+        Assert.False(Directory.Exists(Path.Combine(workspace.MountedImagePath, "Foundry", "Runtime", "Foundry.Connect")));
+        Assert.False(Directory.Exists(Path.Combine(workspace.UsbCacheRootPath, "Runtime", "Foundry.Deploy")));
+    }
+
+    private sealed class FakeRuntimeProcessRunner : IWinPeProcessRunner
+    {
+        public List<WinPeProcessExecution> Executions { get; } = [];
+
+        public Task<WinPeProcessExecution> RunAsync(
+            string fileName,
+            string arguments,
+            string workingDirectory,
+            CancellationToken cancellationToken,
+            IReadOnlyDictionary<string, string>? environmentOverrides = null)
+        {
+            string outputDirectory = ExtractOutputDirectory(arguments);
+            Directory.CreateDirectory(outputDirectory);
+            string executableName = arguments.Contains("Foundry.Connect.csproj", StringComparison.OrdinalIgnoreCase)
+                ? "Foundry.Connect.exe"
+                : "Foundry.Deploy.exe";
+            File.WriteAllText(Path.Combine(outputDirectory, executableName), executableName);
+
+            var execution = new WinPeProcessExecution
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                WorkingDirectory = workingDirectory
+            };
+
+            Executions.Add(execution);
+            return Task.FromResult(execution);
+        }
+
+        public Task<WinPeProcessExecution> RunCmdScriptAsync(
+            string scriptPath,
+            string scriptArguments,
+            string workingDirectory,
+            CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<WinPeProcessExecution> RunCmdScriptDirectAsync(
+            string scriptPath,
+            string scriptArguments,
+            string workingDirectory,
+            CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        private static string ExtractOutputDirectory(string arguments)
+        {
+            int marker = arguments.IndexOf("-o ", StringComparison.Ordinal);
+            Assert.True(marker >= 0, arguments);
+            string remaining = arguments[(marker + 3)..].Trim();
+            if (remaining.StartsWith('"'))
+            {
+                int endQuote = remaining.IndexOf('"', 1);
+                Assert.True(endQuote > 1, remaining);
+                return remaining[1..endQuote];
+            }
+
+            int nextSpace = remaining.IndexOf(' ', StringComparison.Ordinal);
+            return nextSpace < 0 ? remaining : remaining[..nextSpace];
+        }
+    }
+
+    private sealed class TempRuntimeWorkspace : IDisposable
+    {
+        private TempRuntimeWorkspace(string rootPath)
+        {
+            RootPath = rootPath;
+            WorkingDirectoryPath = Path.Combine(rootPath, "work");
+            MountedImagePath = Path.Combine(rootPath, "mount");
+            UsbCacheRootPath = Path.Combine(rootPath, "usb-cache");
+            Directory.CreateDirectory(WorkingDirectoryPath);
+            Directory.CreateDirectory(MountedImagePath);
+            Directory.CreateDirectory(UsbCacheRootPath);
+        }
+
+        public string RootPath { get; }
+        public string WorkingDirectoryPath { get; }
+        public string MountedImagePath { get; }
+        public string UsbCacheRootPath { get; }
+
+        public static TempRuntimeWorkspace Create()
+        {
+            return new TempRuntimeWorkspace(Path.Combine(Path.GetTempPath(), $"foundry-runtime-{Guid.NewGuid():N}"));
+        }
+
+        public string CreateArchive(string archiveName, string executableName)
+        {
+            string payloadPath = Path.Combine(RootPath, "payloads", Path.GetFileNameWithoutExtension(archiveName));
+            Directory.CreateDirectory(payloadPath);
+            File.WriteAllText(Path.Combine(payloadPath, executableName), executableName);
+
+            string archivePath = Path.Combine(RootPath, archiveName);
+            ZipFile.CreateFromDirectory(payloadPath, archivePath);
+            return archivePath;
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(RootPath, recursive: true);
+        }
+    }
+}

--- a/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
@@ -194,6 +194,37 @@ public sealed class WinPeUsbMediaServiceTests
     }
 
     [Fact]
+    public void CreateUsbRuntimePayloadOptions_ScopesRuntimeToCachePartition()
+    {
+        using TempWorkspace workspace = TempWorkspace.Create();
+        var runtimeOptions = new WinPeRuntimePayloadProvisioningOptions
+        {
+            MountedImagePath = Path.Combine(workspace.RootPath, "mount"),
+            UsbCacheRootPath = Path.Combine(workspace.RootPath, "old-cache"),
+            WorkingDirectoryPath = Path.Combine(workspace.RootPath, "runtime-work"),
+            Connect = new WinPeRuntimePayloadApplicationOptions { IsEnabled = true },
+            Deploy = new WinPeRuntimePayloadApplicationOptions { IsEnabled = true }
+        };
+        var artifact = new WinPeBuildArtifact
+        {
+            WorkingDirectoryPath = Path.Combine(workspace.RootPath, "work"),
+            Architecture = WinPeArchitecture.Arm64
+        };
+        string cacheRoot = Path.Combine(workspace.RootPath, "cache");
+
+        WinPeRuntimePayloadProvisioningOptions result = WinPeUsbMediaService.CreateUsbRuntimePayloadOptions(
+            runtimeOptions,
+            artifact,
+            cacheRoot);
+
+        Assert.Equal(cacheRoot, result.UsbCacheRootPath);
+        Assert.Equal(string.Empty, result.MountedImagePath);
+        Assert.Equal(WinPeArchitecture.Arm64, result.Architecture);
+        Assert.Same(runtimeOptions.Connect, result.Connect);
+        Assert.Same(runtimeOptions.Deploy, result.Deploy);
+    }
+
+    [Fact]
     public void ConfigureBootFiles_WhenBootExBinaryExists_ReplacesArchitectureAndMicrosoftBootManagers()
     {
         using TempWorkspace workspace = TempWorkspace.Create();

--- a/src/Foundry.Core.Tests/WinPe/WinPeWorkspacePreparationServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeWorkspacePreparationServiceTests.cs
@@ -16,6 +16,11 @@ public sealed class WinPeWorkspacePreparationServiceTests
             CurlExecutableSourcePath = Path.Combine(temp.RootPath, "curl.exe"),
             IanaWindowsTimeZoneMapJson = "{}"
         };
+        var runtimePayloadProvisioning = new WinPeRuntimePayloadProvisioningOptions
+        {
+            WorkingDirectoryPath = Path.Combine(temp.RootPath, "runtime-work"),
+            Connect = new WinPeRuntimePayloadApplicationOptions { IsEnabled = true }
+        };
         var service = new WinPeWorkspacePreparationService(
             driverResolution,
             customization,
@@ -33,6 +38,7 @@ public sealed class WinPeWorkspacePreparationServiceTests
                 DriverVendors = [WinPeVendorSelection.Dell],
                 WinPeLanguage = "en-US",
                 AssetProvisioning = assetProvisioning,
+                RuntimePayloadProvisioning = runtimePayloadProvisioning,
                 WinReCacheDirectoryPath = Path.Combine(temp.RootPath, "cache")
             },
             CancellationToken.None);
@@ -42,6 +48,7 @@ public sealed class WinPeWorkspacePreparationServiceTests
         Assert.Single(customization.Options);
         Assert.Equal("drivers", Assert.Single(customization.Options[0].DriverPackagePaths));
         Assert.Same(assetProvisioning, customization.Options[0].AssetProvisioning);
+        Assert.Same(runtimePayloadProvisioning, customization.Options[0].RuntimePayloadProvisioning);
         Assert.False(result.Value!.UseBootEx);
     }
 

--- a/src/Foundry.Core/Assets/WinPe/FoundryBootstrap.ps1
+++ b/src/Foundry.Core/Assets/WinPe/FoundryBootstrap.ps1
@@ -316,10 +316,7 @@ function Get-ApplicationBootstrapRoot {
         [string]$ApplicationName
     )
 
-    switch ($ApplicationName) {
-        'Foundry.Connect' { return Join-Path $BootstrapRoot 'Foundry.Connect' }
-        'Foundry.Deploy' { return $BootstrapRoot }
-    }
+    return Join-Path $BootstrapRoot $ApplicationName
 }
 
 function Get-RuntimeCacheRoot {

--- a/src/Foundry.Core/Services/WinPe/IWinPeRuntimePayloadProvisioningService.cs
+++ b/src/Foundry.Core/Services/WinPe/IWinPeRuntimePayloadProvisioningService.cs
@@ -1,0 +1,8 @@
+namespace Foundry.Core.Services.WinPe;
+
+public interface IWinPeRuntimePayloadProvisioningService
+{
+    Task<WinPeResult> ProvisionAsync(
+        WinPeRuntimePayloadProvisioningOptions options,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Foundry.Core/Services/WinPe/UsbOutputOptions.cs
+++ b/src/Foundry.Core/Services/WinPe/UsbOutputOptions.cs
@@ -24,5 +24,6 @@ public sealed record UsbOutputOptions
     public IReadOnlyList<FoundryConnectProvisionedAssetFile> FoundryConnectAssetFiles { get; init; } = [];
     public string? ExpertDeployConfigurationJson { get; init; }
     public IReadOnlyList<AutopilotProfileSettings> AutopilotProfiles { get; init; } = [];
+    public WinPeRuntimePayloadProvisioningOptions? RuntimePayloadProvisioning { get; init; }
     public bool PreserveBuildWorkspace { get; init; }
 }

--- a/src/Foundry.Core/Services/WinPe/WinPeMountedImageCustomizationOptions.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountedImageCustomizationOptions.cs
@@ -8,6 +8,7 @@ public sealed record WinPeMountedImageCustomizationOptions
     public string WinPeLanguage { get; init; } = string.Empty;
     public IReadOnlyList<string> DriverPackagePaths { get; init; } = [];
     public WinPeMountedImageAssetProvisioningOptions? AssetProvisioning { get; init; }
+    public WinPeRuntimePayloadProvisioningOptions? RuntimePayloadProvisioning { get; init; }
     public string WinReCacheDirectoryPath { get; init; } = string.Empty;
     public Uri? WinReCatalogUri { get; init; }
     public IProgress<WinPeMountedImageCustomizationProgress>? Progress { get; init; }

--- a/src/Foundry.Core/Services/WinPe/WinPeMountedImageCustomizationService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountedImageCustomizationService.cs
@@ -6,6 +6,7 @@ public sealed class WinPeMountedImageCustomizationService : IWinPeMountedImageCu
     private readonly IWinPeDriverInjectionService _driverInjectionService;
     private readonly IWinPeImageInternationalizationService _imageInternationalizationService;
     private readonly IWinPeMountedImageAssetProvisioningService _assetProvisioningService;
+    private readonly IWinPeRuntimePayloadProvisioningService _runtimePayloadProvisioningService;
     private readonly IWinReBootImagePreparationService _winReBootImagePreparationService;
 
     public WinPeMountedImageCustomizationService()
@@ -14,6 +15,7 @@ public sealed class WinPeMountedImageCustomizationService : IWinPeMountedImageCu
             new WinPeDriverInjectionService(),
             new WinPeImageInternationalizationService(),
             new WinPeMountedImageAssetProvisioningService(),
+            new WinPeRuntimePayloadProvisioningService(),
             new WinReBootImagePreparationService())
     {
     }
@@ -23,12 +25,14 @@ public sealed class WinPeMountedImageCustomizationService : IWinPeMountedImageCu
         IWinPeDriverInjectionService driverInjectionService,
         IWinPeImageInternationalizationService imageInternationalizationService,
         IWinPeMountedImageAssetProvisioningService assetProvisioningService,
+        IWinPeRuntimePayloadProvisioningService runtimePayloadProvisioningService,
         IWinReBootImagePreparationService winReBootImagePreparationService)
     {
         _processRunner = processRunner;
         _driverInjectionService = driverInjectionService;
         _imageInternationalizationService = imageInternationalizationService;
         _assetProvisioningService = assetProvisioningService;
+        _runtimePayloadProvisioningService = runtimePayloadProvisioningService;
         _winReBootImagePreparationService = winReBootImagePreparationService;
     }
 
@@ -151,6 +155,23 @@ public sealed class WinPeMountedImageCustomizationService : IWinPeMountedImageCu
             if (!assetProvisioningResult.IsSuccess)
             {
                 return await FailWithDiscardAsync(assetProvisioningResult.Error!, session, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        if (options.RuntimePayloadProvisioning is not null)
+        {
+            ReportProgress(options.Progress, 85, "Provisioning Foundry runtime payloads.");
+            WinPeResult runtimePayloadResult = await _runtimePayloadProvisioningService.ProvisionAsync(
+                options.RuntimePayloadProvisioning with
+                {
+                    MountedImagePath = session.MountDirectoryPath,
+                    Architecture = artifact.Architecture
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            if (!runtimePayloadResult.IsSuccess)
+            {
+                return await FailWithDiscardAsync(runtimePayloadResult.Error!, session, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/Foundry.Core/Services/WinPe/WinPeRuntimePayloadApplicationOptions.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeRuntimePayloadApplicationOptions.cs
@@ -1,0 +1,8 @@
+namespace Foundry.Core.Services.WinPe;
+
+public sealed record WinPeRuntimePayloadApplicationOptions
+{
+    public bool IsEnabled { get; init; }
+    public string ArchivePath { get; init; } = string.Empty;
+    public string ProjectPath { get; init; } = string.Empty;
+}

--- a/src/Foundry.Core/Services/WinPe/WinPeRuntimePayloadEnvironmentVariables.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeRuntimePayloadEnvironmentVariables.cs
@@ -1,0 +1,11 @@
+namespace Foundry.Core.Services.WinPe;
+
+public static class WinPeRuntimePayloadEnvironmentVariables
+{
+    public const string LocalConnectEnable = "FOUNDRY_WINPE_LOCAL_CONNECT";
+    public const string LocalConnectArchive = "FOUNDRY_WINPE_LOCAL_CONNECT_ARCHIVE";
+    public const string LocalConnectProject = "FOUNDRY_WINPE_LOCAL_CONNECT_PROJECT";
+    public const string LocalDeployEnable = "FOUNDRY_WINPE_LOCAL_DEPLOY";
+    public const string LocalDeployArchive = "FOUNDRY_WINPE_LOCAL_DEPLOY_ARCHIVE";
+    public const string LocalDeployProject = "FOUNDRY_WINPE_LOCAL_DEPLOY_PROJECT";
+}

--- a/src/Foundry.Core/Services/WinPe/WinPeRuntimePayloadProvisioningOptions.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeRuntimePayloadProvisioningOptions.cs
@@ -1,0 +1,132 @@
+namespace Foundry.Core.Services.WinPe;
+
+public sealed record WinPeRuntimePayloadProvisioningOptions
+{
+    public WinPeArchitecture Architecture { get; init; } = WinPeArchitecture.X64;
+    public string WorkingDirectoryPath { get; init; } = string.Empty;
+    public string MountedImagePath { get; init; } = string.Empty;
+    public string UsbCacheRootPath { get; init; } = string.Empty;
+    public WinPeRuntimePayloadApplicationOptions Connect { get; init; } = new();
+    public WinPeRuntimePayloadApplicationOptions Deploy { get; init; } = new();
+
+    public static WinPeRuntimePayloadProvisioningOptions CreateDeveloperOptions(
+        WinPeArchitecture architecture,
+        string workingDirectoryPath,
+        string mountedImagePath,
+        string usbCacheRootPath,
+        bool isDebuggerAttached,
+        Func<string, string?>? getEnvironmentVariable = null,
+        string? projectDiscoveryStartPath = null)
+    {
+        getEnvironmentVariable ??= Environment.GetEnvironmentVariable;
+
+        return new WinPeRuntimePayloadProvisioningOptions
+        {
+            Architecture = architecture,
+            WorkingDirectoryPath = workingDirectoryPath,
+            MountedImagePath = mountedImagePath,
+            UsbCacheRootPath = usbCacheRootPath,
+            Connect = CreateApplicationOptions(
+                "Foundry.Connect",
+                WinPeRuntimePayloadEnvironmentVariables.LocalConnectEnable,
+                WinPeRuntimePayloadEnvironmentVariables.LocalConnectArchive,
+                WinPeRuntimePayloadEnvironmentVariables.LocalConnectProject,
+                isDebuggerAttached,
+                getEnvironmentVariable,
+                projectDiscoveryStartPath),
+            Deploy = CreateApplicationOptions(
+                "Foundry.Deploy",
+                WinPeRuntimePayloadEnvironmentVariables.LocalDeployEnable,
+                WinPeRuntimePayloadEnvironmentVariables.LocalDeployArchive,
+                WinPeRuntimePayloadEnvironmentVariables.LocalDeployProject,
+                isDebuggerAttached,
+                getEnvironmentVariable,
+                projectDiscoveryStartPath)
+        };
+    }
+
+    private static WinPeRuntimePayloadApplicationOptions CreateApplicationOptions(
+        string applicationName,
+        string enableVariableName,
+        string archiveVariableName,
+        string projectVariableName,
+        bool isDebuggerAttached,
+        Func<string, string?> getEnvironmentVariable,
+        string? projectDiscoveryStartPath)
+    {
+        string archivePath = (getEnvironmentVariable(archiveVariableName) ?? string.Empty).Trim();
+        if (!string.IsNullOrWhiteSpace(archivePath))
+        {
+            return new WinPeRuntimePayloadApplicationOptions
+            {
+                IsEnabled = true,
+                ArchivePath = archivePath
+            };
+        }
+
+        string projectPath = (getEnvironmentVariable(projectVariableName) ?? string.Empty).Trim();
+        if (string.IsNullOrWhiteSpace(projectPath))
+        {
+            projectPath = TryFindProjectPath(applicationName, projectDiscoveryStartPath, out string discoveredProjectPath)
+                ? discoveredProjectPath
+                : string.Empty;
+        }
+
+        bool isExplicitlyEnabled = IsEnabledEnvironmentFlag(getEnvironmentVariable(enableVariableName));
+        bool shouldAutoEnable = isDebuggerAttached && !string.IsNullOrWhiteSpace(projectPath);
+
+        return new WinPeRuntimePayloadApplicationOptions
+        {
+            IsEnabled = isExplicitlyEnabled || shouldAutoEnable,
+            ProjectPath = projectPath
+        };
+    }
+
+    private static bool TryFindProjectPath(
+        string applicationName,
+        string? projectDiscoveryStartPath,
+        out string projectPath)
+    {
+        if (string.IsNullOrWhiteSpace(projectDiscoveryStartPath))
+        {
+            projectPath = string.Empty;
+            return false;
+        }
+
+        var current = new DirectoryInfo(projectDiscoveryStartPath);
+        while (current is not null)
+        {
+            string candidate = Path.Combine(current.FullName, "src", applicationName, $"{applicationName}.csproj");
+            if (File.Exists(candidate))
+            {
+                projectPath = candidate;
+                return true;
+            }
+
+            current = current.Parent;
+        }
+
+        projectPath = string.Empty;
+        return false;
+    }
+
+    private static bool IsEnabledEnvironmentFlag(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        return value.Trim() switch
+        {
+            "1" => true,
+            "true" => true,
+            "TRUE" => true,
+            "yes" => true,
+            "YES" => true,
+            "on" => true,
+            "ON" => true,
+            _ => false
+        };
+    }
+}

--- a/src/Foundry.Core/Services/WinPe/WinPeRuntimePayloadProvisioningService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeRuntimePayloadProvisioningService.cs
@@ -1,0 +1,332 @@
+using System.IO.Compression;
+
+namespace Foundry.Core.Services.WinPe;
+
+public sealed class WinPeRuntimePayloadProvisioningService : IWinPeRuntimePayloadProvisioningService
+{
+    private readonly IWinPeProcessRunner _processRunner;
+
+    public WinPeRuntimePayloadProvisioningService()
+        : this(new WinPeProcessRunner())
+    {
+    }
+
+    internal WinPeRuntimePayloadProvisioningService(IWinPeProcessRunner processRunner)
+    {
+        _processRunner = processRunner;
+    }
+
+    public async Task<WinPeResult> ProvisionAsync(
+        WinPeRuntimePayloadProvisioningOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        WinPeDiagnostic? validationError = ValidateOptions(options);
+        if (validationError is not null)
+        {
+            return WinPeResult.Failure(validationError);
+        }
+
+        try
+        {
+            string runtimeIdentifier = options.Architecture.ToDotnetRuntimeIdentifier();
+
+            await ProvisionApplicationAsync(
+                "Foundry.Connect",
+                options.Connect,
+                options,
+                runtimeIdentifier,
+                cancellationToken).ConfigureAwait(false);
+
+            await ProvisionApplicationAsync(
+                "Foundry.Deploy",
+                options.Deploy,
+                options,
+                runtimeIdentifier,
+                cancellationToken).ConfigureAwait(false);
+
+            return WinPeResult.Success();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException or InvalidOperationException)
+        {
+            return WinPeResult.Failure(
+                WinPeErrorCodes.BuildFailed,
+                "Failed to provision Foundry runtime payloads.",
+                ex.Message);
+        }
+    }
+
+    private async Task ProvisionApplicationAsync(
+        string applicationName,
+        WinPeRuntimePayloadApplicationOptions applicationOptions,
+        WinPeRuntimePayloadProvisioningOptions options,
+        string runtimeIdentifier,
+        CancellationToken cancellationToken)
+    {
+        if (!applicationOptions.IsEnabled)
+        {
+            return;
+        }
+
+        string archivePath = await ResolveArchivePathAsync(
+            applicationName,
+            applicationOptions,
+            options.WorkingDirectoryPath,
+            runtimeIdentifier,
+            cancellationToken).ConfigureAwait(false);
+
+        string extractionRoot = Path.Combine(
+            options.WorkingDirectoryPath,
+            "RuntimePayloads",
+            applicationName,
+            runtimeIdentifier);
+
+        try
+        {
+            WinPeFileSystemHelper.EnsureDirectoryClean(extractionRoot);
+            ZipFile.ExtractToDirectory(archivePath, extractionRoot);
+            string executablePath = Path.Combine(extractionRoot, $"{applicationName}.exe");
+            if (!File.Exists(executablePath))
+            {
+                throw new InvalidOperationException(
+                    $"{applicationName} archive did not contain the expected executable '{applicationName}.exe'.");
+            }
+
+            foreach (string destinationRoot in ResolveDestinationRoots(applicationName, options, runtimeIdentifier))
+            {
+                CopyDirectory(extractionRoot, destinationRoot);
+            }
+
+            RemoveLegacyConnectSeed(applicationName, options);
+        }
+        finally
+        {
+            TryDeleteDirectory(extractionRoot);
+        }
+    }
+
+    private async Task<string> ResolveArchivePathAsync(
+        string applicationName,
+        WinPeRuntimePayloadApplicationOptions options,
+        string workingDirectoryPath,
+        string runtimeIdentifier,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(options.ArchivePath))
+        {
+            string archivePath = Path.GetFullPath(options.ArchivePath);
+            if (!File.Exists(archivePath))
+            {
+                throw new FileNotFoundException($"{applicationName} archive was not found.", archivePath);
+            }
+
+            return archivePath;
+        }
+
+        if (string.IsNullOrWhiteSpace(options.ProjectPath))
+        {
+            throw new ArgumentException($"{applicationName} project path or archive path is required when local runtime provisioning is enabled.");
+        }
+
+        string projectPath = Path.GetFullPath(options.ProjectPath);
+        if (!File.Exists(projectPath))
+        {
+            throw new FileNotFoundException($"{applicationName} project file was not found.", projectPath);
+        }
+
+        return await PublishProjectArchiveAsync(
+            applicationName,
+            projectPath,
+            workingDirectoryPath,
+            runtimeIdentifier,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<string> PublishProjectArchiveAsync(
+        string applicationName,
+        string projectPath,
+        string workingDirectoryPath,
+        string runtimeIdentifier,
+        CancellationToken cancellationToken)
+    {
+        string localWorkspace = Path.Combine(workingDirectoryPath, "LocalRuntime", applicationName);
+        string publishDirectory = Path.Combine(localWorkspace, "publish", runtimeIdentifier);
+        string archivePath = Path.Combine(localWorkspace, $"{applicationName}-{runtimeIdentifier}.zip");
+
+        WinPeFileSystemHelper.EnsureDirectoryClean(publishDirectory);
+        Directory.CreateDirectory(localWorkspace);
+        if (File.Exists(archivePath))
+        {
+            File.Delete(archivePath);
+        }
+
+        string publishArguments = string.Join(
+            " ",
+            "publish",
+            WinPeProcessRunner.Quote(projectPath),
+            "-c", "Release",
+            "-r", runtimeIdentifier,
+            "--self-contained", "true",
+            "/p:PublishSingleFile=true",
+            "/p:EnableCompressionInSingleFile=true",
+            "/p:IncludeNativeLibrariesForSelfExtract=true",
+            "/p:IncludeAllContentForSelfExtract=true",
+            "/p:DebugType=None",
+            "/p:GenerateDocumentationFile=false",
+            "-o", WinPeProcessRunner.Quote(publishDirectory));
+
+        WinPeProcessExecution publish = await _processRunner.RunAsync(
+            "dotnet",
+            publishArguments,
+            workingDirectoryPath,
+            cancellationToken).ConfigureAwait(false);
+
+        if (!publish.IsSuccess)
+        {
+            throw new InvalidOperationException(publish.ToDiagnosticText());
+        }
+
+        string executablePath = Path.Combine(publishDirectory, $"{applicationName}.exe");
+        if (!File.Exists(executablePath))
+        {
+            throw new InvalidOperationException(
+                $"{applicationName} publish output did not contain the expected executable '{executablePath}'.");
+        }
+
+        ZipFile.CreateFromDirectory(publishDirectory, archivePath, CompressionLevel.Optimal, includeBaseDirectory: false);
+        return archivePath;
+    }
+
+    private static IEnumerable<string> ResolveDestinationRoots(
+        string applicationName,
+        WinPeRuntimePayloadProvisioningOptions options,
+        string runtimeIdentifier)
+    {
+        if (!string.IsNullOrWhiteSpace(options.MountedImagePath))
+        {
+            yield return Path.Combine(
+                Path.GetFullPath(options.MountedImagePath),
+                "Foundry",
+                "Runtime",
+                applicationName,
+                runtimeIdentifier);
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.UsbCacheRootPath))
+        {
+            yield return Path.Combine(
+                Path.GetFullPath(options.UsbCacheRootPath),
+                "Runtime",
+                applicationName,
+                runtimeIdentifier);
+        }
+    }
+
+    private static void RemoveLegacyConnectSeed(
+        string applicationName,
+        WinPeRuntimePayloadProvisioningOptions options)
+    {
+        if (!applicationName.Equals("Foundry.Connect", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        foreach (string root in new[] { options.MountedImagePath, options.UsbCacheRootPath })
+        {
+            if (string.IsNullOrWhiteSpace(root))
+            {
+                continue;
+            }
+
+            TryDeleteFile(Path.Combine(root, "Foundry", "Seed", "Foundry.Connect.zip"));
+        }
+    }
+
+    private static void CopyDirectory(string sourceDirectoryPath, string destinationDirectoryPath)
+    {
+        WinPeFileSystemHelper.EnsureDirectoryClean(destinationDirectoryPath);
+
+        foreach (string directoryPath in Directory.EnumerateDirectories(sourceDirectoryPath, "*", SearchOption.AllDirectories))
+        {
+            string relativeDirectoryPath = Path.GetRelativePath(sourceDirectoryPath, directoryPath);
+            Directory.CreateDirectory(Path.Combine(destinationDirectoryPath, relativeDirectoryPath));
+        }
+
+        foreach (string filePath in Directory.EnumerateFiles(sourceDirectoryPath, "*", SearchOption.AllDirectories))
+        {
+            string relativeFilePath = Path.GetRelativePath(sourceDirectoryPath, filePath);
+            string destinationFilePath = Path.Combine(destinationDirectoryPath, relativeFilePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationFilePath)!);
+            File.Copy(filePath, destinationFilePath, overwrite: true);
+        }
+    }
+
+    private static WinPeDiagnostic? ValidateOptions(WinPeRuntimePayloadProvisioningOptions? options)
+    {
+        if (options is null)
+        {
+            return new WinPeDiagnostic(
+                WinPeErrorCodes.ValidationFailed,
+                "Runtime payload provisioning options are required.",
+                "Provide a non-null WinPeRuntimePayloadProvisioningOptions instance.");
+        }
+
+        if (!Enum.IsDefined(options.Architecture))
+        {
+            return new WinPeDiagnostic(
+                WinPeErrorCodes.ValidationFailed,
+                "WinPE architecture value is invalid.",
+                $"Value: '{options.Architecture}'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.WorkingDirectoryPath))
+        {
+            return new WinPeDiagnostic(
+                WinPeErrorCodes.ValidationFailed,
+                "Runtime payload working directory is required.",
+                "Set WinPeRuntimePayloadProvisioningOptions.WorkingDirectoryPath.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.MountedImagePath) &&
+            string.IsNullOrWhiteSpace(options.UsbCacheRootPath))
+        {
+            return new WinPeDiagnostic(
+                WinPeErrorCodes.ValidationFailed,
+                "At least one runtime payload destination is required.",
+                "Set MountedImagePath, UsbCacheRootPath, or both.");
+        }
+
+        return null;
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+}

--- a/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
@@ -6,15 +6,24 @@ namespace Foundry.Core.Services.WinPe;
 public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
 {
     private readonly IWinPeProcessRunner _processRunner;
+    private readonly IWinPeRuntimePayloadProvisioningService _runtimePayloadProvisioningService;
 
     public WinPeUsbMediaService()
-        : this(new WinPeProcessRunner())
+        : this(new WinPeProcessRunner(), new WinPeRuntimePayloadProvisioningService())
     {
     }
 
     internal WinPeUsbMediaService(IWinPeProcessRunner processRunner)
+        : this(processRunner, new WinPeRuntimePayloadProvisioningService(processRunner))
+    {
+    }
+
+    internal WinPeUsbMediaService(
+        IWinPeProcessRunner processRunner,
+        IWinPeRuntimePayloadProvisioningService runtimePayloadProvisioningService)
     {
         _processRunner = processRunner;
+        _runtimePayloadProvisioningService = runtimePayloadProvisioningService;
     }
 
     public async Task<WinPeResult<IReadOnlyList<WinPeUsbDiskCandidate>>> GetUsbCandidatesAsync(
@@ -211,6 +220,18 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
 
         InitializeCachePartitionDirectories(cacheRootPath);
 
+        if (options.RuntimePayloadProvisioning is not null)
+        {
+            WinPeResult runtimePayloadResult = await _runtimePayloadProvisioningService.ProvisionAsync(
+                CreateUsbRuntimePayloadOptions(options.RuntimePayloadProvisioning, artifact, cacheRootPath),
+                cancellationToken).ConfigureAwait(false);
+
+            if (!runtimePayloadResult.IsSuccess)
+            {
+                return WinPeResult<WinPeUsbProvisionResult>.Failure(runtimePayloadResult.Error!);
+            }
+        }
+
         return WinPeResult<WinPeUsbProvisionResult>.Success(new WinPeUsbProvisionResult
         {
             BootDriveLetter = $"{bootDriveLetter}:",
@@ -335,6 +356,22 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
         Directory.CreateDirectory(Path.Combine(cacheRootPath, "Cache", "Firmware"));
         Directory.CreateDirectory(Path.Combine(cacheRootPath, "State"));
         Directory.CreateDirectory(Path.Combine(cacheRootPath, "Temp"));
+    }
+
+    internal static WinPeRuntimePayloadProvisioningOptions CreateUsbRuntimePayloadOptions(
+        WinPeRuntimePayloadProvisioningOptions options,
+        WinPeBuildArtifact artifact,
+        string cacheRootPath)
+    {
+        return options with
+        {
+            MountedImagePath = string.Empty,
+            UsbCacheRootPath = cacheRootPath,
+            WorkingDirectoryPath = string.IsNullOrWhiteSpace(options.WorkingDirectoryPath)
+                ? artifact.WorkingDirectoryPath
+                : options.WorkingDirectoryPath,
+            Architecture = artifact.Architecture
+        };
     }
 
     internal static WinPeResult ConfigureBootFiles(

--- a/src/Foundry.Core/Services/WinPe/WinPeWorkspacePreparationOptions.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeWorkspacePreparationOptions.cs
@@ -11,6 +11,7 @@ public sealed record WinPeWorkspacePreparationOptions
     public string? CustomDriverDirectoryPath { get; init; }
     public string WinPeLanguage { get; init; } = string.Empty;
     public WinPeMountedImageAssetProvisioningOptions? AssetProvisioning { get; init; }
+    public WinPeRuntimePayloadProvisioningOptions? RuntimePayloadProvisioning { get; init; }
     public string WinReCacheDirectoryPath { get; init; } = string.Empty;
     public Uri? WinReCatalogUri { get; init; }
     public IProgress<WinPeWorkspacePreparationStage>? Progress { get; init; }

--- a/src/Foundry.Core/Services/WinPe/WinPeWorkspacePreparationService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeWorkspacePreparationService.cs
@@ -71,6 +71,7 @@ public sealed class WinPeWorkspacePreparationService : IWinPeWorkspacePreparatio
                 WinPeLanguage = options.WinPeLanguage,
                 DriverPackagePaths = drivers.Value!,
                 AssetProvisioning = options.AssetProvisioning,
+                RuntimePayloadProvisioning = options.RuntimePayloadProvisioning,
                 WinReCacheDirectoryPath = options.WinReCacheDirectoryPath,
                 WinReCatalogUri = options.WinReCatalogUri,
                 Progress = options.CustomizationProgress


### PR DESCRIPTION
## Summary
- Normalize Connect and Deploy WinPE runtime payloads under a shared runtime layout.
- Add runtime payload provisioning services and tests for ISO and USB media paths.
- Preserve local/debug runtime source overrides while removing asymmetric bootstrap paths.

## Reason
Phase 12.C needs a consistent runtime payload layout before media folder/ISO/USB layout work continues.

## Main changes
- Added runtime payload provisioning options, environment handling, and provisioning service.
- Wired runtime provisioning into mounted image customization and USB media cache flows.
- Updated bootstrap resolution to use Runtime/<Application>/<rid> for both Connect and Deploy.

## Testing
- dotnet test .\src\Foundry.Core.Tests\Foundry.Core.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~WinPe" -v minimal
- dotnet test .\src\Foundry.Core.Tests\Foundry.Core.Tests.csproj -c Release --nologo -v minimal
- dotnet build .\src\Foundry.slnx -c Release --nologo
- dotnet test .\src\Foundry.slnx -c Release --nologo --no-build -v minimal