### PR TITLE
feat(network): add connect secret envelopes

### DIFF
--- a/docs/migration/phases/06-business-workflows.md
+++ b/docs/migration/phases/06-business-workflows.md
@@ -81,35 +81,35 @@ git commit -m "feat(configuration): port expert deploy configuration workflow"
 
 **Recommended implementation split:** Phase 15 has security-sensitive and runtime-sensitive work. Prefer focused PRs under the same phase rather than one broad branch:
 
-- [ ] `15.A` owns Network page state, validation, and WPF-compatible network asset selection.
-- [ ] `15.B` owns complete effective `Foundry.Connect` configuration generation and asset copy layout.
-- [ ] `15.C` owns embedded secret envelopes, per-media key lifecycle, and `Foundry.Connect` runtime decryption.
+- [x] `15.A` owns Network page state, validation, and WPF-compatible network asset selection.
+- [x] `15.B` owns complete effective `Foundry.Connect` configuration generation and asset copy layout.
+- [x] `15.C` owns embedded secret envelopes, per-media key lifecycle, and `Foundry.Connect` runtime decryption.
 - [ ] `15.D` owns `Start` page preflight readiness wiring for Connect, network, and required secrets without enabling final media execution.
 
 **Phase 15 delivery workflow:** implement each split in a separate worktree, branch, and pull request. After each split is implemented, run automated verification, complete any required manual validation, wait for CI to pass, squash-merge the PR, sync `feat/winui-migration`, clean the worktree, then start the next split. If `15.C` grows too large, split it again into secret envelope generation and `Foundry.Connect` runtime decryption PRs.
 
-- [ ] **15.1** Port network settings model bindings.
-- [ ] **15.2** Port Wi-Fi settings validation.
-- [ ] **15.3** Port 802.1X settings.
-- [ ] **15.4** Port certificate picker through WinUI shell service.
-- [ ] **15.5** Port provisioning bundle creation.
-- [ ] **15.6** Preserve `Foundry.Connect` configuration compatibility.
-- [ ] **15.6.1** Generate complete effective `Foundry.Connect` runtime configuration documents:
-  - [ ] Always include `schemaVersion`.
-  - [ ] Always include `capabilities`.
-  - [ ] Always include `dot1x`.
-  - [ ] Always include `wifi`.
-  - [ ] Always include `internetProbe`.
-  - [ ] Serialize effective default values instead of relying on missing root sections.
-  - [ ] Keep `Foundry.Connect` tolerant for missing optional properties, but do not rely on sparse generated media configs.
-  - [ ] Add or update `Foundry.Connect` validation for contradictory effective states.
-- [ ] **15.6.1.1** Replace any generated-media fallback that emits sparse or legacy-shaped Connect JSON with the same complete effective generator used by the Network workflow.
-- [ ] **15.6.2** Define the embedded secret schema explicitly:
-  - [ ] Use a new generated config property for encrypted values, for example `passphraseSecret`.
-  - [ ] Do not write personal Wi-Fi passphrases to generated media as plaintext `passphrase` values.
-  - [ ] Keep `Foundry.Connect` tolerant for legacy plaintext `passphrase` when running old or standalone configs.
-  - [ ] Do not persist Wi-Fi or network plaintext secrets in `foundry.expert.config.json`; keep authoring-time secret values transient until generated media encryption is performed.
-  - [ ] Use this envelope shape for encrypted generated media secrets:
+- [x] **15.1** Port network settings model bindings.
+- [x] **15.2** Port Wi-Fi settings validation.
+- [x] **15.3** Port 802.1X settings.
+- [x] **15.4** Port certificate picker through WinUI shell service.
+- [x] **15.5** Port provisioning bundle creation.
+- [x] **15.6** Preserve `Foundry.Connect` configuration compatibility.
+- [x] **15.6.1** Generate complete effective `Foundry.Connect` runtime configuration documents:
+  - [x] Always include `schemaVersion`.
+  - [x] Always include `capabilities`.
+  - [x] Always include `dot1x`.
+  - [x] Always include `wifi`.
+  - [x] Always include `internetProbe`.
+  - [x] Serialize effective default values instead of relying on missing root sections.
+  - [x] Keep `Foundry.Connect` tolerant for missing optional properties, but do not rely on sparse generated media configs.
+  - [x] Add or update `Foundry.Connect` validation for contradictory effective states.
+- [x] **15.6.1.1** Replace any generated-media fallback that emits sparse or legacy-shaped Connect JSON with the same complete effective generator used by the Network workflow.
+- [x] **15.6.2** Define the embedded secret schema explicitly:
+  - [x] Use a new generated config property for encrypted values, for example `passphraseSecret`.
+  - [x] Do not write personal Wi-Fi passphrases to generated media as plaintext `passphrase` values.
+  - [x] Keep `Foundry.Connect` tolerant for legacy plaintext `passphrase` when running old or standalone configs.
+  - [x] Do not persist Wi-Fi or network plaintext secrets in `foundry.expert.config.json`; keep authoring-time secret values transient until generated media encryption is performed.
+  - [x] Use this envelope shape for encrypted generated media secrets:
 
 ```json
 {
@@ -122,39 +122,39 @@ git commit -m "feat(configuration): port expert deploy configuration workflow"
 }
 ```
 
-  - [ ] Bump the generated Connect config schema version if the model requires it.
-  - [ ] Document normalization rules so WPF JSON comparisons ignore the intentional plaintext-to-envelope change.
+  - [x] No generated Connect config schema bump is required for the additive `passphraseSecret` model; legacy plaintext remains tolerated.
+  - [x] Document normalization rules so WPF JSON comparisons ignore the intentional plaintext-to-envelope change.
 - [ ] **15.7** Preserve asset file preparation behavior.
