### PR TITLE
feat(autopilot): port manual profile import

### DIFF
--- a/src/Foundry.Core/Services/Configuration/AutopilotProfileImportService.cs
+++ b/src/Foundry.Core/Services/Configuration/AutopilotProfileImportService.cs
@@ -1,0 +1,128 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Core.Services.Configuration;
+
+public sealed class AutopilotProfileImportService : IAutopilotProfileImportService
+{
+    private const string ProfileFileName = "AutopilotConfigurationFile.json";
+
+    public async Task<AutopilotProfileSettings> ImportFromJsonFileAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        string jsonContent = await File.ReadAllTextAsync(filePath, cancellationToken).ConfigureAwait(false);
+        using JsonDocument document = ValidateJsonContent(jsonContent, filePath);
+        string displayName = ResolveDisplayName(document.RootElement, filePath);
+        string id = BuildManualProfileId(jsonContent);
+
+        return CreateProfileSettings(id, displayName, jsonContent, "Manual import", DateTimeOffset.UtcNow);
+    }
+
+    private static AutopilotProfileSettings CreateProfileSettings(
+        string id,
+        string displayName,
+        string jsonContent,
+        string source,
+        DateTimeOffset importedAtUtc)
+    {
+        string normalizedId = string.IsNullOrWhiteSpace(id) ? BuildManualProfileId(jsonContent) : id.Trim();
+        string normalizedDisplayName = string.IsNullOrWhiteSpace(displayName)
+            ? "Autopilot profile"
+            : displayName.Trim();
+
+        return new AutopilotProfileSettings
+        {
+            Id = normalizedId,
+            DisplayName = normalizedDisplayName,
+            FolderName = BuildFolderName(normalizedDisplayName, normalizedId),
+            Source = source,
+            ImportedAtUtc = importedAtUtc,
+            JsonContent = jsonContent
+        };
+    }
+
+    private static JsonDocument ValidateJsonContent(string jsonContent, string sourcePath)
+    {
+        if (string.IsNullOrWhiteSpace(jsonContent))
+        {
+            throw new InvalidOperationException($"The Autopilot JSON file '{sourcePath}' is empty.");
+        }
+
+        JsonDocument document = JsonDocument.Parse(jsonContent);
+
+        string roundTrip = Encoding.ASCII.GetString(Encoding.ASCII.GetBytes(jsonContent));
+        if (!string.Equals(roundTrip, jsonContent, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"The Autopilot JSON file '{sourcePath}' contains non-ASCII characters.");
+        }
+
+        return document;
+    }
+
+    private static string ResolveDisplayName(JsonElement rootElement, string filePath)
+    {
+        if (rootElement.TryGetProperty("Comment_File", out JsonElement commentProperty) &&
+            commentProperty.ValueKind == JsonValueKind.String)
+        {
+            string? comment = commentProperty.GetString();
+            if (!string.IsNullOrWhiteSpace(comment))
+            {
+                return comment.Trim();
+            }
+        }
+
+        string fileName = Path.GetFileNameWithoutExtension(filePath);
+        if (fileName.Equals(ProfileFileName[..^5], StringComparison.OrdinalIgnoreCase))
+        {
+            string? parentDirectoryName = Path.GetFileName(Path.GetDirectoryName(filePath));
+            if (!string.IsNullOrWhiteSpace(parentDirectoryName))
+            {
+                return parentDirectoryName;
+            }
+        }
+
+        return fileName;
+    }
+
+    private static string BuildManualProfileId(string jsonContent)
+    {
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(jsonContent));
+        return $"manual-{Convert.ToHexString(hash[..8]).ToLowerInvariant()}";
+    }
+
+    private static string BuildFolderName(string displayName, string id)
+    {
+        string sanitizedDisplayName = SanitizeFolderName(displayName);
+        string safeId = new(id.Where(ch => char.IsLetterOrDigit(ch) || ch is '-' or '_').ToArray());
+        if (safeId.Length > 8)
+        {
+            safeId = safeId[..8];
+        }
+
+        return string.IsNullOrWhiteSpace(safeId)
+            ? sanitizedDisplayName
+            : $"{sanitizedDisplayName}__{safeId}";
+    }
+
+    private static string SanitizeFolderName(string value)
+    {
+        char[] invalidChars = Path.GetInvalidFileNameChars();
+        string sanitized = new string(value
+                .Select(ch => invalidChars.Contains(ch) ? '_' : ch)
+                .ToArray())
+            .Trim();
+
+        if (string.IsNullOrWhiteSpace(sanitized))
+        {
+            sanitized = "AutopilotProfile";
+        }
+
+        return sanitized.Replace(' ', '_');
+    }
+}

--- a/src/Foundry.Core/Services/Configuration/IAutopilotProfileImportService.cs
+++ b/src/Foundry.Core/Services/Configuration/IAutopilotProfileImportService.cs
@@ -1,0 +1,8 @@
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Core.Services.Configuration;
+
+public interface IAutopilotProfileImportService
+{
+    Task<AutopilotProfileSettings> ImportFromJsonFileAsync(string filePath, CancellationToken cancellationToken = default);
+}

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IExpertConfigurationService, ExpertConfigurationService>();
         services.AddSingleton<IDeployConfigurationGenerator, DeployConfigurationGenerator>();
         services.AddSingleton<IConnectConfigurationGenerator, ConnectConfigurationGenerator>();
+        services.AddSingleton<IAutopilotProfileImportService, AutopilotProfileImportService>();
         services.AddSingleton<ILanguageRegistryService, EmbeddedLanguageRegistryService>();
         services.AddSingleton<INetworkSecretStateService, NetworkSecretStateService>();
         services.AddSingleton<IExpertDeployConfigurationStateService, ExpertDeployConfigurationStateService>();
@@ -54,6 +55,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<GeneralConfigurationViewModel>();
         services.AddTransient<LocalizationConfigurationViewModel>();
         services.AddTransient<NetworkConfigurationViewModel>();
+        services.AddTransient<AutopilotConfigurationViewModel>();
         services.AddTransient<CustomizationConfigurationViewModel>();
         services.AddTransient<StartMediaViewModel>();
         services.AddTransient<GeneralSettingViewModel>();

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -56,6 +56,7 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Common" Version="8.4.2" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.2" />
     <PackageReference Include="DevWinUI" Version="9.9.4" />
     <PackageReference Include="DevWinUI.ContextMenu" Version="9.9.1" />
     <PackageReference Include="DevWinUI.Controls" Version="9.9.4" />

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -56,7 +56,6 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Common" Version="8.4.2" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.2" />
     <PackageReference Include="DevWinUI" Version="9.9.4" />
     <PackageReference Include="DevWinUI.ContextMenu" Version="9.9.1" />
     <PackageReference Include="DevWinUI.Controls" Version="9.9.4" />
