### PR TITLE
feat(media): add start page preflight workflow

### DIFF
--- a/docs/migration/architecture/page-map.md
+++ b/docs/migration/architecture/page-map.md
@@ -118,6 +118,8 @@ Footer
   - [ ] Runtime payloads.
   - [ ] Driver options.
   - [ ] Network validation.
+- [ ] During Phase 13, expose preflight and dry-run summaries only.
+- [ ] Keep final ISO/USB execution disabled until Deploy configuration and Connect/network provisioning are complete.
 - [ ] Provide the primary commands:
   - [ ] Create ISO.
   - [ ] Create USB.

--- a/docs/migration/checklists/testing-strategy.md
+++ b/docs/migration/checklists/testing-strategy.md
@@ -40,3 +40,4 @@
   - [ ] ISO creation.
   - [ ] USB creation.
   - [ ] WinPE VM boot.
+  - [ ] Final generated ISO boots in a VM after final media execution is enabled and confirms bootstrap/config/runtime resolution.

--- a/docs/migration/phases/03-startup-distribution-ci.md
+++ b/docs/migration/phases/03-startup-distribution-ci.md
@@ -34,15 +34,14 @@
   - [x] Shell navigation guard service.
   - Note: localization and update service boundaries are registered; concrete `.resw` migration and Velopack update checks remain in later dedicated phases.
 - [x] **6.8** Remove DevWinUI placeholder update metadata.
-- [ ] **6.8.1** Implement the startup readiness sequence:
+- [x] **6.8.1** Implement the startup readiness sequence:
   - [x] Initialize logging, dependency injection, and Velopack startup hooks.
   - [x] Detect ADK and WinPE Add-on readiness.
   - [x] Apply `AdkBlocked` or `Ready` shell navigation state.
-  - [ ] Refresh USB targets only after ADK is compatible.
-  - Note: ADK readiness and update checks are implemented. USB target refresh remains deferred to Phase 13 after Phase 12 provides WinPE service foundations.
+  - [x] Refresh USB targets only after ADK is compatible.
+  - Note: ADK readiness, update checks, and ADK-gated USB target refresh are implemented.
   - [x] Run update checks after readiness initialization.
   - [x] Ensure startup update checks do not block app usage.
-  - Note: USB refresh is deferred to Phase 13.
 - [x] **6.9** Commit:
 
 ```powershell

--- a/docs/migration/phases/04-localization-logging-shell.md
+++ b/docs/migration/phases/04-localization-logging-shell.md
@@ -160,8 +160,9 @@ git commit -m "refactor: migrate foundry logging for winui"
 - [x] **10.10** Confirm startup failures are logged.
 - [x] **10.11** Confirm update failures are logged.
 - [ ] **10.12** Confirm media creation logs remain readable.
-  - Phase 13 covers readable Start-page preflight and dry-run logging.
-  - Final ISO/USB start, progress, completion, cancellation, and failure log validation is completed when final media execution is enabled after Deploy/Connect provisioning.
+  - [x] Phase 13 confirms readable Start-page preflight and dry-run logging.
+  - [x] Missing USB target is logged as state, not as a global blocking reason.
+  - [ ] Final ISO/USB start, progress, completion, cancellation, and failure log validation is completed when final media execution is enabled after Deploy/Connect provisioning.
 - [x] **10.13** Confirm `Debug` events are absent when `diagnostics.developerMode=false`.
 - [x] **10.14** Confirm `Debug` events are written when `diagnostics.developerMode=true`.
 - [x] **10.15** Confirm concise source context appears for app services.

--- a/docs/migration/phases/04-localization-logging-shell.md
+++ b/docs/migration/phases/04-localization-logging-shell.md
@@ -142,8 +142,8 @@ git commit -m "feat(localization): migrate foundry localization to winui"
 - [ ] **10.6.1** Define future workflow logging contracts without blocking Phase 10 on unimplemented workflows:
   - [x] ADK detection logs required when ADK service/page work is implemented in Phase 12.
   - [ ] ISO/USB build start, progress, completion, cancellation, and failure logs required when media creation work is implemented.
-  - [ ] Bootstrap payload resolution logs required when payload resolution work is implemented in Phase 12.
-  - [ ] Complete the ADK/WinPE portion through Phase 12 implementation and validation.
+  - [x] Bootstrap payload resolution logs required when payload resolution work is implemented in Phase 12.
+  - [x] Complete the ADK/WinPE portion through Phase 12 implementation and validation.
 - [x] **10.7** Keep log folder command in UI.
 - [x] **10.7.1** Log folder command opens `C:\ProgramData\Foundry\Logs`.
 - [x] **10.7.2** Remove unused logging dependencies unless they serve a configured sink:
@@ -160,8 +160,8 @@ git commit -m "refactor: migrate foundry logging for winui"
 - [x] **10.10** Confirm startup failures are logged.
 - [x] **10.11** Confirm update failures are logged.
 - [ ] **10.12** Confirm media creation logs remain readable.
-  - Deferred until Phase 13 implements ISO/USB media creation in WinUI.
-  - Complete this through Phase 13 validation item **13.16**.
+  - Phase 13 covers readable Start-page preflight and dry-run logging.
+  - Final ISO/USB start, progress, completion, cancellation, and failure log validation is completed when final media execution is enabled after Deploy/Connect provisioning.
 - [x] **10.13** Confirm `Debug` events are absent when `diagnostics.developerMode=false`.
 - [x] **10.14** Confirm `Debug` events are written when `diagnostics.developerMode=true`.
 - [x] **10.15** Confirm concise source context appears for app services.

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -385,22 +385,22 @@ git commit -m "feat(media): add start page preflight workflow"
 
 - [x] **13.8** ADK missing or incompatible state blocks `Start` navigation, which disables media dry-run summaries and final media commands through the shell guard and the `General` page `Create media` action.
 - [x] **13.9** Invalid ISO path appears as a global blocking reason and disables the final ISO command.
-- [ ] **13.10** No USB candidate must not appear as a blocking reason in the global summary; the future `Create USB` command remains disabled until a USB target is connected or selected, while ISO readiness remains independent.
-- [ ] **13.11** ARM64 exposes and enforces GPT as the only USB partition style.
+- [x] **13.10** No USB candidate must not appear as a blocking reason in the global summary; the future `Create USB` command remains disabled until a USB target is connected or selected, while ISO readiness remains independent.
+- [x] **13.11** ARM64 exposes and enforces GPT as the only USB partition style.
 - [x] **13.12** Future USB warning contract is represented by dry-run disk identity details, and no destructive formatting runs in Phase 13.
 - [x] **13.13** ADK missing state disables `Start` navigation through the shell guard.
 - [x] **13.14** Global summary clearly shows that final ISO execution is deferred until Deploy/Connect provisioning is complete.
 - [x] **13.15** Global summary clearly shows that final USB execution is deferred until Deploy/Connect provisioning is complete.
-- [ ] **13.16** Confirm media preflight logs remain readable and partially complete deferred Phase 10 validation **10.12**:
-  - [ ] Global preflight logs include readiness, selected options, and global blocking reasons.
-  - [ ] Missing USB target is logged as `UsbTargetSelected=false`, not as a global blocking reason.
-  - [ ] USB preflight logs include selected disk identity when a USB target is selected.
-  - [ ] Logs are readable in `C:\ProgramData\Foundry\Logs\Foundry.log` without enabling `Verbose`.
-- [ ] **13.17** Confirm the selected WinPE boot language flows from the `General` page into media creation:
-  - [ ] Available WinPE boot languages come from the installed ADK `WinPE_OCs` tree.
-  - [ ] The selected language appears in the `Start` page global summary using canonical culture casing such as `fr-FR` or `en-US`.
-  - [ ] The selected language is mapped to the Phase 12 service option that will control language pack and localized optional component package application during final execution.
-  - [ ] The expert `Localization` page is not part of this flow.
+- [x] **13.16** Confirm media preflight logs remain readable and partially complete deferred Phase 10 validation **10.12**:
+  - [x] Global preflight logs include readiness, selected options, and global blocking reasons.
+  - [x] Missing USB target is logged as `UsbTargetSelected=false`, not as a global blocking reason.
+  - [x] USB preflight logs include selected disk identity when a USB target is selected.
+  - [x] Logs are readable in `C:\ProgramData\Foundry\Logs\Foundry.log` without enabling `Verbose`.
+- [x] **13.17** Confirm the selected WinPE boot language flows from the `General` page into media creation:
+  - [x] Available WinPE boot languages come from the installed ADK `WinPE_OCs` tree.
+  - [x] The selected language appears in the `Start` page global summary using canonical culture casing such as `fr-FR` or `en-US`.
+  - [x] The selected language is mapped to the Phase 12 service option that will control language pack and localized optional component package application during final execution.
+  - [x] The expert `Localization` page is not part of this flow.
 - [x] **13.18** Confirm final media command enablement waits for Phase 14 Deploy configuration and Phase 15 Connect/network provisioning readiness:
   - [x] Phase 13 keeps final ISO/USB execution disabled even when the dry-run summary is valid.
   - [x] Phase 13 global summary lists Deploy, Connect, and secret-key provisioning as deferred readiness gates.

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -384,16 +384,16 @@ git commit -m "feat(media): add start page preflight workflow"
 **Validation**
 
 - [x] **13.8** ADK missing or incompatible state blocks `Start` navigation, which disables media dry-run summaries and final media commands through the shell guard and the `General` page `Create media` action.
-- [x] **13.9** Invalid ISO path appears as an ISO-specific blocking reason and disables the final ISO command.
-- [ ] **13.10** No USB candidate appears only as a USB-specific blocking reason and disables the final USB command; it must not block the ISO path or ISO readiness.
+- [x] **13.9** Invalid ISO path appears as a global blocking reason and disables the final ISO command.
+- [ ] **13.10** No USB candidate must not appear as a blocking reason in the global summary; the future `Create USB` command remains disabled until a USB target is connected or selected, while ISO readiness remains independent.
 - [ ] **13.11** ARM64 exposes and enforces GPT as the only USB partition style.
 - [x] **13.12** Future USB warning contract is represented by dry-run disk identity details, and no destructive formatting runs in Phase 13.
 - [x] **13.13** ADK missing state disables `Start` navigation through the shell guard.
 - [x] **13.14** Global summary clearly shows that final ISO execution is deferred until Deploy/Connect provisioning is complete.
 - [x] **13.15** Global summary clearly shows that final USB execution is deferred until Deploy/Connect provisioning is complete.
 - [ ] **13.16** Confirm media preflight logs remain readable and partially complete deferred Phase 10 validation **10.12**:
-  - [ ] Global preflight logs include readiness and selected options.
-  - [ ] Preflight logs keep ISO-specific and USB-specific blocking reasons separate.
+  - [ ] Global preflight logs include readiness, selected options, and global blocking reasons.
+  - [ ] Missing USB target is logged as `UsbTargetSelected=false`, not as a global blocking reason.
   - [ ] USB preflight logs include selected disk identity when a USB target is selected.
   - [ ] Logs are readable in `C:\ProgramData\Foundry\Logs\Foundry.log` without enabling `Verbose`.
 - [ ] **13.17** Confirm the selected WinPE boot language flows from the `General` page into media creation:

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -404,6 +404,7 @@ git commit -m "feat(media): add start page preflight workflow"
 - [x] **13.18** Confirm final media command enablement waits for Phase 14 Deploy configuration and Phase 15 Connect/network provisioning readiness:
   - [x] Phase 13 keeps final ISO/USB execution disabled even when the dry-run summary is valid.
   - [x] Phase 13 global summary lists Deploy, Connect, and secret-key provisioning as deferred readiness gates.
+- [ ] **13.18.1** Confirm final media command enablement after Phases 14 and 15:
   - [ ] Final media enablement after Phases 14 and 15 blocks ISO/USB creation when required Connect configuration is incomplete.
   - [ ] Final media enablement after Phases 14 and 15 blocks ISO/USB creation when required Deploy configuration is incomplete.
   - [ ] Final media enablement after Phases 14 and 15 blocks ISO/USB creation when encrypted secret-key provisioning is required but unavailable.

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -323,18 +323,18 @@ git commit -m "feat(winpe): apply programdata media layout"
 
 **Priority:** medium-high after Phase 12 service prerequisites.
 
-**Goal:** port the standard media configuration surface into the `Start` page, wire readiness/preflight checks, and produce clear dry-run summaries without enabling destructive final ISO/USB execution yet.
+**Goal:** port the standard media configuration defaults into the main `General` page, keep `Start` as a global media summary and execution page, wire readiness/preflight checks, and produce a clear global summary without enabling destructive final ISO/USB execution yet.
 
 **Prerequisites:** Phase 11 shell/overlay contract and the Phase 12 ADK/WinPE service contract must be available before implementing the `Start` page media workflow.
 
-**Provisioning boundary:** the final production ISO/USB creation path also depends on Phase 14 for complete `Foundry.Deploy` configuration generation and Phase 15 for complete `Foundry.Connect` configuration, network asset provisioning, and encrypted embedded Wi-Fi secrets. Phase 13 builds the `Start` page UI, readiness checks, USB discovery, and dry-run summaries. Final Create ISO/Create USB execution remains disabled or explicitly marked incomplete until the final enablement PR after Phases 14 and 15.
+**Provisioning boundary:** the final production ISO/USB creation path also depends on Phase 14 for complete `Foundry.Deploy` configuration generation and Phase 15 for complete `Foundry.Connect` configuration, network asset provisioning, and encrypted embedded Wi-Fi secrets. Phase 13 builds the `General` media defaults UI, the `Start` global summary, readiness checks, and USB discovery. Final Create ISO/Create USB execution remains disabled or explicitly marked incomplete until the final enablement PR after Phases 14 and 15.
 
-- [x] **13.1** Create WinUI view model for media preflight on the `Start` page.
-  - [x] Keep WinPE boot language selection owned by the `General` page because the WPF source stores it in `GeneralSettings.WinPeLanguage`.
-  - [x] The `Start` page consumes the selected WinPE boot language from `General` and shows it in the dry-run summary.
-  - [x] If the `General` page has not yet implemented WinPE boot language selection when media preflight is wired, implement the minimal selector there before enabling dry-run summaries.
+- [x] **13.1** Create WinUI view model for media defaults on the main `General` page and media preflight on the `Start` page.
+  - [x] Keep WinPE boot language selection owned by the main `General` page because the WPF source stores it in `GeneralSettings.WinPeLanguage`.
+  - [x] The `Start` page consumes the selected WinPE boot language from `General` and shows it in the global summary.
+  - [x] If the `General` page has not yet implemented WinPE boot language selection when media preflight is wired, implement the minimal selector there before enabling the global summary.
   - [x] Do not confuse WinPE boot language with the expert `Localization` page; that page owns OS deployment language visibility/default/time-zone settings for `Foundry.Deploy`.
-- [x] **13.2** Port state from WPF `MainWindowViewModel`:
+- [x] **13.2** Port base media state from WPF `MainWindowViewModel` to the main `General` page:
   - [x] ISO output path.
   - [x] Architecture.
   - [x] CA 2023 signature mode.
@@ -343,15 +343,15 @@ git commit -m "feat(winpe): apply programdata media layout"
   - [x] Dell driver inclusion.
   - [x] HP driver inclusion.
   - [x] Custom driver directory.
-  - [x] Selected USB disk.
+  - [x] Keep selected USB disk out of base defaults; it remains owned by `Start` because it is execution-time state.
   - [x] Selected WinPE boot language from `General`.
-- [x] **13.3** Port commands:
+- [x] **13.3** Port commands with clear page ownership:
   - [x] Browse ISO path.
   - [x] Browse custom driver folder.
-  - [x] Refresh USB disks manually from the `Start` page.
+  - [x] Add a `Create media` action on the main `General` page that navigates to `Start`.
+  - [x] Refresh USB disks manually from the `Start` page because USB target selection is execution-time state.
   - [x] Refresh USB disks automatically when the `Start` page loads and ADK is compatible.
-  - [x] Generate ISO dry-run summary.
-  - [x] Generate USB dry-run summary.
+  - [x] Generate one global media summary on the `Start` page.
   - [x] Keep final Create ISO/Create USB execution disabled until the final media enablement PR.
 - [x] **13.4** Prepare the future WinUI destructive USB warning dialog contract in the dry-run flow.
   - [x] Show disk number, friendly name, and size in the USB target summary.
@@ -359,7 +359,7 @@ git commit -m "feat(winpe): apply programdata media layout"
   - [x] Do not perform destructive formatting in Phase 13.
 - [x] **13.5** Use app dispatcher abstraction for UI updates.
 - [x] **13.6** Keep media preflight and future media build orchestration in app/core services, not page code-behind.
-  - [x] **13.6.1** Show a dry-run execution summary before ISO or USB creation can be enabled:
+  - [x] **13.6.1** Show one global execution summary before ISO or USB creation can be enabled:
     - [x] ADK status.
     - [x] WinPE boot language from `General`.
     - [x] Architecture.
@@ -384,25 +384,25 @@ git commit -m "feat(media): add start page preflight workflow"
 **Validation**
 
 - [ ] **13.8** ADK missing or incompatible state blocks `Start` navigation, which disables media dry-run summaries and final media commands through the shell guard.
-- [ ] **13.9** Invalid ISO path disables ISO dry-run summary and final ISO command.
-- [ ] **13.10** No USB candidate disables USB dry-run summary and final USB command.
+- [ ] **13.9** Invalid ISO path appears as a blocking reason in the global summary and disables the final ISO command.
+- [ ] **13.10** No USB candidate appears as a blocking reason in the global summary and disables the final USB command.
 - [ ] **13.11** ARM64 enforces GPT partition style.
 - [ ] **13.12** Future USB warning contract is represented by dry-run disk identity details, and no destructive formatting runs in Phase 13.
 - [ ] **13.13** ADK missing state disables `Start` navigation through the shell guard.
-- [ ] **13.14** ISO dry-run summary clearly shows that final ISO execution is deferred until Deploy/Connect provisioning is complete.
-- [ ] **13.15** USB dry-run summary clearly shows that final USB execution is deferred until Deploy/Connect provisioning is complete.
+- [ ] **13.14** Global summary clearly shows that final ISO execution is deferred until Deploy/Connect provisioning is complete.
+- [ ] **13.15** Global summary clearly shows that final USB execution is deferred until Deploy/Connect provisioning is complete.
 - [ ] **13.16** Confirm media preflight logs remain readable and partially complete deferred Phase 10 validation **10.12**:
-  - [ ] ISO preflight logs include readiness, selected options, and blocking reasons.
-  - [ ] USB preflight logs include readiness, selected options, selected disk identity, and blocking reasons.
+  - [ ] Global preflight logs include readiness, selected options, and blocking reasons.
+  - [ ] USB preflight logs include selected disk identity when a USB target is selected.
   - [ ] Logs are readable in `C:\ProgramData\Foundry\Logs\Foundry.log` without enabling `Verbose`.
 - [ ] **13.17** Confirm the selected WinPE boot language flows from the `General` page into media creation:
   - [ ] Available WinPE boot languages come from the installed ADK `WinPE_OCs` tree.
-  - [ ] The selected language appears in the `Start` page dry-run summary.
+  - [ ] The selected language appears in the `Start` page global summary.
   - [ ] The selected language is mapped to the Phase 12 service option that will control language pack and localized optional component package application during final execution.
   - [ ] The expert `Localization` page is not part of this flow.
 - [ ] **13.18** Confirm final media command enablement waits for Phase 14 Deploy configuration and Phase 15 Connect/network provisioning readiness:
   - [ ] Phase 13 keeps final ISO/USB execution disabled even when the dry-run summary is valid.
-  - [ ] Phase 13 dry-run summaries list Deploy, Connect, and secret-key provisioning as deferred readiness gates.
+  - [ ] Phase 13 global summary lists Deploy, Connect, and secret-key provisioning as deferred readiness gates.
   - [ ] Final media enablement after Phases 14 and 15 blocks ISO/USB creation when required Connect configuration is incomplete.
   - [ ] Final media enablement after Phases 14 and 15 blocks ISO/USB creation when required Deploy configuration is incomplete.
   - [ ] Final media enablement after Phases 14 and 15 blocks ISO/USB creation when encrypted secret-key provisioning is required but unavailable.

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -348,7 +348,7 @@ git commit -m "feat(winpe): apply programdata media layout"
 - [x] **13.3** Port commands with clear page ownership:
   - [x] Browse ISO path.
   - [x] Browse custom driver folder.
-  - [x] Add a `Create media` action on the main `General` page that navigates to `Start`.
+  - [x] Add a `Create media` action on the main `General` page that navigates to `Start` and remains gated by compatible ADK readiness.
   - [x] Refresh USB disks manually from the `Start` page because USB target selection is execution-time state.
   - [x] Refresh USB disks automatically when the `Start` page loads and ADK is compatible.
   - [x] Generate one global media summary on the `Start` page.
@@ -370,7 +370,7 @@ git commit -m "feat(winpe): apply programdata media layout"
     - [x] Network validation.
     - [x] `Foundry.Connect` provisioning readiness from Phase 15.
     - [x] Secret envelope/key provisioning readiness when embedded Wi-Fi secrets are required.
-    - [x] Boot image source selection: standard WinPE or Wi-Fi-capable WinRE path.
+    - [x] No boot image source selector is exposed in Phase 13; Wi-Fi/WinRE-specific provisioning remains owned by the future `Network` page workflow.
   - [x] **13.6.2** Map final ISO creation requirements to a future operation overlay contract without enabling execution.
   - [x] **13.6.3** Map final USB creation requirements to a future operation overlay contract without enabling execution.
   - [x] **13.6.4** Keep final navigation-blocking ISO/USB execution validation deferred until final media command enablement.
@@ -383,7 +383,7 @@ git commit -m "feat(media): add start page preflight workflow"
 
 **Validation**
 
-- [ ] **13.8** ADK missing or incompatible state blocks `Start` navigation, which disables media dry-run summaries and final media commands through the shell guard.
+- [ ] **13.8** ADK missing or incompatible state blocks `Start` navigation, which disables media dry-run summaries and final media commands through the shell guard and the `General` page `Create media` action.
 - [ ] **13.9** Invalid ISO path appears as a blocking reason in the global summary and disables the final ISO command.
 - [ ] **13.10** No USB candidate appears as a blocking reason in the global summary and disables the final USB command.
 - [ ] **13.11** ARM64 enforces GPT partition style.

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -383,26 +383,27 @@ git commit -m "feat(media): add start page preflight workflow"
 
 **Validation**
 
-- [ ] **13.8** ADK missing or incompatible state blocks `Start` navigation, which disables media dry-run summaries and final media commands through the shell guard and the `General` page `Create media` action.
-- [ ] **13.9** Invalid ISO path appears as a blocking reason in the global summary and disables the final ISO command.
-- [ ] **13.10** No USB candidate appears as a blocking reason in the global summary and disables the final USB command.
-- [ ] **13.11** ARM64 enforces GPT partition style.
-- [ ] **13.12** Future USB warning contract is represented by dry-run disk identity details, and no destructive formatting runs in Phase 13.
-- [ ] **13.13** ADK missing state disables `Start` navigation through the shell guard.
-- [ ] **13.14** Global summary clearly shows that final ISO execution is deferred until Deploy/Connect provisioning is complete.
-- [ ] **13.15** Global summary clearly shows that final USB execution is deferred until Deploy/Connect provisioning is complete.
+- [x] **13.8** ADK missing or incompatible state blocks `Start` navigation, which disables media dry-run summaries and final media commands through the shell guard and the `General` page `Create media` action.
+- [x] **13.9** Invalid ISO path appears as an ISO-specific blocking reason and disables the final ISO command.
+- [ ] **13.10** No USB candidate appears only as a USB-specific blocking reason and disables the final USB command; it must not block the ISO path or ISO readiness.
+- [ ] **13.11** ARM64 exposes and enforces GPT as the only USB partition style.
+- [x] **13.12** Future USB warning contract is represented by dry-run disk identity details, and no destructive formatting runs in Phase 13.
+- [x] **13.13** ADK missing state disables `Start` navigation through the shell guard.
+- [x] **13.14** Global summary clearly shows that final ISO execution is deferred until Deploy/Connect provisioning is complete.
+- [x] **13.15** Global summary clearly shows that final USB execution is deferred until Deploy/Connect provisioning is complete.
 - [ ] **13.16** Confirm media preflight logs remain readable and partially complete deferred Phase 10 validation **10.12**:
-  - [ ] Global preflight logs include readiness, selected options, and blocking reasons.
+  - [ ] Global preflight logs include readiness and selected options.
+  - [ ] Preflight logs keep ISO-specific and USB-specific blocking reasons separate.
   - [ ] USB preflight logs include selected disk identity when a USB target is selected.
   - [ ] Logs are readable in `C:\ProgramData\Foundry\Logs\Foundry.log` without enabling `Verbose`.
 - [ ] **13.17** Confirm the selected WinPE boot language flows from the `General` page into media creation:
   - [ ] Available WinPE boot languages come from the installed ADK `WinPE_OCs` tree.
-  - [ ] The selected language appears in the `Start` page global summary.
+  - [ ] The selected language appears in the `Start` page global summary using canonical culture casing such as `fr-FR` or `en-US`.
   - [ ] The selected language is mapped to the Phase 12 service option that will control language pack and localized optional component package application during final execution.
   - [ ] The expert `Localization` page is not part of this flow.
-- [ ] **13.18** Confirm final media command enablement waits for Phase 14 Deploy configuration and Phase 15 Connect/network provisioning readiness:
-  - [ ] Phase 13 keeps final ISO/USB execution disabled even when the dry-run summary is valid.
-  - [ ] Phase 13 global summary lists Deploy, Connect, and secret-key provisioning as deferred readiness gates.
+- [x] **13.18** Confirm final media command enablement waits for Phase 14 Deploy configuration and Phase 15 Connect/network provisioning readiness:
+  - [x] Phase 13 keeps final ISO/USB execution disabled even when the dry-run summary is valid.
+  - [x] Phase 13 global summary lists Deploy, Connect, and secret-key provisioning as deferred readiness gates.
   - [ ] Final media enablement after Phases 14 and 15 blocks ISO/USB creation when required Connect configuration is incomplete.
   - [ ] Final media enablement after Phases 14 and 15 blocks ISO/USB creation when required Deploy configuration is incomplete.
   - [ ] Final media enablement after Phases 14 and 15 blocks ISO/USB creation when encrypted secret-key provisioning is required but unavailable.

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -279,11 +279,11 @@ git commit -m "feat(winpe): apply programdata media layout"
 - [x] **12.19** Local debug Deploy publish override still works.
 - [x] **12.23** New host-side `ProgramData` layout is used without old-folder fallback.
 
-**Manual validation deferred to Phase 13 Start page workflow**
+**Manual validation deferred to final media command enablement after Phases 14 and 15**
 
-- [ ] **12.20** ISO creation works on a test machine with ADK through the final `Start` page command.
-- [ ] **12.21** USB creation works on a disposable test drive through the final `Start` page command.
-- [ ] **12.22** Generated ISO/USB media matches the documented layout from the final `Start` page workflow.
+- [ ] **12.20** ISO creation works on a test machine with ADK through the final `Start` page command after final media execution is enabled.
+- [ ] **12.21** USB creation works on a disposable test drive through the final `Start` page command after final media execution is enabled.
+- [ ] **12.22** Generated ISO/USB media matches the documented layout from the final `Start` page workflow after final media execution is enabled.
 
 **ADK and WinPE service validation completed in Phase 12**
 
@@ -383,11 +383,11 @@ git commit -m "feat(media): add start page preflight workflow"
 
 **Validation**
 
-- [ ] **13.8** ADK missing state disables media dry-run summaries and final media commands.
+- [ ] **13.8** ADK missing or incompatible state blocks `Start` navigation, which disables media dry-run summaries and final media commands through the shell guard.
 - [ ] **13.9** Invalid ISO path disables ISO dry-run summary and final ISO command.
 - [ ] **13.10** No USB candidate disables USB dry-run summary and final USB command.
 - [ ] **13.11** ARM64 enforces GPT partition style.
-- [ ] **13.12** USB warning contract is present but no destructive formatting runs in Phase 13.
+- [ ] **13.12** Future USB warning contract is represented by dry-run disk identity details, and no destructive formatting runs in Phase 13.
 - [ ] **13.13** ADK missing state disables `Start` navigation through the shell guard.
 - [ ] **13.14** ISO dry-run summary clearly shows that final ISO execution is deferred until Deploy/Connect provisioning is complete.
 - [ ] **13.15** USB dry-run summary clearly shows that final USB execution is deferred until Deploy/Connect provisioning is complete.
@@ -401,7 +401,8 @@ git commit -m "feat(media): add start page preflight workflow"
   - [ ] The selected language is mapped to the Phase 12 service option that will control language pack and localized optional component package application during final execution.
   - [ ] The expert `Localization` page is not part of this flow.
 - [ ] **13.18** Confirm final media command enablement waits for Phase 14 Deploy configuration and Phase 15 Connect/network provisioning readiness:
-  - [ ] ISO/USB creation is blocked when required Connect configuration is incomplete.
-  - [ ] ISO/USB creation is blocked when required Deploy configuration is incomplete.
-  - [ ] ISO/USB creation is blocked when encrypted secret-key provisioning is required but unavailable.
-  - [ ] Final ISO/USB execution remains disabled in Phase 13 even when the dry-run summary is valid.
+  - [ ] Phase 13 keeps final ISO/USB execution disabled even when the dry-run summary is valid.
+  - [ ] Phase 13 dry-run summaries list Deploy, Connect, and secret-key provisioning as deferred readiness gates.
+  - [ ] Final media enablement after Phases 14 and 15 blocks ISO/USB creation when required Connect configuration is incomplete.
+  - [ ] Final media enablement after Phases 14 and 15 blocks ISO/USB creation when required Deploy configuration is incomplete.
+  - [ ] Final media enablement after Phases 14 and 15 blocks ISO/USB creation when encrypted secret-key provisioning is required but unavailable.

--- a/docs/migration/phases/05-media-and-winpe.md
+++ b/docs/migration/phases/05-media-and-winpe.md
@@ -37,7 +37,7 @@ The `12.A` to `12.D` labels are implementation slices, not extra phase numbers. 
 **Deferred infrastructure completion:** Phase 12 is also responsible for completing the ADK/WinPE portions of earlier deferred infrastructure work:
 
 - [x] Complete Phase 6 readiness item **6.8.1** for ADK detection, WinPE Add-on readiness, and ADK-gated startup readiness.
-- [ ] Complete Phase 6 readiness item **6.8.1** for USB target service readiness after ADK compatibility is known; keep the final `Start` page refresh command wiring in Phase 13.
+- [x] Complete Phase 6 readiness item **6.8.1** for USB target service readiness after ADK compatibility is known; keep the final `Start` page refresh command wiring in Phase 13.
 - [x] Complete Phase 10 logging contract item **10.6.1** for ADK detection and bootstrap payload resolution logs.
 
 **WPF reference scenario audit:** before implementing each Phase 12 slice, compare the new WinUI/Core behavior against the archived WPF reference without modifying it:
@@ -284,6 +284,9 @@ git commit -m "feat(winpe): apply programdata media layout"
 - [ ] **12.20** ISO creation works on a test machine with ADK through the final `Start` page command.
 - [ ] **12.21** USB creation works on a disposable test drive through the final `Start` page command.
 - [ ] **12.22** Generated ISO/USB media matches the documented layout from the final `Start` page workflow.
+
+**ADK and WinPE service validation completed in Phase 12**
+
 - [x] **12.24** ADK page shows missing state when ADK is absent.
 - [x] **12.25** ADK page shows installed version when ADK is present.
 - [x] **12.26** ADK page shows incompatible state when the version is unsupported.
@@ -316,83 +319,89 @@ git commit -m "feat(winpe): apply programdata media layout"
   - [x] `sources\boot.wim`, `boot\BCD`, and architecture-specific EFI boot files are present.
   - [x] Successful `robocopy` exit codes `0` through `7` are accepted.
 
-## Phase 13: General Media Creation Workflow
+## Phase 13: Start Page Media Preflight Workflow
 
 **Priority:** medium-high after Phase 12 service prerequisites.
 
-**Goal:** port the standard ISO/USB creation workflow into the `Start` page and blocking operation overlay model.
+**Goal:** port the standard media configuration surface into the `Start` page, wire readiness/preflight checks, and produce clear dry-run summaries without enabling destructive final ISO/USB execution yet.
 
-**Prerequisites:** Phase 11 shell/overlay contract and the Phase 12 ADK/WinPE service contract must be available before implementing the final media creation commands.
+**Prerequisites:** Phase 11 shell/overlay contract and the Phase 12 ADK/WinPE service contract must be available before implementing the `Start` page media workflow.
 
-**Provisioning boundary:** the final production ISO/USB creation path also depends on Phase 15 for complete `Foundry.Connect` configuration, network asset provisioning, and encrypted embedded Wi-Fi secrets. Phase 13 may build the `Start` page UI and dry-run summaries before Phase 15, but final Create ISO/Create USB commands must stay disabled or clearly marked incomplete until Phase 15 is implemented.
+**Provisioning boundary:** the final production ISO/USB creation path also depends on Phase 14 for complete `Foundry.Deploy` configuration generation and Phase 15 for complete `Foundry.Connect` configuration, network asset provisioning, and encrypted embedded Wi-Fi secrets. Phase 13 builds the `Start` page UI, readiness checks, USB discovery, and dry-run summaries. Final Create ISO/Create USB execution remains disabled or explicitly marked incomplete until the final enablement PR after Phases 14 and 15.
 
-- [ ] **13.1** Create WinUI view model for media creation on the `Start` page.
-  - [ ] Keep WinPE boot language selection owned by the `General` page because the WPF source stores it in `GeneralSettings.WinPeLanguage`.
-  - [ ] The `Start` page consumes the selected WinPE boot language from `General` and shows it in the final execution summary.
-  - [ ] If the `General` page has not yet implemented WinPE boot language selection when media creation is wired, implement the minimal selector there before enabling ISO/USB commands.
-  - [ ] Do not confuse WinPE boot language with the expert `Localization` page; that page owns OS deployment language visibility/default/time-zone settings for `Foundry.Deploy`.
-- [ ] **13.2** Port state from WPF `MainWindowViewModel`:
-  - [ ] ISO output path.
-  - [ ] Architecture.
-  - [ ] CA 2023 signature mode.
-  - [ ] USB partition style.
-  - [ ] USB format mode.
-  - [ ] Dell driver inclusion.
-  - [ ] HP driver inclusion.
-  - [ ] Custom driver directory.
-  - [ ] Selected USB disk.
-  - [ ] Selected WinPE boot language from `General`.
-- [ ] **13.3** Port commands:
-  - [ ] Browse ISO path.
-  - [ ] Browse custom driver folder.
-  - [ ] Refresh USB disks.
-  - [ ] Create ISO.
-  - [ ] Create USB.
-- [ ] **13.4** Implement WinUI warning dialog for destructive USB formatting.
-- [ ] **13.5** Use app dispatcher abstraction for UI updates.
-- [ ] **13.6** Keep media build service logic in core/app services, not page code-behind.
-  - [ ] **13.6.1** Show a final execution summary before ISO or USB creation:
-    - [ ] ADK status.
-    - [ ] WinPE boot language from `General`.
-    - [ ] Architecture.
-    - [ ] ISO output path.
-    - [ ] USB target.
-    - [ ] Runtime payload readiness.
-    - [ ] Driver options.
-    - [ ] Network validation.
-    - [ ] `Foundry.Connect` provisioning readiness from Phase 15.
-    - [ ] Secret envelope/key provisioning readiness when embedded Wi-Fi secrets are required.
-    - [ ] Boot image source selection: standard WinPE or Wi-Fi-capable WinRE path.
-  - [ ] **13.6.2** Run ISO creation inside the blocking operation overlay.
-  - [ ] **13.6.3** Run USB creation inside the blocking operation overlay.
-  - [ ] **13.6.4** Keep navigation blocked until ISO or USB creation fully completes.
-- [ ] **13.7** Commit:
+- [x] **13.1** Create WinUI view model for media preflight on the `Start` page.
+  - [x] Keep WinPE boot language selection owned by the `General` page because the WPF source stores it in `GeneralSettings.WinPeLanguage`.
+  - [x] The `Start` page consumes the selected WinPE boot language from `General` and shows it in the dry-run summary.
+  - [x] If the `General` page has not yet implemented WinPE boot language selection when media preflight is wired, implement the minimal selector there before enabling dry-run summaries.
+  - [x] Do not confuse WinPE boot language with the expert `Localization` page; that page owns OS deployment language visibility/default/time-zone settings for `Foundry.Deploy`.
+- [x] **13.2** Port state from WPF `MainWindowViewModel`:
+  - [x] ISO output path.
+  - [x] Architecture.
+  - [x] CA 2023 signature mode.
+  - [x] USB partition style.
+  - [x] USB format mode.
+  - [x] Dell driver inclusion.
+  - [x] HP driver inclusion.
+  - [x] Custom driver directory.
+  - [x] Selected USB disk.
+  - [x] Selected WinPE boot language from `General`.
+- [x] **13.3** Port commands:
+  - [x] Browse ISO path.
+  - [x] Browse custom driver folder.
+  - [x] Refresh USB disks manually from the `Start` page.
+  - [x] Refresh USB disks automatically when the `Start` page loads and ADK is compatible.
+  - [x] Generate ISO dry-run summary.
+  - [x] Generate USB dry-run summary.
+  - [x] Keep final Create ISO/Create USB execution disabled until the final media enablement PR.
+- [x] **13.4** Prepare the future WinUI destructive USB warning dialog contract in the dry-run flow.
+  - [x] Show disk number, friendly name, and size in the USB target summary.
+  - [x] Document that the future final USB command must default to cancel/no.
+  - [x] Do not perform destructive formatting in Phase 13.
+- [x] **13.5** Use app dispatcher abstraction for UI updates.
+- [x] **13.6** Keep media preflight and future media build orchestration in app/core services, not page code-behind.
+  - [x] **13.6.1** Show a dry-run execution summary before ISO or USB creation can be enabled:
+    - [x] ADK status.
+    - [x] WinPE boot language from `General`.
+    - [x] Architecture.
+    - [x] ISO output path.
+    - [x] USB target.
+    - [x] Runtime payload readiness.
+    - [x] Driver options.
+    - [x] Network validation.
+    - [x] `Foundry.Connect` provisioning readiness from Phase 15.
+    - [x] Secret envelope/key provisioning readiness when embedded Wi-Fi secrets are required.
+    - [x] Boot image source selection: standard WinPE or Wi-Fi-capable WinRE path.
+  - [x] **13.6.2** Map final ISO creation requirements to a future operation overlay contract without enabling execution.
+  - [x] **13.6.3** Map final USB creation requirements to a future operation overlay contract without enabling execution.
+  - [x] **13.6.4** Keep final navigation-blocking ISO/USB execution validation deferred until final media command enablement.
+- [x] **13.6.5** Complete Phase 6 readiness item **6.8.1** for USB target service readiness after ADK compatibility is known.
+- [x] **13.7** Commit:
 
 ```powershell
