### PR TITLE
feat(winpe): apply programdata media layout

### DIFF
--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -15,7 +15,7 @@ The `12.A` to `12.D` labels are implementation slices, not extra phase numbers. 
 - [x] `12.A` owns user-visible ADK readiness and navigation gating.
 - [x] `12.B` owns pure WinPE service foundations that can be tested without final UI commands.
 - [x] `12.C` owns Connect/Deploy runtime payload layout and bootstrap resolution.
-- [ ] `12.D` owns final host/media filesystem layout enforcement after services and runtime paths are stable.
+- [x] `12.D` owns final host/media filesystem layout enforcement after services and runtime paths are stable.
 
 - [x] **12.A** `feat(adk): add adk status and page integration`.
   - [x] Scope: ADK/WinPE Add-on detection, installed version, compatibility policy, ADK page state/actions, ADK operation progress, ADK install/upgrade overlay entry points, and shell guard readiness.
@@ -38,28 +38,28 @@ The `12.A` to `12.D` labels are implementation slices, not extra phase numbers. 
 
 - [x] Complete Phase 6 readiness item **6.8.1** for ADK detection, WinPE Add-on readiness, and ADK-gated startup readiness.
 - [ ] Complete Phase 6 readiness item **6.8.1** for USB target service readiness after ADK compatibility is known; keep the final `Start` page refresh command wiring in Phase 13.
-- [ ] Complete Phase 10 logging contract item **10.6.1** for ADK detection and bootstrap payload resolution logs.
+- [x] Complete Phase 10 logging contract item **10.6.1** for ADK detection and bootstrap payload resolution logs.
 
 **WPF reference scenario audit:** before implementing each Phase 12 slice, compare the new WinUI/Core behavior against the archived WPF reference without modifying it:
 
-- [ ] Local Debug scenario:
-  - [ ] Preserve Visual Studio/debugger local Connect and Deploy publishing behavior.
-  - [ ] Preserve local archive overrides before local project publish.
-  - [ ] Preserve local project auto-discovery behavior where practical.
-- [ ] Release scenario:
-  - [ ] Preserve release asset resolution for Connect and Deploy.
-  - [ ] Preserve runtime download fallback from the WinPE bootstrap where applicable.
-  - [ ] Preserve SHA256 override checks for runtime archives when provided.
-- [ ] Media scenario:
-  - [ ] Preserve ISO behavior where required runtime/configuration lives inside `X:\Foundry`.
-  - [ ] Preserve USB behavior where persistent runtime/cache data lives on the `Foundry Cache` partition.
-  - [ ] Preserve source marker behavior for local versus release-provisioned payloads.
-  - [ ] Preserve MakeWinPEMedia non-ASCII path handling by using an ASCII-safe temporary workspace/output path when required and copying the result back to the requested destination.
-  - [ ] Preserve PCA2023 `/bootex` capability probing, unsupported-path failure behavior, ISO `/bootex` argument usage, and USB EFI boot file rewriting.
-  - [ ] Preserve USB disk safety checks: USB bus, removable media, non-system disk, non-boot disk, and selected disk identity revalidation before formatting.
-  - [ ] Preserve USB copy/provision verification for `sources\boot.wim`, `boot\BCD`, architecture-specific EFI boot files, and accepted `robocopy` exit codes.
-  - [ ] Preserve idempotent WinPE auto-start wiring by ensuring `startnet.cmd` runs `wpeinit` and invokes `FoundryBootstrap.ps1` exactly once.
-  - [ ] Preserve `curl.exe` provisioning into WinPE `System32` for bootstrap download preference/fallback behavior.
+- [x] Local Debug scenario:
+  - [x] Preserve Visual Studio/debugger local Connect and Deploy publishing behavior.
+  - [x] Preserve local archive overrides before local project publish.
+  - [x] Preserve local project auto-discovery behavior where practical.
+- [x] Release scenario:
+  - [x] Preserve release asset resolution for Connect and Deploy.
+  - [x] Preserve runtime download fallback from the WinPE bootstrap where applicable.
+  - [x] Preserve SHA256 override checks for runtime archives when provided.
+- [x] Media scenario:
+  - [x] Preserve ISO behavior where required runtime/configuration lives inside `X:\Foundry`.
+  - [x] Preserve USB behavior where persistent runtime/cache data lives on the `Foundry Cache` partition.
+  - [x] Preserve source marker behavior for local versus release-provisioned payloads.
+  - [x] Preserve MakeWinPEMedia non-ASCII path handling by using an ASCII-safe temporary workspace/output path when required and copying the result back to the requested destination.
+  - [x] Preserve PCA2023 `/bootex` capability probing, unsupported-path failure behavior, ISO `/bootex` argument usage, and USB EFI boot file rewriting.
+  - [x] Preserve USB disk safety checks: USB bus, removable media, non-system disk, non-boot disk, and selected disk identity revalidation before formatting.
+  - [x] Preserve USB copy/provision verification for `sources\boot.wim`, `boot\BCD`, architecture-specific EFI boot files, and accepted `robocopy` exit codes.
+  - [x] Preserve idempotent WinPE auto-start wiring by ensuring `startnet.cmd` runs `wpeinit` and invokes `FoundryBootstrap.ps1` exactly once.
+  - [x] Preserve `curl.exe` provisioning into WinPE `System32` for bootstrap download preference/fallback behavior.
 - [x] Boot image source scenario:
   - [x] Preserve standard `WinPe` boot image creation through ADK workspace tooling.
   - [x] Preserve `WinReWifi` behavior for Wi-Fi-capable WinRE boot image preparation.
@@ -155,33 +155,33 @@ The `12.A` to `12.D` labels are implementation slices, not extra phase numbers. 
   - [x] Start `WlanSvc` only when WinRE Wi-Fi dependencies are present.
   - [x] Sync internet date/time non-fatally when network probes succeed and clock drift exceeds the configured threshold.
   - [x] Apply timezone from generated configuration or fallback sources without blocking boot when lookup fails.
-- [ ] **12.5** Preserve local debug environment variables:
-  - [ ] Local Connect enable variable.
-  - [ ] Local Connect project path variable.
-  - [ ] Local Connect archive override variable.
-  - [ ] Local Deploy enable variable.
-  - [ ] Local Deploy project path variable.
-  - [ ] Local Deploy archive override variable.
-  - [ ] Auto-enable local Connect/Deploy only for debugger-attached developer runs, not for installed production runs.
-  - [ ] Prefer explicit local archive override over local project publish.
-  - [ ] Fall back to local project publish when no archive override is supplied.
-  - [ ] Preserve self-contained single-file local publish output for each selected RID.
-- [ ] **12.6** Audit and document the filesystem layout contracts before porting the services:
-  - [ ] Host authoring data: `C:\ProgramData\Foundry`.
-  - [ ] New build workspace root.
-  - [ ] New installer/cache root.
-  - [ ] New temporary workspace root.
-  - [ ] New host-side log root: `C:\ProgramData\Foundry\Logs`.
-  - [ ] Boot image runtime: `X:\Foundry`.
-  - [ ] USB boot partition.
-  - [ ] USB cache partition labeled `Foundry Cache`.
-  - [ ] Media secret key path: `X:\Foundry\Config\Secrets\media-secrets.key`.
-  - [ ] Target Windows temporary deployment root.
-- [ ] **12.7** Rename or wrap ambiguous path concepts in `Foundry.Core`:
-  - [ ] Distinguish `RuntimeRoot` from `CacheRoot`.
-  - [ ] Distinguish host build workspace from WinPE runtime workspace.
+- [x] **12.5** Preserve local debug environment variables:
+  - [x] Local Connect enable variable.
+  - [x] Local Connect project path variable.
+  - [x] Local Connect archive override variable.
+  - [x] Local Deploy enable variable.
+  - [x] Local Deploy project path variable.
+  - [x] Local Deploy archive override variable.
+  - [x] Auto-enable local Connect/Deploy only for debugger-attached developer runs, not for installed production runs.
+  - [x] Prefer explicit local archive override over local project publish.
+  - [x] Fall back to local project publish when no archive override is supplied.
+  - [x] Preserve self-contained single-file local publish output for each selected RID.
+- [x] **12.6** Audit and document the filesystem layout contracts before porting the services:
+  - [x] Host authoring data: `C:\ProgramData\Foundry`.
+  - [x] New build workspace root.
+  - [x] New installer/cache root.
+  - [x] New temporary workspace root.
+  - [x] New host-side log root: `C:\ProgramData\Foundry\Logs`.
+  - [x] Boot image runtime: `X:\Foundry`.
+  - [x] USB boot partition.
+  - [x] USB cache partition labeled `Foundry Cache`.
+  - [x] Media secret key path: `X:\Foundry\Config\Secrets\media-secrets.key`.
+  - [x] Target Windows temporary deployment root.
+- [x] **12.7** Rename or wrap ambiguous path concepts in `Foundry.Core`:
+  - [x] Distinguish `RuntimeRoot` from `CacheRoot`.
+  - [x] Distinguish host build workspace from WinPE runtime workspace.
   - [x] Distinguish ISO transient runtime from USB persistent cache for Connect/Deploy runtime payload provisioning.