@@ -71,6 +70,7 @@
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Velopack" Version="0.0.1589-ga2c5a97" />
+    <PackageReference Include="WinUI.TableView" Version="1.4.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Foundry.Core\Foundry.Core.csproj" />

--- a/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
@@ -80,6 +80,14 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 
+    public void UpdateAutopilot(AutopilotSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        Current = Current with { Autopilot = SanitizeAutopilotForPersistence(settings) };
+        Save();
+        StateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
     public string GenerateDeployConfigurationJson()
     {
         return deployConfigurationGenerator.Serialize(deployConfigurationGenerator.Generate(Current));
@@ -128,7 +136,33 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
         return document with
         {
             Network = NetworkConfigurationValidator.SanitizeForPersistence(document.Network),
-            Customization = SanitizeCustomizationForPersistence(document.Customization)
+            Customization = SanitizeCustomizationForPersistence(document.Customization),
+            Autopilot = SanitizeAutopilotForPersistence(document.Autopilot)
+        };
+    }
+
+    private static AutopilotSettings SanitizeAutopilotForPersistence(AutopilotSettings settings)
+    {
+        AutopilotProfileSettings[] profiles = settings.Profiles
+            .Where(profile =>
+                !string.IsNullOrWhiteSpace(profile.Id) &&
+                !string.IsNullOrWhiteSpace(profile.DisplayName) &&
+                !string.IsNullOrWhiteSpace(profile.FolderName) &&
+                !string.IsNullOrWhiteSpace(profile.Source) &&
+                !string.IsNullOrWhiteSpace(profile.JsonContent))
+            .OrderBy(profile => profile.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(profile => profile.Id, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        string? defaultProfileId = profiles.Any(profile =>
+            string.Equals(profile.Id, settings.DefaultProfileId, StringComparison.OrdinalIgnoreCase))
+            ? settings.DefaultProfileId
+            : profiles.FirstOrDefault()?.Id;
+
+        return settings with
+        {
+            DefaultProfileId = defaultProfileId,
+            Profiles = profiles
         };
     }
 

--- a/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
@@ -22,6 +22,8 @@ public interface IExpertDeployConfigurationStateService
 
     void UpdateCustomization(CustomizationSettings settings);
 
+    void UpdateAutopilot(AutopilotSettings settings);
+
     FoundryConnectProvisioningBundle GenerateConnectProvisioningBundle(string stagingDirectoryPath);
 
     string GenerateDeployConfigurationJson();

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -90,6 +90,57 @@
   <data name="AutopilotPage_Title.Text" xml:space="preserve">
     <value>Autopilot</value>
   </data>
+  <data name="Autopilot.Header" xml:space="preserve">
+    <value>Autopilot</value>
+  </data>
+  <data name="Autopilot.Description" xml:space="preserve">
+    <value>Import and select offline Autopilot profiles for deployment media.</value>
+  </data>
+  <data name="Autopilot.EnableLabel" xml:space="preserve">
+    <value>Enable Autopilot</value>
+  </data>
+  <data name="Autopilot.StorageLabel" xml:space="preserve">
+    <value>Boot image storage path</value>
+  </data>
+  <data name="Autopilot.InjectionLabel" xml:space="preserve">
+    <value>Offline injection path</value>
+  </data>
+  <data name="Autopilot.ImportButton" xml:space="preserve">
+    <value>Import profile</value>
+  </data>
+  <data name="Autopilot.RemoveButton" xml:space="preserve">
+    <value>Remove selected</value>
+  </data>
+  <data name="Autopilot.DefaultProfileLabel" xml:space="preserve">
+    <value>Default profile</value>
+  </data>
+  <data name="Autopilot.ProfilesLabel" xml:space="preserve">
+    <value>Imported profiles</value>
+  </data>
+  <data name="Autopilot.ProfilesEmptyLabel" xml:space="preserve">
+    <value>No Autopilot profiles imported.</value>
+  </data>
+  <data name="Autopilot.ColumnName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="Autopilot.ColumnSource" xml:space="preserve">
+    <value>Source</value>
+  </data>
+  <data name="Autopilot.ColumnImported" xml:space="preserve">
+    <value>Imported</value>
+  </data>
+  <data name="Autopilot.ColumnFolder" xml:space="preserve">
+    <value>Folder</value>
+  </data>
+  <data name="Autopilot.ImportPickerTitle" xml:space="preserve">
+    <value>Import Autopilot profile JSON</value>
+  </data>
+  <data name="Autopilot.ImportFailedTitle" xml:space="preserve">
+    <value>Autopilot import failed</value>
+  </data>
+  <data name="Autopilot.ImportFailedMessage" xml:space="preserve">
+    <value>{0}</value>
+  </data>
   <data name="CustomizationPage_Title.Text" xml:space="preserve">
     <value>Customization</value>
   </data>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -99,12 +99,6 @@
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Enable Autopilot</value>
   </data>
-  <data name="Autopilot.StorageLabel" xml:space="preserve">
-    <value>Boot image storage path</value>
-  </data>
-  <data name="Autopilot.InjectionLabel" xml:space="preserve">
-    <value>Offline injection path</value>
-  </data>
   <data name="Autopilot.ImportButton" xml:space="preserve">
     <value>Import profile</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -90,6 +90,57 @@
   <data name="AutopilotPage_Title.Text" xml:space="preserve">
     <value>Autopilot</value>
   </data>
+  <data name="Autopilot.Header" xml:space="preserve">
+    <value>Autopilot</value>
+  </data>
+  <data name="Autopilot.Description" xml:space="preserve">
+    <value>Importer et sélectionner des profils Autopilot hors ligne pour le média de déploiement.</value>
+  </data>
+  <data name="Autopilot.EnableLabel" xml:space="preserve">
+    <value>Activer Autopilot</value>
+  </data>
+  <data name="Autopilot.StorageLabel" xml:space="preserve">
+    <value>Chemin de stockage dans l'image de démarrage</value>
+  </data>
+  <data name="Autopilot.InjectionLabel" xml:space="preserve">
+    <value>Chemin d'injection hors ligne</value>
+  </data>
+  <data name="Autopilot.ImportButton" xml:space="preserve">
+    <value>Importer un profil</value>
+  </data>
+  <data name="Autopilot.RemoveButton" xml:space="preserve">
+    <value>Supprimer la sélection</value>
+  </data>
+  <data name="Autopilot.DefaultProfileLabel" xml:space="preserve">
+    <value>Profil par défaut</value>
+  </data>
+  <data name="Autopilot.ProfilesLabel" xml:space="preserve">
+    <value>Profils importés</value>
+  </data>
+  <data name="Autopilot.ProfilesEmptyLabel" xml:space="preserve">
+    <value>Aucun profil Autopilot importé.</value>
+  </data>
+  <data name="Autopilot.ColumnName" xml:space="preserve">
+    <value>Nom</value>
+  </data>
+  <data name="Autopilot.ColumnSource" xml:space="preserve">
+    <value>Source</value>
+  </data>
+  <data name="Autopilot.ColumnImported" xml:space="preserve">
+    <value>Importé</value>
+  </data>
+  <data name="Autopilot.ColumnFolder" xml:space="preserve">
+    <value>Dossier</value>
+  </data>
+  <data name="Autopilot.ImportPickerTitle" xml:space="preserve">
+    <value>Importer un profil Autopilot JSON</value>
+  </data>
+  <data name="Autopilot.ImportFailedTitle" xml:space="preserve">
+    <value>Échec de l'import Autopilot</value>
+  </data>
+  <data name="Autopilot.ImportFailedMessage" xml:space="preserve">
+    <value>{0}</value>
+  </data>
   <data name="CustomizationPage_Title.Text" xml:space="preserve">
     <value>Personnalisation</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -99,12 +99,6 @@
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Activer Autopilot</value>
   </data>
-  <data name="Autopilot.StorageLabel" xml:space="preserve">
-    <value>Chemin de stockage dans l'image de démarrage</value>
-  </data>
-  <data name="Autopilot.InjectionLabel" xml:space="preserve">
-    <value>Chemin d'injection hors ligne</value>
-  </data>
   <data name="Autopilot.ImportButton" xml:space="preserve">
     <value>Importer un profil</value>
   </data>

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -1,0 +1,326 @@
+using System.Collections.ObjectModel;
+using System.Text.Json;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Application;
+using Foundry.Core.Services.Configuration;
+using Foundry.Services.Configuration;
+using Foundry.Services.Localization;
+using Microsoft.UI.Xaml;
+
+namespace Foundry.ViewModels;
+
+public sealed partial class AutopilotConfigurationViewModel : ObservableObject, IDisposable
+{
+    private readonly IExpertDeployConfigurationStateService configurationStateService;
+    private readonly IAutopilotProfileImportService autopilotProfileImportService;
+    private readonly IFilePickerService filePickerService;
+    private readonly IDialogService dialogService;
+    private readonly IApplicationLocalizationService localizationService;
+    private bool isApplyingState = true;
+    private bool isSavingState;
+
+    public AutopilotConfigurationViewModel(
+        IExpertDeployConfigurationStateService configurationStateService,
+        IAutopilotProfileImportService autopilotProfileImportService,
+        IFilePickerService filePickerService,
+        IDialogService dialogService,
+        IApplicationLocalizationService localizationService)
+    {
+        this.configurationStateService = configurationStateService;
+        this.autopilotProfileImportService = autopilotProfileImportService;
+        this.filePickerService = filePickerService;
+        this.dialogService = dialogService;
+        this.localizationService = localizationService;
+
+        RefreshLocalizedText();
+        ApplyState(configurationStateService.Current.Autopilot);
+
+        localizationService.LanguageChanged += OnLanguageChanged;
+        configurationStateService.StateChanged += OnConfigurationStateChanged;
+        Profiles.CollectionChanged += OnProfilesCollectionChanged;
+        isApplyingState = false;
+    }
+
+    public ObservableCollection<AutopilotProfileEntryViewModel> Profiles { get; } = [];
+
+    public bool IsAutopilotSectionEnabled => IsAutopilotEnabled;
+    public bool HasProfiles => Profiles.Count > 0;
+    public Visibility EmptyProfilesVisibility => HasProfiles ? Visibility.Collapsed : Visibility.Visible;
+    public Visibility ProfilesVisibility => HasProfiles ? Visibility.Visible : Visibility.Collapsed;
+
+    [ObservableProperty]
+    public partial string PageTitle { get; set; }
+
+    [ObservableProperty]
+    public partial string AutopilotHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string AutopilotDescription { get; set; }
+
+    [ObservableProperty]
+    public partial string EnableAutopilotText { get; set; }
+
+    [ObservableProperty]
+    public partial string StorageLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string InjectionLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string BootImageStoragePath { get; set; }
+
+    [ObservableProperty]
+    public partial string OfflineInjectionPath { get; set; }
+
+    [ObservableProperty]
+    public partial string ImportButtonText { get; set; }
+
+    [ObservableProperty]
+    public partial string RemoveButtonText { get; set; }
+
+    [ObservableProperty]
+    public partial string DefaultProfileLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string ProfilesLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string EmptyProfilesText { get; set; }
+
+    [ObservableProperty]
+    public partial string ProfileNameColumnHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string ProfileSourceColumnHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string ProfileImportedColumnHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string ProfileFolderColumnHeader { get; set; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsAutopilotSectionEnabled))]
+    [NotifyCanExecuteChangedFor(nameof(ImportProfileCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RemoveSelectedProfileCommand))]
+    public partial bool IsAutopilotEnabled { get; set; }
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(RemoveSelectedProfileCommand))]
+    public partial AutopilotProfileEntryViewModel? SelectedProfile { get; set; }
+
+    [ObservableProperty]
+    public partial AutopilotProfileEntryViewModel? SelectedDefaultProfile { get; set; }
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ImportProfileCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RemoveSelectedProfileCommand))]
+    public partial bool IsImporting { get; set; }
+
+    public void Dispose()
+    {
+        localizationService.LanguageChanged -= OnLanguageChanged;
+        configurationStateService.StateChanged -= OnConfigurationStateChanged;
+        Profiles.CollectionChanged -= OnProfilesCollectionChanged;
+    }
+
+    [RelayCommand(CanExecute = nameof(CanImportProfile))]
+    private async Task ImportProfileAsync()
+    {
+        string? filePath = await filePickerService.PickOpenFileAsync(
+            new FileOpenPickerRequest(localizationService.GetString("Autopilot.ImportPickerTitle"), [".json"]));
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            return;
+        }
+
+        IsImporting = true;
+        try
+        {
+            AutopilotProfileSettings profile = await autopilotProfileImportService.ImportFromJsonFileAsync(filePath);
+            MergeProfiles([profile]);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or InvalidOperationException or ArgumentException)
+        {
+            await dialogService.ShowMessageAsync(new DialogRequest(
+                localizationService.GetString("Autopilot.ImportFailedTitle"),
+                localizationService.FormatString("Autopilot.ImportFailedMessage", ex.Message)));
+        }
+        finally
+        {
+            IsImporting = false;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRemoveSelectedProfile))]
+    private void RemoveSelectedProfile()
+    {
+        if (SelectedProfile is null)
+        {
+            return;
+        }
+
+        string removedProfileId = SelectedProfile.Id;
+        Profiles.Remove(SelectedProfile);
+
+        SelectedProfile = Profiles.FirstOrDefault();
+        if (SelectedDefaultProfile is null ||
+            string.Equals(SelectedDefaultProfile.Id, removedProfileId, StringComparison.OrdinalIgnoreCase))
+        {
+            SelectedDefaultProfile = Profiles.FirstOrDefault();
+        }
+
+        SaveState();
+    }
+
+    partial void OnIsAutopilotEnabledChanged(bool value)
+    {
+        SaveState();
+    }
+
+    partial void OnSelectedDefaultProfileChanged(AutopilotProfileEntryViewModel? value)
+    {
+        SaveState();
+    }
+
+    private void ApplyState(AutopilotSettings settings)
+    {
+        isApplyingState = true;
+        try
+        {
+            IsAutopilotEnabled = settings.IsEnabled;
+            ReplaceProfiles(
+                settings.Profiles.Select(AutopilotProfileEntryViewModel.FromSettings),
+                settings.DefaultProfileId,
+                SelectedProfile?.Id);
+        }
+        finally
+        {
+            isApplyingState = false;
+        }
+    }
+
+    private void MergeProfiles(IReadOnlyList<AutopilotProfileSettings> incomingProfiles)
+    {
+        Dictionary<string, AutopilotProfileEntryViewModel> mergedProfiles = Profiles
+            .ToDictionary(profile => profile.Id, StringComparer.OrdinalIgnoreCase);
+
+        foreach (AutopilotProfileSettings incomingProfile in incomingProfiles)
+        {
+            mergedProfiles[incomingProfile.Id] = AutopilotProfileEntryViewModel.FromSettings(incomingProfile);
+        }
+
+        string? preferredDefaultProfileId = SelectedDefaultProfile?.Id ?? incomingProfiles.FirstOrDefault()?.Id;
+        ReplaceProfiles(mergedProfiles.Values, preferredDefaultProfileId, SelectedProfile?.Id);
+        SaveState();
+    }
+
+    private void ReplaceProfiles(
+        IEnumerable<AutopilotProfileEntryViewModel> profiles,
+        string? preferredDefaultProfileId,
+        string? preferredSelectedProfileId)
+    {
+        AutopilotProfileEntryViewModel[] orderedProfiles = profiles
+            .OrderBy(profile => profile.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(profile => profile.Id, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        Profiles.Clear();
+        foreach (AutopilotProfileEntryViewModel profile in orderedProfiles)
+        {
+            Profiles.Add(profile);
+        }
+
+        SelectedProfile = Profiles.FirstOrDefault(profile =>
+                              string.Equals(profile.Id, preferredSelectedProfileId, StringComparison.OrdinalIgnoreCase))
+                          ?? Profiles.FirstOrDefault();
+
+        SelectedDefaultProfile = Profiles.FirstOrDefault(profile =>
+                                     string.Equals(profile.Id, preferredDefaultProfileId, StringComparison.OrdinalIgnoreCase))
+                                 ?? Profiles.FirstOrDefault();
+
+        RefreshProfileState();
+    }
+
+    private void SaveState()
+    {
+        if (isApplyingState)
+        {
+            return;
+        }
+
+        isSavingState = true;
+        try
+        {
+            configurationStateService.UpdateAutopilot(new AutopilotSettings
+            {
+                IsEnabled = IsAutopilotEnabled,
+                DefaultProfileId = SelectedDefaultProfile?.Id,
+                Profiles = Profiles.Select(profile => profile.ToSettings()).ToArray()
+            });
+        }
+        finally
+        {
+            isSavingState = false;
+        }
+    }
+
+    private void RefreshLocalizedText()
+    {
+        PageTitle = localizationService.GetString("AutopilotPage_Title.Text");
+        AutopilotHeader = localizationService.GetString("Autopilot.Header");
+        AutopilotDescription = localizationService.GetString("Autopilot.Description");
+        EnableAutopilotText = localizationService.GetString("Autopilot.EnableLabel");
+        StorageLabel = localizationService.GetString("Autopilot.StorageLabel");
+        InjectionLabel = localizationService.GetString("Autopilot.InjectionLabel");
+        BootImageStoragePath = @"X:\Foundry\Config\Autopilot";
+        OfflineInjectionPath = @"%SystemDrive%\Windows\Provisioning\Autopilot\AutopilotConfigurationFile.json";
+        ImportButtonText = localizationService.GetString("Autopilot.ImportButton");
+        RemoveButtonText = localizationService.GetString("Autopilot.RemoveButton");
+        DefaultProfileLabel = localizationService.GetString("Autopilot.DefaultProfileLabel");
+        ProfilesLabel = localizationService.GetString("Autopilot.ProfilesLabel");
+        EmptyProfilesText = localizationService.GetString("Autopilot.ProfilesEmptyLabel");
+        ProfileNameColumnHeader = localizationService.GetString("Autopilot.ColumnName");
+        ProfileSourceColumnHeader = localizationService.GetString("Autopilot.ColumnSource");
+        ProfileImportedColumnHeader = localizationService.GetString("Autopilot.ColumnImported");
+        ProfileFolderColumnHeader = localizationService.GetString("Autopilot.ColumnFolder");
+    }
+
+    private void RefreshProfileState()
+    {
+        OnPropertyChanged(nameof(HasProfiles));
+        OnPropertyChanged(nameof(EmptyProfilesVisibility));
+        OnPropertyChanged(nameof(ProfilesVisibility));
+        RemoveSelectedProfileCommand.NotifyCanExecuteChanged();
+    }
+
+    private void OnProfilesCollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        RefreshProfileState();
+    }
+
+    private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
+    {
+        RefreshLocalizedText();
+    }
+
+    private void OnConfigurationStateChanged(object? sender, EventArgs e)
+    {
+        if (isSavingState)
+        {
+            return;
+        }
+
+        ApplyState(configurationStateService.Current.Autopilot);
+    }
+
+    private bool CanImportProfile()
+    {
+        return IsAutopilotEnabled && !IsImporting;
+    }
+
+    private bool CanRemoveSelectedProfile()
+    {
+        return IsAutopilotEnabled && !IsImporting && SelectedProfile is not null;
+    }
+}

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -61,18 +61,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string EnableAutopilotText { get; set; }
 
     [ObservableProperty]
