### PR TITLE
feat(network): wire connect preflight readiness

### DIFF
--- a/docs/migration/phases/06-business-workflows.md
+++ b/docs/migration/phases/06-business-workflows.md
@@ -84,7 +84,7 @@ git commit -m "feat(configuration): port expert deploy configuration workflow"
 - [x] `15.A` owns Network page state, validation, and WPF-compatible network asset selection.
 - [x] `15.B` owns complete effective `Foundry.Connect` configuration generation and asset copy layout.
 - [x] `15.C` owns embedded secret envelopes, per-media key lifecycle, and `Foundry.Connect` runtime decryption.
-- [ ] `15.D` owns `Start` page preflight readiness wiring for Connect, network, and required secrets without enabling final media execution.
+- [x] `15.D` owns `Start` page preflight readiness wiring for Connect, network, and required secrets without enabling final media execution.
 
 **Phase 15 delivery workflow:** implement each split in a separate worktree, branch, and pull request. After each split is implemented, run automated verification, complete any required manual validation, wait for CI to pass, squash-merge the PR, sync `feat/winui-migration`, clean the worktree, then start the next split. If `15.C` grows too large, split it again into secret envelope generation and `Foundry.Connect` runtime decryption PRs.
 
@@ -124,7 +124,7 @@ git commit -m "feat(configuration): port expert deploy configuration workflow"
 
   - [x] No generated Connect config schema bump is required for the additive `passphraseSecret` model; legacy plaintext remains tolerated.
   - [x] Document normalization rules so WPF JSON comparisons ignore the intentional plaintext-to-envelope change.
-- [ ] **15.7** Preserve asset file preparation behavior.
+- [x] **15.7** Preserve asset file preparation behavior.
   - [x] **15.7.1** Use explicit WinUI `PasswordBox` handling for Wi-Fi and network secrets.
   - [x] **15.7.2** Never log network secrets.
   - [x] **15.7.3** Never display network secrets in the Start summary.
@@ -155,13 +155,13 @@ git commit -m "feat(configuration): port expert deploy configuration workflow"
     - [x] Wired certificates: `Network\Certificates\Wired`.
     - [x] Wi-Fi certificates: `Network\Certificates\Wifi`.
     - [x] Generated config-relative paths must match these folders.
-- [ ] **15.7.10** Wire Connect, network, and required-secret readiness into the `Start` page preflight without enabling final ISO/USB execution:
-  - [ ] Replace the Phase 13 hardcoded network, Connect provisioning, and required-secret readiness placeholders with real readiness values.
-  - [ ] Keep runtime payload readiness and final execution gates blocked until the final media enablement PR.
-- [ ] **15.8** Commit:
+- [x] **15.7.10** Wire Connect, network, and required-secret readiness into the `Start` page preflight without enabling final ISO/USB execution:
+  - [x] Replace the Phase 13 hardcoded network, Connect provisioning, and required-secret readiness placeholders with real readiness values.
+  - [x] Keep runtime payload readiness and final execution gates blocked until the final media enablement PR.
+- [x] **15.8** Commit:
 
 ```powershell
-git commit -m "feat(network): port connect provisioning workflow"
+git commit -m "feat(network): wire connect preflight readiness"
 ```
 
 **Validation**
@@ -190,7 +190,7 @@ git commit -m "feat(network): port connect provisioning workflow"
   - [x] Complete effective Connect config documents.
   - [x] Complete effective Deploy config documents.
   - [x] Encrypted secret envelopes instead of plaintext generated media secrets.
-- [ ] **15.19** `Start` page preflight shows real network, Connect, and required-secret readiness while final ISO/USB execution remains deferred.
+- [x] **15.19** `Start` page preflight shows real network, Connect, and required-secret readiness while final ISO/USB execution remains deferred.
 
 ## Phase 16: Autopilot And Customization Workflows
 

--- a/src/Foundry.Core.Tests/Configuration/NetworkConfigurationValidatorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/NetworkConfigurationValidatorTests.cs
@@ -101,6 +101,64 @@ public sealed class NetworkConfigurationValidatorTests
     }
 
     [Fact]