-- [ ] **12.8** Reassess the current `CacheRootPath` behavior where a path ending in `Runtime` writes `OperatingSystem` and `DriverPack` to its parent.
+- [x] **12.8** Reassess the current `CacheRootPath` behavior where a path ending in `Runtime` writes `OperatingSystem` and `DriverPack` to its parent.
 - [x] **12.9** Normalize the Connect and Deploy runtime cache layout immediately:
   - [x] Use one application-root convention: `Runtime\<ApplicationName>\<rid>`.
   - [x] Store Connect at `Runtime\Foundry.Connect\<rid>`.
@@ -284,7 +284,7 @@ git commit -m "feat(winpe): apply programdata media layout"
 - [x] **12.28** ADK upgrade overlay blocks navigation until completion.
 - [x] **12.29** ADK-compatible state unlocks `General`, `Start`, and `Expert` pages.
 - [x] **12.30** PCA2023 media validation covers both supported and unsupported `/bootex` paths.
-- [x] **12.31** Non-ASCII ISO output path validation confirms the temporary ASCII-safe workaround produces the requested final ISO.
+- [x] **12.31** Non-ASCII ISO workspace/output path validation confirms the temporary ASCII-safe workaround produces the requested final ISO.
 - [x] **12.32** USB disk safety validation rejects:
   - [x] Non-USB disks.
   - [x] Non-removable disks when required.

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -29,10 +29,10 @@ The `12.A` to `12.D` labels are implementation slices, not extra phase numbers. 
   - [x] Scope: normalize `Runtime\Foundry.Connect\<rid>` and `Runtime\Foundry.Deploy\<rid>`, update bootstrap resolution, update ISO runtime provisioning, update USB cache provisioning, remove unnecessary `Foundry.Connect` USB duplication, preserve local debug Connect/Deploy overrides, and preserve release/download fallback behavior.
   - [x] Boundary: touch runtime payload layout and bootstrap assumptions only; do not redesign Connect or Deploy application behavior unless the layout change necessarily flows into them.
   - [x] Reason: Connect/Deploy runtime layout affects ISO, USB, bootstrap, and downstream compatibility, so it needs a focused PR with explicit validation.
-- [ ] **12.D** `feat(winpe): apply programdata and media layout`.
-  - [ ] Scope: enforce the new `C:\ProgramData\Foundry` host layout, `X:\Foundry` boot image layout, USB BOOT/cache layout, cache/temp/log placement, media secret-key placement, no old-folder fallback, failure-path log relocation, and ISO volume-label behavior.
-  - [ ] Boundary: make the documented filesystem contract real after ADK readiness, WinPE service foundations, and runtime payload layout are known.
-  - [ ] Reason: final layout enforcement should happen after the service and runtime contracts are clear, so old path behavior can be removed directly without compatibility fallback.
+- [x] **12.D** `feat(winpe): apply programdata and media layout`.
+  - [x] Scope: enforce the new `C:\ProgramData\Foundry` host layout, `X:\Foundry` boot image layout, USB BOOT/cache layout, cache/temp/log placement, media secret-key placement, no old-folder fallback, failure-path log relocation, and ISO volume-label behavior.
+  - [x] Boundary: make the documented filesystem contract real after ADK readiness, WinPE service foundations, and runtime payload layout are known.
+  - [x] Reason: final layout enforcement should happen after the service and runtime contracts are clear, so old path behavior can be removed directly without compatibility fallback.
 
 **Deferred infrastructure completion:** Phase 12 is also responsible for completing the ADK/WinPE portions of earlier deferred infrastructure work:
 
@@ -216,34 +216,34 @@ The `12.A` to `12.D` labels are implementation slices, not extra phase numbers. 
 - [x] **12.11** Remove or explicitly mark obsolete legacy archive contracts:
   - [x] `Foundry\Seed\Foundry.Connect.zip` appears unused after extracted Connect runtime provisioning.
   - [x] `Foundry\Seed\Foundry.Deploy.zip` remains a valid local Deploy seed package.
-- [ ] **12.12** Fix or remove unused ISO volume-label intent:
-  - [ ] `IsoOutputOptions.VolumeLabel` is currently configured by the app but not passed to `MakeWinPEMedia`.
+- [x] **12.12** Fix or remove unused ISO volume-label intent:
+  - [x] No active WinUI service contract exposes an ISO volume-label setting. The archived WPF value was not passed to `MakeWinPEMedia`, so Phase 12.D keeps the generated-media contract explicit without carrying unused volume-label behavior forward.
 - [x] **12.12.1** Preserve MakeWinPEMedia compatibility details:
   - [x] Probe `/bootex` support before allowing PCA2023 signature mode.
   - [x] Fail PCA2023 media creation clearly when `/bootex` is unavailable.
   - [x] Pass `/bootex` for PCA2023 ISO creation.
   - [x] Rebuild USB EFI boot files from BootEx binaries for PCA2023 USB creation.
   - [x] Use ASCII-safe temporary ISO workspace/output paths when MakeWinPEMedia cannot handle the requested non-ASCII path directly.
-- [ ] **12.13** Implement the new host-side layout directly, with no legacy fallback:
-  - [ ] `C:\ProgramData\Foundry\Workspaces\WinPe`.
-  - [ ] `C:\ProgramData\Foundry\Workspaces\Iso`.
-  - [ ] `C:\ProgramData\Foundry\Cache\OperatingSystems`.
-  - [ ] `C:\ProgramData\Foundry\Cache\Installers`.
-  - [ ] `C:\ProgramData\Foundry\Cache\Tools`.
-  - [ ] `C:\ProgramData\Foundry\Temp`.
-  - [ ] `C:\ProgramData\Foundry\Logs`.
-- [ ] **12.14** Do not read from or migrate old host folders in application code:
-  - [ ] `C:\ProgramData\Foundry\WinPeWorkspace`.
-  - [ ] `C:\ProgramData\Foundry\Installers\os`.
-  - [ ] `C:\ProgramData\Foundry\Installers\OperatingSystems`.
-  - [ ] `C:\ProgramData\Foundry\IsoWorkspace`.
-  - [ ] `C:\ProgramData\Foundry\IsoOutputTemp`.
-- [ ] **12.15** Add failure-path checks for log relocation:
-  - [ ] Startup logs under `X:\Foundry\Logs`.
-  - [ ] USB media must not create or use `Foundry Cache:\Logs`.
-  - [ ] Deployment session logs under the active workspace.
-  - [ ] Target logs under `Windows\Temp\Foundry\Logs`.
-- [ ] **12.16** Commit each Phase 12 slice independently when its validation is complete:
+- [x] **12.13** Implement the new host-side layout directly, with no legacy fallback:
+  - [x] `C:\ProgramData\Foundry\Workspaces\WinPe`.
+  - [x] `C:\ProgramData\Foundry\Workspaces\Iso`.
+  - [x] `C:\ProgramData\Foundry\Cache\OperatingSystems`.
+  - [x] `C:\ProgramData\Foundry\Cache\Installers`.
+  - [x] `C:\ProgramData\Foundry\Cache\Tools`.
+  - [x] `C:\ProgramData\Foundry\Temp`.
+  - [x] `C:\ProgramData\Foundry\Logs`.
+- [x] **12.14** Do not read from or migrate old host folders in application code:
+  - [x] `C:\ProgramData\Foundry\WinPeWorkspace`.
+  - [x] `C:\ProgramData\Foundry\Installers\os`.
+  - [x] `C:\ProgramData\Foundry\Installers\OperatingSystems`.
+  - [x] `C:\ProgramData\Foundry\IsoWorkspace`.
+  - [x] `C:\ProgramData\Foundry\IsoOutputTemp`.
+- [x] **12.15** Add failure-path checks for log relocation:
+  - [x] Startup logs under `X:\Foundry\Logs`.
+  - [x] USB media must not create or use `Foundry Cache:\Logs`.
+  - [x] Deployment session logs under the active workspace.
+  - [x] Target logs under `Windows\Temp\Foundry\Logs`.
+- [x] **12.16** Commit each Phase 12 slice independently when its validation is complete:
   - [x] **12.16.1** Commit Phase 12.A:
 
 ```powershell
@@ -262,7 +262,7 @@ git commit -m "feat(winpe): port service foundations"
 git commit -m "refactor(runtime): normalize connect deploy layout"
 ```
 