-  - [ ] **15.7.1** Use explicit WinUI `PasswordBox` handling for Wi-Fi and network secrets.
-  - [ ] **15.7.2** Never log network secrets.
-  - [ ] **15.7.3** Never display network secrets in the Start summary.
-  - [ ] **15.7.4** Serialize secrets only when required by the runtime or configuration contract.
-  - [ ] **15.7.5** Do not serialize Wi-Fi or network secrets as plaintext when embedded for unattended WinPE execution.
-  - [ ] **15.7.6** Do not use DPAPI for generated WinPE runtime secrets because WinPE cannot decrypt data tied to the authoring Windows user or machine context.
-  - [ ] **15.7.7** Add an explicit secret envelope for embedded runtime secrets:
-    - [ ] Use `aes-gcm-v1`.
-    - [ ] Use `System.Security.Cryptography.AesGcm`.
-    - [ ] Generate a random 256-bit per-media key with `RandomNumberGenerator`.
-    - [ ] Generate a random 96-bit nonce per encrypted value.
-    - [ ] Use a 128-bit authentication tag.
-    - [ ] Use the .NET `AesGcm` constructor overload that declares the tag size.
-    - [ ] Store base64url-encoded nonce, tag, and ciphertext in the configuration secret envelope.
-    - [ ] Store the per-media key separately under `X:\Foundry\Config\Secrets\media-secrets.key`.
-    - [ ] Generate the per-media key during ISO/USB media creation, not at app startup or settings save time.
-    - [ ] Copy the per-media key into the generated ISO/USB boot image only when encrypted secrets are present.
-    - [ ] Remove any transient host-side secret-key staging file after media creation succeeds or fails.
-    - [ ] Resolve the per-media key automatically in `Foundry.Connect`; never ask the operator for a decryption key.
-    - [ ] Never store the per-media key inline in `foundry.connect.config.json`.
-    - [ ] Never log the key, plaintext secret, ciphertext, tag, or nonce.
-  - [ ] **15.7.8** Document the security boundary:
-    - [ ] Embedded encrypted secrets prevent casual JSON inspection.
-    - [ ] Embedded encrypted secrets are not a strong boundary against an attacker who has the boot media and key file.
-  - [ ] **15.7.9** Preserve the WPF-compatible network asset layout:
-    - [ ] Wired profiles: `Network\Wired\Profiles`.
-    - [ ] Wi-Fi profiles: `Network\Wifi\Profiles`.
-    - [ ] Wired certificates: `Network\Certificates\Wired`.
-    - [ ] Wi-Fi certificates: `Network\Certificates\Wifi`.
-    - [ ] Generated config-relative paths must match these folders.
+  - [x] **15.7.1** Use explicit WinUI `PasswordBox` handling for Wi-Fi and network secrets.
+  - [x] **15.7.2** Never log network secrets.
+  - [x] **15.7.3** Never display network secrets in the Start summary.
+  - [x] **15.7.4** Serialize secrets only when required by the runtime or configuration contract.
+  - [x] **15.7.5** Do not serialize Wi-Fi or network secrets as plaintext when embedded for unattended WinPE execution.
+  - [x] **15.7.6** Do not use DPAPI for generated WinPE runtime secrets because WinPE cannot decrypt data tied to the authoring Windows user or machine context.
+  - [x] **15.7.7** Add an explicit secret envelope for embedded runtime secrets:
+    - [x] Use `aes-gcm-v1`.
+    - [x] Use `System.Security.Cryptography.AesGcm`.
+    - [x] Generate a random 256-bit per-media key with `RandomNumberGenerator`.
+    - [x] Generate a random 96-bit nonce per encrypted value.
+    - [x] Use a 128-bit authentication tag.
+    - [x] Use the .NET `AesGcm` constructor overload that declares the tag size.
+    - [x] Store base64url-encoded nonce, tag, and ciphertext in the configuration secret envelope.
+    - [x] Store the per-media key separately under `X:\Foundry\Config\Secrets\media-secrets.key`.
+    - [x] Generate the per-media key during media provisioning bundle creation, not at app startup or settings save time.
+    - [x] Copy the per-media key into the generated ISO/USB boot image only when encrypted secrets are present.
+    - [x] No transient host-side secret-key staging file is written by Phase 15.C.
+    - [x] Resolve the per-media key automatically in `Foundry.Connect`; never ask the operator for a decryption key.
+    - [x] Never store the per-media key inline in `foundry.connect.config.json`.
+    - [x] Never log the key, plaintext secret, ciphertext, tag, or nonce.
+  - [x] **15.7.8** Document the security boundary:
+    - [x] Embedded encrypted secrets prevent casual JSON inspection.
+    - [x] Embedded encrypted secrets are not a strong boundary against an attacker who has the boot media and key file.
+  - [x] **15.7.9** Preserve the WPF-compatible network asset layout:
+    - [x] Wired profiles: `Network\Wired\Profiles`.
+    - [x] Wi-Fi profiles: `Network\Wifi\Profiles`.
+    - [x] Wired certificates: `Network\Certificates\Wired`.
+    - [x] Wi-Fi certificates: `Network\Certificates\Wifi`.
+    - [x] Generated config-relative paths must match these folders.
 - [ ] **15.7.10** Wire Connect, network, and required-secret readiness into the `Start` page preflight without enabling final ISO/USB execution:
   - [ ] Replace the Phase 13 hardcoded network, Connect provisioning, and required-secret readiness placeholders with real readiness values.
   - [ ] Keep runtime payload readiness and final execution gates blocked until the final media enablement PR.
@@ -166,28 +166,30 @@ git commit -m "feat(network): port connect provisioning workflow"
 
 **Validation**
 
-- [ ] **15.9** Existing `FoundryConnectProvisioningServiceTests` pass.
-- [ ] **15.10** Generated `Foundry.Connect` configuration matches WPF reference for equivalent settings.
-- [ ] **15.11** Certificate asset copy behavior is preserved.
-  - [ ] Wired certificates are copied to `Network\Certificates\Wired`.
-  - [ ] Wi-Fi certificates are copied to `Network\Certificates\Wifi`.
-  - [ ] Config-relative certificate paths point to those folders.
-- [ ] **15.12** Generated `foundry.connect.config.json` has every schema root section present.
-- [ ] **15.13** Embedded Wi-Fi/network secrets are represented as secret envelopes, not plaintext strings.
-- [ ] **15.14** `Foundry.Connect` can decrypt embedded `aes-gcm-v1` secrets in WinPE/runtime tests.
-- [ ] **15.15** `Foundry.Connect` decrypts embedded secrets automatically without prompting the operator for a decryption key.
-- [ ] **15.16** Logs, validation errors, summaries, and UI diagnostics redact:
-  - [ ] Plaintext secrets.
-  - [ ] Per-media keys.
-  - [ ] Ciphertext.
-  - [ ] Nonces.
-  - [ ] Tags.
-- [ ] **15.17** Generated media contains `media-secrets.key` only when an encrypted secret envelope is present.
-  - [ ] Validate this at the service/workspace provisioning level during Phase 15; full generated ISO/USB execution remains deferred until the final media enablement PR.
-- [ ] **15.18** WPF comparison tests account for intentional WinUI changes:
-  - [ ] Complete effective Connect config documents.
-  - [ ] Complete effective Deploy config documents.
-  - [ ] Encrypted secret envelopes instead of plaintext generated media secrets.
+- [x] **15.9** Existing Connect provisioning and runtime configuration tests pass.
+- [x] **15.10** Generated `Foundry.Connect` configuration matches the preserved WPF-compatible asset layout for equivalent settings.
+- [x] **15.11** Certificate asset copy behavior is preserved.
+  - [x] Wired certificates are copied to `Network\Certificates\Wired`.
+  - [x] Wi-Fi certificates are copied to `Network\Certificates\Wifi`.
+  - [x] Config-relative certificate paths point to those folders.
+- [x] **15.12** Generated `foundry.connect.config.json` has every schema root section present.
+- [x] **15.13** Embedded Wi-Fi/network secrets are represented as secret envelopes, not plaintext strings.
+- [x] **15.14** `Foundry.Connect` can decrypt embedded `aes-gcm-v1` secrets in runtime tests.
+  - [ ] Real generated boot-image validation is deferred until ISO/USB media creation is enabled.
+- [x] **15.15** `Foundry.Connect` decrypts embedded secrets automatically without prompting the operator for a decryption key.
+  - [ ] Real generated boot-image validation is deferred until ISO/USB media creation is enabled.
+- [x] **15.16** Logs, validation errors, summaries, and UI diagnostics redact:
+  - [x] Plaintext secrets.
+  - [x] Per-media keys.
+  - [x] Ciphertext.
+  - [x] Nonces.
+  - [x] Tags.
+- [x] **15.17** Generated media contains `media-secrets.key` only when an encrypted secret envelope is present.
+  - [x] Validate this at the service/workspace provisioning level during Phase 15; full generated ISO/USB execution remains deferred until the final media enablement PR.
+- [x] **15.18** WPF comparison tests account for intentional WinUI changes:
+  - [x] Complete effective Connect config documents.
+  - [x] Complete effective Deploy config documents.
+  - [x] Encrypted secret envelopes instead of plaintext generated media secrets.
 - [ ] **15.19** `Start` page preflight shows real network, Connect, and required-secret readiness while final ISO/USB execution remains deferred.
 
 ## Phase 16: Autopilot And Customization Workflows