+    public void Validate_WhenWiredCertificatePathDoesNotExist_ReturnsWiredCertificateMissing()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        string profilePath = Path.Combine(tempDirectory.Path, "wired.xml");
+        File.WriteAllText(profilePath, "<LANProfile />");
+
+        NetworkConfigurationValidationResult result = NetworkConfigurationValidator.Validate(
+            new NetworkSettings
+            {
+                Dot1x = new Dot1xSettings
+                {
+                    IsEnabled = true,
+                    ProfileTemplatePath = profilePath,
+                    CertificatePath = Path.Combine(tempDirectory.Path, "missing.cer")
+                }
+            });
+
+        Assert.Equal(NetworkConfigurationValidationCode.WiredCertificateMissing, result.Code);
+    }
+
+    [Fact]
+    public void Validate_WhenWifiCertificatePathDoesNotExist_ReturnsWifiEnterpriseCertificateMissing()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        string profilePath = Path.Combine(tempDirectory.Path, "wifi.xml");
+        File.WriteAllText(
+            profilePath,
+            """
+            <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
+              <MSM>
+                <security>
+                  <authEncryption>
+                    <authentication>WPA2</authentication>
+                  </authEncryption>
+                </security>
+              </MSM>
+            </WLANProfile>
+            """);
+
+        NetworkConfigurationValidationResult result = NetworkConfigurationValidator.Validate(
+            new NetworkSettings
+            {
+                WifiProvisioned = true,
+                Wifi = new WifiSettings
+                {
+                    IsEnabled = true,
+                    Ssid = "CorpWiFi",
+                    SecurityType = NetworkConfigurationValidator.WifiSecurityEnterprise,
+                    HasEnterpriseProfile = true,
+                    EnterpriseProfileTemplatePath = profilePath,
+                    CertificatePath = Path.Combine(tempDirectory.Path, "missing.cer")
+                }
+            });
+
+        Assert.Equal(NetworkConfigurationValidationCode.WifiEnterpriseCertificateMissing, result.Code);
+    }
+
+    [Fact]
     public void SanitizeForPersistence_RemovesPlaintextWifiPassphrase()
     {
         NetworkSettings settings = new()

--- a/src/Foundry.Core.Tests/Configuration/NetworkMediaReadinessEvaluatorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/NetworkMediaReadinessEvaluatorTests.cs
@@ -1,0 +1,114 @@
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Configuration;
+
+namespace Foundry.Core.Tests.Configuration;
+
+public sealed class NetworkMediaReadinessEvaluatorTests
+{
+    [Fact]
+    public void Evaluate_WhenNetworkFeaturesAreDisabled_ReturnsReady()
+    {
+        NetworkMediaReadinessEvaluation evaluation = NetworkMediaReadinessEvaluator.Evaluate(new NetworkSettings());
+
+        Assert.True(evaluation.IsNetworkConfigurationReady);
+        Assert.True(evaluation.IsConnectProvisioningReady);
+        Assert.True(evaluation.AreRequiredSecretsReady);
+    }
+
+    [Fact]
+    public void Evaluate_WhenWiredProfileIsMissing_ReturnsNetworkAndConnectNotReady()
+    {
+        NetworkSettings settings = new()
+        {
+            Dot1x = new Dot1xSettings
+            {
+                IsEnabled = true,
+                ProfileTemplatePath = @"C:\Missing\wired.xml"
+            }
+        };
+
+        NetworkMediaReadinessEvaluation evaluation = NetworkMediaReadinessEvaluator.Evaluate(settings);
+
+        Assert.False(evaluation.IsNetworkConfigurationReady);
+        Assert.False(evaluation.IsConnectProvisioningReady);
+        Assert.True(evaluation.AreRequiredSecretsReady);
+    }
+
+    [Fact]
+    public void Evaluate_WhenPersonalWifiSecretIsMissing_ReturnsSecretAndConnectNotReady()
+    {
+        NetworkSettings settings = CreatePersonalWifiSettings();
+
+        NetworkMediaReadinessEvaluation evaluation = NetworkMediaReadinessEvaluator.Evaluate(settings);
+
+        Assert.True(evaluation.IsNetworkConfigurationReady);
+        Assert.False(evaluation.IsConnectProvisioningReady);
+        Assert.False(evaluation.AreRequiredSecretsReady);
+    }
+
+    [Fact]
+    public void Evaluate_WhenPersonalWifiSecretIsValid_ReturnsReady()
+    {
+        NetworkSettings settings = CreatePersonalWifiSettings();
+
+        NetworkMediaReadinessEvaluation evaluation = NetworkMediaReadinessEvaluator.Evaluate(settings, "ValidPassphrase123");
+
+        Assert.True(evaluation.IsNetworkConfigurationReady);
+        Assert.True(evaluation.IsConnectProvisioningReady);
+        Assert.True(evaluation.AreRequiredSecretsReady);
+    }
+
+    [Fact]
+    public void Evaluate_WhenPersonalWifiSecretExistsOnlyOnSettings_ReturnsSecretAndConnectNotReady()
+    {
+        NetworkSettings settings = CreatePersonalWifiSettings() with
+        {
+            Wifi = CreatePersonalWifiSettings().Wifi with
+            {
+                Passphrase = "PersistedPassphrase123"
+            }
+        };
+
+        NetworkMediaReadinessEvaluation evaluation = NetworkMediaReadinessEvaluator.Evaluate(settings);
+
+        Assert.True(evaluation.IsNetworkConfigurationReady);
+        Assert.False(evaluation.IsConnectProvisioningReady);
+        Assert.False(evaluation.AreRequiredSecretsReady);
+    }
+
+    [Fact]
+    public void ApplyRequiredSecrets_WhenPersonalWifiSecretIsValid_ReturnsSettingsWithPassphrase()
+    {
+        NetworkSettings settings = CreatePersonalWifiSettings();
+
+        NetworkSettings result = NetworkMediaReadinessEvaluator.ApplyRequiredSecrets(settings, "ValidPassphrase123");
+
+        Assert.Equal("ValidPassphrase123", result.Wifi.Passphrase);
+    }
+
+    [Fact]
+    public void Evaluate_WhenPersonalWifiSecretIsInvalid_ReturnsSecretAndConnectNotReady()
+    {
+        NetworkSettings settings = CreatePersonalWifiSettings();
+
+        NetworkMediaReadinessEvaluation evaluation = NetworkMediaReadinessEvaluator.Evaluate(settings, "short");
+
+        Assert.True(evaluation.IsNetworkConfigurationReady);
+        Assert.False(evaluation.IsConnectProvisioningReady);
+        Assert.False(evaluation.AreRequiredSecretsReady);
+    }
+
+    private static NetworkSettings CreatePersonalWifiSettings()
+    {
+        return new NetworkSettings
+        {
+            WifiProvisioned = true,
+            Wifi = new WifiSettings
+            {
+                IsEnabled = true,
+                Ssid = "Foundry",
+                SecurityType = NetworkConfigurationValidator.WifiSecurityPersonal
+            }
+        };
+    }
+}

--- a/src/Foundry.Core.Tests/Configuration/NetworkSecretStateTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/NetworkSecretStateTests.cs
@@ -1,0 +1,61 @@
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Configuration;
+
+namespace Foundry.Core.Tests.Configuration;
+
+public sealed class NetworkSecretStateTests
+{
+    [Fact]
+    public void Update_WhenPersonalWifiPassphraseIsMissingOnLaterSave_PreservesTransientSecret()
+    {
+        NetworkSecretState state = new();
+
+        state.Update(CreatePersonalWifiSettings("ValidPassphrase123"));
+        state.Update(CreatePersonalWifiSettings(null) with
+        {
+            Wifi = CreatePersonalWifiSettings(null).Wifi with
+            {
+                Ssid = "UpdatedFoundry"
+            }
+        });
+
+        Assert.Equal("ValidPassphrase123", state.PersonalWifiPassphrase);
+    }
+
+    [Fact]
+    public void ClearPersonalWifiPassphrase_RemovesTransientSecret()
+    {
+        NetworkSecretState state = new();
+
+        state.Update(CreatePersonalWifiSettings("ValidPassphrase123"));
+        state.ClearPersonalWifiPassphrase();
+
+        Assert.Null(state.PersonalWifiPassphrase);
+    }
+
+    [Fact]
+    public void Update_WhenPersonalWifiIsDisabled_ClearsTransientSecret()
+    {
+        NetworkSecretState state = new();
+
+        state.Update(CreatePersonalWifiSettings("ValidPassphrase123"));
+        state.Update(new NetworkSettings());
+
+        Assert.Null(state.PersonalWifiPassphrase);
+    }
+
+    private static NetworkSettings CreatePersonalWifiSettings(string? passphrase)
+    {
+        return new NetworkSettings
+        {
+            WifiProvisioned = true,
+            Wifi = new WifiSettings
+            {
+                IsEnabled = true,
+                Ssid = "Foundry",
+                SecurityType = NetworkConfigurationValidator.WifiSecurityPersonal,
+                Passphrase = passphrase
+            }
+        };
+    }
+}

--- a/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidationCode.cs
+++ b/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidationCode.cs
@@ -7,6 +7,7 @@ public enum NetworkConfigurationValidationCode
     WiredProfileTemplateRequired,
     WiredProfileTemplateMissing,
     WiredCertificateRequired,
+    WiredCertificateMissing,
     WifiSsidRequired,
     UnsupportedWifiSecurityType,
     WifiPersonalPassphraseInvalid,
@@ -14,5 +15,6 @@ public enum NetworkConfigurationValidationCode
     WifiEnterpriseProfileTemplateMissing,
     WifiEnterpriseAuthenticationUnsupported,
     WifiEnterpriseAuthenticationMismatch,
-    WifiEnterpriseCertificateRequired
+    WifiEnterpriseCertificateRequired,
+    WifiEnterpriseCertificateMissing
 }

