### PR TITLE
feat(network): add expert network configuration state

### DIFF
--- a/src/Foundry.Core.Tests/Configuration/NetworkConfigurationValidatorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/NetworkConfigurationValidatorTests.cs
@@ -1,0 +1,119 @@
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Configuration;
+
+namespace Foundry.Core.Tests.Configuration;
+
+public sealed class NetworkConfigurationValidatorTests
+{
+    [Fact]
+    public void Validate_WhenPersonalWifiPassphraseIsTooShort_ReturnsPassphraseInvalid()
+    {
+        NetworkConfigurationValidationResult result = NetworkConfigurationValidator.Validate(
+            new NetworkSettings
+            {
+                WifiProvisioned = true,
+                Wifi = new WifiSettings
+                {
+                    IsEnabled = true,
+                    Ssid = "CorpWiFi",
+                    SecurityType = NetworkConfigurationValidator.WifiSecurityPersonal,
+                    Passphrase = "short"
+                }
+            });
+
+        Assert.Equal(NetworkConfigurationValidationCode.WifiPersonalPassphraseInvalid, result.Code);
+    }
+
+    [Fact]
+    public void Validate_WhenWpa3EnterpriseTemplateAuthenticationDoesNotMatch_ReturnsMismatch()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        string profilePath = Path.Combine(tempDirectory.Path, "wifi.xml");
+        File.WriteAllText(
+            profilePath,
+            """
+            <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
+              <MSM>
+                <security>
+                  <authEncryption>
+                    <authentication>WPA3ENT</authentication>
+                  </authEncryption>
+                </security>
+              </MSM>
+            </WLANProfile>
+            """);
+
+        NetworkConfigurationValidationResult result = NetworkConfigurationValidator.Validate(
+            new NetworkSettings
+            {
+                WifiProvisioned = true,
+                Wifi = new WifiSettings
+                {
+                    IsEnabled = true,
+                    Ssid = "CorpWiFi",
+                    SecurityType = NetworkConfigurationValidator.WifiSecurityEnterpriseWpa3192,
+                    HasEnterpriseProfile = true,
+                    EnterpriseProfileTemplatePath = profilePath
+                }
+            });
+
+        Assert.Equal(NetworkConfigurationValidationCode.WifiEnterpriseAuthenticationMismatch, result.Code);
+        Assert.Equal(NetworkConfigurationValidator.WifiSecurityEnterpriseWpa3, result.FormatArguments.Single());
+    }
+
+    [Fact]
+    public void Validate_WhenWiredCertificateIsRequiredWithoutPath_ReturnsWiredCertificateRequired()
+    {
+        NetworkConfigurationValidationResult result = NetworkConfigurationValidator.Validate(
+            new NetworkSettings
+            {
+                Dot1x = new Dot1xSettings
+                {
+                    IsEnabled = true,
+                    ProfileTemplatePath = "wired.xml",
+                    RequiresCertificate = true
+                }
+            });
+
+        Assert.Equal(NetworkConfigurationValidationCode.WiredCertificateRequired, result.Code);
+    }
+
+    [Fact]
+    public void SanitizeForPersistence_RemovesPlaintextWifiPassphrase()
+    {
+        NetworkSettings settings = new()
+        {
+            WifiProvisioned = true,
+            Wifi = new WifiSettings
+            {
+                IsEnabled = true,
+                Ssid = "CorpWiFi",
+                SecurityType = NetworkConfigurationValidator.WifiSecurityPersonal,
+                Passphrase = "supersecret"
+            }
+        };
+
+        NetworkSettings sanitized = NetworkConfigurationValidator.SanitizeForPersistence(settings);
+
+        Assert.Null(sanitized.Wifi.Passphrase);
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "Foundry.Core.Tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}

--- a/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidationCode.cs
+++ b/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidationCode.cs
@@ -1,0 +1,17 @@
+namespace Foundry.Core.Services.Configuration;
+
+public enum NetworkConfigurationValidationCode
+{
+    None,
+    WifiProvisioningRequired,
+    WiredProfileTemplateRequired,
+    WiredCertificateRequired,
+    WifiSsidRequired,
+    UnsupportedWifiSecurityType,
+    WifiPersonalPassphraseInvalid,
+    WifiEnterpriseProfileTemplateRequired,
+    WifiEnterpriseProfileTemplateMissing,
+    WifiEnterpriseAuthenticationUnsupported,
+    WifiEnterpriseAuthenticationMismatch,
+    WifiEnterpriseCertificateRequired
+}

--- a/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidationResult.cs
+++ b/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidationResult.cs
@@ -1,0 +1,17 @@
+namespace Foundry.Core.Services.Configuration;
+
+public sealed record NetworkConfigurationValidationResult(
+    NetworkConfigurationValidationCode Code,
+    IReadOnlyList<string> FormatArguments)
+{
+    public static NetworkConfigurationValidationResult Success { get; } = new(NetworkConfigurationValidationCode.None, []);
+
+    public bool IsValid => Code == NetworkConfigurationValidationCode.None;
+
+    public static NetworkConfigurationValidationResult Failure(
+        NetworkConfigurationValidationCode code,
+        params string[] formatArguments)
+    {
+        return new NetworkConfigurationValidationResult(code, formatArguments);
+    }
+}

--- a/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidator.cs
+++ b/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidator.cs
@@ -1,0 +1,246 @@
+using System.Xml.Linq;
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Core.Services.Configuration;
+
+public static class NetworkConfigurationValidator
+{
+    public const string WifiSecurityOpen = "Open";
+    public const string WifiSecurityOwe = "OWE";
+    public const string WifiSecurityPersonal = "WPA2/WPA3-Personal";
+    public const string WifiSecurityEnterprise = "WPA2/WPA3-Enterprise";
+    public const string WifiSecurityEnterpriseWpa3 = "WPA3ENT";
+    public const string WifiSecurityEnterpriseWpa3192 = "WPA3ENT192";
+
+    private static readonly string[] LegacyWifiSecurityPersonalValues = ["WPA2-Personal", "WPA3-Personal", "Personal"];
+    private static readonly string[] LegacyWifiSecurityEnterpriseValues = ["WPA2-Enterprise", "WPA3-Enterprise", "WPA3", "Enterprise"];
+
+    public static NetworkConfigurationValidationResult Validate(NetworkSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        if (settings.Wifi.IsEnabled && !settings.WifiProvisioned)
+        {
+            return NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WifiProvisioningRequired);
+        }
+
+        NetworkConfigurationValidationResult dot1xResult = ValidateDot1x(settings.Dot1x);
+        if (!dot1xResult.IsValid)
+        {
+            return dot1xResult;
+        }
+
+        return ValidateWifi(settings.WifiProvisioned, settings.Wifi);
+    }
+
+    public static NetworkSettings SanitizeForPersistence(NetworkSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        return settings with
+        {
+            Wifi = settings.Wifi with
+            {
+                Passphrase = null
+            }
+        };
+    }
+
+    public static string NormalizeWifiSecurityType(WifiSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        if (string.Equals(settings.SecurityType, WifiSecurityOpen, StringComparison.OrdinalIgnoreCase))
+        {
+            return WifiSecurityOpen;
+        }
+
+        if (string.Equals(settings.SecurityType, WifiSecurityOwe, StringComparison.OrdinalIgnoreCase))
+        {
+            return WifiSecurityOwe;
+        }
+
+        if (string.Equals(settings.SecurityType, WifiSecurityPersonal, StringComparison.OrdinalIgnoreCase) ||
+            LegacyWifiSecurityPersonalValues.Any(value => string.Equals(settings.SecurityType, value, StringComparison.OrdinalIgnoreCase)))
+        {
+            return WifiSecurityPersonal;
+        }
+
+        string? enterpriseSecurityType = NormalizeEnterpriseSecurityType(settings.SecurityType);
+        if (enterpriseSecurityType is not null || settings.HasEnterpriseProfile)
+        {
+            return enterpriseSecurityType ?? WifiSecurityEnterprise;
+        }
+
+        return !string.IsNullOrWhiteSpace(settings.Passphrase)
+            ? WifiSecurityPersonal
+            : WifiSecurityOpen;
+    }
+
+    public static bool IsEnterpriseSecurityType(string? securityType)
+    {
+        return NormalizeEnterpriseSecurityType(securityType) is not null;
+    }
+
+    public static string? NormalizeEnterpriseSecurityType(string? securityType)
+    {
+        if (string.IsNullOrWhiteSpace(securityType))
+        {
+            return null;
+        }
+
+        if (string.Equals(securityType, WifiSecurityEnterprise, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(securityType, "WPA2-Enterprise", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(securityType, "Enterprise", StringComparison.OrdinalIgnoreCase))
+        {
+            return WifiSecurityEnterprise;
+        }
+
+        if (string.Equals(securityType, WifiSecurityEnterpriseWpa3, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(securityType, "WPA3-Enterprise", StringComparison.OrdinalIgnoreCase))
+        {
+            return WifiSecurityEnterpriseWpa3;
+        }
+
+        if (string.Equals(securityType, WifiSecurityEnterpriseWpa3192, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(securityType, "WPA3", StringComparison.OrdinalIgnoreCase))
+        {
+            return WifiSecurityEnterpriseWpa3192;
+        }
+
+        return LegacyWifiSecurityEnterpriseValues.Any(value => string.Equals(securityType, value, StringComparison.OrdinalIgnoreCase))
+            ? WifiSecurityEnterprise
+            : null;
+    }
+
+    private static NetworkConfigurationValidationResult ValidateDot1x(Dot1xSettings settings)
+    {
+        if (!settings.IsEnabled)
+        {
+            return NetworkConfigurationValidationResult.Success;
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.ProfileTemplatePath))
+        {
+            return NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WiredProfileTemplateRequired);
+        }
+
+        if (settings.RequiresCertificate && string.IsNullOrWhiteSpace(settings.CertificatePath))
+        {
+            return NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WiredCertificateRequired);
+        }
+
+        return NetworkConfigurationValidationResult.Success;
+    }
+
+    private static NetworkConfigurationValidationResult ValidateWifi(bool wifiProvisioned, WifiSettings settings)
+    {
+        if (!settings.IsEnabled)
+        {
+            return NetworkConfigurationValidationResult.Success;
+        }
+
+        if (!wifiProvisioned)
+        {
+            return NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WifiProvisioningRequired);
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.Ssid))
+        {
+            return NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WifiSsidRequired);
+        }
+
+        bool isOpen = string.Equals(settings.SecurityType, WifiSecurityOpen, StringComparison.OrdinalIgnoreCase);
+        bool isOwe = string.Equals(settings.SecurityType, WifiSecurityOwe, StringComparison.OrdinalIgnoreCase);
+        bool isPersonal = IsPersonalSecurityType(settings.SecurityType);
+        string? enterpriseSecurityType = NormalizeEnterpriseSecurityType(settings.SecurityType);
+        bool isEnterprise = settings.HasEnterpriseProfile || enterpriseSecurityType is not null;
+
+        if (!isOpen && !isOwe && !isPersonal && !isEnterprise)
+        {
+            return NetworkConfigurationValidationResult.Failure(
+                NetworkConfigurationValidationCode.UnsupportedWifiSecurityType,
+                settings.SecurityType ?? string.Empty);
+        }
+
+        if (isPersonal)
+        {
+            int passphraseLength = settings.Passphrase?.Trim().Length ?? 0;
+            if (passphraseLength is < 8 or > 63)
+            {
+                return NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WifiPersonalPassphraseInvalid);
+            }
+        }
+
+        return isEnterprise
+            ? ValidateEnterpriseWifi(settings, enterpriseSecurityType)
+            : NetworkConfigurationValidationResult.Success;
+    }
+
+    private static NetworkConfigurationValidationResult ValidateEnterpriseWifi(
+        WifiSettings settings,
+        string? enterpriseSecurityType)
+    {
+        if (string.IsNullOrWhiteSpace(settings.EnterpriseProfileTemplatePath))
+        {
+            return NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WifiEnterpriseProfileTemplateRequired);
+        }
+
+        string fullTemplatePath = Path.GetFullPath(settings.EnterpriseProfileTemplatePath);
+        if (!File.Exists(fullTemplatePath))
+        {
+            return NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WifiEnterpriseProfileTemplateMissing);
+        }
+
+        if (RequiresExplicitEnterpriseTemplateAuthentication(enterpriseSecurityType))
+        {
+            string? templateSecurityType = TryReadEnterpriseTemplateSecurityType(fullTemplatePath);
+            if (templateSecurityType is null)
+            {
+                return NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WifiEnterpriseAuthenticationUnsupported);
+            }
+
+            if (!string.Equals(templateSecurityType, enterpriseSecurityType, StringComparison.OrdinalIgnoreCase))
+            {
+                return NetworkConfigurationValidationResult.Failure(
+                    NetworkConfigurationValidationCode.WifiEnterpriseAuthenticationMismatch,
+                    templateSecurityType);
+            }
+        }
+
+        return settings.RequiresCertificate && string.IsNullOrWhiteSpace(settings.CertificatePath)
+            ? NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WifiEnterpriseCertificateRequired)
+            : NetworkConfigurationValidationResult.Success;
+    }
+
+    private static bool IsPersonalSecurityType(string? securityType)
+    {
+        return string.Equals(securityType, WifiSecurityPersonal, StringComparison.OrdinalIgnoreCase) ||
+               LegacyWifiSecurityPersonalValues.Any(value => string.Equals(securityType, value, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool RequiresExplicitEnterpriseTemplateAuthentication(string? securityType)
+    {
+        return string.Equals(securityType, WifiSecurityEnterpriseWpa3, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(securityType, WifiSecurityEnterpriseWpa3192, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? TryReadEnterpriseTemplateSecurityType(string profileTemplatePath)
+    {
+        try
+        {
+            XDocument document = XDocument.Load(Path.GetFullPath(profileTemplatePath));
+            XNamespace wlanProfile = "http://www.microsoft.com/networking/WLAN/profile/v1";
+            string? authentication = document
+                .Descendants(wlanProfile + "authentication")
+                .Select(static element => element.Value?.Trim())
+                .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
+
+            return NormalizeEnterpriseSecurityType(authentication);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -51,6 +51,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ContextMenuService>();
         services.AddTransient<GeneralConfigurationViewModel>();
         services.AddTransient<LocalizationConfigurationViewModel>();
+        services.AddTransient<NetworkConfigurationViewModel>();
         services.AddTransient<StartMediaViewModel>();
         services.AddTransient<GeneralSettingViewModel>();
         services.AddTransient<AdkPageViewModel>();

--- a/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
@@ -51,6 +51,14 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 
+    public void UpdateNetwork(NetworkSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        Current = Current with { Network = settings };
+        Save();
+        StateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
     public string GenerateDeployConfigurationJson()
     {
         return deployConfigurationGenerator.Serialize(deployConfigurationGenerator.Generate(Current));
@@ -78,6 +86,7 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
 
     private void Save()
     {
+        Current = Current with { Network = NetworkConfigurationValidator.SanitizeForPersistence(Current.Network) };
         Directory.CreateDirectory(Constants.ConfigurationWorkspaceDirectoryPath);
         string json = expertConfigurationService.Serialize(Current);
         File.WriteAllText(Constants.ExpertDeployConfigurationStatePath, json);

--- a/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
@@ -10,6 +10,8 @@ public interface IExpertDeployConfigurationStateService
 
     bool IsDeployConfigurationReady { get; }
 
+    void UpdateNetwork(NetworkSettings settings);
+
     void UpdateLocalization(LocalizationSettings settings);
 
     string GenerateDeployConfigurationJson();

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -138,6 +138,120 @@
   <data name="NetworkPage_Title.Text" xml:space="preserve">
     <value>Network</value>
   </data>
+  <data name="Dot1x.EnableLabel" xml:space="preserve">
+    <value>Configure wired 802.1X</value>
+  </data>
+  <data name="Dot1x.CertificateLabel" xml:space="preserve">
+    <value>Trusted root CA certificate file</value>
+  </data>
+  <data name="Dot1x.CertificatePickerTitle" xml:space="preserve">
+    <value>Select 802.1X certificate</value>
+  </data>
+  <data name="Wifi.EnableLabel" xml:space="preserve">
+    <value>Provision Wi-Fi support in the boot image</value>
+  </data>
+  <data name="Wifi.ConfigureLabel" xml:space="preserve">
+    <value>Pre-provision a Wi-Fi profile</value>
+  </data>
+  <data name="Wifi.SsidLabel" xml:space="preserve">
+    <value>SSID</value>
+  </data>
+  <data name="Wifi.SecurityTypeLabel" xml:space="preserve">
+    <value>Security type</value>
+  </data>
+  <data name="Wifi.PassphraseLabel" xml:space="preserve">
+    <value>Passphrase</value>
+  </data>
+  <data name="Wifi.SecurityTypeOpen" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="Wifi.SecurityTypeOwe" xml:space="preserve">
+    <value>OWE (Opportunistic Wireless Encryption)</value>
+  </data>
+  <data name="Wifi.SecurityTypePersonal" xml:space="preserve">
+    <value>WPA2/WPA3 Personal</value>
+  </data>
+  <data name="Wifi.SecurityTypeEnterprise" xml:space="preserve">
+    <value>WPA2/WPA3 Enterprise</value>
+  </data>
+  <data name="Wifi.SecurityTypeEnterpriseWpa3" xml:space="preserve">
+    <value>WPA3 Enterprise (WPA3ENT)</value>
+  </data>
+  <data name="Wifi.SecurityTypeEnterpriseWpa3192" xml:space="preserve">
+    <value>WPA3 Enterprise 192-bit (WPA3ENT192)</value>
+  </data>
+  <data name="Network.EthernetSectionTitle" xml:space="preserve">
+    <value>Ethernet</value>
+  </data>
+  <data name="Network.EthernetHelperText" xml:space="preserve">
+    <value>Standard Ethernet connectivity is available by default. Configure this section only if your wired network requires 802.1X enterprise authentication.</value>
+  </data>
+  <data name="Network.WifiSectionTitle" xml:space="preserve">
+    <value>Wi-Fi</value>
+  </data>
+  <data name="Network.WifiHelperText" xml:space="preserve">
+    <value>Enable this only if the boot image should include Wi-Fi support and Wi-Fi profiles for WinPE startup.</value>
+  </data>
+  <data name="Network.WifiPersonalHelperText" xml:space="preserve">
+    <value>Personal Wi-Fi passphrases remain transient in the authoring app and are not persisted in expert configuration.</value>
+  </data>
+  <data name="Network.EnterpriseTemplateDrivenHelperText" xml:space="preserve">
+    <value>Enterprise behavior is driven by the profile template in this build. Runtime-entered 802.1X credentials are not provisioned here.</value>
+  </data>
+  <data name="Network.WifiEnterpriseAdvancedHeader" xml:space="preserve">
+    <value>Advanced enterprise Wi-Fi</value>
+  </data>
+  <data name="Network.WifiEnterpriseTemplateLabel" xml:space="preserve">
+    <value>Provision an enterprise Wi-Fi profile template</value>
+  </data>
+  <data name="Network.ProfileTemplateLabel" xml:space="preserve">
+    <value>Profile template file</value>
+  </data>
+  <data name="Network.ProfileTemplatePickerTitle" xml:space="preserve">
+    <value>Select a network profile template</value>
+  </data>
+  <data name="Network.RequiresCertificateLabel" xml:space="preserve">
+    <value>Import a trusted root CA certificate</value>
+  </data>
+  <data name="Wifi.CertificateLabel" xml:space="preserve">
+    <value>Trusted root CA certificate file</value>
+  </data>
+  <data name="Wifi.CertificatePickerTitle" xml:space="preserve">
+    <value>Select the Wi-Fi certificate</value>
+  </data>
+  <data name="Network.ErrorWifiProvisioningRequired" xml:space="preserve">
+    <value>Wi-Fi configuration requires Wi-Fi support to be provisioned in the boot image.</value>
+  </data>
+  <data name="Network.ErrorWiredProfileTemplateRequired" xml:space="preserve">
+    <value>Wired 802.1X requires a wired profile template.</value>
+  </data>
+  <data name="Network.ErrorWiredCertificateRequired" xml:space="preserve">
+    <value>Wired 802.1X requires a trusted root CA certificate file when certificate trust is enabled.</value>
+  </data>
+  <data name="Network.ErrorWifiSsidRequired" xml:space="preserve">
+    <value>Wi-Fi configuration requires an SSID.</value>
+  </data>
+  <data name="Network.ErrorUnsupportedWifiSecurityTypeFormat" xml:space="preserve">
+    <value>Unsupported Wi-Fi security type '{0}'.</value>
+  </data>
+  <data name="Network.ErrorWifiPersonalPassphraseInvalid" xml:space="preserve">
+    <value>Personal Wi-Fi requires an 8 to 63 character passphrase.</value>
+  </data>
+  <data name="Network.ErrorWifiEnterpriseProfileTemplateRequired" xml:space="preserve">
+    <value>Enterprise Wi-Fi requires a profile template.</value>
+  </data>
+  <data name="Network.ErrorWifiEnterpriseProfileTemplateMissing" xml:space="preserve">
+    <value>Enterprise Wi-Fi profile template file was not found.</value>
+  </data>
+  <data name="Network.ErrorWifiEnterpriseAuthenticationUnsupported" xml:space="preserve">
+    <value>Enterprise Wi-Fi profile template must contain a supported enterprise authentication value.</value>
+  </data>
+  <data name="Network.ErrorWifiEnterpriseAuthenticationMismatchFormat" xml:space="preserve">
+    <value>Selected enterprise Wi-Fi security type does not match the profile template authentication ({0}).</value>
+  </data>
+  <data name="Network.ErrorWifiEnterpriseCertificateRequired" xml:space="preserve">
+    <value>Enterprise Wi-Fi requires a trusted root CA certificate file when certificate trust is enabled.</value>
+  </data>
   <data name="Shell.OperationRunning" xml:space="preserve">
     <value>Operation in progress</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -138,6 +138,120 @@
   <data name="NetworkPage_Title.Text" xml:space="preserve">
     <value>Réseau</value>
   </data>
+  <data name="Dot1x.EnableLabel" xml:space="preserve">
+    <value>Configurer le 802.1X filaire</value>
+  </data>
+  <data name="Dot1x.CertificateLabel" xml:space="preserve">
+    <value>Fichier de certificat d'autorité racine de confiance</value>
+  </data>
+  <data name="Dot1x.CertificatePickerTitle" xml:space="preserve">
+    <value>Sélectionner le certificat 802.1X</value>
+  </data>
+  <data name="Wifi.EnableLabel" xml:space="preserve">
+    <value>Provisionner la prise en charge Wi-Fi dans l'image de boot</value>
+  </data>
+  <data name="Wifi.ConfigureLabel" xml:space="preserve">
+    <value>Préprovisionner un profil Wi-Fi</value>
+  </data>
+  <data name="Wifi.SsidLabel" xml:space="preserve">
+    <value>SSID</value>
+  </data>
+  <data name="Wifi.SecurityTypeLabel" xml:space="preserve">
+    <value>Type de sécurité</value>
+  </data>
+  <data name="Wifi.PassphraseLabel" xml:space="preserve">
+    <value>Phrase secrète</value>
+  </data>
+  <data name="Wifi.SecurityTypeOpen" xml:space="preserve">
+    <value>Ouvert</value>
+  </data>
+  <data name="Wifi.SecurityTypeOwe" xml:space="preserve">
+    <value>OWE (chiffrement sans fil opportuniste)</value>
+  </data>
+  <data name="Wifi.SecurityTypePersonal" xml:space="preserve">
+    <value>WPA2/WPA3 personnel</value>
+  </data>
+  <data name="Wifi.SecurityTypeEnterprise" xml:space="preserve">
+    <value>WPA2/WPA3 entreprise</value>
+  </data>
+  <data name="Wifi.SecurityTypeEnterpriseWpa3" xml:space="preserve">
+    <value>WPA3 entreprise (WPA3ENT)</value>
+  </data>
+  <data name="Wifi.SecurityTypeEnterpriseWpa3192" xml:space="preserve">
+    <value>WPA3 entreprise 192 bits (WPA3ENT192)</value>
+  </data>
+  <data name="Network.EthernetSectionTitle" xml:space="preserve">
+    <value>Ethernet</value>
+  </data>
+  <data name="Network.EthernetHelperText" xml:space="preserve">
+    <value>La connectivité Ethernet standard est disponible par défaut. Configurez cette section uniquement si votre réseau filaire nécessite une authentification 802.1X.</value>
+  </data>
+  <data name="Network.WifiSectionTitle" xml:space="preserve">
+    <value>Wi-Fi</value>
+  </data>
+  <data name="Network.WifiHelperText" xml:space="preserve">
+    <value>Activez ceci uniquement si l'image de boot doit inclure la prise en charge Wi-Fi et des profils Wi-Fi pour le démarrage WinPE.</value>
+  </data>
+  <data name="Network.WifiPersonalHelperText" xml:space="preserve">
+    <value>Les phrases secrètes Wi-Fi personnelles restent transitoires dans l'application et ne sont pas persistées dans la configuration experte.</value>
+  </data>
+  <data name="Network.EnterpriseTemplateDrivenHelperText" xml:space="preserve">
+    <value>Le comportement entreprise est piloté par le modèle de profil inclus dans cette version. Les informations d'identification 802.1X saisies à l'exécution ne sont pas provisionnées ici.</value>
+  </data>
+  <data name="Network.WifiEnterpriseAdvancedHeader" xml:space="preserve">
+    <value>Wi-Fi entreprise avancé</value>
+  </data>
+  <data name="Network.WifiEnterpriseTemplateLabel" xml:space="preserve">
+    <value>Provisionner un modèle de profil Wi-Fi entreprise</value>
+  </data>
+  <data name="Network.ProfileTemplateLabel" xml:space="preserve">
+    <value>Fichier modèle de profil</value>
+  </data>
+  <data name="Network.ProfileTemplatePickerTitle" xml:space="preserve">
+    <value>Sélectionner un modèle de profil réseau</value>
+  </data>
+  <data name="Network.RequiresCertificateLabel" xml:space="preserve">
+    <value>Importer un certificat d'autorité racine de confiance</value>
+  </data>
+  <data name="Wifi.CertificateLabel" xml:space="preserve">
+    <value>Fichier de certificat d'autorité racine de confiance</value>
+  </data>
+  <data name="Wifi.CertificatePickerTitle" xml:space="preserve">
+    <value>Sélectionner le certificat Wi-Fi</value>
+  </data>
+  <data name="Network.ErrorWifiProvisioningRequired" xml:space="preserve">
+    <value>La configuration Wi-Fi nécessite que la prise en charge Wi-Fi soit provisionnée dans l'image de démarrage.</value>
+  </data>
+  <data name="Network.ErrorWiredProfileTemplateRequired" xml:space="preserve">
+    <value>Le 802.1X filaire nécessite un modèle de profil filaire.</value>
+  </data>
+  <data name="Network.ErrorWiredCertificateRequired" xml:space="preserve">
+    <value>Le 802.1X filaire nécessite un certificat d'autorité racine de confiance lorsque la confiance par certificat est activée.</value>
+  </data>
+  <data name="Network.ErrorWifiSsidRequired" xml:space="preserve">
+    <value>La configuration Wi-Fi nécessite un SSID.</value>
+  </data>
+  <data name="Network.ErrorUnsupportedWifiSecurityTypeFormat" xml:space="preserve">
+    <value>Type de sécurité Wi-Fi non pris en charge : '{0}'.</value>
+  </data>
+  <data name="Network.ErrorWifiPersonalPassphraseInvalid" xml:space="preserve">
+    <value>Le Wi-Fi personnel nécessite une phrase secrète de 8 à 63 caractères.</value>
+  </data>
+  <data name="Network.ErrorWifiEnterpriseProfileTemplateRequired" xml:space="preserve">
+    <value>Le Wi-Fi d'entreprise nécessite un modèle de profil.</value>
+  </data>
+  <data name="Network.ErrorWifiEnterpriseProfileTemplateMissing" xml:space="preserve">
+    <value>Le fichier du modèle de profil Wi-Fi d'entreprise est introuvable.</value>
+  </data>
+  <data name="Network.ErrorWifiEnterpriseAuthenticationUnsupported" xml:space="preserve">
+    <value>Le modèle de profil Wi-Fi d'entreprise doit contenir une valeur d'authentification d'entreprise prise en charge.</value>
+  </data>
+  <data name="Network.ErrorWifiEnterpriseAuthenticationMismatchFormat" xml:space="preserve">
+    <value>Le type de sécurité Wi-Fi d'entreprise sélectionné ne correspond pas à l'authentification du modèle de profil ({0}).</value>
+  </data>
+  <data name="Network.ErrorWifiEnterpriseCertificateRequired" xml:space="preserve">
+    <value>Le Wi-Fi d'entreprise nécessite un certificat d'autorité racine de confiance lorsque la confiance par certificat est activée.</value>
+  </data>
   <data name="Shell.OperationRunning" xml:space="preserve">
     <value>Opération en cours</value>
   </data>

--- a/src/Foundry/ViewModels/NetworkConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/NetworkConfigurationViewModel.cs
@@ -1,0 +1,601 @@
+using System.Collections.ObjectModel;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Application;
+using Foundry.Core.Services.Configuration;
+using Foundry.Services.Configuration;
+using Foundry.Services.Localization;
+using Microsoft.UI.Xaml;
+
+namespace Foundry.ViewModels;
+
+public sealed partial class NetworkConfigurationViewModel : ObservableObject, IDisposable
+{
+    private readonly IExpertDeployConfigurationStateService configurationStateService;
+    private readonly IFilePickerService filePickerService;
+    private readonly IApplicationLocalizationService localizationService;
+    private bool isApplyingState = true;
+    private bool isSavingState;
+
+    public NetworkConfigurationViewModel(
+        IExpertDeployConfigurationStateService configurationStateService,
+        IFilePickerService filePickerService,
+        IApplicationLocalizationService localizationService)
+    {
+        this.configurationStateService = configurationStateService;
+        this.filePickerService = filePickerService;
+        this.localizationService = localizationService;
+
+        RefreshLocalizedText();
+        RefreshWifiSecurityTypes();
+        ApplyState(configurationStateService.Current.Network);
+
+        localizationService.LanguageChanged += OnLanguageChanged;
+        configurationStateService.StateChanged += OnConfigurationStateChanged;
+        isApplyingState = false;
+    }
+
+    public ObservableCollection<SelectionOption<string>> WifiSecurityTypes { get; } = [];
+
+    [ObservableProperty]
+    public partial string PageTitle { get; set; }
+
+    [ObservableProperty]
+    public partial string EthernetHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string EthernetDescription { get; set; }
+
+    [ObservableProperty]
+    public partial string Dot1xEnableText { get; set; }
+
+    [ObservableProperty]
+    public partial string ProfileTemplateLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string Dot1xCertificateLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string RequiresCertificateText { get; set; }
+
+    [ObservableProperty]
+    public partial string WifiHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string WifiDescription { get; set; }
+
+    [ObservableProperty]
+    public partial string WifiProvisionedText { get; set; }
+
+    [ObservableProperty]
+    public partial string WifiConfiguredText { get; set; }
+
+    [ObservableProperty]
+    public partial string WifiSsidLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string WifiSecurityTypeLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string WifiPassphraseLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string WifiPersonalDescription { get; set; }
+
+    [ObservableProperty]
+    public partial string WifiEnterpriseHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string WifiEnterpriseDescription { get; set; }
+
+    [ObservableProperty]
+    public partial string WifiEnterpriseTemplateText { get; set; }
+
+    [ObservableProperty]
+    public partial string WifiCertificateLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string BrowseButtonText { get; set; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsDot1xSectionEnabled))]
+    [NotifyPropertyChangedFor(nameof(IsDot1xCertificatePathEnabled))]
+    [NotifyPropertyChangedFor(nameof(Dot1xValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasDot1xValidationError))]
+    [NotifyPropertyChangedFor(nameof(Dot1xValidationVisibility))]
+    [NotifyPropertyChangedFor(nameof(ValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasValidationError))]
+    public partial bool IsDot1xEnabled { get; set; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Dot1xValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasDot1xValidationError))]
+    [NotifyPropertyChangedFor(nameof(Dot1xValidationVisibility))]
+    [NotifyPropertyChangedFor(nameof(ValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasValidationError))]
+    public partial string Dot1xProfileTemplatePath { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsDot1xCertificatePathEnabled))]
+    [NotifyPropertyChangedFor(nameof(Dot1xValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasDot1xValidationError))]
+    [NotifyPropertyChangedFor(nameof(Dot1xValidationVisibility))]
+    [NotifyPropertyChangedFor(nameof(ValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasValidationError))]
+    public partial bool IsDot1xCertificateRequired { get; set; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Dot1xValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasDot1xValidationError))]
+    [NotifyPropertyChangedFor(nameof(Dot1xValidationVisibility))]
+    [NotifyPropertyChangedFor(nameof(ValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasValidationError))]
+    public partial string Dot1xCertificatePath { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsWifiConfigurationSectionEnabled))]
+    [NotifyPropertyChangedFor(nameof(IsWifiSecuritySelectionEnabled))]
+    [NotifyPropertyChangedFor(nameof(IsWifiPersonalSectionEnabled))]
+    [NotifyPropertyChangedFor(nameof(IsWifiEnterpriseSectionEnabled))]
+    [NotifyPropertyChangedFor(nameof(IsWifiCertificatePathEnabled))]
+    [NotifyPropertyChangedFor(nameof(WifiValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasWifiValidationError))]
+    [NotifyPropertyChangedFor(nameof(WifiValidationVisibility))]
+    [NotifyPropertyChangedFor(nameof(ValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasValidationError))]
+    public partial bool IsWifiProvisioned { get; set; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsWifiConfigurationSectionEnabled))]
+    [NotifyPropertyChangedFor(nameof(IsWifiSecuritySelectionEnabled))]
+    [NotifyPropertyChangedFor(nameof(IsWifiPersonalSectionEnabled))]
+    [NotifyPropertyChangedFor(nameof(IsWifiEnterpriseSectionEnabled))]
+    [NotifyPropertyChangedFor(nameof(IsWifiCertificatePathEnabled))]
+    [NotifyPropertyChangedFor(nameof(WifiValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasWifiValidationError))]
+    [NotifyPropertyChangedFor(nameof(WifiValidationVisibility))]
+    [NotifyPropertyChangedFor(nameof(ValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasValidationError))]
+    public partial bool IsWifiConfigured { get; set; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(WifiValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasWifiValidationError))]
+    [NotifyPropertyChangedFor(nameof(WifiValidationVisibility))]
+    [NotifyPropertyChangedFor(nameof(ValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasValidationError))]
+    public partial string WifiSsid { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsWifiPersonalSectionEnabled))]
+    [NotifyPropertyChangedFor(nameof(IsWifiEnterpriseSectionEnabled))]
+    [NotifyPropertyChangedFor(nameof(IsWifiCertificatePathEnabled))]
+    [NotifyPropertyChangedFor(nameof(WifiValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasWifiValidationError))]
+    [NotifyPropertyChangedFor(nameof(WifiValidationVisibility))]
+    [NotifyPropertyChangedFor(nameof(ValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasValidationError))]
+    public partial SelectionOption<string>? SelectedWifiSecurityType { get; set; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(WifiValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasWifiValidationError))]
+    [NotifyPropertyChangedFor(nameof(WifiValidationVisibility))]
+    [NotifyPropertyChangedFor(nameof(ValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasValidationError))]
+    public partial string WifiPassphrase { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(WifiValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasWifiValidationError))]
+    [NotifyPropertyChangedFor(nameof(WifiValidationVisibility))]
+    [NotifyPropertyChangedFor(nameof(ValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasValidationError))]
+    public partial string WifiEnterpriseProfileTemplatePath { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsWifiCertificatePathEnabled))]
+    [NotifyPropertyChangedFor(nameof(WifiValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasWifiValidationError))]
+    [NotifyPropertyChangedFor(nameof(WifiValidationVisibility))]
+    [NotifyPropertyChangedFor(nameof(ValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasValidationError))]
+    public partial bool IsWifiCertificateRequired { get; set; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(WifiValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasWifiValidationError))]
+    [NotifyPropertyChangedFor(nameof(WifiValidationVisibility))]
+    [NotifyPropertyChangedFor(nameof(ValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasValidationError))]
+    public partial string WifiCertificatePath { get; set; } = string.Empty;
+
+    public bool IsDot1xSectionEnabled => IsDot1xEnabled;
+    public bool IsDot1xCertificatePathEnabled => IsDot1xEnabled && IsDot1xCertificateRequired;
+    public bool IsWifiConfigurationSectionEnabled => IsWifiProvisioned && IsWifiConfigured;
+    public bool IsWifiSecuritySelectionEnabled => IsWifiConfigurationSectionEnabled;
+    public bool IsWifiPersonalSectionEnabled => IsWifiConfigurationSectionEnabled && IsWifiPersonalSelected;
+    public bool IsWifiEnterpriseSectionEnabled => IsWifiConfigurationSectionEnabled && IsWifiEnterpriseSelected;
+    public bool IsWifiCertificatePathEnabled => IsWifiEnterpriseSectionEnabled && IsWifiCertificateRequired;
+    public bool IsWifiPersonalSelected => string.Equals(SelectedWifiSecurityType?.Value, NetworkConfigurationValidator.WifiSecurityPersonal, StringComparison.OrdinalIgnoreCase);
+    public bool IsWifiEnterpriseSelected => NetworkConfigurationValidator.IsEnterpriseSecurityType(SelectedWifiSecurityType?.Value);
+    public bool HasDot1xValidationError => !string.IsNullOrWhiteSpace(Dot1xValidationMessage);
+    public string Dot1xValidationMessage => FormatValidationMessage(NetworkConfigurationValidator.Validate(BuildDot1xOnlySettings()), dot1xOnly: true);
+    public Visibility Dot1xValidationVisibility => HasDot1xValidationError ? Visibility.Visible : Visibility.Collapsed;
+    public bool HasWifiValidationError => !string.IsNullOrWhiteSpace(WifiValidationMessage);
+    public string WifiValidationMessage => FormatValidationMessage(NetworkConfigurationValidator.Validate(BuildWifiOnlySettings()), dot1xOnly: false);
+    public Visibility WifiValidationVisibility => HasWifiValidationError ? Visibility.Visible : Visibility.Collapsed;
+    public bool HasValidationError => HasDot1xValidationError || HasWifiValidationError;
+    public string ValidationMessage => HasDot1xValidationError ? Dot1xValidationMessage : WifiValidationMessage;
+
+    public void Dispose()
+    {
+        localizationService.LanguageChanged -= OnLanguageChanged;
+        configurationStateService.StateChanged -= OnConfigurationStateChanged;
+    }
+
+    [RelayCommand]
+    private async Task BrowseDot1xProfileTemplateAsync()
+    {
+        string? path = await PickOpenFileAsync("Network.ProfileTemplatePickerTitle", [".xml", "*"]);
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            Dot1xProfileTemplatePath = path;
+        }
+    }
+
+    [RelayCommand]
+    private async Task BrowseDot1xCertificateAsync()
+    {
+        string? path = await PickOpenFileAsync("Dot1x.CertificatePickerTitle", [".cer", ".crt", ".pfx", "*"]);
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            Dot1xCertificatePath = path;
+        }
+    }
+
+    [RelayCommand]
+    private async Task BrowseWifiEnterpriseProfileTemplateAsync()
+    {
+        string? path = await PickOpenFileAsync("Network.ProfileTemplatePickerTitle", [".xml", "*"]);
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            WifiEnterpriseProfileTemplatePath = path;
+        }
+    }
+
+    [RelayCommand]
+    private async Task BrowseWifiCertificateAsync()
+    {
+        string? path = await PickOpenFileAsync("Wifi.CertificatePickerTitle", [".cer", ".crt", ".pfx", "*"]);
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            WifiCertificatePath = path;
+        }
+    }
+
+    partial void OnIsDot1xEnabledChanged(bool value)
+    {
+        if (!value)
+        {
+            Dot1xProfileTemplatePath = string.Empty;
+            IsDot1xCertificateRequired = false;
+            Dot1xCertificatePath = string.Empty;
+        }
+
+        SaveState();
+    }
+
+    partial void OnDot1xProfileTemplatePathChanged(string value)
+    {
+        SaveState();
+    }
+
+    partial void OnIsDot1xCertificateRequiredChanged(bool value)
+    {
+        if (!value)
+        {
+            Dot1xCertificatePath = string.Empty;
+        }
+
+        SaveState();
+    }
+
+    partial void OnDot1xCertificatePathChanged(string value)
+    {
+        SaveState();
+    }
+
+    partial void OnIsWifiProvisionedChanged(bool value)
+    {
+        if (!value)
+        {
+            IsWifiConfigured = false;
+        }
+
+        SaveState();
+    }
+
+    partial void OnIsWifiConfiguredChanged(bool value)
+    {
+        if (!value)
+        {
+            WifiSsid = string.Empty;
+            SelectedWifiSecurityType = SelectWifiSecurityOption(NetworkConfigurationValidator.WifiSecurityPersonal);
+            WifiPassphrase = string.Empty;
+            WifiEnterpriseProfileTemplatePath = string.Empty;
+            IsWifiCertificateRequired = false;
+            WifiCertificatePath = string.Empty;
+        }
+
+        SaveState();
+    }
+
+    partial void OnWifiSsidChanged(string value)
+    {
+        SaveState();
+    }
+
+    partial void OnSelectedWifiSecurityTypeChanged(SelectionOption<string>? value)
+    {
+        if (!IsWifiPersonalSelected)
+        {
+            WifiPassphrase = string.Empty;
+        }
+
+        if (!IsWifiEnterpriseSelected)
+        {
+            WifiEnterpriseProfileTemplatePath = string.Empty;
+            IsWifiCertificateRequired = false;
+            WifiCertificatePath = string.Empty;
+        }
+
+        OnPropertyChanged(nameof(IsWifiPersonalSelected));
+        OnPropertyChanged(nameof(IsWifiEnterpriseSelected));
+        SaveState();
+    }
+
+    partial void OnWifiPassphraseChanged(string value)
+    {
+        SaveState();
+    }
+
+    partial void OnWifiEnterpriseProfileTemplatePathChanged(string value)
+    {
+        SaveState();
+    }
+
+    partial void OnIsWifiCertificateRequiredChanged(bool value)
+    {
+        if (!value)
+        {
+            WifiCertificatePath = string.Empty;
+        }
+
+        SaveState();
+    }
+
+    partial void OnWifiCertificatePathChanged(string value)
+    {
+        SaveState();
+    }
+
+    private async Task<string?> PickOpenFileAsync(string titleKey, IReadOnlyList<string> filters)
+    {
+        return await filePickerService.PickOpenFileAsync(
+            new FileOpenPickerRequest(localizationService.GetString(titleKey), filters));
+    }
+
+    private void ApplyState(NetworkSettings settings)
+    {
+        isApplyingState = true;
+        IsDot1xEnabled = settings.Dot1x.IsEnabled;
+        Dot1xProfileTemplatePath = settings.Dot1x.ProfileTemplatePath ?? string.Empty;
+        IsDot1xCertificateRequired = settings.Dot1x.RequiresCertificate;
+        Dot1xCertificatePath = settings.Dot1x.CertificatePath ?? string.Empty;
+
+        IsWifiProvisioned = settings.WifiProvisioned || settings.Wifi.IsEnabled;
+        IsWifiConfigured = settings.Wifi.IsEnabled;
+        WifiSsid = settings.Wifi.Ssid ?? string.Empty;
+        SelectedWifiSecurityType = SelectWifiSecurityOption(NetworkConfigurationValidator.NormalizeWifiSecurityType(settings.Wifi));
+        WifiPassphrase = settings.Wifi.Passphrase ?? string.Empty;
+        WifiEnterpriseProfileTemplatePath = settings.Wifi.EnterpriseProfileTemplatePath ?? string.Empty;
+        IsWifiCertificateRequired = settings.Wifi.RequiresCertificate;
+        WifiCertificatePath = settings.Wifi.CertificatePath ?? string.Empty;
+        isApplyingState = false;
+    }
+
+    private void SaveState()
+    {
+        if (isApplyingState)
+        {
+            return;
+        }
+
+        isSavingState = true;
+        try
+        {
+            configurationStateService.UpdateNetwork(BuildSettingsForValidation());
+        }
+        finally
+        {
+            isSavingState = false;
+        }
+    }
+
+    private NetworkSettings BuildSettingsForValidation()
+    {
+        return new NetworkSettings
+        {
+            Dot1x = new Dot1xSettings
+            {
+                IsEnabled = IsDot1xEnabled,
+                ProfileTemplatePath = IsDot1xEnabled && !string.IsNullOrWhiteSpace(Dot1xProfileTemplatePath)
+                    ? Dot1xProfileTemplatePath.Trim()
+                    : null,
+                AuthenticationMode = NetworkAuthenticationMode.MachineOnly,
+                AllowRuntimeCredentials = false,
+                RequiresCertificate = IsDot1xEnabled && IsDot1xCertificateRequired,
+                CertificatePath = IsDot1xCertificatePathEnabled && !string.IsNullOrWhiteSpace(Dot1xCertificatePath)
+                    ? Dot1xCertificatePath.Trim()
+                    : null
+            },
+            WifiProvisioned = IsWifiProvisioned,
+            Wifi = new WifiSettings
+            {
+                IsEnabled = IsWifiConfigured,
+                Ssid = IsWifiConfigured && !string.IsNullOrWhiteSpace(WifiSsid)
+                    ? WifiSsid.Trim()
+                    : null,
+                SecurityType = IsWifiConfigured && !string.IsNullOrWhiteSpace(SelectedWifiSecurityType?.Value)
+                    ? SelectedWifiSecurityType.Value.Trim()
+                    : null,
+                Passphrase = IsWifiPersonalSectionEnabled && !string.IsNullOrWhiteSpace(WifiPassphrase)
+                    ? WifiPassphrase.Trim()
+                    : null,
+                HasEnterpriseProfile = IsWifiEnterpriseSectionEnabled,
+                EnterpriseProfileTemplatePath = IsWifiEnterpriseSectionEnabled && !string.IsNullOrWhiteSpace(WifiEnterpriseProfileTemplatePath)
+                    ? WifiEnterpriseProfileTemplatePath.Trim()
+                    : null,
+                EnterpriseAuthenticationMode = NetworkAuthenticationMode.UserOnly,
+                AllowRuntimeCredentials = false,
+                RequiresCertificate = IsWifiEnterpriseSectionEnabled && IsWifiCertificateRequired,
+                CertificatePath = IsWifiCertificatePathEnabled && !string.IsNullOrWhiteSpace(WifiCertificatePath)
+                    ? WifiCertificatePath.Trim()
+                    : null
+            }
+        };
+    }
+
+    private NetworkSettings BuildDot1xOnlySettings()
+    {
+        return BuildSettingsForValidation() with
+        {
+            WifiProvisioned = false,
+            Wifi = new WifiSettings()
+        };
+    }
+
+    private NetworkSettings BuildWifiOnlySettings()
+    {
+        return BuildSettingsForValidation() with
+        {
+            Dot1x = new Dot1xSettings()
+        };
+    }
+
+    private void RefreshLocalizedText()
+    {
+        PageTitle = localizationService.GetString("NetworkPage_Title.Text");
+        EthernetHeader = localizationService.GetString("Network.EthernetSectionTitle");
+        EthernetDescription = localizationService.GetString("Network.EthernetHelperText");
+        Dot1xEnableText = localizationService.GetString("Dot1x.EnableLabel");
+        ProfileTemplateLabel = localizationService.GetString("Network.ProfileTemplateLabel");
+        Dot1xCertificateLabel = localizationService.GetString("Dot1x.CertificateLabel");
+        RequiresCertificateText = localizationService.GetString("Network.RequiresCertificateLabel");
+        WifiHeader = localizationService.GetString("Network.WifiSectionTitle");
+        WifiDescription = localizationService.GetString("Network.WifiHelperText");
+        WifiProvisionedText = localizationService.GetString("Wifi.EnableLabel");
+        WifiConfiguredText = localizationService.GetString("Wifi.ConfigureLabel");
+        WifiSsidLabel = localizationService.GetString("Wifi.SsidLabel");
+        WifiSecurityTypeLabel = localizationService.GetString("Wifi.SecurityTypeLabel");
+        WifiPassphraseLabel = localizationService.GetString("Wifi.PassphraseLabel");
+        WifiPersonalDescription = localizationService.GetString("Network.WifiPersonalHelperText");
+        WifiEnterpriseHeader = localizationService.GetString("Network.WifiEnterpriseAdvancedHeader");
+        WifiEnterpriseDescription = localizationService.GetString("Network.EnterpriseTemplateDrivenHelperText");
+        WifiEnterpriseTemplateText = localizationService.GetString("Network.WifiEnterpriseTemplateLabel");
+        WifiCertificateLabel = localizationService.GetString("Wifi.CertificateLabel");
+        BrowseButtonText = localizationService.GetString("Common.Browse");
+    }
+
+    private void RefreshWifiSecurityTypes()
+    {
+        string? selectedValue = SelectedWifiSecurityType?.Value ?? NetworkConfigurationValidator.WifiSecurityPersonal;
+        WifiSecurityTypes.Clear();
+        WifiSecurityTypes.Add(new(NetworkConfigurationValidator.WifiSecurityOpen, localizationService.GetString("Wifi.SecurityTypeOpen")));
+        WifiSecurityTypes.Add(new(NetworkConfigurationValidator.WifiSecurityOwe, localizationService.GetString("Wifi.SecurityTypeOwe")));
+        WifiSecurityTypes.Add(new(NetworkConfigurationValidator.WifiSecurityPersonal, localizationService.GetString("Wifi.SecurityTypePersonal")));
+        WifiSecurityTypes.Add(new(NetworkConfigurationValidator.WifiSecurityEnterprise, localizationService.GetString("Wifi.SecurityTypeEnterprise")));
+        WifiSecurityTypes.Add(new(NetworkConfigurationValidator.WifiSecurityEnterpriseWpa3, localizationService.GetString("Wifi.SecurityTypeEnterpriseWpa3")));
+        WifiSecurityTypes.Add(new(NetworkConfigurationValidator.WifiSecurityEnterpriseWpa3192, localizationService.GetString("Wifi.SecurityTypeEnterpriseWpa3192")));
+        SelectedWifiSecurityType = SelectWifiSecurityOption(selectedValue);
+    }
+
+    private SelectionOption<string> SelectWifiSecurityOption(string? value)
+    {
+        return WifiSecurityTypes.FirstOrDefault(option => string.Equals(option.Value, value, StringComparison.OrdinalIgnoreCase))
+            ?? WifiSecurityTypes.First(option => string.Equals(option.Value, NetworkConfigurationValidator.WifiSecurityPersonal, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
+    {
+        RefreshLocalizedText();
+        RefreshWifiSecurityTypes();
+    }
+
+    private void OnConfigurationStateChanged(object? sender, EventArgs e)
+    {
+        if (isSavingState)
+        {
+            return;
+        }
+
+        ApplyState(configurationStateService.Current.Network);
+    }
+
+    private string FormatValidationMessage(NetworkConfigurationValidationResult result, bool dot1xOnly)
+    {
+        if (result.IsValid)
+        {
+            return string.Empty;
+        }
+
+        if (dot1xOnly && result.Code is not (NetworkConfigurationValidationCode.WiredProfileTemplateRequired or NetworkConfigurationValidationCode.WiredCertificateRequired))
+        {
+            return string.Empty;
+        }
+
+        if (!dot1xOnly && result.Code is NetworkConfigurationValidationCode.WiredProfileTemplateRequired or NetworkConfigurationValidationCode.WiredCertificateRequired)
+        {
+            return string.Empty;
+        }
+
+        string key = result.Code switch
+        {
+            NetworkConfigurationValidationCode.WifiProvisioningRequired => "Network.ErrorWifiProvisioningRequired",
+            NetworkConfigurationValidationCode.WiredProfileTemplateRequired => "Network.ErrorWiredProfileTemplateRequired",
+            NetworkConfigurationValidationCode.WiredCertificateRequired => "Network.ErrorWiredCertificateRequired",
+            NetworkConfigurationValidationCode.WifiSsidRequired => "Network.ErrorWifiSsidRequired",
+            NetworkConfigurationValidationCode.UnsupportedWifiSecurityType => "Network.ErrorUnsupportedWifiSecurityTypeFormat",
+            NetworkConfigurationValidationCode.WifiPersonalPassphraseInvalid => "Network.ErrorWifiPersonalPassphraseInvalid",
+            NetworkConfigurationValidationCode.WifiEnterpriseProfileTemplateRequired => "Network.ErrorWifiEnterpriseProfileTemplateRequired",
+            NetworkConfigurationValidationCode.WifiEnterpriseProfileTemplateMissing => "Network.ErrorWifiEnterpriseProfileTemplateMissing",
+            NetworkConfigurationValidationCode.WifiEnterpriseAuthenticationUnsupported => "Network.ErrorWifiEnterpriseAuthenticationUnsupported",
+            NetworkConfigurationValidationCode.WifiEnterpriseAuthenticationMismatch => "Network.ErrorWifiEnterpriseAuthenticationMismatchFormat",
+            NetworkConfigurationValidationCode.WifiEnterpriseCertificateRequired => "Network.ErrorWifiEnterpriseCertificateRequired",
+            _ => string.Empty
+        };
+
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return string.Empty;
+        }
+
+        object[] arguments = result.Code == NetworkConfigurationValidationCode.WifiEnterpriseAuthenticationMismatch
+            ? result.FormatArguments.Select(FormatEnterpriseSecurityTypeLabel).Cast<object>().ToArray()
+            : result.FormatArguments.Cast<object>().ToArray();
+
+        return result.FormatArguments.Count == 0
+            ? localizationService.GetString(key)
+            : localizationService.FormatString(key, arguments);
+    }
+
+    private string FormatEnterpriseSecurityTypeLabel(string securityType)
+    {
+        return securityType switch
+        {
+            NetworkConfigurationValidator.WifiSecurityEnterpriseWpa3 => localizationService.GetString("Wifi.SecurityTypeEnterpriseWpa3"),
+            NetworkConfigurationValidator.WifiSecurityEnterpriseWpa3192 => localizationService.GetString("Wifi.SecurityTypeEnterpriseWpa3192"),
+            _ => localizationService.GetString("Wifi.SecurityTypeEnterprise")
+        };
+    }
+}

--- a/src/Foundry/Views/NetworkPage.xaml
+++ b/src/Foundry/Views/NetworkPage.xaml
@@ -18,7 +18,7 @@
             <dev:SettingsExpander Header="{x:Bind ViewModel.EthernetHeader, Mode=OneWay}"
                                   Description="{x:Bind ViewModel.EthernetDescription, Mode=OneWay}"
                                   HeaderIcon="{dev:FontIcon GlyphCode=E839}">
-                <ToggleSwitch Header="{x:Bind ViewModel.Dot1xEnableText, Mode=OneWay}"
+                <ToggleSwitch AutomationProperties.Name="{x:Bind ViewModel.Dot1xEnableText, Mode=OneWay}"
                               IsOn="{x:Bind ViewModel.IsDot1xEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 <dev:SettingsExpander.Items>
                     <dev:SettingsCard Header="{x:Bind ViewModel.ProfileTemplateLabel, Mode=OneWay}"
@@ -57,14 +57,13 @@
             <dev:SettingsExpander Header="{x:Bind ViewModel.WifiHeader, Mode=OneWay}"
                                   Description="{x:Bind ViewModel.WifiDescription, Mode=OneWay}"
                                   HeaderIcon="{dev:FontIcon GlyphCode=E701}">
-                <StackPanel Spacing="8">
-                    <ToggleSwitch Header="{x:Bind ViewModel.WifiProvisionedText, Mode=OneWay}"
-                                  IsOn="{x:Bind ViewModel.IsWifiProvisioned, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                    <ToggleSwitch Header="{x:Bind ViewModel.WifiConfiguredText, Mode=OneWay}"
-                                  IsEnabled="{x:Bind ViewModel.IsWifiProvisioned, Mode=OneWay}"
-                                  IsOn="{x:Bind ViewModel.IsWifiConfigured, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                </StackPanel>
+                <ToggleSwitch AutomationProperties.Name="{x:Bind ViewModel.WifiProvisionedText, Mode=OneWay}"
+                              IsOn="{x:Bind ViewModel.IsWifiProvisioned, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 <dev:SettingsExpander.Items>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.WifiConfiguredText, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsWifiProvisioned, Mode=OneWay}">
+                        <ToggleSwitch IsOn="{x:Bind ViewModel.IsWifiConfigured, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </dev:SettingsCard>
                     <dev:SettingsCard Header="{x:Bind ViewModel.WifiSsidLabel, Mode=OneWay}"
                                       IsEnabled="{x:Bind ViewModel.IsWifiConfigurationSectionEnabled, Mode=OneWay}">
                         <TextBox MinWidth="420"

--- a/src/Foundry/Views/NetworkPage.xaml
+++ b/src/Foundry/Views/NetworkPage.xaml
@@ -1,13 +1,126 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Page x:Class="Foundry.Views.NetworkPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:dev="using:DevWinUI"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
-                Padding="{ThemeResource ContentPagePadding}">
+                Padding="{ThemeResource ContentPagePadding}"
+                VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="10"
-                    Spacing="5">
-            <TextBlock x:Uid="NetworkPage_Title"
+                    dev:PanelAttach.ChildrenTransitions="Default"
+                    Spacing="8">
+            <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
                        Style="{ThemeResource TitleTextBlockStyle}" />
+
+            <dev:SettingsExpander Header="{x:Bind ViewModel.EthernetHeader, Mode=OneWay}"
+                                  Description="{x:Bind ViewModel.EthernetDescription, Mode=OneWay}"
+                                  HeaderIcon="{dev:FontIcon GlyphCode=E839}">
+                <ToggleSwitch Header="{x:Bind ViewModel.Dot1xEnableText, Mode=OneWay}"
+                              IsOn="{x:Bind ViewModel.IsDot1xEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <dev:SettingsExpander.Items>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.ProfileTemplateLabel, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsDot1xSectionEnabled, Mode=OneWay}">
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="10">
+                            <TextBox MinWidth="420"
+                                     Text="{x:Bind ViewModel.Dot1xProfileTemplatePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    Command="{x:Bind ViewModel.BrowseDot1xProfileTemplateCommand}"
+                                    Content="{x:Bind ViewModel.BrowseButtonText, Mode=OneWay}" />
+                        </StackPanel>
+                    </dev:SettingsCard>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.RequiresCertificateText, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsDot1xSectionEnabled, Mode=OneWay}">
+                        <ToggleSwitch IsOn="{x:Bind ViewModel.IsDot1xCertificateRequired, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </dev:SettingsCard>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.Dot1xCertificateLabel, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsDot1xCertificatePathEnabled, Mode=OneWay}">
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="10">
+                            <TextBox MinWidth="420"
+                                     Text="{x:Bind ViewModel.Dot1xCertificatePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    Command="{x:Bind ViewModel.BrowseDot1xCertificateCommand}"
+                                    Content="{x:Bind ViewModel.BrowseButtonText, Mode=OneWay}" />
+                        </StackPanel>
+                    </dev:SettingsCard>
+                    <dev:SettingsCard Visibility="{x:Bind ViewModel.Dot1xValidationVisibility, Mode=OneWay}">
+                        <TextBlock Text="{x:Bind ViewModel.Dot1xValidationMessage, Mode=OneWay}"
+                                   TextWrapping="Wrap" />
+                    </dev:SettingsCard>
+                </dev:SettingsExpander.Items>
+            </dev:SettingsExpander>
+
+            <dev:SettingsExpander Header="{x:Bind ViewModel.WifiHeader, Mode=OneWay}"
+                                  Description="{x:Bind ViewModel.WifiDescription, Mode=OneWay}"
+                                  HeaderIcon="{dev:FontIcon GlyphCode=E701}">
+                <StackPanel Spacing="8">
+                    <ToggleSwitch Header="{x:Bind ViewModel.WifiProvisionedText, Mode=OneWay}"
+                                  IsOn="{x:Bind ViewModel.IsWifiProvisioned, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <ToggleSwitch Header="{x:Bind ViewModel.WifiConfiguredText, Mode=OneWay}"
+                                  IsEnabled="{x:Bind ViewModel.IsWifiProvisioned, Mode=OneWay}"
+                                  IsOn="{x:Bind ViewModel.IsWifiConfigured, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </StackPanel>
+                <dev:SettingsExpander.Items>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.WifiSsidLabel, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsWifiConfigurationSectionEnabled, Mode=OneWay}">
+                        <TextBox MinWidth="420"
+                                 Text="{x:Bind ViewModel.WifiSsid, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </dev:SettingsCard>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.WifiSecurityTypeLabel, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsWifiSecuritySelectionEnabled, Mode=OneWay}">
+                        <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                  DisplayMemberPath="DisplayName"
+                                  ItemsSource="{x:Bind ViewModel.WifiSecurityTypes, Mode=OneWay}"
+                                  SelectedItem="{x:Bind ViewModel.SelectedWifiSecurityType, Mode=TwoWay}" />
+                    </dev:SettingsCard>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.WifiPassphraseLabel, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.WifiPersonalDescription, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsWifiPersonalSectionEnabled, Mode=OneWay}">
+                        <PasswordBox x:Name="WifiPassphraseBox"
+                                     MinWidth="420"
+                                     Loaded="WifiPassphraseBox_OnLoaded"
+                                     PasswordChanged="WifiPassphraseBox_OnPasswordChanged" />
+                    </dev:SettingsCard>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.WifiEnterpriseHeader, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.WifiEnterpriseDescription, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsWifiEnterpriseSectionEnabled, Mode=OneWay}">
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="{x:Bind ViewModel.WifiEnterpriseTemplateText, Mode=OneWay}" />
+                            <StackPanel Orientation="Horizontal"
+                                        Spacing="10">
+                                <TextBox MinWidth="420"
+                                         Text="{x:Bind ViewModel.WifiEnterpriseProfileTemplatePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                        Command="{x:Bind ViewModel.BrowseWifiEnterpriseProfileTemplateCommand}"
+                                        Content="{x:Bind ViewModel.BrowseButtonText, Mode=OneWay}" />
+                            </StackPanel>
+                        </StackPanel>
+                    </dev:SettingsCard>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.RequiresCertificateText, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsWifiEnterpriseSectionEnabled, Mode=OneWay}">
+                        <ToggleSwitch IsOn="{x:Bind ViewModel.IsWifiCertificateRequired, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </dev:SettingsCard>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.WifiCertificateLabel, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsWifiCertificatePathEnabled, Mode=OneWay}">
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="10">
+                            <TextBox MinWidth="420"
+                                     Text="{x:Bind ViewModel.WifiCertificatePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    Command="{x:Bind ViewModel.BrowseWifiCertificateCommand}"
+                                    Content="{x:Bind ViewModel.BrowseButtonText, Mode=OneWay}" />
+                        </StackPanel>
+                    </dev:SettingsCard>
+                    <dev:SettingsCard Visibility="{x:Bind ViewModel.WifiValidationVisibility, Mode=OneWay}">
+                        <TextBlock Text="{x:Bind ViewModel.WifiValidationMessage, Mode=OneWay}"
+                                   TextWrapping="Wrap" />
+                    </dev:SettingsCard>
+                </dev:SettingsExpander.Items>
+            </dev:SettingsExpander>
         </StackPanel>
     </ScrollView>
 </Page>

