### PR TITLE
feat(network): generate connect provisioning bundle

### DIFF
--- a/src/Foundry.Connect.Tests/ConnectConfigurationServiceTests.cs
+++ b/src/Foundry.Connect.Tests/ConnectConfigurationServiceTests.cs
@@ -1,7 +1,9 @@
 using System.Text.Json;
 using Foundry.Connect.Models.Configuration;
 using Foundry.Connect.Services.Configuration;
+using Foundry.Core.Services.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using CoreConfiguration = Foundry.Core.Models.Configuration;
 
 namespace Foundry.Connect.Tests;
 
@@ -77,11 +79,51 @@ public sealed class ConnectConfigurationServiceTests
         Assert.Equal(5, configuration.SchemaVersion);
     }
 
+    [Fact]
+    public void Load_WhenCoreGeneratedConfigurationIsProvided_PreservesEffectiveNetworkPaths()
+    {
+        using var environmentScope = new EnvironmentVariableScope("FOUNDRY_CONNECT_CONFIG", null);
+        using var tempDirectory = new TemporaryDirectory();
+        string wiredProfilePath = CreateFile(tempDirectory.Path, "wired.xml", "<LANProfile />");
+        string configurationJson = new ConnectConfigurationGenerator().CreateProvisioningBundle(
+            new CoreConfiguration.FoundryExpertConfigurationDocument
+            {
+                Network = new CoreConfiguration.NetworkSettings
+                {
+                    Dot1x = new CoreConfiguration.Dot1xSettings
+                    {
+                        IsEnabled = true,
+                        ProfileTemplatePath = wiredProfilePath
+                    }
+                }
+            },
+            tempDirectory.Path).ConfigurationJson;
+        string configurationPath = CreateJsonFile(tempDirectory.Path, "core-generated.json", configurationJson);
+
+        var service = new ConnectConfigurationService(["--config", configurationPath], NullLogger<ConnectConfigurationService>.Instance);
+
+        FoundryConnectConfiguration configuration = service.Load();
+
+        Assert.True(service.IsLoadedFromDisk);
+        Assert.Equal(CoreConfiguration.FoundryConnectConfigurationDocument.CurrentSchemaVersion, configuration.SchemaVersion);
+        Assert.Equal(@"Network\Wired\Profiles\wired.xml", configuration.Dot1x.ProfileTemplatePath);
+        Assert.NotNull(configuration.Capabilities);
+        Assert.NotNull(configuration.Wifi);
+        Assert.NotNull(configuration.InternetProbe);
+    }
+
     private static string CreateJsonFile(string directoryPath, string fileName, string contents)
     {
         string filePath = System.IO.Path.Combine(directoryPath, fileName);
         using JsonDocument document = JsonDocument.Parse(contents);
         File.WriteAllText(filePath, document.RootElement.GetRawText());
+        return filePath;
+    }
+
+    private static string CreateFile(string directoryPath, string fileName, string contents)
+    {
+        string filePath = System.IO.Path.Combine(directoryPath, fileName);
+        File.WriteAllText(filePath, contents);
         return filePath;
     }
 

--- a/src/Foundry.Connect.Tests/Foundry.Connect.Tests.csproj
+++ b/src/Foundry.Connect.Tests/Foundry.Connect.Tests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Foundry.Core\Foundry.Core.csproj" />
     <ProjectReference Include="..\Foundry.Connect\Foundry.Connect.csproj" />
   </ItemGroup>
 