-  - [ ] **12.16.4** Commit Phase 12.D:
+  - [x] **12.16.4** Commit Phase 12.D:
 
 ```powershell
 git commit -m "feat(winpe): apply programdata media layout"

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -275,9 +275,9 @@ git commit -m "feat(winpe): apply programdata media layout"
 
 **Manual validation available during Phase 12**
 
-- [ ] **12.18** Local debug Connect publish override still works.
-- [ ] **12.19** Local debug Deploy publish override still works.
-- [ ] **12.23** New host-side `ProgramData` layout is used without old-folder fallback.
+- [x] **12.18** Local debug Connect publish override still works.
+- [x] **12.19** Local debug Deploy publish override still works.
+- [x] **12.23** New host-side `ProgramData` layout is used without old-folder fallback.
 
 **Manual validation deferred to Phase 13 Start page workflow**
 

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -271,12 +271,19 @@ git commit -m "feat(winpe): apply programdata media layout"
 **Validation**
 
 - [x] **12.17** Existing WinPE unit tests pass after moving logic.
+- [x] **12.17.1** Split Phase 12 manual validation between service-level checks that are testable now and final `Start` page workflow checks that must wait for Phase 13.
+
+**Manual validation available during Phase 12**
+
 - [ ] **12.18** Local debug Connect publish override still works.
 - [ ] **12.19** Local debug Deploy publish override still works.
-- [ ] **12.20** ISO creation works on a test machine with ADK.
-- [ ] **12.21** USB creation works on a disposable test drive.
-- [ ] **12.22** Generated ISO/USB media matches the documented layout.
 - [ ] **12.23** New host-side `ProgramData` layout is used without old-folder fallback.
+
+**Manual validation deferred to Phase 13 Start page workflow**
+
+- [ ] **12.20** ISO creation works on a test machine with ADK through the final `Start` page command.
+- [ ] **12.21** USB creation works on a disposable test drive through the final `Start` page command.
+- [ ] **12.22** Generated ISO/USB media matches the documented layout from the final `Start` page workflow.
 - [x] **12.24** ADK page shows missing state when ADK is absent.
 - [x] **12.25** ADK page shows installed version when ADK is present.
 - [x] **12.26** ADK page shows incompatible state when the version is unsupported.

--- a/src/Foundry.Core.Tests/Adk/AdkInstallationDetectorTests.cs
+++ b/src/Foundry.Core.Tests/Adk/AdkInstallationDetectorTests.cs
@@ -54,6 +54,29 @@ public sealed class AdkInstallationDetectorTests
         Assert.False(status.CanCreateMedia);
     }
 
+    [Fact]
+    public void Detect_WhenWinPeAddonFolderExistsButRequiredToolsAreMissing_BlocksMediaCreation()
+    {
+        string kitsRootPath = @"C:\Program Files (x86)\Windows Kits\10\";
+        FakeAdkInstallationProbe probe = new()
+        {
+            KitsRootPath = kitsRootPath,
+            ExistingDirectories =
+            [
+                Path.Combine(kitsRootPath, AdkInstallationDetector.DeploymentToolsRelativePath),
+                Path.Combine(kitsRootPath, AdkInstallationDetector.WinPeRelativePath)
+            ],
+            Products = [new("Windows Assessment and Deployment Kit", "10.1.26100.2454")]
+        };
+
+        AdkInstallationStatus status = new AdkInstallationDetector(probe).Detect();
+
+        Assert.True(status.IsInstalled);
+        Assert.True(status.IsCompatible);
+        Assert.False(status.IsWinPeAddonInstalled);
+        Assert.False(status.CanCreateMedia);
+    }
+
     [Theory]
     [InlineData("10.1.26100.1", false)]
     [InlineData("10.1.26100.2453", false)]
@@ -99,6 +122,11 @@ public sealed class AdkInstallationDetectorTests
             [
                 Path.Combine(kitsRootPath, AdkInstallationDetector.DeploymentToolsRelativePath),
                 Path.Combine(kitsRootPath, AdkInstallationDetector.WinPeRelativePath)
+            ],
+            ExistingFiles =
+            [
+                Path.Combine(kitsRootPath, AdkInstallationDetector.WinPeRelativePath, "copype.cmd"),
+                Path.Combine(kitsRootPath, AdkInstallationDetector.WinPeRelativePath, "MakeWinPEMedia.cmd")
             ]
         };
 
@@ -114,6 +142,7 @@ public sealed class AdkInstallationDetectorTests
     {
         public string? KitsRootPath { get; init; }
         public IReadOnlyCollection<string> ExistingDirectories { get; init; } = [];
+        public IReadOnlyCollection<string> ExistingFiles { get; init; } = [];
         public IReadOnlyList<AdkInstalledProduct> Products { get; set; } = [];
 
         public string? GetKitsRootPath() => KitsRootPath;
@@ -121,6 +150,18 @@ public sealed class AdkInstallationDetectorTests
         public bool DirectoryExists(string path)
         {
             return ExistingDirectories.Contains(path, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public bool FileExists(string path)
+        {
+            return ExistingFiles.Contains(path, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public bool DirectoryContainsFile(string directoryPath, string fileName)
+        {
+            return ExistingFiles.Any(path =>
+                path.StartsWith(directoryPath, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(Path.GetFileName(path), fileName, StringComparison.OrdinalIgnoreCase));
         }
 
         public IReadOnlyList<AdkInstalledProduct> GetInstalledProducts() => Products;

--- a/src/Foundry.Core.Tests/WinPe/WinPeBuildServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeBuildServiceTests.cs
@@ -40,4 +40,110 @@ public sealed class WinPeBuildServiceTests
         Assert.False(result.IsSuccess);
         Assert.Equal(WinPeErrorCodes.ValidationFailed, result.Error?.Code);
     }
+
+    [Fact]
+    public async Task BuildAsync_WhenCopypeSucceeds_CreatesExpectedWorkspaceFolders()
+    {
+        using TempWinPeBuildWorkspace workspace = TempWinPeBuildWorkspace.Create();
+        var runner = new FakeBuildRunner();
+        var service = new WinPeBuildService(
+            new WinPeToolResolver(() => workspace.KitsRootPath),
+            runner);
+
+        WinPeResult<WinPeBuildArtifact> result = await service.BuildAsync(
+            new WinPeBuildOptions
+            {
+                OutputDirectoryPath = workspace.OutputDirectoryPath,
+                Architecture = WinPeArchitecture.X64
+            },
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Error?.Details);
+        Assert.True(Directory.Exists(Path.Combine(result.Value!.WorkingDirectoryPath, "media")));
+        Assert.True(Directory.Exists(Path.Combine(result.Value.WorkingDirectoryPath, "mount")));
+        Assert.True(Directory.Exists(Path.Combine(result.Value.WorkingDirectoryPath, "drivers")));
+        Assert.True(Directory.Exists(Path.Combine(result.Value.WorkingDirectoryPath, "logs")));
+        Assert.True(Directory.Exists(Path.Combine(result.Value.WorkingDirectoryPath, "temp")));
+    }
+
+    private sealed class FakeBuildRunner : IWinPeProcessRunner
+    {
+        public Task<WinPeProcessExecution> RunAsync(
+            string fileName,
+            string arguments,
+            string workingDirectory,
+            CancellationToken cancellationToken,
+            IReadOnlyDictionary<string, string>? environmentOverrides = null)
+        {
+            return Task.FromResult(new WinPeProcessExecution
+            {
+                ExitCode = 0,
+                FileName = fileName,
+                Arguments = arguments,
+                WorkingDirectory = workingDirectory
+            });
+        }
+
+        public Task<WinPeProcessExecution> RunCmdScriptAsync(
+            string scriptPath,
+            string scriptArguments,
+            string workingDirectory,
+            CancellationToken cancellationToken)
+        {
+            string workingRoot = scriptArguments.Split(' ', StringSplitOptions.RemoveEmptyEntries).Last().Trim('"');
+            string bootWimPath = Path.Combine(workingRoot, "media", "sources", "boot.wim");
+            Directory.CreateDirectory(Path.GetDirectoryName(bootWimPath)!);
+            File.WriteAllText(bootWimPath, "boot");
+
+            return Task.FromResult(new WinPeProcessExecution
+            {
+                ExitCode = 0,
+                FileName = scriptPath,
+                Arguments = scriptArguments,
+                WorkingDirectory = workingDirectory
+            });
+        }
+
+        public Task<WinPeProcessExecution> RunCmdScriptDirectAsync(
+            string scriptPath,
+            string scriptArguments,
+            string workingDirectory,
+            CancellationToken cancellationToken)
+        {
+            return RunCmdScriptAsync(scriptPath, scriptArguments, workingDirectory, cancellationToken);
+        }
+    }
+
+    private sealed class TempWinPeBuildWorkspace : IDisposable
+    {
+        private TempWinPeBuildWorkspace(string rootPath)
+        {
+            RootPath = rootPath;
+            OutputDirectoryPath = Path.Combine(rootPath, "Workspaces", "WinPe");
+            KitsRootPath = Path.Combine(rootPath, "Kits");
+
+            string winPeRoot = Path.Combine(
+                KitsRootPath,
+                "Assessment and Deployment Kit",
+                "Windows Preinstallation Environment");
+            Directory.CreateDirectory(winPeRoot);
+            File.WriteAllText(Path.Combine(winPeRoot, "copype.cmd"), "copype");
+            File.WriteAllText(Path.Combine(winPeRoot, "MakeWinPEMedia.cmd"), "makewinpemedia");
+        }
+
+        public string RootPath { get; }
+        public string OutputDirectoryPath { get; }
+        public string KitsRootPath { get; }
+
+        public static TempWinPeBuildWorkspace Create()
+        {
+            string rootPath = Path.Combine(Path.GetTempPath(), $"foundry-winpe-build-{Guid.NewGuid():N}");
+            return new TempWinPeBuildWorkspace(rootPath);
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(RootPath, recursive: true);
+        }
+    }
 }

--- a/src/Foundry.Core.Tests/WinPe/WinPeIsoMediaServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeIsoMediaServiceTests.cs
@@ -52,6 +52,45 @@ public sealed class WinPeIsoMediaServiceTests
         Assert.DoesNotContain("foundry-é.iso", runner.Executions[0].Arguments);
     }
 
+    [Fact]
+    public async Task CreateAsync_WhenWorkspacePathContainsNonAscii_UsesAsciiSafeWorkspace()
+    {
+        using TempPreparedWorkspace temp = TempPreparedWorkspace.Create(useBootEx: false, rootName: $"foundry-réseau-{Guid.NewGuid():N}");
+        string outputIsoPath = Path.Combine(Path.GetTempPath(), $"foundry-output-{Guid.NewGuid():N}", "foundry.iso");
+        var runner = new FakeIsoRunner();
+        var service = new WinPeIsoMediaService(runner);
+
+        try
+        {
+            WinPeResult result = await service.CreateAsync(
+                new WinPeIsoMediaOptions
+                {
+                    PreparedWorkspace = temp.PreparedWorkspace,
+                    OutputIsoPath = outputIsoPath,
+                    IsoTempDirectoryPath = Path.Combine(Path.GetTempPath(), $"foundry-iso-temp-{Guid.NewGuid():N}")
+                },
+                CancellationToken.None);
+
+            Assert.True(result.IsSuccess, result.Error?.Details);
+            WinPeProcessExecution execution = Assert.Single(runner.Executions);
+            Assert.DoesNotContain("réseau", execution.Arguments);
+            Assert.DoesNotContain("réseau", execution.WorkingDirectory);
+        }
+        finally
+        {
+            if (File.Exists(outputIsoPath))
+            {
+                File.Delete(outputIsoPath);
+            }
+
+            string? outputDirectory = Path.GetDirectoryName(outputIsoPath);
+            if (!string.IsNullOrWhiteSpace(outputDirectory) && Directory.Exists(outputDirectory))
+            {
+                Directory.Delete(outputDirectory, recursive: true);
+            }
+        }
+    }
+
     private sealed class TempPreparedWorkspace : IDisposable
     {
         private TempPreparedWorkspace(string rootPath, WinPeWorkspacePreparationResult preparedWorkspace)
@@ -63,9 +102,9 @@ public sealed class WinPeIsoMediaServiceTests
         public string RootPath { get; }
         public WinPeWorkspacePreparationResult PreparedWorkspace { get; }
 
-        public static TempPreparedWorkspace Create(bool useBootEx)
+        public static TempPreparedWorkspace Create(bool useBootEx, string? rootName = null)
         {
-            string root = Path.Combine(Path.GetTempPath(), $"foundry-iso-{Guid.NewGuid():N}");
+            string root = Path.Combine(Path.GetTempPath(), rootName ?? $"foundry-iso-{Guid.NewGuid():N}");
             string media = Path.Combine(root, "work", "media");
             string bootWim = Path.Combine(media, "sources", "boot.wim");
             Directory.CreateDirectory(Path.GetDirectoryName(bootWim)!);

--- a/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
@@ -123,6 +123,31 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
     }
 
     [Fact]
+    public async Task ProvisionAsync_CreatesRuntimeLogAndTempDirectories()
+    {
+        using TempMountedImage image = TempMountedImage.Create();
+        string curlSourcePath = Path.Combine(image.RootPath, "curl.exe");
+        File.WriteAllText(curlSourcePath, "curl");
+
+        var service = new WinPeMountedImageAssetProvisioningService();
+
+        WinPeResult result = await service.ProvisionAsync(
+            new WinPeMountedImageAssetProvisioningOptions
+            {
+                MountedImagePath = image.MountedImagePath,
+                Architecture = WinPeArchitecture.X64,
+                BootstrapScriptContent = "bootstrap",
+                CurlExecutableSourcePath = curlSourcePath,
+                IanaWindowsTimeZoneMapJson = "{}"
+            },
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Error?.Details);
+        Assert.True(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Logs")));
+        Assert.True(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Temp")));
+    }
+
+    [Fact]
     public async Task ProvisionAsync_WhenDeployConfigurationIsMissing_WritesCompleteDefaultDeployConfiguration()
     {
         using TempMountedImage image = TempMountedImage.Create();

--- a/src/Foundry.Core.Tests/WinPe/WinPeRuntimePayloadProvisioningServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeRuntimePayloadProvisioningServiceTests.cs
@@ -112,6 +112,40 @@ public sealed class WinPeRuntimePayloadProvisioningServiceTests
     }
 
     [Fact]
+    public async Task ProvisionAsync_WhenConnectProjectIsProvided_PublishesSingleFileBeforeProvisioning()
+    {
+        using TempRuntimeWorkspace workspace = TempRuntimeWorkspace.Create();
+        string projectPath = Path.Combine(workspace.RootPath, "src", "Foundry.Connect", "Foundry.Connect.csproj");
+        Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
+        File.WriteAllText(projectPath, "<Project />");
+        var runner = new FakeRuntimeProcessRunner();
+
+        var service = new WinPeRuntimePayloadProvisioningService(runner);
+
+        WinPeResult result = await service.ProvisionAsync(
+            new WinPeRuntimePayloadProvisioningOptions
+            {
+                Architecture = WinPeArchitecture.X64,
+                WorkingDirectoryPath = workspace.WorkingDirectoryPath,
+                MountedImagePath = workspace.MountedImagePath,
+                Connect = new WinPeRuntimePayloadApplicationOptions
+                {
+                    IsEnabled = true,
+                    ProjectPath = projectPath
+                }
+            },
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Error?.Details);
+        WinPeProcessExecution execution = Assert.Single(runner.Executions);
+        Assert.Equal("dotnet", execution.FileName);
+        Assert.Contains("publish", execution.Arguments);
+        Assert.Contains("-r win-x64", execution.Arguments);
+        Assert.Contains("/p:PublishSingleFile=true", execution.Arguments);
+        Assert.True(File.Exists(Path.Combine(workspace.MountedImagePath, "Foundry", "Runtime", "Foundry.Connect", "win-x64", "Foundry.Connect.exe")));
+    }
+
+    [Fact]
     public async Task ProvisionAsync_WhenApplicationIsDisabled_DoesNotCreateRuntimeRoot()
     {
         using TempRuntimeWorkspace workspace = TempRuntimeWorkspace.Create();

--- a/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
@@ -77,6 +77,28 @@ public sealed class WinPeUsbMediaServiceTests
         Assert.Equal(WinPeErrorCodes.UsbIdentityMismatch, result.Error?.Code);
     }
 
+    [Fact]
+    public void ValidateDiskSafety_WhenTargetIsBootDisk_ReturnsUnsafeTarget()
+    {
+        WinPeResult result = WinPeUsbMediaService.ValidateDiskSafety(
+            new UsbOutputOptions
+            {
+                TargetDiskNumber = 3,
+                ExpectedDiskFriendlyName = "Boot USB"
+            },
+            new WinPeUsbDiskIdentity
+            {
+                Number = 3,
+                FriendlyName = "Boot USB",
+                BusType = "USB",
+                IsRemovable = true,
+                IsBoot = true
+            });
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(WinPeErrorCodes.UsbUnsafeTarget, result.Error?.Code);
+    }
+
     [Theory]
     [InlineData(0, true)]
     [InlineData(7, true)]

--- a/src/Foundry.Core.Tests/WinPe/WinReBootImagePreparationServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinReBootImagePreparationServiceTests.cs
@@ -166,12 +166,11 @@ public sealed class WinReBootImagePreparationServiceTests
         string mediaPath = Path.Combine(workingPath, "media");
         string sourcesPath = Path.Combine(mediaPath, "sources");
         string cachePath = Path.Combine(root, "cache");
-        string osCachePath = Path.Combine(cachePath, "os");
         Directory.CreateDirectory(sourcesPath);
-        Directory.CreateDirectory(osCachePath);
+        Directory.CreateDirectory(cachePath);
 
         string bootWimPath = Path.Combine(sourcesPath, "boot.wim");
-        string cachedSourcePath = Path.Combine(osCachePath, "source.esd");
+        string cachedSourcePath = Path.Combine(cachePath, "source.esd");
         await File.WriteAllTextAsync(bootWimPath, "original");
         await File.WriteAllTextAsync(cachedSourcePath, "cached source");
         string cachedSourceHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes("cached source")));

--- a/src/Foundry.Core/Services/Adk/AdkInstallationDetector.cs
+++ b/src/Foundry.Core/Services/Adk/AdkInstallationDetector.cs
@@ -14,8 +14,7 @@ public sealed class AdkInstallationDetector(IAdkInstallationProbe probe)
         bool hasKitsRoot = !string.IsNullOrWhiteSpace(kitsRootPath);
         bool hasDeploymentTools = hasKitsRoot
             && probe.DirectoryExists(Path.Combine(kitsRootPath!, DeploymentToolsRelativePath));
-        bool hasWinPeAddon = hasKitsRoot
-            && probe.DirectoryExists(Path.Combine(kitsRootPath!, WinPeRelativePath));
+        bool hasWinPeAddon = hasKitsRoot && HasUsableWinPeAddon(kitsRootPath!);
         string? installedVersion = ResolveInstalledVersion(probe.GetInstalledProducts());
         bool isInstalled = hasDeploymentTools;
         bool isCompatible = isInstalled && IsCompatibleVersion(installedVersion);
@@ -42,6 +41,24 @@ public sealed class AdkInstallationDetector(IAdkInstallationProbe probe)
         }
 
         return false;
+    }
+
+    private bool HasUsableWinPeAddon(string kitsRootPath)
+    {
+        string winPeRootPath = Path.Combine(kitsRootPath, WinPeRelativePath);
+        if (!probe.DirectoryExists(winPeRootPath))
+        {
+            return false;
+        }
+
+        return ProbeFileInTree(winPeRootPath, "copype.cmd")
+            && ProbeFileInTree(winPeRootPath, "MakeWinPEMedia.cmd");
+    }
+
+    private bool ProbeFileInTree(string directoryPath, string fileName)
+    {
+        string directPath = Path.Combine(directoryPath, fileName);
+        return probe.FileExists(directPath) || probe.DirectoryContainsFile(directoryPath, fileName);
     }
 
     private static string? ResolveInstalledVersion(IReadOnlyList<AdkInstalledProduct> products)

--- a/src/Foundry.Core/Services/Adk/IAdkInstallationProbe.cs
+++ b/src/Foundry.Core/Services/Adk/IAdkInstallationProbe.cs
@@ -4,5 +4,7 @@ public interface IAdkInstallationProbe
 {
     string? GetKitsRootPath();
     bool DirectoryExists(string path);
+    bool FileExists(string path);
+    bool DirectoryContainsFile(string directoryPath, string fileName);
     IReadOnlyList<AdkInstalledProduct> GetInstalledProducts();
 }

--- a/src/Foundry.Core/Services/Adk/WindowsAdkInstallationProbe.cs
+++ b/src/Foundry.Core/Services/Adk/WindowsAdkInstallationProbe.cs
@@ -23,6 +23,28 @@ public sealed class WindowsAdkInstallationProbe : IAdkInstallationProbe
         return Directory.Exists(path);
     }
 
+    public bool FileExists(string path)
+    {
+        return File.Exists(path);
+    }
+
+    public bool DirectoryContainsFile(string directoryPath, string fileName)
+    {
+        if (!Directory.Exists(directoryPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            return Directory.EnumerateFiles(directoryPath, fileName, SearchOption.AllDirectories).Any();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     public IReadOnlyList<AdkInstalledProduct> GetInstalledProducts()
     {
         List<AdkInstalledProduct> products = [];

--- a/src/Foundry.Core/Services/WinPe/WinPeBuildService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeBuildService.cs
@@ -73,10 +73,12 @@ public sealed class WinPeBuildService : IWinPeBuildService
             string mountDirectory = Path.Combine(workingDirectory, "mount");
             string driverWorkspace = Path.Combine(workingDirectory, "drivers");
             string logsDirectory = Path.Combine(workingDirectory, "logs");
+            string tempDirectory = Path.Combine(workingDirectory, "temp");
 
             Directory.CreateDirectory(mountDirectory);
             Directory.CreateDirectory(driverWorkspace);
             Directory.CreateDirectory(logsDirectory);
+            Directory.CreateDirectory(tempDirectory);
 
             return WinPeResult<WinPeBuildArtifact>.Success(new WinPeBuildArtifact
             {

--- a/src/Foundry.Core/Services/WinPe/WinPeIsoMediaService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeIsoMediaService.cs
@@ -29,11 +29,16 @@ public sealed class WinPeIsoMediaService : IWinPeIsoMediaService
         WinPeWorkspacePreparationResult preparedWorkspace = options.PreparedWorkspace!;
         string requestedOutputPath = options.OutputIsoPath.Trim();
         string? preparedOutputPath = null;
+        string? safeWorkspacePath = null;
 
         try
         {
             EnsureOutputDirectoryExists(requestedOutputPath);
             preparedOutputPath = PrepareOutputPath(requestedOutputPath, options.IsoTempDirectoryPath);
+            string makeWinPeMediaWorkspacePath = PrepareWorkspacePath(
+                preparedWorkspace.Artifact.WorkingDirectoryPath,
+                options.IsoTempDirectoryPath,
+                out safeWorkspacePath);
 
             if (options.ForceOverwriteOutput && File.Exists(preparedOutputPath))
             {
@@ -41,13 +46,13 @@ public sealed class WinPeIsoMediaService : IWinPeIsoMediaService
             }
 
             string arguments =
-                $"/ISO /F {WinPeProcessRunner.Quote(preparedWorkspace.Artifact.WorkingDirectoryPath)} {WinPeProcessRunner.Quote(preparedOutputPath)}" +
+                $"/ISO /F {WinPeProcessRunner.Quote(makeWinPeMediaWorkspacePath)} {WinPeProcessRunner.Quote(preparedOutputPath)}" +
                 (preparedWorkspace.UseBootEx ? " /bootex" : string.Empty);
 
             WinPeProcessExecution execution = await _processRunner.RunCmdScriptAsync(
                 preparedWorkspace.Tools.MakeWinPeMediaPath,
                 arguments,
-                preparedWorkspace.Artifact.WorkingDirectoryPath,
+                makeWinPeMediaWorkspacePath,
                 cancellationToken).ConfigureAwait(false);
 
             if (!execution.IsSuccess || !File.Exists(preparedOutputPath))
@@ -71,6 +76,7 @@ public sealed class WinPeIsoMediaService : IWinPeIsoMediaService
         finally
         {
             CleanupPreparedOutput(requestedOutputPath, preparedOutputPath);
+            CleanupPreparedWorkspace(safeWorkspacePath);
         }
     }
 
@@ -118,15 +124,34 @@ public sealed class WinPeIsoMediaService : IWinPeIsoMediaService
                 $"Path: '{options.OutputIsoPath}'.");
         }
 
-        if (ContainsNonAscii(options.OutputIsoPath) && string.IsNullOrWhiteSpace(options.IsoTempDirectoryPath))
+        if ((ContainsNonAscii(options.OutputIsoPath) ||
+             ContainsNonAscii(options.PreparedWorkspace.Artifact.WorkingDirectoryPath)) &&
+            string.IsNullOrWhiteSpace(options.IsoTempDirectoryPath))
         {
             return new WinPeDiagnostic(
                 WinPeErrorCodes.ValidationFailed,
-                "ISO temporary directory path is required for non-ASCII output paths.",
+                "ISO temporary directory path is required for non-ASCII MakeWinPEMedia paths.",
                 "Set WinPeIsoMediaOptions.IsoTempDirectoryPath.");
         }
 
         return null;
+    }
+
+    private static string PrepareWorkspacePath(
+        string requestedWorkspacePath,
+        string isoTempDirectoryPath,
+        out string? safeWorkspacePath)
+    {
+        safeWorkspacePath = null;
+        if (!ContainsNonAscii(requestedWorkspacePath))
+        {
+            return requestedWorkspacePath;
+        }
+
+        Directory.CreateDirectory(isoTempDirectoryPath);
+        safeWorkspacePath = Path.Combine(isoTempDirectoryPath, $"workspace-{Guid.NewGuid():N}");
+        CopyDirectoryContents(requestedWorkspacePath, safeWorkspacePath);
+        return safeWorkspacePath;
     }
 
     private static string PrepareOutputPath(string requestedOutputPath, string isoTempDirectoryPath)
@@ -177,6 +202,42 @@ public sealed class WinPeIsoMediaService : IWinPeIsoMediaService
         catch
         {
             // Best-effort cleanup.
+        }
+    }
+
+    private static void CleanupPreparedWorkspace(string? safeWorkspacePath)
+    {
+        if (string.IsNullOrWhiteSpace(safeWorkspacePath) || !Directory.Exists(safeWorkspacePath))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.Delete(safeWorkspacePath, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private static void CopyDirectoryContents(string sourceDirectoryPath, string targetDirectoryPath)
+    {
+        Directory.CreateDirectory(targetDirectoryPath);
+
+        foreach (string directoryPath in Directory.EnumerateDirectories(sourceDirectoryPath, "*", SearchOption.AllDirectories))
+        {
+            string relativePath = Path.GetRelativePath(sourceDirectoryPath, directoryPath);
+            Directory.CreateDirectory(Path.Combine(targetDirectoryPath, relativePath));
+        }
+
+        foreach (string filePath in Directory.EnumerateFiles(sourceDirectoryPath, "*", SearchOption.AllDirectories))
+        {
+            string relativePath = Path.GetRelativePath(sourceDirectoryPath, filePath);
+            string targetFilePath = Path.Combine(targetDirectoryPath, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(targetFilePath)!);
+            File.Copy(filePath, targetFilePath, overwrite: true);
         }
     }
 

--- a/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningService.cs
@@ -28,10 +28,13 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
         {
             string mountedImagePath = Path.GetFullPath(options.MountedImagePath);
             string system32Path = Path.Combine(mountedImagePath, "Windows", "System32");
-            string foundryConfigPath = Path.Combine(mountedImagePath, "Foundry", "Config");
+            string foundryRootPath = Path.Combine(mountedImagePath, "Foundry");
+            string foundryConfigPath = Path.Combine(foundryRootPath, "Config");
 
             Directory.CreateDirectory(system32Path);
             Directory.CreateDirectory(foundryConfigPath);
+            Directory.CreateDirectory(Path.Combine(foundryRootPath, "Logs"));
+            Directory.CreateDirectory(Path.Combine(foundryRootPath, "Temp"));
 
             await File.WriteAllTextAsync(
                 Path.Combine(system32Path, BootstrapFileName),

--- a/src/Foundry.Core/Services/WinPe/WinReBootImagePreparationService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinReBootImagePreparationService.cs
@@ -434,6 +434,7 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
     {
         string sourceCachePath = BuildCachedSourcePath(cacheDirectoryPath, source);
         Directory.CreateDirectory(Path.GetDirectoryName(sourceCachePath)!);
+        string temporaryDownloadPath = $"{sourceCachePath}.{Guid.NewGuid():N}.download";
 
         if (File.Exists(sourceCachePath))
         {
@@ -467,23 +468,31 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
 
             response.EnsureSuccessStatusCode();
             await using Stream sourceStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-            await using FileStream destinationStream = new(
-                sourceCachePath,
-                FileMode.Create,
-                FileAccess.Write,
-                FileShare.None,
-                81920,
-                useAsync: true);
+            await using (FileStream destinationStream = new(
+                             temporaryDownloadPath,
+                             FileMode.Create,
+                             FileAccess.Write,
+                             FileShare.None,
+                             81920,
+                             useAsync: true))
+            {
+                await sourceStream.CopyToAsync(destinationStream, cancellationToken).ConfigureAwait(false);
+            }
 
-            await sourceStream.CopyToAsync(destinationStream, cancellationToken).ConfigureAwait(false);
+            File.Move(temporaryDownloadPath, sourceCachePath, overwrite: true);
         }
         catch (Exception ex) when (ex is HttpRequestException or IOException or UnauthorizedAccessException)
         {
             TryDeleteFile(sourceCachePath);
+            TryDeleteFile(temporaryDownloadPath);
             return WinPeResult<string>.Failure(
                 WinPeErrorCodes.DownloadFailed,
                 "Failed to download the WinRE source package.",
                 ex.Message);
+        }
+        finally
+        {
+            TryDeleteFile(temporaryDownloadPath);
         }
 
         WinPeResult hashResult = await ValidateHashIfRequestedAsync(
@@ -572,7 +581,6 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
 
         return Path.Combine(
             cacheDirectoryPath,
-            "os",
             WinPeFileSystemHelper.SanitizePathSegment(fileName));
     }
 

--- a/src/Foundry.Deploy.Tests/DeploymentOrchestratorTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentOrchestratorTests.cs
@@ -1,0 +1,189 @@
+using Foundry.Deploy.Models;
+using Foundry.Deploy.Services.Deployment;
+using Foundry.Deploy.Services.Hardware;
+using Foundry.Deploy.Services.Logging;
+using Foundry.Deploy.Services.Operations;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class DeploymentOrchestratorTests
+{
+    [Fact]
+    public async Task RunAsync_WhenDeploymentFailsAfterTargetLayout_ReturnsActualReboundLogPath()
+    {
+        using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
+        string targetWindowsRoot = Path.Combine(workspace.RootPath, "TargetWindows");
+        IDeploymentStep[] steps = CreateSteps(targetWindowsRoot);
+        var logService = new FakeDeploymentLogService();
+        var orchestrator = new DeploymentOrchestrator(
+            new FakeOperationProgressService(),
+            logService,
+            new FakeTargetDiskService(),
+            steps,
+            NullLogger<DeploymentOrchestrator>.Instance);
+
+        DeploymentResult result = await orchestrator.RunAsync(new DeploymentContext
+        {
+            Mode = DeploymentMode.Iso,
+            IsDryRun = false,
+            CacheRootPath = workspace.RootPath,
+            TargetDiskNumber = 1,
+            TargetComputerName = "LAB01",
+            OperatingSystem = new OperatingSystemCatalogItem(),
+            DriverPackSelectionKind = DriverPackSelectionKind.None
+        });
+
+        string expectedFinalLogsPath = Path.Combine(targetWindowsRoot, "Windows", "Temp", "Foundry", "Logs");
+        Assert.False(result.IsSuccess);
+        Assert.Equal(expectedFinalLogsPath, result.LogsDirectoryPath);
+        Assert.True(Directory.Exists(expectedFinalLogsPath));
+    }
+
+    private static IDeploymentStep[] CreateSteps(string targetWindowsRoot)
+    {
+        return DeploymentStepNames.All
+            .Select((name, index) => (IDeploymentStep)(name switch
+            {
+                DeploymentStepNames.PrepareTargetDiskLayout => new PrepareTargetLayoutStep(index + 1, targetWindowsRoot),
+                DeploymentStepNames.DownloadOperatingSystemImage => new FailingStep(index + 1, name),
+                _ => new SucceedingStep(index + 1, name)
+            }))
+            .ToArray();
+    }
+
+    private sealed class PrepareTargetLayoutStep(int order, string targetWindowsRoot) : IDeploymentStep
+    {
+        public int Order => order;
+        public string Name => DeploymentStepNames.PrepareTargetDiskLayout;
+
+        public async Task<DeploymentStepResult> ExecuteAsync(
+            DeploymentStepExecutionContext context,
+            CancellationToken cancellationToken)
+        {
+            context.RuntimeState.TargetWindowsPartitionRoot = targetWindowsRoot;
+            context.RuntimeState.TargetFoundryRoot = Path.Combine(targetWindowsRoot, "Foundry");
+            Directory.CreateDirectory(context.RuntimeState.TargetFoundryRoot);
+            await context.RebindLogSessionToTargetAsync(context.RuntimeState.TargetFoundryRoot, cancellationToken);
+            return DeploymentStepResult.Succeeded("Prepared target layout.");
+        }
+    }
+
+    private sealed class FailingStep(int order, string name) : IDeploymentStep
+    {
+        public int Order => order;
+        public string Name { get; } = name;
+
+        public Task<DeploymentStepResult> ExecuteAsync(
+            DeploymentStepExecutionContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(DeploymentStepResult.Failed("Synthetic failure after target layout."));
+        }
+    }
+
+    private sealed class SucceedingStep(int order, string name) : IDeploymentStep
+    {
+        public int Order => order;
+        public string Name { get; } = name;
+
+        public Task<DeploymentStepResult> ExecuteAsync(
+            DeploymentStepExecutionContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(DeploymentStepResult.Succeeded($"Completed {Name}."));
+        }
+    }
+
+    private sealed class FakeDeploymentLogService : IDeploymentLogService
+    {
+        public DeploymentLogSession Initialize(string rootPath)
+        {
+            string logsDirectory = Path.Combine(rootPath, "Logs");
+            string stateDirectory = Path.Combine(rootPath, "State");
+            Directory.CreateDirectory(logsDirectory);
+            Directory.CreateDirectory(stateDirectory);
+            return new DeploymentLogSession
+            {
+                RootPath = rootPath,
+                LogsDirectoryPath = logsDirectory,
+                StateDirectoryPath = stateDirectory,
+                LogFilePath = Path.Combine(logsDirectory, "FoundryDeploy.log"),
+                StateFilePath = Path.Combine(stateDirectory, "deployment-state.json")
+            };
+        }
+
+        public async Task AppendAsync(
+            DeploymentLogSession session,
+            DeploymentLogLevel level,
+            string message,
+            CancellationToken cancellationToken = default)
+        {
+            Directory.CreateDirectory(session.LogsDirectoryPath);
+            await File.AppendAllTextAsync(session.LogFilePath, $"{level}: {message}{Environment.NewLine}", cancellationToken);
+        }
+
+        public async Task SaveStateAsync<TState>(
+            DeploymentLogSession session,
+            TState state,
+            CancellationToken cancellationToken = default)
+        {
+            Directory.CreateDirectory(session.StateDirectoryPath);
+            await File.WriteAllTextAsync(session.StateFilePath, "{}", cancellationToken);
+        }
+
+        public void Release(DeploymentLogSession session)
+        {
+        }
+    }
+
+    private sealed class FakeOperationProgressService : IOperationProgressService
+    {
+        public bool IsOperationInProgress => false;
+        public int Progress => 0;
+        public string? Status => null;
+        public OperationKind? CurrentOperation => null;
+        public bool CanStartOperation => true;
+        public event EventHandler? ProgressChanged;
+        public bool TryStart(OperationKind kind, string initialStatus, int initialProgress = 0) => true;
+        public void Report(int progress, string? status = null) => ProgressChanged?.Invoke(this, EventArgs.Empty);
+        public void Complete(string? status = null) => ProgressChanged?.Invoke(this, EventArgs.Empty);
+        public void Fail(string status) => ProgressChanged?.Invoke(this, EventArgs.Empty);
+        public void ResetToIdle() => ProgressChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private sealed class FakeTargetDiskService : ITargetDiskService
+    {
+        public Task<IReadOnlyList<TargetDiskInfo>> GetDisksAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<TargetDiskInfo>>([]);
+        }
+
+        public Task<int?> GetDiskNumberForPathAsync(string path, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<int?>(null);
+        }
+    }
+
+    private sealed class TempDeploymentWorkspace : IDisposable
+    {
+        private TempDeploymentWorkspace(string rootPath)
+        {
+            RootPath = rootPath;
+        }
+
+        public string RootPath { get; }
+
+        public static TempDeploymentWorkspace Create()
+        {
+            string rootPath = Path.Combine(Path.GetTempPath(), $"foundry-orchestrator-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(rootPath);
+            return new TempDeploymentWorkspace(rootPath);
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(RootPath, recursive: true);
+        }
+    }
+}

--- a/src/Foundry.Deploy.Tests/DeploymentStepExecutionContextTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentStepExecutionContextTests.cs
@@ -1,4 +1,9 @@
+using Foundry.Deploy.Models;
+using Foundry.Deploy.Services.Cache;
 using Foundry.Deploy.Services.Deployment;
+using Foundry.Deploy.Services.Hardware;
+using Foundry.Deploy.Services.Logging;
+using Foundry.Deploy.Services.Operations;
 
 namespace Foundry.Deploy.Tests;
 
@@ -42,5 +47,190 @@ public sealed class DeploymentStepExecutionContextTests
         string sanitized = DeploymentStepExecutionContext.SanitizePathSegment("   ");
 
         Assert.Equal("item", sanitized);
+    }
+
+    [Fact]
+    public void ResolveOperatingSystemCacheRoot_WhenUsbRuntimeRootIsResolved_UsesPersistentCacheLayout()
+    {
+        using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
+        DeploymentStepExecutionContext context = CreateExecutionContext(
+            workspace.RootPath,
+            resolvedCacheRootPath: Path.Combine(workspace.CacheRootPath, "Runtime"));
+
+        string root = context.ResolveOperatingSystemCacheRoot();
+
+        Assert.Equal(Path.Combine(workspace.CacheRootPath, "Cache", "OperatingSystems"), root);
+    }
+
+    [Fact]
+    public void ResolveDriverPackCacheRoot_WhenUsbRuntimeRootIsResolved_UsesPersistentCacheLayout()
+    {
+        using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
+        DeploymentStepExecutionContext context = CreateExecutionContext(
+            workspace.RootPath,
+            resolvedCacheRootPath: Path.Combine(workspace.CacheRootPath, "Runtime"));
+
+        string root = context.ResolveDriverPackCacheRoot();
+
+        Assert.Equal(Path.Combine(workspace.CacheRootPath, "Cache", "DriverPacks"), root);
+    }
+
+    [Fact]
+    public void ResolveOperatingSystemCacheRoot_WhenIsoTargetRootIsResolved_UsesTargetCacheLayout()
+    {
+        using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
+        string targetFoundryRoot = Path.Combine(workspace.RootPath, "Windows", "Foundry");
+        DeploymentStepExecutionContext context = CreateExecutionContext(
+            workspace.RootPath,
+            resolvedCacheRootPath: Path.Combine(workspace.CacheRootPath, "Runtime"),
+            mode: DeploymentMode.Iso,
+            targetFoundryRoot: targetFoundryRoot);
+
+        string root = context.ResolveOperatingSystemCacheRoot();
+
+        Assert.Equal(Path.Combine(targetFoundryRoot, "Cache", "OperatingSystems"), root);
+    }
+
+    [Fact]
+    public void ResolveDriverPackCacheRoot_WhenIsoTargetRootIsResolved_UsesTargetCacheLayout()
+    {
+        using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
+        string targetFoundryRoot = Path.Combine(workspace.RootPath, "Windows", "Foundry");
+        DeploymentStepExecutionContext context = CreateExecutionContext(
+            workspace.RootPath,
+            resolvedCacheRootPath: Path.Combine(workspace.CacheRootPath, "Runtime"),
+            mode: DeploymentMode.Iso,
+            targetFoundryRoot: targetFoundryRoot);
+
+        string root = context.ResolveDriverPackCacheRoot();
+
+        Assert.Equal(Path.Combine(targetFoundryRoot, "Cache", "DriverPacks"), root);
+    }
+
+    private static DeploymentStepExecutionContext CreateExecutionContext(
+        string workspaceRoot,
+        string resolvedCacheRootPath,
+        DeploymentMode mode = DeploymentMode.Usb,
+        string? targetFoundryRoot = null)
+    {
+        var request = new DeploymentContext
+        {
+            Mode = mode,
+            CacheRootPath = resolvedCacheRootPath,
+            TargetDiskNumber = 1,
+            TargetComputerName = "LAB01",
+            OperatingSystem = new OperatingSystemCatalogItem(),
+            DriverPackSelectionKind = DriverPackSelectionKind.None,
+            IsDryRun = false
+        };
+
+        var runtimeState = new DeploymentRuntimeState
+        {
+            WorkspaceRoot = workspaceRoot,
+            Mode = mode,
+            TargetFoundryRoot = targetFoundryRoot,
+            ResolvedCache = new CacheResolution
+            {
+                RootPath = resolvedCacheRootPath,
+                Source = "test"
+            }
+        };
+
+        return new DeploymentStepExecutionContext(
+            request,
+            runtimeState,
+            [],
+            new FakeOperationProgressService(),
+            new FakeDeploymentLogService(),
+            new FakeTargetDiskService(),
+            _ => { });
+    }
+
+    private sealed class TempDeploymentWorkspace : IDisposable
+    {
+        private TempDeploymentWorkspace(string rootPath)
+        {
+            RootPath = rootPath;
+            CacheRootPath = Path.Combine(rootPath, "Foundry Cache");
+        }
+
+        public string RootPath { get; }
+        public string CacheRootPath { get; }
+
+        public static TempDeploymentWorkspace Create()
+        {
+            string rootPath = Path.Combine(Path.GetTempPath(), $"foundry-deploy-context-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(rootPath);
+            return new TempDeploymentWorkspace(rootPath);
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(RootPath, recursive: true);
+        }
+    }
+
+    private sealed class FakeDeploymentLogService : IDeploymentLogService
+    {
+        public DeploymentLogSession Initialize(string rootPath)
+        {
+            return new DeploymentLogSession
+            {
+                RootPath = rootPath,
+                LogsDirectoryPath = Path.Combine(rootPath, "Logs"),
+                StateDirectoryPath = Path.Combine(rootPath, "State"),
+                LogFilePath = Path.Combine(rootPath, "Logs", "FoundryDeploy.log"),
+                StateFilePath = Path.Combine(rootPath, "State", "deployment-state.json")
+            };
+        }
+
+        public Task AppendAsync(
+            DeploymentLogSession session,
+            DeploymentLogLevel level,
+            string message,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task SaveStateAsync<TState>(
+            DeploymentLogSession session,
+            TState state,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public void Release(DeploymentLogSession session)
+        {
+        }
+    }
+
+    private sealed class FakeOperationProgressService : IOperationProgressService
+    {
+        public bool IsOperationInProgress => false;
+        public int Progress => 0;
+        public string? Status => null;
+        public OperationKind? CurrentOperation => null;
+        public bool CanStartOperation => true;
+        public event EventHandler? ProgressChanged;
+        public bool TryStart(OperationKind kind, string initialStatus, int initialProgress = 0) => true;
+        public void Report(int progress, string? status = null) => ProgressChanged?.Invoke(this, EventArgs.Empty);
+        public void Complete(string? status = null) => ProgressChanged?.Invoke(this, EventArgs.Empty);
+        public void Fail(string status) => ProgressChanged?.Invoke(this, EventArgs.Empty);
+        public void ResetToIdle() => ProgressChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private sealed class FakeTargetDiskService : ITargetDiskService
+    {
+        public Task<IReadOnlyList<TargetDiskInfo>> GetDisksAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<TargetDiskInfo>>([]);
+        }
+
+        public Task<int?> GetDiskNumberForPathAsync(string path, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<int?>(null);
+        }
     }
 }

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentOrchestrator.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentOrchestrator.cs
@@ -165,6 +165,7 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
             _logger.LogWarning("Deployment orchestration cancelled.");
             if (executionContext is not null)
             {
+                await TryRebindLogsToFinalTargetAsync(executionContext, CancellationToken.None).ConfigureAwait(false);
                 await executionContext
                     .AppendLogAsync(DeploymentLogLevel.Warning, "[WARN] Deployment cancelled by user.", CancellationToken.None)
                     .ConfigureAwait(false);
@@ -183,6 +184,7 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
             _logger.LogError(ex, "Deployment orchestration failed.");
             if (executionContext is not null)
             {
+                await TryRebindLogsToFinalTargetAsync(executionContext, CancellationToken.None).ConfigureAwait(false);
                 await executionContext
                     .AppendLogAsync(DeploymentLogLevel.Error, $"[ERROR] {ex}", CancellationToken.None)
                     .ConfigureAwait(false);
@@ -202,20 +204,45 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
         return (int)Math.Round((double)stepIndex / _steps.Count * 100d);
     }
 
+    private static async Task TryRebindLogsToFinalTargetAsync(
+        DeploymentStepExecutionContext executionContext,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(executionContext.RuntimeState.TargetWindowsPartitionRoot))
+        {
+            return;
+        }
+
+        string finalRoot = Path.Combine(executionContext.RuntimeState.TargetWindowsPartitionRoot, "Windows", "Temp", "Foundry");
+        if (executionContext.LogSession.RootPath.Equals(finalRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        try
+        {
+            await executionContext.RebindLogSessionToTargetAsync(finalRoot, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Keep the original log session available if final target log relocation fails.
+        }
+    }
+
     private static string ResolveLogsDirectory(
         DeploymentStepExecutionContext? executionContext,
         DeploymentRuntimeState? runtimeState = null)
     {
-        DeploymentRuntimeState? effectiveRuntimeState = executionContext?.RuntimeState ?? runtimeState;
-        if (!string.IsNullOrWhiteSpace(effectiveRuntimeState?.TargetWindowsPartitionRoot))
-        {
-            return Path.Combine(effectiveRuntimeState.TargetWindowsPartitionRoot, "Windows", "Temp", "Foundry", "Logs");
-        }
-
         if (executionContext is not null &&
             !string.IsNullOrWhiteSpace(executionContext.LogSession.LogsDirectoryPath))
         {
             return executionContext.LogSession.LogsDirectoryPath;
+        }
+
+        DeploymentRuntimeState? effectiveRuntimeState = executionContext?.RuntimeState ?? runtimeState;
+        if (!string.IsNullOrWhiteSpace(effectiveRuntimeState?.TargetWindowsPartitionRoot))
+        {
+            return Path.Combine(effectiveRuntimeState.TargetWindowsPartitionRoot, "Windows", "Temp", "Foundry", "Logs");
         }
 
         return executionContext?.ResolveWorkspaceLogsPath() ?? string.Empty;

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentStepExecutionContext.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentStepExecutionContext.cs
@@ -16,6 +16,9 @@ public sealed class DeploymentStepExecutionContext
     private const string TempFolderName = "Temp";
     private const string StateFolderName = "State";
     private const string RuntimeFolderName = "Runtime";
+    private const string CacheFolderName = "Cache";
+    private const string OperatingSystemsFolderName = "OperatingSystems";
+    private const string DriverPacksFolderName = "DriverPacks";
     private const string DryRunWorkspaceFolderName = "DryRun";
     private const string RuntimeWorkspaceFolderName = "Runtime";
     private const long UnknownTotalDownloadProgressIncrementBytes = 16L * 1024 * 1024;
@@ -202,10 +205,10 @@ public sealed class DeploymentStepExecutionContext
         if (RuntimeState.Mode == DeploymentMode.Iso &&
             !string.IsNullOrWhiteSpace(RuntimeState.TargetFoundryRoot))
         {
-            return Path.Combine(RuntimeState.TargetFoundryRoot, "OperatingSystem");
+            return Path.Combine(RuntimeState.TargetFoundryRoot, CacheFolderName, OperatingSystemsFolderName);
         }
 
-        return Path.Combine(EnsureCacheBaseRoot(), "OperatingSystem");
+        return Path.Combine(EnsureCacheBaseRoot(), CacheFolderName, OperatingSystemsFolderName);
     }
 
     public string ResolveDriverPackCacheRoot()
@@ -213,10 +216,10 @@ public sealed class DeploymentStepExecutionContext
         if (RuntimeState.Mode == DeploymentMode.Iso &&
             !string.IsNullOrWhiteSpace(RuntimeState.TargetFoundryRoot))
         {
-            return Path.Combine(RuntimeState.TargetFoundryRoot, "DriverPack");
+            return Path.Combine(RuntimeState.TargetFoundryRoot, CacheFolderName, DriverPacksFolderName);
         }
 
-        return Path.Combine(EnsureCacheBaseRoot(), "DriverPack");
+        return Path.Combine(EnsureCacheBaseRoot(), CacheFolderName, DriverPacksFolderName);
     }
 
     public string EnsureTargetFoundryRoot()

--- a/src/Foundry.Deploy/Services/Deployment/Steps/PrepareTargetDiskLayoutStep.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Steps/PrepareTargetDiskLayoutStep.cs
@@ -45,8 +45,8 @@ public sealed class PrepareTargetDiskLayoutStep : DeploymentStepBase
 
         if (context.RuntimeState.Mode == DeploymentMode.Iso)
         {
-            Directory.CreateDirectory(Path.Combine(context.RuntimeState.TargetFoundryRoot, "OperatingSystem"));
-            Directory.CreateDirectory(Path.Combine(context.RuntimeState.TargetFoundryRoot, "DriverPack"));
+            Directory.CreateDirectory(Path.Combine(context.RuntimeState.TargetFoundryRoot, "Cache", "OperatingSystems"));
+            Directory.CreateDirectory(Path.Combine(context.RuntimeState.TargetFoundryRoot, "Cache", "DriverPacks"));
         }
 
         context.EmitCurrentStepIndeterminate("Preparing target disk layout...", "Preparing target workspace...");

--- a/src/Foundry/Common/Constants.cs
+++ b/src/Foundry/Common/Constants.cs
@@ -13,8 +13,15 @@ namespace Foundry.Common
         public static readonly string LogDirectoryPath = Path.Combine(RootDirectoryPath, "Logs");
         public static readonly string CacheDirectoryPath = Path.Combine(RootDirectoryPath, "Cache");
         public static readonly string InstallerCacheDirectoryPath = Path.Combine(CacheDirectoryPath, "Installers");
+        public static readonly string OperatingSystemCacheDirectoryPath = Path.Combine(CacheDirectoryPath, "OperatingSystems");
+        public static readonly string ToolCacheDirectoryPath = Path.Combine(CacheDirectoryPath, "Tools");
         public static readonly string WorkspacesDirectoryPath = Path.Combine(RootDirectoryPath, "Workspaces");
+        public static readonly string WinPeWorkspaceDirectoryPath = Path.Combine(WorkspacesDirectoryPath, "WinPe");
+        public static readonly string IsoWorkspaceDirectoryPath = Path.Combine(WorkspacesDirectoryPath, "Iso");
         public static readonly string TempDirectoryPath = Path.Combine(RootDirectoryPath, "Temp");
+        public static readonly string UsbQueryTempDirectoryPath = Path.Combine(TempDirectoryPath, "UsbQuery");
+        public static readonly string WinReTempDirectoryPath = Path.Combine(TempDirectoryPath, "WinRe");
+        public static readonly string DownloadsTempDirectoryPath = Path.Combine(TempDirectoryPath, "Downloads");
         public static readonly string LogFilePath = Path.Combine(LogDirectoryPath, "Foundry.log");
         public static readonly string AppSettingsPath = Path.Combine(SettingsDirectoryPath, "appsettings.json");
 
@@ -28,8 +35,15 @@ namespace Foundry.Common
             Directory.CreateDirectory(LogDirectoryPath);
             Directory.CreateDirectory(CacheDirectoryPath);
             Directory.CreateDirectory(InstallerCacheDirectoryPath);
+            Directory.CreateDirectory(OperatingSystemCacheDirectoryPath);
+            Directory.CreateDirectory(ToolCacheDirectoryPath);
             Directory.CreateDirectory(WorkspacesDirectoryPath);
+            Directory.CreateDirectory(WinPeWorkspaceDirectoryPath);
+            Directory.CreateDirectory(IsoWorkspaceDirectoryPath);
             Directory.CreateDirectory(TempDirectoryPath);
+            Directory.CreateDirectory(UsbQueryTempDirectoryPath);
+            Directory.CreateDirectory(WinReTempDirectoryPath);
+            Directory.CreateDirectory(DownloadsTempDirectoryPath);
         }
     }
 }

--- a/src/Foundry/Services/Adk/AdkService.cs
+++ b/src/Foundry/Services/Adk/AdkService.cs
@@ -32,7 +32,7 @@ internal sealed class AdkService(
         false,
         null,
         null,
-        "Windows ADK 10.1.26100.*");
+        "Windows ADK 10.1.26100.2454+ with the latest ADK servicing patch");
 
     public Task<AdkInstallationStatus> RefreshStatusAsync(CancellationToken cancellationToken = default)
     {

--- a/src/Foundry/Services/Shell/ShellNavigationGuardService.cs
+++ b/src/Foundry/Services/Shell/ShellNavigationGuardService.cs
@@ -8,7 +8,7 @@ internal sealed class ShellNavigationGuardService(ILogger logger) : IShellNaviga
 
     public event EventHandler? StateChanged;
 
-    public ShellNavigationState State { get; private set; } = ShellNavigationState.Ready;
+    public ShellNavigationState State { get; private set; } = ShellNavigationState.AdkBlocked;
 
     public void SetState(ShellNavigationState state)
     {


### PR DESCRIPTION
## Summary
Apply the Phase 12.D filesystem layout contract for host ProgramData, WinPE runtime folders, and Deploy cache paths.

## Reason
The final ISO/USB workflow needs stable, explicit paths before Phase 13 wires the user-facing media creation commands.

## Main changes
- Add explicit ProgramData workspace/cache/temp directory constants.
- Create WinPE workspace `temp` plus boot-image `X:\Foundry\Logs` and `X:\Foundry\Temp` folders.
- Normalize Deploy OS and driver cache paths under `Cache\OperatingSystems` and `Cache\DriverPacks` for USB and ISO target layouts.
- Update Phase 12.D plan status while keeping manual ISO/USB validation items open.
- Add regression tests for WinPE workspace folders, mounted image runtime folders, and Deploy cache path resolution.

## Testing
- `dotnet test .\src\Foundry.Core.Tests\Foundry.Core.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~WinPe" -v minimal`
- `dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj -c Release --nologo -v minimal`
- `dotnet build .\src\Foundry.slnx -c Release --nologo`
- `git diff --check`

Manual validation still needed for Phase 12.18 through 12.23.