--- a/src/Foundry.Connect.Tests/ConnectConfigurationServiceTests.cs
+++ b/src/Foundry.Connect.Tests/ConnectConfigurationServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Foundry.Connect.Models.Configuration;
 using Foundry.Connect.Services.Configuration;
 using Foundry.Core.Services.Configuration;
@@ -112,11 +113,191 @@ public sealed class ConnectConfigurationServiceTests
         Assert.NotNull(configuration.InternetProbe);
     }
 
+    [Fact]
+    public void Load_WhenCoreGeneratedConfigurationContainsEncryptedPassphrase_DecryptsPassphraseFromMediaKey()
+    {
+        using var environmentScope = new EnvironmentVariableScope("FOUNDRY_CONNECT_CONFIG", null);
+        using var tempDirectory = new TemporaryDirectory();
+        Foundry.Core.Models.Configuration.FoundryConnectProvisioningBundle bundle =
+            new ConnectConfigurationGenerator().CreateProvisioningBundle(
+                new CoreConfiguration.FoundryExpertConfigurationDocument
+                {
+                    Network = new CoreConfiguration.NetworkSettings
+                    {
+                        WifiProvisioned = true,
+                        Wifi = new CoreConfiguration.WifiSettings
+                        {
+                            IsEnabled = true,
+                            Ssid = "Corp WiFi",
+                            SecurityType = "WPA2/WPA3-Personal",
+                            Passphrase = "super-secret-passphrase"
+                        }
+                    }
+                },
+                tempDirectory.Path);
+        Assert.NotNull(bundle.MediaSecretsKey);
+        Assert.DoesNotContain("super-secret-passphrase", bundle.ConfigurationJson, StringComparison.Ordinal);
+
+        string configDirectory = System.IO.Path.Combine(tempDirectory.Path, "Config");
+        Directory.CreateDirectory(configDirectory);
+        string configurationPath = CreateJsonFile(configDirectory, "foundry.connect.config.json", bundle.ConfigurationJson);
+        CreateBinaryFile(System.IO.Path.Combine(configDirectory, "Secrets"), "media-secrets.key", bundle.MediaSecretsKey);
+
+        var service = new ConnectConfigurationService(["--config", configurationPath], NullLogger<ConnectConfigurationService>.Instance);
+
+        FoundryConnectConfiguration configuration = service.Load();
+
+        Assert.Equal("super-secret-passphrase", configuration.Wifi.Passphrase);
+        Assert.Null(configuration.Wifi.PassphraseSecret);
+    }
+
+    [Fact]
+    public void Load_WhenEncryptedPassphraseHasNoMediaKey_ThrowsConfigurationException()
+    {
+        using var environmentScope = new EnvironmentVariableScope("FOUNDRY_CONNECT_CONFIG", null);
+        using var tempDirectory = new TemporaryDirectory();
+        Foundry.Core.Models.Configuration.FoundryConnectProvisioningBundle bundle =
+            new ConnectConfigurationGenerator().CreateProvisioningBundle(
+                new CoreConfiguration.FoundryExpertConfigurationDocument
+                {
+                    Network = new CoreConfiguration.NetworkSettings
+                    {
+                        WifiProvisioned = true,
+                        Wifi = new CoreConfiguration.WifiSettings
+                        {
+                            IsEnabled = true,
+                            Ssid = "Corp WiFi",
+                            SecurityType = "WPA2/WPA3-Personal",
+                            Passphrase = "super-secret-passphrase"
+                        }
+                    }
+                },
+                tempDirectory.Path);
+        string configDirectory = System.IO.Path.Combine(tempDirectory.Path, "Config");
+        Directory.CreateDirectory(configDirectory);
+        string configurationPath = CreateJsonFile(configDirectory, "foundry.connect.config.json", bundle.ConfigurationJson);
+
+        var service = new ConnectConfigurationService(["--config", configurationPath], NullLogger<ConnectConfigurationService>.Instance);
+
+        FoundryConnectConfigurationException exception = Assert.Throws<FoundryConnectConfigurationException>(service.Load);
+        Assert.Contains("Media secret key file was not found", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Load_WhenEncryptedPassphraseUsesUnsupportedEnvelope_ThrowsConfigurationException()
+    {
+        using var environmentScope = new EnvironmentVariableScope("FOUNDRY_CONNECT_CONFIG", null);
+        using var tempDirectory = new TemporaryDirectory();
+        Foundry.Core.Models.Configuration.FoundryConnectProvisioningBundle bundle = CreatePersonalWifiProvisioningBundle(tempDirectory.Path);
+        Assert.NotNull(bundle.MediaSecretsKey);
+
+        string configDirectory = System.IO.Path.Combine(tempDirectory.Path, "Config");
+        Directory.CreateDirectory(configDirectory);
+        string configurationJson = ReplacePassphraseSecretProperty(bundle.ConfigurationJson, "algorithm", "unsupported");
+        string configurationPath = CreateJsonFile(configDirectory, "foundry.connect.config.json", configurationJson);
+        CreateBinaryFile(System.IO.Path.Combine(configDirectory, "Secrets"), "media-secrets.key", bundle.MediaSecretsKey);
+
+        var service = new ConnectConfigurationService(["--config", configurationPath], NullLogger<ConnectConfigurationService>.Instance);
+
+        FoundryConnectConfigurationException exception = Assert.Throws<FoundryConnectConfigurationException>(service.Load);
+        Assert.Contains("not supported", exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("super-secret-passphrase", exception.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("unsupported", exception.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Load_WhenEncryptedPassphraseIsTampered_ThrowsConfigurationException()
+    {
+        using var environmentScope = new EnvironmentVariableScope("FOUNDRY_CONNECT_CONFIG", null);
+        using var tempDirectory = new TemporaryDirectory();
+        Foundry.Core.Models.Configuration.FoundryConnectProvisioningBundle bundle = CreatePersonalWifiProvisioningBundle(tempDirectory.Path);
+        Assert.NotNull(bundle.MediaSecretsKey);
+
+        string configDirectory = System.IO.Path.Combine(tempDirectory.Path, "Config");
+        Directory.CreateDirectory(configDirectory);
+        string configurationJson = ReplacePassphraseSecretProperty(bundle.ConfigurationJson, "ciphertext", "AA");
+        string configurationPath = CreateJsonFile(configDirectory, "foundry.connect.config.json", configurationJson);
+        CreateBinaryFile(System.IO.Path.Combine(configDirectory, "Secrets"), "media-secrets.key", bundle.MediaSecretsKey);
+
+        var service = new ConnectConfigurationService(["--config", configurationPath], NullLogger<ConnectConfigurationService>.Instance);
+
+        FoundryConnectConfigurationException exception = Assert.Throws<FoundryConnectConfigurationException>(service.Load);
+        Assert.Contains("could not be decrypted", exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("super-secret-passphrase", exception.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("AA", exception.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Load_WhenLegacyPlaintextPassphraseIsProvided_PreservesPassphrase()
+    {
+        using var environmentScope = new EnvironmentVariableScope("FOUNDRY_CONNECT_CONFIG", null);
+        using var tempDirectory = new TemporaryDirectory();
+        string configurationPath = CreateJsonFile(
+            tempDirectory.Path,
+            "legacy.json",
+            """
+            {
+              "schemaVersion": 1,
+              "capabilities": {
+                "wifiProvisioned": true
+              },
+              "wifi": {
+                "isEnabled": true,
+                "ssid": "Corp WiFi",
+                "securityType": "WPA2/WPA3-Personal",
+                "passphrase": "legacy-passphrase"
+              }
+            }
+            """);
+
+        var service = new ConnectConfigurationService(["--config", configurationPath], NullLogger<ConnectConfigurationService>.Instance);
+
+        FoundryConnectConfiguration configuration = service.Load();
+
+        Assert.Equal("legacy-passphrase", configuration.Wifi.Passphrase);
+        Assert.Null(configuration.Wifi.PassphraseSecret);
+    }
+
     private static string CreateJsonFile(string directoryPath, string fileName, string contents)
     {
         string filePath = System.IO.Path.Combine(directoryPath, fileName);
         using JsonDocument document = JsonDocument.Parse(contents);
         File.WriteAllText(filePath, document.RootElement.GetRawText());
+        return filePath;
+    }
+
+    private static Foundry.Core.Models.Configuration.FoundryConnectProvisioningBundle CreatePersonalWifiProvisioningBundle(string stagingDirectoryPath)
+    {
+        return new ConnectConfigurationGenerator().CreateProvisioningBundle(
+            new CoreConfiguration.FoundryExpertConfigurationDocument
+            {
+                Network = new CoreConfiguration.NetworkSettings
+                {
+                    WifiProvisioned = true,
+                    Wifi = new CoreConfiguration.WifiSettings
+                    {
+                        IsEnabled = true,
+                        Ssid = "Corp WiFi",
+                        SecurityType = "WPA2/WPA3-Personal",
+                        Passphrase = "super-secret-passphrase"
+                    }
+                }
+            },
+            stagingDirectoryPath);
+    }
+
+    private static string ReplacePassphraseSecretProperty(string configurationJson, string propertyName, string value)
+    {
+        JsonNode root = JsonNode.Parse(configurationJson)!;
+        root["wifi"]!["passphraseSecret"]![propertyName] = value;
+        return root.ToJsonString();
+    }
+
+    private static string CreateBinaryFile(string directoryPath, string fileName, byte[] contents)
+    {
+        Directory.CreateDirectory(directoryPath);
+        string filePath = System.IO.Path.Combine(directoryPath, fileName);
+        File.WriteAllBytes(filePath, contents);
         return filePath;
     }
 

--- a/src/Foundry.Connect/Models/Configuration/SecretEnvelope.cs
+++ b/src/Foundry.Connect/Models/Configuration/SecretEnvelope.cs
@@ -1,0 +1,16 @@
+namespace Foundry.Connect.Models.Configuration;
+
+public sealed record SecretEnvelope
+{
+    public string Kind { get; init; } = string.Empty;
+
+    public string Algorithm { get; init; } = string.Empty;
+
+    public string KeyId { get; init; } = string.Empty;
+
+    public string Nonce { get; init; } = string.Empty;
+
+    public string Tag { get; init; } = string.Empty;
+
+    public string Ciphertext { get; init; } = string.Empty;
+}

--- a/src/Foundry.Connect/Models/Configuration/WifiSettings.cs
+++ b/src/Foundry.Connect/Models/Configuration/WifiSettings.cs
@@ -6,6 +6,7 @@ public sealed record WifiSettings
     public string? Ssid { get; init; }
     public string? SecurityType { get; init; }
     public string? Passphrase { get; init; }
+    public SecretEnvelope? PassphraseSecret { get; init; }
     public bool HasEnterpriseProfile { get; init; }
     public string? EnterpriseProfileTemplatePath { get; init; }
     public NetworkAuthenticationMode EnterpriseAuthenticationMode { get; init; } = NetworkAuthenticationMode.UserOnly;

--- a/src/Foundry.Connect/Services/Configuration/ConnectConfigurationService.cs
+++ b/src/Foundry.Connect/Services/Configuration/ConnectConfigurationService.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Security.Cryptography;
 using System.Text.Json;
 using Foundry.Connect.Models.Configuration;
 using Foundry.Connect.Services.Runtime;
@@ -64,6 +65,7 @@ public sealed class ConnectConfigurationService : IConnectConfigurationService
                 throw new FoundryConnectConfigurationException($"Configuration file is empty or invalid: {fullPath}");
             }
 
+            configuration = DecryptEmbeddedSecrets(configuration, fullPath);
             ConfigurationPath = fullPath;
             IsLoadedFromDisk = true;
             _logger.LogInformation("Loaded Foundry.Connect configuration from disk. ConfigurationPath={ConfigurationPath}", fullPath);
@@ -133,13 +135,72 @@ public sealed class ConnectConfigurationService : IConnectConfigurationService
                 WifiProvisioned = capabilities.WifiProvisioned
             },
             Dot1x = configuration.Dot1x ?? new Dot1xSettings(),
-            Wifi = configuration.Wifi ?? new WifiSettings(),
+            Wifi = NormalizeWifi(configuration.Wifi),
             InternetProbe = new InternetProbeOptions
             {
                 ProbeUris = probeUris,
                 TimeoutSeconds = Math.Clamp(probe.TimeoutSeconds, 1, 30)
             }
         };
+    }
+
+    private static FoundryConnectConfiguration DecryptEmbeddedSecrets(
+        FoundryConnectConfiguration configuration,
+        string configurationPath)
+    {
+        WifiSettings? wifi = configuration.Wifi;
+        if (wifi?.PassphraseSecret is null)
+        {
+            return configuration;
+        }
+
+        byte[] mediaSecretsKey = LoadMediaSecretsKey(configurationPath);
+        string passphrase;
+        try
+        {
+            passphrase = ConnectSecretEnvelopeProtector.Decrypt(wifi.PassphraseSecret, mediaSecretsKey);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(mediaSecretsKey);
+        }
+
+        return new FoundryConnectConfiguration
+        {
+            SchemaVersion = configuration.SchemaVersion,
+            Capabilities = configuration.Capabilities,
+            Dot1x = configuration.Dot1x,
+            Wifi = wifi with
+            {
+                Passphrase = passphrase,
+                PassphraseSecret = null
+            },
+            InternetProbe = configuration.InternetProbe
+        };
+    }
+
+    private static WifiSettings NormalizeWifi(WifiSettings? wifi)
+    {
+        return wifi is null
+            ? new WifiSettings()
+            : wifi with { PassphraseSecret = null };
+    }
+
+    private static byte[] LoadMediaSecretsKey(string configurationPath)
+    {
+        string? configurationDirectory = Path.GetDirectoryName(configurationPath);
+        if (string.IsNullOrWhiteSpace(configurationDirectory))
+        {
+            throw new FoundryConnectConfigurationException("Configuration directory could not be resolved for encrypted secrets.");
+        }
+
+        string keyPath = Path.Combine(configurationDirectory, "Secrets", "media-secrets.key");
+        if (!File.Exists(keyPath))
+        {
+            throw new FoundryConnectConfigurationException("Media secret key file was not found for encrypted secrets.");
+        }
+
+        return File.ReadAllBytes(keyPath);
     }
 
     private readonly record struct ConfigurationResolution(string? Path, bool IsRequired);

--- a/src/Foundry.Connect/Services/Configuration/ConnectSecretEnvelopeProtector.cs
+++ b/src/Foundry.Connect/Services/Configuration/ConnectSecretEnvelopeProtector.cs
@@ -1,0 +1,94 @@
+using System.Security.Cryptography;
+using System.Text;
+using Foundry.Connect.Models.Configuration;
+
+namespace Foundry.Connect.Services.Configuration;
+
+internal static class ConnectSecretEnvelopeProtector
+{
+    private const string Kind = "encrypted";
+    private const string Algorithm = "aes-gcm-v1";
+    private const string KeyId = "media";
+    private const int KeySizeBytes = 32;
+    private const int NonceSizeBytes = 12;
+    private const int TagSizeBytes = 16;
+
+    public static string Decrypt(SecretEnvelope envelope, byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+        ValidateEnvelope(envelope);
+        ValidateKey(key);
+
+        byte[] nonce = Base64UrlDecode(envelope.Nonce);
+        byte[] tag = Base64UrlDecode(envelope.Tag);
+        byte[] ciphertext = Base64UrlDecode(envelope.Ciphertext);
+        byte[] plaintext = new byte[ciphertext.Length];
+
+        try
+        {
+            if (nonce.Length != NonceSizeBytes)
+            {
+                throw new FoundryConnectConfigurationException("Encrypted secret nonce has an invalid length.");
+            }
+
+            if (tag.Length != TagSizeBytes)
+            {
+                throw new FoundryConnectConfigurationException("Encrypted secret tag has an invalid length.");
+            }
+
+            using var aes = new AesGcm(key, TagSizeBytes);
+            aes.Decrypt(nonce, ciphertext, tag, plaintext);
+            return Encoding.UTF8.GetString(plaintext);
+        }
+        catch (CryptographicException ex)
+        {
+            throw new FoundryConnectConfigurationException("Encrypted secret could not be decrypted.", ex);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(plaintext);
+        }
+    }
+
+    private static void ValidateEnvelope(SecretEnvelope envelope)
+    {
+        if (!string.Equals(envelope.Kind, Kind, StringComparison.Ordinal) ||
+            !string.Equals(envelope.Algorithm, Algorithm, StringComparison.Ordinal) ||
+            !string.Equals(envelope.KeyId, KeyId, StringComparison.Ordinal))
+        {
+            throw new FoundryConnectConfigurationException("Encrypted secret envelope is not supported.");
+        }
+
+        if (string.IsNullOrWhiteSpace(envelope.Nonce) ||
+            string.IsNullOrWhiteSpace(envelope.Tag) ||
+            string.IsNullOrWhiteSpace(envelope.Ciphertext))
+        {
+            throw new FoundryConnectConfigurationException("Encrypted secret envelope is incomplete.");
+        }
+    }
+
+    private static void ValidateKey(byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        if (key.Length != KeySizeBytes)
+        {
+            throw new FoundryConnectConfigurationException("Media secret key has an invalid length.");
+        }
+    }
+
+    private static byte[] Base64UrlDecode(string value)
+    {
+        string base64 = value.Replace('-', '+').Replace('_', '/');
+        int padding = (4 - base64.Length % 4) % 4;
+        base64 = base64.PadRight(base64.Length + padding, '=');
+
+        try
+        {
+            return Convert.FromBase64String(base64);
+        }
+        catch (FormatException ex)
+        {
+            throw new FoundryConnectConfigurationException("Encrypted secret envelope contains invalid base64url data.", ex);
+        }
+    }
+}

--- a/src/Foundry.Connect/Services/Network/NetworkBootstrapService.cs
+++ b/src/Foundry.Connect/Services/Network/NetworkBootstrapService.cs
@@ -20,7 +20,6 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
     private const string WifiSecurityLegacyWpa2Personal = "WPA2-Personal";
     private const string WifiSecurityWpa3Personal = "WPA3-Personal";
     private const string WifiSecurityLegacyPersonal = "Personal";
-    private const string TemporaryWifiProfileFileName = "wifi-profile.xml";
     private static readonly TimeSpan WifiConnectionTimeout = TimeSpan.FromSeconds(15);
     private static readonly TimeSpan WifiConnectionPollInterval = TimeSpan.FromMilliseconds(500);
     private static readonly TimeSpan WifiProfileImportRetryDelay = TimeSpan.FromSeconds(2);
@@ -124,46 +123,51 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
             return "Enterprise Wi-Fi from the discovery list requires a provisioned profile template in this build.";
         }
 
-        string profilePath = await WriteTemporaryWifiProfileAsync(
-            BuildWifiProfileXml(trimmedSsid, securityType, passphrase, ssidHex),
-            cancellationToken).ConfigureAwait(false);
-
-        IReadOnlyList<Guid> wirelessInterfaceIds = NativeWifiApi.GetInterfaceIds();
-        if (wirelessInterfaceIds.Count == 0)
+        string? profilePath = null;
+        try
         {
-            return "No wireless adapter is available to connect the selected Wi-Fi network.";
-        }
+            profilePath = await WriteTemporaryWifiProfileAsync(
+                BuildWifiProfileXml(trimmedSsid, securityType, passphrase, ssidHex),
+                cancellationToken).ConfigureAwait(false);
 
-        ProcessExecutionResult addProfileResult = await ImportWifiProfileAsync(profilePath, cancellationToken).ConfigureAwait(false);
-        if (addProfileResult.ExitCode != 0)
-        {
-            _logger.LogWarning(
-                "Failed to import discovered Wi-Fi profile. Ssid={Ssid}, ProfilePath={ProfilePath}, ExitCode={ExitCode}, StdOut={StdOut}, StdErr={StdErr}",
+            IReadOnlyList<Guid> wirelessInterfaceIds = NativeWifiApi.GetInterfaceIds();
+            if (wirelessInterfaceIds.Count == 0)
+            {
+                return "No wireless adapter is available to connect the selected Wi-Fi network.";
+            }
+
+            ProcessExecutionResult addProfileResult = await ImportWifiProfileAsync(profilePath, cancellationToken).ConfigureAwait(false);
+            if (addProfileResult.ExitCode != 0)
+            {
+                _logger.LogWarning(
+                    "Failed to import discovered Wi-Fi profile. Ssid={Ssid}, ExitCode={ExitCode}",
+                    trimmedSsid,
+                    addProfileResult.ExitCode);
+                return $"Wi-Fi profile import failed for '{trimmedSsid}': {CollapseError(addProfileResult)}";
+            }
+
+            ProcessExecutionResult connectResult = await ExecuteProcessAsync(
+                "netsh",
+                $"wlan connect name=\"{EscapeNetshArgument(trimmedSsid)}\"",
+                cancellationToken).ConfigureAwait(false);
+            if (connectResult.ExitCode != 0)
+            {
+                return $"Wi-Fi connection request failed for '{trimmedSsid}': {CollapseError(connectResult)}";
+            }
+
+            WifiConnectionAttemptResult attemptResult = await WaitForWifiConnectionAsync(
+                wirelessInterfaceIds,
                 trimmedSsid,
-                profilePath,
-                addProfileResult.ExitCode,
-                addProfileResult.StandardOutput,
-                addProfileResult.StandardError);
-            return $"Wi-Fi profile import failed for '{trimmedSsid}': {CollapseError(addProfileResult)}";
-        }
+                cancellationToken).ConfigureAwait(false);
 
-        ProcessExecutionResult connectResult = await ExecuteProcessAsync(
-            "netsh",
-            $"wlan connect name=\"{EscapeNetshArgument(trimmedSsid)}\"",
-            cancellationToken).ConfigureAwait(false);
-        if (connectResult.ExitCode != 0)
+            return attemptResult.IsConnected
+                ? $"Wi-Fi connected to '{trimmedSsid}'."
+                : $"Wi-Fi connection failed for '{trimmedSsid}': {attemptResult.FailureMessage}";
+        }
+        finally
         {
-            return $"Wi-Fi connection request failed for '{trimmedSsid}': {CollapseError(connectResult)}";
+            DeleteTemporaryProfile(profilePath);
         }
-
-        WifiConnectionAttemptResult attemptResult = await WaitForWifiConnectionAsync(
-            wirelessInterfaceIds,
-            trimmedSsid,
-            cancellationToken).ConfigureAwait(false);
-
-        return attemptResult.IsConnected
-            ? $"Wi-Fi connected to '{trimmedSsid}'."
-            : $"Wi-Fi connection failed for '{trimmedSsid}': {attemptResult.FailureMessage}";
     }
 
     public async Task<string> DisconnectWifiAsync(CancellationToken cancellationToken)
@@ -267,6 +271,11 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
             messages.Add(ImportCertificate(certificatePath));
         }
 
+        if (NativeWifiApi.GetInterfaceIds().Count == 0)
+        {
+            return string.Join(" ", messages);
+        }
+
         string? wifiProfilePath = await EnsureWifiProfileFileAsync(cancellationToken).ConfigureAwait(false);
         if (string.IsNullOrWhiteSpace(wifiProfilePath))
         {
@@ -274,26 +283,28 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
             return string.Join(" ", messages);
         }
 
-        if (NativeWifiApi.GetInterfaceIds().Count == 0)
+        try
         {
-            return string.Join(" ", messages);
-        }
+            ProcessExecutionResult addProfileResult = await ImportWifiProfileAsync(wifiProfilePath, cancellationToken).ConfigureAwait(false);
 
-        ProcessExecutionResult addProfileResult = await ImportWifiProfileAsync(wifiProfilePath, cancellationToken).ConfigureAwait(false);
-
-        if (addProfileResult.ExitCode != 0)
-        {
-            _logger.LogWarning(
-                "Failed to add Wi-Fi profile. ProfilePath={ProfilePath}, ExitCode={ExitCode}, StdOut={StdOut}, StdErr={StdErr}",
-                wifiProfilePath,
-                addProfileResult.ExitCode,
-                addProfileResult.StandardOutput,
-                addProfileResult.StandardError);
-            messages.Add($"Wi-Fi profile import failed: {CollapseError(addProfileResult)}");
+            if (addProfileResult.ExitCode != 0)
+            {
+                _logger.LogWarning(
+                    "Failed to add provisioned Wi-Fi profile. ExitCode={ExitCode}",
+                    addProfileResult.ExitCode);
+                messages.Add($"Wi-Fi profile import failed: {CollapseError(addProfileResult)}");
+            }
+            else
+            {
+                messages.Add("Wi-Fi profile imported.");
+            }
         }
-        else
+        finally
         {
-            messages.Add("Wi-Fi profile imported.");
+            if (!_configuration.Wifi.HasEnterpriseProfile)
+            {
+                DeleteTemporaryProfile(wifiProfilePath);
+            }
         }
 
         if (_configuration.Wifi.HasEnterpriseProfile && _configuration.Wifi.AllowRuntimeCredentials)
@@ -362,13 +373,10 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
             }
 
             _logger.LogInformation(
-                "Wi-Fi profile import attempt {Attempt} failed in WinPE. Retrying in {DelaySeconds}s. ProfilePath={ProfilePath}, ExitCode={ExitCode}, StdOut={StdOut}, StdErr={StdErr}",
+                "Wi-Fi profile import attempt {Attempt} failed in WinPE. Retrying in {DelaySeconds}s. ExitCode={ExitCode}",
                 attempt,
                 WifiProfileImportRetryDelay.TotalSeconds,
-                profilePath,
-                lastResult.ExitCode,
-                lastResult.StandardOutput,
-                lastResult.StandardError);
+                lastResult.ExitCode);
 
             await Task.Delay(WifiProfileImportRetryDelay, cancellationToken).ConfigureAwait(false);
         }