--- a/src/Foundry.Core.Tests/Configuration/ConnectConfigurationGeneratorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/ConnectConfigurationGeneratorTests.cs
@@ -1,0 +1,206 @@
+using System.Text.Json;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Configuration;
+
+namespace Foundry.Core.Tests.Configuration;
+
+public sealed class ConnectConfigurationGeneratorTests
+{
+    [Fact]
+    public void CreateProvisioningBundle_WhenNetworkIsDefault_WritesCompleteEffectiveConfiguration()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var generator = new ConnectConfigurationGenerator();
+
+        FoundryConnectProvisioningBundle bundle = generator.CreateProvisioningBundle(
+            new FoundryExpertConfigurationDocument(),
+            tempDirectory.Path);
+
+        using JsonDocument document = JsonDocument.Parse(bundle.ConfigurationJson);
+        JsonElement root = document.RootElement;
+        Assert.Equal(FoundryConnectConfigurationDocument.CurrentSchemaVersion, root.GetProperty("schemaVersion").GetInt32());
+        Assert.True(root.TryGetProperty("capabilities", out JsonElement capabilities));
+        Assert.True(root.TryGetProperty("dot1x", out _));
+        Assert.True(root.TryGetProperty("wifi", out _));
+        Assert.True(root.TryGetProperty("internetProbe", out JsonElement internetProbe));
+        Assert.False(capabilities.GetProperty("wifiProvisioned").GetBoolean());
+        Assert.Equal(5, internetProbe.GetProperty("timeoutSeconds").GetInt32());
+        Assert.NotEmpty(internetProbe.GetProperty("probeUris").EnumerateArray());
+        Assert.Empty(bundle.AssetFiles);
+    }
+
+    [Fact]
+    public void CreateProvisioningBundle_WhenProfilesAndCertificatesAreConfigured_UsesWpfCompatibleNetworkLayout()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        string wiredProfilePath = tempDirectory.CreateFile("source", "wired.xml", "<LANProfile />");
+        string wiredCertificatePath = tempDirectory.CreateFile("source", "wired.cer", "wired-cert");
+        string wifiProfilePath = tempDirectory.CreateFile(
+            "source",
+            "wifi.xml",
+            """
+            <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
+              <name>Corp WiFi</name>
+              <MSM>
+                <security>
+                  <authEncryption>
+                    <authentication>WPA3ENT</authentication>
+                  </authEncryption>
+                </security>
+              </MSM>
+            </WLANProfile>
+            """);
+        string wifiCertificatePath = tempDirectory.CreateFile("source", "wifi.cer", "wifi-cert");
+        var generator = new ConnectConfigurationGenerator();
+
+        FoundryConnectProvisioningBundle bundle = generator.CreateProvisioningBundle(
+            new FoundryExpertConfigurationDocument
+            {
+                Network = new NetworkSettings
+                {
+                    WifiProvisioned = true,
+                    Dot1x = new Dot1xSettings
+                    {
+                        IsEnabled = true,
+                        ProfileTemplatePath = wiredProfilePath,
+                        RequiresCertificate = true,
+                        CertificatePath = wiredCertificatePath
+                    },
+                    Wifi = new WifiSettings
+                    {
+                        IsEnabled = true,
+                        Ssid = "Corp WiFi",
+                        SecurityType = NetworkConfigurationValidator.WifiSecurityEnterpriseWpa3,
+                        HasEnterpriseProfile = true,
+                        EnterpriseProfileTemplatePath = wifiProfilePath,
+                        RequiresCertificate = true,
+                        CertificatePath = wifiCertificatePath
+                    }
+                }
+            },
+            tempDirectory.Path);
+
+        AssertAsset(bundle, tempDirectory.Path, @"Network\Wired\Profiles\wired.xml", @"Foundry\Config\Network\Wired\Profiles\wired.xml");
+        AssertAsset(bundle, tempDirectory.Path, @"Network\Certificates\Wired\wired.cer", @"Foundry\Config\Network\Certificates\Wired\wired.cer");
+        AssertAsset(bundle, tempDirectory.Path, @"Network\Wifi\Profiles\wifi.xml", @"Foundry\Config\Network\Wifi\Profiles\wifi.xml");
+        AssertAsset(bundle, tempDirectory.Path, @"Network\Certificates\Wifi\wifi.cer", @"Foundry\Config\Network\Certificates\Wifi\wifi.cer");
+
+        using JsonDocument document = JsonDocument.Parse(bundle.ConfigurationJson);
+        JsonElement root = document.RootElement;
+        Assert.Equal(@"Network\Wired\Profiles\wired.xml", root.GetProperty("dot1x").GetProperty("profileTemplatePath").GetString());
+        Assert.Equal(@"Network\Certificates\Wired\wired.cer", root.GetProperty("dot1x").GetProperty("certificatePath").GetString());
+        Assert.Equal(@"Network\Wifi\Profiles\wifi.xml", root.GetProperty("wifi").GetProperty("enterpriseProfileTemplatePath").GetString());
+        Assert.Equal(@"Network\Certificates\Wifi\wifi.cer", root.GetProperty("wifi").GetProperty("certificatePath").GetString());
+    }
+
+    [Fact]
+    public void CreateProvisioningBundle_WhenPersonalWifiHasTransientPassphrase_PreservesPassphraseForCurrentRuntime()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var generator = new ConnectConfigurationGenerator();
+
+        FoundryConnectProvisioningBundle bundle = generator.CreateProvisioningBundle(
+            new FoundryExpertConfigurationDocument
+            {
+                Network = new NetworkSettings
+                {
+                    WifiProvisioned = true,
+                    Wifi = new WifiSettings
+                    {
+                        IsEnabled = true,
+                        Ssid = "Corp WiFi",
+                        SecurityType = NetworkConfigurationValidator.WifiSecurityPersonal,
+                        Passphrase = "super-secret-passphrase"
+                    }
+                }
+            },
+            tempDirectory.Path);
+
+        using JsonDocument document = JsonDocument.Parse(bundle.ConfigurationJson);
+        Assert.Equal("super-secret-passphrase", document.RootElement.GetProperty("wifi").GetProperty("passphrase").GetString());
+        Assert.Empty(bundle.AssetFiles);
+    }
+
+    [Fact]
+    public void CreateProvisioningBundle_WhenCertificatePathsAreProvided_CopiesCertificatesEvenWhenNotRequired()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        string wiredCertificatePath = tempDirectory.CreateFile("source", "wired.cer", "wired-cert");
+        string wifiCertificatePath = tempDirectory.CreateFile("source", "wifi.cer", "wifi-cert");
+        var generator = new ConnectConfigurationGenerator();
+
+        FoundryConnectProvisioningBundle bundle = generator.CreateProvisioningBundle(
+            new FoundryExpertConfigurationDocument
+            {
+                Network = new NetworkSettings
+                {
+                    WifiProvisioned = true,
+                    Dot1x = new Dot1xSettings
+                    {
+                        IsEnabled = true,
+                        ProfileTemplatePath = tempDirectory.CreateFile("source", "wired.xml", "<LANProfile />"),
+                        RequiresCertificate = false,
+                        CertificatePath = wiredCertificatePath
+                    },
+                    Wifi = new WifiSettings
+                    {
+                        IsEnabled = true,
+                        Ssid = "Corp WiFi",
+                        SecurityType = NetworkConfigurationValidator.WifiSecurityPersonal,
+                        Passphrase = "super-secret-passphrase",
+                        RequiresCertificate = false,
+                        CertificatePath = wifiCertificatePath
+                    }
+                }
+            },
+            tempDirectory.Path);
+
+        AssertAsset(bundle, tempDirectory.Path, @"Network\Certificates\Wired\wired.cer", @"Foundry\Config\Network\Certificates\Wired\wired.cer");
+        AssertAsset(bundle, tempDirectory.Path, @"Network\Certificates\Wifi\wifi.cer", @"Foundry\Config\Network\Certificates\Wifi\wifi.cer");
+        using JsonDocument document = JsonDocument.Parse(bundle.ConfigurationJson);
+        Assert.Equal(@"Network\Certificates\Wired\wired.cer", document.RootElement.GetProperty("dot1x").GetProperty("certificatePath").GetString());
+        Assert.Equal(@"Network\Certificates\Wifi\wifi.cer", document.RootElement.GetProperty("wifi").GetProperty("certificatePath").GetString());
+    }
+
+    private static void AssertAsset(
+        FoundryConnectProvisioningBundle bundle,
+        string stagingDirectoryPath,
+        string stagedRelativePath,
+        string relativeDestinationPath)
+    {
+        string expectedSourcePath = System.IO.Path.Combine(stagingDirectoryPath, "FoundryConnectAssets", stagedRelativePath);
+        Assert.Contains(
+            bundle.AssetFiles,
+            asset => string.Equals(asset.SourcePath, expectedSourcePath, StringComparison.Ordinal) &&
+                     string.Equals(asset.RelativeDestinationPath, relativeDestinationPath, StringComparison.Ordinal));
+        Assert.True(File.Exists(expectedSourcePath));
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "Foundry.Core.Tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public string CreateFile(string directoryName, string fileName, string contents)
+        {
+            string directoryPath = System.IO.Path.Combine(Path, directoryName);
+            Directory.CreateDirectory(directoryPath);
+            string path = System.IO.Path.Combine(directoryPath, fileName);
+            File.WriteAllText(path, contents);
+            return path;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}

--- a/src/Foundry.Core.Tests/Configuration/NetworkConfigurationValidatorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/NetworkConfigurationValidatorTests.cs
@@ -64,18 +64,40 @@ public sealed class NetworkConfigurationValidatorTests
     [Fact]
     public void Validate_WhenWiredCertificateIsRequiredWithoutPath_ReturnsWiredCertificateRequired()
     {
+        using var tempDirectory = new TemporaryDirectory();
+        string profilePath = Path.Combine(tempDirectory.Path, "wired.xml");
+        File.WriteAllText(profilePath, "<LANProfile />");
+
         NetworkConfigurationValidationResult result = NetworkConfigurationValidator.Validate(
             new NetworkSettings
             {
                 Dot1x = new Dot1xSettings
                 {
                     IsEnabled = true,
-                    ProfileTemplatePath = "wired.xml",
+                    ProfileTemplatePath = profilePath,
                     RequiresCertificate = true
                 }
             });
 
         Assert.Equal(NetworkConfigurationValidationCode.WiredCertificateRequired, result.Code);
+    }
+
+    [Fact]
+    public void Validate_WhenWiredProfilePathDoesNotExist_ReturnsWiredProfileTemplateMissing()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+
+        NetworkConfigurationValidationResult result = NetworkConfigurationValidator.Validate(
+            new NetworkSettings
+            {
+                Dot1x = new Dot1xSettings
+                {
+                    IsEnabled = true,
+                    ProfileTemplatePath = Path.Combine(tempDirectory.Path, "missing.xml")
+                }
+            });
+
+        Assert.Equal(NetworkConfigurationValidationCode.WiredProfileTemplateMissing, result.Code);
     }
 
     [Fact]