-    public partial string StorageLabel { get; set; }
-
-    [ObservableProperty]
-    public partial string InjectionLabel { get; set; }
-
-    [ObservableProperty]
-    public partial string BootImageStoragePath { get; set; }
-
-    [ObservableProperty]
-    public partial string OfflineInjectionPath { get; set; }
-
-    [ObservableProperty]
     public partial string ImportButtonText { get; set; }
 
     [ObservableProperty]
@@ -271,10 +259,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         AutopilotHeader = localizationService.GetString("Autopilot.Header");
         AutopilotDescription = localizationService.GetString("Autopilot.Description");
         EnableAutopilotText = localizationService.GetString("Autopilot.EnableLabel");
-        StorageLabel = localizationService.GetString("Autopilot.StorageLabel");
-        InjectionLabel = localizationService.GetString("Autopilot.InjectionLabel");
-        BootImageStoragePath = @"X:\Foundry\Config\Autopilot";
-        OfflineInjectionPath = @"%SystemDrive%\Windows\Provisioning\Autopilot\AutopilotConfigurationFile.json";
         ImportButtonText = localizationService.GetString("Autopilot.ImportButton");
         RemoveButtonText = localizationService.GetString("Autopilot.RemoveButton");
         DefaultProfileLabel = localizationService.GetString("Autopilot.DefaultProfileLabel");

