### PR TITLE
feat(customization): port machine naming settings

### DIFF
--- a/docs/migration/phases/06-business-workflows.md
+++ b/docs/migration/phases/06-business-workflows.md
@@ -198,31 +198,106 @@ git commit -m "feat(network): wire connect preflight readiness"
 
 **Goal:** port remaining expert workflow features after core media creation is functional.
 
-**Prerequisites and boundary:** Phase 16 extends the media workflow with optional Autopilot and customization payloads. Media creation must remain usable when Autopilot is disabled, and Graph authentication, token cache behavior, environment-variable-driven Graph configuration, and Graph HTTP calls must remain in the WinUI app/infrastructure layer.
+**Prerequisites and boundary:** Phase 16 extends the media workflow with optional Autopilot and customization payloads. Media creation must remain usable when Autopilot is disabled. Microsoft Graph authentication, token cache behavior, environment-variable-driven Graph configuration, and Graph HTTP calls must remain in the WinUI `Foundry` app/infrastructure layer, not in `Foundry.Core`.
 
-- [ ] **16.1** Port Autopilot profile selection.
-- [ ] **16.2** Port Autopilot profile import/selection dialog.
-  - [ ] **16.2.1** Use the blocking operation overlay for profile import.
-  - [ ] **16.2.2** Keep Microsoft Graph authentication in the WinUI `Foundry` app/infrastructure layer.
-  - [ ] **16.2.3** Keep `InteractiveBrowserCredential`, token cache behavior, environment-variable-driven Graph configuration, and Graph HTTP calls out of `Foundry.Core`.
-  - [ ] **16.2.4** Move only pure Autopilot conversion, validation, and file transformation logic to `Foundry.Core` when useful.
-- [ ] **16.3** Port customization settings.
-- [ ] **16.3.1** Use the blocking operation overlay for Autopilot tenant download.
-- [ ] **16.4** Preserve generated deploy configuration output.
-- [ ] **16.5** Preserve profile file embedding into WinPE media.
-- [ ] **16.5.1** Wire Autopilot/customization readiness into the `Start` page preflight:
-  - [ ] Do not block media creation when Autopilot is disabled.
-  - [ ] Block or warn when Autopilot is enabled but no valid profile is selected.
-  - [ ] Show selected profile metadata without exposing tenant tokens or Graph response bodies.
-- [ ] **16.6** Commit:
+**Scope boundary:** preserve user-visible WPF parity for machine naming, Autopilot profile import, Autopilot tenant download, profile selection, generated deploy config, and WinPE profile embedding where those contracts remain valid. Do not preserve obsolete WPF-era runtime quirks. Do not implement APPX removal or custom deploy configuration editing in Phase 16; the WPF app only exposed those as disabled placeholders.
+
+**Architecture direction:** do not add backward-compatibility logic for obsolete WPF-era contracts. If Phase 16 reveals that `Foundry.Deploy`, `Foundry.Connect`, or shared configuration contracts should be simplified or adjusted, make the focused change in the same split and update the generated runtime contracts/tests accordingly. Prefer clear WinUI/Core-era contracts and maintainable runtime behavior over preserving legacy implementation quirks.
+
+**Recommended implementation split:** Phase 16 has a low-risk local customization slice and higher-risk Autopilot/Graph slices. Implement each split in a separate worktree, branch, and pull request. After each split is implemented, run automated verification, complete required manual validation, wait for CI to pass, squash-merge the PR, sync `feat/winui-migration`, clean the worktree, then start the next split.
+
+- [ ] **16.A** Port customization machine naming.
+  - [ ] **16.A.1** Add the WinUI customization settings page state for:
+    - [ ] Enable machine naming rules.
+    - [ ] Machine name prefix.
+    - [ ] Auto-generate the suffix after the prefix.
+    - [ ] Allow manual editing after the prefix.
+  - [ ] **16.A.2** Preserve WPF normalization:
+    - [ ] Disabled machine naming writes no prefix.
+    - [ ] Disabled machine naming forces `autoGenerateName=false`.
+    - [ ] Disabled machine naming forces `allowManualSuffixEdit=true`.
+    - [ ] Enabled machine naming trims the prefix before persistence/generation.
+  - [ ] **16.A.2.1** Validate machine naming prefix early in the WinUI authoring flow using the same computer-name rules that `Foundry.Deploy` enforces at runtime.
+  - [ ] **16.A.3** Preserve generated Deploy config output for `customization.machineNaming`.
+  - [ ] **16.A.4** Keep APPX removal and custom deploy configuration editing out of scope.
+
+- [ ] **16.B** Port Autopilot manual profile import and local profile management.
+  - [ ] **16.B.1** Add the WinUI Autopilot page state for:
+    - [ ] Enable Autopilot.
+    - [ ] Import profile JSON.
+    - [ ] Remove selected profile.
+    - [ ] Select default profile.
+    - [ ] Show imported profiles with display name, source, imported timestamp, and folder name.
+  - [ ] **16.B.2** Preserve WPF manual import behavior:
+    - [ ] Parse and validate JSON.
+    - [ ] Reject empty, invalid, or non-ASCII profile JSON.
+    - [ ] Resolve display name from `Comment_File`, filename, or parent folder.
+    - [ ] Generate `manual-<sha>` IDs from profile JSON.
+    - [ ] Sanitize profile folder names.
+    - [ ] Merge duplicate profiles by ID.
+    - [ ] Sort profiles by display name, then ID.
+    - [ ] Fall back to the first profile when the default profile is removed or missing.
+  - [ ] **16.B.3** Persist full imported profile JSON in expert configuration.
+  - [ ] **16.B.3.1** Add explicit expert configuration state updates for Autopilot and Customization:
+    - [ ] `UpdateAutopilot(AutopilotSettings settings)`.
+    - [ ] `UpdateCustomization(CustomizationSettings settings)`.
+  - [ ] **16.B.4** Preserve generated Deploy config output:
+    - [ ] `autopilot.isEnabled`.
+    - [ ] `autopilot.defaultProfileFolderName`.
+  - [ ] **16.B.5** Preserve Autopilot profile path contracts:
+    - [ ] Embedded WinPE relative path: `Foundry\Config\Autopilot\<FolderName>\AutopilotConfigurationFile.json`.
+    - [ ] Runtime WinPE path consumed by `Foundry.Deploy`: `X:\Foundry\Config\Autopilot\<FolderName>\AutopilotConfigurationFile.json`.
+    - [ ] Target Windows staging path written by `Foundry.Deploy`: `%SystemDrive%\Windows\Provisioning\Autopilot\AutopilotConfigurationFile.json`.
+    - [ ] Generated Deploy config stores the selected/default profile folder name, not a full path.
+
+- [ ] **16.C** Port Autopilot Microsoft Graph tenant import.
+  - [ ] **16.C.1** Keep Microsoft Graph authentication in the WinUI `Foundry` app/infrastructure layer.
+  - [ ] **16.C.2** Keep `InteractiveBrowserCredential`, token cache behavior, environment-variable-driven Graph configuration, and Graph HTTP calls out of `Foundry.Core`.
+  - [ ] **16.C.3** Preserve WPF Graph behavior:
+    - [ ] Use `DeviceManagementServiceConfig.Read.All` and `User.Read` scopes.
+    - [ ] Preserve `FOUNDRY_AUTOPILOT_GRAPH_CLIENT_ID` and `FOUNDRY_AUTOPILOT_GRAPH_TENANT_ID` overrides.
+    - [ ] Query `v1.0/organization?$select=id,verifiedDomains` for tenant information and verified domain.
+    - [ ] Query `beta/deviceManagement/windowsAutopilotDeploymentProfiles`.
+    - [ ] Handle paged Graph responses.
+    - [ ] Convert tenant deployment profiles into offline `AutopilotConfigurationFile.json` content.
+  - [ ] **16.C.4** Use the blocking operation overlay for tenant authentication/download, then close the overlay before showing profile selection.
+  - [ ] **16.C.5** Use a WinUI `ContentDialog` for downloaded profile selection instead of a separate WPF-style window:
+    - [ ] Profiles selected by default.
+    - [ ] Select all.
+    - [ ] Clear.
+    - [ ] Selected count.
+    - [ ] Import disabled when no profile is selected.
+    - [ ] Cancel returns no imported profiles.
+  - [ ] **16.C.6** Do not show tenant tokens or raw Graph response bodies in UI, summaries, logs, or diagnostics.
+
+- [ ] **16.D** Wire Autopilot/customization readiness into `Start` preflight and finish Phase 16 validation.
+  - [ ] **16.D.1** Do not block media creation when Autopilot is disabled.
+  - [ ] **16.D.2** Block or warn when Autopilot is enabled but no valid default profile is selected.
+  - [ ] **16.D.3** Show selected Autopilot profile metadata without exposing tenant tokens or Graph response bodies.
+  - [ ] **16.D.4** Keep final ISO/USB execution disabled until the final media enablement PR.
+  - [ ] **16.D.5** Preserve generated Deploy config and Autopilot profile path contracts across the final Phase 16 state.
+  - [ ] **16.D.6** Update `Foundry.Deploy` Autopilot startup behavior so generated Deploy config is the source of truth:
+    - [ ] Respect `autopilot.isEnabled=false` even when embedded Autopilot profiles exist.
+    - [ ] Select/use a default Autopilot profile only when `autopilot.isEnabled=true`.
+    - [ ] Remove any automatic enablement based only on profile presence.
+
+- [ ] **16.6** Commit each split independently:
 
 ```powershell
-git commit -m "feat(autopilot): port autopilot and customization workflows"
+git commit -m "feat(customization): port machine naming settings"
+git commit -m "feat(autopilot): port manual profile import"
+git commit -m "feat(autopilot): add graph profile import"
+git commit -m "feat(autopilot): wire start readiness"
 ```
 
 **Validation**
 