--- a/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidator.cs
+++ b/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidator.cs
@@ -135,6 +135,12 @@ public static class NetworkConfigurationValidator
             return NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WiredCertificateRequired);
         }
 
+        if (!string.IsNullOrWhiteSpace(settings.CertificatePath) &&
+            !File.Exists(Path.GetFullPath(settings.CertificatePath)))
+        {
+            return NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WiredCertificateMissing);
+        }
+
         return NetworkConfigurationValidationResult.Success;
     }
 
@@ -213,9 +219,18 @@ public static class NetworkConfigurationValidator
             }
         }
 
-        return settings.RequiresCertificate && string.IsNullOrWhiteSpace(settings.CertificatePath)
-            ? NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WifiEnterpriseCertificateRequired)
-            : NetworkConfigurationValidationResult.Success;
+        if (settings.RequiresCertificate && string.IsNullOrWhiteSpace(settings.CertificatePath))
+        {
+            return NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WifiEnterpriseCertificateRequired);
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.CertificatePath) &&
+            !File.Exists(Path.GetFullPath(settings.CertificatePath)))
+        {
+            return NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WifiEnterpriseCertificateMissing);
+        }
+
+        return NetworkConfigurationValidationResult.Success;
     }
 
     private static bool IsPersonalSecurityType(string? securityType)

--- a/src/Foundry.Core/Services/Configuration/NetworkMediaReadinessEvaluation.cs
+++ b/src/Foundry.Core/Services/Configuration/NetworkMediaReadinessEvaluation.cs
@@ -1,0 +1,8 @@
+namespace Foundry.Core.Services.Configuration;
+
+public sealed record NetworkMediaReadinessEvaluation
+{
+    public bool IsNetworkConfigurationReady { get; init; }
+    public bool IsConnectProvisioningReady { get; init; }
+    public bool AreRequiredSecretsReady { get; init; }
+}