--- a/src/Foundry/ViewModels/AutopilotProfileEntryViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotProfileEntryViewModel.cs
@@ -1,0 +1,41 @@
+using System.Globalization;
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.ViewModels;
+
+public sealed record AutopilotProfileEntryViewModel(
+    string Id,
+    string DisplayName,
+    string FolderName,
+    string Source,
+    DateTimeOffset ImportedAtUtc,
+    string JsonContent)
+{
+    public string ImportedAtDisplay => ImportedAtUtc.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
+
+    public static AutopilotProfileEntryViewModel FromSettings(AutopilotProfileSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        return new AutopilotProfileEntryViewModel(
+            settings.Id,
+            settings.DisplayName,
+            settings.FolderName,
+            settings.Source,
+            settings.ImportedAtUtc,
+            settings.JsonContent);
+    }
+
+    public AutopilotProfileSettings ToSettings()
+    {
+        return new AutopilotProfileSettings
+        {
+            Id = Id,
+            DisplayName = DisplayName,
+            FolderName = FolderName,
+            Source = Source,
+            ImportedAtUtc = ImportedAtUtc,
+            JsonContent = JsonContent
+        };
+    }
+}

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -1,13 +1,119 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Page x:Class="Foundry.Views.AutopilotPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:dev="using:DevWinUI"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:viewModels="using:Foundry.ViewModels"
+      mc:Ignorable="d">
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
-                Padding="{ThemeResource ContentPagePadding}">
+                Padding="{ThemeResource ContentPagePadding}"
+                VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="10"
-                    Spacing="5">
-            <TextBlock x:Uid="AutopilotPage_Title"
+                    dev:PanelAttach.ChildrenTransitions="Default"
+                    Spacing="8">
+            <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
                        Style="{ThemeResource TitleTextBlockStyle}" />