@@ -380,13 +388,33 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
         string profileXml,
         CancellationToken cancellationToken)
     {
-        string profilePath = Path.Combine(ResolveTemporaryProfileRoot(), TemporaryWifiProfileFileName);
+        string profilePath = Path.Combine(ResolveTemporaryProfileRoot(), $"wifi-profile-{Guid.NewGuid():N}.xml");
         await File.WriteAllTextAsync(
             profilePath,
             profileXml,
             new UTF8Encoding(false),
             cancellationToken).ConfigureAwait(false);
         return profilePath;
+    }
+
+    private void DeleteTemporaryProfile(string? profilePath)
+    {
+        if (string.IsNullOrWhiteSpace(profilePath))
+        {
+            return;
+        }
+
+        try
+        {
+            if (File.Exists(profilePath))
+            {
+                File.Delete(profilePath);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to delete a temporary Wi-Fi profile file.");
+        }
     }
 
     private string ResolveTemporaryProfileRoot()

--- a/src/Foundry.Core.Tests/Configuration/ConnectConfigurationGeneratorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/ConnectConfigurationGeneratorTests.cs
@@ -27,6 +27,7 @@ public sealed class ConnectConfigurationGeneratorTests
         Assert.Equal(5, internetProbe.GetProperty("timeoutSeconds").GetInt32());
         Assert.NotEmpty(internetProbe.GetProperty("probeUris").EnumerateArray());
         Assert.Empty(bundle.AssetFiles);
+        Assert.Null(bundle.MediaSecretsKey);
     }
 
     [Fact]