--- a/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Foundry.Core.Models.Configuration;
 using Foundry.Core.Services.WinPe;
 
@@ -173,6 +174,38 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
         Assert.Contains("\"localization\":", deployConfigurationJson, StringComparison.Ordinal);
         Assert.Contains("\"customization\":", deployConfigurationJson, StringComparison.Ordinal);
         Assert.Contains("\"autopilot\":", deployConfigurationJson, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_WhenConnectConfigurationIsMissing_WritesCompleteDefaultConnectConfiguration()
+    {
+        using TempMountedImage image = TempMountedImage.Create();
+        string curlSourcePath = Path.Combine(image.RootPath, "curl.exe");
+        File.WriteAllText(curlSourcePath, "curl");
+
+        var service = new WinPeMountedImageAssetProvisioningService();
+
+        WinPeResult result = await service.ProvisionAsync(
+            new WinPeMountedImageAssetProvisioningOptions
+            {
+                MountedImagePath = image.MountedImagePath,
+                Architecture = WinPeArchitecture.X64,
+                BootstrapScriptContent = "bootstrap",
+                CurlExecutableSourcePath = curlSourcePath,
+                IanaWindowsTimeZoneMapJson = "{}"
+            },
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Error?.Details);
+        string connectConfigurationJson = await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.connect.config.json"));
+        using JsonDocument document = JsonDocument.Parse(connectConfigurationJson);
+        JsonElement root = document.RootElement;
+        Assert.True(root.TryGetProperty("schemaVersion", out _));
+        Assert.True(root.TryGetProperty("capabilities", out _));
+        Assert.True(root.TryGetProperty("dot1x", out _));
+        Assert.True(root.TryGetProperty("wifi", out _));
+        Assert.True(root.TryGetProperty("internetProbe", out _));
+        Assert.False(root.TryGetProperty("network", out _));
     }
 
     [Fact]

--- a/src/Foundry.Core/Models/Configuration/FoundryConnectProvisioningBundle.cs
+++ b/src/Foundry.Core/Models/Configuration/FoundryConnectProvisioningBundle.cs
@@ -2,6 +2,8 @@ namespace Foundry.Core.Models.Configuration;
 
 public sealed record FoundryConnectProvisioningBundle
 {
+    public FoundryConnectConfigurationDocument Configuration { get; init; } = new();
+
     public string ConfigurationJson { get; init; } = string.Empty;
 
     public IReadOnlyList<FoundryConnectProvisionedAssetFile> AssetFiles { get; init; } = Array.Empty<FoundryConnectProvisionedAssetFile>();

--- a/src/Foundry.Core/Services/Configuration/ConnectConfigurationGenerator.cs
+++ b/src/Foundry.Core/Services/Configuration/ConnectConfigurationGenerator.cs
@@ -1,0 +1,146 @@
+using System.Text.Json;
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Core.Services.Configuration;
+
+public sealed class ConnectConfigurationGenerator : IConnectConfigurationGenerator
+{
+    private const string StagedAssetRootFolderName = "FoundryConnectAssets";
+    private const string MediaConfigRoot = @"Foundry\Config";
+    private const string WiredProfileFolder = @"Network\Wired\Profiles";
+    private const string WifiProfileFolder = @"Network\Wifi\Profiles";
+    private const string WiredCertificateFolder = @"Network\Certificates\Wired";
+    private const string WifiCertificateFolder = @"Network\Certificates\Wifi";
+
+    public FoundryConnectConfigurationDocument Generate(FoundryExpertConfigurationDocument document, string stagingDirectoryPath)
+    {
+        return CreateProvisioningBundle(document, stagingDirectoryPath).Configuration;
+    }
+
+    public FoundryConnectProvisioningBundle CreateProvisioningBundle(
+        FoundryExpertConfigurationDocument document,
+        string stagingDirectoryPath)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentException.ThrowIfNullOrWhiteSpace(stagingDirectoryPath);
+
+        NetworkConfigurationValidationResult validationResult = NetworkConfigurationValidator.Validate(document.Network);
+        if (!validationResult.IsValid)
+        {
+            throw new InvalidOperationException($"Network configuration is invalid: {validationResult.Code}.");
+        }
+
+        string assetRootPath = Path.Combine(stagingDirectoryPath, StagedAssetRootFolderName);
+        EnsureDirectoryClean(assetRootPath);
+
+        List<FoundryConnectProvisionedAssetFile> assetFiles = [];
+        NetworkSettings network = document.Network;
+        Dot1xSettings dot1x = network.Dot1x;
+        WifiSettings wifi = network.Wifi;
+        bool isWifiEnabled = network.WifiProvisioned && wifi.IsEnabled;
+
+        string? wiredProfileRelativePath = dot1x.IsEnabled
+            ? CopyAsset(dot1x.ProfileTemplatePath, assetRootPath, WiredProfileFolder, assetFiles)
+            : null;
+        string? wiredCertificateRelativePath = dot1x.IsEnabled
+            ? CopyAsset(dot1x.CertificatePath, assetRootPath, WiredCertificateFolder, assetFiles)
+            : null;
+        string? wifiProfileRelativePath = isWifiEnabled && wifi.HasEnterpriseProfile
+            ? CopyAsset(wifi.EnterpriseProfileTemplatePath, assetRootPath, WifiProfileFolder, assetFiles)
+            : null;
+        string? wifiCertificateRelativePath = isWifiEnabled
+            ? CopyAsset(wifi.CertificatePath, assetRootPath, WifiCertificateFolder, assetFiles)
+            : null;
+
+        FoundryConnectConfigurationDocument configuration = new()
+        {
+            Capabilities = new ConnectNetworkCapabilitiesSettings
+            {
+                WifiProvisioned = network.WifiProvisioned
+            },
+            Dot1x = dot1x with
+            {
+                ProfileTemplatePath = wiredProfileRelativePath,
+                CertificatePath = wiredCertificateRelativePath,
+                AuthenticationMode = NetworkAuthenticationMode.MachineOnly,
+                AllowRuntimeCredentials = false
+            },
+            Wifi = wifi with
+            {
+                IsEnabled = isWifiEnabled,
+                SecurityType = isWifiEnabled
+                    ? NetworkConfigurationValidator.NormalizeWifiSecurityType(wifi)
+                    : null,
+                Passphrase = isWifiEnabled && !wifi.HasEnterpriseProfile
+                    ? wifi.Passphrase
+                    : null,
+                EnterpriseProfileTemplatePath = isWifiEnabled && wifi.HasEnterpriseProfile
+                    ? wifiProfileRelativePath
+                    : null,
+                CertificatePath = wifiCertificateRelativePath,
+                EnterpriseAuthenticationMode = NetworkAuthenticationMode.UserOnly,
+                AllowRuntimeCredentials = false
+            }
+        };
+
+        return new FoundryConnectProvisioningBundle
+        {
+            Configuration = configuration,
+            ConfigurationJson = Serialize(configuration),
+            AssetFiles = assetFiles
+        };
+    }
+
+    public string Serialize(FoundryConnectConfigurationDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        return JsonSerializer.Serialize(document, ConfigurationJsonDefaults.SerializerOptions);
+    }
+
+    private static string? CopyAsset(
+        string? sourcePath,
+        string assetRootPath,
+        string relativeConfigFolder,
+        ICollection<FoundryConnectProvisionedAssetFile> assetFiles)
+    {
+        if (string.IsNullOrWhiteSpace(sourcePath))
+        {
+            return null;
+        }
+
+        string fullSourcePath = Path.GetFullPath(sourcePath);
+        if (!File.Exists(fullSourcePath))
+        {
+            throw new FileNotFoundException($"Foundry Connect asset source file was not found: '{fullSourcePath}'.", fullSourcePath);
+        }
+
+        string fileName = Path.GetFileName(fullSourcePath);
+        string stagedRelativePath = Path.Combine(relativeConfigFolder, fileName);
+        string stagedFilePath = Path.Combine(assetRootPath, stagedRelativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(stagedFilePath)!);
+        File.Copy(fullSourcePath, stagedFilePath, overwrite: true);
+
+        assetFiles.Add(new FoundryConnectProvisionedAssetFile
+        {
+            SourcePath = stagedFilePath,
+            RelativeDestinationPath = NormalizeEmbeddedRelativePath(Path.Combine(MediaConfigRoot, stagedRelativePath))
+        });
+
+        return NormalizeEmbeddedRelativePath(stagedRelativePath);
+    }
+
+    private static void EnsureDirectoryClean(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+
+        Directory.CreateDirectory(path);
+    }
+
+    private static string NormalizeEmbeddedRelativePath(string relativePath)
+    {
+        return relativePath.Replace('/', '\\').TrimStart('\\');
+    }
+}

--- a/src/Foundry.Core/Services/Configuration/IConnectConfigurationGenerator.cs
+++ b/src/Foundry.Core/Services/Configuration/IConnectConfigurationGenerator.cs
@@ -1,0 +1,12 @@
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Core.Services.Configuration;
+
+public interface IConnectConfigurationGenerator
+{
+    FoundryConnectConfigurationDocument Generate(FoundryExpertConfigurationDocument document, string stagingDirectoryPath);
+
+    FoundryConnectProvisioningBundle CreateProvisioningBundle(FoundryExpertConfigurationDocument document, string stagingDirectoryPath);
+
+    string Serialize(FoundryConnectConfigurationDocument document);
+}

--- a/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidationCode.cs
+++ b/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidationCode.cs
@@ -5,6 +5,7 @@ public enum NetworkConfigurationValidationCode
     None,
     WifiProvisioningRequired,
     WiredProfileTemplateRequired,
+    WiredProfileTemplateMissing,
     WiredCertificateRequired,
     WifiSsidRequired,
     UnsupportedWifiSecurityType,

--- a/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidator.cs
+++ b/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidator.cs
@@ -125,6 +125,11 @@ public static class NetworkConfigurationValidator
             return NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WiredProfileTemplateRequired);
         }
 
