### PR TITLE
feat(configuration): port expert deploy configuration workflow

### DIFF
--- a/docs/migration/phases/06-business-workflows.md
+++ b/docs/migration/phases/06-business-workflows.md
@@ -10,52 +10,52 @@
 
 **Scope boundary:** Phase 14 owns Expert Deploy configuration state, runtime deploy configuration generation, and deployment localization behavior. It may create or bind minimal expert page state needed for persistence and runtime config generation, but full Network provisioning belongs to Phase 15, and full Autopilot/customization workflows belong to Phase 16.
 
-- [ ] **14.1** Port expert sections without exposing `General` as an Expert navigation page:
-  - [ ] Network document state only; full provisioning UI and runtime handoff are Phase 15.
-  - [ ] Localization.
-  - [ ] Autopilot document state only; profile import, tenant download, and profile embedding are Phase 16.
-  - [ ] Customization document state only; deployment customization controls are Phase 16.
-  - [ ] Keep `General` in the General navigation section.
-  - [ ] Preserve the existing expert document `general` section internally when required by schema compatibility.
-- [ ] **14.1.1** Keep expert `Localization` scoped to OS deployment localization, not WinPE boot language:
-  - [ ] Port WPF `LocalizationSettingsViewModel` behavior for deployment language selection.
-  - [ ] Preserve `LocalizationSettings.VisibleLanguageCodes`.
-  - [ ] Preserve `LocalizationSettings.DefaultLanguageCodeOverride`.
-  - [ ] Preserve `LocalizationSettings.DefaultTimeZoneId`.
-  - [ ] Preserve `LocalizationSettings.ForceSingleVisibleLanguage`.
-  - [ ] Preserve `DeployConfigurationGenerator` mapping to `DeployLocalizationSettings` for `Foundry.Deploy`.
-  - [ ] Do not move `GeneralSettings.WinPeLanguage` into the expert `Localization` page.
-- [ ] **14.1.2** Preserve deployment timezone runtime support:
-  - [ ] Add or update the `Foundry.Deploy` runtime model for `localization.defaultTimeZoneId`.
-  - [ ] Keep `Foundry.Deploy` backward compatible when `defaultTimeZoneId` is missing.
-  - [ ] Preserve bootstrap timezone resolution order:
-    - [ ] `FOUNDRY_WINPE_TIMEZONE_ID`.
-    - [ ] `foundry.deploy.config.json` `localization.defaultTimeZoneId`.
-    - [ ] Public-IP auto-detection mapped through `iana-windows-timezones.json`.
-    - [ ] `UTC` fallback.
-  - [ ] Do not confuse deployment timezone with WinPE boot display language from `General`.
-- [ ] **14.2** Persist Expert Deploy configuration through the approved app workflow state path.
-- [ ] **14.3** Do not add user-facing manual configuration file commands.
-- [ ] **14.4** Generate the `Foundry.Deploy` runtime configuration internally for media creation.
-- [ ] **14.5** Preserve JSON defaults.
-- [ ] **14.6** Preserve validation behavior.
-- [ ] **14.7** Preserve schema compatibility.
-- [ ] **14.7.1** Generate complete effective `Foundry.Deploy` runtime configuration documents:
-  - [ ] Always include `schemaVersion`.
-  - [ ] Always include `localization`.
-  - [ ] Always include `customization`.
-  - [ ] Always include `autopilot`.
-  - [ ] Serialize effective default values instead of relying on missing root sections.
-  - [ ] Keep `Foundry.Deploy` tolerant for missing optional properties, but do not rely on sparse generated media configs.
-  - [ ] Add or update `Foundry.Deploy` validation for contradictory effective states.
-  - [ ] Generated WinUI media always includes a complete effective `foundry.deploy.config.json`, even for standard workflow defaults.
-  - [ ] Treat this as an intentional WinUI migration improvement over WPF, where deploy config embedding was tied to expert mode.
-- [ ] **14.7.2** Wire deploy configuration readiness into the `Start` page preflight without enabling final ISO/USB execution:
-  - [ ] Replace the Phase 13 hardcoded deploy readiness placeholder with real deploy configuration readiness.
-  - [ ] Keep runtime, Connect provisioning, network provisioning, secret readiness, and final execution gates blocked until their planned phases are complete.
-  - [ ] Leave **13.18.1** unchecked until the final media enablement PR after Phases 14 and 15.
-- [ ] **14.8** Add tests only where business logic changed.
-- [ ] **14.9** Commit:
+- [x] **14.1** Port expert sections without exposing `General` as an Expert navigation page:
+  - [x] Network document state only; full provisioning UI and runtime handoff are Phase 15.
+  - [x] Localization.
+  - [x] Autopilot document state only; profile import, tenant download, and profile embedding are Phase 16.
+  - [x] Customization document state only; deployment customization controls are Phase 16.
+  - [x] Keep `General` in the General navigation section.
+  - [x] Preserve the existing expert document `general` section internally when required by schema compatibility.
+- [x] **14.1.1** Keep expert `Localization` scoped to OS deployment localization, not WinPE boot language:
+  - [x] Port WPF `LocalizationSettingsViewModel` behavior for deployment language selection.
+  - [x] Preserve `LocalizationSettings.VisibleLanguageCodes`.
+  - [x] Preserve `LocalizationSettings.DefaultLanguageCodeOverride`.
+  - [x] Preserve `LocalizationSettings.DefaultTimeZoneId`.
+  - [x] Preserve `LocalizationSettings.ForceSingleVisibleLanguage`.
+  - [x] Preserve `DeployConfigurationGenerator` mapping to `DeployLocalizationSettings` for `Foundry.Deploy`.
+  - [x] Do not move `GeneralSettings.WinPeLanguage` into the expert `Localization` page.
+- [x] **14.1.2** Preserve deployment timezone runtime support:
+  - [x] Add or update the `Foundry.Deploy` runtime model for `localization.defaultTimeZoneId`.
+  - [x] Keep `Foundry.Deploy` backward compatible when `defaultTimeZoneId` is missing.
+  - [x] Preserve bootstrap timezone resolution order:
+    - [x] `FOUNDRY_WINPE_TIMEZONE_ID`.
+    - [x] `foundry.deploy.config.json` `localization.defaultTimeZoneId`.
+    - [x] Public-IP auto-detection mapped through `iana-windows-timezones.json`.
+    - [x] `UTC` fallback.
+  - [x] Do not confuse deployment timezone with WinPE boot display language from `General`.
+- [x] **14.2** Persist Expert Deploy configuration through the approved app workflow state path.
+- [x] **14.3** Do not add user-facing manual configuration file commands.
+- [x] **14.4** Generate the `Foundry.Deploy` runtime configuration internally for media creation.
+- [x] **14.5** Preserve JSON defaults.
+- [x] **14.6** Preserve validation behavior.
+- [x] **14.7** Preserve schema compatibility.
+- [x] **14.7.1** Generate complete effective `Foundry.Deploy` runtime configuration documents:
+  - [x] Always include `schemaVersion`.
+  - [x] Always include `localization`.
+  - [x] Always include `customization`.
+  - [x] Always include `autopilot`.
+  - [x] Serialize effective default values instead of relying on missing root sections.
+  - [x] Keep `Foundry.Deploy` tolerant for missing optional properties, but do not rely on sparse generated media configs.
+  - [x] Add or update `Foundry.Deploy` validation for contradictory effective states.
+  - [x] Generated WinUI media always includes a complete effective `foundry.deploy.config.json`, even for standard workflow defaults.
+  - [x] Treat this as an intentional WinUI migration improvement over WPF, where deploy config embedding was tied to expert mode.
+- [x] **14.7.2** Wire deploy configuration readiness into the `Start` page preflight without enabling final ISO/USB execution:
+  - [x] Replace the Phase 13 hardcoded deploy readiness placeholder with real deploy configuration readiness.
+  - [x] Keep runtime, Connect provisioning, network provisioning, secret readiness, and final execution gates blocked until their planned phases are complete.
+  - [x] Leave **13.18.1** unchecked until the final media enablement PR after Phases 14 and 15.
+- [x] **14.8** Add tests only where business logic changed.
+- [x] **14.9** Commit:
 
 ```powershell
 git commit -m "feat(configuration): port expert deploy configuration workflow"
@@ -63,12 +63,13 @@ git commit -m "feat(configuration): port expert deploy configuration workflow"
 
 **Validation**
 
-- [ ] **14.10** Confirm no user-facing manual configuration file commands are exposed.
-- [ ] **14.11** Validate Expert Deploy settings persist through the normal app workflow state path.
-- [ ] **14.12** Validate generated runtime Deploy config for representative standard and expert settings.
+- [x] **14.10** Confirm no user-facing manual configuration file commands are exposed.
+- [x] **14.11** Validate Expert Deploy settings persist through the normal app workflow state path.
+- [x] **14.12** Validate generated runtime Deploy config for representative standard and expert settings.
 - [ ] **14.13** Generate deploy config and validate `Foundry.Deploy` can consume it.
-- [ ] **14.14** Validate `Foundry.Deploy` applies or tolerates `localization.defaultTimeZoneId`.
-- [ ] **14.15** Validate generated standard media deploy config contains complete default root sections.
+  - Deferred until final ISO/USB media creation is enabled after Phase 15; Phase 14 validates generation and model compatibility, but cannot run the real generated-media `Foundry.Deploy` path yet.
+- [x] **14.14** Validate `Foundry.Deploy` applies or tolerates `localization.defaultTimeZoneId`.
+- [x] **14.15** Validate generated standard media deploy config contains complete default root sections.
 
 ## Phase 15: Network Provisioning Workflow
 

--- a/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
@@ -55,6 +55,23 @@ public sealed class DeployConfigurationGeneratorTests
     }
 
     [Fact]
+    public void Serialize_WhenDefaultTimeZoneIdIsSet_WritesCamelCaseProperty()
+    {
+        var generator = new DeployConfigurationGenerator();
+        var document = generator.Generate(new FoundryExpertConfigurationDocument
+        {
+            Localization = new LocalizationSettings
+            {
+                DefaultTimeZoneId = "Romance Standard Time"
+            }
+        });
+
+        string json = generator.Serialize(document);
+
+        Assert.Contains("\"defaultTimeZoneId\": \"Romance Standard Time\"", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Generate_ResolvesDefaultAutopilotProfileFolder()
     {
         var generator = new DeployConfigurationGenerator();

--- a/src/Foundry.Deploy.Tests/DeploymentLaunchPreparationServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentLaunchPreparationServiceTests.cs
@@ -80,6 +80,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
                 targetComputerName: " LAB_01 ",
                 driverPackSelectionKind: DriverPackSelectionKind.OemCatalog,
                 selectedDriverPack: driverPack,
+                defaultTimeZoneId: " Romance Standard Time ",
                 isAutopilotEnabled: true,
                 selectedAutopilotProfile: autopilotProfile));
 
@@ -88,6 +89,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
         Assert.Equal(1, shell.ConfirmationCallCount);
         Assert.Equal(targetDisk.DiskNumber, result.Context?.TargetDiskNumber);
         Assert.Equal("LAB01", result.Context?.TargetComputerName);
+        Assert.Equal("Romance Standard Time", result.Context?.DefaultTimeZoneId);
         Assert.Same(driverPack, result.Context?.DriverPack);
         Assert.Same(autopilotProfile, result.Context?.SelectedAutopilotProfile);
     }
@@ -95,6 +97,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
     private static DeploymentLaunchRequest CreateRequest(
         TargetDiskInfo? selectedTargetDisk,
         string targetComputerName = "LAB-01",
+        string? defaultTimeZoneId = null,
         DriverPackSelectionKind driverPackSelectionKind = DriverPackSelectionKind.None,
         DriverPackCatalogItem? selectedDriverPack = null,
         bool isAutopilotEnabled = false,
@@ -106,6 +109,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
             Mode = DeploymentMode.Usb,
             CacheRootPath = @"X:\Foundry\Runtime",
             TargetComputerName = targetComputerName,
+            DefaultTimeZoneId = defaultTimeZoneId,
             SelectedTargetDisk = selectedTargetDisk,
             SelectedOperatingSystem = new OperatingSystemCatalogItem
             {

--- a/src/Foundry.Deploy.Tests/ExpertDeployConfigurationModelTests.cs
+++ b/src/Foundry.Deploy.Tests/ExpertDeployConfigurationModelTests.cs
@@ -1,0 +1,31 @@
+using System.Text.Json;
+using Foundry.Deploy.Models.Configuration;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class ExpertDeployConfigurationModelTests
+{
+    [Fact]
+    public void Deserialize_WhenLocalizationIncludesDefaultTimeZoneId_PreservesValue()
+    {
+        const string json = """
+            {
+              "schemaVersion": 2,
+              "localization": {
+                "defaultTimeZoneId": "Romance Standard Time"
+              }
+            }
+            """;
+
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        FoundryDeployConfigurationDocument? document = JsonSerializer.Deserialize<FoundryDeployConfigurationDocument>(json, options);
+
+        Assert.NotNull(document);
+        Assert.Equal("Romance Standard Time", document.Localization.DefaultTimeZoneId);
+    }
+}

--- a/src/Foundry.Deploy.Tests/WindowsDeploymentServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/WindowsDeploymentServiceTests.cs
@@ -1,0 +1,109 @@
+using System.Xml.Linq;
+using Foundry.Deploy.Services.Deployment;
+using Foundry.Deploy.Services.System;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class WindowsDeploymentServiceTests
+{
+    [Fact]
+    public async Task ConfigureOfflineComputerNameAsync_WhenDefaultTimeZoneIdIsProvided_WritesUnattendTimeZone()
+    {
+        using var workspace = new TemporaryWorkspace();
+        string windowsRoot = Path.Combine(workspace.RootPath, "WindowsRoot");
+        string workingDirectory = Path.Combine(workspace.RootPath, "Work");
+        Directory.CreateDirectory(windowsRoot);
+
+        var service = new WindowsDeploymentService(new NoOpProcessRunner(), NullLogger<WindowsDeploymentService>.Instance);
+
+        await service.ConfigureOfflineComputerNameAsync(
+            windowsRoot,
+            "LAB01",
+            "amd64",
+            workingDirectory,
+            "Romance Standard Time");
+
+        string unattendPath = Path.Combine(windowsRoot, "Windows", "Panther", "unattend.xml");
+        XDocument document = XDocument.Load(unattendPath);
+        XNamespace ns = "urn:schemas-microsoft-com:unattend";
+
+        Assert.Equal("LAB01", document.Descendants(ns + "ComputerName").Single().Value);
+        Assert.Equal("Romance Standard Time", document.Descendants(ns + "TimeZone").Single().Value);
+    }
+
+    [Fact]
+    public async Task ConfigureOfflineComputerNameAsync_WhenIanaTimeZoneIdIsProvided_WritesWindowsTimeZoneId()
+    {
+        using var workspace = new TemporaryWorkspace();
+        string windowsRoot = Path.Combine(workspace.RootPath, "WindowsRoot");
+        string workingDirectory = Path.Combine(workspace.RootPath, "Work");
+        Directory.CreateDirectory(windowsRoot);
+
+        var service = new WindowsDeploymentService(new NoOpProcessRunner(), NullLogger<WindowsDeploymentService>.Instance);
+
+        await service.ConfigureOfflineComputerNameAsync(
+            windowsRoot,
+            "LAB01",
+            "amd64",
+            workingDirectory,
+            "Europe/Paris");
+
+        string unattendPath = Path.Combine(windowsRoot, "Windows", "Panther", "unattend.xml");
+        XDocument document = XDocument.Load(unattendPath);
+        XNamespace ns = "urn:schemas-microsoft-com:unattend";
+
+        Assert.Equal("Romance Standard Time", document.Descendants(ns + "TimeZone").Single().Value);
+    }
+
+    private sealed class TemporaryWorkspace : IDisposable
+    {
+        public TemporaryWorkspace()
+        {
+            RootPath = Path.Combine(Path.GetTempPath(), $"foundry-deploy-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(RootPath);
+        }
+
+        public string RootPath { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+
+    private sealed class NoOpProcessRunner : IProcessRunner
+    {
+        public Task<ProcessExecutionResult> RunAsync(
+            string fileName,
+            string arguments,
+            string workingDirectory,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new ProcessExecutionResult { ExitCode = 0 });
+        }
+
+        public Task<ProcessExecutionResult> RunAsync(
+            string fileName,
+            IEnumerable<string> arguments,
+            string workingDirectory,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new ProcessExecutionResult { ExitCode = 0 });
+        }
+
+        public Task<ProcessExecutionResult> RunAsync(
+            string fileName,
+            IEnumerable<string> arguments,
+            string workingDirectory,
+            Action<string>? onOutputData,
+            Action<string>? onErrorData,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new ProcessExecutionResult { ExitCode = 0 });
+        }
+    }
+}

--- a/src/Foundry.Deploy/Models/Configuration/DeployLocalizationSettings.cs
+++ b/src/Foundry.Deploy/Models/Configuration/DeployLocalizationSettings.cs
@@ -4,5 +4,6 @@ public sealed record DeployLocalizationSettings
 {
     public IReadOnlyList<string> VisibleLanguageCodes { get; init; } = Array.Empty<string>();
     public string? DefaultLanguageCodeOverride { get; init; }
+    public string? DefaultTimeZoneId { get; init; }
     public bool ForceSingleVisibleLanguage { get; init; }
 }

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentContext.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentContext.cs
@@ -8,6 +8,7 @@ public sealed record DeploymentContext
     public required string CacheRootPath { get; init; }
     public required int TargetDiskNumber { get; init; }
     public required string TargetComputerName { get; init; }
+    public string? DefaultTimeZoneId { get; init; }
     public required OperatingSystemCatalogItem OperatingSystem { get; init; }
     public required DriverPackSelectionKind DriverPackSelectionKind { get; init; }
     public DriverPackCatalogItem? DriverPack { get; init; }

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchPreparationService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchPreparationService.cs
@@ -74,6 +74,7 @@ public sealed class DeploymentLaunchPreparationService : IDeploymentLaunchPrepar
             CacheRootPath = request.CacheRootPath,
             TargetDiskNumber = effectiveTargetDisk.DiskNumber,
             TargetComputerName = normalizedComputerName,
+            DefaultTimeZoneId = string.IsNullOrWhiteSpace(request.DefaultTimeZoneId) ? null : request.DefaultTimeZoneId.Trim(),
             OperatingSystem = request.SelectedOperatingSystem,
             DriverPackSelectionKind = request.DriverPackSelectionKind,
             DriverPack = request.SelectedDriverPack,

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchRequest.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchRequest.cs
@@ -7,6 +7,7 @@ public sealed record DeploymentLaunchRequest
     public required DeploymentMode Mode { get; init; }
     public required string CacheRootPath { get; init; }
     public required string TargetComputerName { get; init; }
+    public string? DefaultTimeZoneId { get; init; }
     public required TargetDiskInfo? SelectedTargetDisk { get; init; }
     public required OperatingSystemCatalogItem? SelectedOperatingSystem { get; init; }
     public required DriverPackSelectionKind DriverPackSelectionKind { get; init; }

--- a/src/Foundry.Deploy/Services/Deployment/IWindowsDeploymentService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/IWindowsDeploymentService.cs
@@ -32,6 +32,7 @@ public interface IWindowsDeploymentService
         string computerName,
         string processorArchitecture,
         string workingDirectory,
+        string? defaultTimeZoneId = null,
         CancellationToken cancellationToken = default);
 
     Task ConfigureRecoveryEnvironmentAsync(

--- a/src/Foundry.Deploy/Services/Deployment/Steps/ConfigureTargetComputerNameStep.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Steps/ConfigureTargetComputerNameStep.cs
@@ -34,6 +34,7 @@ public sealed class ConfigureTargetComputerNameStep : DeploymentStepBase
                 context.RuntimeState.TargetComputerName,
                 context.Request.OperatingSystem.Architecture,
                 workingDirectory,
+                context.Request.DefaultTimeZoneId,
                 cancellationToken)
             .ConfigureAwait(false);
 
@@ -63,6 +64,7 @@ public sealed class ConfigureTargetComputerNameStep : DeploymentStepBase
                 context.RuntimeState.TargetComputerName,
                 context.Request.OperatingSystem.Architecture,
                 workingDirectory,
+                context.Request.DefaultTimeZoneId,
                 cancellationToken)
             .ConfigureAwait(false);
 

--- a/src/Foundry.Deploy/Services/Deployment/WindowsDeploymentService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/WindowsDeploymentService.cs
@@ -263,6 +263,7 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
         string computerName,
         string processorArchitecture,
         string workingDirectory,
+        string? defaultTimeZoneId = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -335,16 +336,54 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
 
         computerNameElement.Value = computerName;
 
+        XElement timeZoneElement = component.Element(unattendNamespace + "TimeZone")
+            ?? new XElement(unattendNamespace + "TimeZone");
+
+        string? unattendTimeZoneId = ResolveUnattendTimeZoneId(defaultTimeZoneId);
+        if (string.IsNullOrWhiteSpace(unattendTimeZoneId))
+        {
+            timeZoneElement.Remove();
+        }
+        else
+        {
+            if (timeZoneElement.Parent is null)
+            {
+                component.Add(timeZoneElement);
+            }
+
+            timeZoneElement.Value = unattendTimeZoneId;
+        }
+
         document.Declaration ??= new XDeclaration("1.0", "utf-8", "yes");
         document.Save(unattendPath);
 
         _logger.LogInformation(
-            "Offline computer name configured. ComputerName={ComputerName}, UnattendPath={UnattendPath}, ProcessorArchitecture={ProcessorArchitecture}",
+            "Offline computer name configured. ComputerName={ComputerName}, UnattendPath={UnattendPath}, ProcessorArchitecture={ProcessorArchitecture}, DefaultTimeZoneConfigured={DefaultTimeZoneConfigured}",
             computerName,
             unattendPath,
-            normalizedArchitecture);
+            normalizedArchitecture,
+            !string.IsNullOrWhiteSpace(unattendTimeZoneId));
 
         return Task.CompletedTask;
+    }
+
+    private static string? ResolveUnattendTimeZoneId(string? timeZoneId)
+    {
+        if (string.IsNullOrWhiteSpace(timeZoneId))
+        {
+            return null;
+        }
+
+        string normalizedTimeZoneId = timeZoneId.Trim();
+        if (TimeZoneInfo.TryConvertIanaIdToWindowsId(normalizedTimeZoneId, out string? windowsTimeZoneId) &&
+            !string.IsNullOrWhiteSpace(windowsTimeZoneId))
+        {
+            return windowsTimeZoneId;
+        }
+
+        return normalizedTimeZoneId.Contains('/', StringComparison.Ordinal)
+            ? null
+            : normalizedTimeZoneId;
     }
 
     public async Task ConfigureRecoveryEnvironmentAsync(

--- a/src/Foundry.Deploy/Services/Wizard/DeploymentWizardContext.cs
+++ b/src/Foundry.Deploy/Services/Wizard/DeploymentWizardContext.cs
@@ -33,6 +33,7 @@ public sealed class DeploymentWizardContext : IDisposable
     public DeploymentPreparationViewModel Preparation { get; }
     public OperatingSystemCatalogViewModel OperatingSystemCatalog { get; }
     public DriverPackSelectionViewModel DriverPackSelection { get; }
+    public string? DefaultTimeZoneId { get; private set; }
 
     public event EventHandler? StateChanged;
     public event Action<string>? StatusMessageGenerated;
@@ -109,6 +110,9 @@ public sealed class DeploymentWizardContext : IDisposable
             document.Localization.VisibleLanguageCodes,
             document.Localization.DefaultLanguageCodeOverride,
             document.Localization.ForceSingleVisibleLanguage);
+        DefaultTimeZoneId = string.IsNullOrWhiteSpace(document.Localization.DefaultTimeZoneId)
+            ? null
+            : document.Localization.DefaultTimeZoneId.Trim();
         Preparation.ApplyMachineNamingConfiguration(
             document.Customization.MachineNaming ?? new DeployMachineNamingSettings(),
             string.IsNullOrWhiteSpace(Preparation.TargetComputerName)

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -272,6 +272,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
                 Mode = _deploymentRuntimeContext.Mode,
                 CacheRootPath = Preparation.CacheRootPath,
                 TargetComputerName = Preparation.TargetComputerName,
+                DefaultTimeZoneId = _wizardContext.DefaultTimeZoneId,
                 SelectedTargetDisk = Preparation.SelectedTargetDisk,
                 SelectedOperatingSystem = OperatingSystemCatalog.SelectedOperatingSystem,
                 DriverPackSelectionKind = effectiveDriverPackKind,

--- a/src/Foundry/Common/Constants.cs
+++ b/src/Foundry/Common/Constants.cs
@@ -16,6 +16,7 @@ namespace Foundry.Common
         public static readonly string OperatingSystemCacheDirectoryPath = Path.Combine(CacheDirectoryPath, "OperatingSystems");
         public static readonly string ToolCacheDirectoryPath = Path.Combine(CacheDirectoryPath, "Tools");
         public static readonly string WorkspacesDirectoryPath = Path.Combine(RootDirectoryPath, "Workspaces");
+        public static readonly string ConfigurationWorkspaceDirectoryPath = Path.Combine(WorkspacesDirectoryPath, "Configuration");
         public static readonly string WinPeWorkspaceDirectoryPath = Path.Combine(WorkspacesDirectoryPath, "WinPe");
         public static readonly string IsoWorkspaceDirectoryPath = Path.Combine(WorkspacesDirectoryPath, "Iso");
         public static readonly string TempDirectoryPath = Path.Combine(RootDirectoryPath, "Temp");
@@ -24,6 +25,7 @@ namespace Foundry.Common
         public static readonly string DownloadsTempDirectoryPath = Path.Combine(TempDirectoryPath, "Downloads");
         public static readonly string LogFilePath = Path.Combine(LogDirectoryPath, "Foundry.log");
         public static readonly string AppSettingsPath = Path.Combine(SettingsDirectoryPath, "appsettings.json");
+        public static readonly string ExpertDeployConfigurationStatePath = Path.Combine(ConfigurationWorkspaceDirectoryPath, "foundry.expert.config.json");
 
         public const string RepositoryUrl = "https://github.com/foundry-osd/foundry";
         public const string LatestReleaseUrl = RepositoryUrl + "/releases/latest";
@@ -38,6 +40,7 @@ namespace Foundry.Common
             Directory.CreateDirectory(OperatingSystemCacheDirectoryPath);
             Directory.CreateDirectory(ToolCacheDirectoryPath);
             Directory.CreateDirectory(WorkspacesDirectoryPath);
+            Directory.CreateDirectory(ConfigurationWorkspaceDirectoryPath);
             Directory.CreateDirectory(WinPeWorkspaceDirectoryPath);
             Directory.CreateDirectory(IsoWorkspaceDirectoryPath);
             Directory.CreateDirectory(TempDirectoryPath);

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,8 +1,10 @@
 using Foundry.Core.Services.Application;
 using Foundry.Core.Services.Adk;
+using Foundry.Core.Services.Configuration;
 using Foundry.Core.Services.WinPe;
 using Foundry.Services.Application;
 using Foundry.Services.Adk;
+using Foundry.Services.Configuration;
 using Foundry.Services.Localization;
 using Foundry.Services.Operations;
 using Foundry.Services.Settings;
@@ -23,6 +25,10 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<IAppSettingsService, JsonAppSettingsService>();
         services.AddSingleton<IAdkInstallationProbe, WindowsAdkInstallationProbe>();
+        services.AddSingleton<IExpertConfigurationService, ExpertConfigurationService>();
+        services.AddSingleton<IDeployConfigurationGenerator, DeployConfigurationGenerator>();
+        services.AddSingleton<ILanguageRegistryService, EmbeddedLanguageRegistryService>();
+        services.AddSingleton<IExpertDeployConfigurationStateService, ExpertDeployConfigurationStateService>();
         services.AddSingleton<IWinPeLanguageDiscoveryService, WinPeLanguageDiscoveryService>();
         services.AddSingleton<IWinPeUsbMediaService, WinPeUsbMediaService>();
         services.AddSingleton<IOperationProgressService, OperationProgressService>();
@@ -44,6 +50,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<MainViewModel>();
         services.AddSingleton<ContextMenuService>();
         services.AddTransient<GeneralConfigurationViewModel>();
+        services.AddTransient<LocalizationConfigurationViewModel>();
         services.AddTransient<StartMediaViewModel>();
         services.AddTransient<GeneralSettingViewModel>();
         services.AddTransient<AdkPageViewModel>();

--- a/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
@@ -1,0 +1,113 @@
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Configuration;
+using Serilog;
+
+namespace Foundry.Services.Configuration;
+
+internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfigurationStateService
+{
+    private readonly IExpertConfigurationService expertConfigurationService;
+    private readonly IDeployConfigurationGenerator deployConfigurationGenerator;
+    private readonly ILogger logger;
+
+    public ExpertDeployConfigurationStateService(
+        IExpertConfigurationService expertConfigurationService,
+        IDeployConfigurationGenerator deployConfigurationGenerator,
+        ILogger logger)
+    {
+        this.expertConfigurationService = expertConfigurationService;
+        this.deployConfigurationGenerator = deployConfigurationGenerator;
+        this.logger = logger.ForContext<ExpertDeployConfigurationStateService>();
+        Current = Load();
+        Save();
+    }
+
+    public event EventHandler? StateChanged;
+
+    public FoundryExpertConfigurationDocument Current { get; private set; }
+
+    public bool IsDeployConfigurationReady
+    {
+        get
+        {
+            try
+            {
+                _ = GenerateDeployConfigurationJson();
+                return true;
+            }
+            catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+            {
+                logger.Warning(ex, "Expert Deploy configuration is not ready.");
+                return false;
+            }
+        }
+    }
+
+    public void UpdateLocalization(LocalizationSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        Current = Current with { Localization = settings };
+        Save();
+        StateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public string GenerateDeployConfigurationJson()
+    {
+        return deployConfigurationGenerator.Serialize(deployConfigurationGenerator.Generate(Current));
+    }
+
+    private FoundryExpertConfigurationDocument Load()
+    {
+        if (!File.Exists(Constants.ExpertDeployConfigurationStatePath))
+        {
+            return new FoundryExpertConfigurationDocument();
+        }
+
+        try
+        {
+            string json = File.ReadAllText(Constants.ExpertDeployConfigurationStatePath);
+            return expertConfigurationService.Deserialize(json);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Text.Json.JsonException or ArgumentException)
+        {
+            string backupPath = Constants.ExpertDeployConfigurationStatePath + ".invalid";
+            TryMoveInvalidState(backupPath, ex);
+            return new FoundryExpertConfigurationDocument();
+        }
+    }
+
+    private void Save()
+    {
+        Directory.CreateDirectory(Constants.ConfigurationWorkspaceDirectoryPath);
+        string json = expertConfigurationService.Serialize(Current);
+        File.WriteAllText(Constants.ExpertDeployConfigurationStatePath, json);
+    }
+
+    private void TryMoveInvalidState(string backupPath, Exception originalException)
+    {
+        try
+        {
+            if (File.Exists(backupPath))
+            {
+                File.Delete(backupPath);
+            }
+
+            File.Move(Constants.ExpertDeployConfigurationStatePath, backupPath);
+            logger.Warning(
+                originalException,
+                "Expert Deploy configuration state was invalid and defaults were restored. StatePath={StatePath}, BackupPath={BackupPath}",
+                Constants.ExpertDeployConfigurationStatePath,
+                backupPath);
+        }
+        catch (Exception backupException) when (backupException is IOException or UnauthorizedAccessException)
+        {
+            logger.Error(
+                backupException,
+                "Failed to back up invalid Expert Deploy configuration state. StatePath={StatePath}, BackupPath={BackupPath}, OriginalError={OriginalError}",
+                Constants.ExpertDeployConfigurationStatePath,
+                backupPath,
+                originalException.Message);
+            throw;
+        }
+    }
+}

--- a/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
@@ -1,0 +1,16 @@
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Services.Configuration;
+
+public interface IExpertDeployConfigurationStateService
+{
+    event EventHandler? StateChanged;
+
+    FoundryExpertConfigurationDocument Current { get; }
+
+    bool IsDeployConfigurationReady { get; }
+
+    void UpdateLocalization(LocalizationSettings settings);
+
+    string GenerateDeployConfigurationJson();
+}

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -120,6 +120,21 @@
   <data name="LocalizationPage_Title.Text" xml:space="preserve">
     <value>Localization</value>
   </data>
+  <data name="Localization.VisibleLanguages.Header" xml:space="preserve">
+    <value>Visible deployment languages</value>
+  </data>
+  <data name="Localization.DefaultLanguage.Header" xml:space="preserve">
+    <value>Default deployment language</value>
+  </data>
+  <data name="Localization.TimeZone.Header" xml:space="preserve">
+    <value>Deployment time zone</value>
+  </data>
+  <data name="Localization.ForceSingleVisibleLanguage" xml:space="preserve">
+    <value>Force single visible language</value>
+  </data>
+  <data name="Localization.AutomaticOption" xml:space="preserve">
+    <value>Automatic</value>
+  </data>
   <data name="NetworkPage_Title.Text" xml:space="preserve">
     <value>Network</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -120,6 +120,21 @@
   <data name="LocalizationPage_Title.Text" xml:space="preserve">
     <value>Localisation</value>
   </data>
+  <data name="Localization.VisibleLanguages.Header" xml:space="preserve">
+    <value>Langues de déploiement visibles</value>
+  </data>
+  <data name="Localization.DefaultLanguage.Header" xml:space="preserve">
+    <value>Langue de déploiement par défaut</value>
+  </data>
+  <data name="Localization.TimeZone.Header" xml:space="preserve">
+    <value>Fuseau horaire de déploiement</value>
+  </data>
+  <data name="Localization.ForceSingleVisibleLanguage" xml:space="preserve">
+    <value>Forcer une seule langue visible</value>
+  </data>
+  <data name="Localization.AutomaticOption" xml:space="preserve">
+    <value>Automatique</value>
+  </data>
   <data name="NetworkPage_Title.Text" xml:space="preserve">
     <value>Réseau</value>
   </data>

--- a/src/Foundry/ViewModels/LocalizationConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/LocalizationConfigurationViewModel.cs
@@ -1,0 +1,305 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Configuration;
+using Foundry.Services.Configuration;
+using Foundry.Services.Localization;
+
+namespace Foundry.ViewModels;
+
+public sealed partial class LocalizationConfigurationViewModel : ObservableObject, IDisposable
+{
+    private const string AutomaticSelectionValue = "";
+
+    private readonly IExpertDeployConfigurationStateService configurationStateService;
+    private readonly IApplicationLocalizationService localizationService;
+    private bool isApplyingState = true;
+    private bool isRefreshingOptions;
+    private bool isSavingState;
+
+    public LocalizationConfigurationViewModel(
+        IExpertDeployConfigurationStateService configurationStateService,
+        ILanguageRegistryService languageRegistryService,
+        IApplicationLocalizationService localizationService)
+    {
+        this.configurationStateService = configurationStateService;
+        this.localizationService = localizationService;
+
+        PageTitle = localizationService.GetString("LocalizationPage_Title.Text");
+        VisibleLanguagesHeader = localizationService.GetString("Localization.VisibleLanguages.Header");
+        DefaultLanguageHeader = localizationService.GetString("Localization.DefaultLanguage.Header");
+        TimeZoneHeader = localizationService.GetString("Localization.TimeZone.Header");
+        ForceSingleVisibleLanguageText = localizationService.GetString("Localization.ForceSingleVisibleLanguage");
+        AutomaticOptionText = localizationService.GetString("Localization.AutomaticOption");
+
+        BuildLanguageOptions(languageRegistryService.GetLanguages());
+        RefreshTimeZones();
+        ApplyState(configurationStateService.Current.Localization);
+
+        localizationService.LanguageChanged += OnLanguageChanged;
+        configurationStateService.StateChanged += OnConfigurationStateChanged;
+        isApplyingState = false;
+    }
+
+    public ObservableCollection<LocalizationLanguageOptionViewModel> AvailableLanguages { get; } = [];
+    public ObservableCollection<SelectionOption<string>> DefaultLanguageOptions { get; } = [];
+    public ObservableCollection<SelectionOption<string>> TimeZoneOptions { get; } = [];
+
+    [ObservableProperty]
+    public partial string PageTitle { get; set; }
+
+    [ObservableProperty]
+    public partial string VisibleLanguagesHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string DefaultLanguageHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string TimeZoneHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string ForceSingleVisibleLanguageText { get; set; }
+
+    [ObservableProperty]
+    public partial string AutomaticOptionText { get; set; }
+
+    [ObservableProperty]
+    public partial SelectionOption<string>? SelectedDefaultLanguage { get; set; }
+
+    [ObservableProperty]
+    public partial SelectionOption<string>? SelectedTimeZone { get; set; }
+
+    [ObservableProperty]
+    public partial bool ForceSingleVisibleLanguage { get; set; }
+
+    public void Dispose()
+    {
+        localizationService.LanguageChanged -= OnLanguageChanged;
+        configurationStateService.StateChanged -= OnConfigurationStateChanged;
+        foreach (LocalizationLanguageOptionViewModel option in AvailableLanguages)
+        {
+            option.PropertyChanged -= OnLanguageOptionPropertyChanged;
+        }
+    }
+
+    partial void OnSelectedDefaultLanguageChanged(SelectionOption<string>? value)
+    {
+        SaveState();
+    }
+
+    partial void OnSelectedTimeZoneChanged(SelectionOption<string>? value)
+    {
+        SaveState();
+    }
+
+    partial void OnForceSingleVisibleLanguageChanged(bool value)
+    {
+        SaveState();
+    }
+
+    private void BuildLanguageOptions(IReadOnlyList<LanguageRegistryEntry> languages)
+    {
+        foreach (LanguageRegistryEntry language in languages)
+        {
+            string code = Canonicalize(language.Code);
+            var option = new LocalizationLanguageOptionViewModel(
+                code,
+                $"{language.DisplayName} ({code})",
+                language.SortOrder,
+                false);
+            option.PropertyChanged += OnLanguageOptionPropertyChanged;
+            AvailableLanguages.Add(option);
+        }
+    }
+
+    private void ApplyState(LocalizationSettings settings)
+    {
+        isApplyingState = true;
+
+        HashSet<string> visibleCodes = settings.VisibleLanguageCodes
+            .Select(NormalizeForComparison)
+            .Where(code => code.Length > 0)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (LocalizationLanguageOptionViewModel option in AvailableLanguages)
+        {
+            option.IsSelected = visibleCodes.Contains(NormalizeForComparison(option.Code));
+        }
+
+        ForceSingleVisibleLanguage = settings.ForceSingleVisibleLanguage;
+        RefreshDefaultLanguageOptions(settings.DefaultLanguageCodeOverride);
+        SelectedTimeZone = SelectStringOption(TimeZoneOptions, settings.DefaultTimeZoneId);
+
+        isApplyingState = false;
+    }
+
+    private void SaveState()
+    {
+        if (isApplyingState || isRefreshingOptions)
+        {
+            return;
+        }
+
+        string[] visibleLanguageCodes = AvailableLanguages
+            .Where(option => option.IsSelected)
+            .OrderBy(option => option.SortOrder)
+            .ThenBy(option => option.Code, StringComparer.OrdinalIgnoreCase)
+            .Select(option => Canonicalize(option.Code))
+            .Where(code => !string.IsNullOrWhiteSpace(code))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        string? selectedDefaultLanguage = SelectedDefaultLanguage?.Value;
+        string? defaultLanguageCodeOverride = visibleLanguageCodes.Any(code =>
+            string.Equals(
+                NormalizeForComparison(code),
+                NormalizeForComparison(selectedDefaultLanguage),
+                StringComparison.OrdinalIgnoreCase))
+            ? Canonicalize(selectedDefaultLanguage)
+            : null;
+
+        string? defaultTimeZoneId = string.IsNullOrWhiteSpace(SelectedTimeZone?.Value)
+            ? null
+            : SelectedTimeZone.Value.Trim();
+
+        isSavingState = true;
+        try
+        {
+            configurationStateService.UpdateLocalization(new LocalizationSettings
+            {
+                VisibleLanguageCodes = visibleLanguageCodes,
+                DefaultLanguageCodeOverride = defaultLanguageCodeOverride,
+                DefaultTimeZoneId = defaultTimeZoneId,
+                ForceSingleVisibleLanguage = ForceSingleVisibleLanguage
+            });
+        }
+        finally
+        {
+            isSavingState = false;
+        }
+    }
+
+    private void OnLanguageOptionPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (isApplyingState ||
+            !string.Equals(e.PropertyName, nameof(LocalizationLanguageOptionViewModel.IsSelected), StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        SelectionOption<string>? previousDefault = SelectedDefaultLanguage;
+        RefreshDefaultLanguageOptions(previousDefault?.Value);
+        SaveState();
+    }
+
+    private void RefreshDefaultLanguageOptions(string? preferredDefaultLanguageCode)
+    {
+        string? selectedValue = preferredDefaultLanguageCode;
+
+        isRefreshingOptions = true;
+        try
+        {
+            DefaultLanguageOptions.Clear();
+            DefaultLanguageOptions.Add(new(AutomaticSelectionValue, AutomaticOptionText));
+
+            foreach (LocalizationLanguageOptionViewModel option in AvailableLanguages.Where(option => option.IsSelected))
+            {
+                DefaultLanguageOptions.Add(new(option.Code, option.DisplayName));
+            }
+
+            SelectedDefaultLanguage = SelectLanguageOption(DefaultLanguageOptions, selectedValue) ?? DefaultLanguageOptions[0];
+        }
+        finally
+        {
+            isRefreshingOptions = false;
+        }
+    }
+
+    private void RefreshTimeZones()
+    {
+        string? selectedValue = SelectedTimeZone?.Value;
+
+        isRefreshingOptions = true;
+        try
+        {
+            TimeZoneOptions.Clear();
+            TimeZoneOptions.Add(new(AutomaticSelectionValue, AutomaticOptionText));
+            foreach (TimeZoneInfo timeZone in TimeZoneInfo.GetSystemTimeZones()
+                         .OrderBy(timeZone => timeZone.BaseUtcOffset)
+                         .ThenBy(timeZone => timeZone.DisplayName, StringComparer.CurrentCulture))
+            {
+                TimeZoneOptions.Add(new(timeZone.Id, $"{timeZone.DisplayName} ({timeZone.Id})"));
+            }
+
+            SelectedTimeZone = SelectStringOption(TimeZoneOptions, selectedValue) ?? TimeZoneOptions[0];
+        }
+        finally
+        {
+            isRefreshingOptions = false;
+        }
+    }
+
+    private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
+    {
+        PageTitle = localizationService.GetString("LocalizationPage_Title.Text");
+        VisibleLanguagesHeader = localizationService.GetString("Localization.VisibleLanguages.Header");
+        DefaultLanguageHeader = localizationService.GetString("Localization.DefaultLanguage.Header");
+        TimeZoneHeader = localizationService.GetString("Localization.TimeZone.Header");
+        ForceSingleVisibleLanguageText = localizationService.GetString("Localization.ForceSingleVisibleLanguage");
+        AutomaticOptionText = localizationService.GetString("Localization.AutomaticOption");
+        RefreshDefaultLanguageOptions(SelectedDefaultLanguage?.Value);
+        RefreshTimeZones();
+    }
+
+    private void OnConfigurationStateChanged(object? sender, EventArgs e)
+    {
+        if (isSavingState)
+        {
+            return;
+        }
+
+        ApplyState(configurationStateService.Current.Localization);
+    }
+
+    private static SelectionOption<string>? SelectLanguageOption(IEnumerable<SelectionOption<string>> options, string? value)
+    {
+        return options.FirstOrDefault(option =>
+            string.Equals(
+                NormalizeForComparison(option.Value),
+                NormalizeForComparison(value),
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static SelectionOption<string>? SelectStringOption(IEnumerable<SelectionOption<string>> options, string? value)
+    {
+        return options.FirstOrDefault(option =>
+            string.Equals(option.Value, value?.Trim(), StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string Canonicalize(string? languageCode)
+    {
+        string normalized = string.IsNullOrWhiteSpace(languageCode)
+            ? string.Empty
+            : languageCode.Trim().Replace('_', '-');
+
+        if (normalized.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            return CultureInfo.GetCultureInfo(normalized).Name;
+        }
+        catch (CultureNotFoundException)
+        {
+            return normalized;
+        }
+    }
+
+    private static string NormalizeForComparison(string? languageCode)
+    {
+        return Canonicalize(languageCode).ToLowerInvariant();
+    }
+}

--- a/src/Foundry/ViewModels/LocalizationLanguageOptionViewModel.cs
+++ b/src/Foundry/ViewModels/LocalizationLanguageOptionViewModel.cs
@@ -1,0 +1,19 @@
+namespace Foundry.ViewModels;
+
+public sealed partial class LocalizationLanguageOptionViewModel : ObservableObject
+{
+    public LocalizationLanguageOptionViewModel(string code, string displayName, int sortOrder, bool isSelected)
+    {
+        Code = code;
+        DisplayName = displayName;
+        SortOrder = sortOrder;
+        IsSelected = isSelected;
+    }
+
+    public string Code { get; }
+    public string DisplayName { get; }
+    public int SortOrder { get; }
+
+    [ObservableProperty]
+    public partial bool IsSelected { get; set; }
+}

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -5,6 +5,7 @@ using Foundry.Core.Services.Application;
 using Foundry.Core.Services.Media;
 using Foundry.Core.Services.WinPe;
 using Foundry.Services.Adk;
+using Foundry.Services.Configuration;
 using Foundry.Services.Localization;
 using Foundry.Services.Settings;
 using Serilog;
@@ -17,6 +18,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     private readonly IAdkService adkService;
     private readonly IWinPeLanguageDiscoveryService languageDiscoveryService;
     private readonly IWinPeUsbMediaService usbMediaService;
+    private readonly IExpertDeployConfigurationStateService expertDeployConfigurationStateService;
     private readonly IApplicationLocalizationService localizationService;
     private readonly IAppDispatcher appDispatcher;
     private readonly ILogger logger;
@@ -27,6 +29,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         IAdkService adkService,
         IWinPeLanguageDiscoveryService languageDiscoveryService,
         IWinPeUsbMediaService usbMediaService,
+        IExpertDeployConfigurationStateService expertDeployConfigurationStateService,
         IApplicationLocalizationService localizationService,
         IAppDispatcher appDispatcher,
         ILogger logger)
@@ -35,6 +38,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         this.adkService = adkService;
         this.languageDiscoveryService = languageDiscoveryService;
         this.usbMediaService = usbMediaService;
+        this.expertDeployConfigurationStateService = expertDeployConfigurationStateService;
         this.localizationService = localizationService;
         this.appDispatcher = appDispatcher;
         this.logger = logger.ForContext<StartMediaViewModel>();
@@ -60,6 +64,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         CustomDriverDirectoryPath = appSettingsService.Current.Media.CustomDriverDirectoryPath ?? string.Empty;
 
         adkService.StatusChanged += OnAdkStatusChanged;
+        expertDeployConfigurationStateService.StateChanged += OnExpertDeployConfigurationStateChanged;
         localizationService.LanguageChanged += OnLanguageChanged;
 
         ApplyLocalizedText();
@@ -128,6 +133,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     public void Dispose()
     {
         adkService.StatusChanged -= OnAdkStatusChanged;
+        expertDeployConfigurationStateService.StateChanged -= OnExpertDeployConfigurationStateChanged;
         localizationService.LanguageChanged -= OnLanguageChanged;
     }
 
@@ -212,6 +218,14 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         }
     }
 
+    private void OnExpertDeployConfigurationStateChanged(object? sender, EventArgs e)
+    {
+        if (!appDispatcher.TryEnqueue(RefreshEvaluation))
+        {
+            logger.Warning("Failed to enqueue Start page Expert Deploy configuration refresh.");
+        }
+    }
+
     private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
     {
         if (!appDispatcher.TryEnqueue(() =>
@@ -279,7 +293,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             IsAdkReady = adkService.CurrentStatus.CanCreateMedia,
             IsRuntimePayloadReady = false,
             IsNetworkConfigurationReady = false,
-            IsDeployConfigurationReady = false,
+            IsDeployConfigurationReady = expertDeployConfigurationStateService.IsDeployConfigurationReady,
             IsConnectProvisioningReady = false,
             AreRequiredSecretsReady = false,
             IsFinalExecutionEnabled = false,

--- a/src/Foundry/Views/LocalizationPage.xaml
+++ b/src/Foundry/Views/LocalizationPage.xaml
@@ -1,13 +1,55 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Page x:Class="Foundry.Views.LocalizationPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:dev="using:DevWinUI"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:viewModels="using:Foundry.ViewModels"
+      mc:Ignorable="d">
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
-                Padding="{ThemeResource ContentPagePadding}">
+                Padding="{ThemeResource ContentPagePadding}"
+                VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="10"
-                    Spacing="5">
-            <TextBlock x:Uid="LocalizationPage_Title"
+                    dev:PanelAttach.ChildrenTransitions="Default"
+                    Spacing="8">
+            <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
                        Style="{ThemeResource TitleTextBlockStyle}" />
+
+            <dev:SettingsCard Header="{x:Bind ViewModel.VisibleLanguagesHeader, Mode=OneWay}"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E8AB}">
+                <ListView MaxHeight="360"
+                          ItemsSource="{x:Bind ViewModel.AvailableLanguages, Mode=OneWay}"
+                          SelectionMode="None">
+                    <ListView.ItemTemplate>
+                        <DataTemplate x:DataType="viewModels:LocalizationLanguageOptionViewModel">
+                            <CheckBox Content="{x:Bind DisplayName, Mode=OneWay}"
+                                      IsChecked="{x:Bind IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+            </dev:SettingsCard>
+
+            <dev:SettingsCard Header="{x:Bind ViewModel.DefaultLanguageHeader, Mode=OneWay}"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E774}">
+                <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                          DisplayMemberPath="DisplayName"
+                          ItemsSource="{x:Bind ViewModel.DefaultLanguageOptions, Mode=OneWay}"
+                          SelectedItem="{x:Bind ViewModel.SelectedDefaultLanguage, Mode=TwoWay}" />
+            </dev:SettingsCard>
+
+            <dev:SettingsCard Header="{x:Bind ViewModel.TimeZoneHeader, Mode=OneWay}"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E916}">
+                <ComboBox MinWidth="420"
+                          DisplayMemberPath="DisplayName"
+                          ItemsSource="{x:Bind ViewModel.TimeZoneOptions, Mode=OneWay}"
+                          SelectedItem="{x:Bind ViewModel.SelectedTimeZone, Mode=TwoWay}" />
+            </dev:SettingsCard>
+
+            <dev:SettingsCard Header="{x:Bind ViewModel.ForceSingleVisibleLanguageText, Mode=OneWay}"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E8FB}">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.ForceSingleVisibleLanguage, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            </dev:SettingsCard>
         </StackPanel>
     </ScrollView>
 </Page>

--- a/src/Foundry/Views/LocalizationPage.xaml.cs
+++ b/src/Foundry/Views/LocalizationPage.xaml.cs
@@ -2,8 +2,18 @@ namespace Foundry.Views;
 
 public sealed partial class LocalizationPage : Page
 {
+    public LocalizationConfigurationViewModel ViewModel { get; }
+
     public LocalizationPage()
     {
+        ViewModel = App.GetService<LocalizationConfigurationViewModel>();
         InitializeComponent();
+        Unloaded += OnUnloaded;
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        Unloaded -= OnUnloaded;
+        ViewModel.Dispose();
     }
 }


### PR DESCRIPTION
## Summary

Ports Phase 14 Expert Deploy configuration workflow without user-facing config import/export.

## Reason

Phase 14 needs durable Expert Deploy state, generated runtime Deploy configuration, and real Deploy readiness before Connect/network provisioning work starts.

## Main changes

- Adds internal Expert Deploy configuration state persistence under ProgramData workflow state.
- Adds WinUI Localization Expert page bindings for visible deployment languages, default deployment language, deployment timezone, and single-language mode.
- Wires Start page Deploy readiness to generated Deploy config readiness while leaving final ISO/USB execution blocked.
- Adds `localization.defaultTimeZoneId` support to `Foundry.Deploy` and applies it to offline Windows unattend timezone configuration.
- Updates Phase 14 checklist status.

## Testing notes

- `dotnet test .\src\Foundry.Core.Tests\Foundry.Core.Tests.csproj -c Release --nologo` passed: 139 tests.
- `dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj -c Release --nologo` passed: 48 tests.
- `dotnet test .\src\Foundry.Connect.Tests\Foundry.Connect.Tests.csproj -c Release --nologo` passed: 15 tests.
- `dotnet build .\src\Foundry.slnx -c Release --nologo` passed with 0 warnings and 0 errors.
- Search confirmed no live user-facing configuration import/export symbols outside archive.