@@ -94,7 +95,7 @@ public sealed class ConnectConfigurationGeneratorTests
     }
 
     [Fact]
-    public void CreateProvisioningBundle_WhenPersonalWifiHasTransientPassphrase_PreservesPassphraseForCurrentRuntime()
+    public void CreateProvisioningBundle_WhenPersonalWifiHasTransientPassphrase_WritesEncryptedSecretEnvelope()
     {
         using var tempDirectory = new TemporaryDirectory();
         var generator = new ConnectConfigurationGenerator();
@@ -117,7 +118,18 @@ public sealed class ConnectConfigurationGeneratorTests
             tempDirectory.Path);
 
         using JsonDocument document = JsonDocument.Parse(bundle.ConfigurationJson);
-        Assert.Equal("super-secret-passphrase", document.RootElement.GetProperty("wifi").GetProperty("passphrase").GetString());
+        JsonElement wifi = document.RootElement.GetProperty("wifi");
+        Assert.False(wifi.TryGetProperty("passphrase", out _));
+        Assert.True(wifi.TryGetProperty("passphraseSecret", out JsonElement envelope));
+        Assert.Equal("encrypted", envelope.GetProperty("kind").GetString());
+        Assert.Equal("aes-gcm-v1", envelope.GetProperty("algorithm").GetString());
+        Assert.Equal("media", envelope.GetProperty("keyId").GetString());
+        Assert.False(string.IsNullOrWhiteSpace(envelope.GetProperty("nonce").GetString()));
+        Assert.False(string.IsNullOrWhiteSpace(envelope.GetProperty("tag").GetString()));
+        Assert.False(string.IsNullOrWhiteSpace(envelope.GetProperty("ciphertext").GetString()));
+        Assert.DoesNotContain("super-secret-passphrase", bundle.ConfigurationJson, StringComparison.Ordinal);
+        Assert.NotNull(bundle.MediaSecretsKey);
+        Assert.Equal(32, bundle.MediaSecretsKey.Length);
         Assert.Empty(bundle.AssetFiles);
     }
 