+        if (!File.Exists(Path.GetFullPath(settings.ProfileTemplatePath)))
+        {
+            return NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WiredProfileTemplateMissing);
+        }
+
         if (settings.RequiresCertificate && string.IsNullOrWhiteSpace(settings.CertificatePath))
         {
             return NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WiredCertificateRequired);

--- a/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningService.cs
@@ -267,21 +267,7 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
 
     private static string CreateFallbackFoundryConnectConfigurationJson()
     {
-        return """
-               {
-                 "schemaVersion": 1,
-                 "capabilities": {
-                   "wifiProvisioned": false
-                 },
-                 "network": {
-                   "internetProbes": [
-                     "http://www.msftconnecttest.com/connecttest.txt",
-                     "https://www.google.com/generate_204"
-                   ],
-                   "timeoutSeconds": 5
-                 }
-               }
-               """;
+        return JsonSerializer.Serialize(new FoundryConnectConfigurationDocument(), ConfigurationJsonDefaults.SerializerOptions);
     }
 
     private static string CreateFallbackDeployConfigurationJson()

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IAdkInstallationProbe, WindowsAdkInstallationProbe>();
         services.AddSingleton<IExpertConfigurationService, ExpertConfigurationService>();
         services.AddSingleton<IDeployConfigurationGenerator, DeployConfigurationGenerator>();