+
+            <dev:SettingsExpander Header="{x:Bind ViewModel.AutopilotHeader, Mode=OneWay}"
+                                  Description="{x:Bind ViewModel.AutopilotDescription, Mode=OneWay}"
+                                  HeaderIcon="{dev:FontIcon GlyphCode=E7BF}"
+                                  IsExpanded="True">
+                <ToggleSwitch AutomationProperties.Name="{x:Bind ViewModel.EnableAutopilotText, Mode=OneWay}"
+                              IsOn="{x:Bind ViewModel.IsAutopilotEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <dev:SettingsExpander.Items>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.StorageLabel, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
+                        <TextBlock Text="{x:Bind ViewModel.BootImageStoragePath, Mode=OneWay}"
+                                   TextWrapping="Wrap" />
+                    </dev:SettingsCard>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.InjectionLabel, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
+                        <TextBlock Text="{x:Bind ViewModel.OfflineInjectionPath, Mode=OneWay}"
+                                   TextWrapping="Wrap" />
+                    </dev:SettingsCard>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.ImportButtonText, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="10">
+                            <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    Command="{x:Bind ViewModel.ImportProfileCommand}"
+                                    Content="{x:Bind ViewModel.ImportButtonText, Mode=OneWay}" />
+                            <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    Command="{x:Bind ViewModel.RemoveSelectedProfileCommand}"
+                                    Content="{x:Bind ViewModel.RemoveButtonText, Mode=OneWay}" />
+                        </StackPanel>
+                    </dev:SettingsCard>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.DefaultProfileLabel, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
+                        <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                  DisplayMemberPath="DisplayName"
+                                  ItemsSource="{x:Bind ViewModel.Profiles, Mode=OneWay}"
+                                  SelectedItem="{x:Bind ViewModel.SelectedDefaultProfile, Mode=TwoWay}" />
+                    </dev:SettingsCard>
+                    <dev:SettingsCard Header="{x:Bind ViewModel.ProfilesLabel, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="{x:Bind ViewModel.EmptyProfilesText, Mode=OneWay}"
+                                       TextWrapping="Wrap"
+                                       Visibility="{x:Bind ViewModel.EmptyProfilesVisibility, Mode=OneWay}" />
+                            <Grid Visibility="{x:Bind ViewModel.ProfilesVisibility, Mode=OneWay}">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+                                <Grid ColumnSpacing="12">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="2*" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="2*" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0"
+                                               Text="{x:Bind ViewModel.ProfileNameColumnHeader, Mode=OneWay}" />
+                                    <TextBlock Grid.Column="1"
+                                               Text="{x:Bind ViewModel.ProfileSourceColumnHeader, Mode=OneWay}" />
+                                    <TextBlock Grid.Column="2"
+                                               Text="{x:Bind ViewModel.ProfileImportedColumnHeader, Mode=OneWay}" />
+                                    <TextBlock Grid.Column="3"
+                                               Text="{x:Bind ViewModel.ProfileFolderColumnHeader, Mode=OneWay}" />
+                                </Grid>
+                                <ListView Grid.Row="1"
+                                          MaxHeight="320"
+                                          ItemsSource="{x:Bind ViewModel.Profiles, Mode=OneWay}"
+                                          SelectedItem="{x:Bind ViewModel.SelectedProfile, Mode=TwoWay}"
+                                          SelectionMode="Single">
+                                    <ListView.ItemTemplate>
+                                        <DataTemplate x:DataType="viewModels:AutopilotProfileEntryViewModel">
+                                            <Grid ColumnSpacing="12">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="2*" />
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="2*" />
+                                                </Grid.ColumnDefinitions>
+                                                <TextBlock Grid.Column="0"
+                                                           Text="{x:Bind DisplayName, Mode=OneWay}"
+                                                           TextWrapping="Wrap" />
+                                                <TextBlock Grid.Column="1"
+                                                           Text="{x:Bind Source, Mode=OneWay}"
+                                                           TextWrapping="Wrap" />
+                                                <TextBlock Grid.Column="2"
+                                                           Text="{x:Bind ImportedAtDisplay, Mode=OneWay}"
+                                                           TextWrapping="Wrap" />
+                                                <TextBlock Grid.Column="3"
+                                                           Text="{x:Bind FolderName, Mode=OneWay}"
+                                                           TextWrapping="Wrap" />
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ListView.ItemTemplate>
+                                </ListView>
+                            </Grid>
+                        </StackPanel>
+                    </dev:SettingsCard>
+                </dev:SettingsExpander.Items>
+            </dev:SettingsExpander>
         </StackPanel>
     </ScrollView>
 </Page>

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -2,10 +2,10 @@
 <Page x:Class="Foundry.Views.AutopilotPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:dev="using:DevWinUI"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:tv="using:WinUI.TableView"
       xmlns:viewModels="using:Foundry.ViewModels"
       mc:Ignorable="d">
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
@@ -49,29 +49,28 @@
                             <TextBlock Text="{x:Bind ViewModel.EmptyProfilesText, Mode=OneWay}"
                                        TextWrapping="Wrap"
                                        Visibility="{x:Bind ViewModel.EmptyProfilesVisibility, Mode=OneWay}" />