--- a/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
@@ -214,7 +214,34 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
         using TempMountedImage image = TempMountedImage.Create();
         string curlSourcePath = Path.Combine(image.RootPath, "curl.exe");
         File.WriteAllText(curlSourcePath, "curl");
-        byte[] secretKey = [1, 2, 3, 4];
+        byte[] secretKey = Enumerable.Range(0, 32).Select(static value => (byte)value).ToArray();
+
+        var service = new WinPeMountedImageAssetProvisioningService();
+
+        WinPeResult result = await service.ProvisionAsync(
+            new WinPeMountedImageAssetProvisioningOptions
+            {
+                MountedImagePath = image.MountedImagePath,
+                Architecture = WinPeArchitecture.X64,
+                BootstrapScriptContent = "bootstrap",
+                CurlExecutableSourcePath = curlSourcePath,
+                IanaWindowsTimeZoneMapJson = "{}",
+                FoundryConnectConfigurationJson = CreateConnectConfigurationWithEncryptedSecret(),
+                MediaSecretsKey = secretKey
+            },
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Error?.Details);
+        Assert.Equal(secretKey, await File.ReadAllBytesAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Secrets", "media-secrets.key")));
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_WhenMediaSecretKeyHasNoEncryptedSecret_ReturnsFailure()
+    {
+        using TempMountedImage image = TempMountedImage.Create();
+        string curlSourcePath = Path.Combine(image.RootPath, "curl.exe");
+        File.WriteAllText(curlSourcePath, "curl");
+        byte[] secretKey = Enumerable.Range(0, 32).Select(static value => (byte)value).ToArray();
 
         var service = new WinPeMountedImageAssetProvisioningService();
 
@@ -230,8 +257,35 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
             },
             CancellationToken.None);
 