-- [ ] **16.7** Existing Autopilot-related tests pass.
-- [ ] **16.8** Generated deploy config includes selected profiles.
-- [ ] **16.9** WinPE media includes expected profile payload.
+- [ ] **16.7** Existing Autopilot-related and Deploy configuration tests pass.
+- [ ] **16.8** Generated Deploy config includes machine naming and selected Autopilot profile settings.
+- [ ] **16.9** WinPE asset provisioning service-level validation includes expected Autopilot profile payloads; real generated boot-media validation remains deferred until final ISO/USB media execution is enabled.
 - [ ] **16.10** `Foundry.Core` has no dependency on Azure Identity, Microsoft Graph clients, `InteractiveBrowserCredential`, or Graph HTTP plumbing.
+- [ ] **16.11** Manual Autopilot JSON import rejects empty, invalid, or non-ASCII JSON.
+- [ ] **16.12** Manual Autopilot JSON import preserves WPF-compatible profile ID, display name, folder name, merge, sort, and default-profile fallback behavior.
+- [ ] **16.13** Graph tenant import downloads profiles through the blocking overlay and imports selected profiles through a WinUI `ContentDialog`.
+- [ ] **16.14** Autopilot disabled does not block `Start` preflight.
+- [ ] **16.15** Autopilot enabled without a valid default profile blocks or warns in `Start` preflight.