-                            <controls:DataGrid AutoGenerateColumns="False"
-                                               HeadersVisibility="Column"
-                                               IsReadOnly="True"
-                                               ItemsSource="{x:Bind ViewModel.Profiles, Mode=OneWay}"
-                                               MaxHeight="320"
-                                               SelectedItem="{x:Bind ViewModel.SelectedProfile, Mode=TwoWay}"
-                                               SelectionMode="Single"
-                                               Visibility="{x:Bind ViewModel.ProfilesVisibility, Mode=OneWay}">
-                                <controls:DataGrid.Columns>
-                                    <controls:DataGridTextColumn Binding="{Binding DisplayName}"
-                                                                 Header="{x:Bind ViewModel.ProfileNameColumnHeader, Mode=OneWay}"
-                                                                 Width="2*" />
-                                    <controls:DataGridTextColumn Binding="{Binding Source}"
-                                                                 Header="{x:Bind ViewModel.ProfileSourceColumnHeader, Mode=OneWay}"
-                                                                 Width="*" />
-                                    <controls:DataGridTextColumn Binding="{Binding ImportedAtDisplay}"
-                                                                 Header="{x:Bind ViewModel.ProfileImportedColumnHeader, Mode=OneWay}"
-                                                                 Width="*" />
-                                    <controls:DataGridTextColumn Binding="{Binding FolderName}"
-                                                                 Header="{x:Bind ViewModel.ProfileFolderColumnHeader, Mode=OneWay}"
-                                                                 Width="2*" />
-                                </controls:DataGrid.Columns>
-                            </controls:DataGrid>
+                            <tv:TableView AutoGenerateColumns="False"
+                                          IsReadOnly="True"
+                                          ItemsSource="{x:Bind ViewModel.Profiles, Mode=OneWay}"
+                                          MaxHeight="320"
+                                          SelectedItem="{x:Bind ViewModel.SelectedProfile, Mode=TwoWay}"
+                                          SelectionMode="Single"
+                                          Visibility="{x:Bind ViewModel.ProfilesVisibility, Mode=OneWay}">
+                                <tv:TableView.Columns>
+                                    <tv:TableViewTextColumn Binding="{Binding DisplayName}"
+                                                            Header="{x:Bind ViewModel.ProfileNameColumnHeader, Mode=OneWay}"
+                                                            Width="2*" />
+                                    <tv:TableViewTextColumn Binding="{Binding Source}"
+                                                            Header="{x:Bind ViewModel.ProfileSourceColumnHeader, Mode=OneWay}"
+                                                            Width="*" />
+                                    <tv:TableViewTextColumn Binding="{Binding ImportedAtDisplay}"
+                                                            Header="{x:Bind ViewModel.ProfileImportedColumnHeader, Mode=OneWay}"
+                                                            Width="*" />
+                                    <tv:TableViewTextColumn Binding="{Binding FolderName}"
+                                                            Header="{x:Bind ViewModel.ProfileFolderColumnHeader, Mode=OneWay}"
+                                                            Width="2*" />
+                                </tv:TableView.Columns>
+                            </tv:TableView>
                         </StackPanel>
                     </dev:SettingsCard>
                 </dev:SettingsExpander.Items>

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -2,6 +2,7 @@
 <Page x:Class="Foundry.Views.AutopilotPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:dev="using:DevWinUI"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -23,16 +24,6 @@
                 <ToggleSwitch AutomationProperties.Name="{x:Bind ViewModel.EnableAutopilotText, Mode=OneWay}"
                               IsOn="{x:Bind ViewModel.IsAutopilotEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 <dev:SettingsExpander.Items>
-                    <dev:SettingsCard Header="{x:Bind ViewModel.StorageLabel, Mode=OneWay}"
-                                      IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
-                        <TextBlock Text="{x:Bind ViewModel.BootImageStoragePath, Mode=OneWay}"
-                                   TextWrapping="Wrap" />
-                    </dev:SettingsCard>
-                    <dev:SettingsCard Header="{x:Bind ViewModel.InjectionLabel, Mode=OneWay}"
-                                      IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
-                        <TextBlock Text="{x:Bind ViewModel.OfflineInjectionPath, Mode=OneWay}"
-                                   TextWrapping="Wrap" />
-                    </dev:SettingsCard>
                     <dev:SettingsCard Header="{x:Bind ViewModel.ImportButtonText, Mode=OneWay}"
                                       IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
                         <StackPanel Orientation="Horizontal"
@@ -58,58 +49,29 @@
                             <TextBlock Text="{x:Bind ViewModel.EmptyProfilesText, Mode=OneWay}"
                                        TextWrapping="Wrap"
                                        Visibility="{x:Bind ViewModel.EmptyProfilesVisibility, Mode=OneWay}" />