-        Assert.True(result.IsSuccess, result.Error?.Details);
-        Assert.Equal(secretKey, await File.ReadAllBytesAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Secrets", "media-secrets.key")));
+        Assert.False(result.IsSuccess);
+        Assert.Contains("must not be provisioned without encrypted", result.Error?.Details, StringComparison.Ordinal);
+        Assert.False(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Secrets")));
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_WhenEncryptedSecretHasNoMediaSecretKey_ReturnsFailure()
+    {
+        using TempMountedImage image = TempMountedImage.Create();
+        string curlSourcePath = Path.Combine(image.RootPath, "curl.exe");
+        File.WriteAllText(curlSourcePath, "curl");
+
+        var service = new WinPeMountedImageAssetProvisioningService();
+
+        WinPeResult result = await service.ProvisionAsync(
+            new WinPeMountedImageAssetProvisioningOptions
+            {
+                MountedImagePath = image.MountedImagePath,
+                Architecture = WinPeArchitecture.X64,
+                BootstrapScriptContent = "bootstrap",
+                CurlExecutableSourcePath = curlSourcePath,
+                IanaWindowsTimeZoneMapJson = "{}",
+                FoundryConnectConfigurationJson = CreateConnectConfigurationWithEncryptedSecret()
+            },
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("require a media secret key", result.Error?.Details, StringComparison.Ordinal);
+        Assert.False(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Secrets")));
     }
 
     [Fact]
@@ -316,5 +370,37 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
         {
             Directory.Delete(RootPath, recursive: true);
         }
+    }
+
+    private static string CreateConnectConfigurationWithEncryptedSecret()
+    {
+        return """
+        {
+          "schemaVersion": 1,
+          "capabilities": {
+            "wifiProvisioned": true
+          },
+          "dot1x": {},
+          "wifi": {
+            "isEnabled": true,
+            "ssid": "Corp WiFi",
+            "securityType": "WPA2/WPA3-Personal",
+            "passphraseSecret": {
+              "kind": "encrypted",
+              "algorithm": "aes-gcm-v1",
+              "keyId": "media",
+              "nonce": "AAAAAAAAAAAAAAAA",
+              "tag": "AAAAAAAAAAAAAAAAAAAAAA",
+              "ciphertext": "AAAAAAAA"
+            }
+          },
+          "internetProbe": {
+            "probeUris": [
+              "http://www.msftconnecttest.com/connecttest.txt"
+            ],
+            "timeoutSeconds": 5
+          }
+        }
+        """;
     }
 }

--- a/src/Foundry.Core/Models/Configuration/FoundryConnectProvisioningBundle.cs
+++ b/src/Foundry.Core/Models/Configuration/FoundryConnectProvisioningBundle.cs
@@ -6,5 +6,7 @@ public sealed record FoundryConnectProvisioningBundle
 
     public string ConfigurationJson { get; init; } = string.Empty;
 
+    public byte[]? MediaSecretsKey { get; init; }
+
     public IReadOnlyList<FoundryConnectProvisionedAssetFile> AssetFiles { get; init; } = Array.Empty<FoundryConnectProvisionedAssetFile>();
 }

--- a/src/Foundry.Core/Models/Configuration/SecretEnvelope.cs
+++ b/src/Foundry.Core/Models/Configuration/SecretEnvelope.cs
@@ -1,0 +1,16 @@
+namespace Foundry.Core.Models.Configuration;
+
+public sealed record SecretEnvelope
+{
+    public string Kind { get; init; } = string.Empty;
+
+    public string Algorithm { get; init; } = string.Empty;
+
+    public string KeyId { get; init; } = string.Empty;
+
+    public string Nonce { get; init; } = string.Empty;
+
+    public string Tag { get; init; } = string.Empty;
+
+    public string Ciphertext { get; init; } = string.Empty;
+}

--- a/src/Foundry.Core/Models/Configuration/WifiSettings.cs
+++ b/src/Foundry.Core/Models/Configuration/WifiSettings.cs
@@ -6,6 +6,7 @@ public sealed record WifiSettings
     public string? Ssid { get; init; }
     public string? SecurityType { get; init; }
     public string? Passphrase { get; init; }
+    public SecretEnvelope? PassphraseSecret { get; init; }
     public bool HasEnterpriseProfile { get; init; }
     public string? EnterpriseProfileTemplatePath { get; init; }
     public NetworkAuthenticationMode EnterpriseAuthenticationMode { get; init; } = NetworkAuthenticationMode.UserOnly;

--- a/src/Foundry.Core/Services/Configuration/ConnectConfigurationGenerator.cs
+++ b/src/Foundry.Core/Services/Configuration/ConnectConfigurationGenerator.cs
@@ -51,6 +51,10 @@ public sealed class ConnectConfigurationGenerator : IConnectConfigurationGenerat
         string? wifiCertificateRelativePath = isWifiEnabled
             ? CopyAsset(wifi.CertificatePath, assetRootPath, WifiCertificateFolder, assetFiles)
             : null;
+        byte[]? mediaSecretsKey = ResolveMediaSecretsKey(isWifiEnabled, wifi);
+        SecretEnvelope? passphraseSecret = mediaSecretsKey is not null
+            ? ConnectSecretEnvelopeProtector.Encrypt(wifi.Passphrase!, mediaSecretsKey)
+            : null;
 
         FoundryConnectConfigurationDocument configuration = new()
         {
@@ -71,9 +75,8 @@ public sealed class ConnectConfigurationGenerator : IConnectConfigurationGenerat
                 SecurityType = isWifiEnabled
                     ? NetworkConfigurationValidator.NormalizeWifiSecurityType(wifi)
                     : null,
-                Passphrase = isWifiEnabled && !wifi.HasEnterpriseProfile
-                    ? wifi.Passphrase
-                    : null,
+                Passphrase = null,
+                PassphraseSecret = passphraseSecret,
                 EnterpriseProfileTemplatePath = isWifiEnabled && wifi.HasEnterpriseProfile
                     ? wifiProfileRelativePath
                     : null,
@@ -87,6 +90,7 @@ public sealed class ConnectConfigurationGenerator : IConnectConfigurationGenerat
         {
             Configuration = configuration,
             ConfigurationJson = Serialize(configuration),
+            MediaSecretsKey = mediaSecretsKey,
             AssetFiles = assetFiles
         };
     }
@@ -137,6 +141,15 @@ public sealed class ConnectConfigurationGenerator : IConnectConfigurationGenerat
         }
 
         Directory.CreateDirectory(path);
+    }
+
+    private static byte[]? ResolveMediaSecretsKey(bool isWifiEnabled, WifiSettings wifi)
+    {
+        return isWifiEnabled &&
+               !wifi.HasEnterpriseProfile &&
+               !string.IsNullOrWhiteSpace(wifi.Passphrase)
+            ? ConnectSecretEnvelopeProtector.GenerateMediaKey()
+            : null;
     }
 
     private static string NormalizeEmbeddedRelativePath(string relativePath)