-git commit -m "feat(media): port creation workflow to winui"
+git commit -m "feat(media): add start page preflight workflow"
 ```
 
 **Validation**
 
-- [ ] **13.8** ADK missing state disables media creation.
-- [ ] **13.9** Invalid ISO path disables ISO creation.
-- [ ] **13.10** No USB candidate disables USB creation.
+- [ ] **13.8** ADK missing state disables media dry-run summaries and final media commands.
+- [ ] **13.9** Invalid ISO path disables ISO dry-run summary and final ISO command.
+- [ ] **13.10** No USB candidate disables USB dry-run summary and final USB command.
 - [ ] **13.11** ARM64 enforces GPT partition style.
-- [ ] **13.12** USB warning appears before formatting.
+- [ ] **13.12** USB warning contract is present but no destructive formatting runs in Phase 13.
 - [ ] **13.13** ADK missing state disables `Start` navigation through the shell guard.
-- [ ] **13.14** ISO creation overlay blocks navigation until completion.
-- [ ] **13.15** USB creation overlay blocks navigation until completion.
-- [ ] **13.16** Confirm media creation logs remain readable and complete deferred Phase 10 validation **10.12**:
-  - [ ] ISO creation logs include start, progress, completion, cancellation, and failure details.
-  - [ ] USB creation logs include start, progress, completion, cancellation, and failure details.
+- [ ] **13.14** ISO dry-run summary clearly shows that final ISO execution is deferred until Deploy/Connect provisioning is complete.
+- [ ] **13.15** USB dry-run summary clearly shows that final USB execution is deferred until Deploy/Connect provisioning is complete.
+- [ ] **13.16** Confirm media preflight logs remain readable and partially complete deferred Phase 10 validation **10.12**:
+  - [ ] ISO preflight logs include readiness, selected options, and blocking reasons.
+  - [ ] USB preflight logs include readiness, selected options, selected disk identity, and blocking reasons.
   - [ ] Logs are readable in `C:\ProgramData\Foundry\Logs\Foundry.log` without enabling `Verbose`.
 - [ ] **13.17** Confirm the selected WinPE boot language flows from the `General` page into media creation:
   - [ ] Available WinPE boot languages come from the installed ADK `WinPE_OCs` tree.
-  - [ ] The selected language controls the language pack and localized optional component packages applied during Phase 12 service execution.
-  - [ ] The `Start` page summary shows the selected WinPE boot language before ISO or USB creation.
+  - [ ] The selected language appears in the `Start` page dry-run summary.
+  - [ ] The selected language is mapped to the Phase 12 service option that will control language pack and localized optional component package application during final execution.
   - [ ] The expert `Localization` page is not part of this flow.
-- [ ] **13.18** Confirm final media command enablement waits for Phase 15 network provisioning readiness:
+- [ ] **13.18** Confirm final media command enablement waits for Phase 14 Deploy configuration and Phase 15 Connect/network provisioning readiness:
   - [ ] ISO/USB creation is blocked when required Connect configuration is incomplete.
+  - [ ] ISO/USB creation is blocked when required Deploy configuration is incomplete.
   - [ ] ISO/USB creation is blocked when encrypted secret-key provisioning is required but unavailable.
-  - [ ] ISO mode contains all required runtime/configuration content under `X:\Foundry`.
-  - [ ] USB mode keeps BOOT minimal and resolves persistent runtime/cache content from the `Foundry Cache` partition.
+  - [ ] Final ISO/USB execution remains disabled in Phase 13 even when the dry-run summary is valid.

--- a/src/Foundry.Core.Tests/Media/MediaPreflightServiceTests.cs
+++ b/src/Foundry.Core.Tests/Media/MediaPreflightServiceTests.cs
@@ -1,0 +1,98 @@
+using Foundry.Core.Services.Media;
+using Foundry.Core.Services.WinPe;
+
+namespace Foundry.Core.Tests.Media;
+
+public sealed class MediaPreflightServiceTests
+{
+    [Fact]
+    public void Evaluate_WhenBasicsAreReady_AllowsDryRunButKeepsFinalExecutionDisabled()
+    {
+        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(CreateReadyOptions());
+
+        Assert.True(evaluation.CanGenerateIsoSummary);
+        Assert.True(evaluation.CanGenerateUsbSummary);
+        Assert.False(evaluation.CanCreateIso);
+        Assert.False(evaluation.CanCreateUsb);
+        Assert.Contains(MediaPreflightBlockingReason.FinalExecutionDeferred, evaluation.IsoBlockingReasons);
+        Assert.Contains(MediaPreflightBlockingReason.FinalExecutionDeferred, evaluation.UsbBlockingReasons);
+    }
+
+    [Fact]
+    public void Evaluate_WhenIsoPathIsInvalid_BlocksIsoDryRun()
+    {
+        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(
+            CreateReadyOptions() with { IsoOutputPath = @"C:\Temp\Foundry.txt" });
+
+        Assert.False(evaluation.CanGenerateIsoSummary);
+        Assert.Contains(MediaPreflightBlockingReason.InvalidIsoPath, evaluation.IsoBlockingReasons);
+    }
+
+    [Fact]
+    public void Evaluate_WhenUsbCandidateIsMissing_BlocksUsbDryRun()
+    {
+        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(
+            CreateReadyOptions() with { SelectedUsbDisk = null });
+
+        Assert.False(evaluation.CanGenerateUsbSummary);
+        Assert.Contains(MediaPreflightBlockingReason.NoUsbTarget, evaluation.UsbBlockingReasons);
+    }
+
+    [Fact]
+    public void Evaluate_WhenWinPeLanguageIsNotAvailableForArchitecture_BlocksDryRun()
+    {
+        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(
+            CreateReadyOptions() with
+            {
+                WinPeLanguage = "fr-FR",
+                AvailableWinPeLanguages = ["en-US"]
+            });
+
+        Assert.False(evaluation.CanGenerateIsoSummary);
+        Assert.False(evaluation.CanGenerateUsbSummary);
+        Assert.Contains(MediaPreflightBlockingReason.WinPeLanguageUnavailable, evaluation.IsoBlockingReasons);
+        Assert.Contains(MediaPreflightBlockingReason.WinPeLanguageUnavailable, evaluation.UsbBlockingReasons);
+    }
+
+    [Fact]
+    public void Evaluate_WhenArchitectureIsArm64_EnforcesGptPartitionStyle()
+    {
+        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(
+            CreateReadyOptions() with
+            {
+                Architecture = WinPeArchitecture.Arm64,
+                UsbPartitionStyle = UsbPartitionStyle.Mbr
+            });
+
+        Assert.Equal(UsbPartitionStyle.Gpt, evaluation.EffectiveUsbPartitionStyle);
+        Assert.Contains(MediaPreflightBlockingReason.Arm64RequiresGpt, evaluation.UsbBlockingReasons);
+    }
+
+    private static MediaPreflightOptions CreateReadyOptions()
+    {
+        return new MediaPreflightOptions
+        {
+            IsAdkReady = true,
+            IsRuntimePayloadReady = true,
+            IsNetworkConfigurationReady = true,
+            IsDeployConfigurationReady = true,
+            IsConnectProvisioningReady = true,
+            AreRequiredSecretsReady = true,
+            IsoOutputPath = @"C:\Temp\Foundry.iso",
+            WinPeLanguage = "en-US",
+            Architecture = WinPeArchitecture.X64,
+            UsbPartitionStyle = UsbPartitionStyle.Gpt,
+            UsbFormatMode = UsbFormatMode.Quick,
+            SelectedUsbDisk = new WinPeUsbDiskCandidate
+            {
+                DiskNumber = 3,
+                FriendlyName = "Safe USB",
+                SerialNumber = "USB123",
+                UniqueId = "USB-ID",
+                BusType = "USB",
+                IsRemovable = true,
+                SizeBytes = 64_000_000_000
+            }
+        };
+    }
+}

--- a/src/Foundry.Core/Services/Media/MediaPreflightBlockingReason.cs
+++ b/src/Foundry.Core/Services/Media/MediaPreflightBlockingReason.cs
@@ -1,0 +1,19 @@
+namespace Foundry.Core.Services.Media;
+
+public enum MediaPreflightBlockingReason
+{
+    AdkNotReady,
+    InvalidIsoPath,
+    MissingWinPeLanguage,
+    WinPeLanguageUnavailable,
+    RuntimePayloadNotReady,
+    NetworkConfigurationNotReady,
+    DeployConfigurationNotReady,
+    ConnectProvisioningNotReady,
+    RequiredSecretsNotReady,
+    NoUsbTarget,
+    Arm64RequiresGpt,
+    CustomDriverDirectoryNotFound,
+    CustomDriverDirectoryHasNoInfFiles,
+    FinalExecutionDeferred
+}

--- a/src/Foundry.Core/Services/Media/MediaPreflightEvaluation.cs
+++ b/src/Foundry.Core/Services/Media/MediaPreflightEvaluation.cs
@@ -1,0 +1,14 @@
+using Foundry.Core.Services.WinPe;
+
+namespace Foundry.Core.Services.Media;
+
+public sealed record MediaPreflightEvaluation
+{
+    public bool CanGenerateIsoSummary { get; init; }
+    public bool CanGenerateUsbSummary { get; init; }
+    public bool CanCreateIso { get; init; }
+    public bool CanCreateUsb { get; init; }
+    public UsbPartitionStyle EffectiveUsbPartitionStyle { get; init; }
+    public IReadOnlyList<MediaPreflightBlockingReason> IsoBlockingReasons { get; init; } = [];
+    public IReadOnlyList<MediaPreflightBlockingReason> UsbBlockingReasons { get; init; } = [];
+}

--- a/src/Foundry.Core/Services/Media/MediaPreflightOptions.cs
+++ b/src/Foundry.Core/Services/Media/MediaPreflightOptions.cs
@@ -1,0 +1,25 @@
+using Foundry.Core.Services.WinPe;
+
+namespace Foundry.Core.Services.Media;
+
+public sealed record MediaPreflightOptions
+{
+    public bool IsAdkReady { get; init; }
+    public bool IsRuntimePayloadReady { get; init; }
+    public bool IsNetworkConfigurationReady { get; init; }
+    public bool IsDeployConfigurationReady { get; init; }
+    public bool IsConnectProvisioningReady { get; init; }
+    public bool AreRequiredSecretsReady { get; init; }
+    public bool IsFinalExecutionEnabled { get; init; }
+    public string IsoOutputPath { get; init; } = string.Empty;
+    public WinPeArchitecture Architecture { get; init; } = WinPeArchitecture.X64;
+    public WinPeSignatureMode SignatureMode { get; init; } = WinPeSignatureMode.Pca2011;
+    public UsbPartitionStyle UsbPartitionStyle { get; init; } = UsbPartitionStyle.Gpt;
+    public UsbFormatMode UsbFormatMode { get; init; } = UsbFormatMode.Quick;
+    public string WinPeLanguage { get; init; } = string.Empty;
+    public IReadOnlyList<string> AvailableWinPeLanguages { get; init; } = [];
+    public WinPeBootImageSource BootImageSource { get; init; } = WinPeBootImageSource.WinPe;
+    public IReadOnlyList<WinPeVendorSelection> DriverVendors { get; init; } = [];
+    public string? CustomDriverDirectoryPath { get; init; }
+    public WinPeUsbDiskCandidate? SelectedUsbDisk { get; init; }
+}

--- a/src/Foundry.Core/Services/Media/MediaPreflightService.cs
+++ b/src/Foundry.Core/Services/Media/MediaPreflightService.cs
@@ -1,0 +1,136 @@
+using Foundry.Core.Services.WinPe;
+
+namespace Foundry.Core.Services.Media;
+
+public static class MediaPreflightService
+{
+    public static MediaPreflightEvaluation Evaluate(MediaPreflightOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        List<MediaPreflightBlockingReason> sharedReasons = GetSharedBlockingReasons(options);
+        List<MediaPreflightBlockingReason> isoReasons = [.. sharedReasons];
+        List<MediaPreflightBlockingReason> usbReasons = [.. sharedReasons];
+
+        if (!IsIsoPathValid(options.IsoOutputPath))
+        {
+            isoReasons.Add(MediaPreflightBlockingReason.InvalidIsoPath);
+        }
+
+        if (options.SelectedUsbDisk is null)
+        {
+            usbReasons.Add(MediaPreflightBlockingReason.NoUsbTarget);
+        }
+
+        UsbPartitionStyle effectiveUsbPartitionStyle = options.UsbPartitionStyle;
+        if (options.Architecture == WinPeArchitecture.Arm64 && options.UsbPartitionStyle == UsbPartitionStyle.Mbr)
+        {
+            effectiveUsbPartitionStyle = UsbPartitionStyle.Gpt;
+            usbReasons.Add(MediaPreflightBlockingReason.Arm64RequiresGpt);
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.CustomDriverDirectoryPath))
+        {
+            if (!Directory.Exists(options.CustomDriverDirectoryPath))
+            {
+                isoReasons.Add(MediaPreflightBlockingReason.CustomDriverDirectoryNotFound);
+                usbReasons.Add(MediaPreflightBlockingReason.CustomDriverDirectoryNotFound);
+            }
+            else if (!Directory.EnumerateFiles(options.CustomDriverDirectoryPath, "*.inf", SearchOption.AllDirectories).Any())
+            {
+                isoReasons.Add(MediaPreflightBlockingReason.CustomDriverDirectoryHasNoInfFiles);
+                usbReasons.Add(MediaPreflightBlockingReason.CustomDriverDirectoryHasNoInfFiles);
+            }
+        }
+
+        bool canGenerateIsoSummary = !isoReasons.Except(GetDryRunAllowedBlockingReasons()).Any();
+        bool canGenerateUsbSummary = !usbReasons.Except(
+            [.. GetDryRunAllowedBlockingReasons(), MediaPreflightBlockingReason.Arm64RequiresGpt]).Any();
+
+        return new MediaPreflightEvaluation
+        {
+            CanGenerateIsoSummary = canGenerateIsoSummary,
+            CanGenerateUsbSummary = canGenerateUsbSummary,
+            CanCreateIso = canGenerateIsoSummary && options.IsFinalExecutionEnabled && !isoReasons.Any(),
+            CanCreateUsb = canGenerateUsbSummary && options.IsFinalExecutionEnabled && !usbReasons.Any(),
+            EffectiveUsbPartitionStyle = effectiveUsbPartitionStyle,
+            IsoBlockingReasons = isoReasons,
+            UsbBlockingReasons = usbReasons
+        };
+    }
+
+    private static List<MediaPreflightBlockingReason> GetSharedBlockingReasons(MediaPreflightOptions options)
+    {
+        List<MediaPreflightBlockingReason> reasons = [];
+
+        if (!options.IsAdkReady)
+        {
+            reasons.Add(MediaPreflightBlockingReason.AdkNotReady);
+        }
+
+        if (!options.IsRuntimePayloadReady)
+        {
+            reasons.Add(MediaPreflightBlockingReason.RuntimePayloadNotReady);
+        }
+
+        if (!options.IsNetworkConfigurationReady)
+        {
+            reasons.Add(MediaPreflightBlockingReason.NetworkConfigurationNotReady);
+        }
+
+        if (!options.IsDeployConfigurationReady)
+        {
+            reasons.Add(MediaPreflightBlockingReason.DeployConfigurationNotReady);
+        }
+
+        if (!options.IsConnectProvisioningReady)
+        {
+            reasons.Add(MediaPreflightBlockingReason.ConnectProvisioningNotReady);
+        }
+
+        if (!options.AreRequiredSecretsReady)
+        {
+            reasons.Add(MediaPreflightBlockingReason.RequiredSecretsNotReady);
+        }
+
+        if (string.IsNullOrWhiteSpace(options.WinPeLanguage))
+        {
+            reasons.Add(MediaPreflightBlockingReason.MissingWinPeLanguage);
+        }
+        else if (options.AvailableWinPeLanguages.Count > 0
+            && !options.AvailableWinPeLanguages.Contains(options.WinPeLanguage, StringComparer.OrdinalIgnoreCase))
+        {
+            reasons.Add(MediaPreflightBlockingReason.WinPeLanguageUnavailable);
+        }
+
+        if (!options.IsFinalExecutionEnabled)
+        {
+            reasons.Add(MediaPreflightBlockingReason.FinalExecutionDeferred);
+        }
+
+        return reasons;
+    }
+
+    private static bool IsIsoPathValid(string isoOutputPath)
+    {
+        if (string.IsNullOrWhiteSpace(isoOutputPath))
+        {
+            return false;
+        }
+
+        return string.Equals(Path.GetExtension(isoOutputPath), ".iso", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IReadOnlyList<MediaPreflightBlockingReason> GetDryRunAllowedBlockingReasons()
+    {
+        return
+        [
+            MediaPreflightBlockingReason.RuntimePayloadNotReady,
+            MediaPreflightBlockingReason.NetworkConfigurationNotReady,
+            MediaPreflightBlockingReason.DeployConfigurationNotReady,
+            MediaPreflightBlockingReason.ConnectProvisioningNotReady,
+            MediaPreflightBlockingReason.RequiredSecretsNotReady,
+            MediaPreflightBlockingReason.FinalExecutionDeferred
+        ];
+    }
+}

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -43,6 +43,7 @@ public static class ServiceCollectionExtensions
 
         services.AddTransient<MainViewModel>();
         services.AddSingleton<ContextMenuService>();
+        services.AddTransient<GeneralConfigurationViewModel>();
         services.AddTransient<StartMediaViewModel>();
         services.AddTransient<GeneralSettingViewModel>();
         services.AddTransient<AdkPageViewModel>();

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Foundry.Core.Services.Application;
 using Foundry.Core.Services.Adk;
+using Foundry.Core.Services.WinPe;
 using Foundry.Services.Application;
 using Foundry.Services.Adk;
 using Foundry.Services.Localization;
@@ -22,6 +23,8 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<IAppSettingsService, JsonAppSettingsService>();
         services.AddSingleton<IAdkInstallationProbe, WindowsAdkInstallationProbe>();
+        services.AddSingleton<IWinPeLanguageDiscoveryService, WinPeLanguageDiscoveryService>();
+        services.AddSingleton<IWinPeUsbMediaService, WinPeUsbMediaService>();
         services.AddSingleton<IOperationProgressService, OperationProgressService>();
         services.AddSingleton<IAdkService, AdkService>();
         services.AddSingleton<IShellNavigationGuardService, ShellNavigationGuardService>();
@@ -40,6 +43,7 @@ public static class ServiceCollectionExtensions
 
         services.AddTransient<MainViewModel>();
         services.AddSingleton<ContextMenuService>();
+        services.AddTransient<StartMediaViewModel>();
         services.AddTransient<GeneralSettingViewModel>();
         services.AddTransient<AdkPageViewModel>();
         services.AddTransient<AppUpdateSettingViewModel>();

--- a/src/Foundry/Services/Settings/FoundryAppSettings.cs
+++ b/src/Foundry/Services/Settings/FoundryAppSettings.cs
@@ -5,6 +5,7 @@ public sealed class FoundryAppSettings
     public int SchemaVersion { get; set; } = 1;
     public AppearanceSettings Appearance { get; set; } = new();
     public LocalizationSettings Localization { get; set; } = new();
+    public MediaSettings Media { get; set; } = new();
     public UpdateSettings Updates { get; set; } = new();
     public DiagnosticsSettings Diagnostics { get; set; } = new();
 }
@@ -17,6 +18,19 @@ public sealed class AppearanceSettings
 public sealed class LocalizationSettings
 {
     public string Language { get; set; } = "en-US";
+}
+
+public sealed class MediaSettings
+{
+    public string IsoOutputPath { get; set; } = Path.Combine(Constants.IsoWorkspaceDirectoryPath, "Foundry.iso");
+    public string Architecture { get; set; } = "X64";
+    public bool UseCa2023Signature { get; set; }
+    public string UsbPartitionStyle { get; set; } = "Gpt";
+    public string UsbFormatMode { get; set; } = "Quick";
+    public bool IncludeDellDrivers { get; set; }
+    public bool IncludeHpDrivers { get; set; }
+    public string? CustomDriverDirectoryPath { get; set; }
+    public string WinPeLanguage { get; set; } = string.Empty;
 }
 
 public sealed class UpdateSettings

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -75,15 +75,6 @@
   <data name="GeneralSetting_StartupCard.Header" xml:space="preserve">
     <value>Run at startup</value>
   </data>
-  <data name="GeneralSetting_WinPeLanguage.NotReady" xml:space="preserve">
-    <value>Install a compatible Windows ADK and WinPE Add-on to discover boot languages.</value>
-  </data>
-  <data name="GeneralSetting_WinPeLanguage.Empty" xml:space="preserve">
-    <value>No WinPE boot languages were found in the installed ADK.</value>
-  </data>
-  <data name="GeneralSetting_WinPeLanguage.Status" xml:space="preserve">
-    <value>{0} WinPE boot languages available.</value>
-  </data>
   <data name="Language.English" xml:space="preserve">
     <value>English</value>
   </data>
@@ -242,9 +233,6 @@
   </data>
   <data name="StartMedia.Field.WinPeLanguage" xml:space="preserve">
     <value>WinPE boot language</value>
-  </data>
-  <data name="StartMedia.Field.AvailableWinPeLanguages" xml:space="preserve">
-    <value>Available WinPE boot languages</value>
   </data>
   <data name="StartMedia.Field.Architecture" xml:space="preserve">
     <value>Architecture</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -225,14 +225,8 @@
   <data name="StartMedia.Summary.BlockingReasons" xml:space="preserve">
     <value>Blocking or deferred items:</value>
   </data>
-  <data name="StartMedia.Summary.IsoBlockingReasons" xml:space="preserve">
-    <value>ISO blocking or deferred items:</value>
-  </data>
-  <data name="StartMedia.Summary.UsbBlockingReasons" xml:space="preserve">
-    <value>USB blocking or deferred items:</value>
-  </data>
   <data name="StartMedia.Status" xml:space="preserve">
-    <value>Media summary: ISO {0}; USB {1}</value>
+    <value>Media summary: {0}; blocking or deferred items: {1}</value>
   </data>
   <data name="StartMedia.Field.Adk" xml:space="preserve">
     <value>ADK</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -237,9 +237,6 @@
   <data name="StartMedia.Field.Architecture" xml:space="preserve">
     <value>Architecture</value>
   </data>
-  <data name="StartMedia.Field.BootImageSource" xml:space="preserve">
-    <value>Boot image source</value>
-  </data>
   <data name="StartMedia.Field.IsoPath" xml:space="preserve">
     <value>ISO output path</value>
   </data>
@@ -314,12 +311,6 @@
   </data>
   <data name="StartMedia.BlockingReason.FinalExecutionDeferred" xml:space="preserve">
     <value>Final media execution is deferred.</value>
-  </data>
-  <data name="StartMedia.BootImageSource.WinPe" xml:space="preserve">
-    <value>ADK WinPE boot image</value>
-  </data>
-  <data name="StartMedia.BootImageSource.WinReWifi" xml:space="preserve">
-    <value>WinRE Wi-Fi boot image</value>
   </data>
   <data name="StartMedia.SignatureMode.Pca2011" xml:space="preserve">
     <value>PCA 2011</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -51,6 +51,12 @@
   <data name="Common.Enabled" xml:space="preserve">
     <value>Enabled</value>
   </data>
+  <data name="Common.Browse" xml:space="preserve">
+    <value>Browse</value>
+  </data>
+  <data name="Common.Refresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
     <value>Enable developer diagnostics and open the Foundry log folder.</value>
   </data>
@@ -68,6 +74,21 @@
   </data>
   <data name="GeneralSetting_StartupCard.Header" xml:space="preserve">
     <value>Run at startup</value>
+  </data>
+  <data name="GeneralSetting_WinPeLanguageCard.Header" xml:space="preserve">
+    <value>WinPE boot language</value>
+  </data>
+  <data name="GeneralSetting_WinPeLanguageCard.Description" xml:space="preserve">
+    <value>Select the language applied to generated WinPE boot media.</value>
+  </data>
+  <data name="GeneralSetting_WinPeLanguage.NotReady" xml:space="preserve">
+    <value>Install a compatible Windows ADK and WinPE Add-on to discover boot languages.</value>
+  </data>
+  <data name="GeneralSetting_WinPeLanguage.Empty" xml:space="preserve">
+    <value>No WinPE boot languages were found in the installed ADK.</value>
+  </data>
+  <data name="GeneralSetting_WinPeLanguage.Status" xml:space="preserve">
+    <value>{0} WinPE boot languages available.</value>
   </data>
   <data name="Language.English" xml:space="preserve">
     <value>English</value>
@@ -113,6 +134,240 @@
   </data>
   <data name="StartPage_Title.Text" xml:space="preserve">
     <value>Start</value>
+  </data>
+  <data name="StartMedia.IsoSummaryButton" xml:space="preserve">
+    <value>Review ISO</value>
+  </data>
+  <data name="StartMedia.UsbSummaryButton" xml:space="preserve">
+    <value>Review USB</value>
+  </data>
+  <data name="StartMedia.IsoPath.Header" xml:space="preserve">
+    <value>ISO output</value>
+  </data>
+  <data name="StartMedia.IsoPath.Description" xml:space="preserve">
+    <value>Choose where the generated Foundry ISO will be written.</value>
+  </data>
+  <data name="StartMedia.Architecture.Header" xml:space="preserve">
+    <value>Architecture and signature</value>
+  </data>
+  <data name="StartMedia.Architecture.Description" xml:space="preserve">
+    <value>Select the boot architecture and PCA signature mode.</value>
+  </data>
+  <data name="StartMedia.Signature.Ca2011" xml:space="preserve">
+    <value>PCA 2011</value>
+  </data>
+  <data name="StartMedia.Signature.Ca2023" xml:space="preserve">
+    <value>PCA 2023</value>
+  </data>
+  <data name="StartMedia.WinPeLanguage.Header" xml:space="preserve">
+    <value>WinPE boot language</value>
+  </data>
+  <data name="StartMedia.WinPeLanguage.Description" xml:space="preserve">
+    <value>Controlled by the General settings page.</value>
+  </data>
+  <data name="StartMedia.UsbTarget.Header" xml:space="preserve">
+    <value>USB target</value>
+  </data>
+  <data name="StartMedia.UsbLayout.Header" xml:space="preserve">
+    <value>USB layout</value>
+  </data>
+  <data name="StartMedia.UsbLayout.Description" xml:space="preserve">
+    <value>Select partition style and format mode for the future USB creation command.</value>
+  </data>
+  <data name="StartMedia.DriverOptions.Header" xml:space="preserve">
+    <value>Driver options</value>
+  </data>
+  <data name="StartMedia.DriverOptions.Description" xml:space="preserve">
+    <value>Select optional vendor drivers and a custom driver folder.</value>
+  </data>
+  <data name="StartMedia.DriverOptions.Dell" xml:space="preserve">
+    <value>Dell</value>
+  </data>
+  <data name="StartMedia.DriverOptions.Hp" xml:space="preserve">
+    <value>HP</value>
+  </data>
+  <data name="StartMedia.CustomDrivers.Header" xml:space="preserve">
+    <value>Custom driver folder</value>
+  </data>
+  <data name="StartMedia.CustomDrivers.Description" xml:space="preserve">
+    <value>Optional folder containing additional .inf drivers.</value>
+  </data>
+  <data name="StartMedia.FinalCommands.Header" xml:space="preserve">
+    <value>Final media commands</value>
+  </data>
+  <data name="StartMedia.FinalCommands.Description" xml:space="preserve">
+    <value>Final ISO and USB execution stays disabled until Deploy and Connect provisioning are complete.</value>
+  </data>
+  <data name="StartMedia.CreateIsoButton" xml:space="preserve">
+    <value>Create ISO</value>
+  </data>
+  <data name="StartMedia.CreateUsbButton" xml:space="preserve">
+    <value>Create USB</value>
+  </data>
+  <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
+    <value>Quick format</value>
+  </data>
+  <data name="StartMedia.FormatMode.Complete" xml:space="preserve">
+    <value>Full format</value>
+  </data>
+  <data name="StartMedia.FinalExecution.Deferred" xml:space="preserve">
+    <value>Final ISO/USB execution is deferred until Deploy and Connect provisioning are complete.</value>
+  </data>
+  <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
+    <value>Select ISO output path</value>
+  </data>
+  <data name="StartMedia.IsoPicker.Filter" xml:space="preserve">
+    <value>ISO image</value>
+  </data>
+  <data name="StartMedia.CustomDriversPicker.Title" xml:space="preserve">
+    <value>Select custom driver folder</value>
+  </data>
+  <data name="StartMedia.Usb.AdkBlocked" xml:space="preserve">
+    <value>USB targets can be refreshed after ADK readiness is complete.</value>
+  </data>
+  <data name="StartMedia.Usb.QueryFailed" xml:space="preserve">
+    <value>USB target refresh failed.</value>
+  </data>
+  <data name="StartMedia.Usb.CandidatesFound" xml:space="preserve">
+    <value>{0} USB target candidates found.</value>
+  </data>
+  <data name="StartMedia.Usb.DiskDisplay" xml:space="preserve">
+    <value>Disk {0} - {1} ({2})</value>
+  </data>
+  <data name="StartMedia.Summary.IsoTitle" xml:space="preserve">
+    <value>ISO dry-run summary</value>
+  </data>
+  <data name="StartMedia.Summary.UsbTitle" xml:space="preserve">
+    <value>USB dry-run summary</value>
+  </data>
+  <data name="StartMedia.Summary.BlockingReasons" xml:space="preserve">
+    <value>Blocking or deferred items:</value>
+  </data>
+  <data name="StartMedia.Status" xml:space="preserve">
+    <value>ISO summary: {0}; USB summary: {1}; ISO items: {2}; USB items: {3}</value>
+  </data>
+  <data name="StartMedia.Field.Adk" xml:space="preserve">
+    <value>ADK</value>
+  </data>
+  <data name="StartMedia.Field.WinPeLanguage" xml:space="preserve">
+    <value>WinPE boot language</value>
+  </data>
+  <data name="StartMedia.Field.AvailableWinPeLanguages" xml:space="preserve">
+    <value>Available WinPE boot languages</value>
+  </data>
+  <data name="StartMedia.Field.Architecture" xml:space="preserve">
+    <value>Architecture</value>
+  </data>
+  <data name="StartMedia.Field.BootImageSource" xml:space="preserve">
+    <value>Boot image source</value>
+  </data>
+  <data name="StartMedia.Field.IsoPath" xml:space="preserve">
+    <value>ISO output path</value>
+  </data>
+  <data name="StartMedia.Field.UsbTarget" xml:space="preserve">
+    <value>USB target</value>
+  </data>
+  <data name="StartMedia.Field.Signature" xml:space="preserve">
+    <value>Signature mode</value>
+  </data>
+  <data name="StartMedia.Field.PartitionStyle" xml:space="preserve">
+    <value>USB partition style</value>
+  </data>
+  <data name="StartMedia.Field.FormatMode" xml:space="preserve">
+    <value>USB format mode</value>
+  </data>
+  <data name="StartMedia.Field.Drivers" xml:space="preserve">
+    <value>Drivers</value>
+  </data>
+  <data name="StartMedia.Field.Runtime" xml:space="preserve">
+    <value>Runtime payloads</value>
+  </data>
+  <data name="StartMedia.Field.Network" xml:space="preserve">
+    <value>Network configuration</value>
+  </data>
+  <data name="StartMedia.Field.Deploy" xml:space="preserve">
+    <value>Deploy configuration</value>
+  </data>
+  <data name="StartMedia.Field.Connect" xml:space="preserve">
+    <value>Connect provisioning</value>
+  </data>
+  <data name="StartMedia.Field.Secrets" xml:space="preserve">
+    <value>Media secrets</value>
+  </data>
+  <data name="StartMedia.BlockingReason.AdkNotReady" xml:space="preserve">
+    <value>ADK or WinPE Add-on is not ready.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.InvalidIsoPath" xml:space="preserve">
+    <value>ISO output path must end with .iso.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.MissingWinPeLanguage" xml:space="preserve">
+    <value>WinPE boot language is not selected.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.WinPeLanguageUnavailable" xml:space="preserve">
+    <value>Selected WinPE boot language is not available for the selected architecture.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.RuntimePayloadNotReady" xml:space="preserve">
+    <value>Runtime payload readiness is deferred.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.NetworkConfigurationNotReady" xml:space="preserve">
+    <value>Network validation is deferred.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.DeployConfigurationNotReady" xml:space="preserve">
+    <value>Deploy configuration generation is deferred.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.ConnectProvisioningNotReady" xml:space="preserve">
+    <value>Connect provisioning is deferred.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.RequiredSecretsNotReady" xml:space="preserve">
+    <value>Encrypted media secret provisioning is deferred.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.NoUsbTarget" xml:space="preserve">
+    <value>No USB target is selected.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.Arm64RequiresGpt" xml:space="preserve">
+    <value>ARM64 media requires GPT partition style.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.CustomDriverDirectoryNotFound" xml:space="preserve">
+    <value>Custom driver folder does not exist.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.CustomDriverDirectoryHasNoInfFiles" xml:space="preserve">
+    <value>Custom driver folder does not contain .inf files.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.FinalExecutionDeferred" xml:space="preserve">
+    <value>Final media execution is deferred.</value>
+  </data>
+  <data name="StartMedia.BootImageSource.WinPe" xml:space="preserve">
+    <value>ADK WinPE boot image</value>
+  </data>
+  <data name="StartMedia.BootImageSource.WinReWifi" xml:space="preserve">
+    <value>WinRE Wi-Fi boot image</value>
+  </data>
+  <data name="StartMedia.SignatureMode.Pca2011" xml:space="preserve">
+    <value>PCA 2011</value>
+  </data>
+  <data name="StartMedia.SignatureMode.Pca2023" xml:space="preserve">
+    <value>PCA 2023</value>
+  </data>
+  <data name="StartMedia.DriverVendor.Dell" xml:space="preserve">
+    <value>Dell</value>
+  </data>
+  <data name="StartMedia.DriverVendor.Hp" xml:space="preserve">
+    <value>HP</value>
+  </data>
+  <data name="StartMedia.ByteUnit.B" xml:space="preserve">
+    <value>B</value>
+  </data>
+  <data name="StartMedia.ByteUnit.KB" xml:space="preserve">
+    <value>KB</value>
+  </data>
+  <data name="StartMedia.ByteUnit.MB" xml:space="preserve">
+    <value>MB</value>
+  </data>
+  <data name="StartMedia.ByteUnit.GB" xml:space="preserve">
+    <value>GB</value>
+  </data>
+  <data name="StartMedia.ByteUnit.TB" xml:space="preserve">
+    <value>TB</value>
   </data>
   <data name="UpdateBanner.Action" xml:space="preserve">
     <value>View update</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -225,8 +225,14 @@
   <data name="StartMedia.Summary.BlockingReasons" xml:space="preserve">
     <value>Blocking or deferred items:</value>
   </data>
+  <data name="StartMedia.Summary.IsoBlockingReasons" xml:space="preserve">
+    <value>ISO blocking or deferred items:</value>
+  </data>
+  <data name="StartMedia.Summary.UsbBlockingReasons" xml:space="preserve">
+    <value>USB blocking or deferred items:</value>
+  </data>
   <data name="StartMedia.Status" xml:space="preserve">
-    <value>Media summary: {0}; blocking or deferred items: {1}</value>
+    <value>Media summary: ISO {0}; USB {1}</value>
   </data>
   <data name="StartMedia.Field.Adk" xml:space="preserve">
     <value>ADK</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -75,12 +75,6 @@
   <data name="GeneralSetting_StartupCard.Header" xml:space="preserve">
     <value>Run at startup</value>
   </data>
-  <data name="GeneralSetting_WinPeLanguageCard.Header" xml:space="preserve">
-    <value>WinPE boot language</value>
-  </data>
-  <data name="GeneralSetting_WinPeLanguageCard.Description" xml:space="preserve">
-    <value>Select the language applied to generated WinPE boot media.</value>
-  </data>
   <data name="GeneralSetting_WinPeLanguage.NotReady" xml:space="preserve">
     <value>Install a compatible Windows ADK and WinPE Add-on to discover boot languages.</value>
   </data>
@@ -123,6 +117,15 @@
   <data name="GeneralConfigurationPage_Title.Text" xml:space="preserve">
     <value>General</value>
   </data>
+  <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
+    <value>Create media</value>
+  </data>
+  <data name="GeneralConfiguration_CreateMedia.Description" xml:space="preserve">
+    <value>Review the configured media settings and start ISO or USB creation from the Start page.</value>
+  </data>
+  <data name="GeneralConfiguration_CreateMedia.Button" xml:space="preserve">
+    <value>Create media</value>
+  </data>
   <data name="LocalizationPage_Title.Text" xml:space="preserve">
     <value>Localization</value>
   </data>
@@ -134,12 +137,6 @@
   </data>
   <data name="StartPage_Title.Text" xml:space="preserve">
     <value>Start</value>
-  </data>
-  <data name="StartMedia.IsoSummaryButton" xml:space="preserve">
-    <value>Review ISO</value>
-  </data>
-  <data name="StartMedia.UsbSummaryButton" xml:space="preserve">
-    <value>Review USB</value>
   </data>
   <data name="StartMedia.IsoPath.Header" xml:space="preserve">
     <value>ISO output</value>
@@ -234,17 +231,11 @@
   <data name="StartMedia.Usb.DiskDisplay" xml:space="preserve">
     <value>Disk {0} - {1} ({2})</value>
   </data>
-  <data name="StartMedia.Summary.IsoTitle" xml:space="preserve">
-    <value>ISO dry-run summary</value>
-  </data>
-  <data name="StartMedia.Summary.UsbTitle" xml:space="preserve">
-    <value>USB dry-run summary</value>
-  </data>
   <data name="StartMedia.Summary.BlockingReasons" xml:space="preserve">
     <value>Blocking or deferred items:</value>
   </data>
   <data name="StartMedia.Status" xml:space="preserve">
-    <value>ISO summary: {0}; USB summary: {1}; ISO items: {2}; USB items: {3}</value>
+    <value>Media summary: {0}; blocking or deferred items: {1}</value>
   </data>
   <data name="StartMedia.Field.Adk" xml:space="preserve">
     <value>ADK</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -75,15 +75,6 @@
   <data name="GeneralSetting_StartupCard.Header" xml:space="preserve">
     <value>Lancer au démarrage</value>
   </data>
-  <data name="GeneralSetting_WinPeLanguage.NotReady" xml:space="preserve">
-    <value>Installez un ADK Windows compatible et le module complémentaire WinPE pour détecter les langues de démarrage.</value>
-  </data>
-  <data name="GeneralSetting_WinPeLanguage.Empty" xml:space="preserve">
-    <value>Aucune langue de démarrage WinPE n'a été trouvée dans l'ADK installé.</value>
-  </data>
-  <data name="GeneralSetting_WinPeLanguage.Status" xml:space="preserve">
-    <value>{0} langues de démarrage WinPE disponibles.</value>
-  </data>
   <data name="Language.English" xml:space="preserve">
     <value>Anglais</value>
   </data>
@@ -242,9 +233,6 @@
   </data>
   <data name="StartMedia.Field.WinPeLanguage" xml:space="preserve">
     <value>Langue de démarrage WinPE</value>
-  </data>
-  <data name="StartMedia.Field.AvailableWinPeLanguages" xml:space="preserve">
-    <value>Langues de démarrage WinPE disponibles</value>
   </data>
   <data name="StartMedia.Field.Architecture" xml:space="preserve">
     <value>Architecture</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -237,9 +237,6 @@
   <data name="StartMedia.Field.Architecture" xml:space="preserve">
     <value>Architecture</value>
   </data>
-  <data name="StartMedia.Field.BootImageSource" xml:space="preserve">
-    <value>Source de l'image de démarrage</value>
-  </data>
   <data name="StartMedia.Field.IsoPath" xml:space="preserve">
     <value>Chemin de sortie ISO</value>
   </data>
@@ -314,12 +311,6 @@
   </data>
   <data name="StartMedia.BlockingReason.FinalExecutionDeferred" xml:space="preserve">
     <value>L'exécution média finale est différée.</value>
-  </data>
-  <data name="StartMedia.BootImageSource.WinPe" xml:space="preserve">
-    <value>Image de démarrage WinPE de l'ADK</value>
-  </data>
-  <data name="StartMedia.BootImageSource.WinReWifi" xml:space="preserve">
-    <value>Image de démarrage WinRE Wi-Fi</value>
   </data>
   <data name="StartMedia.SignatureMode.Pca2011" xml:space="preserve">
     <value>PCA 2011</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -75,12 +75,6 @@
   <data name="GeneralSetting_StartupCard.Header" xml:space="preserve">
     <value>Lancer au démarrage</value>
   </data>
-  <data name="GeneralSetting_WinPeLanguageCard.Header" xml:space="preserve">
-    <value>Langue de démarrage WinPE</value>
-  </data>
-  <data name="GeneralSetting_WinPeLanguageCard.Description" xml:space="preserve">
-    <value>Sélectionner la langue appliquée au média de démarrage WinPE généré.</value>
-  </data>
   <data name="GeneralSetting_WinPeLanguage.NotReady" xml:space="preserve">
     <value>Installez un ADK Windows compatible et le module complémentaire WinPE pour détecter les langues de démarrage.</value>
   </data>
@@ -123,6 +117,15 @@
   <data name="GeneralConfigurationPage_Title.Text" xml:space="preserve">
     <value>Général</value>
   </data>
+  <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
+    <value>Créer un média</value>
+  </data>
+  <data name="GeneralConfiguration_CreateMedia.Description" xml:space="preserve">
+    <value>Vérifier les paramètres média configurés et lancer la création ISO ou USB depuis la page Démarrer.</value>
+  </data>
+  <data name="GeneralConfiguration_CreateMedia.Button" xml:space="preserve">
+    <value>Créer un média</value>
+  </data>
   <data name="LocalizationPage_Title.Text" xml:space="preserve">
     <value>Localisation</value>
   </data>
@@ -134,12 +137,6 @@
   </data>
   <data name="StartPage_Title.Text" xml:space="preserve">
     <value>Démarrer</value>
-  </data>
-  <data name="StartMedia.IsoSummaryButton" xml:space="preserve">
-    <value>Vérifier l'ISO</value>
-  </data>
-  <data name="StartMedia.UsbSummaryButton" xml:space="preserve">
-    <value>Vérifier l'USB</value>
   </data>
   <data name="StartMedia.IsoPath.Header" xml:space="preserve">
     <value>Sortie ISO</value>
@@ -234,17 +231,11 @@
   <data name="StartMedia.Usb.DiskDisplay" xml:space="preserve">
     <value>Disque {0} - {1} ({2})</value>
   </data>
-  <data name="StartMedia.Summary.IsoTitle" xml:space="preserve">
-    <value>Résumé dry-run ISO</value>
-  </data>
-  <data name="StartMedia.Summary.UsbTitle" xml:space="preserve">
-    <value>Résumé dry-run USB</value>
-  </data>
   <data name="StartMedia.Summary.BlockingReasons" xml:space="preserve">
     <value>Points bloquants ou différés :</value>
   </data>
   <data name="StartMedia.Status" xml:space="preserve">
-    <value>Résumé ISO : {0}; résumé USB : {1}; points ISO : {2}; points USB : {3}</value>
+    <value>Résumé média : {0}; points bloquants ou différés : {1}</value>
   </data>
   <data name="StartMedia.Field.Adk" xml:space="preserve">
     <value>ADK</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -225,8 +225,14 @@
   <data name="StartMedia.Summary.BlockingReasons" xml:space="preserve">
     <value>Points bloquants ou différés :</value>
   </data>
+  <data name="StartMedia.Summary.IsoBlockingReasons" xml:space="preserve">
+    <value>Points bloquants ou différés ISO :</value>
+  </data>
+  <data name="StartMedia.Summary.UsbBlockingReasons" xml:space="preserve">
+    <value>Points bloquants ou différés USB :</value>
+  </data>
   <data name="StartMedia.Status" xml:space="preserve">
-    <value>Résumé média : {0}; points bloquants ou différés : {1}</value>
+    <value>Résumé média : ISO {0}; USB {1}</value>
   </data>
   <data name="StartMedia.Field.Adk" xml:space="preserve">
     <value>ADK</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -51,6 +51,12 @@
   <data name="Common.Enabled" xml:space="preserve">
     <value>Activé</value>
   </data>
+  <data name="Common.Browse" xml:space="preserve">
+    <value>Parcourir</value>
+  </data>
+  <data name="Common.Refresh" xml:space="preserve">
+    <value>Actualiser</value>
+  </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
     <value>Activer les diagnostics développeur et ouvrir le dossier des journaux Foundry.</value>
   </data>
@@ -68,6 +74,21 @@
   </data>
   <data name="GeneralSetting_StartupCard.Header" xml:space="preserve">
     <value>Lancer au démarrage</value>
+  </data>
+  <data name="GeneralSetting_WinPeLanguageCard.Header" xml:space="preserve">
+    <value>Langue de démarrage WinPE</value>
+  </data>
+  <data name="GeneralSetting_WinPeLanguageCard.Description" xml:space="preserve">
+    <value>Sélectionner la langue appliquée au média de démarrage WinPE généré.</value>
+  </data>
+  <data name="GeneralSetting_WinPeLanguage.NotReady" xml:space="preserve">
+    <value>Installez un ADK Windows compatible et le module complémentaire WinPE pour détecter les langues de démarrage.</value>
+  </data>
+  <data name="GeneralSetting_WinPeLanguage.Empty" xml:space="preserve">
+    <value>Aucune langue de démarrage WinPE n'a été trouvée dans l'ADK installé.</value>
+  </data>
+  <data name="GeneralSetting_WinPeLanguage.Status" xml:space="preserve">
+    <value>{0} langues de démarrage WinPE disponibles.</value>
   </data>
   <data name="Language.English" xml:space="preserve">
     <value>Anglais</value>
@@ -113,6 +134,240 @@
   </data>
   <data name="StartPage_Title.Text" xml:space="preserve">
     <value>Démarrer</value>
+  </data>
+  <data name="StartMedia.IsoSummaryButton" xml:space="preserve">
+    <value>Vérifier l'ISO</value>
+  </data>
+  <data name="StartMedia.UsbSummaryButton" xml:space="preserve">
+    <value>Vérifier l'USB</value>
+  </data>
+  <data name="StartMedia.IsoPath.Header" xml:space="preserve">
+    <value>Sortie ISO</value>
+  </data>
+  <data name="StartMedia.IsoPath.Description" xml:space="preserve">
+    <value>Choisir où l'ISO Foundry générée sera écrite.</value>
+  </data>
+  <data name="StartMedia.Architecture.Header" xml:space="preserve">
+    <value>Architecture et signature</value>
+  </data>
+  <data name="StartMedia.Architecture.Description" xml:space="preserve">
+    <value>Sélectionner l'architecture de démarrage et le mode de signature PCA.</value>
+  </data>
+  <data name="StartMedia.Signature.Ca2011" xml:space="preserve">
+    <value>PCA 2011</value>
+  </data>
+  <data name="StartMedia.Signature.Ca2023" xml:space="preserve">
+    <value>PCA 2023</value>
+  </data>
+  <data name="StartMedia.WinPeLanguage.Header" xml:space="preserve">
+    <value>Langue de démarrage WinPE</value>
+  </data>
+  <data name="StartMedia.WinPeLanguage.Description" xml:space="preserve">
+    <value>Contrôlée par la page Paramètres généraux.</value>
+  </data>
+  <data name="StartMedia.UsbTarget.Header" xml:space="preserve">
+    <value>Cible USB</value>
+  </data>
+  <data name="StartMedia.UsbLayout.Header" xml:space="preserve">
+    <value>Disposition USB</value>
+  </data>
+  <data name="StartMedia.UsbLayout.Description" xml:space="preserve">
+    <value>Sélectionner le style de partition et le mode de formatage pour la future commande USB.</value>
+  </data>
+  <data name="StartMedia.DriverOptions.Header" xml:space="preserve">
+    <value>Options de pilotes</value>
+  </data>
+  <data name="StartMedia.DriverOptions.Description" xml:space="preserve">
+    <value>Sélectionner les pilotes constructeur optionnels et un dossier de pilotes personnalisé.</value>
+  </data>
+  <data name="StartMedia.DriverOptions.Dell" xml:space="preserve">
+    <value>Dell</value>
+  </data>
+  <data name="StartMedia.DriverOptions.Hp" xml:space="preserve">
+    <value>HP</value>
+  </data>
+  <data name="StartMedia.CustomDrivers.Header" xml:space="preserve">
+    <value>Dossier de pilotes personnalisé</value>
+  </data>
+  <data name="StartMedia.CustomDrivers.Description" xml:space="preserve">
+    <value>Dossier optionnel contenant des pilotes .inf supplémentaires.</value>
+  </data>
+  <data name="StartMedia.FinalCommands.Header" xml:space="preserve">
+    <value>Commandes média finales</value>
+  </data>
+  <data name="StartMedia.FinalCommands.Description" xml:space="preserve">
+    <value>L'exécution ISO et USB finale reste désactivée tant que le provisionnement Deploy et Connect n'est pas terminé.</value>
+  </data>
+  <data name="StartMedia.CreateIsoButton" xml:space="preserve">
+    <value>Créer l'ISO</value>
+  </data>
+  <data name="StartMedia.CreateUsbButton" xml:space="preserve">
+    <value>Créer l'USB</value>
+  </data>
+  <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
+    <value>Formatage rapide</value>
+  </data>
+  <data name="StartMedia.FormatMode.Complete" xml:space="preserve">
+    <value>Formatage complet</value>
+  </data>
+  <data name="StartMedia.FinalExecution.Deferred" xml:space="preserve">
+    <value>L'exécution ISO/USB finale est différée jusqu'à la fin du provisionnement Deploy et Connect.</value>
+  </data>
+  <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
+    <value>Sélectionner le chemin de sortie ISO</value>
+  </data>
+  <data name="StartMedia.IsoPicker.Filter" xml:space="preserve">
+    <value>Image ISO</value>
+  </data>
+  <data name="StartMedia.CustomDriversPicker.Title" xml:space="preserve">
+    <value>Sélectionner le dossier de pilotes personnalisé</value>
+  </data>
+  <data name="StartMedia.Usb.AdkBlocked" xml:space="preserve">
+    <value>Les cibles USB peuvent être actualisées après la validation de l'ADK.</value>
+  </data>
+  <data name="StartMedia.Usb.QueryFailed" xml:space="preserve">
+    <value>L'actualisation des cibles USB a échoué.</value>
+  </data>
+  <data name="StartMedia.Usb.CandidatesFound" xml:space="preserve">
+    <value>{0} cibles USB candidates trouvées.</value>
+  </data>
+  <data name="StartMedia.Usb.DiskDisplay" xml:space="preserve">
+    <value>Disque {0} - {1} ({2})</value>
+  </data>
+  <data name="StartMedia.Summary.IsoTitle" xml:space="preserve">
+    <value>Résumé dry-run ISO</value>
+  </data>
+  <data name="StartMedia.Summary.UsbTitle" xml:space="preserve">
+    <value>Résumé dry-run USB</value>
+  </data>
+  <data name="StartMedia.Summary.BlockingReasons" xml:space="preserve">
+    <value>Points bloquants ou différés :</value>
+  </data>
+  <data name="StartMedia.Status" xml:space="preserve">
+    <value>Résumé ISO : {0}; résumé USB : {1}; points ISO : {2}; points USB : {3}</value>
+  </data>
+  <data name="StartMedia.Field.Adk" xml:space="preserve">
+    <value>ADK</value>
+  </data>
+  <data name="StartMedia.Field.WinPeLanguage" xml:space="preserve">
+    <value>Langue de démarrage WinPE</value>
+  </data>
+  <data name="StartMedia.Field.AvailableWinPeLanguages" xml:space="preserve">
+    <value>Langues de démarrage WinPE disponibles</value>
+  </data>
+  <data name="StartMedia.Field.Architecture" xml:space="preserve">
+    <value>Architecture</value>
+  </data>
+  <data name="StartMedia.Field.BootImageSource" xml:space="preserve">
+    <value>Source de l'image de démarrage</value>
+  </data>
+  <data name="StartMedia.Field.IsoPath" xml:space="preserve">
+    <value>Chemin de sortie ISO</value>
+  </data>
+  <data name="StartMedia.Field.UsbTarget" xml:space="preserve">
+    <value>Cible USB</value>
+  </data>
+  <data name="StartMedia.Field.Signature" xml:space="preserve">
+    <value>Mode de signature</value>
+  </data>
+  <data name="StartMedia.Field.PartitionStyle" xml:space="preserve">
+    <value>Style de partition USB</value>
+  </data>
+  <data name="StartMedia.Field.FormatMode" xml:space="preserve">
+    <value>Mode de formatage USB</value>
+  </data>
+  <data name="StartMedia.Field.Drivers" xml:space="preserve">
+    <value>Pilotes</value>
+  </data>
+  <data name="StartMedia.Field.Runtime" xml:space="preserve">
+    <value>Payloads runtime</value>
+  </data>
+  <data name="StartMedia.Field.Network" xml:space="preserve">
+    <value>Configuration réseau</value>
+  </data>
+  <data name="StartMedia.Field.Deploy" xml:space="preserve">
+    <value>Configuration Deploy</value>
+  </data>
+  <data name="StartMedia.Field.Connect" xml:space="preserve">
+    <value>Provisionnement Connect</value>
+  </data>
+  <data name="StartMedia.Field.Secrets" xml:space="preserve">
+    <value>Secrets média</value>
+  </data>
+  <data name="StartMedia.BlockingReason.AdkNotReady" xml:space="preserve">
+    <value>L'ADK ou le module complémentaire WinPE n'est pas prêt.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.InvalidIsoPath" xml:space="preserve">
+    <value>Le chemin de sortie ISO doit se terminer par .iso.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.MissingWinPeLanguage" xml:space="preserve">
+    <value>La langue de démarrage WinPE n'est pas sélectionnée.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.WinPeLanguageUnavailable" xml:space="preserve">
+    <value>La langue de démarrage WinPE sélectionnée n'est pas disponible pour l'architecture sélectionnée.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.RuntimePayloadNotReady" xml:space="preserve">
+    <value>La validation des payloads runtime est différée.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.NetworkConfigurationNotReady" xml:space="preserve">
+    <value>La validation réseau est différée.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.DeployConfigurationNotReady" xml:space="preserve">
+    <value>La génération de configuration Deploy est différée.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.ConnectProvisioningNotReady" xml:space="preserve">
+    <value>Le provisionnement Connect est différé.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.RequiredSecretsNotReady" xml:space="preserve">
+    <value>Le provisionnement chiffré des secrets média est différé.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.NoUsbTarget" xml:space="preserve">
+    <value>Aucune cible USB n'est sélectionnée.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.Arm64RequiresGpt" xml:space="preserve">
+    <value>Le média ARM64 exige le style de partition GPT.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.CustomDriverDirectoryNotFound" xml:space="preserve">
+    <value>Le dossier de pilotes personnalisé n'existe pas.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.CustomDriverDirectoryHasNoInfFiles" xml:space="preserve">
+    <value>Le dossier de pilotes personnalisé ne contient aucun fichier .inf.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.FinalExecutionDeferred" xml:space="preserve">
+    <value>L'exécution média finale est différée.</value>
+  </data>
+  <data name="StartMedia.BootImageSource.WinPe" xml:space="preserve">
+    <value>Image de démarrage WinPE de l'ADK</value>
+  </data>
+  <data name="StartMedia.BootImageSource.WinReWifi" xml:space="preserve">
+    <value>Image de démarrage WinRE Wi-Fi</value>
+  </data>
+  <data name="StartMedia.SignatureMode.Pca2011" xml:space="preserve">
+    <value>PCA 2011</value>
+  </data>
+  <data name="StartMedia.SignatureMode.Pca2023" xml:space="preserve">
+    <value>PCA 2023</value>
+  </data>
+  <data name="StartMedia.DriverVendor.Dell" xml:space="preserve">
+    <value>Dell</value>
+  </data>
+  <data name="StartMedia.DriverVendor.Hp" xml:space="preserve">
+    <value>HP</value>
+  </data>
+  <data name="StartMedia.ByteUnit.B" xml:space="preserve">
+    <value>o</value>
+  </data>
+  <data name="StartMedia.ByteUnit.KB" xml:space="preserve">
+    <value>Ko</value>
+  </data>
+  <data name="StartMedia.ByteUnit.MB" xml:space="preserve">
+    <value>Mo</value>
+  </data>
+  <data name="StartMedia.ByteUnit.GB" xml:space="preserve">
+    <value>Go</value>
+  </data>
+  <data name="StartMedia.ByteUnit.TB" xml:space="preserve">
+    <value>To</value>
   </data>
   <data name="UpdateBanner.Action" xml:space="preserve">
     <value>Voir la mise à jour</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -225,14 +225,8 @@
   <data name="StartMedia.Summary.BlockingReasons" xml:space="preserve">
     <value>Points bloquants ou différés :</value>
   </data>
-  <data name="StartMedia.Summary.IsoBlockingReasons" xml:space="preserve">
-    <value>Points bloquants ou différés ISO :</value>
-  </data>
-  <data name="StartMedia.Summary.UsbBlockingReasons" xml:space="preserve">
-    <value>Points bloquants ou différés USB :</value>
-  </data>
   <data name="StartMedia.Status" xml:space="preserve">
-    <value>Résumé média : ISO {0}; USB {1}</value>
+    <value>Résumé média : {0}; points bloquants ou différés : {1}</value>
   </data>
   <data name="StartMedia.Field.Adk" xml:space="preserve">
     <value>ADK</value>

--- a/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Globalization;
 using Foundry.Core.Services.Application;
 using Foundry.Core.Services.Media;
 using Foundry.Core.Services.WinPe;
@@ -39,16 +40,12 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
             new(WinPeArchitecture.X64, "x64"),
             new(WinPeArchitecture.Arm64, "arm64")
         ];
-        PartitionStyles =
-        [
-            new(UsbPartitionStyle.Gpt, "GPT"),
-            new(UsbPartitionStyle.Mbr, "MBR")
-        ];
+        PartitionStyles = [];
 
         IsoOutputPath = appSettingsService.Current.Media.IsoOutputPath;
         SelectedArchitecture = SelectOption(Architectures, ParseEnum(appSettingsService.Current.Media.Architecture, WinPeArchitecture.X64));
         UseCa2023Signature = appSettingsService.Current.Media.UseCa2023Signature;
-        SelectedPartitionStyle = SelectOption(PartitionStyles, ParseEnum(appSettingsService.Current.Media.UsbPartitionStyle, UsbPartitionStyle.Gpt));
+        RefreshPartitionStyles();
         IncludeDellDrivers = appSettingsService.Current.Media.IncludeDellDrivers;
         IncludeHpDrivers = appSettingsService.Current.Media.IncludeHpDrivers;
         CustomDriverDirectoryPath = appSettingsService.Current.Media.CustomDriverDirectoryPath ?? string.Empty;
@@ -176,8 +173,9 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
             return;
         }
 
-        string selected = SelectWinPeLanguage(result.Value, appSettingsService.Current.Media.WinPeLanguage, localizationService.CurrentLanguage);
-        foreach (string language in result.Value)
+        List<string> languages = result.Value.Select(NormalizeCultureName).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        string selected = SelectWinPeLanguage(languages, appSettingsService.Current.Media.WinPeLanguage, localizationService.CurrentLanguage);
+        foreach (string language in languages)
         {
             AvailableWinPeLanguages.Add(language);
         }
@@ -195,9 +193,9 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
             return;
         }
 
-        appSettingsService.Current.Media.WinPeLanguage = selectedLanguage;
+        appSettingsService.Current.Media.WinPeLanguage = NormalizeCultureName(selectedLanguage);
         appSettingsService.Save();
-        SelectedWinPeLanguage = selectedLanguage;
+        SelectedWinPeLanguage = appSettingsService.Current.Media.WinPeLanguage;
     }
 
     partial void OnIsoOutputPathChanged(string value)
@@ -219,10 +217,7 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
         }
 
         appSettingsService.Current.Media.Architecture = value.Value.ToString();
-        if (value.Value == WinPeArchitecture.Arm64 && SelectedPartitionStyle?.Value == UsbPartitionStyle.Mbr)
-        {
-            SelectedPartitionStyle = SelectOption(PartitionStyles, UsbPartitionStyle.Gpt);
-        }
+        RefreshPartitionStyles();
 
         Save();
         RefreshWinPeLanguages();
@@ -305,6 +300,24 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
         appSettingsService.Save();
     }
 
+    private void RefreshPartitionStyles()
+    {
+        UsbPartitionStyle selectedValue = SelectedArchitecture?.Value == WinPeArchitecture.Arm64
+            ? UsbPartitionStyle.Gpt
+            : SelectedPartitionStyle?.Value ?? ParseEnum(appSettingsService.Current.Media.UsbPartitionStyle, UsbPartitionStyle.Gpt);
+
+        PartitionStyles.Clear();
+        PartitionStyles.Add(new(UsbPartitionStyle.Gpt, "GPT"));
+
+        if (SelectedArchitecture?.Value != WinPeArchitecture.Arm64)
+        {
+            PartitionStyles.Add(new(UsbPartitionStyle.Mbr, "MBR"));
+        }
+
+        SelectedPartitionStyle = SelectOption(PartitionStyles, selectedValue) ?? PartitionStyles[0];
+        appSettingsService.Current.Media.UsbPartitionStyle = SelectedPartitionStyle.Value.ToString();
+    }
+
     private static string SelectWinPeLanguage(IReadOnlyList<string> languages, string? preferredLanguage, string currentLanguage)
     {
         string? exact = languages.FirstOrDefault(language => string.Equals(language, preferredLanguage, StringComparison.OrdinalIgnoreCase))
@@ -319,6 +332,23 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
         string? family = languages.FirstOrDefault(language => language.StartsWith(currentPrefix + "-", StringComparison.OrdinalIgnoreCase));
 
         return family ?? languages[0];
+    }
+
+    private static string NormalizeCultureName(string language)
+    {
+        if (string.IsNullOrWhiteSpace(language))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            return CultureInfo.GetCultureInfo(language).Name;
+        }
+        catch (CultureNotFoundException)
+        {
+            return language;
+        }
     }
 
     private static T ParseEnum<T>(string? value, T fallback)

--- a/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
@@ -91,6 +91,9 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
     [ObservableProperty]
     public partial bool HasWinPeLanguages { get; set; }
 
+    [ObservableProperty]
+    public partial bool CanCreateMedia { get; set; }
+
     [RelayCommand]
     private async Task BrowseIsoOutputPathAsync()
     {
@@ -130,12 +133,18 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
         SelectedFormatMode = SelectOption(FormatModes, selectedValue);
     }
 
+    public void RefreshAdkState()
+    {
+        CanCreateMedia = adkService.CurrentStatus.CanCreateMedia;
+    }
+
     public void RefreshWinPeLanguages()
     {
+        RefreshAdkState();
         AvailableWinPeLanguages.Clear();
         HasWinPeLanguages = false;
 
-        if (!adkService.CurrentStatus.CanCreateMedia)
+        if (!CanCreateMedia)
         {
             SelectedWinPeLanguage = null;
             return;

--- a/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
@@ -1,0 +1,339 @@
+using System.Collections.ObjectModel;
+using Foundry.Core.Services.Application;
+using Foundry.Core.Services.Media;
+using Foundry.Core.Services.WinPe;
+using Foundry.Services.Adk;
+using Foundry.Services.Localization;
+using Foundry.Services.Settings;
+using Serilog;
+
+namespace Foundry.ViewModels;
+
+public sealed partial class GeneralConfigurationViewModel : ObservableObject
+{
+    private readonly IAppSettingsService appSettingsService;
+    private readonly IAdkService adkService;
+    private readonly IWinPeLanguageDiscoveryService winPeLanguageDiscoveryService;
+    private readonly IFilePickerService filePickerService;
+    private readonly IApplicationLocalizationService localizationService;
+    private readonly ILogger logger;
+    private bool isInitializing = true;
+
+    public GeneralConfigurationViewModel(
+        IAppSettingsService appSettingsService,
+        IAdkService adkService,
+        IWinPeLanguageDiscoveryService winPeLanguageDiscoveryService,
+        IFilePickerService filePickerService,
+        IApplicationLocalizationService localizationService,
+        ILogger logger)
+    {
+        this.appSettingsService = appSettingsService;
+        this.adkService = adkService;
+        this.winPeLanguageDiscoveryService = winPeLanguageDiscoveryService;
+        this.filePickerService = filePickerService;
+        this.localizationService = localizationService;
+        this.logger = logger.ForContext<GeneralConfigurationViewModel>();
+
+        Architectures =
+        [
+            new(WinPeArchitecture.X64, "x64"),
+            new(WinPeArchitecture.Arm64, "arm64")
+        ];
+        PartitionStyles =
+        [
+            new(UsbPartitionStyle.Gpt, "GPT"),
+            new(UsbPartitionStyle.Mbr, "MBR")
+        ];
+
+        IsoOutputPath = appSettingsService.Current.Media.IsoOutputPath;
+        SelectedArchitecture = SelectOption(Architectures, ParseEnum(appSettingsService.Current.Media.Architecture, WinPeArchitecture.X64));
+        UseCa2023Signature = appSettingsService.Current.Media.UseCa2023Signature;
+        SelectedPartitionStyle = SelectOption(PartitionStyles, ParseEnum(appSettingsService.Current.Media.UsbPartitionStyle, UsbPartitionStyle.Gpt));
+        IncludeDellDrivers = appSettingsService.Current.Media.IncludeDellDrivers;
+        IncludeHpDrivers = appSettingsService.Current.Media.IncludeHpDrivers;
+        CustomDriverDirectoryPath = appSettingsService.Current.Media.CustomDriverDirectoryPath ?? string.Empty;
+        RefreshLocalizedOptions();
+        isInitializing = false;
+    }
+
+    public ObservableCollection<SelectionOption<WinPeArchitecture>> Architectures { get; }
+    public ObservableCollection<SelectionOption<UsbPartitionStyle>> PartitionStyles { get; }
+    public ObservableCollection<SelectionOption<UsbFormatMode>> FormatModes { get; } = [];
+    public ObservableCollection<string> AvailableWinPeLanguages { get; } = [];
+
+    [ObservableProperty]
+    public partial string IsoOutputPath { get; set; }
+
+    [ObservableProperty]
+    public partial SelectionOption<WinPeArchitecture>? SelectedArchitecture { get; set; }
+
+    [ObservableProperty]
+    public partial bool UseCa2023Signature { get; set; }
+
+    [ObservableProperty]
+    public partial SelectionOption<UsbPartitionStyle>? SelectedPartitionStyle { get; set; }
+
+    [ObservableProperty]
+    public partial SelectionOption<UsbFormatMode>? SelectedFormatMode { get; set; }
+
+    [ObservableProperty]
+    public partial bool IncludeDellDrivers { get; set; }
+
+    [ObservableProperty]
+    public partial bool IncludeHpDrivers { get; set; }
+
+    [ObservableProperty]
+    public partial string CustomDriverDirectoryPath { get; set; }
+
+    [ObservableProperty]
+    public partial string? SelectedWinPeLanguage { get; set; }
+
+    [ObservableProperty]
+    public partial bool HasWinPeLanguages { get; set; }
+
+    [ObservableProperty]
+    public partial string WinPeLanguageStatus { get; set; } = string.Empty;
+
+    [RelayCommand]
+    private async Task BrowseIsoOutputPathAsync()
+    {
+        string? path = await filePickerService.PickSaveFileAsync(
+            new FileSavePickerRequest(
+                localizationService.GetString("StartMedia.IsoPicker.Title"),
+                "Foundry",
+                [new(localizationService.GetString("StartMedia.IsoPicker.Filter"), [".iso"])],
+                ".iso"));
+
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            IsoOutputPath = path;
+        }
+    }
+
+    [RelayCommand]
+    private async Task BrowseCustomDriverDirectoryAsync()
+    {
+        string? path = await filePickerService.PickFolderAsync(
+            new FolderPickerRequest(localizationService.GetString("StartMedia.CustomDriversPicker.Title")));
+
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            CustomDriverDirectoryPath = path;
+        }
+    }
+
+    [RelayCommand]
+    public Task RefreshWinPeLanguagesAsync()
+    {
+        RefreshWinPeLanguages();
+        return Task.CompletedTask;
+    }
+
+    public void RefreshLocalizedOptions()
+    {
+        UsbFormatMode selectedValue = SelectedFormatMode?.Value
+            ?? ParseEnum(appSettingsService.Current.Media.UsbFormatMode, UsbFormatMode.Quick);
+
+        FormatModes.Clear();
+        FormatModes.Add(new(UsbFormatMode.Quick, localizationService.GetString("StartMedia.FormatMode.Quick")));
+        FormatModes.Add(new(UsbFormatMode.Complete, localizationService.GetString("StartMedia.FormatMode.Complete")));
+        SelectedFormatMode = SelectOption(FormatModes, selectedValue);
+    }
+
+    public void RefreshWinPeLanguages()
+    {
+        AvailableWinPeLanguages.Clear();
+        HasWinPeLanguages = false;
+
+        if (!adkService.CurrentStatus.CanCreateMedia)
+        {
+            WinPeLanguageStatus = localizationService.GetString("GeneralSetting_WinPeLanguage.NotReady");
+            SelectedWinPeLanguage = null;
+            return;
+        }
+
+        WinPeResult<WinPeToolPaths> toolsResult = new WinPeToolResolver().ResolveTools(adkService.CurrentStatus.KitsRootPath);
+        if (!toolsResult.IsSuccess || toolsResult.Value is null)
+        {
+            WinPeLanguageStatus = toolsResult.Error?.Message ?? localizationService.GetString("GeneralSetting_WinPeLanguage.NotReady");
+            logger.Warning("WinPE language discovery skipped because ADK tools were not resolved. ErrorCode={ErrorCode}", toolsResult.Error?.Code);
+            SelectedWinPeLanguage = null;
+            return;
+        }
+
+        WinPeArchitecture architecture = SelectedArchitecture?.Value ?? WinPeArchitecture.X64;
+        WinPeResult<IReadOnlyList<string>> result = winPeLanguageDiscoveryService.GetAvailableLanguages(
+            new WinPeLanguageDiscoveryOptions
+            {
+                Architecture = architecture,
+                Tools = toolsResult.Value
+            });
+
+        if (!result.IsSuccess || result.Value is null || result.Value.Count == 0)
+        {
+            WinPeLanguageStatus = result.Error?.Message ?? localizationService.GetString("GeneralSetting_WinPeLanguage.Empty");
+            logger.Warning(
+                "WinPE language discovery returned no languages. Architecture={Architecture}, ErrorCode={ErrorCode}",
+                architecture,
+                result.Error?.Code);
+            SelectedWinPeLanguage = null;
+            return;
+        }
+
+        string selected = SelectWinPeLanguage(result.Value, appSettingsService.Current.Media.WinPeLanguage, localizationService.CurrentLanguage);
+        foreach (string language in result.Value)
+        {
+            AvailableWinPeLanguages.Add(language);
+        }
+
+        HasWinPeLanguages = true;
+        WinPeLanguageStatus = string.Format(localizationService.GetString("GeneralSetting_WinPeLanguage.Status"), result.Value.Count);
+        SelectedWinPeLanguage = selected;
+        appSettingsService.Current.Media.WinPeLanguage = selected;
+        appSettingsService.Save();
+    }
+
+    public void SetWinPeLanguage(string? selectedLanguage)
+    {
+        if (string.IsNullOrWhiteSpace(selectedLanguage))
+        {
+            return;
+        }
+
+        appSettingsService.Current.Media.WinPeLanguage = selectedLanguage;
+        appSettingsService.Save();
+        SelectedWinPeLanguage = selectedLanguage;
+    }
+
+    partial void OnIsoOutputPathChanged(string value)
+    {
+        if (isInitializing)
+        {
+            return;
+        }
+
+        appSettingsService.Current.Media.IsoOutputPath = value;
+        Save();
+    }
+
+    partial void OnSelectedArchitectureChanged(SelectionOption<WinPeArchitecture>? value)
+    {
+        if (value is null || isInitializing)
+        {
+            return;
+        }
+
+        appSettingsService.Current.Media.Architecture = value.Value.ToString();
+        if (value.Value == WinPeArchitecture.Arm64 && SelectedPartitionStyle?.Value == UsbPartitionStyle.Mbr)
+        {
+            SelectedPartitionStyle = SelectOption(PartitionStyles, UsbPartitionStyle.Gpt);
+        }
+
+        Save();
+        RefreshWinPeLanguages();
+    }
+
+    partial void OnUseCa2023SignatureChanged(bool value)
+    {
+        if (isInitializing)
+        {
+            return;
+        }
+
+        appSettingsService.Current.Media.UseCa2023Signature = value;
+        Save();
+    }
+
+    partial void OnSelectedPartitionStyleChanged(SelectionOption<UsbPartitionStyle>? value)
+    {
+        if (value is null || isInitializing)
+        {
+            return;
+        }
+
+        if (SelectedArchitecture?.Value == WinPeArchitecture.Arm64 && value.Value == UsbPartitionStyle.Mbr)
+        {
+            SelectedPartitionStyle = SelectOption(PartitionStyles, UsbPartitionStyle.Gpt);
+            return;
+        }
+
+        appSettingsService.Current.Media.UsbPartitionStyle = value.Value.ToString();
+        Save();
+    }
+
+    partial void OnSelectedFormatModeChanged(SelectionOption<UsbFormatMode>? value)
+    {
+        if (value is null || isInitializing)
+        {
+            return;
+        }
+
+        appSettingsService.Current.Media.UsbFormatMode = value.Value.ToString();
+        Save();
+    }
+
+    partial void OnIncludeDellDriversChanged(bool value)
+    {
+        if (isInitializing)
+        {
+            return;
+        }
+
+        appSettingsService.Current.Media.IncludeDellDrivers = value;
+        Save();
+    }
+
+    partial void OnIncludeHpDriversChanged(bool value)
+    {
+        if (isInitializing)
+        {
+            return;
+        }
+
+        appSettingsService.Current.Media.IncludeHpDrivers = value;
+        Save();
+    }
+
+    partial void OnCustomDriverDirectoryPathChanged(string value)
+    {
+        if (isInitializing)
+        {
+            return;
+        }
+
+        appSettingsService.Current.Media.CustomDriverDirectoryPath = string.IsNullOrWhiteSpace(value) ? null : value;
+        Save();
+    }
+
+    private void Save()
+    {
+        appSettingsService.Save();
+    }
+
+    private static string SelectWinPeLanguage(IReadOnlyList<string> languages, string? preferredLanguage, string currentLanguage)
+    {
+        string? exact = languages.FirstOrDefault(language => string.Equals(language, preferredLanguage, StringComparison.OrdinalIgnoreCase))
+            ?? languages.FirstOrDefault(language => string.Equals(language, currentLanguage, StringComparison.OrdinalIgnoreCase));
+
+        if (!string.IsNullOrWhiteSpace(exact))
+        {
+            return exact;
+        }
+
+        string currentPrefix = currentLanguage.Split('-', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? string.Empty;
+        string? family = languages.FirstOrDefault(language => language.StartsWith(currentPrefix + "-", StringComparison.OrdinalIgnoreCase));
+
+        return family ?? languages[0];
+    }
+
+    private static T ParseEnum<T>(string? value, T fallback)
+        where T : struct, Enum
+    {
+        return Enum.TryParse(value, ignoreCase: true, out T result) ? result : fallback;
+    }
+
+    private static SelectionOption<T>? SelectOption<T>(IEnumerable<SelectionOption<T>> options, T value)
+    {
+        return options.FirstOrDefault(option => EqualityComparer<T>.Default.Equals(option.Value, value));
+    }
+}

--- a/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
@@ -91,9 +91,6 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
     [ObservableProperty]
     public partial bool HasWinPeLanguages { get; set; }
 
-    [ObservableProperty]
-    public partial string WinPeLanguageStatus { get; set; } = string.Empty;
-
     [RelayCommand]
     private async Task BrowseIsoOutputPathAsync()
     {
@@ -122,13 +119,6 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
         }
     }
 
-    [RelayCommand]
-    public Task RefreshWinPeLanguagesAsync()
-    {
-        RefreshWinPeLanguages();
-        return Task.CompletedTask;
-    }
-
     public void RefreshLocalizedOptions()
     {
         UsbFormatMode selectedValue = SelectedFormatMode?.Value
@@ -147,7 +137,6 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
 
         if (!adkService.CurrentStatus.CanCreateMedia)
         {
-            WinPeLanguageStatus = localizationService.GetString("GeneralSetting_WinPeLanguage.NotReady");
             SelectedWinPeLanguage = null;
             return;
         }
@@ -155,7 +144,6 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
         WinPeResult<WinPeToolPaths> toolsResult = new WinPeToolResolver().ResolveTools(adkService.CurrentStatus.KitsRootPath);
         if (!toolsResult.IsSuccess || toolsResult.Value is null)
         {
-            WinPeLanguageStatus = toolsResult.Error?.Message ?? localizationService.GetString("GeneralSetting_WinPeLanguage.NotReady");
             logger.Warning("WinPE language discovery skipped because ADK tools were not resolved. ErrorCode={ErrorCode}", toolsResult.Error?.Code);
             SelectedWinPeLanguage = null;
             return;
@@ -171,7 +159,6 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
 
         if (!result.IsSuccess || result.Value is null || result.Value.Count == 0)
         {
-            WinPeLanguageStatus = result.Error?.Message ?? localizationService.GetString("GeneralSetting_WinPeLanguage.Empty");
             logger.Warning(
                 "WinPE language discovery returned no languages. Architecture={Architecture}, ErrorCode={ErrorCode}",
                 architecture,
@@ -187,7 +174,6 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
         }
 
         HasWinPeLanguages = true;
-        WinPeLanguageStatus = string.Format(localizationService.GetString("GeneralSetting_WinPeLanguage.Status"), result.Value.Count);
         SelectedWinPeLanguage = selected;
         appSettingsService.Current.Media.WinPeLanguage = selected;
         appSettingsService.Save();

--- a/src/Foundry/ViewModels/SelectionOption.cs
+++ b/src/Foundry/ViewModels/SelectionOption.cs
@@ -1,0 +1,3 @@
+namespace Foundry.ViewModels;
+
+public sealed record SelectionOption<T>(T Value, string DisplayName);

--- a/src/Foundry/ViewModels/Settings/GeneralSettingViewModel.cs
+++ b/src/Foundry/ViewModels/Settings/GeneralSettingViewModel.cs
@@ -1,11 +1,8 @@
 using System.Collections.ObjectModel;
 using Foundry.Core.Localization;
 using Foundry.Core.Services.Application;
-using Foundry.Core.Services.WinPe;
-using Foundry.Services.Adk;
 using Foundry.Services.Localization;
 using Foundry.Services.Settings;
-using Serilog;
 
 namespace Foundry.ViewModels
 {
@@ -14,30 +11,20 @@ namespace Foundry.ViewModels
         private readonly IAppSettingsService appSettingsService;
         private readonly IExternalProcessLauncher externalProcessLauncher;
         private readonly IApplicationLocalizationService localizationService;
-        private readonly IAdkService adkService;
-        private readonly IWinPeLanguageDiscoveryService winPeLanguageDiscoveryService;
-        private readonly ILogger logger;
 
         public GeneralSettingViewModel(
             IAppSettingsService appSettingsService,
             IExternalProcessLauncher externalProcessLauncher,
-            IApplicationLocalizationService localizationService,
-            IAdkService adkService,
-            IWinPeLanguageDiscoveryService winPeLanguageDiscoveryService,
-            ILogger logger)
+            IApplicationLocalizationService localizationService)
         {
             this.appSettingsService = appSettingsService;
             this.externalProcessLauncher = externalProcessLauncher;
             this.localizationService = localizationService;
-            this.adkService = adkService;
-            this.winPeLanguageDiscoveryService = winPeLanguageDiscoveryService;
-            this.logger = logger.ForContext<GeneralSettingViewModel>();
             IsDeveloperMode = appSettingsService.Current.Diagnostics.DeveloperMode;
             RefreshSupportedLanguages();
         }
 
         public ObservableCollection<SupportedCultureOption> SupportedLanguages { get; } = [];
-        public ObservableCollection<string> AvailableWinPeLanguages { get; } = [];
 
         public string LogDirectoryPath => Constants.LogDirectoryPath;
 
@@ -47,15 +34,6 @@ namespace Foundry.ViewModels
         [ObservableProperty]
         public partial SupportedCultureOption? SelectedLanguage { get; set; }
 
-        [ObservableProperty]
-        public partial string? SelectedWinPeLanguage { get; set; }
-
-        [ObservableProperty]
-        public partial bool HasWinPeLanguages { get; set; }
-
-        [ObservableProperty]
-        public partial string WinPeLanguageStatus { get; set; } = string.Empty;
-
         public async Task SetLanguageAsync(SupportedCultureOption? selectedLanguage)
         {
             if (selectedLanguage is null)
@@ -64,18 +42,6 @@ namespace Foundry.ViewModels
             }
 
             await localizationService.SetLanguageAsync(selectedLanguage.Code);
-        }
-
-        public void SetWinPeLanguage(string? selectedLanguage)
-        {
-            if (string.IsNullOrWhiteSpace(selectedLanguage))
-            {
-                return;
-            }
-
-            appSettingsService.Current.Media.WinPeLanguage = selectedLanguage;
-            appSettingsService.Save();
-            SelectedWinPeLanguage = selectedLanguage;
         }
 
         partial void OnIsDeveloperModeChanged(bool value)
@@ -89,13 +55,6 @@ namespace Foundry.ViewModels
         private Task OpenLogFolderAsync()
         {
             return externalProcessLauncher.OpenFolderAsync(Constants.LogDirectoryPath);
-        }
-
-        [RelayCommand]
-        public Task RefreshWinPeLanguagesAsync()
-        {
-            RefreshWinPeLanguages();
-            return Task.CompletedTask;
         }
 
         public void RefreshSupportedLanguages()
@@ -115,84 +74,5 @@ namespace Foundry.ViewModels
             SelectedLanguage = selectedOption;
         }
 
-        public void RefreshWinPeLanguages()
-        {
-            AvailableWinPeLanguages.Clear();
-            HasWinPeLanguages = false;
-
-            if (!adkService.CurrentStatus.CanCreateMedia)
-            {
-                WinPeLanguageStatus = localizationService.GetString("GeneralSetting_WinPeLanguage.NotReady");
-                SelectedWinPeLanguage = null;
-                return;
-            }
-
-            WinPeResult<WinPeToolPaths> toolsResult = new WinPeToolResolver().ResolveTools(adkService.CurrentStatus.KitsRootPath);
-            if (!toolsResult.IsSuccess || toolsResult.Value is null)
-            {
-                WinPeLanguageStatus = toolsResult.Error?.Message ?? localizationService.GetString("GeneralSetting_WinPeLanguage.NotReady");
-                logger.Warning("WinPE language discovery skipped because ADK tools were not resolved. ErrorCode={ErrorCode}", toolsResult.Error?.Code);
-                SelectedWinPeLanguage = null;
-                return;
-            }
-
-            WinPeArchitecture architecture = ParseArchitecture(appSettingsService.Current.Media.Architecture);
-            WinPeResult<IReadOnlyList<string>> result = winPeLanguageDiscoveryService.GetAvailableLanguages(
-                new WinPeLanguageDiscoveryOptions
-                {
-                    Architecture = architecture,
-                    Tools = toolsResult.Value
-                });
-
-            if (!result.IsSuccess || result.Value is null || result.Value.Count == 0)
-            {
-                WinPeLanguageStatus = result.Error?.Message ?? localizationService.GetString("GeneralSetting_WinPeLanguage.Empty");
-                logger.Warning(
-                    "WinPE language discovery returned no languages. Architecture={Architecture}, ErrorCode={ErrorCode}",
-                    architecture,
-                    result.Error?.Code);
-                SelectedWinPeLanguage = null;
-                return;
-            }
-
-            string? previousSelection = appSettingsService.Current.Media.WinPeLanguage;
-            string selected = SelectWinPeLanguage(result.Value, previousSelection, localizationService.CurrentLanguage);
-
-            foreach (string language in result.Value)
-            {
-                AvailableWinPeLanguages.Add(language);
-            }
-
-            HasWinPeLanguages = true;
-            WinPeLanguageStatus = string.Format(
-                localizationService.GetString("GeneralSetting_WinPeLanguage.Status"),
-                result.Value.Count);
-            SelectedWinPeLanguage = selected;
-            appSettingsService.Current.Media.WinPeLanguage = selected;
-            appSettingsService.Save();
-        }
-
-        private static WinPeArchitecture ParseArchitecture(string? value)
-        {
-            return Enum.TryParse(value, ignoreCase: true, out WinPeArchitecture architecture)
-                ? architecture
-                : WinPeArchitecture.X64;
-        }
-
-        private static string SelectWinPeLanguage(IReadOnlyList<string> languages, string? preferredLanguage, string currentLanguage)
-        {
-            string? exact = languages.FirstOrDefault(language => string.Equals(language, preferredLanguage, StringComparison.OrdinalIgnoreCase))
-                ?? languages.FirstOrDefault(language => string.Equals(language, currentLanguage, StringComparison.OrdinalIgnoreCase));
-
-            if (!string.IsNullOrWhiteSpace(exact))
-            {
-                return exact;
-            }
-
-            string currentPrefix = currentLanguage.Split('-', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? string.Empty;
-            string? family = languages.FirstOrDefault(language => language.StartsWith(currentPrefix + "-", StringComparison.OrdinalIgnoreCase));
-
-            return family ?? languages[0];
-        }
     }
 }

--- a/src/Foundry/ViewModels/Settings/GeneralSettingViewModel.cs
+++ b/src/Foundry/ViewModels/Settings/GeneralSettingViewModel.cs
@@ -1,8 +1,11 @@
 using System.Collections.ObjectModel;
 using Foundry.Core.Localization;
 using Foundry.Core.Services.Application;
+using Foundry.Core.Services.WinPe;
+using Foundry.Services.Adk;
 using Foundry.Services.Localization;
 using Foundry.Services.Settings;
+using Serilog;
 
 namespace Foundry.ViewModels
 {
@@ -11,20 +14,30 @@ namespace Foundry.ViewModels
         private readonly IAppSettingsService appSettingsService;
         private readonly IExternalProcessLauncher externalProcessLauncher;
         private readonly IApplicationLocalizationService localizationService;
+        private readonly IAdkService adkService;
+        private readonly IWinPeLanguageDiscoveryService winPeLanguageDiscoveryService;
+        private readonly ILogger logger;
 
         public GeneralSettingViewModel(
             IAppSettingsService appSettingsService,
             IExternalProcessLauncher externalProcessLauncher,
-            IApplicationLocalizationService localizationService)
+            IApplicationLocalizationService localizationService,
+            IAdkService adkService,
+            IWinPeLanguageDiscoveryService winPeLanguageDiscoveryService,
+            ILogger logger)
         {
             this.appSettingsService = appSettingsService;
             this.externalProcessLauncher = externalProcessLauncher;
             this.localizationService = localizationService;
+            this.adkService = adkService;
+            this.winPeLanguageDiscoveryService = winPeLanguageDiscoveryService;
+            this.logger = logger.ForContext<GeneralSettingViewModel>();
             IsDeveloperMode = appSettingsService.Current.Diagnostics.DeveloperMode;
             RefreshSupportedLanguages();
         }
 
         public ObservableCollection<SupportedCultureOption> SupportedLanguages { get; } = [];
+        public ObservableCollection<string> AvailableWinPeLanguages { get; } = [];
 
         public string LogDirectoryPath => Constants.LogDirectoryPath;
 
@@ -34,6 +47,15 @@ namespace Foundry.ViewModels
         [ObservableProperty]
         public partial SupportedCultureOption? SelectedLanguage { get; set; }
 
+        [ObservableProperty]
+        public partial string? SelectedWinPeLanguage { get; set; }
+
+        [ObservableProperty]
+        public partial bool HasWinPeLanguages { get; set; }
+
+        [ObservableProperty]
+        public partial string WinPeLanguageStatus { get; set; } = string.Empty;
+
         public async Task SetLanguageAsync(SupportedCultureOption? selectedLanguage)
         {
             if (selectedLanguage is null)
@@ -42,6 +64,18 @@ namespace Foundry.ViewModels
             }
 
             await localizationService.SetLanguageAsync(selectedLanguage.Code);
+        }
+
+        public void SetWinPeLanguage(string? selectedLanguage)
+        {
+            if (string.IsNullOrWhiteSpace(selectedLanguage))
+            {
+                return;
+            }
+
+            appSettingsService.Current.Media.WinPeLanguage = selectedLanguage;
+            appSettingsService.Save();
+            SelectedWinPeLanguage = selectedLanguage;
         }
 
         partial void OnIsDeveloperModeChanged(bool value)
@@ -55,6 +89,13 @@ namespace Foundry.ViewModels
         private Task OpenLogFolderAsync()
         {
             return externalProcessLauncher.OpenFolderAsync(Constants.LogDirectoryPath);
+        }
+
+        [RelayCommand]
+        public Task RefreshWinPeLanguagesAsync()
+        {
+            RefreshWinPeLanguages();
+            return Task.CompletedTask;
         }
 
         public void RefreshSupportedLanguages()
@@ -72,6 +113,86 @@ namespace Foundry.ViewModels
             }
 
             SelectedLanguage = selectedOption;
+        }
+
+        public void RefreshWinPeLanguages()
+        {
+            AvailableWinPeLanguages.Clear();
+            HasWinPeLanguages = false;
+
+            if (!adkService.CurrentStatus.CanCreateMedia)
+            {
+                WinPeLanguageStatus = localizationService.GetString("GeneralSetting_WinPeLanguage.NotReady");
+                SelectedWinPeLanguage = null;
+                return;
+            }
+
+            WinPeResult<WinPeToolPaths> toolsResult = new WinPeToolResolver().ResolveTools(adkService.CurrentStatus.KitsRootPath);
+            if (!toolsResult.IsSuccess || toolsResult.Value is null)
+            {
+                WinPeLanguageStatus = toolsResult.Error?.Message ?? localizationService.GetString("GeneralSetting_WinPeLanguage.NotReady");
+                logger.Warning("WinPE language discovery skipped because ADK tools were not resolved. ErrorCode={ErrorCode}", toolsResult.Error?.Code);
+                SelectedWinPeLanguage = null;
+                return;
+            }
+
+            WinPeArchitecture architecture = ParseArchitecture(appSettingsService.Current.Media.Architecture);
+            WinPeResult<IReadOnlyList<string>> result = winPeLanguageDiscoveryService.GetAvailableLanguages(
+                new WinPeLanguageDiscoveryOptions
+                {
+                    Architecture = architecture,
+                    Tools = toolsResult.Value
+                });
+
+            if (!result.IsSuccess || result.Value is null || result.Value.Count == 0)
+            {
+                WinPeLanguageStatus = result.Error?.Message ?? localizationService.GetString("GeneralSetting_WinPeLanguage.Empty");
+                logger.Warning(
+                    "WinPE language discovery returned no languages. Architecture={Architecture}, ErrorCode={ErrorCode}",
+                    architecture,
+                    result.Error?.Code);
+                SelectedWinPeLanguage = null;
+                return;
+            }
+
+            string? previousSelection = appSettingsService.Current.Media.WinPeLanguage;
+            string selected = SelectWinPeLanguage(result.Value, previousSelection, localizationService.CurrentLanguage);
+
+            foreach (string language in result.Value)
+            {
+                AvailableWinPeLanguages.Add(language);
+            }
+
+            HasWinPeLanguages = true;
+            WinPeLanguageStatus = string.Format(
+                localizationService.GetString("GeneralSetting_WinPeLanguage.Status"),
+                result.Value.Count);
+            SelectedWinPeLanguage = selected;
+            appSettingsService.Current.Media.WinPeLanguage = selected;
+            appSettingsService.Save();
+        }
+
+        private static WinPeArchitecture ParseArchitecture(string? value)
+        {
+            return Enum.TryParse(value, ignoreCase: true, out WinPeArchitecture architecture)
+                ? architecture
+                : WinPeArchitecture.X64;
+        }
+
+        private static string SelectWinPeLanguage(IReadOnlyList<string> languages, string? preferredLanguage, string currentLanguage)
+        {
+            string? exact = languages.FirstOrDefault(language => string.Equals(language, preferredLanguage, StringComparison.OrdinalIgnoreCase))
+                ?? languages.FirstOrDefault(language => string.Equals(language, currentLanguage, StringComparison.OrdinalIgnoreCase));
+
+            if (!string.IsNullOrWhiteSpace(exact))
+            {
+                return exact;
+            }
+
+            string currentPrefix = currentLanguage.Split('-', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? string.Empty;
+            string? family = languages.FirstOrDefault(language => language.StartsWith(currentPrefix + "-", StringComparison.OrdinalIgnoreCase));
+
+            return family ?? languages[0];
         }
     }
 }

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -1,0 +1,661 @@
+using System.Collections.ObjectModel;
+using System.Text;
+using Foundry.Core.Services.Application;
+using Foundry.Core.Services.Media;
+using Foundry.Core.Services.WinPe;
+using Foundry.Services.Adk;
+using Foundry.Services.Localization;
+using Foundry.Services.Settings;
+using Serilog;
+
+namespace Foundry.ViewModels;
+
+public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
+{
+    private readonly IAppSettingsService appSettingsService;
+    private readonly IAdkService adkService;
+    private readonly IWinPeLanguageDiscoveryService languageDiscoveryService;
+    private readonly IWinPeUsbMediaService usbMediaService;
+    private readonly IFilePickerService filePickerService;
+    private readonly IDialogService dialogService;
+    private readonly IApplicationLocalizationService localizationService;
+    private readonly IAppDispatcher appDispatcher;
+    private readonly ILogger logger;
+    private IReadOnlyList<string> availableWinPeLanguages = [];
+
+    public StartMediaViewModel(
+        IAppSettingsService appSettingsService,
+        IAdkService adkService,
+        IWinPeLanguageDiscoveryService languageDiscoveryService,
+        IWinPeUsbMediaService usbMediaService,
+        IFilePickerService filePickerService,
+        IDialogService dialogService,
+        IApplicationLocalizationService localizationService,
+        IAppDispatcher appDispatcher,
+        ILogger logger)
+    {
+        this.appSettingsService = appSettingsService;
+        this.adkService = adkService;
+        this.languageDiscoveryService = languageDiscoveryService;
+        this.usbMediaService = usbMediaService;
+        this.filePickerService = filePickerService;
+        this.dialogService = dialogService;
+        this.localizationService = localizationService;
+        this.appDispatcher = appDispatcher;
+        this.logger = logger.ForContext<StartMediaViewModel>();
+
+        Architectures =
+        [
+            new(WinPeArchitecture.X64, "x64"),
+            new(WinPeArchitecture.Arm64, "arm64")
+        ];
+        PartitionStyles =
+        [
+            new(UsbPartitionStyle.Gpt, "GPT"),
+            new(UsbPartitionStyle.Mbr, "MBR")
+        ];
+        FormatModes = [];
+
+        IsoOutputPath = appSettingsService.Current.Media.IsoOutputPath;
+        SelectedArchitecture = SelectOption(Architectures, ParseEnum(appSettingsService.Current.Media.Architecture, WinPeArchitecture.X64));
+        UseCa2023Signature = appSettingsService.Current.Media.UseCa2023Signature;
+        SelectedPartitionStyle = SelectOption(PartitionStyles, ParseEnum(appSettingsService.Current.Media.UsbPartitionStyle, UsbPartitionStyle.Gpt));
+        IncludeDellDrivers = appSettingsService.Current.Media.IncludeDellDrivers;
+        IncludeHpDrivers = appSettingsService.Current.Media.IncludeHpDrivers;
+        CustomDriverDirectoryPath = appSettingsService.Current.Media.CustomDriverDirectoryPath ?? string.Empty;
+
+        adkService.StatusChanged += OnAdkStatusChanged;
+        localizationService.LanguageChanged += OnLanguageChanged;
+
+        ApplyLocalizedText();
+        RefreshEvaluation();
+    }
+
+    public ObservableCollection<SelectionOption<WinPeArchitecture>> Architectures { get; }
+    public ObservableCollection<SelectionOption<UsbPartitionStyle>> PartitionStyles { get; }
+    public ObservableCollection<SelectionOption<UsbFormatMode>> FormatModes { get; }
+    public ObservableCollection<SelectionOption<WinPeUsbDiskCandidate>> UsbCandidates { get; } = [];
+
+    [ObservableProperty]
+    public partial string PageTitle { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string IsoOutputPath { get; set; }
+
+    [ObservableProperty]
+    public partial SelectionOption<WinPeArchitecture>? SelectedArchitecture { get; set; }
+
+    [ObservableProperty]
+    public partial bool UseCa2023Signature { get; set; }
+
+    [ObservableProperty]
+    public partial SelectionOption<UsbPartitionStyle>? SelectedPartitionStyle { get; set; }
+
+    [ObservableProperty]
+    public partial SelectionOption<UsbFormatMode>? SelectedFormatMode { get; set; }
+
+    [ObservableProperty]
+    public partial bool IncludeDellDrivers { get; set; }
+
+    [ObservableProperty]
+    public partial bool IncludeHpDrivers { get; set; }
+
+    [ObservableProperty]
+    public partial string CustomDriverDirectoryPath { get; set; }
+
+    [ObservableProperty]
+    public partial SelectionOption<WinPeUsbDiskCandidate>? SelectedUsbDisk { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsRefreshingUsbCandidates { get; set; }
+
+    [ObservableProperty]
+    public partial bool CanGenerateIsoSummary { get; set; }
+
+    [ObservableProperty]
+    public partial bool CanGenerateUsbSummary { get; set; }
+
+    [ObservableProperty]
+    public partial string StatusSummary { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string FinalExecutionStatus { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string WinPeLanguage { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string UsbCandidateStatus { get; set; } = string.Empty;
+
+    public void Dispose()
+    {
+        adkService.StatusChanged -= OnAdkStatusChanged;
+        localizationService.LanguageChanged -= OnLanguageChanged;
+    }
+
+    public async Task InitializeAsync()
+    {
+        RefreshEvaluation();
+
+        if (adkService.CurrentStatus.CanCreateMedia)
+        {
+            await RefreshUsbCandidatesAsync();
+        }
+    }
+
+    [RelayCommand]
+    private async Task BrowseIsoOutputPathAsync()
+    {
+        string? path = await filePickerService.PickSaveFileAsync(
+            new FileSavePickerRequest(
+                localizationService.GetString("StartMedia.IsoPicker.Title"),
+                "Foundry",
+                [new(localizationService.GetString("StartMedia.IsoPicker.Filter"), [".iso"])],
+                ".iso"));
+
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            IsoOutputPath = path;
+        }
+    }
+
+    [RelayCommand]
+    private async Task BrowseCustomDriverDirectoryAsync()
+    {
+        string? path = await filePickerService.PickFolderAsync(
+            new FolderPickerRequest(localizationService.GetString("StartMedia.CustomDriversPicker.Title")));
+
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            CustomDriverDirectoryPath = path;
+        }
+    }
+
+    [RelayCommand]
+    private async Task RefreshUsbCandidatesAsync()
+    {
+        if (!adkService.CurrentStatus.CanCreateMedia)
+        {
+            UsbCandidateStatus = localizationService.GetString("StartMedia.Usb.AdkBlocked");
+            RefreshEvaluation();
+            return;
+        }
+
+        WinPeResult<WinPeToolPaths> toolsResult = new WinPeToolResolver().ResolveTools(adkService.CurrentStatus.KitsRootPath);
+        if (!toolsResult.IsSuccess || toolsResult.Value is null)
+        {
+            UsbCandidateStatus = toolsResult.Error?.Message ?? localizationService.GetString("StartMedia.Usb.QueryFailed");
+            logger.Warning("USB target refresh skipped because ADK tools were not resolved. ErrorCode={ErrorCode}", toolsResult.Error?.Code);
+            RefreshEvaluation();
+            return;
+        }
+
+        IsRefreshingUsbCandidates = true;
+
+        try
+        {
+            WinPeResult<IReadOnlyList<WinPeUsbDiskCandidate>> result = await usbMediaService.GetUsbCandidatesAsync(
+                toolsResult.Value,
+                Constants.UsbQueryTempDirectoryPath,
+                CancellationToken.None);
+
+                UsbCandidates.Clear();
+                if (result.IsSuccess && result.Value is not null)
+                {
+                    foreach (WinPeUsbDiskCandidate candidate in result.Value)
+                    {
+                    UsbCandidates.Add(CreateUsbDiskOption(candidate));
+                    }
+
+                SelectedUsbDisk = UsbCandidates.FirstOrDefault(option => option.Value.DiskNumber == SelectedUsbDisk?.Value.DiskNumber)
+                    ?? UsbCandidates.FirstOrDefault();
+                UsbCandidateStatus = string.Format(localizationService.GetString("StartMedia.Usb.CandidatesFound"), UsbCandidates.Count);
+                logger.Information("USB targets refreshed. CandidateCount={CandidateCount}", UsbCandidates.Count);
+            }
+            else
+            {
+                SelectedUsbDisk = null;
+                UsbCandidateStatus = result.Error?.Message ?? localizationService.GetString("StartMedia.Usb.QueryFailed");
+                logger.Warning("USB target refresh failed. ErrorCode={ErrorCode}", result.Error?.Code);
+            }
+        }
+        finally
+        {
+            IsRefreshingUsbCandidates = false;
+            RefreshEvaluation();
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanGenerateIsoSummary))]
+    private Task ShowIsoSummaryAsync()
+    {
+        MediaPreflightOptions options = CreatePreflightOptions();
+        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(options);
+        string summary = BuildSummary(isUsbSummary: false, options, evaluation);
+        LogDryRunSummary("ISO", options, evaluation);
+        return dialogService.ShowMessageAsync(new DialogRequest(PageTitle, summary, localizationService.GetString("Common.Close")));
+    }
+
+    [RelayCommand(CanExecute = nameof(CanGenerateUsbSummary))]
+    private Task ShowUsbSummaryAsync()
+    {
+        MediaPreflightOptions options = CreatePreflightOptions();
+        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(options);
+        string summary = BuildSummary(isUsbSummary: true, options, evaluation);
+        LogDryRunSummary("USB", options, evaluation);
+        return dialogService.ShowMessageAsync(new DialogRequest(PageTitle, summary, localizationService.GetString("Common.Close")));
+    }
+
+    partial void OnIsoOutputPathChanged(string value)
+    {
+        appSettingsService.Current.Media.IsoOutputPath = value;
+        SaveAndRefresh();
+    }
+
+    partial void OnSelectedArchitectureChanged(SelectionOption<WinPeArchitecture>? value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        appSettingsService.Current.Media.Architecture = value.Value.ToString();
+        if (value.Value == WinPeArchitecture.Arm64 && SelectedPartitionStyle?.Value == UsbPartitionStyle.Mbr)
+        {
+            SelectedPartitionStyle = SelectOption(PartitionStyles, UsbPartitionStyle.Gpt);
+        }
+
+        SaveAndRefresh();
+    }
+
+    partial void OnUseCa2023SignatureChanged(bool value)
+    {
+        appSettingsService.Current.Media.UseCa2023Signature = value;
+        SaveAndRefresh();
+    }
+
+    partial void OnSelectedPartitionStyleChanged(SelectionOption<UsbPartitionStyle>? value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        appSettingsService.Current.Media.UsbPartitionStyle = value.Value.ToString();
+        SaveAndRefresh();
+    }
+
+    partial void OnSelectedFormatModeChanged(SelectionOption<UsbFormatMode>? value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        appSettingsService.Current.Media.UsbFormatMode = value.Value.ToString();
+        SaveAndRefresh();
+    }
+
+    partial void OnIncludeDellDriversChanged(bool value)
+    {
+        appSettingsService.Current.Media.IncludeDellDrivers = value;
+        SaveAndRefresh();
+    }
+
+    partial void OnIncludeHpDriversChanged(bool value)
+    {
+        appSettingsService.Current.Media.IncludeHpDrivers = value;
+        SaveAndRefresh();
+    }
+
+    partial void OnCustomDriverDirectoryPathChanged(string value)
+    {
+        appSettingsService.Current.Media.CustomDriverDirectoryPath = string.IsNullOrWhiteSpace(value) ? null : value;
+        SaveAndRefresh();
+    }
+
+    partial void OnSelectedUsbDiskChanged(SelectionOption<WinPeUsbDiskCandidate>? value)
+    {
+        RefreshEvaluation();
+    }
+
+    private void SaveAndRefresh()
+    {
+        appSettingsService.Save();
+        RefreshEvaluation();
+    }
+
+    private void OnAdkStatusChanged(object? sender, AdkStatusChangedEventArgs e)
+    {
+        if (!appDispatcher.TryEnqueue(RefreshEvaluation))
+        {
+            logger.Warning("Failed to enqueue Start page ADK status refresh. IsReady={IsReady}", e.Status.CanCreateMedia);
+        }
+    }
+
+    private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
+    {
+        if (!appDispatcher.TryEnqueue(() =>
+        {
+            ApplyLocalizedText();
+            RefreshEvaluation();
+        }))
+        {
+            logger.Warning(
+                "Failed to enqueue Start page localization refresh. OldLanguage={OldLanguage}, NewLanguage={NewLanguage}",
+                e.OldLanguage,
+                e.NewLanguage);
+        }
+    }
+
+    private void ApplyLocalizedText()
+    {
+        PageTitle = localizationService.GetString("StartPage_Title.Text");
+        FinalExecutionStatus = localizationService.GetString("StartMedia.FinalExecution.Deferred");
+        RebuildFormatModes();
+        RebuildUsbCandidateDisplayNames();
+    }
+
+    private void RefreshEvaluation()
+    {
+        WinPeLanguage = appSettingsService.Current.Media.WinPeLanguage;
+        availableWinPeLanguages = GetAvailableWinPeLanguages();
+        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(CreatePreflightOptions());
+        CanGenerateIsoSummary = evaluation.CanGenerateIsoSummary;
+        CanGenerateUsbSummary = evaluation.CanGenerateUsbSummary;
+        StatusSummary = BuildStatusText(evaluation);
+
+        ShowIsoSummaryCommand.NotifyCanExecuteChanged();
+        ShowUsbSummaryCommand.NotifyCanExecuteChanged();
+    }
+
+    private MediaPreflightOptions CreatePreflightOptions()
+    {
+        List<WinPeVendorSelection> vendors = [];
+        if (IncludeDellDrivers)
+        {
+            vendors.Add(WinPeVendorSelection.Dell);
+        }
+
+        if (IncludeHpDrivers)
+        {
+            vendors.Add(WinPeVendorSelection.Hp);
+        }
+
+        return new MediaPreflightOptions
+        {
+            IsAdkReady = adkService.CurrentStatus.CanCreateMedia,
+            IsRuntimePayloadReady = false,
+            IsNetworkConfigurationReady = false,
+            IsDeployConfigurationReady = false,
+            IsConnectProvisioningReady = false,
+            AreRequiredSecretsReady = false,
+            IsFinalExecutionEnabled = false,
+            IsoOutputPath = IsoOutputPath,
+            Architecture = SelectedArchitecture?.Value ?? WinPeArchitecture.X64,
+            SignatureMode = UseCa2023Signature ? WinPeSignatureMode.Pca2023 : WinPeSignatureMode.Pca2011,
+            UsbPartitionStyle = SelectedPartitionStyle?.Value ?? UsbPartitionStyle.Gpt,
+            UsbFormatMode = SelectedFormatMode?.Value ?? UsbFormatMode.Quick,
+            WinPeLanguage = WinPeLanguage,
+            AvailableWinPeLanguages = availableWinPeLanguages,
+            BootImageSource = WinPeBootImageSource.WinPe,
+            DriverVendors = vendors,
+            CustomDriverDirectoryPath = CustomDriverDirectoryPath,
+            SelectedUsbDisk = SelectedUsbDisk?.Value
+        };
+    }
+
+    private string BuildSummary(bool isUsbSummary)
+    {
+        MediaPreflightOptions options = CreatePreflightOptions();
+        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(options);
+        return BuildSummary(isUsbSummary, options, evaluation);
+    }
+
+    private string BuildSummary(bool isUsbSummary, MediaPreflightOptions options, MediaPreflightEvaluation evaluation)
+    {
+        IReadOnlyList<MediaPreflightBlockingReason> reasons = isUsbSummary
+            ? evaluation.UsbBlockingReasons
+            : evaluation.IsoBlockingReasons;
+
+        var builder = new StringBuilder();
+        builder.AppendLine(isUsbSummary ? localizationService.GetString("StartMedia.Summary.UsbTitle") : localizationService.GetString("StartMedia.Summary.IsoTitle"));
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Adk")}: {FormatReady(adkService.CurrentStatus.CanCreateMedia)}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.WinPeLanguage")}: {FormatValue(options.WinPeLanguage)}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.AvailableWinPeLanguages")}: {FormatAvailableLanguages(options.AvailableWinPeLanguages)}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Architecture")}: {FormatArchitecture(options.Architecture)}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.BootImageSource")}: {FormatBootImageSource(options.BootImageSource)}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.IsoPath")}: {FormatValue(options.IsoOutputPath)}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.UsbTarget")}: {FormatUsbCandidate(options.SelectedUsbDisk)}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Signature")}: {FormatSignatureMode(options.SignatureMode)}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.PartitionStyle")}: {evaluation.EffectiveUsbPartitionStyle}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.FormatMode")}: {FormatUsbFormatMode(options.UsbFormatMode)}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Drivers")}: {FormatDriverOptions(options.DriverVendors, options.CustomDriverDirectoryPath)}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Runtime")}: {FormatReady(options.IsRuntimePayloadReady)}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Network")}: {FormatReady(options.IsNetworkConfigurationReady)}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Deploy")}: {FormatReady(options.IsDeployConfigurationReady)}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Connect")}: {FormatReady(options.IsConnectProvisioningReady)}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Secrets")}: {FormatReady(options.AreRequiredSecretsReady)}");
+        builder.AppendLine();
+        builder.AppendLine(localizationService.GetString("StartMedia.FinalExecution.Deferred"));
+
+        if (reasons.Count > 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine(localizationService.GetString("StartMedia.Summary.BlockingReasons"));
+            foreach (MediaPreflightBlockingReason reason in reasons.Distinct())
+            {
+                builder.AppendLine($"- {GetBlockingReasonText(reason)}");
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private string BuildStatusText(MediaPreflightEvaluation evaluation)
+    {
+        return string.Format(
+            localizationService.GetString("StartMedia.Status"),
+            FormatReady(CanGenerateIsoSummary),
+            FormatReady(CanGenerateUsbSummary),
+            evaluation.IsoBlockingReasons.Count,
+            evaluation.UsbBlockingReasons.Count);
+    }
+
+    private string GetBlockingReasonText(MediaPreflightBlockingReason reason)
+    {
+        return localizationService.GetString($"StartMedia.BlockingReason.{reason}");
+    }
+
+    private void LogDryRunSummary(string mediaKind, MediaPreflightOptions options, MediaPreflightEvaluation evaluation)
+    {
+        IReadOnlyList<MediaPreflightBlockingReason> reasons = string.Equals(mediaKind, "USB", StringComparison.OrdinalIgnoreCase)
+            ? evaluation.UsbBlockingReasons
+            : evaluation.IsoBlockingReasons;
+
+        logger.Information(
+            "{MediaKind} media dry-run summary generated. Architecture={Architecture}, WinPeLanguage={WinPeLanguage}, BootImageSource={BootImageSource}, IsoOutputPath={IsoOutputPath}, DiskNumber={DiskNumber}, DiskName={DiskName}, RuntimeReady={RuntimeReady}, NetworkReady={NetworkReady}, DeployReady={DeployReady}, ConnectReady={ConnectReady}, SecretsReady={SecretsReady}, BlockingReasons={BlockingReasons}",
+            mediaKind,
+            options.Architecture,
+            options.WinPeLanguage,
+            options.BootImageSource,
+            options.IsoOutputPath,
+            options.SelectedUsbDisk?.DiskNumber,
+            options.SelectedUsbDisk?.FriendlyName,
+            options.IsRuntimePayloadReady,
+            options.IsNetworkConfigurationReady,
+            options.IsDeployConfigurationReady,
+            options.IsConnectProvisioningReady,
+            options.AreRequiredSecretsReady,
+            string.Join(",", reasons.Distinct()));
+    }
+
+    private IReadOnlyList<string> GetAvailableWinPeLanguages()
+    {
+        if (!adkService.CurrentStatus.CanCreateMedia)
+        {
+            return [];
+        }
+
+        WinPeResult<WinPeToolPaths> toolsResult = new WinPeToolResolver().ResolveTools(adkService.CurrentStatus.KitsRootPath);
+        if (!toolsResult.IsSuccess || toolsResult.Value is null)
+        {
+            logger.Warning("WinPE language validation skipped because ADK tools were not resolved. ErrorCode={ErrorCode}", toolsResult.Error?.Code);
+            return [];
+        }
+
+        WinPeResult<IReadOnlyList<string>> languagesResult = languageDiscoveryService.GetAvailableLanguages(
+            new WinPeLanguageDiscoveryOptions
+            {
+                Tools = toolsResult.Value,
+                Architecture = SelectedArchitecture?.Value ?? WinPeArchitecture.X64
+            });
+
+        if (!languagesResult.IsSuccess || languagesResult.Value is null)
+        {
+            logger.Warning("WinPE language validation skipped because language discovery failed. ErrorCode={ErrorCode}", languagesResult.Error?.Code);
+            return [];
+        }
+
+        return languagesResult.Value;
+    }
+
+    private void RebuildFormatModes()
+    {
+        UsbFormatMode selectedValue = SelectedFormatMode?.Value
+            ?? ParseEnum(appSettingsService.Current.Media.UsbFormatMode, UsbFormatMode.Quick);
+
+        FormatModes.Clear();
+        FormatModes.Add(new(UsbFormatMode.Quick, localizationService.GetString("StartMedia.FormatMode.Quick")));
+        FormatModes.Add(new(UsbFormatMode.Complete, localizationService.GetString("StartMedia.FormatMode.Complete")));
+        SelectedFormatMode = SelectOption(FormatModes, selectedValue);
+    }
+
+    private void RebuildUsbCandidateDisplayNames()
+    {
+        List<WinPeUsbDiskCandidate> candidates = UsbCandidates.Select(option => option.Value).ToList();
+        WinPeUsbDiskCandidate? selectedCandidate = SelectedUsbDisk?.Value;
+
+        UsbCandidates.Clear();
+        foreach (WinPeUsbDiskCandidate candidate in candidates)
+        {
+            UsbCandidates.Add(CreateUsbDiskOption(candidate));
+        }
+
+        SelectedUsbDisk = UsbCandidates.FirstOrDefault(option => option.Value.DiskNumber == selectedCandidate?.DiskNumber)
+            ?? UsbCandidates.FirstOrDefault();
+    }
+
+    private SelectionOption<WinPeUsbDiskCandidate> CreateUsbDiskOption(WinPeUsbDiskCandidate candidate)
+    {
+        return new SelectionOption<WinPeUsbDiskCandidate>(
+            candidate,
+            string.Format(
+                localizationService.GetString("StartMedia.Usb.DiskDisplay"),
+                candidate.DiskNumber,
+                candidate.FriendlyName,
+                FormatByteSize(candidate.SizeBytes)));
+    }
+
+    private string FormatReady(bool isReady)
+    {
+        return isReady ? localizationService.GetString("Common.Enabled") : localizationService.GetString("Common.Disabled");
+    }
+
+    private static string FormatValue(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? "-" : value;
+    }
+
+    private string FormatDriverOptions(IReadOnlyList<WinPeVendorSelection> vendors, string? customDriverDirectoryPath)
+    {
+        List<string> parts = vendors.Select(FormatDriverVendor).ToList();
+        if (!string.IsNullOrWhiteSpace(customDriverDirectoryPath))
+        {
+            parts.Add(customDriverDirectoryPath);
+        }
+
+        return parts.Count == 0 ? "-" : string.Join(", ", parts);
+    }
+
+    private string FormatUsbCandidate(WinPeUsbDiskCandidate? candidate)
+    {
+        if (candidate is null)
+        {
+            return "-";
+        }
+
+        return string.Format(
+            localizationService.GetString("StartMedia.Usb.DiskDisplay"),
+            candidate.DiskNumber,
+            candidate.FriendlyName,
+            FormatByteSize(candidate.SizeBytes));
+    }
+
+    private string FormatAvailableLanguages(IReadOnlyList<string> languages)
+    {
+        return languages.Count == 0 ? "-" : string.Join(", ", languages);
+    }
+
+    private string FormatArchitecture(WinPeArchitecture architecture)
+    {
+        return architecture switch
+        {
+            WinPeArchitecture.X64 => "x64",
+            WinPeArchitecture.Arm64 => "arm64",
+            _ => architecture.ToString()
+        };
+    }
+
+    private string FormatBootImageSource(WinPeBootImageSource bootImageSource)
+    {
+        return localizationService.GetString($"StartMedia.BootImageSource.{bootImageSource}");
+    }
+
+    private string FormatSignatureMode(WinPeSignatureMode signatureMode)
+    {
+        return localizationService.GetString($"StartMedia.SignatureMode.{signatureMode}");
+    }
+
+    private string FormatUsbFormatMode(UsbFormatMode formatMode)
+    {
+        return localizationService.GetString($"StartMedia.FormatMode.{formatMode}");
+    }
+
+    private string FormatDriverVendor(WinPeVendorSelection vendor)
+    {
+        return localizationService.GetString($"StartMedia.DriverVendor.{vendor}");
+    }
+
+    private string FormatByteSize(ulong bytes)
+    {
+        double size = bytes;
+        string[] units =
+        [
+            localizationService.GetString("StartMedia.ByteUnit.B"),
+            localizationService.GetString("StartMedia.ByteUnit.KB"),
+            localizationService.GetString("StartMedia.ByteUnit.MB"),
+            localizationService.GetString("StartMedia.ByteUnit.GB"),
+            localizationService.GetString("StartMedia.ByteUnit.TB")
+        ];
+        int unitIndex = 0;
+        while (size >= 1024 && unitIndex < units.Length - 1)
+        {
+            size /= 1024;
+            unitIndex++;
+        }
+
+        return $"{size:0.#} {units[unitIndex]}";
+    }
+
+    private static T ParseEnum<T>(string? value, T fallback)
+        where T : struct, Enum
+    {
+        return Enum.TryParse(value, ignoreCase: true, out T result) ? result : fallback;
+    }
+
+    private static SelectionOption<T>? SelectOption<T>(IEnumerable<SelectionOption<T>> options, T value)
+    {
+        return options.FirstOrDefault(option => EqualityComparer<T>.Default.Equals(option.Value, value));
+    }
+}

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -281,6 +281,12 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             return;
         }
 
+        if (SelectedArchitecture?.Value == WinPeArchitecture.Arm64 && value.Value == UsbPartitionStyle.Mbr)
+        {
+            SelectedPartitionStyle = SelectOption(PartitionStyles, UsbPartitionStyle.Gpt);
+            return;
+        }
+
         appSettingsService.Current.Media.UsbPartitionStyle = value.Value.ToString();
         SaveAndRefresh();
     }

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Text;
 using Foundry.Core.Services.Application;
 using Foundry.Core.Services.Media;
@@ -237,7 +238,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     private void RefreshEvaluation()
     {
         LoadConfigurationFromSettings();
-        WinPeLanguage = appSettingsService.Current.Media.WinPeLanguage;
+        WinPeLanguage = NormalizeCultureName(appSettingsService.Current.Media.WinPeLanguage);
         availableWinPeLanguages = GetAvailableWinPeLanguages();
         MediaPreflightOptions options = CreatePreflightOptions();
         MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(options);
@@ -298,27 +299,17 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private string BuildStatusText(MediaPreflightEvaluation evaluation)
     {
-        int blockingReasonCount = evaluation.IsoBlockingReasons
-            .Concat(evaluation.UsbBlockingReasons)
-            .Distinct()
-            .Count();
-
         return string.Format(
             localizationService.GetString("StartMedia.Status"),
-            FormatReady(evaluation.CanGenerateIsoSummary || evaluation.CanGenerateUsbSummary),
-            blockingReasonCount);
+            FormatReady(evaluation.CanGenerateIsoSummary),
+            FormatReady(evaluation.CanGenerateUsbSummary));
     }
 
     private string BuildGlobalSummary(MediaPreflightOptions options, MediaPreflightEvaluation evaluation)
     {
-        IReadOnlyList<MediaPreflightBlockingReason> reasons = evaluation.IsoBlockingReasons
-            .Concat(evaluation.UsbBlockingReasons)
-            .Distinct()
-            .ToList();
-
         var builder = new StringBuilder();
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Adk")}: {FormatReady(adkService.CurrentStatus.CanCreateMedia)}");
-        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.WinPeLanguage")}: {FormatValue(options.WinPeLanguage)}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.WinPeLanguage")}: {FormatValue(NormalizeCultureName(options.WinPeLanguage))}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Architecture")}: {FormatArchitecture(options.Architecture)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.IsoPath")}: {FormatValue(options.IsoOutputPath)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.UsbTarget")}: {FormatUsbCandidate(options.SelectedUsbDisk)}");
@@ -334,17 +325,25 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         builder.AppendLine();
         builder.AppendLine(localizationService.GetString("StartMedia.FinalExecution.Deferred"));
 
-        if (reasons.Count > 0)
-        {
-            builder.AppendLine();
-            builder.AppendLine(localizationService.GetString("StartMedia.Summary.BlockingReasons"));
-            foreach (MediaPreflightBlockingReason reason in reasons)
-            {
-                builder.AppendLine($"- {GetBlockingReasonText(reason)}");
-            }
-        }
+        AppendBlockingReasons(builder, "StartMedia.Summary.IsoBlockingReasons", evaluation.IsoBlockingReasons);
+        AppendBlockingReasons(builder, "StartMedia.Summary.UsbBlockingReasons", evaluation.UsbBlockingReasons);
 
         return builder.ToString();
+    }
+
+    private void AppendBlockingReasons(StringBuilder builder, string headerResourceKey, IReadOnlyList<MediaPreflightBlockingReason> reasons)
+    {
+        if (reasons.Count == 0)
+        {
+            return;
+        }
+
+        builder.AppendLine();
+        builder.AppendLine(localizationService.GetString(headerResourceKey));
+        foreach (MediaPreflightBlockingReason reason in reasons)
+        {
+            builder.AppendLine($"- {GetBlockingReasonText(reason)}");
+        }
     }
 
     private string GetBlockingReasonText(MediaPreflightBlockingReason reason)
@@ -354,15 +353,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private void LogPreflightSummary(MediaPreflightOptions options, MediaPreflightEvaluation evaluation)
     {
-        IReadOnlyList<MediaPreflightBlockingReason> reasons = evaluation.IsoBlockingReasons
-            .Concat(evaluation.UsbBlockingReasons)
-            .Distinct()
-            .ToList();
-
         logger.Information(
-            "Media preflight summary refreshed. Architecture={Architecture}, WinPeLanguage={WinPeLanguage}, BootImageSource={BootImageSource}, IsoOutputPath={IsoOutputPath}, DiskNumber={DiskNumber}, DiskName={DiskName}, RuntimeReady={RuntimeReady}, NetworkReady={NetworkReady}, DeployReady={DeployReady}, ConnectReady={ConnectReady}, SecretsReady={SecretsReady}, BlockingReasons={BlockingReasons}",
+            "Media preflight summary refreshed. Architecture={Architecture}, WinPeLanguage={WinPeLanguage}, BootImageSource={BootImageSource}, IsoOutputPath={IsoOutputPath}, DiskNumber={DiskNumber}, DiskName={DiskName}, RuntimeReady={RuntimeReady}, NetworkReady={NetworkReady}, DeployReady={DeployReady}, ConnectReady={ConnectReady}, SecretsReady={SecretsReady}, IsoReady={IsoReady}, UsbReady={UsbReady}, IsoBlockingReasons={IsoBlockingReasons}, UsbBlockingReasons={UsbBlockingReasons}",
             options.Architecture,
-            options.WinPeLanguage,
+            NormalizeCultureName(options.WinPeLanguage),
             options.BootImageSource,
             options.IsoOutputPath,
             options.SelectedUsbDisk?.DiskNumber,
@@ -372,7 +366,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             options.IsDeployConfigurationReady,
             options.IsConnectProvisioningReady,
             options.AreRequiredSecretsReady,
-            string.Join(",", reasons));
+            evaluation.CanGenerateIsoSummary,
+            evaluation.CanGenerateUsbSummary,
+            string.Join(",", evaluation.IsoBlockingReasons),
+            string.Join(",", evaluation.UsbBlockingReasons));
     }
 
     private IReadOnlyList<string> GetAvailableWinPeLanguages()
@@ -402,7 +399,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             return [];
         }
 
-        return languagesResult.Value;
+        return languagesResult.Value.Select(NormalizeCultureName).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
     }
 
     private void RebuildFormatModes()
@@ -450,6 +447,23 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     private static string FormatValue(string? value)
     {
         return string.IsNullOrWhiteSpace(value) ? "-" : value;
+    }
+
+    private static string NormalizeCultureName(string? language)
+    {
+        if (string.IsNullOrWhiteSpace(language))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            return CultureInfo.GetCultureInfo(language).Name;
+        }
+        catch (CultureNotFoundException)
+        {
+            return language;
+        }
     }
 
     private string FormatDriverOptions(IReadOnlyList<WinPeVendorSelection> vendors, string? customDriverDirectoryPath)

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -320,7 +320,6 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Adk")}: {FormatReady(adkService.CurrentStatus.CanCreateMedia)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.WinPeLanguage")}: {FormatValue(options.WinPeLanguage)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Architecture")}: {FormatArchitecture(options.Architecture)}");
-        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.BootImageSource")}: {FormatBootImageSource(options.BootImageSource)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.IsoPath")}: {FormatValue(options.IsoOutputPath)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.UsbTarget")}: {FormatUsbCandidate(options.SelectedUsbDisk)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Signature")}: {FormatSignatureMode(options.SignatureMode)}");
@@ -486,11 +485,6 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             WinPeArchitecture.Arm64 => "arm64",
             _ => architecture.ToString()
         };
-    }
-
-    private string FormatBootImageSource(WinPeBootImageSource bootImageSource)
-    {
-        return localizationService.GetString($"StartMedia.BootImageSource.{bootImageSource}");
     }
 
     private string FormatSignatureMode(WinPeSignatureMode signatureMode)

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -299,14 +299,17 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private string BuildStatusText(MediaPreflightEvaluation evaluation)
     {
+        IReadOnlyList<MediaPreflightBlockingReason> reasons = GetGlobalBlockingReasons(evaluation);
+
         return string.Format(
             localizationService.GetString("StartMedia.Status"),
-            FormatReady(evaluation.CanGenerateIsoSummary),
-            FormatReady(evaluation.CanGenerateUsbSummary));
+            FormatReady(evaluation.CanGenerateIsoSummary || evaluation.CanGenerateUsbSummary),
+            reasons.Count);
     }
 
     private string BuildGlobalSummary(MediaPreflightOptions options, MediaPreflightEvaluation evaluation)
     {
+        IReadOnlyList<MediaPreflightBlockingReason> reasons = GetGlobalBlockingReasons(evaluation);
         var builder = new StringBuilder();
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Adk")}: {FormatReady(adkService.CurrentStatus.CanCreateMedia)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.WinPeLanguage")}: {FormatValue(NormalizeCultureName(options.WinPeLanguage))}");
@@ -325,13 +328,12 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         builder.AppendLine();
         builder.AppendLine(localizationService.GetString("StartMedia.FinalExecution.Deferred"));
 
-        AppendBlockingReasons(builder, "StartMedia.Summary.IsoBlockingReasons", evaluation.IsoBlockingReasons);
-        AppendBlockingReasons(builder, "StartMedia.Summary.UsbBlockingReasons", evaluation.UsbBlockingReasons);
+        AppendBlockingReasons(builder, reasons);
 
         return builder.ToString();
     }
 
-    private void AppendBlockingReasons(StringBuilder builder, string headerResourceKey, IReadOnlyList<MediaPreflightBlockingReason> reasons)
+    private void AppendBlockingReasons(StringBuilder builder, IReadOnlyList<MediaPreflightBlockingReason> reasons)
     {
         if (reasons.Count == 0)
         {
@@ -339,7 +341,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         }
 
         builder.AppendLine();
-        builder.AppendLine(localizationService.GetString(headerResourceKey));
+        builder.AppendLine(localizationService.GetString("StartMedia.Summary.BlockingReasons"));
         foreach (MediaPreflightBlockingReason reason in reasons)
         {
             builder.AppendLine($"- {GetBlockingReasonText(reason)}");
@@ -353,12 +355,15 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private void LogPreflightSummary(MediaPreflightOptions options, MediaPreflightEvaluation evaluation)
     {
+        IReadOnlyList<MediaPreflightBlockingReason> reasons = GetGlobalBlockingReasons(evaluation);
+
         logger.Information(
-            "Media preflight summary refreshed. Architecture={Architecture}, WinPeLanguage={WinPeLanguage}, BootImageSource={BootImageSource}, IsoOutputPath={IsoOutputPath}, DiskNumber={DiskNumber}, DiskName={DiskName}, RuntimeReady={RuntimeReady}, NetworkReady={NetworkReady}, DeployReady={DeployReady}, ConnectReady={ConnectReady}, SecretsReady={SecretsReady}, IsoReady={IsoReady}, UsbReady={UsbReady}, IsoBlockingReasons={IsoBlockingReasons}, UsbBlockingReasons={UsbBlockingReasons}",
+            "Media preflight summary refreshed. Architecture={Architecture}, WinPeLanguage={WinPeLanguage}, BootImageSource={BootImageSource}, IsoOutputPath={IsoOutputPath}, UsbTargetSelected={UsbTargetSelected}, DiskNumber={DiskNumber}, DiskName={DiskName}, RuntimeReady={RuntimeReady}, NetworkReady={NetworkReady}, DeployReady={DeployReady}, ConnectReady={ConnectReady}, SecretsReady={SecretsReady}, SummaryReady={SummaryReady}, BlockingReasons={BlockingReasons}",
             options.Architecture,
             NormalizeCultureName(options.WinPeLanguage),
             options.BootImageSource,
             options.IsoOutputPath,
+            options.SelectedUsbDisk is not null,
             options.SelectedUsbDisk?.DiskNumber,
             options.SelectedUsbDisk?.FriendlyName,
             options.IsRuntimePayloadReady,
@@ -366,10 +371,17 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             options.IsDeployConfigurationReady,
             options.IsConnectProvisioningReady,
             options.AreRequiredSecretsReady,
-            evaluation.CanGenerateIsoSummary,
-            evaluation.CanGenerateUsbSummary,
-            string.Join(",", evaluation.IsoBlockingReasons),
-            string.Join(",", evaluation.UsbBlockingReasons));
+            evaluation.CanGenerateIsoSummary || evaluation.CanGenerateUsbSummary,
+            string.Join(",", reasons));
+    }
+
+    private static IReadOnlyList<MediaPreflightBlockingReason> GetGlobalBlockingReasons(MediaPreflightEvaluation evaluation)
+    {
+        return evaluation.IsoBlockingReasons
+            .Concat(evaluation.UsbBlockingReasons)
+            .Where(reason => reason != MediaPreflightBlockingReason.NoUsbTarget)
+            .Distinct()
+            .ToList();
     }
 
     private IReadOnlyList<string> GetAvailableWinPeLanguages()

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -16,8 +16,6 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     private readonly IAdkService adkService;
     private readonly IWinPeLanguageDiscoveryService languageDiscoveryService;
     private readonly IWinPeUsbMediaService usbMediaService;
-    private readonly IFilePickerService filePickerService;
-    private readonly IDialogService dialogService;
     private readonly IApplicationLocalizationService localizationService;
     private readonly IAppDispatcher appDispatcher;
     private readonly ILogger logger;
@@ -28,8 +26,6 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         IAdkService adkService,
         IWinPeLanguageDiscoveryService languageDiscoveryService,
         IWinPeUsbMediaService usbMediaService,
-        IFilePickerService filePickerService,
-        IDialogService dialogService,
         IApplicationLocalizationService localizationService,
         IAppDispatcher appDispatcher,
         ILogger logger)
@@ -38,8 +34,6 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         this.adkService = adkService;
         this.languageDiscoveryService = languageDiscoveryService;
         this.usbMediaService = usbMediaService;
-        this.filePickerService = filePickerService;
-        this.dialogService = dialogService;
         this.localizationService = localizationService;
         this.appDispatcher = appDispatcher;
         this.logger = logger.ForContext<StartMediaViewModel>();
@@ -122,6 +116,9 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     public partial string FinalExecutionStatus { get; set; } = string.Empty;
 
     [ObservableProperty]
+    public partial string GlobalSummary { get; set; } = string.Empty;
+
+    [ObservableProperty]
     public partial string WinPeLanguage { get; set; } = string.Empty;
 
     [ObservableProperty]
@@ -141,34 +138,9 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         {
             await RefreshUsbCandidatesAsync();
         }
-    }
 
-    [RelayCommand]
-    private async Task BrowseIsoOutputPathAsync()
-    {
-        string? path = await filePickerService.PickSaveFileAsync(
-            new FileSavePickerRequest(
-                localizationService.GetString("StartMedia.IsoPicker.Title"),
-                "Foundry",
-                [new(localizationService.GetString("StartMedia.IsoPicker.Filter"), [".iso"])],
-                ".iso"));
-
-        if (!string.IsNullOrWhiteSpace(path))
-        {
-            IsoOutputPath = path;
-        }
-    }
-
-    [RelayCommand]
-    private async Task BrowseCustomDriverDirectoryAsync()
-    {
-        string? path = await filePickerService.PickFolderAsync(
-            new FolderPickerRequest(localizationService.GetString("StartMedia.CustomDriversPicker.Title")));
-
-        if (!string.IsNullOrWhiteSpace(path))
-        {
-            CustomDriverDirectoryPath = path;
-        }
+        MediaPreflightOptions options = CreatePreflightOptions();
+        LogPreflightSummary(options, MediaPreflightService.Evaluate(options));
     }
 
     [RelayCommand]
@@ -226,108 +198,8 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         }
     }
 
-    [RelayCommand(CanExecute = nameof(CanGenerateIsoSummary))]
-    private Task ShowIsoSummaryAsync()
-    {
-        MediaPreflightOptions options = CreatePreflightOptions();
-        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(options);
-        string summary = BuildSummary(isUsbSummary: false, options, evaluation);
-        LogDryRunSummary("ISO", options, evaluation);
-        return dialogService.ShowMessageAsync(new DialogRequest(PageTitle, summary, localizationService.GetString("Common.Close")));
-    }
-
-    [RelayCommand(CanExecute = nameof(CanGenerateUsbSummary))]
-    private Task ShowUsbSummaryAsync()
-    {
-        MediaPreflightOptions options = CreatePreflightOptions();
-        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(options);
-        string summary = BuildSummary(isUsbSummary: true, options, evaluation);
-        LogDryRunSummary("USB", options, evaluation);
-        return dialogService.ShowMessageAsync(new DialogRequest(PageTitle, summary, localizationService.GetString("Common.Close")));
-    }
-
-    partial void OnIsoOutputPathChanged(string value)
-    {
-        appSettingsService.Current.Media.IsoOutputPath = value;
-        SaveAndRefresh();
-    }
-
-    partial void OnSelectedArchitectureChanged(SelectionOption<WinPeArchitecture>? value)
-    {
-        if (value is null)
-        {
-            return;
-        }
-
-        appSettingsService.Current.Media.Architecture = value.Value.ToString();
-        if (value.Value == WinPeArchitecture.Arm64 && SelectedPartitionStyle?.Value == UsbPartitionStyle.Mbr)
-        {
-            SelectedPartitionStyle = SelectOption(PartitionStyles, UsbPartitionStyle.Gpt);
-        }
-
-        SaveAndRefresh();
-    }
-
-    partial void OnUseCa2023SignatureChanged(bool value)
-    {
-        appSettingsService.Current.Media.UseCa2023Signature = value;
-        SaveAndRefresh();
-    }
-
-    partial void OnSelectedPartitionStyleChanged(SelectionOption<UsbPartitionStyle>? value)
-    {
-        if (value is null)
-        {
-            return;
-        }
-
-        if (SelectedArchitecture?.Value == WinPeArchitecture.Arm64 && value.Value == UsbPartitionStyle.Mbr)
-        {
-            SelectedPartitionStyle = SelectOption(PartitionStyles, UsbPartitionStyle.Gpt);
-            return;
-        }
-
-        appSettingsService.Current.Media.UsbPartitionStyle = value.Value.ToString();
-        SaveAndRefresh();
-    }
-
-    partial void OnSelectedFormatModeChanged(SelectionOption<UsbFormatMode>? value)
-    {
-        if (value is null)
-        {
-            return;
-        }
-
-        appSettingsService.Current.Media.UsbFormatMode = value.Value.ToString();
-        SaveAndRefresh();
-    }
-
-    partial void OnIncludeDellDriversChanged(bool value)
-    {
-        appSettingsService.Current.Media.IncludeDellDrivers = value;
-        SaveAndRefresh();
-    }
-
-    partial void OnIncludeHpDriversChanged(bool value)
-    {
-        appSettingsService.Current.Media.IncludeHpDrivers = value;
-        SaveAndRefresh();
-    }
-
-    partial void OnCustomDriverDirectoryPathChanged(string value)
-    {
-        appSettingsService.Current.Media.CustomDriverDirectoryPath = string.IsNullOrWhiteSpace(value) ? null : value;
-        SaveAndRefresh();
-    }
-
     partial void OnSelectedUsbDiskChanged(SelectionOption<WinPeUsbDiskCandidate>? value)
     {
-        RefreshEvaluation();
-    }
-
-    private void SaveAndRefresh()
-    {
-        appSettingsService.Save();
         RefreshEvaluation();
     }
 
@@ -364,15 +236,28 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private void RefreshEvaluation()
     {
+        LoadConfigurationFromSettings();
         WinPeLanguage = appSettingsService.Current.Media.WinPeLanguage;
         availableWinPeLanguages = GetAvailableWinPeLanguages();
-        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(CreatePreflightOptions());
+        MediaPreflightOptions options = CreatePreflightOptions();
+        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(options);
         CanGenerateIsoSummary = evaluation.CanGenerateIsoSummary;
         CanGenerateUsbSummary = evaluation.CanGenerateUsbSummary;
         StatusSummary = BuildStatusText(evaluation);
+        GlobalSummary = BuildGlobalSummary(options, evaluation);
 
-        ShowIsoSummaryCommand.NotifyCanExecuteChanged();
-        ShowUsbSummaryCommand.NotifyCanExecuteChanged();
+    }
+
+    private void LoadConfigurationFromSettings()
+    {
+        IsoOutputPath = appSettingsService.Current.Media.IsoOutputPath;
+        SelectedArchitecture = SelectOption(Architectures, ParseEnum(appSettingsService.Current.Media.Architecture, WinPeArchitecture.X64));
+        UseCa2023Signature = appSettingsService.Current.Media.UseCa2023Signature;
+        SelectedPartitionStyle = SelectOption(PartitionStyles, ParseEnum(appSettingsService.Current.Media.UsbPartitionStyle, UsbPartitionStyle.Gpt));
+        SelectedFormatMode = SelectOption(FormatModes, ParseEnum(appSettingsService.Current.Media.UsbFormatMode, UsbFormatMode.Quick));
+        IncludeDellDrivers = appSettingsService.Current.Media.IncludeDellDrivers;
+        IncludeHpDrivers = appSettingsService.Current.Media.IncludeHpDrivers;
+        CustomDriverDirectoryPath = appSettingsService.Current.Media.CustomDriverDirectoryPath ?? string.Empty;
     }
 
     private MediaPreflightOptions CreatePreflightOptions()
@@ -411,21 +296,27 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         };
     }
 
-    private string BuildSummary(bool isUsbSummary)
+    private string BuildStatusText(MediaPreflightEvaluation evaluation)
     {
-        MediaPreflightOptions options = CreatePreflightOptions();
-        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(options);
-        return BuildSummary(isUsbSummary, options, evaluation);
+        int blockingReasonCount = evaluation.IsoBlockingReasons
+            .Concat(evaluation.UsbBlockingReasons)
+            .Distinct()
+            .Count();
+
+        return string.Format(
+            localizationService.GetString("StartMedia.Status"),
+            FormatReady(evaluation.CanGenerateIsoSummary || evaluation.CanGenerateUsbSummary),
+            blockingReasonCount);
     }
 
-    private string BuildSummary(bool isUsbSummary, MediaPreflightOptions options, MediaPreflightEvaluation evaluation)
+    private string BuildGlobalSummary(MediaPreflightOptions options, MediaPreflightEvaluation evaluation)
     {
-        IReadOnlyList<MediaPreflightBlockingReason> reasons = isUsbSummary
-            ? evaluation.UsbBlockingReasons
-            : evaluation.IsoBlockingReasons;
+        IReadOnlyList<MediaPreflightBlockingReason> reasons = evaluation.IsoBlockingReasons
+            .Concat(evaluation.UsbBlockingReasons)
+            .Distinct()
+            .ToList();
 
         var builder = new StringBuilder();
-        builder.AppendLine(isUsbSummary ? localizationService.GetString("StartMedia.Summary.UsbTitle") : localizationService.GetString("StartMedia.Summary.IsoTitle"));
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Adk")}: {FormatReady(adkService.CurrentStatus.CanCreateMedia)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.WinPeLanguage")}: {FormatValue(options.WinPeLanguage)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.AvailableWinPeLanguages")}: {FormatAvailableLanguages(options.AvailableWinPeLanguages)}");
@@ -449,7 +340,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         {
             builder.AppendLine();
             builder.AppendLine(localizationService.GetString("StartMedia.Summary.BlockingReasons"));
-            foreach (MediaPreflightBlockingReason reason in reasons.Distinct())
+            foreach (MediaPreflightBlockingReason reason in reasons)
             {
                 builder.AppendLine($"- {GetBlockingReasonText(reason)}");
             }
@@ -458,30 +349,20 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         return builder.ToString();
     }
 
-    private string BuildStatusText(MediaPreflightEvaluation evaluation)
-    {
-        return string.Format(
-            localizationService.GetString("StartMedia.Status"),
-            FormatReady(CanGenerateIsoSummary),
-            FormatReady(CanGenerateUsbSummary),
-            evaluation.IsoBlockingReasons.Count,
-            evaluation.UsbBlockingReasons.Count);
-    }
-
     private string GetBlockingReasonText(MediaPreflightBlockingReason reason)
     {
         return localizationService.GetString($"StartMedia.BlockingReason.{reason}");
     }
 
-    private void LogDryRunSummary(string mediaKind, MediaPreflightOptions options, MediaPreflightEvaluation evaluation)
+    private void LogPreflightSummary(MediaPreflightOptions options, MediaPreflightEvaluation evaluation)
     {
-        IReadOnlyList<MediaPreflightBlockingReason> reasons = string.Equals(mediaKind, "USB", StringComparison.OrdinalIgnoreCase)
-            ? evaluation.UsbBlockingReasons
-            : evaluation.IsoBlockingReasons;
+        IReadOnlyList<MediaPreflightBlockingReason> reasons = evaluation.IsoBlockingReasons
+            .Concat(evaluation.UsbBlockingReasons)
+            .Distinct()
+            .ToList();
 
         logger.Information(
-            "{MediaKind} media dry-run summary generated. Architecture={Architecture}, WinPeLanguage={WinPeLanguage}, BootImageSource={BootImageSource}, IsoOutputPath={IsoOutputPath}, DiskNumber={DiskNumber}, DiskName={DiskName}, RuntimeReady={RuntimeReady}, NetworkReady={NetworkReady}, DeployReady={DeployReady}, ConnectReady={ConnectReady}, SecretsReady={SecretsReady}, BlockingReasons={BlockingReasons}",
-            mediaKind,
+            "Media preflight summary refreshed. Architecture={Architecture}, WinPeLanguage={WinPeLanguage}, BootImageSource={BootImageSource}, IsoOutputPath={IsoOutputPath}, DiskNumber={DiskNumber}, DiskName={DiskName}, RuntimeReady={RuntimeReady}, NetworkReady={NetworkReady}, DeployReady={DeployReady}, ConnectReady={ConnectReady}, SecretsReady={SecretsReady}, BlockingReasons={BlockingReasons}",
             options.Architecture,
             options.WinPeLanguage,
             options.BootImageSource,
@@ -493,7 +374,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             options.IsDeployConfigurationReady,
             options.IsConnectProvisioningReady,
             options.AreRequiredSecretsReady,
-            string.Join(",", reasons.Distinct()));
+            string.Join(",", reasons));
     }
 
     private IReadOnlyList<string> GetAvailableWinPeLanguages()

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -319,7 +319,6 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         var builder = new StringBuilder();
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Adk")}: {FormatReady(adkService.CurrentStatus.CanCreateMedia)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.WinPeLanguage")}: {FormatValue(options.WinPeLanguage)}");
-        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.AvailableWinPeLanguages")}: {FormatAvailableLanguages(options.AvailableWinPeLanguages)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Architecture")}: {FormatArchitecture(options.Architecture)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.BootImageSource")}: {FormatBootImageSource(options.BootImageSource)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.IsoPath")}: {FormatValue(options.IsoOutputPath)}");
@@ -477,11 +476,6 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             candidate.DiskNumber,
             candidate.FriendlyName,
             FormatByteSize(candidate.SizeBytes));
-    }
-
-    private string FormatAvailableLanguages(IReadOnlyList<string> languages)
-    {
-        return languages.Count == 0 ? "-" : string.Join(", ", languages);
     }
 
     private string FormatArchitecture(WinPeArchitecture architecture)

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml
@@ -52,9 +52,6 @@
                               ItemsSource="{x:Bind ViewModel.AvailableWinPeLanguages, Mode=OneWay}"
                               SelectedItem="{x:Bind ViewModel.SelectedWinPeLanguage, Mode=TwoWay}"
                               SelectionChanged="WinPeLanguageComboBox_SelectionChanged" />
-                    <Button x:Name="WinPeLanguageRefreshButton"
-                            MinWidth="{StaticResource SettingActionControlMinWidth}"
-                            Command="{x:Bind ViewModel.RefreshWinPeLanguagesCommand}" />
                 </StackPanel>
             </dev:SettingsCard>
 

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml
@@ -97,6 +97,7 @@
                               HeaderIcon="{dev:FontIcon GlyphCode=E768}">
                 <Button x:Name="CreateMediaButton"
                         MinWidth="{StaticResource SettingActionControlMinWidth}"
+                        IsEnabled="{x:Bind ViewModel.CanCreateMedia, Mode=OneWay}"
                         Click="CreateMediaButton_Click" />
             </dev:SettingsCard>
         </StackPanel>

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml
@@ -1,13 +1,107 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Page x:Class="Foundry.Views.GeneralConfigurationPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:dev="using:DevWinUI"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
-                Padding="{ThemeResource ContentPagePadding}">
+                Padding="{ThemeResource ContentPagePadding}"
+                VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="10"
-                    Spacing="5">
+                    dev:PanelAttach.ChildrenTransitions="Default"
+                    Spacing="8">
             <TextBlock x:Uid="GeneralConfigurationPage_Title"
                        Style="{ThemeResource TitleTextBlockStyle}" />
+
+            <dev:SettingsCard x:Name="IsoPathCard"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E8A5}">
+                <StackPanel Orientation="Horizontal"
+                            Spacing="10">
+                    <TextBox MinWidth="420"
+                             Text="{x:Bind ViewModel.IsoOutputPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <Button x:Name="BrowseIsoButton"
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            Command="{x:Bind ViewModel.BrowseIsoOutputPathCommand}" />
+                </StackPanel>
+            </dev:SettingsCard>
+
+            <dev:SettingsCard x:Name="ArchitectureCard"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E7F4}">
+                <StackPanel Orientation="Horizontal"
+                            Spacing="10">
+                    <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                              DisplayMemberPath="DisplayName"
+                              ItemsSource="{x:Bind ViewModel.Architectures, Mode=OneWay}"
+                              SelectedItem="{x:Bind ViewModel.SelectedArchitecture, Mode=TwoWay}" />
+                    <ToggleSwitch x:Name="Ca2023Toggle"
+                                  IsOn="{x:Bind ViewModel.UseCa2023Signature, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </StackPanel>
+            </dev:SettingsCard>
+
+            <dev:SettingsCard x:Name="WinPeLanguageCard">
+                <dev:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE8AB;" />
+                </dev:SettingsCard.HeaderIcon>
+                <StackPanel Orientation="Horizontal"
+                            Spacing="10">
+                    <ComboBox x:Name="WinPeLanguageComboBox"
+                              MinWidth="{StaticResource SettingActionControlMinWidth}"
+                              IsEnabled="{x:Bind ViewModel.HasWinPeLanguages, Mode=OneWay}"
+                              ItemsSource="{x:Bind ViewModel.AvailableWinPeLanguages, Mode=OneWay}"
+                              SelectedItem="{x:Bind ViewModel.SelectedWinPeLanguage, Mode=TwoWay}"
+                              SelectionChanged="WinPeLanguageComboBox_SelectionChanged" />
+                    <Button x:Name="WinPeLanguageRefreshButton"
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            Command="{x:Bind ViewModel.RefreshWinPeLanguagesCommand}" />
+                </StackPanel>
+            </dev:SettingsCard>
+
+            <dev:SettingsCard x:Name="UsbLayoutCard"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E7C3}">
+                <StackPanel Orientation="Horizontal"
+                            Spacing="10">
+                    <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                              DisplayMemberPath="DisplayName"
+                              ItemsSource="{x:Bind ViewModel.PartitionStyles, Mode=OneWay}"
+                              SelectedItem="{x:Bind ViewModel.SelectedPartitionStyle, Mode=TwoWay}" />
+                    <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                              DisplayMemberPath="DisplayName"
+                              ItemsSource="{x:Bind ViewModel.FormatModes, Mode=OneWay}"
+                              SelectedItem="{x:Bind ViewModel.SelectedFormatMode, Mode=TwoWay}" />
+                </StackPanel>
+            </dev:SettingsCard>
+
+            <dev:SettingsExpander x:Name="DriverOptionsCard"
+                                  HeaderIcon="{dev:FontIcon GlyphCode=E90F}">
+                <StackPanel Orientation="Horizontal"
+                            Spacing="10">
+                    <ToggleSwitch x:Name="DellDriversToggle"
+                                  IsOn="{x:Bind ViewModel.IncludeDellDrivers, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <ToggleSwitch x:Name="HpDriversToggle"
+                                  IsOn="{x:Bind ViewModel.IncludeHpDrivers, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </StackPanel>
+                <dev:SettingsExpander.Items>
+                    <dev:SettingsCard x:Name="CustomDriverDirectoryCard">
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="10">
+                            <TextBox MinWidth="420"
+                                     Text="{x:Bind ViewModel.CustomDriverDirectoryPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Button x:Name="BrowseCustomDriversButton"
+                                    MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    Command="{x:Bind ViewModel.BrowseCustomDriverDirectoryCommand}" />
+                        </StackPanel>
+                    </dev:SettingsCard>
+                </dev:SettingsExpander.Items>
+            </dev:SettingsExpander>
+
+            <dev:SettingsCard x:Name="CreateMediaCard"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E768}">
+                <Button x:Name="CreateMediaButton"
+                        MinWidth="{StaticResource SettingActionControlMinWidth}"
+                        Click="CreateMediaButton_Click" />
+            </dev:SettingsCard>
         </StackPanel>
     </ScrollView>
 </Page>

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
@@ -37,6 +37,11 @@ public sealed partial class GeneralConfigurationPage : Page
 
     private void CreateMediaButton_Click(object sender, RoutedEventArgs e)
     {
+        if (!ViewModel.CanCreateMedia)
+        {
+            return;
+        }
+
         App.Current.NavService.NavigateTo(typeof(StartPage), localizationService.GetString("StartPage_Title.Text"));
     }
 
@@ -89,6 +94,7 @@ public sealed partial class GeneralConfigurationPage : Page
         CreateMediaButton.Content = localizationService.GetString("GeneralConfiguration_CreateMedia.Button");
 
         ViewModel.RefreshLocalizedOptions();
+        ViewModel.RefreshAdkState();
 
         bool wasInitializingWinPeLanguageSelection = isInitializingWinPeLanguageSelection;
         isInitializingWinPeLanguageSelection = true;

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
@@ -69,7 +69,7 @@ public sealed partial class GeneralConfigurationPage : Page
         Ca2023Toggle.OffContent = localizationService.GetString("StartMedia.Signature.Ca2011");
 
         WinPeLanguageCard.Header = localizationService.GetString("StartMedia.WinPeLanguage.Header");
-        WinPeLanguageRefreshButton.Content = localizationService.GetString("Common.Refresh");
+        WinPeLanguageCard.Description = localizationService.GetString("StartMedia.WinPeLanguage.Description");
 
         UsbLayoutCard.Header = localizationService.GetString("StartMedia.UsbLayout.Header");
         UsbLayoutCard.Description = localizationService.GetString("StartMedia.UsbLayout.Description");
@@ -93,9 +93,6 @@ public sealed partial class GeneralConfigurationPage : Page
         bool wasInitializingWinPeLanguageSelection = isInitializingWinPeLanguageSelection;
         isInitializingWinPeLanguageSelection = true;
         ViewModel.RefreshWinPeLanguages();
-        WinPeLanguageCard.Description = string.IsNullOrWhiteSpace(ViewModel.WinPeLanguageStatus)
-            ? localizationService.GetString("StartMedia.WinPeLanguage.Description")
-            : ViewModel.WinPeLanguageStatus;
         WinPeLanguageComboBox.SelectedItem = ViewModel.SelectedWinPeLanguage;
         isInitializingWinPeLanguageSelection = wasInitializingWinPeLanguageSelection;
     }

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
@@ -1,9 +1,108 @@
+using Foundry.Services.Localization;
+using Serilog;
+
 namespace Foundry.Views;
 
 public sealed partial class GeneralConfigurationPage : Page
 {
+    private bool isInitializingWinPeLanguageSelection = true;
+    private readonly IApplicationLocalizationService localizationService;
+    private readonly ILogger logger = Log.ForContext<GeneralConfigurationPage>();
+
+    public GeneralConfigurationViewModel ViewModel { get; }
+
     public GeneralConfigurationPage()
     {
+        localizationService = App.GetService<IApplicationLocalizationService>();
+        ViewModel = App.GetService<GeneralConfigurationViewModel>();
         InitializeComponent();
+        ApplyLocalizedText();
+        localizationService.LanguageChanged += OnLanguageChanged;
+        Unloaded += OnUnloaded;
+        isInitializingWinPeLanguageSelection = false;
+    }
+
+    private void WinPeLanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (isInitializingWinPeLanguageSelection)
+        {
+            return;
+        }
+
+        if (e.AddedItems.FirstOrDefault() is string selectedLanguage)
+        {
+            ViewModel.SetWinPeLanguage(selectedLanguage);
+        }
+    }
+
+    private void CreateMediaButton_Click(object sender, RoutedEventArgs e)
+    {
+        App.Current.NavService.NavigateTo(typeof(StartPage), localizationService.GetString("StartPage_Title.Text"));
+    }
+
+    private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
+    {
+        if (DispatcherQueue.HasThreadAccess)
+        {
+            ApplyLocalizedText();
+            return;
+        }
+
+        if (!DispatcherQueue.TryEnqueue(ApplyLocalizedText))
+        {
+            logger.Warning(
+                "Failed to enqueue general configuration localization refresh. OldLanguage={OldLanguage}, NewLanguage={NewLanguage}",
+                e.OldLanguage,
+                e.NewLanguage);
+        }
+    }
+
+    private void ApplyLocalizedText()
+    {
+        IsoPathCard.Header = localizationService.GetString("StartMedia.IsoPath.Header");
+        IsoPathCard.Description = localizationService.GetString("StartMedia.IsoPath.Description");
+        BrowseIsoButton.Content = localizationService.GetString("Common.Browse");
+
+        ArchitectureCard.Header = localizationService.GetString("StartMedia.Architecture.Header");
+        ArchitectureCard.Description = localizationService.GetString("StartMedia.Architecture.Description");
+        Ca2023Toggle.OnContent = localizationService.GetString("StartMedia.Signature.Ca2023");
+        Ca2023Toggle.OffContent = localizationService.GetString("StartMedia.Signature.Ca2011");
+
+        WinPeLanguageCard.Header = localizationService.GetString("StartMedia.WinPeLanguage.Header");
+        WinPeLanguageRefreshButton.Content = localizationService.GetString("Common.Refresh");
+
+        UsbLayoutCard.Header = localizationService.GetString("StartMedia.UsbLayout.Header");
+        UsbLayoutCard.Description = localizationService.GetString("StartMedia.UsbLayout.Description");
+
+        DriverOptionsCard.Header = localizationService.GetString("StartMedia.DriverOptions.Header");
+        DriverOptionsCard.Description = localizationService.GetString("StartMedia.DriverOptions.Description");
+        DellDriversToggle.OnContent = localizationService.GetString("StartMedia.DriverOptions.Dell");
+        DellDriversToggle.OffContent = localizationService.GetString("StartMedia.DriverOptions.Dell");
+        HpDriversToggle.OnContent = localizationService.GetString("StartMedia.DriverOptions.Hp");
+        HpDriversToggle.OffContent = localizationService.GetString("StartMedia.DriverOptions.Hp");
+        CustomDriverDirectoryCard.Header = localizationService.GetString("StartMedia.CustomDrivers.Header");
+        CustomDriverDirectoryCard.Description = localizationService.GetString("StartMedia.CustomDrivers.Description");
+        BrowseCustomDriversButton.Content = localizationService.GetString("Common.Browse");
+
+        CreateMediaCard.Header = localizationService.GetString("GeneralConfiguration_CreateMedia.Header");
+        CreateMediaCard.Description = localizationService.GetString("GeneralConfiguration_CreateMedia.Description");
+        CreateMediaButton.Content = localizationService.GetString("GeneralConfiguration_CreateMedia.Button");
+
+        ViewModel.RefreshLocalizedOptions();
+
+        bool wasInitializingWinPeLanguageSelection = isInitializingWinPeLanguageSelection;
+        isInitializingWinPeLanguageSelection = true;
+        ViewModel.RefreshWinPeLanguages();
+        WinPeLanguageCard.Description = string.IsNullOrWhiteSpace(ViewModel.WinPeLanguageStatus)
+            ? localizationService.GetString("StartMedia.WinPeLanguage.Description")
+            : ViewModel.WinPeLanguageStatus;
+        WinPeLanguageComboBox.SelectedItem = ViewModel.SelectedWinPeLanguage;
+        isInitializingWinPeLanguageSelection = wasInitializingWinPeLanguageSelection;
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        localizationService.LanguageChanged -= OnLanguageChanged;
+        Unloaded -= OnUnloaded;
     }
 }

--- a/src/Foundry/Views/MainWindow.xaml.cs
+++ b/src/Foundry/Views/MainWindow.xaml.cs
@@ -210,6 +210,7 @@ namespace Foundry.Views
 
         private void OnNavFrameNavigated(object sender, NavigationEventArgs e)
         {
+            SynchronizeSelectedNavigationItem(e.SourcePageType);
             ApplyShellNavigationState();
         }
 
@@ -420,6 +421,51 @@ namespace Foundry.Views
             return !string.IsNullOrWhiteSpace(operationProgressService.State.Status)
                 ? operationProgressService.State.Status
                 : localizationService.GetString("Shell.OperationRunning");
+        }
+
+        private void SynchronizeSelectedNavigationItem(Type? pageType)
+        {
+            if (pageType is null)
+            {
+                return;
+            }
+
+            NavigationViewItem? item = FindNavigationItem(NavView.MenuItems, pageType.FullName)
+                ?? FindNavigationItem(NavView.FooterMenuItems, pageType.FullName);
+
+            if (item is not null && !ReferenceEquals(NavView.SelectedItem, item))
+            {
+                NavView.SelectedItem = item;
+            }
+        }
+
+        private static NavigationViewItem? FindNavigationItem(IList<object> items, string? uniqueId)
+        {
+            if (string.IsNullOrWhiteSpace(uniqueId))
+            {
+                return null;
+            }
+
+            foreach (object item in items)
+            {
+                if (item is not NavigationViewItem navigationItem)
+                {
+                    continue;
+                }
+
+                if (string.Equals(navigationItem.Tag as string, uniqueId, StringComparison.Ordinal))
+                {
+                    return navigationItem;
+                }
+
+                NavigationViewItem? child = FindNavigationItem(navigationItem.MenuItems, uniqueId);
+                if (child is not null)
+                {
+                    return child;
+                }
+            }
+
+            return null;
         }
     }
 

--- a/src/Foundry/Views/Settings/GeneralSettingPage.xaml
+++ b/src/Foundry/Views/Settings/GeneralSettingPage.xaml
@@ -41,24 +41,6 @@
                 </ComboBox>
             </dev:SettingsCard>
 
-            <dev:SettingsCard x:Name="WinPeLanguageCard">
-                <dev:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE8AB;" />
-                </dev:SettingsCard.HeaderIcon>
-                <StackPanel Orientation="Horizontal"
-                            Spacing="10">
-                    <ComboBox x:Name="WinPeLanguageComboBox"
-                              MinWidth="{StaticResource SettingActionControlMinWidth}"
-                              IsEnabled="{x:Bind ViewModel.HasWinPeLanguages, Mode=OneWay}"
-                              ItemsSource="{x:Bind ViewModel.AvailableWinPeLanguages, Mode=OneWay}"
-                              SelectedItem="{x:Bind ViewModel.SelectedWinPeLanguage, Mode=TwoWay}"
-                              SelectionChanged="WinPeLanguageComboBox_SelectionChanged" />
-                    <Button x:Name="WinPeLanguageRefreshButton"
-                            MinWidth="{StaticResource SettingActionControlMinWidth}"
-                            Command="{x:Bind ViewModel.RefreshWinPeLanguagesCommand}" />
-                </StackPanel>
-            </dev:SettingsCard>
-
             <dev:SettingsExpander x:Name="DiagnosticsCard"
                                   x:Uid="GeneralSetting_DiagnosticsCard"
                                   HeaderIcon="{dev:BitmapIcon Source=Assets/Fluent/DevMode.png}">

--- a/src/Foundry/Views/Settings/GeneralSettingPage.xaml
+++ b/src/Foundry/Views/Settings/GeneralSettingPage.xaml
@@ -41,6 +41,24 @@
                 </ComboBox>
             </dev:SettingsCard>
 
+            <dev:SettingsCard x:Name="WinPeLanguageCard">
+                <dev:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE8AB;" />
+                </dev:SettingsCard.HeaderIcon>
+                <StackPanel Orientation="Horizontal"
+                            Spacing="10">
+                    <ComboBox x:Name="WinPeLanguageComboBox"
+                              MinWidth="{StaticResource SettingActionControlMinWidth}"
+                              IsEnabled="{x:Bind ViewModel.HasWinPeLanguages, Mode=OneWay}"
+                              ItemsSource="{x:Bind ViewModel.AvailableWinPeLanguages, Mode=OneWay}"
+                              SelectedItem="{x:Bind ViewModel.SelectedWinPeLanguage, Mode=TwoWay}"
+                              SelectionChanged="WinPeLanguageComboBox_SelectionChanged" />
+                    <Button x:Name="WinPeLanguageRefreshButton"
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            Command="{x:Bind ViewModel.RefreshWinPeLanguagesCommand}" />
+                </StackPanel>
+            </dev:SettingsCard>
+
             <dev:SettingsExpander x:Name="DiagnosticsCard"
                                   x:Uid="GeneralSetting_DiagnosticsCard"
                                   HeaderIcon="{dev:BitmapIcon Source=Assets/Fluent/DevMode.png}">

--- a/src/Foundry/Views/Settings/GeneralSettingPage.xaml.cs
+++ b/src/Foundry/Views/Settings/GeneralSettingPage.xaml.cs
@@ -4,12 +4,11 @@ using Serilog;
 
 namespace Foundry.Views;
 
-    public sealed partial class GeneralSettingPage : Page
-    {
-        private bool isInitializingLanguageSelection = true;
-        private bool isInitializingWinPeLanguageSelection = true;
-        private readonly IApplicationLocalizationService localizationService;
-        private readonly ILogger logger = Log.ForContext<GeneralSettingPage>();
+public sealed partial class GeneralSettingPage : Page
+{
+    private bool isInitializingLanguageSelection = true;
+    private readonly IApplicationLocalizationService localizationService;
+    private readonly ILogger logger = Log.ForContext<GeneralSettingPage>();
 
     public GeneralSettingViewModel ViewModel { get; }
 
@@ -22,7 +21,6 @@ namespace Foundry.Views;
         localizationService.LanguageChanged += OnLanguageChanged;
         Unloaded += OnUnloaded;
         isInitializingLanguageSelection = false;
-        isInitializingWinPeLanguageSelection = false;
     }
 
     private async void LanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -35,19 +33,6 @@ namespace Foundry.Views;
         if (e.AddedItems.FirstOrDefault() is SupportedCultureOption selectedLanguage)
         {
             await ViewModel.SetLanguageAsync(selectedLanguage);
-        }
-    }
-
-    private void WinPeLanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-    {
-        if (isInitializingWinPeLanguageSelection)
-        {
-            return;
-        }
-
-        if (e.AddedItems.FirstOrDefault() is string selectedLanguage)
-        {
-            ViewModel.SetWinPeLanguage(selectedLanguage);
         }
     }
 
@@ -75,11 +60,6 @@ namespace Foundry.Views;
         StartupCard.Description = localizationService.GetString("GeneralSetting_StartupCard.Description");
         LanguageCard.Header = localizationService.GetString("GeneralSetting_LanguageCard.Header");
         LanguageCard.Description = localizationService.GetString("GeneralSetting_LanguageCard.Description");
-        WinPeLanguageCard.Header = localizationService.GetString("GeneralSetting_WinPeLanguageCard.Header");
-        WinPeLanguageCard.Description = string.IsNullOrWhiteSpace(ViewModel.WinPeLanguageStatus)
-            ? localizationService.GetString("GeneralSetting_WinPeLanguageCard.Description")
-            : ViewModel.WinPeLanguageStatus;
-        WinPeLanguageRefreshButton.Content = localizationService.GetString("Common.Refresh");
         DiagnosticsCard.Header = localizationService.GetString("GeneralSetting_DiagnosticsCard.Header");
         DiagnosticsCard.Description = localizationService.GetString("GeneralSetting_DiagnosticsCard.Description");
         StartupToggle.OnContent = localizationService.GetString("Common.Enabled");
@@ -95,14 +75,6 @@ namespace Foundry.Views;
         LanguageComboBox.SelectedItem = ViewModel.SelectedLanguage;
         isInitializingLanguageSelection = wasInitializingLanguageSelection;
 
-        bool wasInitializingWinPeLanguageSelection = isInitializingWinPeLanguageSelection;
-        isInitializingWinPeLanguageSelection = true;
-        ViewModel.RefreshWinPeLanguages();
-        WinPeLanguageCard.Description = string.IsNullOrWhiteSpace(ViewModel.WinPeLanguageStatus)
-            ? localizationService.GetString("GeneralSetting_WinPeLanguageCard.Description")
-            : ViewModel.WinPeLanguageStatus;
-        WinPeLanguageComboBox.SelectedItem = ViewModel.SelectedWinPeLanguage;
-        isInitializingWinPeLanguageSelection = wasInitializingWinPeLanguageSelection;
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)

--- a/src/Foundry/Views/Settings/GeneralSettingPage.xaml.cs
+++ b/src/Foundry/Views/Settings/GeneralSettingPage.xaml.cs
@@ -4,11 +4,12 @@ using Serilog;
 
 namespace Foundry.Views;
 
-public sealed partial class GeneralSettingPage : Page
-{
-    private bool isInitializingLanguageSelection = true;
-    private readonly IApplicationLocalizationService localizationService;
-    private readonly ILogger logger = Log.ForContext<GeneralSettingPage>();
+    public sealed partial class GeneralSettingPage : Page
+    {
+        private bool isInitializingLanguageSelection = true;
+        private bool isInitializingWinPeLanguageSelection = true;
+        private readonly IApplicationLocalizationService localizationService;
+        private readonly ILogger logger = Log.ForContext<GeneralSettingPage>();
 
     public GeneralSettingViewModel ViewModel { get; }
 
@@ -21,6 +22,7 @@ public sealed partial class GeneralSettingPage : Page
         localizationService.LanguageChanged += OnLanguageChanged;
         Unloaded += OnUnloaded;
         isInitializingLanguageSelection = false;
+        isInitializingWinPeLanguageSelection = false;
     }
 
     private async void LanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -33,6 +35,19 @@ public sealed partial class GeneralSettingPage : Page
         if (e.AddedItems.FirstOrDefault() is SupportedCultureOption selectedLanguage)
         {
             await ViewModel.SetLanguageAsync(selectedLanguage);
+        }
+    }
+
+    private void WinPeLanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (isInitializingWinPeLanguageSelection)
+        {
+            return;
+        }
+
+        if (e.AddedItems.FirstOrDefault() is string selectedLanguage)
+        {
+            ViewModel.SetWinPeLanguage(selectedLanguage);
         }
     }
 
@@ -60,6 +75,11 @@ public sealed partial class GeneralSettingPage : Page
         StartupCard.Description = localizationService.GetString("GeneralSetting_StartupCard.Description");
         LanguageCard.Header = localizationService.GetString("GeneralSetting_LanguageCard.Header");
         LanguageCard.Description = localizationService.GetString("GeneralSetting_LanguageCard.Description");
+        WinPeLanguageCard.Header = localizationService.GetString("GeneralSetting_WinPeLanguageCard.Header");
+        WinPeLanguageCard.Description = string.IsNullOrWhiteSpace(ViewModel.WinPeLanguageStatus)
+            ? localizationService.GetString("GeneralSetting_WinPeLanguageCard.Description")
+            : ViewModel.WinPeLanguageStatus;
+        WinPeLanguageRefreshButton.Content = localizationService.GetString("Common.Refresh");
         DiagnosticsCard.Header = localizationService.GetString("GeneralSetting_DiagnosticsCard.Header");
         DiagnosticsCard.Description = localizationService.GetString("GeneralSetting_DiagnosticsCard.Description");
         StartupToggle.OnContent = localizationService.GetString("Common.Enabled");
@@ -74,6 +94,15 @@ public sealed partial class GeneralSettingPage : Page
         ViewModel.RefreshSupportedLanguages();
         LanguageComboBox.SelectedItem = ViewModel.SelectedLanguage;
         isInitializingLanguageSelection = wasInitializingLanguageSelection;
+
+        bool wasInitializingWinPeLanguageSelection = isInitializingWinPeLanguageSelection;
+        isInitializingWinPeLanguageSelection = true;
+        ViewModel.RefreshWinPeLanguages();
+        WinPeLanguageCard.Description = string.IsNullOrWhiteSpace(ViewModel.WinPeLanguageStatus)
+            ? localizationService.GetString("GeneralSetting_WinPeLanguageCard.Description")
+            : ViewModel.WinPeLanguageStatus;
+        WinPeLanguageComboBox.SelectedItem = ViewModel.SelectedWinPeLanguage;
+        isInitializingWinPeLanguageSelection = wasInitializingWinPeLanguageSelection;
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)

--- a/src/Foundry/Views/StartPage.xaml
+++ b/src/Foundry/Views/StartPage.xaml
@@ -1,13 +1,130 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Page x:Class="Foundry.Views.StartPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:dev="using:DevWinUI"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
-                Padding="{ThemeResource ContentPagePadding}">
+                Padding="{ThemeResource ContentPagePadding}"
+                VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="10"
-                    Spacing="5">
-            <TextBlock x:Uid="StartPage_Title"
+                    dev:PanelAttach.ChildrenTransitions="Default"
+                    Spacing="8">
+            <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
                        Style="{ThemeResource TitleTextBlockStyle}" />
+
+            <dev:SettingsCard Description="{x:Bind ViewModel.FinalExecutionStatus, Mode=OneWay}"
+                              Header="{x:Bind ViewModel.StatusSummary, Mode=OneWay}"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E946}">
+                <StackPanel Orientation="Horizontal"
+                            Spacing="10">
+                    <Button x:Name="IsoSummaryButton"
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            Command="{x:Bind ViewModel.ShowIsoSummaryCommand}" />
+                    <Button x:Name="UsbSummaryButton"
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            Command="{x:Bind ViewModel.ShowUsbSummaryCommand}" />
+                </StackPanel>
+            </dev:SettingsCard>
+
+            <dev:SettingsCard x:Name="IsoPathCard"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E8A5}">
+                <StackPanel Orientation="Horizontal"
+                            Spacing="10">
+                    <TextBox MinWidth="420"
+                             Text="{x:Bind ViewModel.IsoOutputPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <Button x:Name="BrowseIsoButton"
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            Command="{x:Bind ViewModel.BrowseIsoOutputPathCommand}" />
+                </StackPanel>
+            </dev:SettingsCard>
+
+            <dev:SettingsCard x:Name="ArchitectureCard"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E7F4}">
+                <StackPanel Orientation="Horizontal"
+                            Spacing="10">
+                    <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                              DisplayMemberPath="DisplayName"
+                              ItemsSource="{x:Bind ViewModel.Architectures, Mode=OneWay}"
+                              SelectedItem="{x:Bind ViewModel.SelectedArchitecture, Mode=TwoWay}" />
+                    <ToggleSwitch x:Name="Ca2023Toggle"
+                                  IsOn="{x:Bind ViewModel.UseCa2023Signature, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </StackPanel>
+            </dev:SettingsCard>
+
+            <dev:SettingsCard x:Name="WinPeLanguageCard"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E8AB}">
+                <TextBlock MinWidth="{StaticResource SettingActionControlMinWidth}"
+                           Text="{x:Bind ViewModel.WinPeLanguage, Mode=OneWay}" />
+            </dev:SettingsCard>
+
+            <dev:SettingsCard x:Name="UsbTargetCard"
+                              Description="{x:Bind ViewModel.UsbCandidateStatus, Mode=OneWay}"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E88E}">
+                <StackPanel Orientation="Horizontal"
+                            Spacing="10">
+                    <ComboBox MinWidth="360"
+                              DisplayMemberPath="DisplayName"
+                              ItemsSource="{x:Bind ViewModel.UsbCandidates, Mode=OneWay}"
+                              SelectedItem="{x:Bind ViewModel.SelectedUsbDisk, Mode=TwoWay}" />
+                    <Button x:Name="RefreshUsbButton"
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            Command="{x:Bind ViewModel.RefreshUsbCandidatesCommand}" />
+                </StackPanel>
+            </dev:SettingsCard>
+
+            <dev:SettingsCard x:Name="UsbLayoutCard"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E7C3}">
+                <StackPanel Orientation="Horizontal"
+                            Spacing="10">
+                    <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                              DisplayMemberPath="DisplayName"
+                              ItemsSource="{x:Bind ViewModel.PartitionStyles, Mode=OneWay}"
+                              SelectedItem="{x:Bind ViewModel.SelectedPartitionStyle, Mode=TwoWay}" />
+                    <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                              DisplayMemberPath="DisplayName"
+                              ItemsSource="{x:Bind ViewModel.FormatModes, Mode=OneWay}"
+                              SelectedItem="{x:Bind ViewModel.SelectedFormatMode, Mode=TwoWay}" />
+                </StackPanel>
+            </dev:SettingsCard>
+
+            <dev:SettingsExpander x:Name="DriverOptionsCard"
+                                  HeaderIcon="{dev:FontIcon GlyphCode=E90F}">
+                <StackPanel Orientation="Horizontal"
+                            Spacing="10">
+                    <ToggleSwitch x:Name="DellDriversToggle"
+                                  IsOn="{x:Bind ViewModel.IncludeDellDrivers, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <ToggleSwitch x:Name="HpDriversToggle"
+                                  IsOn="{x:Bind ViewModel.IncludeHpDrivers, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </StackPanel>
+                <dev:SettingsExpander.Items>
+                    <dev:SettingsCard x:Name="CustomDriverDirectoryCard">
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="10">
+                            <TextBox MinWidth="420"
+                                     Text="{x:Bind ViewModel.CustomDriverDirectoryPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Button x:Name="BrowseCustomDriversButton"
+                                    MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    Command="{x:Bind ViewModel.BrowseCustomDriverDirectoryCommand}" />
+                        </StackPanel>
+                    </dev:SettingsCard>
+                </dev:SettingsExpander.Items>
+            </dev:SettingsExpander>
+
+            <dev:SettingsCard x:Name="FinalCommandsCard"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E7C1}">
+                <StackPanel Orientation="Horizontal"
+                            Spacing="10">
+                    <Button x:Name="CreateIsoButton"
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            IsEnabled="False" />
+                    <Button x:Name="CreateUsbButton"
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            IsEnabled="False" />
+                </StackPanel>
+            </dev:SettingsCard>
         </StackPanel>
     </ScrollView>
 </Page>

--- a/src/Foundry/Views/StartPage.xaml
+++ b/src/Foundry/Views/StartPage.xaml
@@ -18,46 +18,8 @@
             <dev:SettingsCard Description="{x:Bind ViewModel.FinalExecutionStatus, Mode=OneWay}"
                               Header="{x:Bind ViewModel.StatusSummary, Mode=OneWay}"
                               HeaderIcon="{dev:FontIcon GlyphCode=E946}">
-                <StackPanel Orientation="Horizontal"
-                            Spacing="10">
-                    <Button x:Name="IsoSummaryButton"
-                            MinWidth="{StaticResource SettingActionControlMinWidth}"
-                            Command="{x:Bind ViewModel.ShowIsoSummaryCommand}" />
-                    <Button x:Name="UsbSummaryButton"
-                            MinWidth="{StaticResource SettingActionControlMinWidth}"
-                            Command="{x:Bind ViewModel.ShowUsbSummaryCommand}" />
-                </StackPanel>
-            </dev:SettingsCard>
-
-            <dev:SettingsCard x:Name="IsoPathCard"
-                              HeaderIcon="{dev:FontIcon GlyphCode=E8A5}">
-                <StackPanel Orientation="Horizontal"
-                            Spacing="10">
-                    <TextBox MinWidth="420"
-                             Text="{x:Bind ViewModel.IsoOutputPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                    <Button x:Name="BrowseIsoButton"
-                            MinWidth="{StaticResource SettingActionControlMinWidth}"
-                            Command="{x:Bind ViewModel.BrowseIsoOutputPathCommand}" />
-                </StackPanel>
-            </dev:SettingsCard>
-
-            <dev:SettingsCard x:Name="ArchitectureCard"
-                              HeaderIcon="{dev:FontIcon GlyphCode=E7F4}">
-                <StackPanel Orientation="Horizontal"
-                            Spacing="10">
-                    <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
-                              DisplayMemberPath="DisplayName"
-                              ItemsSource="{x:Bind ViewModel.Architectures, Mode=OneWay}"
-                              SelectedItem="{x:Bind ViewModel.SelectedArchitecture, Mode=TwoWay}" />
-                    <ToggleSwitch x:Name="Ca2023Toggle"
-                                  IsOn="{x:Bind ViewModel.UseCa2023Signature, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                </StackPanel>
-            </dev:SettingsCard>
-
-            <dev:SettingsCard x:Name="WinPeLanguageCard"
-                              HeaderIcon="{dev:FontIcon GlyphCode=E8AB}">
-                <TextBlock MinWidth="{StaticResource SettingActionControlMinWidth}"
-                           Text="{x:Bind ViewModel.WinPeLanguage, Mode=OneWay}" />
+                <TextBlock Text="{x:Bind ViewModel.GlobalSummary, Mode=OneWay}"
+                           TextWrapping="Wrap" />
             </dev:SettingsCard>
 
             <dev:SettingsCard x:Name="UsbTargetCard"
@@ -74,44 +36,6 @@
                             Command="{x:Bind ViewModel.RefreshUsbCandidatesCommand}" />
                 </StackPanel>
             </dev:SettingsCard>
-
-            <dev:SettingsCard x:Name="UsbLayoutCard"
-                              HeaderIcon="{dev:FontIcon GlyphCode=E7C3}">
-                <StackPanel Orientation="Horizontal"
-                            Spacing="10">
-                    <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
-                              DisplayMemberPath="DisplayName"
-                              ItemsSource="{x:Bind ViewModel.PartitionStyles, Mode=OneWay}"
-                              SelectedItem="{x:Bind ViewModel.SelectedPartitionStyle, Mode=TwoWay}" />
-                    <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
-                              DisplayMemberPath="DisplayName"
-                              ItemsSource="{x:Bind ViewModel.FormatModes, Mode=OneWay}"
-                              SelectedItem="{x:Bind ViewModel.SelectedFormatMode, Mode=TwoWay}" />
-                </StackPanel>
-            </dev:SettingsCard>
-
-            <dev:SettingsExpander x:Name="DriverOptionsCard"
-                                  HeaderIcon="{dev:FontIcon GlyphCode=E90F}">
-                <StackPanel Orientation="Horizontal"
-                            Spacing="10">
-                    <ToggleSwitch x:Name="DellDriversToggle"
-                                  IsOn="{x:Bind ViewModel.IncludeDellDrivers, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                    <ToggleSwitch x:Name="HpDriversToggle"
-                                  IsOn="{x:Bind ViewModel.IncludeHpDrivers, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                </StackPanel>
-                <dev:SettingsExpander.Items>
-                    <dev:SettingsCard x:Name="CustomDriverDirectoryCard">
-                        <StackPanel Orientation="Horizontal"
-                                    Spacing="10">
-                            <TextBox MinWidth="420"
-                                     Text="{x:Bind ViewModel.CustomDriverDirectoryPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                            <Button x:Name="BrowseCustomDriversButton"
-                                    MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                    Command="{x:Bind ViewModel.BrowseCustomDriverDirectoryCommand}" />
-                        </StackPanel>
-                    </dev:SettingsCard>
-                </dev:SettingsExpander.Items>
-            </dev:SettingsExpander>
 
             <dev:SettingsCard x:Name="FinalCommandsCard"
                               HeaderIcon="{dev:FontIcon GlyphCode=E7C1}">

--- a/src/Foundry/Views/StartPage.xaml
+++ b/src/Foundry/Views/StartPage.xaml
@@ -15,12 +15,30 @@
             <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
                        Style="{ThemeResource TitleTextBlockStyle}" />
 
-            <dev:SettingsCard Description="{x:Bind ViewModel.FinalExecutionStatus, Mode=OneWay}"
-                              Header="{x:Bind ViewModel.StatusSummary, Mode=OneWay}"
-                              HeaderIcon="{dev:FontIcon GlyphCode=E946}">
-                <TextBlock Text="{x:Bind ViewModel.GlobalSummary, Mode=OneWay}"
-                           TextWrapping="Wrap" />
-            </dev:SettingsCard>
+            <Border Padding="18"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="4">
+                <Grid ColumnDefinitions="Auto,*"
+                      ColumnSpacing="16">
+                    <FontIcon Grid.Column="0"
+                              Glyph="&#xE946;"
+                              VerticalAlignment="Top" />
+                    <StackPanel Grid.Column="1"
+                                Spacing="6">
+                        <TextBlock FontWeight="SemiBold"
+                                   Text="{x:Bind ViewModel.StatusSummary, Mode=OneWay}"
+                                   TextWrapping="WrapWholeWords" />
+                        <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   Text="{x:Bind ViewModel.FinalExecutionStatus, Mode=OneWay}"
+                                   TextWrapping="WrapWholeWords" />
+                        <TextBlock MaxWidth="1120"
+                                   Text="{x:Bind ViewModel.GlobalSummary, Mode=OneWay}"
+                                   TextWrapping="WrapWholeWords" />
+                    </StackPanel>
+                </Grid>
+            </Border>
 
             <dev:SettingsCard x:Name="UsbTargetCard"
                               Description="{x:Bind ViewModel.UsbCandidateStatus, Mode=OneWay}"

--- a/src/Foundry/Views/StartPage.xaml.cs
+++ b/src/Foundry/Views/StartPage.xaml.cs
@@ -26,36 +26,8 @@ public sealed partial class StartPage : Page
 
     private void ApplyLocalizedText()
     {
-        IsoSummaryButton.Content = localizationService.GetString("StartMedia.IsoSummaryButton");
-        UsbSummaryButton.Content = localizationService.GetString("StartMedia.UsbSummaryButton");
-
-        IsoPathCard.Header = localizationService.GetString("StartMedia.IsoPath.Header");
-        IsoPathCard.Description = localizationService.GetString("StartMedia.IsoPath.Description");
-        BrowseIsoButton.Content = localizationService.GetString("Common.Browse");
-
-        ArchitectureCard.Header = localizationService.GetString("StartMedia.Architecture.Header");
-        ArchitectureCard.Description = localizationService.GetString("StartMedia.Architecture.Description");
-        Ca2023Toggle.OnContent = localizationService.GetString("StartMedia.Signature.Ca2023");
-        Ca2023Toggle.OffContent = localizationService.GetString("StartMedia.Signature.Ca2011");
-
-        WinPeLanguageCard.Header = localizationService.GetString("StartMedia.WinPeLanguage.Header");
-        WinPeLanguageCard.Description = localizationService.GetString("StartMedia.WinPeLanguage.Description");
-
         UsbTargetCard.Header = localizationService.GetString("StartMedia.UsbTarget.Header");
         RefreshUsbButton.Content = localizationService.GetString("Common.Refresh");
-
-        UsbLayoutCard.Header = localizationService.GetString("StartMedia.UsbLayout.Header");
-        UsbLayoutCard.Description = localizationService.GetString("StartMedia.UsbLayout.Description");
-
-        DriverOptionsCard.Header = localizationService.GetString("StartMedia.DriverOptions.Header");
-        DriverOptionsCard.Description = localizationService.GetString("StartMedia.DriverOptions.Description");
-        DellDriversToggle.OnContent = localizationService.GetString("StartMedia.DriverOptions.Dell");
-        DellDriversToggle.OffContent = localizationService.GetString("StartMedia.DriverOptions.Dell");
-        HpDriversToggle.OnContent = localizationService.GetString("StartMedia.DriverOptions.Hp");
-        HpDriversToggle.OffContent = localizationService.GetString("StartMedia.DriverOptions.Hp");
-        CustomDriverDirectoryCard.Header = localizationService.GetString("StartMedia.CustomDrivers.Header");
-        CustomDriverDirectoryCard.Description = localizationService.GetString("StartMedia.CustomDrivers.Description");
-        BrowseCustomDriversButton.Content = localizationService.GetString("Common.Browse");
 
         FinalCommandsCard.Header = localizationService.GetString("StartMedia.FinalCommands.Header");
         FinalCommandsCard.Description = localizationService.GetString("StartMedia.FinalCommands.Description");

--- a/src/Foundry/Views/StartPage.xaml.cs
+++ b/src/Foundry/Views/StartPage.xaml.cs
@@ -1,9 +1,84 @@
+using Foundry.Services.Localization;
+
 namespace Foundry.Views;
 
 public sealed partial class StartPage : Page
 {
+    private readonly IApplicationLocalizationService localizationService;
+
+    public StartMediaViewModel ViewModel { get; }
+
     public StartPage()
     {
+        localizationService = App.GetService<IApplicationLocalizationService>();
+        ViewModel = App.GetService<StartMediaViewModel>();
         InitializeComponent();
+        ApplyLocalizedText();
+        localizationService.LanguageChanged += OnLanguageChanged;
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+    }
+
+    private async void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        await ViewModel.InitializeAsync();
+    }
+
+    private void ApplyLocalizedText()
+    {
+        IsoSummaryButton.Content = localizationService.GetString("StartMedia.IsoSummaryButton");
+        UsbSummaryButton.Content = localizationService.GetString("StartMedia.UsbSummaryButton");
+
+        IsoPathCard.Header = localizationService.GetString("StartMedia.IsoPath.Header");
+        IsoPathCard.Description = localizationService.GetString("StartMedia.IsoPath.Description");
+        BrowseIsoButton.Content = localizationService.GetString("Common.Browse");
+
+        ArchitectureCard.Header = localizationService.GetString("StartMedia.Architecture.Header");
+        ArchitectureCard.Description = localizationService.GetString("StartMedia.Architecture.Description");
+        Ca2023Toggle.OnContent = localizationService.GetString("StartMedia.Signature.Ca2023");
+        Ca2023Toggle.OffContent = localizationService.GetString("StartMedia.Signature.Ca2011");
+
+        WinPeLanguageCard.Header = localizationService.GetString("StartMedia.WinPeLanguage.Header");
+        WinPeLanguageCard.Description = localizationService.GetString("StartMedia.WinPeLanguage.Description");
+
+        UsbTargetCard.Header = localizationService.GetString("StartMedia.UsbTarget.Header");
+        RefreshUsbButton.Content = localizationService.GetString("Common.Refresh");
+
+        UsbLayoutCard.Header = localizationService.GetString("StartMedia.UsbLayout.Header");
+        UsbLayoutCard.Description = localizationService.GetString("StartMedia.UsbLayout.Description");
+
+        DriverOptionsCard.Header = localizationService.GetString("StartMedia.DriverOptions.Header");
+        DriverOptionsCard.Description = localizationService.GetString("StartMedia.DriverOptions.Description");
+        DellDriversToggle.OnContent = localizationService.GetString("StartMedia.DriverOptions.Dell");
+        DellDriversToggle.OffContent = localizationService.GetString("StartMedia.DriverOptions.Dell");
+        HpDriversToggle.OnContent = localizationService.GetString("StartMedia.DriverOptions.Hp");
+        HpDriversToggle.OffContent = localizationService.GetString("StartMedia.DriverOptions.Hp");
+        CustomDriverDirectoryCard.Header = localizationService.GetString("StartMedia.CustomDrivers.Header");
+        CustomDriverDirectoryCard.Description = localizationService.GetString("StartMedia.CustomDrivers.Description");
+        BrowseCustomDriversButton.Content = localizationService.GetString("Common.Browse");
+
+        FinalCommandsCard.Header = localizationService.GetString("StartMedia.FinalCommands.Header");
+        FinalCommandsCard.Description = localizationService.GetString("StartMedia.FinalCommands.Description");
+        CreateIsoButton.Content = localizationService.GetString("StartMedia.CreateIsoButton");
+        CreateUsbButton.Content = localizationService.GetString("StartMedia.CreateUsbButton");
+    }
+
+    private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
+    {
+        if (DispatcherQueue.HasThreadAccess)
+        {
+            ApplyLocalizedText();
+            return;
+        }
+
+        _ = DispatcherQueue.TryEnqueue(ApplyLocalizedText);
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        ViewModel.Dispose();
+        localizationService.LanguageChanged -= OnLanguageChanged;
+        Loaded -= OnLoaded;
+        Unloaded -= OnUnloaded;
     }
 }


### PR DESCRIPTION
## Summary
Add the Phase 13 Start page media preflight workflow for ISO/USB readiness without enabling destructive final media execution.

## Reason
The Start page needs to expose the media configuration surface and dry-run validation before final ISO/USB execution is enabled after Deploy and Connect provisioning phases.

## Main changes
- Added Core media preflight evaluation and tests.
- Added Start page media state, USB discovery, dry-run summaries, and localized UI text.
- Added WinPE boot language selection to General settings and consumed it from the Start page.
- Updated the migration plan to reflect the Phase 13 preflight boundary and completed implementation items.

## Testing
- `dotnet build .\src\Foundry\Foundry.csproj -c Debug --nologo`
- `dotnet test .\src\Foundry.Core.Tests\Foundry.Core.Tests.csproj -c Release --nologo -v minimal`

Manual Phase 13 validations remain pending and the PR must not be squashed until they are approved.