-                            <Grid Visibility="{x:Bind ViewModel.ProfilesVisibility, Mode=OneWay}">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
-                                <Grid ColumnSpacing="12">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="2*" />
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="2*" />
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock Grid.Column="0"
-                                               Text="{x:Bind ViewModel.ProfileNameColumnHeader, Mode=OneWay}" />
-                                    <TextBlock Grid.Column="1"
-                                               Text="{x:Bind ViewModel.ProfileSourceColumnHeader, Mode=OneWay}" />
-                                    <TextBlock Grid.Column="2"
-                                               Text="{x:Bind ViewModel.ProfileImportedColumnHeader, Mode=OneWay}" />
-                                    <TextBlock Grid.Column="3"
-                                               Text="{x:Bind ViewModel.ProfileFolderColumnHeader, Mode=OneWay}" />
-                                </Grid>
-                                <ListView Grid.Row="1"
-                                          MaxHeight="320"
-                                          ItemsSource="{x:Bind ViewModel.Profiles, Mode=OneWay}"
-                                          SelectedItem="{x:Bind ViewModel.SelectedProfile, Mode=TwoWay}"
-                                          SelectionMode="Single">
-                                    <ListView.ItemTemplate>
-                                        <DataTemplate x:DataType="viewModels:AutopilotProfileEntryViewModel">
-                                            <Grid ColumnSpacing="12">
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="2*" />
-                                                    <ColumnDefinition Width="*" />
-                                                    <ColumnDefinition Width="*" />
-                                                    <ColumnDefinition Width="2*" />
-                                                </Grid.ColumnDefinitions>
-                                                <TextBlock Grid.Column="0"
-                                                           Text="{x:Bind DisplayName, Mode=OneWay}"
-                                                           TextWrapping="Wrap" />
-                                                <TextBlock Grid.Column="1"
-                                                           Text="{x:Bind Source, Mode=OneWay}"
-                                                           TextWrapping="Wrap" />
-                                                <TextBlock Grid.Column="2"
-                                                           Text="{x:Bind ImportedAtDisplay, Mode=OneWay}"
-                                                           TextWrapping="Wrap" />
-                                                <TextBlock Grid.Column="3"
-                                                           Text="{x:Bind FolderName, Mode=OneWay}"
-                                                           TextWrapping="Wrap" />
-                                            </Grid>
-                                        </DataTemplate>
-                                    </ListView.ItemTemplate>
-                                </ListView>
-                            </Grid>
+                            <controls:DataGrid AutoGenerateColumns="False"
+                                               HeadersVisibility="Column"
+                                               IsReadOnly="True"
+                                               ItemsSource="{x:Bind ViewModel.Profiles, Mode=OneWay}"
+                                               MaxHeight="320"
+                                               SelectedItem="{x:Bind ViewModel.SelectedProfile, Mode=TwoWay}"
+                                               SelectionMode="Single"
+                                               Visibility="{x:Bind ViewModel.ProfilesVisibility, Mode=OneWay}">
+                                <controls:DataGrid.Columns>
+                                    <controls:DataGridTextColumn Binding="{Binding DisplayName}"
+                                                                 Header="{x:Bind ViewModel.ProfileNameColumnHeader, Mode=OneWay}"
+                                                                 Width="2*" />
+                                    <controls:DataGridTextColumn Binding="{Binding Source}"
+                                                                 Header="{x:Bind ViewModel.ProfileSourceColumnHeader, Mode=OneWay}"
+                                                                 Width="*" />
+                                    <controls:DataGridTextColumn Binding="{Binding ImportedAtDisplay}"
+                                                                 Header="{x:Bind ViewModel.ProfileImportedColumnHeader, Mode=OneWay}"
+                                                                 Width="*" />
+                                    <controls:DataGridTextColumn Binding="{Binding FolderName}"
+                                                                 Header="{x:Bind ViewModel.ProfileFolderColumnHeader, Mode=OneWay}"
+                                                                 Width="2*" />
+                                </controls:DataGrid.Columns>
+                            </controls:DataGrid>
                         </StackPanel>
                     </dev:SettingsCard>
                 </dev:SettingsExpander.Items>

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -6,7 +6,6 @@
       xmlns:dev="using:DevWinUI"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:tv="using:WinUI.TableView"
-      xmlns:viewModels="using:Foundry.ViewModels"
       mc:Ignorable="d">
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
                 Padding="{ThemeResource ContentPagePadding}"
@@ -17,64 +16,68 @@
             <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
                        Style="{ThemeResource TitleTextBlockStyle}" />
 
-            <dev:SettingsExpander Header="{x:Bind ViewModel.AutopilotHeader, Mode=OneWay}"
-                                  Description="{x:Bind ViewModel.AutopilotDescription, Mode=OneWay}"
-                                  HeaderIcon="{dev:FontIcon GlyphCode=E7BF}"
-                                  IsExpanded="True">
+            <dev:SettingsCard Header="{x:Bind ViewModel.AutopilotHeader, Mode=OneWay}"
+                              Description="{x:Bind ViewModel.AutopilotDescription, Mode=OneWay}"
+                              HeaderIcon="{dev:FontIcon GlyphCode=E7BF}">
                 <ToggleSwitch AutomationProperties.Name="{x:Bind ViewModel.EnableAutopilotText, Mode=OneWay}"
                               IsOn="{x:Bind ViewModel.IsAutopilotEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                <dev:SettingsExpander.Items>
-                    <dev:SettingsCard Header="{x:Bind ViewModel.ImportButtonText, Mode=OneWay}"
-                                      IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
-                        <StackPanel Orientation="Horizontal"
-                                    Spacing="10">
-                            <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                    Command="{x:Bind ViewModel.ImportProfileCommand}"
-                                    Content="{x:Bind ViewModel.ImportButtonText, Mode=OneWay}" />
-                            <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                    Command="{x:Bind ViewModel.RemoveSelectedProfileCommand}"
-                                    Content="{x:Bind ViewModel.RemoveButtonText, Mode=OneWay}" />
-                        </StackPanel>
-                    </dev:SettingsCard>
-                    <dev:SettingsCard Header="{x:Bind ViewModel.DefaultProfileLabel, Mode=OneWay}"
-                                      IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
-                        <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                  DisplayMemberPath="DisplayName"
+            </dev:SettingsCard>
+
+            <dev:SettingsCard Header="{x:Bind ViewModel.ImportButtonText, Mode=OneWay}"
+                              IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
+                <StackPanel Orientation="Horizontal"
+                            Spacing="10">
+                    <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            Command="{x:Bind ViewModel.ImportProfileCommand}"
+                            Content="{x:Bind ViewModel.ImportButtonText, Mode=OneWay}" />
+                    <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            Command="{x:Bind ViewModel.RemoveSelectedProfileCommand}"
+                            Content="{x:Bind ViewModel.RemoveButtonText, Mode=OneWay}" />
+                </StackPanel>
+            </dev:SettingsCard>
+
+            <dev:SettingsCard Header="{x:Bind ViewModel.DefaultProfileLabel, Mode=OneWay}"
+                              IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
+                <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                          DisplayMemberPath="DisplayName"
+                          ItemsSource="{x:Bind ViewModel.Profiles, Mode=OneWay}"
+                          SelectedItem="{x:Bind ViewModel.SelectedDefaultProfile, Mode=TwoWay}" />
+            </dev:SettingsCard>
+
+            <dev:SettingsCard Header="{x:Bind ViewModel.ProfilesLabel, Mode=OneWay}"
+                              IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
+                <StackPanel Spacing="8">
+                    <TextBlock Text="{x:Bind ViewModel.EmptyProfilesText, Mode=OneWay}"
+                               TextWrapping="Wrap"
+                               Visibility="{x:Bind ViewModel.EmptyProfilesVisibility, Mode=OneWay}" />
+                    <tv:TableView AutoGenerateColumns="False"
+                                  CanFilterColumns="False"
+                                  CanReorderColumns="False"
+                                  CanResizeColumns="False"
+                                  CanSortColumns="False"
+                                  CornerButtonMode="None"
+                                  HeadersVisibility="Columns"
+                                  IsReadOnly="True"
                                   ItemsSource="{x:Bind ViewModel.Profiles, Mode=OneWay}"