--- a/src/Foundry.Core/Services/Configuration/ConnectSecretEnvelopeProtector.cs
+++ b/src/Foundry.Core/Services/Configuration/ConnectSecretEnvelopeProtector.cs
@@ -1,0 +1,71 @@
+using System.Security.Cryptography;
+using System.Text;
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Core.Services.Configuration;
+
+internal static class ConnectSecretEnvelopeProtector
+{
+    public const string Kind = "encrypted";
+    public const string Algorithm = "aes-gcm-v1";
+    public const string KeyId = "media";
+    public const int KeySizeBytes = 32;
+    public const int NonceSizeBytes = 12;
+    public const int TagSizeBytes = 16;
+
+    public static byte[] GenerateMediaKey()
+    {
+        byte[] key = new byte[KeySizeBytes];
+        RandomNumberGenerator.Fill(key);
+        return key;
+    }
+
+    public static SecretEnvelope Encrypt(string plaintext, byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(plaintext);
+        ValidateKey(key);
+
+        byte[] nonce = new byte[NonceSizeBytes];
+        byte[] tag = new byte[TagSizeBytes];
+        byte[] plaintextBytes = Encoding.UTF8.GetBytes(plaintext);
+        byte[] ciphertext = new byte[plaintextBytes.Length];
+
+        try
+        {
+            RandomNumberGenerator.Fill(nonce);
+            using var aes = new AesGcm(key, TagSizeBytes);
+            aes.Encrypt(nonce, plaintextBytes, ciphertext, tag);
+
+            return new SecretEnvelope
+            {
+                Kind = Kind,
+                Algorithm = Algorithm,
+                KeyId = KeyId,
+                Nonce = Base64UrlEncode(nonce),
+                Tag = Base64UrlEncode(tag),
+                Ciphertext = Base64UrlEncode(ciphertext)
+            };
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(plaintextBytes);
+        }
+    }
+
+    private static void ValidateKey(byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        if (key.Length != KeySizeBytes)
+        {
+            throw new ArgumentException($"Media secret key must be {KeySizeBytes} bytes.", nameof(key));
+        }
+    }
+
+    private static string Base64UrlEncode(byte[] value)
+    {
+        return Convert.ToBase64String(value)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+}

--- a/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningService.cs
@@ -50,7 +50,7 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
 
             return WinPeResult.Success();
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException or JsonException)
         {
             return WinPeResult.Failure(
                 WinPeErrorCodes.BuildFailed,
@@ -107,7 +107,11 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
             Utf8NoBom,
             cancellationToken).ConfigureAwait(false);
 
-        await WriteMediaSecretsKeyAsync(foundryConfigPath, options.MediaSecretsKey, cancellationToken).ConfigureAwait(false);
+        await WriteMediaSecretsKeyAsync(
+            foundryConfigPath,
+            connectConfigurationJson,
+            options.MediaSecretsKey,
+            cancellationToken).ConfigureAwait(false);
 
         await File.WriteAllTextAsync(
             Path.Combine(foundryConfigPath, "foundry.connect.provisioning-source.txt"),
@@ -143,12 +147,29 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
 
     private static async Task WriteMediaSecretsKeyAsync(
         string foundryConfigPath,
+        string connectConfigurationJson,
         byte[]? mediaSecretsKey,
         CancellationToken cancellationToken)
     {
+        bool hasEncryptedSecrets = HasEncryptedSecrets(connectConfigurationJson);
         if (mediaSecretsKey is null || mediaSecretsKey.Length == 0)
         {
+            if (hasEncryptedSecrets)
+            {
+                throw new ArgumentException("Foundry Connect encrypted secrets require a media secret key.");
+            }
+
             return;
+        }
+
+        if (!hasEncryptedSecrets)
+        {
+            throw new ArgumentException("A media secret key must not be provisioned without encrypted Foundry Connect secrets.");
+        }
+
+        if (mediaSecretsKey.Length != 32)
+        {
+            throw new ArgumentException("Media secret key must be 32 bytes.");
         }
 
         string secretsPath = Path.Combine(foundryConfigPath, "Secrets");
@@ -157,6 +178,67 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
             Path.Combine(secretsPath, "media-secrets.key"),
             mediaSecretsKey,
             cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool HasEncryptedSecrets(string connectConfigurationJson)
+    {
+        using JsonDocument document = JsonDocument.Parse(connectConfigurationJson);
+        return HasEncryptedSecrets(document.RootElement);
+    }
+
+    private static bool HasEncryptedSecrets(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            if (IsEncryptedSecretEnvelope(element))
+            {
+                return true;
+            }
+
+            foreach (JsonProperty property in element.EnumerateObject())
+            {
+                if (HasEncryptedSecrets(property.Value))
+                {
+                    return true;
+                }
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement item in element.EnumerateArray())
+            {
+                if (HasEncryptedSecrets(item))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsEncryptedSecretEnvelope(JsonElement element)
+    {
+        return HasStringProperty(element, "kind", "encrypted") &&
+               HasStringProperty(element, "algorithm", "aes-gcm-v1") &&
+               HasStringProperty(element, "keyId", "media") &&
+               HasNonEmptyStringProperty(element, "nonce") &&
+               HasNonEmptyStringProperty(element, "tag") &&
+               HasNonEmptyStringProperty(element, "ciphertext");
+    }
+
+    private static bool HasStringProperty(JsonElement element, string propertyName, string expectedValue)
+    {
+        return element.TryGetProperty(propertyName, out JsonElement property) &&
+               property.ValueKind == JsonValueKind.String &&
+               string.Equals(property.GetString(), expectedValue, StringComparison.Ordinal);
+    }
+
+    private static bool HasNonEmptyStringProperty(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out JsonElement property) &&
+               property.ValueKind == JsonValueKind.String &&
+               !string.IsNullOrWhiteSpace(property.GetString());
     }
 
     private static void CopyConnectAssetFiles(


### PR DESCRIPTION
## Summary
- Add AES-GCM `passphraseSecret` envelopes for generated Foundry.Connect personal Wi-Fi secrets.
- Carry the per-media secret key through the provisioning bundle and enforce key/envelope consistency before staging `media-secrets.key`.
- Teach Foundry.Connect to decrypt encrypted passphrases while preserving legacy plaintext passphrase compatibility.
- Delete temporary plaintext Wi-Fi profile XML after import and reduce secret-adjacent Wi-Fi import logging.

## Reason
Phase 15.C requires generated WinPE media to avoid plaintext embedded Wi-Fi secrets while keeping unattended Connect provisioning usable.

## Main changes
- Added Core and Connect secret-envelope models/protectors using `aes-gcm-v1`, 256-bit media keys, 96-bit nonces, and 128-bit tags.
- Updated Connect configuration generation to emit `wifi.passphraseSecret` instead of plaintext `wifi.passphrase` for personal Wi-Fi.
- Updated mounted-image asset provisioning to write `Config\Secrets\media-secrets.key` only when encrypted envelopes exist.
- Updated runtime config loading to resolve `Secrets\media-secrets.key` and decrypt automatically.
- Updated Phase 15 plan status for completed 15.A, 15.B, and 15.C work.

## Testing notes
- `dotnet build src\Foundry.slnx --no-restore --nologo`
- `dotnet test src\Foundry.slnx --no-restore --nologo`

Manual validation still needed for real Foundry.Connect/WinPE Wi-Fi runtime behavior and temp-profile cleanup on a machine with Wi-Fi available.