+        services.AddSingleton<IConnectConfigurationGenerator, ConnectConfigurationGenerator>();
         services.AddSingleton<ILanguageRegistryService, EmbeddedLanguageRegistryService>();
         services.AddSingleton<IExpertDeployConfigurationStateService, ExpertDeployConfigurationStateService>();
         services.AddSingleton<IWinPeLanguageDiscoveryService, WinPeLanguageDiscoveryService>();

--- a/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
@@ -8,15 +8,18 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
 {
     private readonly IExpertConfigurationService expertConfigurationService;
     private readonly IDeployConfigurationGenerator deployConfigurationGenerator;
+    private readonly IConnectConfigurationGenerator connectConfigurationGenerator;
     private readonly ILogger logger;
 
     public ExpertDeployConfigurationStateService(
         IExpertConfigurationService expertConfigurationService,
         IDeployConfigurationGenerator deployConfigurationGenerator,
+        IConnectConfigurationGenerator connectConfigurationGenerator,
         ILogger logger)
     {
         this.expertConfigurationService = expertConfigurationService;
         this.deployConfigurationGenerator = deployConfigurationGenerator;
+        this.connectConfigurationGenerator = connectConfigurationGenerator;
         this.logger = logger.ForContext<ExpertDeployConfigurationStateService>();
         Current = Load();
         Save();
@@ -62,6 +65,11 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
     public string GenerateDeployConfigurationJson()
     {
         return deployConfigurationGenerator.Serialize(deployConfigurationGenerator.Generate(Current));
+    }
+
+    public FoundryConnectProvisioningBundle GenerateConnectProvisioningBundle(string stagingDirectoryPath)
+    {
+        return connectConfigurationGenerator.CreateProvisioningBundle(Current, stagingDirectoryPath);
     }
 
     private FoundryExpertConfigurationDocument Load()

--- a/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
@@ -14,5 +14,7 @@ public interface IExpertDeployConfigurationStateService
 
     void UpdateLocalization(LocalizationSettings settings);
 
+    FoundryConnectProvisioningBundle GenerateConnectProvisioningBundle(string stagingDirectoryPath);
+
     string GenerateDeployConfigurationJson();
 }

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -225,6 +225,9 @@
   <data name="Network.ErrorWiredProfileTemplateRequired" xml:space="preserve">
     <value>Wired 802.1X requires a wired profile template.</value>
   </data>
+  <data name="Network.ErrorWiredProfileTemplateMissing" xml:space="preserve">
+    <value>Wired 802.1X profile template file was not found.</value>
+  </data>
   <data name="Network.ErrorWiredCertificateRequired" xml:space="preserve">
     <value>Wired 802.1X requires a trusted root CA certificate file when certificate trust is enabled.</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -225,6 +225,9 @@
   <data name="Network.ErrorWiredProfileTemplateRequired" xml:space="preserve">
     <value>Le 802.1X filaire nécessite un modèle de profil filaire.</value>
   </data>
+  <data name="Network.ErrorWiredProfileTemplateMissing" xml:space="preserve">
+    <value>Le fichier du modèle de profil 802.1X filaire est introuvable.</value>
+  </data>
   <data name="Network.ErrorWiredCertificateRequired" xml:space="preserve">
     <value>Le 802.1X filaire nécessite un certificat d'autorité racine de confiance lorsque la confiance par certificat est activée.</value>
   </data>

--- a/src/Foundry/ViewModels/NetworkConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/NetworkConfigurationViewModel.cs
@@ -236,7 +236,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
     [RelayCommand]
     private async Task BrowseDot1xProfileTemplateAsync()
     {
-        string? path = await PickOpenFileAsync("Network.ProfileTemplatePickerTitle", [".xml", "*"]);
+        string? path = await PickOpenFileAsync("Network.ProfileTemplatePickerTitle", [".xml"]);
         if (!string.IsNullOrWhiteSpace(path))
         {
             Dot1xProfileTemplatePath = path;
@@ -256,7 +256,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
     [RelayCommand]
     private async Task BrowseWifiEnterpriseProfileTemplateAsync()
     {
-        string? path = await PickOpenFileAsync("Network.ProfileTemplatePickerTitle", [".xml", "*"]);
+        string? path = await PickOpenFileAsync("Network.ProfileTemplatePickerTitle", [".xml"]);
         if (!string.IsNullOrWhiteSpace(path))
         {
             WifiEnterpriseProfileTemplatePath = path;
@@ -549,12 +549,18 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
             return string.Empty;
         }
 
-        if (dot1xOnly && result.Code is not (NetworkConfigurationValidationCode.WiredProfileTemplateRequired or NetworkConfigurationValidationCode.WiredCertificateRequired))
+        if (dot1xOnly && result.Code is not (
+            NetworkConfigurationValidationCode.WiredProfileTemplateRequired or
+            NetworkConfigurationValidationCode.WiredProfileTemplateMissing or
+            NetworkConfigurationValidationCode.WiredCertificateRequired))
         {
             return string.Empty;
         }
 
-        if (!dot1xOnly && result.Code is NetworkConfigurationValidationCode.WiredProfileTemplateRequired or NetworkConfigurationValidationCode.WiredCertificateRequired)
+        if (!dot1xOnly && result.Code is
+            NetworkConfigurationValidationCode.WiredProfileTemplateRequired or
+            NetworkConfigurationValidationCode.WiredProfileTemplateMissing or
+            NetworkConfigurationValidationCode.WiredCertificateRequired)
         {
             return string.Empty;
         }
@@ -563,6 +569,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
         {
             NetworkConfigurationValidationCode.WifiProvisioningRequired => "Network.ErrorWifiProvisioningRequired",
             NetworkConfigurationValidationCode.WiredProfileTemplateRequired => "Network.ErrorWiredProfileTemplateRequired",
+            NetworkConfigurationValidationCode.WiredProfileTemplateMissing => "Network.ErrorWiredProfileTemplateMissing",
             NetworkConfigurationValidationCode.WiredCertificateRequired => "Network.ErrorWiredCertificateRequired",
             NetworkConfigurationValidationCode.WifiSsidRequired => "Network.ErrorWifiSsidRequired",
             NetworkConfigurationValidationCode.UnsupportedWifiSecurityType => "Network.ErrorUnsupportedWifiSecurityTypeFormat",


### PR DESCRIPTION
## Summary
- Adds a Core `Foundry.Connect` provisioning generator for Phase 15.B.
- Generates complete effective Connect configuration documents with all root sections present.
- Stages wired/Wi-Fi profiles and certificates into the WPF-compatible network asset layout.
- Replaces the sparse WinPE fallback Connect JSON with the canonical complete document shape.

## Reason
Phase 15.B needs a single generated-media handoff for `Foundry.Connect` configuration and network assets before secret envelopes and Start preflight readiness are implemented in later Phase 15 splits.

## Main changes
- New `IConnectConfigurationGenerator` and `ConnectConfigurationGenerator` in Core.
- `FoundryConnectProvisioningBundle` now carries the generated configuration document, JSON, and staged asset files.
- App state service exposes `GenerateConnectProvisioningBundle(...)` and registers the generator in DI.
- WinPE asset provisioning fallback now writes complete Connect JSON instead of the legacy sparse `network` section.
- Network validation now reports missing wired 802.1X profile files on page load, matching Wi-Fi enterprise missing-file behavior.
- Added Core and Connect compatibility tests for complete root sections, config-relative paths, WPF asset layout, certificate copy behavior, current personal Wi-Fi runtime passphrase compatibility, and missing wired profile validation.

## Testing notes
- `dotnet test src/Foundry.Core.Tests/Foundry.Core.Tests.csproj -c Release --nologo` -> 149 passed.
- `dotnet test src/Foundry.Connect.Tests/Foundry.Connect.Tests.csproj -c Release --nologo` -> 16 passed.
- `dotnet test src/Foundry.Deploy.Tests/Foundry.Deploy.Tests.csproj -c Release --nologo` -> 49 passed.
- `dotnet build src/Foundry.slnx -c Release --nologo` -> 0 warnings, 0 errors.
- `git diff --check` -> passed, only CRLF normalization warnings.