--- a/src/Foundry/Views/NetworkPage.xaml.cs
+++ b/src/Foundry/Views/NetworkPage.xaml.cs
@@ -2,8 +2,52 @@ namespace Foundry.Views;
 
 public sealed partial class NetworkPage : Page
 {
+    public NetworkConfigurationViewModel ViewModel { get; }
+
     public NetworkPage()
     {
+        ViewModel = App.GetService<NetworkConfigurationViewModel>();
         InitializeComponent();
+        ViewModel.PropertyChanged += OnViewModelPropertyChanged;
+        Unloaded += OnUnloaded;
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        Unloaded -= OnUnloaded;
+        ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+        ViewModel.Dispose();
+    }
+
+    private void WifiPassphraseBox_OnLoaded(object sender, RoutedEventArgs e)
+    {
+        SyncWifiPassphraseBox();
+    }
+
+    private void WifiPassphraseBox_OnPasswordChanged(object sender, RoutedEventArgs e)
+    {
+        if (sender is not PasswordBox passwordBox ||
+            string.Equals(ViewModel.WifiPassphrase, passwordBox.Password, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        ViewModel.WifiPassphrase = passwordBox.Password;
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (string.Equals(e.PropertyName, nameof(NetworkConfigurationViewModel.WifiPassphrase), StringComparison.Ordinal))
+        {
+            SyncWifiPassphraseBox();
+        }
+    }
+
+    private void SyncWifiPassphraseBox()
+    {
+        if (!string.Equals(WifiPassphraseBox.Password, ViewModel.WifiPassphrase, StringComparison.Ordinal))
+        {
+            WifiPassphraseBox.Password = ViewModel.WifiPassphrase;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Adds the WinUI Network expert page state workflow for wired 802.1X and Wi-Fi provisioning settings.
- Adds shared Core network validation and normalization rules ported from the WPF reference behavior.
- Persists network authoring state while stripping plaintext Wi-Fi passphrases from `foundry.expert.config.json`.

## Reason
Phase 15.A starts the Network provisioning workflow with state, validation, and picker handling before Connect config generation, secret envelopes, or Start preflight wiring.

## Main changes
- New `NetworkConfigurationViewModel` and expanded `NetworkPage` UI.
- Explicit WinUI `PasswordBox` handling for transient Wi-Fi passphrases.
- `UpdateNetwork` support in expert configuration state service.
- Localized Network/Wi-Fi/802.1X strings.
- Core validator tests for passphrase validation, enterprise profile authentication mismatch, wired certificate validation, and persistence sanitization.

## Testing notes
- `dotnet test src/Foundry.Core.Tests/Foundry.Core.Tests.csproj -c Release --nologo` -> 143 passed.
- `dotnet test src/Foundry.Connect.Tests/Foundry.Connect.Tests.csproj -c Release --nologo` -> 15 passed.
- `dotnet test src/Foundry.Deploy.Tests/Foundry.Deploy.Tests.csproj -c Release --nologo` -> 49 passed.
- `dotnet build src/Foundry.slnx -c Release --nologo` -> 0 warnings, 0 errors.