--- a/src/Foundry.Core/Services/Configuration/ComputerNameRules.cs
+++ b/src/Foundry.Core/Services/Configuration/ComputerNameRules.cs
@@ -1,0 +1,86 @@
+using System.Text;
+
+namespace Foundry.Core.Services.Configuration;
+
+public static class ComputerNameRules
+{
+    public const int MaxLength = 15;
+    public const string FallbackName = "PC";
+    public const string ValidationMessage = "Computer name must contain 1 to 15 characters using A-Z, a-z, 0-9, or -.";
+
+    public static string Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(MaxLength);
+        foreach (char character in value)
+        {
+            if (!IsAllowedCharacter(character))
+            {
+                continue;
+            }
+
+            builder.Append(character);
+            if (builder.Length >= MaxLength)
+            {
+                break;
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    public static bool IsValid(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || value.Length > MaxLength)
+        {
+            return false;
+        }
+
+        foreach (char character in value)
+        {
+            if (!IsAllowedCharacter(character))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static bool IsAllowedText(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return false;
+        }
+
+        foreach (char character in value)
+        {
+            if (!IsAllowedCharacter(character))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static string GetValidationMessage(string? value)
+    {
+        return IsValid(value)
+            ? string.Empty
+            : ValidationMessage;
+    }
+
+    public static bool IsAllowedCharacter(char character)
+    {
+        return (character >= 'A' && character <= 'Z') ||
+               (character >= 'a' && character <= 'z') ||
+               (character >= '0' && character <= '9') ||
+               character == '-';
+    }
+}

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -54,6 +54,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<GeneralConfigurationViewModel>();
         services.AddTransient<LocalizationConfigurationViewModel>();
         services.AddTransient<NetworkConfigurationViewModel>();
+        services.AddTransient<CustomizationConfigurationViewModel>();
         services.AddTransient<StartMediaViewModel>();
         services.AddTransient<GeneralSettingViewModel>();
         services.AddTransient<AdkPageViewModel>();

--- a/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
@@ -72,6 +72,14 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 
+    public void UpdateCustomization(CustomizationSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        Current = Current with { Customization = SanitizeCustomizationForPersistence(settings) };
+        Save();
+        StateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
     public string GenerateDeployConfigurationJson()
     {
         return deployConfigurationGenerator.Serialize(deployConfigurationGenerator.Generate(Current));
@@ -119,7 +127,27 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
     {
         return document with
         {
-            Network = NetworkConfigurationValidator.SanitizeForPersistence(document.Network)
+            Network = NetworkConfigurationValidator.SanitizeForPersistence(document.Network),
+            Customization = SanitizeCustomizationForPersistence(document.Customization)
+        };
+    }
+
+    private static CustomizationSettings SanitizeCustomizationForPersistence(CustomizationSettings settings)
+    {
+        string normalizedPrefix = ComputerNameRules.Normalize(settings.MachineNaming.Prefix?.Trim());
+        string? prefix = string.IsNullOrWhiteSpace(normalizedPrefix)
+            ? null
+            : normalizedPrefix;
+
+        return settings with
+        {
+            MachineNaming = new MachineNamingSettings
+            {
+                IsEnabled = settings.MachineNaming.IsEnabled,
+                Prefix = settings.MachineNaming.IsEnabled ? prefix : null,
+                AutoGenerateName = settings.MachineNaming.IsEnabled && settings.MachineNaming.AutoGenerateName,
+                AllowManualSuffixEdit = !settings.MachineNaming.IsEnabled || settings.MachineNaming.AllowManualSuffixEdit
+            }
         };
     }
 

--- a/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
@@ -20,6 +20,8 @@ public interface IExpertDeployConfigurationStateService
 
     void UpdateLocalization(LocalizationSettings settings);
 
+    void UpdateCustomization(CustomizationSettings settings);
+
     FoundryConnectProvisioningBundle GenerateConnectProvisioningBundle(string stagingDirectoryPath);
 
     string GenerateDeployConfigurationJson();

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -93,6 +93,27 @@
   <data name="CustomizationPage_Title.Text" xml:space="preserve">
     <value>Customization</value>
   </data>
+  <data name="Customization.MachineNamingHeader" xml:space="preserve">
+    <value>Machine naming</value>
+  </data>
+  <data name="Customization.MachineNamingDescription" xml:space="preserve">
+    <value>Control the target computer name generated during deployment.</value>
+  </data>
+  <data name="Customization.MachineNamingEnableLabel" xml:space="preserve">
+    <value>Enable machine naming rules</value>
+  </data>
+  <data name="Customization.MachineNamingPrefixLabel" xml:space="preserve">
+    <value>Prefix</value>
+  </data>
+  <data name="Customization.MachineNamingAutoGenerateLabel" xml:space="preserve">
+    <value>Auto-generate the suffix after the prefix</value>
+  </data>
+  <data name="Customization.MachineNamingAllowManualSuffixLabel" xml:space="preserve">
+    <value>Allow manual editing after the prefix</value>
+  </data>
+  <data name="Customization.MachineNamingPrefixValidation" xml:space="preserve">
+    <value>Prefix must use 1 to 15 characters from A-Z, a-z, 0-9, or -.</value>
+  </data>
   <data name="DocumentationPage_DocsLink.Content" xml:space="preserve">
     <value>Documentation</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -93,6 +93,27 @@
   <data name="CustomizationPage_Title.Text" xml:space="preserve">
     <value>Personnalisation</value>
   </data>
+  <data name="Customization.MachineNamingHeader" xml:space="preserve">
+    <value>Nommage machine</value>
+  </data>
+  <data name="Customization.MachineNamingDescription" xml:space="preserve">
+    <value>Contrôler le nom d'ordinateur cible généré pendant le déploiement.</value>
+  </data>
+  <data name="Customization.MachineNamingEnableLabel" xml:space="preserve">
+    <value>Activer les règles de nommage machine</value>
+  </data>
+  <data name="Customization.MachineNamingPrefixLabel" xml:space="preserve">
+    <value>Préfixe</value>
+  </data>
+  <data name="Customization.MachineNamingAutoGenerateLabel" xml:space="preserve">
+    <value>Générer automatiquement le suffixe après le préfixe</value>
+  </data>
+  <data name="Customization.MachineNamingAllowManualSuffixLabel" xml:space="preserve">
+    <value>Autoriser la modification manuelle après le préfixe</value>
+  </data>
+  <data name="Customization.MachineNamingPrefixValidation" xml:space="preserve">
+    <value>Le préfixe doit utiliser 1 à 15 caractères parmi A-Z, a-z, 0-9 ou -.</value>
+  </data>
   <data name="DocumentationPage_DocsLink.Content" xml:space="preserve">
     <value>Documentation</value>
   </data>

--- a/src/Foundry/ViewModels/CustomizationConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/CustomizationConfigurationViewModel.cs
@@ -1,0 +1,212 @@
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Configuration;
+using Foundry.Services.Configuration;
+using Foundry.Services.Localization;
+using Microsoft.UI.Xaml;
+
+namespace Foundry.ViewModels;
+
+public sealed partial class CustomizationConfigurationViewModel : ObservableObject, IDisposable
+{
+    private readonly IExpertDeployConfigurationStateService configurationStateService;
+    private readonly IApplicationLocalizationService localizationService;
+    private bool isApplyingState = true;
+    private bool isSavingState;
+
+    public CustomizationConfigurationViewModel(
+        IExpertDeployConfigurationStateService configurationStateService,
+        IApplicationLocalizationService localizationService)
+    {
+        this.configurationStateService = configurationStateService;
+        this.localizationService = localizationService;
+
+        RefreshLocalizedText();
+        ApplyState(configurationStateService.Current.Customization);
+
+        localizationService.LanguageChanged += OnLanguageChanged;
+        configurationStateService.StateChanged += OnConfigurationStateChanged;
+        isApplyingState = false;
+    }
+
+    public int MachineNamePrefixMaxLength => ComputerNameRules.MaxLength;
+    public bool IsMachineNamingOptionsEnabled => IsMachineNamingEnabled;
+    public bool HasMachineNamePrefixValidationError => !string.IsNullOrWhiteSpace(MachineNamePrefixValidationMessage);
+    public Visibility MachineNamePrefixValidationVisibility => HasMachineNamePrefixValidationError
+        ? Visibility.Visible
+        : Visibility.Collapsed;
+
+    [ObservableProperty]
+    public partial string PageTitle { get; set; }
+
+    [ObservableProperty]
+    public partial string MachineNamingHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string MachineNamingDescription { get; set; }
+
+    [ObservableProperty]
+    public partial string MachineNamingEnableText { get; set; }
+
+    [ObservableProperty]
+    public partial string MachineNamingPrefixLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string MachineNamingAutoGenerateText { get; set; }
+
+    [ObservableProperty]
+    public partial string MachineNamingAllowManualSuffixEditText { get; set; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsMachineNamingOptionsEnabled))]
+    [NotifyPropertyChangedFor(nameof(MachineNamePrefixValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasMachineNamePrefixValidationError))]
+    [NotifyPropertyChangedFor(nameof(MachineNamePrefixValidationVisibility))]
+    public partial bool IsMachineNamingEnabled { get; set; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(MachineNamePrefixValidationMessage))]
+    [NotifyPropertyChangedFor(nameof(HasMachineNamePrefixValidationError))]
+    [NotifyPropertyChangedFor(nameof(MachineNamePrefixValidationVisibility))]
+    public partial string MachineNamePrefix { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial bool MachineNameAutoGenerate { get; set; }
+
+    [ObservableProperty]
+    public partial bool AllowManualSuffixEdit { get; set; } = true;
+
+    public string MachineNamePrefixValidationMessage
+    {
+        get
+        {
+            if (!IsMachineNamingEnabled || string.IsNullOrWhiteSpace(MachineNamePrefix))
+            {
+                return string.Empty;
+            }
+
+            return ComputerNameRules.IsValid(MachineNamePrefix.Trim())
+                ? string.Empty
+                : localizationService.GetString("Customization.MachineNamingPrefixValidation");
+        }
+    }
+
+    public void Dispose()
+    {
+        localizationService.LanguageChanged -= OnLanguageChanged;
+        configurationStateService.StateChanged -= OnConfigurationStateChanged;
+    }
+
+    partial void OnIsMachineNamingEnabledChanged(bool value)
+    {
+        SaveState();
+    }
+
+    partial void OnMachineNamePrefixChanged(string value)
+    {
+        if (isApplyingState)
+        {
+            return;
+        }
+
+        string normalizedPrefix = NormalizePrefix(value);
+        if (!string.Equals(value, normalizedPrefix, StringComparison.Ordinal))
+        {
+            MachineNamePrefix = normalizedPrefix;
+            return;
+        }
+
+        SaveState();
+    }
+
+    partial void OnMachineNameAutoGenerateChanged(bool value)
+    {
+        SaveState();
+    }
+
+    partial void OnAllowManualSuffixEditChanged(bool value)
+    {
+        SaveState();
+    }
+
+    private void ApplyState(CustomizationSettings settings)
+    {
+        isApplyingState = true;
+        try
+        {
+            IsMachineNamingEnabled = settings.MachineNaming.IsEnabled;
+            MachineNamePrefix = settings.MachineNaming.Prefix ?? string.Empty;
+            MachineNameAutoGenerate = settings.MachineNaming.AutoGenerateName;
+            AllowManualSuffixEdit = settings.MachineNaming.AllowManualSuffixEdit;
+        }
+        finally
+        {
+            isApplyingState = false;
+        }
+    }
+
+    private void SaveState()
+    {
+        if (isApplyingState || HasMachineNamePrefixValidationError)
+        {
+            return;
+        }
+
+        string normalizedPrefix = NormalizePrefix(MachineNamePrefix);
+        string? prefix = string.IsNullOrWhiteSpace(normalizedPrefix)
+            ? null
+            : normalizedPrefix;
+
+        isSavingState = true;
+        try
+        {
+            configurationStateService.UpdateCustomization(new CustomizationSettings
+            {
+                MachineNaming = new MachineNamingSettings
+                {
+                    IsEnabled = IsMachineNamingEnabled,
+                    Prefix = IsMachineNamingEnabled ? prefix : null,
+                    AutoGenerateName = IsMachineNamingEnabled && MachineNameAutoGenerate,
+                    AllowManualSuffixEdit = !IsMachineNamingEnabled || AllowManualSuffixEdit
+                }
+            });
+        }
+        finally
+        {
+            isSavingState = false;
+        }
+    }
+
+    private void RefreshLocalizedText()
+    {
+        PageTitle = localizationService.GetString("CustomizationPage_Title.Text");
+        MachineNamingHeader = localizationService.GetString("Customization.MachineNamingHeader");
+        MachineNamingDescription = localizationService.GetString("Customization.MachineNamingDescription");
+        MachineNamingEnableText = localizationService.GetString("Customization.MachineNamingEnableLabel");
+        MachineNamingPrefixLabel = localizationService.GetString("Customization.MachineNamingPrefixLabel");
+        MachineNamingAutoGenerateText = localizationService.GetString("Customization.MachineNamingAutoGenerateLabel");
+        MachineNamingAllowManualSuffixEditText = localizationService.GetString("Customization.MachineNamingAllowManualSuffixLabel");
+        OnPropertyChanged(nameof(MachineNamePrefixValidationMessage));
+        OnPropertyChanged(nameof(HasMachineNamePrefixValidationError));
+        OnPropertyChanged(nameof(MachineNamePrefixValidationVisibility));
+    }
+
+    private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
+    {
+        RefreshLocalizedText();
+    }
+
+    private void OnConfigurationStateChanged(object? sender, EventArgs e)
+    {
+        if (isSavingState)
+        {
+            return;
+        }
+
+        ApplyState(configurationStateService.Current.Customization);
+    }
+
+    private static string NormalizePrefix(string? value)
+    {
+        return ComputerNameRules.Normalize(value?.Trim());
+    }
+}

--- a/src/Foundry/Views/CustomizationPage.xaml
+++ b/src/Foundry/Views/CustomizationPage.xaml
@@ -1,13 +1,47 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Page x:Class="Foundry.Views.CustomizationPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:dev="using:DevWinUI"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
-                Padding="{ThemeResource ContentPagePadding}">
+                Padding="{ThemeResource ContentPagePadding}"
+                VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="10"
-                    Spacing="5">
-            <TextBlock x:Uid="CustomizationPage_Title"
+                    dev:PanelAttach.ChildrenTransitions="Default"
+                    Spacing="8">
+            <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
                        Style="{ThemeResource TitleTextBlockStyle}" />
+
+            <dev:SettingsExpander Header="{x:Bind ViewModel.MachineNamingHeader, Mode=OneWay}"
+                                  Description="{x:Bind ViewModel.MachineNamingDescription, Mode=OneWay}"
+                                  HeaderIcon="{dev:FontIcon GlyphCode=E8D4}"
+                                  IsExpanded="True">
+                <ToggleSwitch AutomationProperties.Name="{x:Bind ViewModel.MachineNamingEnableText, Mode=OneWay}"
+                              IsOn="{x:Bind ViewModel.IsMachineNamingEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <dev:SettingsExpander.Items>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.MachineNamingPrefixLabel, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsMachineNamingOptionsEnabled, Mode=OneWay}">
+                        <TextBox MinWidth="420"
+                                 MaxLength="{x:Bind ViewModel.MachineNamePrefixMaxLength, Mode=OneWay}"
+                                 Text="{x:Bind ViewModel.MachineNamePrefix, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </dev:SettingsCard>
+                    <dev:SettingsCard Visibility="{x:Bind ViewModel.MachineNamePrefixValidationVisibility, Mode=OneWay}">
+                        <TextBlock Text="{x:Bind ViewModel.MachineNamePrefixValidationMessage, Mode=OneWay}"
+                                   TextWrapping="Wrap" />
+                    </dev:SettingsCard>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.MachineNamingAutoGenerateText, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsMachineNamingOptionsEnabled, Mode=OneWay}">
+                        <ToggleSwitch IsOn="{x:Bind ViewModel.MachineNameAutoGenerate, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </dev:SettingsCard>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.MachineNamingAllowManualSuffixEditText, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsMachineNamingOptionsEnabled, Mode=OneWay}">
+                        <ToggleSwitch IsOn="{x:Bind ViewModel.AllowManualSuffixEdit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </dev:SettingsCard>
+                </dev:SettingsExpander.Items>
+            </dev:SettingsExpander>
         </StackPanel>
     </ScrollView>
 </Page>

--- a/src/Foundry/Views/CustomizationPage.xaml.cs
+++ b/src/Foundry/Views/CustomizationPage.xaml.cs
@@ -2,8 +2,18 @@ namespace Foundry.Views;
 
 public sealed partial class CustomizationPage : Page
 {
+    public CustomizationConfigurationViewModel ViewModel { get; }
+
     public CustomizationPage()
     {
+        ViewModel = App.GetService<CustomizationConfigurationViewModel>();
         InitializeComponent();
+        Unloaded += OnUnloaded;
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        Unloaded -= OnUnloaded;
+        ViewModel.Dispose();
     }
 }


### PR DESCRIPTION
## Summary
- Adds the Phase 16.A customization machine naming page and view model.
- Persists machine naming settings through expert configuration state.
- Adds shared authoring-side computer name normalization matching Deploy runtime rules.
- Updates the migration plan with the Phase 16 split and validation scope.

## Reason
Phase 16.A restores the WPF machine naming workflow in WinUI before moving to Autopilot profile import and Graph integration.

## Main changes
- Added machine naming controls for enablement, prefix, auto-generated suffix, and manual suffix editing.
- Added `UpdateCustomization` to expert configuration state.
- Normalizes saved prefixes with the same character and length rules used by Deploy runtime.
- Registered the new customization view model and localized the UI strings.

## Testing
- `dotnet build src\Foundry\Foundry.csproj --no-restore`
- `dotnet build src\Foundry.Deploy\Foundry.Deploy.csproj --no-restore`
- `dotnet test src\Foundry.Core.Tests\Foundry.Core.Tests.csproj --no-restore`
- `dotnet test src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --no-restore`