--- a/src/Foundry.Core/Services/Configuration/NetworkMediaReadinessEvaluator.cs
+++ b/src/Foundry.Core/Services/Configuration/NetworkMediaReadinessEvaluator.cs
@@ -1,0 +1,72 @@
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Core.Services.Configuration;
+
+public static class NetworkMediaReadinessEvaluator
+{
+    private const string ValidationPassphrasePlaceholder = "FoundryTransientSecret";
+
+    public static NetworkMediaReadinessEvaluation Evaluate(NetworkSettings settings, string? personalWifiPassphrase = null)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        bool requiresPersonalWifiPassphrase = RequiresPersonalWifiPassphrase(settings);
+        NetworkSettings validationSettings = requiresPersonalWifiPassphrase
+            ? settings with
+            {
+                Wifi = settings.Wifi with
+                {
+                    Passphrase = ValidationPassphrasePlaceholder
+                }
+            }
+            : settings;
+
+        bool isNetworkConfigurationReady = NetworkConfigurationValidator.Validate(validationSettings).IsValid;
+        bool areRequiredSecretsReady = !requiresPersonalWifiPassphrase ||
+            IsPersonalWifiPassphraseValid(personalWifiPassphrase);
+
+        return new NetworkMediaReadinessEvaluation
+        {
+            IsNetworkConfigurationReady = isNetworkConfigurationReady,
+            IsConnectProvisioningReady = isNetworkConfigurationReady && areRequiredSecretsReady,
+            AreRequiredSecretsReady = areRequiredSecretsReady
+        };
+    }
+
+    public static NetworkSettings ApplyRequiredSecrets(NetworkSettings settings, string? personalWifiPassphrase)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        if (!RequiresPersonalWifiPassphrase(settings) || !IsPersonalWifiPassphraseValid(personalWifiPassphrase))
+        {
+            return settings;
+        }
+
+        return settings with
+        {
+            Wifi = settings.Wifi with
+            {
+                Passphrase = personalWifiPassphrase!.Trim()
+            }
+        };
+    }
+
+    private static bool RequiresPersonalWifiPassphrase(NetworkSettings settings)
+    {
+        if (!settings.WifiProvisioned || !settings.Wifi.IsEnabled || settings.Wifi.HasEnterpriseProfile)
+        {
+            return false;
+        }
+
+        return string.Equals(
+            NetworkConfigurationValidator.NormalizeWifiSecurityType(settings.Wifi),
+            NetworkConfigurationValidator.WifiSecurityPersonal,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsPersonalWifiPassphraseValid(string? passphrase)
+    {
+        int length = passphrase?.Trim().Length ?? 0;
+        return length is >= 8 and <= 63;
+    }
+}

--- a/src/Foundry.Core/Services/Configuration/NetworkSecretState.cs
+++ b/src/Foundry.Core/Services/Configuration/NetworkSecretState.cs
@@ -1,0 +1,45 @@
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Core.Services.Configuration;
+
+public sealed class NetworkSecretState
+{
+    public string? PersonalWifiPassphrase { get; private set; }
+
+    public void Update(NetworkSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        if (!RequiresPersonalWifiPassphrase(settings))
+        {
+            PersonalWifiPassphrase = null;
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.Wifi.Passphrase))
+        {
+            PersonalWifiPassphrase = settings.Wifi.Passphrase.Trim();
+        }
+    }
+
+    public void ClearPersonalWifiPassphrase()
+    {
+        PersonalWifiPassphrase = null;
+    }
+
+    public NetworkSettings ApplyRequiredSecrets(NetworkSettings settings)
+    {
+        return NetworkMediaReadinessEvaluator.ApplyRequiredSecrets(settings, PersonalWifiPassphrase);
+    }
+
+    private static bool RequiresPersonalWifiPassphrase(NetworkSettings settings)
+    {
+        return settings.WifiProvisioned &&
+               settings.Wifi.IsEnabled &&
+               !settings.Wifi.HasEnterpriseProfile &&
+               string.Equals(
+                   NetworkConfigurationValidator.NormalizeWifiSecurityType(settings.Wifi),
+                   NetworkConfigurationValidator.WifiSecurityPersonal,
+                   StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IDeployConfigurationGenerator, DeployConfigurationGenerator>();
         services.AddSingleton<IConnectConfigurationGenerator, ConnectConfigurationGenerator>();
         services.AddSingleton<ILanguageRegistryService, EmbeddedLanguageRegistryService>();
+        services.AddSingleton<INetworkSecretStateService, NetworkSecretStateService>();
         services.AddSingleton<IExpertDeployConfigurationStateService, ExpertDeployConfigurationStateService>();
         services.AddSingleton<IWinPeLanguageDiscoveryService, WinPeLanguageDiscoveryService>();
         services.AddSingleton<IWinPeUsbMediaService, WinPeUsbMediaService>();

--- a/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
@@ -9,25 +9,30 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
     private readonly IExpertConfigurationService expertConfigurationService;
     private readonly IDeployConfigurationGenerator deployConfigurationGenerator;
     private readonly IConnectConfigurationGenerator connectConfigurationGenerator;
+    private readonly INetworkSecretStateService networkSecretStateService;
     private readonly ILogger logger;
 
     public ExpertDeployConfigurationStateService(
         IExpertConfigurationService expertConfigurationService,
         IDeployConfigurationGenerator deployConfigurationGenerator,
         IConnectConfigurationGenerator connectConfigurationGenerator,
+        INetworkSecretStateService networkSecretStateService,
         ILogger logger)
     {
         this.expertConfigurationService = expertConfigurationService;
         this.deployConfigurationGenerator = deployConfigurationGenerator;
         this.connectConfigurationGenerator = connectConfigurationGenerator;
+        this.networkSecretStateService = networkSecretStateService;
         this.logger = logger.ForContext<ExpertDeployConfigurationStateService>();
-        Current = Load();
+        Current = SanitizeForPersistence(Load());
         Save();
     }
 
     public event EventHandler? StateChanged;
 
     public FoundryExpertConfigurationDocument Current { get; private set; }
+
+    public bool IsNetworkConfigurationReady => EvaluateNetworkMediaReadiness().IsNetworkConfigurationReady;
 
     public bool IsDeployConfigurationReady
     {
@@ -46,6 +51,10 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
         }
     }
 
+    public bool IsConnectProvisioningReady => EvaluateNetworkMediaReadiness().IsConnectProvisioningReady;
+
+    public bool AreRequiredSecretsReady => EvaluateNetworkMediaReadiness().AreRequiredSecretsReady;
+
     public void UpdateLocalization(LocalizationSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
@@ -57,7 +66,8 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
     public void UpdateNetwork(NetworkSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
-        Current = Current with { Network = settings };
+        networkSecretStateService.Update(settings);
+        Current = Current with { Network = NetworkConfigurationValidator.SanitizeForPersistence(settings) };
         Save();
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
@@ -69,7 +79,12 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
 
     public FoundryConnectProvisioningBundle GenerateConnectProvisioningBundle(string stagingDirectoryPath)
     {
-        return connectConfigurationGenerator.CreateProvisioningBundle(Current, stagingDirectoryPath);
+        FoundryExpertConfigurationDocument document = Current with
+        {
+            Network = networkSecretStateService.ApplyRequiredSecrets(Current.Network)
+        };
+
+        return connectConfigurationGenerator.CreateProvisioningBundle(document, stagingDirectoryPath);
     }
 
     private FoundryExpertConfigurationDocument Load()
@@ -94,10 +109,23 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
 
     private void Save()
     {
-        Current = Current with { Network = NetworkConfigurationValidator.SanitizeForPersistence(Current.Network) };
         Directory.CreateDirectory(Constants.ConfigurationWorkspaceDirectoryPath);
-        string json = expertConfigurationService.Serialize(Current);
+        FoundryExpertConfigurationDocument document = SanitizeForPersistence(Current);
+        string json = expertConfigurationService.Serialize(document);
         File.WriteAllText(Constants.ExpertDeployConfigurationStatePath, json);
+    }
+
+    private static FoundryExpertConfigurationDocument SanitizeForPersistence(FoundryExpertConfigurationDocument document)
+    {
+        return document with
+        {
+            Network = NetworkConfigurationValidator.SanitizeForPersistence(document.Network)
+        };
+    }
+
+    private NetworkMediaReadinessEvaluation EvaluateNetworkMediaReadiness()
+    {
+        return NetworkMediaReadinessEvaluator.Evaluate(Current.Network, networkSecretStateService.PersonalWifiPassphrase);
     }
 
     private void TryMoveInvalidState(string backupPath, Exception originalException)

--- a/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
@@ -8,7 +8,13 @@ public interface IExpertDeployConfigurationStateService
 
     FoundryExpertConfigurationDocument Current { get; }
 
+    bool IsNetworkConfigurationReady { get; }
+
     bool IsDeployConfigurationReady { get; }
+
+    bool IsConnectProvisioningReady { get; }
+
+    bool AreRequiredSecretsReady { get; }
 
     void UpdateNetwork(NetworkSettings settings);
 

--- a/src/Foundry/Services/Configuration/INetworkSecretStateService.cs
+++ b/src/Foundry/Services/Configuration/INetworkSecretStateService.cs
@@ -1,0 +1,14 @@
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Services.Configuration;
+
+public interface INetworkSecretStateService
+{
+    string? PersonalWifiPassphrase { get; }
+
+    void Update(NetworkSettings settings);
+
+    void ClearPersonalWifiPassphrase();
+
+    NetworkSettings ApplyRequiredSecrets(NetworkSettings settings);
+}

--- a/src/Foundry/Services/Configuration/NetworkSecretStateService.cs
+++ b/src/Foundry/Services/Configuration/NetworkSecretStateService.cs
@@ -1,0 +1,26 @@
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Configuration;
+
+namespace Foundry.Services.Configuration;
+
+internal sealed class NetworkSecretStateService : INetworkSecretStateService
+{
+    private readonly NetworkSecretState state = new();
+
+    public string? PersonalWifiPassphrase => state.PersonalWifiPassphrase;
+
+    public void Update(NetworkSettings settings)
+    {
+        state.Update(settings);
+    }
+
+    public void ClearPersonalWifiPassphrase()
+    {
+        state.ClearPersonalWifiPassphrase();
+    }
+
+    public NetworkSettings ApplyRequiredSecrets(NetworkSettings settings)
+    {
+        return state.ApplyRequiredSecrets(settings);
+    }
+}

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -231,6 +231,9 @@
   <data name="Network.ErrorWiredCertificateRequired" xml:space="preserve">
     <value>Wired 802.1X requires a trusted root CA certificate file when certificate trust is enabled.</value>
   </data>
+  <data name="Network.ErrorWiredCertificateMissing" xml:space="preserve">
+    <value>Wired 802.1X trusted root CA certificate file was not found.</value>
+  </data>
   <data name="Network.ErrorWifiSsidRequired" xml:space="preserve">
     <value>Wi-Fi configuration requires an SSID.</value>
   </data>
@@ -254,6 +257,9 @@
   </data>
   <data name="Network.ErrorWifiEnterpriseCertificateRequired" xml:space="preserve">
     <value>Enterprise Wi-Fi requires a trusted root CA certificate file when certificate trust is enabled.</value>
+  </data>
+  <data name="Network.ErrorWifiEnterpriseCertificateMissing" xml:space="preserve">
+    <value>Enterprise Wi-Fi trusted root CA certificate file was not found.</value>
   </data>
   <data name="Shell.OperationRunning" xml:space="preserve">
     <value>Operation in progress</value>
@@ -316,7 +322,7 @@
     <value>Final media commands</value>
   </data>
   <data name="StartMedia.FinalCommands.Description" xml:space="preserve">
-    <value>Final ISO and USB execution stays disabled until Deploy and Connect provisioning are complete.</value>
+    <value>Final ISO and USB execution stays disabled until the final media enablement phase.</value>
   </data>
   <data name="StartMedia.CreateIsoButton" xml:space="preserve">
     <value>Create ISO</value>
@@ -331,7 +337,7 @@
     <value>Full format</value>
   </data>
   <data name="StartMedia.FinalExecution.Deferred" xml:space="preserve">
-    <value>Final ISO/USB execution is deferred until Deploy and Connect provisioning are complete.</value>
+    <value>Final ISO/USB execution is deferred until the final media enablement phase.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Select ISO output path</value>
@@ -418,16 +424,16 @@
     <value>Runtime payload readiness is deferred.</value>
   </data>
   <data name="StartMedia.BlockingReason.NetworkConfigurationNotReady" xml:space="preserve">
-    <value>Network validation is deferred.</value>
+    <value>Network configuration is not ready.</value>
   </data>
   <data name="StartMedia.BlockingReason.DeployConfigurationNotReady" xml:space="preserve">
     <value>Deploy configuration generation is deferred.</value>
   </data>
   <data name="StartMedia.BlockingReason.ConnectProvisioningNotReady" xml:space="preserve">
-    <value>Connect provisioning is deferred.</value>
+    <value>Connect provisioning is not ready.</value>
   </data>
   <data name="StartMedia.BlockingReason.RequiredSecretsNotReady" xml:space="preserve">
-    <value>Encrypted media secret provisioning is deferred.</value>
+    <value>Required media secrets are not ready.</value>
   </data>
   <data name="StartMedia.BlockingReason.NoUsbTarget" xml:space="preserve">
     <value>No USB target is selected.</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -231,6 +231,9 @@
   <data name="Network.ErrorWiredCertificateRequired" xml:space="preserve">
     <value>Le 802.1X filaire nécessite un certificat d'autorité racine de confiance lorsque la confiance par certificat est activée.</value>
   </data>
+  <data name="Network.ErrorWiredCertificateMissing" xml:space="preserve">
+    <value>Le fichier du certificat d'autorité racine de confiance 802.1X filaire est introuvable.</value>
+  </data>
   <data name="Network.ErrorWifiSsidRequired" xml:space="preserve">
     <value>La configuration Wi-Fi nécessite un SSID.</value>
   </data>
@@ -254,6 +257,9 @@
   </data>
   <data name="Network.ErrorWifiEnterpriseCertificateRequired" xml:space="preserve">
     <value>Le Wi-Fi d'entreprise nécessite un certificat d'autorité racine de confiance lorsque la confiance par certificat est activée.</value>
+  </data>
+  <data name="Network.ErrorWifiEnterpriseCertificateMissing" xml:space="preserve">
+    <value>Le fichier du certificat d'autorité racine de confiance Wi-Fi d'entreprise est introuvable.</value>
   </data>
   <data name="Shell.OperationRunning" xml:space="preserve">
     <value>Opération en cours</value>
@@ -316,7 +322,7 @@
     <value>Commandes média finales</value>
   </data>
   <data name="StartMedia.FinalCommands.Description" xml:space="preserve">
-    <value>L'exécution ISO et USB finale reste désactivée tant que le provisionnement Deploy et Connect n'est pas terminé.</value>
+    <value>L'exécution ISO et USB finale reste désactivée jusqu'à la phase d'activation finale des médias.</value>
   </data>
   <data name="StartMedia.CreateIsoButton" xml:space="preserve">
     <value>Créer l'ISO</value>
@@ -331,7 +337,7 @@
     <value>Formatage complet</value>
   </data>
   <data name="StartMedia.FinalExecution.Deferred" xml:space="preserve">
-    <value>L'exécution ISO/USB finale est différée jusqu'à la fin du provisionnement Deploy et Connect.</value>
+    <value>L'exécution ISO/USB finale est différée jusqu'à la phase d'activation finale des médias.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Sélectionner le chemin de sortie ISO</value>
@@ -418,16 +424,16 @@
     <value>La validation des payloads runtime est différée.</value>
   </data>
   <data name="StartMedia.BlockingReason.NetworkConfigurationNotReady" xml:space="preserve">
-    <value>La validation réseau est différée.</value>
+    <value>La configuration réseau n'est pas prête.</value>
   </data>
   <data name="StartMedia.BlockingReason.DeployConfigurationNotReady" xml:space="preserve">
     <value>La génération de configuration Deploy est différée.</value>
   </data>
   <data name="StartMedia.BlockingReason.ConnectProvisioningNotReady" xml:space="preserve">
-    <value>Le provisionnement Connect est différé.</value>
+    <value>Le provisionnement Connect n'est pas prêt.</value>
   </data>
   <data name="StartMedia.BlockingReason.RequiredSecretsNotReady" xml:space="preserve">
-    <value>Le provisionnement chiffré des secrets média est différé.</value>
+    <value>Les secrets média requis ne sont pas prêts.</value>
   </data>
   <data name="StartMedia.BlockingReason.NoUsbTarget" xml:space="preserve">
     <value>Aucune cible USB n'est sélectionnée.</value>

--- a/src/Foundry/ViewModels/NetworkConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/NetworkConfigurationViewModel.cs
@@ -11,6 +11,7 @@ namespace Foundry.ViewModels;
 public sealed partial class NetworkConfigurationViewModel : ObservableObject, IDisposable
 {
     private readonly IExpertDeployConfigurationStateService configurationStateService;
+    private readonly INetworkSecretStateService networkSecretStateService;
     private readonly IFilePickerService filePickerService;
     private readonly IApplicationLocalizationService localizationService;
     private bool isApplyingState = true;
@@ -18,10 +19,12 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
 
     public NetworkConfigurationViewModel(
         IExpertDeployConfigurationStateService configurationStateService,
+        INetworkSecretStateService networkSecretStateService,
         IFilePickerService filePickerService,
         IApplicationLocalizationService localizationService)
     {
         this.configurationStateService = configurationStateService;
+        this.networkSecretStateService = networkSecretStateService;
         this.filePickerService = filePickerService;
         this.localizationService = localizationService;
 
@@ -310,6 +313,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
         if (!value)
         {
             IsWifiConfigured = false;
+            networkSecretStateService.ClearPersonalWifiPassphrase();
         }
 
         SaveState();
@@ -325,6 +329,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
             WifiEnterpriseProfileTemplatePath = string.Empty;
             IsWifiCertificateRequired = false;
             WifiCertificatePath = string.Empty;
+            networkSecretStateService.ClearPersonalWifiPassphrase();
         }
 
         SaveState();
@@ -340,6 +345,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
         if (!IsWifiPersonalSelected)
         {
             WifiPassphrase = string.Empty;
+            networkSecretStateService.ClearPersonalWifiPassphrase();
         }
 
         if (!IsWifiEnterpriseSelected)
@@ -356,6 +362,11 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
 
     partial void OnWifiPassphraseChanged(string value)
     {
+        if (!isApplyingState && IsWifiPersonalSectionEnabled && string.IsNullOrWhiteSpace(value))
+        {
+            networkSecretStateService.ClearPersonalWifiPassphrase();
+        }
+
         SaveState();
     }
 
@@ -397,7 +408,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
         IsWifiConfigured = settings.Wifi.IsEnabled;
         WifiSsid = settings.Wifi.Ssid ?? string.Empty;
         SelectedWifiSecurityType = SelectWifiSecurityOption(NetworkConfigurationValidator.NormalizeWifiSecurityType(settings.Wifi));
-        WifiPassphrase = settings.Wifi.Passphrase ?? string.Empty;
+        WifiPassphrase = ResolveWifiPassphrase(settings);
         WifiEnterpriseProfileTemplatePath = settings.Wifi.EnterpriseProfileTemplatePath ?? string.Empty;
         IsWifiCertificateRequired = settings.Wifi.RequiresCertificate;
         WifiCertificatePath = settings.Wifi.CertificatePath ?? string.Empty;
@@ -542,6 +553,20 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
         ApplyState(configurationStateService.Current.Network);
     }
 
+    private string ResolveWifiPassphrase(NetworkSettings settings)
+    {
+        if (!(settings.WifiProvisioned || settings.Wifi.IsEnabled) ||
+            !settings.Wifi.IsEnabled ||
+            !IsWifiPersonalSelected)
+        {
+            return string.Empty;
+        }
+
+        return !string.IsNullOrWhiteSpace(settings.Wifi.Passphrase)
+            ? settings.Wifi.Passphrase.Trim()
+            : networkSecretStateService.PersonalWifiPassphrase ?? string.Empty;
+    }
+
     private string FormatValidationMessage(NetworkConfigurationValidationResult result, bool dot1xOnly)
     {
         if (result.IsValid)
@@ -552,7 +577,8 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
         if (dot1xOnly && result.Code is not (
             NetworkConfigurationValidationCode.WiredProfileTemplateRequired or
             NetworkConfigurationValidationCode.WiredProfileTemplateMissing or
-            NetworkConfigurationValidationCode.WiredCertificateRequired))
+            NetworkConfigurationValidationCode.WiredCertificateRequired or
+            NetworkConfigurationValidationCode.WiredCertificateMissing))
         {
             return string.Empty;
         }
@@ -560,7 +586,8 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
         if (!dot1xOnly && result.Code is
             NetworkConfigurationValidationCode.WiredProfileTemplateRequired or
             NetworkConfigurationValidationCode.WiredProfileTemplateMissing or
-            NetworkConfigurationValidationCode.WiredCertificateRequired)
+            NetworkConfigurationValidationCode.WiredCertificateRequired or
+            NetworkConfigurationValidationCode.WiredCertificateMissing)
         {
             return string.Empty;
         }
@@ -571,6 +598,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
             NetworkConfigurationValidationCode.WiredProfileTemplateRequired => "Network.ErrorWiredProfileTemplateRequired",
             NetworkConfigurationValidationCode.WiredProfileTemplateMissing => "Network.ErrorWiredProfileTemplateMissing",
             NetworkConfigurationValidationCode.WiredCertificateRequired => "Network.ErrorWiredCertificateRequired",
+            NetworkConfigurationValidationCode.WiredCertificateMissing => "Network.ErrorWiredCertificateMissing",
             NetworkConfigurationValidationCode.WifiSsidRequired => "Network.ErrorWifiSsidRequired",
             NetworkConfigurationValidationCode.UnsupportedWifiSecurityType => "Network.ErrorUnsupportedWifiSecurityTypeFormat",
             NetworkConfigurationValidationCode.WifiPersonalPassphraseInvalid => "Network.ErrorWifiPersonalPassphraseInvalid",
@@ -579,6 +607,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
             NetworkConfigurationValidationCode.WifiEnterpriseAuthenticationUnsupported => "Network.ErrorWifiEnterpriseAuthenticationUnsupported",
             NetworkConfigurationValidationCode.WifiEnterpriseAuthenticationMismatch => "Network.ErrorWifiEnterpriseAuthenticationMismatchFormat",
             NetworkConfigurationValidationCode.WifiEnterpriseCertificateRequired => "Network.ErrorWifiEnterpriseCertificateRequired",
+            NetworkConfigurationValidationCode.WifiEnterpriseCertificateMissing => "Network.ErrorWifiEnterpriseCertificateMissing",
             _ => string.Empty
         };
 

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -292,10 +292,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         {
             IsAdkReady = adkService.CurrentStatus.CanCreateMedia,
             IsRuntimePayloadReady = false,
-            IsNetworkConfigurationReady = false,
+            IsNetworkConfigurationReady = expertDeployConfigurationStateService.IsNetworkConfigurationReady,
             IsDeployConfigurationReady = expertDeployConfigurationStateService.IsDeployConfigurationReady,
-            IsConnectProvisioningReady = false,
-            AreRequiredSecretsReady = false,
+            IsConnectProvisioningReady = expertDeployConfigurationStateService.IsConnectProvisioningReady,
+            AreRequiredSecretsReady = expertDeployConfigurationStateService.AreRequiredSecretsReady,
             IsFinalExecutionEnabled = false,
             IsoOutputPath = IsoOutputPath,
             Architecture = SelectedArchitecture?.Value ?? WinPeArchitecture.X64,

--- a/src/Foundry/Views/NetworkPage.xaml
+++ b/src/Foundry/Views/NetworkPage.xaml
@@ -17,7 +17,8 @@
 
             <dev:SettingsExpander Header="{x:Bind ViewModel.EthernetHeader, Mode=OneWay}"
                                   Description="{x:Bind ViewModel.EthernetDescription, Mode=OneWay}"
-                                  HeaderIcon="{dev:FontIcon GlyphCode=E839}">
+                                  HeaderIcon="{dev:FontIcon GlyphCode=E839}"
+                                  IsExpanded="True">
                 <ToggleSwitch AutomationProperties.Name="{x:Bind ViewModel.Dot1xEnableText, Mode=OneWay}"
                               IsOn="{x:Bind ViewModel.IsDot1xEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 <dev:SettingsExpander.Items>
@@ -56,7 +57,8 @@
 
             <dev:SettingsExpander Header="{x:Bind ViewModel.WifiHeader, Mode=OneWay}"
                                   Description="{x:Bind ViewModel.WifiDescription, Mode=OneWay}"
-                                  HeaderIcon="{dev:FontIcon GlyphCode=E701}">
+                                  HeaderIcon="{dev:FontIcon GlyphCode=E701}"
+                                  IsExpanded="True">
                 <ToggleSwitch AutomationProperties.Name="{x:Bind ViewModel.WifiProvisionedText, Mode=OneWay}"
                               IsOn="{x:Bind ViewModel.IsWifiProvisioned, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 <dev:SettingsExpander.Items>


### PR DESCRIPTION
## Summary
- Wire Start preflight to real network, Connect, and required-secret readiness.
- Keep runtime payload readiness and final ISO/USB execution blocked until final media enablement.
- Preserve transient personal Wi-Fi secrets without persisting them, and clear them on explicit passphrase clear.

## Reason
Phase 15.D replaces Phase 13 placeholder readiness values while keeping final media execution disabled.

## Main changes
- Added network media readiness evaluation and transient network secret state.
- Updated expert configuration state service to expose network/connect/secrets readiness and sanitize persisted state.
- Added missing certificate-path validation so Connect readiness cannot be true when asset copy would fail.
- Updated Start preflight copy and Phase 15 plan status.

## Testing
- `dotnet build src\Foundry.slnx --no-restore --nologo`
- `dotnet test src\Foundry.slnx --no-restore --nologo`
- Subagent code review: no blocking findings after fixes.