-                                  SelectedItem="{x:Bind ViewModel.SelectedDefaultProfile, Mode=TwoWay}" />
-                    </dev:SettingsCard>
-                    <dev:SettingsCard Header="{x:Bind ViewModel.ProfilesLabel, Mode=OneWay}"
-                                      IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
-                        <StackPanel Spacing="8">
-                            <TextBlock Text="{x:Bind ViewModel.EmptyProfilesText, Mode=OneWay}"
-                                       TextWrapping="Wrap"
-                                       Visibility="{x:Bind ViewModel.EmptyProfilesVisibility, Mode=OneWay}" />
-                            <tv:TableView AutoGenerateColumns="False"
-                                          IsReadOnly="True"
-                                          ItemsSource="{x:Bind ViewModel.Profiles, Mode=OneWay}"
-                                          MaxHeight="320"
-                                          SelectedItem="{x:Bind ViewModel.SelectedProfile, Mode=TwoWay}"
-                                          SelectionMode="Single"
-                                          Visibility="{x:Bind ViewModel.ProfilesVisibility, Mode=OneWay}">
-                                <tv:TableView.Columns>
-                                    <tv:TableViewTextColumn Binding="{Binding DisplayName}"
-                                                            Header="{x:Bind ViewModel.ProfileNameColumnHeader, Mode=OneWay}"
-                                                            Width="2*" />
-                                    <tv:TableViewTextColumn Binding="{Binding Source}"
-                                                            Header="{x:Bind ViewModel.ProfileSourceColumnHeader, Mode=OneWay}"
-                                                            Width="*" />
-                                    <tv:TableViewTextColumn Binding="{Binding ImportedAtDisplay}"
-                                                            Header="{x:Bind ViewModel.ProfileImportedColumnHeader, Mode=OneWay}"
-                                                            Width="*" />
-                                    <tv:TableViewTextColumn Binding="{Binding FolderName}"
-                                                            Header="{x:Bind ViewModel.ProfileFolderColumnHeader, Mode=OneWay}"
-                                                            Width="2*" />
-                                </tv:TableView.Columns>
-                            </tv:TableView>
-                        </StackPanel>
-                    </dev:SettingsCard>
-                </dev:SettingsExpander.Items>
-            </dev:SettingsExpander>
+                                  MaxHeight="320"
+                                  SelectedItem="{x:Bind ViewModel.SelectedProfile, Mode=TwoWay}"
+                                  SelectionMode="Single"
+                                  SelectionUnit="Row"
+                                  ShowExportOptions="False"
+                                  Visibility="{x:Bind ViewModel.ProfilesVisibility, Mode=OneWay}">
+                        <tv:TableView.Columns>
+                            <tv:TableViewTextColumn Binding="{Binding DisplayName}"
+                                                    Header="{x:Bind ViewModel.ProfileNameColumnHeader, Mode=OneWay}" />
+                            <tv:TableViewTextColumn Binding="{Binding Source}"
+                                                    Header="{x:Bind ViewModel.ProfileSourceColumnHeader, Mode=OneWay}" />
+                            <tv:TableViewTextColumn Binding="{Binding ImportedAtDisplay}"
+                                                    Header="{x:Bind ViewModel.ProfileImportedColumnHeader, Mode=OneWay}" />
+                            <tv:TableViewTextColumn Binding="{Binding FolderName}"
+                                                    Header="{x:Bind ViewModel.ProfileFolderColumnHeader, Mode=OneWay}" />
+                        </tv:TableView.Columns>
+                    </tv:TableView>
+                </StackPanel>
+            </dev:SettingsCard>
         </StackPanel>
     </ScrollView>
 </Page>

--- a/src/Foundry/Views/AutopilotPage.xaml.cs
+++ b/src/Foundry/Views/AutopilotPage.xaml.cs
@@ -2,8 +2,18 @@ namespace Foundry.Views;
 
 public sealed partial class AutopilotPage : Page
 {
+    public AutopilotConfigurationViewModel ViewModel { get; }
+
     public AutopilotPage()
     {
+        ViewModel = App.GetService<AutopilotConfigurationViewModel>();
         InitializeComponent();
+        Unloaded += OnUnloaded;
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        Unloaded -= OnUnloaded;
+        ViewModel.Dispose();
     }
 }


### PR DESCRIPTION
## Summary
- Adds the WinUI Autopilot page for manual profile import and local profile management.
- Persists imported Autopilot profiles and default selection in expert configuration.
- Adds a pure Core manual import service for WPF-compatible JSON validation, profile IDs, folder names, sorting, merge, and fallback behavior.

## Reason
Phase 16.B restores the manual Autopilot profile workflow before Graph tenant import and Start preflight readiness are handled in later Phase 16 slices.

## Main changes
- Enables Autopilot state, JSON import, selected profile removal, and default profile selection.
- Stores full imported profile JSON in `foundry.expert.config.json`.
- Preserves deploy config behavior by resolving `autopilot.defaultProfileFolderName` from the selected default profile.
- Keeps Graph download out of scope for Phase 16.C.

## Testing
- `dotnet build src\Foundry\Foundry.csproj --no-restore`
- `dotnet test src\Foundry.Core.Tests\Foundry.Core.Tests.csproj --no-restore`
- `dotnet test src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --no-restore`
