### PR TITLE
feat(autopilot): add graph profile import

### DIFF
--- a/docs/migration/phases/06-business-workflows.md
+++ b/docs/migration/phases/06-business-workflows.md
@@ -298,6 +298,6 @@ git commit -m "feat(autopilot): wire start readiness"
 - [x] **16.10** `Foundry.Core` has no dependency on Azure Identity, Microsoft Graph clients, `InteractiveBrowserCredential`, or Graph HTTP plumbing.
 - [x] **16.11** Manual Autopilot JSON import rejects empty, invalid, or non-ASCII JSON.
 - [x] **16.12** Manual Autopilot JSON import preserves WPF-compatible profile ID, display name, folder name, merge, sort, and default-profile fallback behavior.
-- [ ] **16.13** Graph tenant import downloads profiles through a cancellable WinUI `ContentDialog` and imports selected profiles through a separate WinUI `ContentDialog`.
+- [x] **16.13** Graph tenant import downloads profiles through a cancellable WinUI `ContentDialog` and imports selected profiles through a separate WinUI `ContentDialog`.
 - [ ] **16.14** Autopilot disabled does not block `Start` preflight.
 - [ ] **16.15** Autopilot enabled without a valid default profile blocks or warns in `Start` preflight.

--- a/docs/migration/phases/06-business-workflows.md
+++ b/docs/migration/phases/06-business-workflows.md
@@ -250,25 +250,25 @@ git commit -m "feat(network): wire connect preflight readiness"
     - [x] Target Windows staging path written by `Foundry.Deploy`: `%SystemDrive%\Windows\Provisioning\Autopilot\AutopilotConfigurationFile.json`.
     - [x] Generated Deploy config stores the selected/default profile folder name, not a full path.
 
-- [ ] **16.C** Port Autopilot Microsoft Graph tenant import.
-  - [ ] **16.C.1** Keep Microsoft Graph authentication in the WinUI `Foundry` app/infrastructure layer.
-  - [ ] **16.C.2** Keep `InteractiveBrowserCredential`, token cache behavior, environment-variable-driven Graph configuration, and Graph HTTP calls out of `Foundry.Core`.
-  - [ ] **16.C.3** Preserve WPF Graph behavior:
-    - [ ] Use `DeviceManagementServiceConfig.Read.All` and `User.Read` scopes.
-    - [ ] Preserve `FOUNDRY_AUTOPILOT_GRAPH_CLIENT_ID` and `FOUNDRY_AUTOPILOT_GRAPH_TENANT_ID` overrides.
-    - [ ] Query `v1.0/organization?$select=id,verifiedDomains` for tenant information and verified domain.
-    - [ ] Query `beta/deviceManagement/windowsAutopilotDeploymentProfiles`.
-    - [ ] Handle paged Graph responses.
-    - [ ] Convert tenant deployment profiles into offline `AutopilotConfigurationFile.json` content.
-  - [ ] **16.C.4** Use the blocking operation overlay for tenant authentication/download, then close the overlay before showing profile selection.
-  - [ ] **16.C.5** Use a WinUI `ContentDialog` for downloaded profile selection instead of a separate WPF-style window:
-    - [ ] Profiles selected by default.
-    - [ ] Select all.
-    - [ ] Clear.
-    - [ ] Selected count.
-    - [ ] Import disabled when no profile is selected.
-    - [ ] Cancel returns no imported profiles.
-  - [ ] **16.C.6** Do not show tenant tokens or raw Graph response bodies in UI, summaries, logs, or diagnostics.
+- [x] **16.C** Port Autopilot Microsoft Graph tenant import.
+  - [x] **16.C.1** Keep Microsoft Graph authentication in the WinUI `Foundry` app/infrastructure layer.
+  - [x] **16.C.2** Keep `InteractiveBrowserCredential`, token cache behavior, environment-variable-driven Graph configuration, and Graph HTTP calls out of `Foundry.Core`.
+  - [x] **16.C.3** Preserve WPF Graph behavior:
+    - [x] Use `DeviceManagementServiceConfig.Read.All` and `User.Read` scopes.
+    - [x] Preserve `FOUNDRY_AUTOPILOT_GRAPH_CLIENT_ID` and `FOUNDRY_AUTOPILOT_GRAPH_TENANT_ID` overrides.
+    - [x] Query `v1.0/organization?$select=id,verifiedDomains` for tenant information and verified domain.
+    - [x] Query `beta/deviceManagement/windowsAutopilotDeploymentProfiles`.
+    - [x] Handle paged Graph responses.
+    - [x] Convert tenant deployment profiles into offline `AutopilotConfigurationFile.json` content.
+  - [x] **16.C.4** Use the blocking operation overlay for tenant authentication/download, then close the overlay before showing profile selection.
+  - [x] **16.C.5** Use a WinUI `ContentDialog` for downloaded profile selection instead of a separate WPF-style window:
+    - [x] Profiles selected by default.
+    - [x] Select all.
+    - [x] Clear.
+    - [x] Selected count.
+    - [x] Import disabled when no profile is selected.
+    - [x] Cancel returns no imported profiles.
+  - [x] **16.C.6** Do not show tenant tokens or raw Graph response bodies in UI, summaries, logs, or diagnostics.
 
 - [ ] **16.D** Wire Autopilot/customization readiness into `Start` preflight and finish Phase 16 validation.
   - [ ] **16.D.1** Do not block media creation when Autopilot is disabled.

--- a/docs/migration/phases/06-business-workflows.md
+++ b/docs/migration/phases/06-business-workflows.md
@@ -260,7 +260,7 @@ git commit -m "feat(network): wire connect preflight readiness"
     - [x] Query `beta/deviceManagement/windowsAutopilotDeploymentProfiles`.
     - [x] Handle paged Graph responses.
     - [x] Convert tenant deployment profiles into offline `AutopilotConfigurationFile.json` content.
-  - [x] **16.C.4** Use the blocking operation overlay for tenant authentication/download, then close the overlay before showing profile selection.
+  - [x] **16.C.4** Use a cancellable WinUI `ContentDialog` for tenant authentication/download, then close it before showing profile selection.
   - [x] **16.C.5** Use a WinUI `ContentDialog` for downloaded profile selection instead of a separate WPF-style window:
     - [x] Profiles selected by default.
     - [x] Select all.
@@ -298,6 +298,6 @@ git commit -m "feat(autopilot): wire start readiness"
 - [x] **16.10** `Foundry.Core` has no dependency on Azure Identity, Microsoft Graph clients, `InteractiveBrowserCredential`, or Graph HTTP plumbing.
 - [x] **16.11** Manual Autopilot JSON import rejects empty, invalid, or non-ASCII JSON.
 - [x] **16.12** Manual Autopilot JSON import preserves WPF-compatible profile ID, display name, folder name, merge, sort, and default-profile fallback behavior.
-- [ ] **16.13** Graph tenant import downloads profiles through the blocking overlay and imports selected profiles through a WinUI `ContentDialog`.
+- [ ] **16.13** Graph tenant import downloads profiles through a cancellable WinUI `ContentDialog` and imports selected profiles through a separate WinUI `ContentDialog`.
 - [ ] **16.14** Autopilot disabled does not block `Start` preflight.
 - [ ] **16.15** Autopilot enabled without a valid default profile blocks or warns in `Start` preflight.

--- a/src/Foundry.Core/Services/Configuration/AutopilotProfileImportService.cs
+++ b/src/Foundry.Core/Services/Configuration/AutopilotProfileImportService.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Foundry.Core.Models.Configuration;
@@ -18,32 +17,9 @@ public sealed class AutopilotProfileImportService : IAutopilotProfileImportServi
         string jsonContent = await File.ReadAllTextAsync(filePath, cancellationToken).ConfigureAwait(false);
         using JsonDocument document = ValidateJsonContent(jsonContent, filePath);
         string displayName = ResolveDisplayName(document.RootElement, filePath);
-        string id = BuildManualProfileId(jsonContent);
+        string id = AutopilotProfileSettingsFactory.BuildManualProfileId(jsonContent);
 
-        return CreateProfileSettings(id, displayName, jsonContent, "Manual import", DateTimeOffset.UtcNow);
-    }
-
-    private static AutopilotProfileSettings CreateProfileSettings(
-        string id,
-        string displayName,
-        string jsonContent,
-        string source,
-        DateTimeOffset importedAtUtc)
-    {
-        string normalizedId = string.IsNullOrWhiteSpace(id) ? BuildManualProfileId(jsonContent) : id.Trim();
-        string normalizedDisplayName = string.IsNullOrWhiteSpace(displayName)
-            ? "Autopilot profile"
-            : displayName.Trim();
-
-        return new AutopilotProfileSettings
-        {
-            Id = normalizedId,
-            DisplayName = normalizedDisplayName,
-            FolderName = BuildFolderName(normalizedDisplayName, normalizedId),
-            Source = source,
-            ImportedAtUtc = importedAtUtc,
-            JsonContent = jsonContent
-        };
+        return AutopilotProfileSettingsFactory.Create(id, displayName, jsonContent, "Manual import", DateTimeOffset.UtcNow);
     }
 
     private static JsonDocument ValidateJsonContent(string jsonContent, string sourcePath)
@@ -90,39 +66,4 @@ public sealed class AutopilotProfileImportService : IAutopilotProfileImportServi
         return fileName;
     }
 
-    private static string BuildManualProfileId(string jsonContent)
-    {
-        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(jsonContent));
-        return $"manual-{Convert.ToHexString(hash[..8]).ToLowerInvariant()}";
-    }
-
-    private static string BuildFolderName(string displayName, string id)
-    {
-        string sanitizedDisplayName = SanitizeFolderName(displayName);
-        string safeId = new(id.Where(ch => char.IsLetterOrDigit(ch) || ch is '-' or '_').ToArray());
-        if (safeId.Length > 8)
-        {
-            safeId = safeId[..8];
-        }
-
-        return string.IsNullOrWhiteSpace(safeId)
-            ? sanitizedDisplayName
-            : $"{sanitizedDisplayName}__{safeId}";
-    }
-
-    private static string SanitizeFolderName(string value)
-    {
-        char[] invalidChars = Path.GetInvalidFileNameChars();
-        string sanitized = new string(value
-                .Select(ch => invalidChars.Contains(ch) ? '_' : ch)
-                .ToArray())
-            .Trim();
-
-        if (string.IsNullOrWhiteSpace(sanitized))
-        {
-            sanitized = "AutopilotProfile";
-        }
-
-        return sanitized.Replace(' ', '_');
-    }
 }

--- a/src/Foundry.Core/Services/Configuration/AutopilotProfileSettingsFactory.cs
+++ b/src/Foundry.Core/Services/Configuration/AutopilotProfileSettingsFactory.cs
@@ -1,0 +1,75 @@
+using System.Security.Cryptography;
+using System.Text;
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Core.Services.Configuration;
+
+public static class AutopilotProfileSettingsFactory
+{
+    public static AutopilotProfileSettings Create(
+        string id,
+        string displayName,
+        string jsonContent,
+        string source,
+        DateTimeOffset importedAtUtc,
+        string? preferredFolderName = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(jsonContent);
+        ArgumentException.ThrowIfNullOrWhiteSpace(source);
+
+        string normalizedId = string.IsNullOrWhiteSpace(id) ? BuildManualProfileId(jsonContent) : id.Trim();
+        string normalizedDisplayName = string.IsNullOrWhiteSpace(displayName)
+            ? "Autopilot profile"
+            : displayName.Trim();
+
+        return new AutopilotProfileSettings
+        {
+            Id = normalizedId,
+            DisplayName = normalizedDisplayName,
+            FolderName = string.IsNullOrWhiteSpace(preferredFolderName)
+                ? BuildFolderName(normalizedDisplayName, normalizedId)
+                : SanitizeFolderName(preferredFolderName),
+            Source = source,
+            ImportedAtUtc = importedAtUtc,
+            JsonContent = jsonContent
+        };
+    }
+
+    public static string BuildManualProfileId(string jsonContent)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(jsonContent);
+
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(jsonContent));
+        return $"manual-{Convert.ToHexString(hash[..8]).ToLowerInvariant()}";
+    }
+
+    private static string BuildFolderName(string displayName, string id)
+    {
+        string sanitizedDisplayName = SanitizeFolderName(displayName);
+        string safeId = new(id.Where(ch => char.IsLetterOrDigit(ch) || ch is '-' or '_').ToArray());
+        if (safeId.Length > 8)
+        {
+            safeId = safeId[..8];
+        }
+
+        return string.IsNullOrWhiteSpace(safeId)
+            ? sanitizedDisplayName
+            : $"{sanitizedDisplayName}__{safeId}";
+    }
+
+    private static string SanitizeFolderName(string value)
+    {
+        char[] invalidChars = Path.GetInvalidFileNameChars();
+        string sanitized = new string(value
+                .Select(ch => invalidChars.Contains(ch) ? '_' : ch)
+                .ToArray())
+            .Trim();
+
+        if (string.IsNullOrWhiteSpace(sanitized))
+        {
+            sanitized = "AutopilotProfile";
+        }
+
+        return sanitized.Replace(' ', '_');
+    }
+}

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IConnectConfigurationGenerator, ConnectConfigurationGenerator>();
         services.AddSingleton<IAutopilotProfileImportService, AutopilotProfileImportService>();
         services.AddSingleton<IAutopilotTenantProfileService, AutopilotTenantProfileService>();
+        services.AddSingleton<IAutopilotTenantDownloadDialogService, AutopilotTenantDownloadDialogService>();
         services.AddSingleton<IAutopilotProfileSelectionDialogService, AutopilotProfileSelectionDialogService>();
         services.AddSingleton<ILanguageRegistryService, EmbeddedLanguageRegistryService>();
         services.AddSingleton<INetworkSecretStateService, NetworkSecretStateService>();

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Foundry.Core.Services.Configuration;
 using Foundry.Core.Services.WinPe;
 using Foundry.Services.Application;
 using Foundry.Services.Adk;
+using Foundry.Services.Autopilot;
 using Foundry.Services.Configuration;
 using Foundry.Services.Localization;
 using Foundry.Services.Operations;
@@ -29,6 +30,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IDeployConfigurationGenerator, DeployConfigurationGenerator>();
         services.AddSingleton<IConnectConfigurationGenerator, ConnectConfigurationGenerator>();
         services.AddSingleton<IAutopilotProfileImportService, AutopilotProfileImportService>();
+        services.AddSingleton<IAutopilotTenantProfileService, AutopilotTenantProfileService>();
+        services.AddSingleton<IAutopilotProfileSelectionDialogService, AutopilotProfileSelectionDialogService>();
         services.AddSingleton<ILanguageRegistryService, EmbeddedLanguageRegistryService>();
         services.AddSingleton<INetworkSecretStateService, NetworkSecretStateService>();
         services.AddSingleton<IExpertDeployConfigurationStateService, ExpertDeployConfigurationStateService>();

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -54,6 +54,7 @@
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="CommunityToolkit.Common" Version="8.4.2" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="DevWinUI" Version="9.9.4" />

--- a/src/Foundry/Services/Autopilot/AutopilotProfileSelectionDialogService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotProfileSelectionDialogService.cs
@@ -1,0 +1,32 @@
+using Foundry.Core.Models.Configuration;
+using Foundry.Services.Localization;
+
+namespace Foundry.Services.Autopilot;
+
+public sealed class AutopilotProfileSelectionDialogService(
+    IApplicationLocalizationService localizationService) : IAutopilotProfileSelectionDialogService
+{
+    public async Task<IReadOnlyList<AutopilotProfileSettings>?> PickProfilesAsync(
+        IReadOnlyList<AutopilotProfileSettings> availableProfiles)
+    {
+        ArgumentNullException.ThrowIfNull(availableProfiles);
+
+        var viewModel = new AutopilotProfileSelectionDialogViewModel(localizationService, availableProfiles);
+        var dialog = new AutopilotProfileSelectionDialog(viewModel)
+        {
+            XamlRoot = App.MainWindow.Content.XamlRoot
+        };
+
+        try
+        {
+            ContentDialogResult result = await dialog.ShowAsync();
+            return result == ContentDialogResult.Primary
+                ? viewModel.GetSelectedProfiles()
+                : null;
+        }
+        finally
+        {
+            viewModel.Dispose();
+        }
+    }
+}

--- a/src/Foundry/Services/Autopilot/AutopilotTenantDownloadDialogService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantDownloadDialogService.cs
@@ -1,0 +1,83 @@
+using Foundry.Core.Models.Configuration;
+using Foundry.Services.Localization;
+
+namespace Foundry.Services.Autopilot;
+
+public sealed class AutopilotTenantDownloadDialogService(
+    IApplicationLocalizationService localizationService) : IAutopilotTenantDownloadDialogService
+{
+    public async Task<IReadOnlyList<AutopilotProfileSettings>?> DownloadAsync(
+        Func<CancellationToken, Task<IReadOnlyList<AutopilotProfileSettings>>> downloadProfilesAsync)
+    {
+        ArgumentNullException.ThrowIfNull(downloadProfilesAsync);
+
+        using var cancellationTokenSource = new CancellationTokenSource();
+        ContentDialog dialog = CreateDialog(cancellationTokenSource);
+        Task<IReadOnlyList<AutopilotProfileSettings>> downloadTask = downloadProfilesAsync(cancellationTokenSource.Token);
+        Task<ContentDialogResult> dialogTask = dialog.ShowAsync().AsTask();
+
+        Task completedTask = await Task.WhenAny(downloadTask, dialogTask);
+        if (completedTask == dialogTask)
+        {
+            cancellationTokenSource.Cancel();
+            _ = ObserveDownloadTaskAsync(downloadTask);
+            return null;
+        }
+
+        dialog.DispatcherQueue.TryEnqueue(dialog.Hide);
+        await dialogTask;
+        return await downloadTask;
+    }
+
+    private ContentDialog CreateDialog(CancellationTokenSource cancellationTokenSource)
+    {
+        var dialog = new ContentDialog
+        {
+            XamlRoot = App.MainWindow.Content.XamlRoot,
+            Title = localizationService.GetString("Autopilot.TenantDownloadDialogTitle"),
+            Content = CreateDialogContent(),
+            CloseButtonText = localizationService.GetString("Autopilot.TenantDownloadDialogCancel"),
+            DefaultButton = ContentDialogButton.Close
+        };
+
+        dialog.CloseButtonClick += (_, _) => cancellationTokenSource.Cancel();
+        return dialog;
+    }
+
+    private FrameworkElement CreateDialogContent()
+    {
+        return new StackPanel
+        {
+            MinWidth = 360,
+            Spacing = 16,
+            Children =
+            {
+                new Microsoft.UI.Xaml.Controls.ProgressRing
+                {
+                    Width = 48,
+                    Height = 48,
+                    IsActive = true,
+                    HorizontalAlignment = HorizontalAlignment.Center
+                },
+                new TextBlock
+                {
+                    Text = localizationService.GetString("Autopilot.TenantDownloadDialogMessage"),
+                    TextWrapping = TextWrapping.Wrap,
+                    TextAlignment = TextAlignment.Center
+                }
+            }
+        };
+    }
+
+    private static async Task ObserveDownloadTaskAsync(Task<IReadOnlyList<AutopilotProfileSettings>> downloadTask)
+    {
+        try
+        {
+            await downloadTask.ConfigureAwait(false);
+        }
+        catch
+        {
+            // The user canceled the dialog; late task completion is intentionally ignored.
+        }
+    }
+}

--- a/src/Foundry/Services/Autopilot/AutopilotTenantDownloadDialogService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantDownloadDialogService.cs
@@ -24,9 +24,10 @@ public sealed class AutopilotTenantDownloadDialogService(
             return null;
         }
 
-        dialog.DispatcherQueue.TryEnqueue(dialog.Hide);
+        IReadOnlyList<AutopilotProfileSettings> profiles = await downloadTask;
+        dialog.Hide();
         await dialogTask;
-        return await downloadTask;
+        return profiles;
     }
 
     private ContentDialog CreateDialog(CancellationTokenSource cancellationTokenSource)

--- a/src/Foundry/Services/Autopilot/AutopilotTenantDownloadDialogService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantDownloadDialogService.cs
@@ -13,9 +13,21 @@ public sealed class AutopilotTenantDownloadDialogService(
 
         using var cancellationTokenSource = new CancellationTokenSource();
         ContentDialog dialog = CreateDialog(cancellationTokenSource);
-        Task<IReadOnlyList<AutopilotProfileSettings>> downloadTask = downloadProfilesAsync(cancellationTokenSource.Token);
+        TaskCompletionSource dialogOpenedTask = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        dialog.Opened += OnDialogOpened;
         Task<ContentDialogResult> dialogTask = dialog.ShowAsync().AsTask();
 
+        Task completedBeforeOpenTask = await Task.WhenAny(dialogOpenedTask.Task, dialogTask);
+        dialog.Opened -= OnDialogOpened;
+        if (completedBeforeOpenTask == dialogTask)
+        {
+            cancellationTokenSource.Cancel();
+            return null;
+        }
+
+        Task<IReadOnlyList<AutopilotProfileSettings>> downloadTask = Task.Run(
+            () => downloadProfilesAsync(cancellationTokenSource.Token),
+            cancellationTokenSource.Token);
         Task completedTask = await Task.WhenAny(downloadTask, dialogTask);
         if (completedTask == dialogTask)
         {
@@ -24,10 +36,24 @@ public sealed class AutopilotTenantDownloadDialogService(
             return null;
         }
 
-        IReadOnlyList<AutopilotProfileSettings> profiles = await downloadTask;
-        dialog.Hide();
-        await dialogTask;
+        IReadOnlyList<AutopilotProfileSettings> profiles;
+        try
+        {
+            profiles = await downloadTask;
+        }
+        catch
+        {
+            await CloseDialogAsync(dialog, dialogTask);
+            throw;
+        }
+
+        await CloseDialogAsync(dialog, dialogTask);
         return profiles;
+
+        void OnDialogOpened(ContentDialog sender, ContentDialogOpenedEventArgs args)
+        {
+            dialogOpenedTask.TrySetResult();
+        }
     }
 
     private ContentDialog CreateDialog(CancellationTokenSource cancellationTokenSource)
@@ -80,5 +106,15 @@ public sealed class AutopilotTenantDownloadDialogService(
         {
             // The user canceled the dialog; late task completion is intentionally ignored.
         }
+    }
+
+    private static async Task CloseDialogAsync(ContentDialog dialog, Task<ContentDialogResult> dialogTask)
+    {
+        if (!dialogTask.IsCompleted)
+        {
+            dialog.Hide();
+        }
+
+        await dialogTask;
     }
 }

--- a/src/Foundry/Services/Autopilot/AutopilotTenantProfileService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantProfileService.cs
@@ -1,0 +1,375 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using Azure.Core;
+using Azure.Identity;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Configuration;
+using Serilog;
+
+namespace Foundry.Services.Autopilot;
+
+public sealed class AutopilotTenantProfileService(ILogger logger) : IAutopilotTenantProfileService
+{
+    private const string DefaultClientId = "83eb3a92-030d-49b7-881b-32a1eb3e110a";
+    private const string ClientIdEnvironmentVariableName = "FOUNDRY_AUTOPILOT_GRAPH_CLIENT_ID";
+    private const string TenantIdEnvironmentVariableName = "FOUNDRY_AUTOPILOT_GRAPH_TENANT_ID";
+    private const string DefaultTenantId = "common";
+    private const string DefaultRedirectUri = "http://localhost";
+    private const string OrganizationRequestPath = "v1.0/organization?$select=id,verifiedDomains";
+    private const string AutopilotProfilesRequestPath = "beta/deviceManagement/windowsAutopilotDeploymentProfiles";
+    private const string TenantDownloadSource = "Tenant download";
+
+    private static readonly string[] GraphScopes =
+    [
+        "DeviceManagementServiceConfig.Read.All",
+        "User.Read"
+    ];
+
+    private static readonly HttpClient GraphHttpClient = new()
+    {
+        BaseAddress = new Uri("https://graph.microsoft.com/", UriKind.Absolute)
+    };
+
+    private readonly ILogger logger = logger.ForContext<AutopilotTenantProfileService>();
+
+    public async Task<IReadOnlyList<AutopilotProfileSettings>> DownloadFromTenantAsync(CancellationToken cancellationToken = default)
+    {
+        TokenCredential credential = CreateCredential();
+
+        logger.Information("Authenticating to Microsoft Graph for Autopilot profile download.");
+        string accessToken = await AcquireAccessTokenAsync(credential, cancellationToken).ConfigureAwait(false);
+        OrganizationInfo organization = await GetOrganizationAsync(accessToken, cancellationToken).ConfigureAwait(false);
+        logger.Information(
+            "Authenticated to Microsoft Graph for Autopilot profile download. TenantId={TenantId}, TenantDomain={TenantDomain}",
+            organization.Id,
+            organization.DefaultDomain);
+
+        IReadOnlyList<AutopilotDeploymentProfile> profiles = await GetAutopilotProfilesAsync(accessToken, cancellationToken)
+            .ConfigureAwait(false);
+
+        AutopilotProfileSettings[] downloadedProfiles = profiles
+            .Select(profile => CreateProfileSettings(profile, organization))
+            .ToArray();
+
+        logger.Information("Downloaded {ProfileCount} Autopilot profile(s) from Microsoft Graph.", downloadedProfiles.Length);
+        return downloadedProfiles;
+    }
+
+    private static TokenCredential CreateCredential()
+    {
+        string clientId = Environment.GetEnvironmentVariable(ClientIdEnvironmentVariableName)?.Trim()
+            ?? DefaultClientId;
+        string? tenantId = Environment.GetEnvironmentVariable(TenantIdEnvironmentVariableName);
+
+        return new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
+        {
+            ClientId = clientId,
+            TenantId = string.IsNullOrWhiteSpace(tenantId) ? DefaultTenantId : tenantId.Trim(),
+            RedirectUri = new Uri(DefaultRedirectUri, UriKind.Absolute),
+            TokenCachePersistenceOptions = new TokenCachePersistenceOptions
+            {
+                Name = "FoundryAutopilotGraph"
+            }
+        });
+    }
+
+    private static async Task<string> AcquireAccessTokenAsync(TokenCredential credential, CancellationToken cancellationToken)
+    {
+        AccessToken accessToken = await credential.GetTokenAsync(new TokenRequestContext(GraphScopes), cancellationToken)
+            .ConfigureAwait(false);
+        return accessToken.Token;
+    }
+
+    private static AutopilotProfileSettings CreateProfileSettings(
+        AutopilotDeploymentProfile profile,
+        OrganizationInfo organization)
+    {
+        string displayName = string.IsNullOrWhiteSpace(profile.DisplayName)
+            ? "Autopilot profile"
+            : profile.DisplayName.Trim();
+        string jsonContent = BuildOfflineConfigurationJson(profile, organization, displayName);
+        string id = string.IsNullOrWhiteSpace(profile.Id)
+            ? AutopilotProfileSettingsFactory.BuildManualProfileId(jsonContent)
+            : profile.Id.Trim();
+
+        return AutopilotProfileSettingsFactory.Create(
+            id,
+            displayName,
+            jsonContent,
+            TenantDownloadSource,
+            DateTimeOffset.UtcNow);
+    }
+
+    private static string BuildOfflineConfigurationJson(
+        AutopilotDeploymentProfile profile,
+        OrganizationInfo organization,
+        string displayName)
+    {
+        OutOfBoxExperienceSettings oobeSettings = profile.OutOfBoxExperienceSettings ?? new();
+        bool hideEscapeLink = oobeSettings.HideEscapeLink ?? oobeSettings.EscapeLinkHidden ?? false;
+        bool hidePrivacySettings = oobeSettings.HidePrivacySettings ?? oobeSettings.PrivacySettingsHidden ?? false;
+        bool hideEula = oobeSettings.HideEula ?? oobeSettings.EulaHidden ?? false;
+        bool skipKeyboardSelectionPage = oobeSettings.SkipKeyboardSelectionPage ?? oobeSettings.KeyboardSelectionPageSkipped ?? false;
+        int forcedEnrollment = hideEscapeLink ? 1 : 0;
+        int oobeConfig = 8 + 256;
+
+        if (string.Equals(oobeSettings.UserType, "standard", StringComparison.OrdinalIgnoreCase))
+        {
+            oobeConfig += 2;
+        }
+
+        if (hidePrivacySettings)
+        {
+            oobeConfig += 4;
+        }
+
+        if (hideEula)
+        {
+            oobeConfig += 16;
+        }
+
+        if (skipKeyboardSelectionPage)
+        {
+            oobeConfig += 1024;
+        }
+
+        if (string.Equals(oobeSettings.DeviceUsageType, "shared", StringComparison.OrdinalIgnoreCase))
+        {
+            oobeConfig += 96;
+        }
+
+        string aadServerData = JsonSerializer.Serialize(
+            new CloudAssignedAadServerData(
+                new ZeroTouchConfig(
+                    organization.DefaultDomain,
+                    string.Empty,
+                    forcedEnrollment)),
+            AutopilotGraphJsonSerializerContext.Default.CloudAssignedAadServerData);
+
+        var configuration = new OfflineAutopilotConfiguration
+        {
+            CommentFile = $"Profile {displayName}",
+            Version = 2049,
+            ZtdCorrelationId = profile.Id ?? string.Empty,
+            CloudAssignedDomainJoinMethod = string.Equals(
+                profile.ODataType,
+                "#microsoft.graph.activeDirectoryWindowsAutopilotDeploymentProfile",
+                StringComparison.OrdinalIgnoreCase) ? 1 : 0,
+            CloudAssignedOobeConfig = oobeConfig,
+            CloudAssignedForcedEnrollment = forcedEnrollment,
+            CloudAssignedTenantId = organization.Id,
+            CloudAssignedTenantDomain = organization.DefaultDomain,
+            CloudAssignedAadServerData = aadServerData,
+            CloudAssignedAutopilotUpdateDisabled = 1,
+            CloudAssignedAutopilotUpdateTimeout = 1800000
+        };
+
+        if (!string.IsNullOrWhiteSpace(profile.DeviceNameTemplate))
+        {
+            configuration.CloudAssignedDeviceName = profile.DeviceNameTemplate;
+        }
+
+        if (skipKeyboardSelectionPage && !string.IsNullOrWhiteSpace(profile.Language))
+        {
+            configuration.CloudAssignedLanguage = profile.Language;
+            configuration.CloudAssignedRegion = profile.Language;
+        }
+
+        if (profile.HybridAzureAdJoinSkipConnectivityCheck == true)
+        {
+            configuration.HybridJoinSkipDcConnectivityCheck = 1;
+        }
+
+        return JsonSerializer.Serialize(
+            configuration,
+            AutopilotGraphJsonSerializerContext.Default.OfflineAutopilotConfiguration);
+    }
+
+    private async Task<OrganizationInfo> GetOrganizationAsync(string accessToken, CancellationToken cancellationToken)
+    {
+        GraphCollectionResponse<OrganizationResponse>? response = await SendGraphRequestAsync(
+            OrganizationRequestPath,
+            accessToken,
+            AutopilotGraphJsonSerializerContext.Default.GraphCollectionResponseOrganizationResponse,
+            cancellationToken).ConfigureAwait(false);
+
+        OrganizationResponse organization = response?.Value?.FirstOrDefault()
+            ?? throw new InvalidOperationException("Microsoft Graph did not return organization information for the signed-in tenant.");
+
+        string defaultDomain = organization.VerifiedDomains?
+            .FirstOrDefault(domain => domain.IsDefault)?
+            .Name
+            ?? organization.VerifiedDomains?.FirstOrDefault()?.Name
+            ?? throw new InvalidOperationException("Microsoft Graph did not return a verified domain for the signed-in tenant.");
+
+        return new OrganizationInfo(
+            organization.Id ?? throw new InvalidOperationException("Microsoft Graph did not return the tenant organization ID."),
+            defaultDomain);
+    }
+
+    private async Task<IReadOnlyList<AutopilotDeploymentProfile>> GetAutopilotProfilesAsync(
+        string accessToken,
+        CancellationToken cancellationToken)
+    {
+        var profiles = new List<AutopilotDeploymentProfile>();
+        string? requestPath = AutopilotProfilesRequestPath;
+
+        logger.Information("Requesting Autopilot deployment profiles from Microsoft Graph.");
+        while (!string.IsNullOrWhiteSpace(requestPath))
+        {
+            GraphCollectionResponse<AutopilotDeploymentProfile>? response =
+                await SendGraphRequestAsync(
+                    requestPath,
+                    accessToken,
+                    AutopilotGraphJsonSerializerContext.Default.GraphCollectionResponseAutopilotDeploymentProfile,
+                    cancellationToken).ConfigureAwait(false);
+
+            if (response?.Value is not null)
+            {
+                profiles.AddRange(response.Value.Where(profile =>
+                    !string.IsNullOrWhiteSpace(profile.Id) &&
+                    !string.IsNullOrWhiteSpace(profile.DisplayName)));
+            }
+
+            requestPath = response?.NextLink;
+        }
+
+        logger.Information("Retrieved {ProfileCount} Autopilot deployment profile record(s) from Microsoft Graph.", profiles.Count);
+        return profiles;
+    }
+
+    private async Task<T?> SendGraphRequestAsync<T>(
+        string requestPath,
+        string accessToken,
+        JsonTypeInfo<T> jsonTypeInfo,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, requestPath);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        using HttpResponseMessage response = await GraphHttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            string safeRequestName = GetSafeRequestName(requestPath);
+            logger.Warning(
+                "Microsoft Graph request failed. Request={Request}, StatusCode={StatusCode}, ReasonPhrase={ReasonPhrase}",
+                safeRequestName,
+                response.StatusCode,
+                response.ReasonPhrase);
+            throw new InvalidOperationException(
+                $"Microsoft Graph request failed for '{safeRequestName}' with status code {(int)response.StatusCode}.");
+        }
+
+        await using Stream responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        return await JsonSerializer.DeserializeAsync(
+            responseStream,
+            jsonTypeInfo,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string GetSafeRequestName(string requestPath)
+    {
+        return requestPath.Contains("windowsAutopilotDeploymentProfiles", StringComparison.OrdinalIgnoreCase)
+            ? "Autopilot deployment profiles"
+            : "Tenant organization";
+    }
+}
+
+internal sealed record OrganizationInfo(string Id, string DefaultDomain);
+
+internal sealed record GraphCollectionResponse<TItem>
+{
+    public List<TItem>? Value { get; init; }
+
+    [JsonPropertyName("@odata.nextLink")]
+    public string? NextLink { get; init; }
+}
+
+internal sealed record OrganizationResponse
+{
+    public string? Id { get; init; }
+    public List<VerifiedDomain>? VerifiedDomains { get; init; }
+}
+
+internal sealed record VerifiedDomain
+{
+    public string? Name { get; init; }
+    public bool IsDefault { get; init; }
+}
+
+internal sealed record AutopilotDeploymentProfile
+{
+    [JsonPropertyName("@odata.type")]
+    public string? ODataType { get; init; }
+
+    public string? Id { get; init; }
+    public string? DisplayName { get; init; }
+    public string? DeviceNameTemplate { get; init; }
+    public string? Language { get; init; }
+
+    [JsonPropertyName("hybridAzureADJoinSkipConnectivityCheck")]
+    public bool? HybridAzureAdJoinSkipConnectivityCheck { get; init; }
+
+    public OutOfBoxExperienceSettings? OutOfBoxExperienceSettings { get; init; }
+}
+
+internal sealed record OutOfBoxExperienceSettings
+{
+    public string? UserType { get; init; }
+    public string? DeviceUsageType { get; init; }
+    public bool? HidePrivacySettings { get; init; }
+    public bool? PrivacySettingsHidden { get; init; }
+
+    [JsonPropertyName("hideEULA")]
+    public bool? HideEula { get; init; }
+
+    [JsonPropertyName("eulaHidden")]
+    public bool? EulaHidden { get; init; }
+
+    public bool? SkipKeyboardSelectionPage { get; init; }
+    public bool? KeyboardSelectionPageSkipped { get; init; }
+    public bool? HideEscapeLink { get; init; }
+    public bool? EscapeLinkHidden { get; init; }
+}
+
+internal sealed record CloudAssignedAadServerData(ZeroTouchConfig ZeroTouchConfig);
+
+internal sealed record ZeroTouchConfig(
+    string CloudAssignedTenantDomain,
+    string CloudAssignedTenantUpn,
+    int ForcedEnrollment);
+
+internal sealed record OfflineAutopilotConfiguration
+{
+    [JsonPropertyName("Comment_File")]
+    public required string CommentFile { get; init; }
+
+    public required int Version { get; init; }
+    public required string ZtdCorrelationId { get; init; }
+    public required int CloudAssignedDomainJoinMethod { get; init; }
+    public required int CloudAssignedOobeConfig { get; init; }
+    public required int CloudAssignedForcedEnrollment { get; init; }
+    public required string CloudAssignedTenantId { get; init; }
+    public required string CloudAssignedTenantDomain { get; init; }
+    public required string CloudAssignedAadServerData { get; init; }
+    public required int CloudAssignedAutopilotUpdateDisabled { get; init; }
+    public required int CloudAssignedAutopilotUpdateTimeout { get; init; }
+    public string? CloudAssignedDeviceName { get; set; }
+    public string? CloudAssignedLanguage { get; set; }
+    public string? CloudAssignedRegion { get; set; }
+
+    [JsonPropertyName("HybridJoinSkipDCConnectivityCheck")]
+    public int? HybridJoinSkipDcConnectivityCheck { get; set; }
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNameCaseInsensitive = true,
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(GraphCollectionResponse<OrganizationResponse>))]
+[JsonSerializable(typeof(GraphCollectionResponse<AutopilotDeploymentProfile>))]
+[JsonSerializable(typeof(CloudAssignedAadServerData))]
+[JsonSerializable(typeof(OfflineAutopilotConfiguration))]
+internal sealed partial class AutopilotGraphJsonSerializerContext : JsonSerializerContext;

--- a/src/Foundry/Services/Autopilot/IAutopilotProfileSelectionDialogService.cs
+++ b/src/Foundry/Services/Autopilot/IAutopilotProfileSelectionDialogService.cs
@@ -1,0 +1,9 @@
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Services.Autopilot;
+
+public interface IAutopilotProfileSelectionDialogService
+{
+    Task<IReadOnlyList<AutopilotProfileSettings>?> PickProfilesAsync(
+        IReadOnlyList<AutopilotProfileSettings> availableProfiles);
+}

--- a/src/Foundry/Services/Autopilot/IAutopilotTenantDownloadDialogService.cs
+++ b/src/Foundry/Services/Autopilot/IAutopilotTenantDownloadDialogService.cs
@@ -1,0 +1,9 @@
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Services.Autopilot;
+
+public interface IAutopilotTenantDownloadDialogService
+{
+    Task<IReadOnlyList<AutopilotProfileSettings>?> DownloadAsync(
+        Func<CancellationToken, Task<IReadOnlyList<AutopilotProfileSettings>>> downloadProfilesAsync);
+}

--- a/src/Foundry/Services/Autopilot/IAutopilotTenantProfileService.cs
+++ b/src/Foundry/Services/Autopilot/IAutopilotTenantProfileService.cs
@@ -1,0 +1,8 @@
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Services.Autopilot;
+
+public interface IAutopilotTenantProfileService
+{
+    Task<IReadOnlyList<AutopilotProfileSettings>> DownloadFromTenantAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Foundry/Services/Operations/OperationKind.cs
+++ b/src/Foundry/Services/Operations/OperationKind.cs
@@ -4,6 +4,5 @@ public enum OperationKind
 {
     None,
     AdkInstall,
-    AdkUpgrade,
-    AutopilotProfileDownload
+    AdkUpgrade
 }

--- a/src/Foundry/Services/Operations/OperationKind.cs
+++ b/src/Foundry/Services/Operations/OperationKind.cs
@@ -4,5 +4,6 @@ public enum OperationKind
 {
     None,
     AdkInstall,
-    AdkUpgrade
+    AdkUpgrade,
+    AutopilotProfileDownload
 }

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -102,6 +102,9 @@
   <data name="Autopilot.ImportButton" xml:space="preserve">
     <value>Import profile</value>
   </data>
+  <data name="Autopilot.DownloadButton" xml:space="preserve">
+    <value>Download from tenant</value>
+  </data>
   <data name="Autopilot.RemoveButton" xml:space="preserve">
     <value>Remove selected</value>
   </data>
@@ -134,6 +137,48 @@
   </data>
   <data name="Autopilot.ImportFailedMessage" xml:space="preserve">
     <value>{0}</value>
+  </data>
+  <data name="Autopilot.DownloadInProgress" xml:space="preserve">
+    <value>Downloading Autopilot profiles from tenant...</value>
+  </data>
+  <data name="Autopilot.DownloadConnecting" xml:space="preserve">
+    <value>Connecting to Microsoft Graph...</value>
+  </data>
+  <data name="Autopilot.DownloadSelectProfiles" xml:space="preserve">
+    <value>Select the Autopilot profiles to import.</value>
+  </data>
+  <data name="Autopilot.DownloadCanceled" xml:space="preserve">
+    <value>Autopilot profile import was canceled.</value>
+  </data>
+  <data name="Autopilot.DownloadCompletedNoProfiles" xml:space="preserve">
+    <value>No Autopilot profiles were returned by the tenant.</value>
+  </data>
+  <data name="Autopilot.DownloadFailedTitle" xml:space="preserve">
+    <value>Autopilot download failed</value>
+  </data>
+  <data name="Autopilot.DownloadFailedFormat" xml:space="preserve">
+    <value>Autopilot profile download failed: {0}</value>
+  </data>
+  <data name="Autopilot.TenantPickerTitle" xml:space="preserve">
+    <value>Select Autopilot profiles</value>
+  </data>
+  <data name="Autopilot.TenantPickerDescription" xml:space="preserve">
+    <value>Choose which tenant profiles should be imported into Foundry.</value>
+  </data>
+  <data name="Autopilot.TenantPickerSelectAll" xml:space="preserve">
+    <value>Select all</value>
+  </data>
+  <data name="Autopilot.TenantPickerClear" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="Autopilot.TenantPickerImport" xml:space="preserve">
+    <value>Import</value>
+  </data>
+  <data name="Autopilot.TenantPickerCancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Autopilot.TenantPickerSelectedCountFormat" xml:space="preserve">
+    <value>{0} of {1} profile(s) selected</value>
   </data>
   <data name="CustomizationPage_Title.Text" xml:space="preserve">
     <value>Customization</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -159,6 +159,9 @@
   <data name="Autopilot.DownloadFailedFormat" xml:space="preserve">
     <value>Autopilot profile download failed: {0}</value>
   </data>
+  <data name="Autopilot.DownloadTimedOut" xml:space="preserve">
+    <value>Autopilot profile download timed out. Try again and complete the browser sign-in prompt.</value>
+  </data>
   <data name="Autopilot.TenantPickerTitle" xml:space="preserve">
     <value>Select Autopilot profiles</value>
   </data>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -138,17 +138,17 @@
   <data name="Autopilot.ImportFailedMessage" xml:space="preserve">
     <value>{0}</value>
   </data>
-  <data name="Autopilot.DownloadInProgress" xml:space="preserve">
-    <value>Downloading Autopilot profiles from tenant...</value>
+  <data name="Autopilot.TenantDownloadDialogTitle" xml:space="preserve">
+    <value>Sign in to Microsoft Graph</value>
   </data>
-  <data name="Autopilot.DownloadConnecting" xml:space="preserve">
-    <value>Connecting to Microsoft Graph...</value>
+  <data name="Autopilot.TenantDownloadDialogMessage" xml:space="preserve">
+    <value>Complete sign-in in the browser to download Autopilot profiles.</value>
   </data>
-  <data name="Autopilot.DownloadSelectProfiles" xml:space="preserve">
-    <value>Select the Autopilot profiles to import.</value>
+  <data name="Autopilot.TenantDownloadDialogCancel" xml:space="preserve">
+    <value>Cancel</value>
   </data>
-  <data name="Autopilot.DownloadCanceled" xml:space="preserve">
-    <value>Autopilot profile import was canceled.</value>
+  <data name="Autopilot.DownloadNoProfilesTitle" xml:space="preserve">
+    <value>No Autopilot profiles found</value>
   </data>
   <data name="Autopilot.DownloadCompletedNoProfiles" xml:space="preserve">
     <value>No Autopilot profiles were returned by the tenant.</value>
@@ -158,9 +158,6 @@
   </data>
   <data name="Autopilot.DownloadFailedFormat" xml:space="preserve">
     <value>Autopilot profile download failed: {0}</value>
-  </data>
-  <data name="Autopilot.DownloadTimedOut" xml:space="preserve">
-    <value>Autopilot profile download timed out. Try again and complete the browser sign-in prompt.</value>
   </data>
   <data name="Autopilot.TenantPickerTitle" xml:space="preserve">
     <value>Select Autopilot profiles</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -102,6 +102,9 @@
   <data name="Autopilot.ImportButton" xml:space="preserve">
     <value>Importer un profil</value>
   </data>
+  <data name="Autopilot.DownloadButton" xml:space="preserve">
+    <value>Télécharger depuis le tenant</value>
+  </data>
   <data name="Autopilot.RemoveButton" xml:space="preserve">
     <value>Supprimer la sélection</value>
   </data>
@@ -134,6 +137,48 @@
   </data>
   <data name="Autopilot.ImportFailedMessage" xml:space="preserve">
     <value>{0}</value>
+  </data>
+  <data name="Autopilot.DownloadInProgress" xml:space="preserve">
+    <value>Téléchargement des profils Autopilot depuis le tenant...</value>
+  </data>
+  <data name="Autopilot.DownloadConnecting" xml:space="preserve">
+    <value>Connexion à Microsoft Graph...</value>
+  </data>
+  <data name="Autopilot.DownloadSelectProfiles" xml:space="preserve">
+    <value>Sélectionnez les profils Autopilot à importer.</value>
+  </data>
+  <data name="Autopilot.DownloadCanceled" xml:space="preserve">
+    <value>L'import des profils Autopilot a été annulé.</value>
+  </data>
+  <data name="Autopilot.DownloadCompletedNoProfiles" xml:space="preserve">
+    <value>Aucun profil Autopilot n'a été renvoyé par le tenant.</value>
+  </data>
+  <data name="Autopilot.DownloadFailedTitle" xml:space="preserve">
+    <value>Échec du téléchargement Autopilot</value>
+  </data>
+  <data name="Autopilot.DownloadFailedFormat" xml:space="preserve">
+    <value>Le téléchargement des profils Autopilot a échoué : {0}</value>
+  </data>
+  <data name="Autopilot.TenantPickerTitle" xml:space="preserve">
+    <value>Sélectionner les profils Autopilot</value>
+  </data>
+  <data name="Autopilot.TenantPickerDescription" xml:space="preserve">
+    <value>Choisissez les profils du tenant à importer dans Foundry.</value>
+  </data>
+  <data name="Autopilot.TenantPickerSelectAll" xml:space="preserve">
+    <value>Tout sélectionner</value>
+  </data>
+  <data name="Autopilot.TenantPickerClear" xml:space="preserve">
+    <value>Effacer</value>
+  </data>
+  <data name="Autopilot.TenantPickerImport" xml:space="preserve">
+    <value>Importer</value>
+  </data>
+  <data name="Autopilot.TenantPickerCancel" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="Autopilot.TenantPickerSelectedCountFormat" xml:space="preserve">
+    <value>{0} profil(s) sélectionné(s) sur {1}</value>
   </data>
   <data name="CustomizationPage_Title.Text" xml:space="preserve">
     <value>Personnalisation</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -159,6 +159,9 @@
   <data name="Autopilot.DownloadFailedFormat" xml:space="preserve">
     <value>Le téléchargement des profils Autopilot a échoué : {0}</value>
   </data>
+  <data name="Autopilot.DownloadTimedOut" xml:space="preserve">
+    <value>Le téléchargement des profils Autopilot a expiré. Réessayez et terminez l'authentification dans le navigateur.</value>
+  </data>
   <data name="Autopilot.TenantPickerTitle" xml:space="preserve">
     <value>Sélectionner les profils Autopilot</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -138,17 +138,17 @@
   <data name="Autopilot.ImportFailedMessage" xml:space="preserve">
     <value>{0}</value>
   </data>
-  <data name="Autopilot.DownloadInProgress" xml:space="preserve">
-    <value>Téléchargement des profils Autopilot depuis le tenant...</value>
+  <data name="Autopilot.TenantDownloadDialogTitle" xml:space="preserve">
+    <value>Connexion à Microsoft Graph</value>
   </data>
-  <data name="Autopilot.DownloadConnecting" xml:space="preserve">
-    <value>Connexion à Microsoft Graph...</value>
+  <data name="Autopilot.TenantDownloadDialogMessage" xml:space="preserve">
+    <value>Terminez l'authentification dans le navigateur pour télécharger les profils Autopilot.</value>
   </data>
-  <data name="Autopilot.DownloadSelectProfiles" xml:space="preserve">
-    <value>Sélectionnez les profils Autopilot à importer.</value>
+  <data name="Autopilot.TenantDownloadDialogCancel" xml:space="preserve">
+    <value>Annuler</value>
   </data>
-  <data name="Autopilot.DownloadCanceled" xml:space="preserve">
-    <value>L'import des profils Autopilot a été annulé.</value>
+  <data name="Autopilot.DownloadNoProfilesTitle" xml:space="preserve">
+    <value>Aucun profil Autopilot trouvé</value>
   </data>
   <data name="Autopilot.DownloadCompletedNoProfiles" xml:space="preserve">
     <value>Aucun profil Autopilot n'a été renvoyé par le tenant.</value>
@@ -158,9 +158,6 @@
   </data>
   <data name="Autopilot.DownloadFailedFormat" xml:space="preserve">
     <value>Le téléchargement des profils Autopilot a échoué : {0}</value>
-  </data>
-  <data name="Autopilot.DownloadTimedOut" xml:space="preserve">
-    <value>Le téléchargement des profils Autopilot a expiré. Réessayez et terminez l'authentification dans le navigateur.</value>
   </data>
   <data name="Autopilot.TenantPickerTitle" xml:space="preserve">
     <value>Sélectionner les profils Autopilot</value>

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -16,6 +16,8 @@ namespace Foundry.ViewModels;
 
 public sealed partial class AutopilotConfigurationViewModel : ObservableObject, IDisposable
 {
+    private static readonly TimeSpan TenantDownloadTimeout = TimeSpan.FromMinutes(3);
+
     private readonly IExpertDeployConfigurationStateService configurationStateService;
     private readonly IAutopilotProfileImportService autopilotProfileImportService;
     private readonly IAutopilotTenantProfileService autopilotTenantProfileService;
@@ -183,11 +185,12 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             localizationService.GetString("Autopilot.DownloadInProgress"));
 
         IReadOnlyList<AutopilotProfileSettings> availableProfiles;
+        using CancellationTokenSource downloadTimeout = new(TenantDownloadTimeout);
         try
         {
             logger.Information("Starting Autopilot profile download from tenant.");
             operationProgressService.Report(20, localizationService.GetString("Autopilot.DownloadConnecting"));
-            availableProfiles = await autopilotTenantProfileService.DownloadFromTenantAsync();
+            availableProfiles = await autopilotTenantProfileService.DownloadFromTenantAsync(downloadTimeout.Token);
 
             if (availableProfiles.Count == 0)
             {
@@ -199,6 +202,16 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
             terminalStatus = localizationService.GetString("Autopilot.DownloadSelectProfiles");
             operationProgressService.Report(70, terminalStatus);
+        }
+        catch (OperationCanceledException ex) when (downloadTimeout.IsCancellationRequested)
+        {
+            terminalStatus = localizationService.GetString("Autopilot.DownloadTimedOut");
+            operationProgressService.Complete(terminalStatus);
+            logger.Warning(ex, "Autopilot tenant download timed out.");
+            await dialogService.ShowMessageAsync(new DialogRequest(
+                localizationService.GetString("Autopilot.DownloadFailedTitle"),
+                terminalStatus));
+            return;
         }
         catch (Exception ex) when (ex is OperationCanceledException or InvalidOperationException or HttpRequestException or JsonException or AuthenticationFailedException)
         {

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -1,11 +1,16 @@
 using System.Collections.ObjectModel;
 using System.Text.Json;
+using Azure.Identity;
 using Foundry.Core.Models.Configuration;
 using Foundry.Core.Services.Application;
 using Foundry.Core.Services.Configuration;
+using Foundry.Services.Autopilot;
 using Foundry.Services.Configuration;
 using Foundry.Services.Localization;
+using Foundry.Services.Operations;
+using Foundry.Services.Shell;
 using Microsoft.UI.Xaml;
+using Serilog;
 
 namespace Foundry.ViewModels;
 
@@ -13,24 +18,39 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 {
     private readonly IExpertDeployConfigurationStateService configurationStateService;
     private readonly IAutopilotProfileImportService autopilotProfileImportService;
+    private readonly IAutopilotTenantProfileService autopilotTenantProfileService;
+    private readonly IAutopilotProfileSelectionDialogService profileSelectionDialogService;
     private readonly IFilePickerService filePickerService;
     private readonly IDialogService dialogService;
+    private readonly IOperationProgressService operationProgressService;
+    private readonly IShellNavigationGuardService shellNavigationGuardService;
     private readonly IApplicationLocalizationService localizationService;
+    private readonly ILogger logger;
     private bool isApplyingState = true;
     private bool isSavingState;
 
     public AutopilotConfigurationViewModel(
         IExpertDeployConfigurationStateService configurationStateService,
         IAutopilotProfileImportService autopilotProfileImportService,
+        IAutopilotTenantProfileService autopilotTenantProfileService,
+        IAutopilotProfileSelectionDialogService profileSelectionDialogService,
         IFilePickerService filePickerService,
         IDialogService dialogService,
-        IApplicationLocalizationService localizationService)
+        IOperationProgressService operationProgressService,
+        IShellNavigationGuardService shellNavigationGuardService,
+        IApplicationLocalizationService localizationService,
+        ILogger logger)
     {
         this.configurationStateService = configurationStateService;
         this.autopilotProfileImportService = autopilotProfileImportService;
+        this.autopilotTenantProfileService = autopilotTenantProfileService;
+        this.profileSelectionDialogService = profileSelectionDialogService;
         this.filePickerService = filePickerService;
         this.dialogService = dialogService;
+        this.operationProgressService = operationProgressService;
+        this.shellNavigationGuardService = shellNavigationGuardService;
         this.localizationService = localizationService;
+        this.logger = logger.ForContext<AutopilotConfigurationViewModel>();
 
         RefreshLocalizedText();
         ApplyState(configurationStateService.Current.Autopilot);
@@ -64,6 +84,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string ImportButtonText { get; set; }
 
     [ObservableProperty]
+    public partial string DownloadButtonText { get; set; }
+
+    [ObservableProperty]
     public partial string RemoveButtonText { get; set; }
 
     [ObservableProperty]
@@ -90,6 +113,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsAutopilotSectionEnabled))]
     [NotifyCanExecuteChangedFor(nameof(ImportProfileCommand))]
+    [NotifyCanExecuteChangedFor(nameof(DownloadProfilesCommand))]
     [NotifyCanExecuteChangedFor(nameof(RemoveSelectedProfileCommand))]
     public partial bool IsAutopilotEnabled { get; set; }
 
@@ -102,8 +126,15 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(ImportProfileCommand))]
+    [NotifyCanExecuteChangedFor(nameof(DownloadProfilesCommand))]
     [NotifyCanExecuteChangedFor(nameof(RemoveSelectedProfileCommand))]
     public partial bool IsImporting { get; set; }
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ImportProfileCommand))]
+    [NotifyCanExecuteChangedFor(nameof(DownloadProfilesCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RemoveSelectedProfileCommand))]
+    public partial bool IsDownloading { get; set; }
 
     public void Dispose()
     {
@@ -138,6 +169,69 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         {
             IsImporting = false;
         }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanDownloadProfiles))]
+    private async Task DownloadProfilesAsync()
+    {
+        IsDownloading = true;
+        ShellNavigationState previousShellState = shellNavigationGuardService.State;
+        string terminalStatus = localizationService.GetString("Autopilot.DownloadCanceled");
+        shellNavigationGuardService.SetState(ShellNavigationState.OperationRunning);
+        operationProgressService.Start(
+            OperationKind.AutopilotProfileDownload,
+            localizationService.GetString("Autopilot.DownloadInProgress"));
+
+        IReadOnlyList<AutopilotProfileSettings> availableProfiles;
+        try
+        {
+            logger.Information("Starting Autopilot profile download from tenant.");
+            operationProgressService.Report(20, localizationService.GetString("Autopilot.DownloadConnecting"));
+            availableProfiles = await autopilotTenantProfileService.DownloadFromTenantAsync();
+
+            if (availableProfiles.Count == 0)
+            {
+                terminalStatus = localizationService.GetString("Autopilot.DownloadCompletedNoProfiles");
+                operationProgressService.Complete(terminalStatus);
+                logger.Information("Autopilot tenant download completed. ProfileCount=0");
+                return;
+            }
+
+            terminalStatus = localizationService.GetString("Autopilot.DownloadSelectProfiles");
+            operationProgressService.Report(70, terminalStatus);
+        }
+        catch (Exception ex) when (ex is OperationCanceledException or InvalidOperationException or HttpRequestException or JsonException or AuthenticationFailedException)
+        {
+            terminalStatus = localizationService.FormatString("Autopilot.DownloadFailedFormat", ex.Message);
+            operationProgressService.Complete(terminalStatus);
+            logger.Error(ex, "Autopilot tenant download failed.");
+            await dialogService.ShowMessageAsync(new DialogRequest(
+                localizationService.GetString("Autopilot.DownloadFailedTitle"),
+                terminalStatus));
+            return;
+        }
+        finally
+        {
+            operationProgressService.Reset(terminalStatus);
+            shellNavigationGuardService.SetState(previousShellState == ShellNavigationState.OperationRunning
+                ? ShellNavigationState.Ready
+                : previousShellState);
+            IsDownloading = false;
+        }
+
+        IReadOnlyList<AutopilotProfileSettings>? selectedProfiles =
+            await profileSelectionDialogService.PickProfilesAsync(availableProfiles);
+        if (selectedProfiles is null)
+        {
+            logger.Information("Autopilot tenant download was canceled from the profile selection dialog.");
+            return;
+        }
+
+        MergeProfiles(selectedProfiles);
+        logger.Information(
+            "Autopilot tenant download completed. RetrievedProfileCount={RetrievedProfileCount}, ImportedProfileCount={ImportedProfileCount}",
+            availableProfiles.Count,
+            selectedProfiles.Count);
     }
 
     [RelayCommand(CanExecute = nameof(CanRemoveSelectedProfile))]
@@ -260,6 +354,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         AutopilotDescription = localizationService.GetString("Autopilot.Description");
         EnableAutopilotText = localizationService.GetString("Autopilot.EnableLabel");
         ImportButtonText = localizationService.GetString("Autopilot.ImportButton");
+        DownloadButtonText = localizationService.GetString("Autopilot.DownloadButton");
         RemoveButtonText = localizationService.GetString("Autopilot.RemoveButton");
         DefaultProfileLabel = localizationService.GetString("Autopilot.DefaultProfileLabel");
         ProfilesLabel = localizationService.GetString("Autopilot.ProfilesLabel");
@@ -300,11 +395,16 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     private bool CanImportProfile()
     {
-        return IsAutopilotEnabled && !IsImporting;
+        return IsAutopilotEnabled && !IsImporting && !IsDownloading;
+    }
+
+    private bool CanDownloadProfiles()
+    {
+        return IsAutopilotEnabled && !IsImporting && !IsDownloading;
     }
 
     private bool CanRemoveSelectedProfile()
     {
-        return IsAutopilotEnabled && !IsImporting && SelectedProfile is not null;
+        return IsAutopilotEnabled && !IsImporting && !IsDownloading && SelectedProfile is not null;
     }
 }

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -7,8 +7,6 @@ using Foundry.Core.Services.Configuration;
 using Foundry.Services.Autopilot;
 using Foundry.Services.Configuration;
 using Foundry.Services.Localization;
-using Foundry.Services.Operations;
-using Foundry.Services.Shell;
 using Microsoft.UI.Xaml;
 using Serilog;
 
@@ -16,16 +14,13 @@ namespace Foundry.ViewModels;
 
 public sealed partial class AutopilotConfigurationViewModel : ObservableObject, IDisposable
 {
-    private static readonly TimeSpan TenantDownloadTimeout = TimeSpan.FromMinutes(3);
-
     private readonly IExpertDeployConfigurationStateService configurationStateService;
     private readonly IAutopilotProfileImportService autopilotProfileImportService;
     private readonly IAutopilotTenantProfileService autopilotTenantProfileService;
+    private readonly IAutopilotTenantDownloadDialogService tenantDownloadDialogService;
     private readonly IAutopilotProfileSelectionDialogService profileSelectionDialogService;
     private readonly IFilePickerService filePickerService;
     private readonly IDialogService dialogService;
-    private readonly IOperationProgressService operationProgressService;
-    private readonly IShellNavigationGuardService shellNavigationGuardService;
     private readonly IApplicationLocalizationService localizationService;
     private readonly ILogger logger;
     private bool isApplyingState = true;
@@ -35,22 +30,20 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         IExpertDeployConfigurationStateService configurationStateService,
         IAutopilotProfileImportService autopilotProfileImportService,
         IAutopilotTenantProfileService autopilotTenantProfileService,
+        IAutopilotTenantDownloadDialogService tenantDownloadDialogService,
         IAutopilotProfileSelectionDialogService profileSelectionDialogService,
         IFilePickerService filePickerService,
         IDialogService dialogService,
-        IOperationProgressService operationProgressService,
-        IShellNavigationGuardService shellNavigationGuardService,
         IApplicationLocalizationService localizationService,
         ILogger logger)
     {
         this.configurationStateService = configurationStateService;
         this.autopilotProfileImportService = autopilotProfileImportService;
         this.autopilotTenantProfileService = autopilotTenantProfileService;
+        this.tenantDownloadDialogService = tenantDownloadDialogService;
         this.profileSelectionDialogService = profileSelectionDialogService;
         this.filePickerService = filePickerService;
         this.dialogService = dialogService;
-        this.operationProgressService = operationProgressService;
-        this.shellNavigationGuardService = shellNavigationGuardService;
         this.localizationService = localizationService;
         this.logger = logger.ForContext<AutopilotConfigurationViewModel>();
 
@@ -177,74 +170,58 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private async Task DownloadProfilesAsync()
     {
         IsDownloading = true;
-        ShellNavigationState previousShellState = shellNavigationGuardService.State;
-        string terminalStatus = localizationService.GetString("Autopilot.DownloadCanceled");
-        shellNavigationGuardService.SetState(ShellNavigationState.OperationRunning);
-        operationProgressService.Start(
-            OperationKind.AutopilotProfileDownload,
-            localizationService.GetString("Autopilot.DownloadInProgress"));
-
-        IReadOnlyList<AutopilotProfileSettings> availableProfiles;
-        using CancellationTokenSource downloadTimeout = new(TenantDownloadTimeout);
         try
         {
             logger.Information("Starting Autopilot profile download from tenant.");
-            operationProgressService.Report(20, localizationService.GetString("Autopilot.DownloadConnecting"));
-            availableProfiles = await autopilotTenantProfileService.DownloadFromTenantAsync(downloadTimeout.Token);
-
-            if (availableProfiles.Count == 0)
+            IReadOnlyList<AutopilotProfileSettings>? availableProfiles =
+                await tenantDownloadDialogService.DownloadAsync(autopilotTenantProfileService.DownloadFromTenantAsync);
+            if (availableProfiles is null)
             {
-                terminalStatus = localizationService.GetString("Autopilot.DownloadCompletedNoProfiles");
-                operationProgressService.Complete(terminalStatus);
-                logger.Information("Autopilot tenant download completed. ProfileCount=0");
+                logger.Information("Autopilot tenant download was canceled.");
                 return;
             }
 
-            terminalStatus = localizationService.GetString("Autopilot.DownloadSelectProfiles");
-            operationProgressService.Report(70, terminalStatus);
+            if (availableProfiles.Count == 0)
+            {
+                logger.Information("Autopilot tenant download completed. ProfileCount=0");
+                await dialogService.ShowMessageAsync(new DialogRequest(
+                    localizationService.GetString("Autopilot.DownloadNoProfilesTitle"),
+                    localizationService.GetString("Autopilot.DownloadCompletedNoProfiles")));
+                return;
+            }
+
+            IReadOnlyList<AutopilotProfileSettings>? selectedProfiles =
+                await profileSelectionDialogService.PickProfilesAsync(availableProfiles);
+            if (selectedProfiles is null)
+            {
+                logger.Information("Autopilot tenant download was canceled from the profile selection dialog.");
+                return;
+            }
+
+            MergeProfiles(selectedProfiles);
+            logger.Information(
+                "Autopilot tenant download completed. RetrievedProfileCount={RetrievedProfileCount}, ImportedProfileCount={ImportedProfileCount}",
+                availableProfiles.Count,
+                selectedProfiles.Count);
         }
-        catch (OperationCanceledException ex) when (downloadTimeout.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
-            terminalStatus = localizationService.GetString("Autopilot.DownloadTimedOut");
-            operationProgressService.Complete(terminalStatus);
-            logger.Warning(ex, "Autopilot tenant download timed out.");
-            await dialogService.ShowMessageAsync(new DialogRequest(
-                localizationService.GetString("Autopilot.DownloadFailedTitle"),
-                terminalStatus));
+            logger.Information("Autopilot tenant download was canceled.");
             return;
         }
-        catch (Exception ex) when (ex is OperationCanceledException or InvalidOperationException or HttpRequestException or JsonException or AuthenticationFailedException)
+        catch (Exception ex) when (ex is InvalidOperationException or HttpRequestException or JsonException or AuthenticationFailedException)
         {
-            terminalStatus = localizationService.FormatString("Autopilot.DownloadFailedFormat", ex.Message);
-            operationProgressService.Complete(terminalStatus);
+            string failureMessage = localizationService.FormatString("Autopilot.DownloadFailedFormat", ex.Message);
             logger.Error(ex, "Autopilot tenant download failed.");
             await dialogService.ShowMessageAsync(new DialogRequest(
                 localizationService.GetString("Autopilot.DownloadFailedTitle"),
-                terminalStatus));
+                failureMessage));
             return;
         }
         finally
         {
-            operationProgressService.Reset(terminalStatus);
-            shellNavigationGuardService.SetState(previousShellState == ShellNavigationState.OperationRunning
-                ? ShellNavigationState.Ready
-                : previousShellState);
             IsDownloading = false;
         }
-
-        IReadOnlyList<AutopilotProfileSettings>? selectedProfiles =
-            await profileSelectionDialogService.PickProfilesAsync(availableProfiles);
-        if (selectedProfiles is null)
-        {
-            logger.Information("Autopilot tenant download was canceled from the profile selection dialog.");
-            return;
-        }
-
-        MergeProfiles(selectedProfiles);
-        logger.Information(
-            "Autopilot tenant download completed. RetrievedProfileCount={RetrievedProfileCount}, ImportedProfileCount={ImportedProfileCount}",
-            availableProfiles.Count,
-            selectedProfiles.Count);
     }
 
     [RelayCommand(CanExecute = nameof(CanRemoveSelectedProfile))]

--- a/src/Foundry/ViewModels/AutopilotProfileSelectionDialogViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotProfileSelectionDialogViewModel.cs
@@ -62,6 +62,9 @@ public sealed partial class AutopilotProfileSelectionDialogViewModel : Observabl
     [ObservableProperty]
     public partial bool HasSelectedProfiles { get; set; }
 
+    [ObservableProperty]
+    public partial SelectableAutopilotProfileEntryViewModel? SelectedProfile { get; set; }
+
     public IReadOnlyList<AutopilotProfileSettings> GetSelectedProfiles()
     {
         return Profiles
@@ -135,6 +138,17 @@ public sealed partial class AutopilotProfileSelectionDialogViewModel : Observabl
     private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
     {
         RefreshLocalizedText();
+    }
+
+    partial void OnSelectedProfileChanged(SelectableAutopilotProfileEntryViewModel? value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        value.IsSelected = !value.IsSelected;
+        SelectedProfile = null;
     }
 }
 

--- a/src/Foundry/ViewModels/AutopilotProfileSelectionDialogViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotProfileSelectionDialogViewModel.cs
@@ -1,0 +1,155 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using Foundry.Core.Models.Configuration;
+using Foundry.Services.Localization;
+
+namespace Foundry.ViewModels;
+
+public sealed partial class AutopilotProfileSelectionDialogViewModel : ObservableObject, IDisposable
+{
+    private readonly IApplicationLocalizationService localizationService;
+
+    public AutopilotProfileSelectionDialogViewModel(
+        IApplicationLocalizationService localizationService,
+        IReadOnlyList<AutopilotProfileSettings> availableProfiles)
+    {
+        this.localizationService = localizationService;
+        ArgumentNullException.ThrowIfNull(availableProfiles);
+
+        RefreshLocalizedText();
+        foreach (AutopilotProfileSettings profile in availableProfiles
+                     .OrderBy(profile => profile.DisplayName, StringComparer.OrdinalIgnoreCase)
+                     .ThenBy(profile => profile.Id, StringComparer.OrdinalIgnoreCase))
+        {
+            var entry = new SelectableAutopilotProfileEntryViewModel(profile);
+            entry.PropertyChanged += OnProfilePropertyChanged;
+            Profiles.Add(entry);
+        }
+
+        RefreshSelectionState();
+        localizationService.LanguageChanged += OnLanguageChanged;
+    }
+
+    public ObservableCollection<SelectableAutopilotProfileEntryViewModel> Profiles { get; } = [];
+
+    [ObservableProperty]
+    public partial string Title { get; set; }
+
+    [ObservableProperty]
+    public partial string Description { get; set; }
+
+    [ObservableProperty]
+    public partial string SelectAllText { get; set; }
+
+    [ObservableProperty]
+    public partial string ClearText { get; set; }
+
+    [ObservableProperty]
+    public partial string ImportText { get; set; }
+
+    [ObservableProperty]
+    public partial string CancelText { get; set; }
+
+    [ObservableProperty]
+    public partial string NameColumnHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string FolderColumnHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string SelectedCountDisplay { get; set; }
+
+    [ObservableProperty]
+    public partial bool HasSelectedProfiles { get; set; }
+
+    public IReadOnlyList<AutopilotProfileSettings> GetSelectedProfiles()
+    {
+        return Profiles
+            .Where(profile => profile.IsSelected)
+            .Select(profile => profile.Profile)
+            .ToArray();
+    }
+
+    public void Dispose()
+    {
+        localizationService.LanguageChanged -= OnLanguageChanged;
+        foreach (SelectableAutopilotProfileEntryViewModel profile in Profiles)
+        {
+            profile.PropertyChanged -= OnProfilePropertyChanged;
+        }
+    }
+
+    [RelayCommand]
+    private void SelectAll()
+    {
+        foreach (SelectableAutopilotProfileEntryViewModel profile in Profiles)
+        {
+            profile.IsSelected = true;
+        }
+
+        RefreshSelectionState();
+    }
+
+    [RelayCommand]
+    private void Clear()
+    {
+        foreach (SelectableAutopilotProfileEntryViewModel profile in Profiles)
+        {
+            profile.IsSelected = false;
+        }
+
+        RefreshSelectionState();
+    }
+
+    private void RefreshLocalizedText()
+    {
+        Title = localizationService.GetString("Autopilot.TenantPickerTitle");
+        Description = localizationService.GetString("Autopilot.TenantPickerDescription");
+        SelectAllText = localizationService.GetString("Autopilot.TenantPickerSelectAll");
+        ClearText = localizationService.GetString("Autopilot.TenantPickerClear");
+        ImportText = localizationService.GetString("Autopilot.TenantPickerImport");
+        CancelText = localizationService.GetString("Autopilot.TenantPickerCancel");
+        NameColumnHeader = localizationService.GetString("Autopilot.ColumnName");
+        FolderColumnHeader = localizationService.GetString("Autopilot.ColumnFolder");
+        RefreshSelectionState();
+    }
+
+    private void RefreshSelectionState()
+    {
+        int selectedCount = Profiles.Count(profile => profile.IsSelected);
+        HasSelectedProfiles = selectedCount > 0;
+        SelectedCountDisplay = localizationService.FormatString(
+            "Autopilot.TenantPickerSelectedCountFormat",
+            selectedCount,
+            Profiles.Count);
+    }
+
+    private void OnProfilePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (string.Equals(e.PropertyName, nameof(SelectableAutopilotProfileEntryViewModel.IsSelected), StringComparison.Ordinal))
+        {
+            RefreshSelectionState();
+        }
+    }
+
+    private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
+    {
+        RefreshLocalizedText();
+    }
+}
+
+public sealed partial class SelectableAutopilotProfileEntryViewModel : ObservableObject
+{
+    public SelectableAutopilotProfileEntryViewModel(AutopilotProfileSettings profile)
+    {
+        Profile = profile ?? throw new ArgumentNullException(nameof(profile));
+        IsSelected = true;
+    }
+
+    public AutopilotProfileSettings Profile { get; }
+    public string DisplayName => Profile.DisplayName;
+    public string FolderName => Profile.FolderName;
+
+    [ObservableProperty]
+    public partial bool IsSelected { get; set; }
+}

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -31,6 +31,9 @@
                             Command="{x:Bind ViewModel.ImportProfileCommand}"
                             Content="{x:Bind ViewModel.ImportButtonText, Mode=OneWay}" />
                     <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            Command="{x:Bind ViewModel.DownloadProfilesCommand}"
+                            Content="{x:Bind ViewModel.DownloadButtonText, Mode=OneWay}" />
+                    <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
                             Command="{x:Bind ViewModel.RemoveSelectedProfileCommand}"
                             Content="{x:Bind ViewModel.RemoveButtonText, Mode=OneWay}" />
                 </StackPanel>

--- a/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml
+++ b/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml
@@ -4,11 +4,11 @@
                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+               xmlns:tv="using:WinUI.TableView"
                DefaultButton="Primary"
+               Loaded="OnLoaded"
                mc:Ignorable="d">
-    <Grid MinWidth="460"
-          MaxWidth="560"
-          MaxHeight="520"
+    <Grid x:Name="DialogContentRoot"
           RowSpacing="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -40,39 +40,27 @@
                     Content="{Binding ClearText}" />
         </Grid>
 
-        <ListView Grid.Row="1"
-                  ItemsSource="{Binding Profiles}"
-                  MaxHeight="360"
-                  SelectionMode="None">
-            <ListView.ItemContainerStyle>
-                <Style TargetType="ListViewItem">
-                    <Setter Property="HorizontalContentAlignment"
-                            Value="Stretch" />
-                </Style>
-            </ListView.ItemContainerStyle>
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <Grid Padding="12,8"
-                          ColumnSpacing="12"
-                          HorizontalAlignment="Stretch">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="40" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <CheckBox HorizontalAlignment="Center"
-                                  VerticalAlignment="Center"
-                                  IsChecked="{Binding IsSelected, Mode=TwoWay}" />
-                        <StackPanel Grid.Column="1"
-                                    Spacing="2">
-                            <TextBlock Text="{Binding DisplayName}"
-                                       TextTrimming="CharacterEllipsis" />
-                            <TextBlock Style="{ThemeResource CaptionTextBlockStyle}"
-                                       Text="{Binding FolderName}"
-                                       TextTrimming="CharacterEllipsis" />
-                        </StackPanel>
-                    </Grid>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
+        <tv:TableView Grid.Row="1"
+                      AutoGenerateColumns="False"
+                      CanFilterColumns="False"
+                      CanReorderColumns="False"
+                      CanResizeColumns="False"
+                      CanSortColumns="False"
+                      CornerButtonMode="None"
+                      HeadersVisibility="Columns"
+                      ItemsSource="{Binding Profiles}"
+                      SelectionMode="Single"
+                      SelectionUnit="Row"
+                      ShowExportOptions="False">
+            <tv:TableView.Columns>
+                <tv:TableViewCheckBoxColumn Binding="{Binding IsSelected, Mode=TwoWay}"
+                                            Header=""
+                                            MinWidth="48" />
+                <tv:TableViewTextColumn Binding="{Binding DisplayName}"
+                                        Header="{x:Bind ViewModel.NameColumnHeader, Mode=OneWay}" />
+                <tv:TableViewTextColumn Binding="{Binding FolderName}"
+                                        Header="{x:Bind ViewModel.FolderColumnHeader, Mode=OneWay}" />
+            </tv:TableView.Columns>
+        </tv:TableView>
     </Grid>
 </ContentDialog>

--- a/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml
+++ b/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentDialog x:Class="Foundry.Views.AutopilotProfileSelectionDialog"
+               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+               xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+               xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+               DefaultButton="Primary"
+               mc:Ignorable="d">
+    <Grid Width="760"
+          MaxHeight="520"
+          RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Spacing="6">
+                <TextBlock Text="{Binding Description}"
+                           TextWrapping="Wrap" />
+                <TextBlock Style="{ThemeResource CaptionTextBlockStyle}"
+                           Text="{Binding SelectedCountDisplay}" />
+            </StackPanel>
+
+            <Button Grid.Column="1"
+                    MinWidth="110"
+                    Margin="12,0,8,0"
+                    Command="{Binding SelectAllCommand}"
+                    Content="{Binding SelectAllText}" />
+            <Button Grid.Column="2"
+                    MinWidth="110"
+                    Command="{Binding ClearCommand}"
+                    Content="{Binding ClearText}" />
+        </Grid>
+
+        <ListView Grid.Row="1"
+                  ItemsSource="{Binding Profiles}"
+                  SelectionMode="None">
+            <ListView.Header>
+                <Grid Padding="12,0,12,8"
+                      ColumnSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="48" />
+                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition Width="3*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="1"
+                               FontWeight="SemiBold"
+                               Text="{Binding NameColumnHeader}" />
+                    <TextBlock Grid.Column="2"
+                               FontWeight="SemiBold"
+                               Text="{Binding FolderColumnHeader}" />
+                </Grid>
+            </ListView.Header>
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <Grid Padding="12,8"
+                          ColumnSpacing="12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="48" />
+                            <ColumnDefinition Width="2*" />
+                            <ColumnDefinition Width="3*" />
+                        </Grid.ColumnDefinitions>
+                        <CheckBox HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"
+                                  IsChecked="{Binding IsSelected, Mode=TwoWay}" />
+                        <TextBlock Grid.Column="1"
+                                   VerticalAlignment="Center"
+                                   Text="{Binding DisplayName}"
+                                   TextTrimming="CharacterEllipsis" />
+                        <TextBlock Grid.Column="2"
+                                   VerticalAlignment="Center"
+                                   Text="{Binding FolderName}"
+                                   TextTrimming="CharacterEllipsis" />
+                    </Grid>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+    </Grid>
+</ContentDialog>

--- a/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml
+++ b/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml
@@ -6,28 +6,28 @@
                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                xmlns:tv="using:WinUI.TableView"
                DefaultButton="Primary"
-               Loaded="OnLoaded"
                mc:Ignorable="d">
     <Grid x:Name="DialogContentRoot"
           RowSpacing="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <Grid>
+        <TextBlock Text="{Binding Description}"
+                   TextWrapping="Wrap" />
+
+        <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
-            <StackPanel Spacing="6">
-                <TextBlock Text="{Binding Description}"
-                           TextWrapping="Wrap" />
-                <TextBlock Style="{ThemeResource CaptionTextBlockStyle}"
-                           Text="{Binding SelectedCountDisplay}" />
-            </StackPanel>
+            <TextBlock VerticalAlignment="Center"
+                       Style="{ThemeResource CaptionTextBlockStyle}"
+                       Text="{Binding SelectedCountDisplay}" />
 
             <Button Grid.Column="1"
                     MinWidth="110"
@@ -40,7 +40,8 @@
                     Content="{Binding ClearText}" />
         </Grid>
 
-        <tv:TableView Grid.Row="1"
+        <tv:TableView x:Name="ProfilesTable"
+                      Grid.Row="2"
                       AutoGenerateColumns="False"
                       CanFilterColumns="False"
                       CanReorderColumns="False"
@@ -49,13 +50,24 @@
                       CornerButtonMode="None"
                       HeadersVisibility="Columns"
                       ItemsSource="{Binding Profiles}"
+                      SelectedItem="{Binding SelectedProfile, Mode=TwoWay}"
                       SelectionMode="Single"
                       SelectionUnit="Row"
                       ShowExportOptions="False">
             <tv:TableView.Columns>
-                <tv:TableViewCheckBoxColumn Binding="{Binding IsSelected, Mode=TwoWay}"
-                                            Header=""
-                                            MinWidth="48" />
+                <tv:TableViewTemplateColumn Header=""
+                                            MaxWidth="48"
+                                            MinWidth="48"
+                                            Width="48">
+                    <tv:TableViewTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <CheckBox HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      IsChecked="{Binding IsSelected, Mode=OneWay}"
+                                      IsHitTestVisible="False" />
+                        </DataTemplate>
+                    </tv:TableViewTemplateColumn.CellTemplate>
+                </tv:TableViewTemplateColumn>
                 <tv:TableViewTextColumn Binding="{Binding DisplayName}"
                                         Header="{x:Bind ViewModel.NameColumnHeader, Mode=OneWay}" />
                 <tv:TableViewTextColumn Binding="{Binding FolderName}"

--- a/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml
+++ b/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml
@@ -6,7 +6,8 @@
                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                DefaultButton="Primary"
                mc:Ignorable="d">
-    <Grid Width="760"
+    <Grid MinWidth="460"
+          MaxWidth="560"
           MaxHeight="520"
           RowSpacing="12">
         <Grid.RowDefinitions>
@@ -41,43 +42,34 @@
 
         <ListView Grid.Row="1"
                   ItemsSource="{Binding Profiles}"
+                  MaxHeight="360"
                   SelectionMode="None">
-            <ListView.Header>
-                <Grid Padding="12,0,12,8"
-                      ColumnSpacing="12">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="48" />
-                        <ColumnDefinition Width="2*" />
-                        <ColumnDefinition Width="3*" />
-                    </Grid.ColumnDefinitions>
-                    <TextBlock Grid.Column="1"
-                               FontWeight="SemiBold"
-                               Text="{Binding NameColumnHeader}" />
-                    <TextBlock Grid.Column="2"
-                               FontWeight="SemiBold"
-                               Text="{Binding FolderColumnHeader}" />
-                </Grid>
-            </ListView.Header>
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="HorizontalContentAlignment"
+                            Value="Stretch" />
+                </Style>
+            </ListView.ItemContainerStyle>
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="12,8"
-                          ColumnSpacing="12">
+                          ColumnSpacing="12"
+                          HorizontalAlignment="Stretch">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="48" />
-                            <ColumnDefinition Width="2*" />
-                            <ColumnDefinition Width="3*" />
+                            <ColumnDefinition Width="40" />
+                            <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <CheckBox HorizontalAlignment="Center"
                                   VerticalAlignment="Center"
                                   IsChecked="{Binding IsSelected, Mode=TwoWay}" />
-                        <TextBlock Grid.Column="1"
-                                   VerticalAlignment="Center"
-                                   Text="{Binding DisplayName}"
-                                   TextTrimming="CharacterEllipsis" />
-                        <TextBlock Grid.Column="2"
-                                   VerticalAlignment="Center"
-                                   Text="{Binding FolderName}"
-                                   TextTrimming="CharacterEllipsis" />
+                        <StackPanel Grid.Column="1"
+                                    Spacing="2">
+                            <TextBlock Text="{Binding DisplayName}"
+                                       TextTrimming="CharacterEllipsis" />
+                            <TextBlock Style="{ThemeResource CaptionTextBlockStyle}"
+                                       Text="{Binding FolderName}"
+                                       TextTrimming="CharacterEllipsis" />
+                        </StackPanel>
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>

--- a/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml.cs
+++ b/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml.cs
@@ -1,0 +1,53 @@
+using System.ComponentModel;
+
+namespace Foundry.Views;
+
+public sealed partial class AutopilotProfileSelectionDialog : ContentDialog
+{
+    public AutopilotProfileSelectionDialog(AutopilotProfileSelectionDialogViewModel viewModel)
+    {
+        ViewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+        InitializeComponent();
+        DataContext = ViewModel;
+        Title = ViewModel.Title;
+        PrimaryButtonText = ViewModel.ImportText;
+        CloseButtonText = ViewModel.CancelText;
+        IsPrimaryButtonEnabled = ViewModel.HasSelectedProfiles;
+        ViewModel.PropertyChanged += OnViewModelPropertyChanged;
+        Closed += OnClosed;
+    }
+
+    public AutopilotProfileSelectionDialogViewModel ViewModel { get; }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (string.Equals(e.PropertyName, nameof(AutopilotProfileSelectionDialogViewModel.HasSelectedProfiles), StringComparison.Ordinal))
+        {
+            IsPrimaryButtonEnabled = ViewModel.HasSelectedProfiles;
+            return;
+        }
+
+        if (string.Equals(e.PropertyName, nameof(AutopilotProfileSelectionDialogViewModel.Title), StringComparison.Ordinal))
+        {
+            Title = ViewModel.Title;
+            return;
+        }
+
+        if (string.Equals(e.PropertyName, nameof(AutopilotProfileSelectionDialogViewModel.ImportText), StringComparison.Ordinal))
+        {
+            PrimaryButtonText = ViewModel.ImportText;
+            return;
+        }
+
+        if (string.Equals(e.PropertyName, nameof(AutopilotProfileSelectionDialogViewModel.CancelText), StringComparison.Ordinal))
+        {
+            CloseButtonText = ViewModel.CancelText;
+        }
+    }
+
+    private void OnClosed(ContentDialog sender, ContentDialogClosedEventArgs args)
+    {
+        ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+        Closed -= OnClosed;
+    }
+}

--- a/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml.cs
+++ b/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml.cs
@@ -4,6 +4,13 @@ namespace Foundry.Views;
 
 public sealed partial class AutopilotProfileSelectionDialog : ContentDialog
 {
+    private const double DialogHorizontalMargin = 360;
+    private const double DialogVerticalMargin = 260;
+    private const double MinimumDialogContentWidth = 520;
+    private const double MaximumDialogContentWidth = 980;
+    private const double MinimumDialogContentHeight = 360;
+    private const double MaximumDialogContentHeight = 640;
+
     public AutopilotProfileSelectionDialog(AutopilotProfileSelectionDialogViewModel viewModel)
     {
         ViewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
@@ -47,7 +54,39 @@ public sealed partial class AutopilotProfileSelectionDialog : ContentDialog
 
     private void OnClosed(ContentDialog sender, ContentDialogClosedEventArgs args)
     {
+        App.MainWindow.SizeChanged -= OnMainWindowSizeChanged;
         ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
         Closed -= OnClosed;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        App.MainWindow.SizeChanged -= OnMainWindowSizeChanged;
+        App.MainWindow.SizeChanged += OnMainWindowSizeChanged;
+        UpdateDialogSize();
+    }
+
+    private void OnMainWindowSizeChanged(object sender, WindowSizeChangedEventArgs args)
+    {
+        UpdateDialogSize();
+    }
+
+    private void UpdateDialogSize()
+    {
+        double windowWidth = App.MainWindow.AppWindow.Size.Width;
+        double windowHeight = App.MainWindow.AppWindow.Size.Height;
+        double contentWidth = Math.Clamp(
+            windowWidth - DialogHorizontalMargin,
+            MinimumDialogContentWidth,
+            MaximumDialogContentWidth);
+        double contentHeight = Math.Clamp(
+            windowHeight - DialogVerticalMargin,
+            MinimumDialogContentHeight,
+            MaximumDialogContentHeight);
+
+        MaxWidth = contentWidth + 96;
+        MaxHeight = contentHeight + 180;
+        DialogContentRoot.Width = contentWidth;
+        DialogContentRoot.MaxHeight = contentHeight;
     }
 }

--- a/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml.cs
+++ b/src/Foundry/Views/AutopilotProfileSelectionDialog.xaml.cs
@@ -4,12 +4,15 @@ namespace Foundry.Views;
 
 public sealed partial class AutopilotProfileSelectionDialog : ContentDialog
 {
-    private const double DialogHorizontalMargin = 360;
-    private const double DialogVerticalMargin = 260;
-    private const double MinimumDialogContentWidth = 520;
-    private const double MaximumDialogContentWidth = 980;
-    private const double MinimumDialogContentHeight = 360;
-    private const double MaximumDialogContentHeight = 640;
+    private const double DialogChromeWidth = 96;
+    private const double MinimumContentWidth = 560;
+    private const double MaximumContentWidth = 980;
+    private const double SelectionColumnWidth = 48;
+    private const double ColumnPaddingWidth = 96;
+    private const double AverageCharacterWidth = 7.5;
+    private const double TableHeaderHeight = 36;
+    private const double TableRowHeight = 41;
+    private const int MaximumVisibleRows = 8;
 
     public AutopilotProfileSelectionDialog(AutopilotProfileSelectionDialogViewModel viewModel)
     {
@@ -20,6 +23,7 @@ public sealed partial class AutopilotProfileSelectionDialog : ContentDialog
         PrimaryButtonText = ViewModel.ImportText;
         CloseButtonText = ViewModel.CancelText;
         IsPrimaryButtonEnabled = ViewModel.HasSelectedProfiles;
+        ApplyContentLayout();
         ViewModel.PropertyChanged += OnViewModelPropertyChanged;
         Closed += OnClosed;
     }
@@ -54,39 +58,37 @@ public sealed partial class AutopilotProfileSelectionDialog : ContentDialog
 
     private void OnClosed(ContentDialog sender, ContentDialogClosedEventArgs args)
     {
-        App.MainWindow.SizeChanged -= OnMainWindowSizeChanged;
         ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
         Closed -= OnClosed;
     }
 
-    private void OnLoaded(object sender, RoutedEventArgs e)
+    private void ApplyContentLayout()
     {
-        App.MainWindow.SizeChanged -= OnMainWindowSizeChanged;
-        App.MainWindow.SizeChanged += OnMainWindowSizeChanged;
-        UpdateDialogSize();
-    }
-
-    private void OnMainWindowSizeChanged(object sender, WindowSizeChangedEventArgs args)
-    {
-        UpdateDialogSize();
-    }
-
-    private void UpdateDialogSize()
-    {
-        double windowWidth = App.MainWindow.AppWindow.Size.Width;
-        double windowHeight = App.MainWindow.AppWindow.Size.Height;
+        double availableWindowWidth = Math.Max(MinimumContentWidth, App.MainWindow.AppWindow.Size.Width * 0.72);
         double contentWidth = Math.Clamp(
-            windowWidth - DialogHorizontalMargin,
-            MinimumDialogContentWidth,
-            MaximumDialogContentWidth);
-        double contentHeight = Math.Clamp(
-            windowHeight - DialogVerticalMargin,
-            MinimumDialogContentHeight,
-            MaximumDialogContentHeight);
+            CalculateDesiredContentWidth(),
+            MinimumContentWidth,
+            Math.Min(MaximumContentWidth, availableWindowWidth));
+        int visibleRows = Math.Clamp(ViewModel.Profiles.Count, 1, MaximumVisibleRows);
 
-        MaxWidth = contentWidth + 96;
-        MaxHeight = contentHeight + 180;
+        Resources["ContentDialogMaxWidth"] = contentWidth + DialogChromeWidth;
         DialogContentRoot.Width = contentWidth;
-        DialogContentRoot.MaxHeight = contentHeight;
+        ProfilesTable.Height = TableHeaderHeight + (visibleRows * TableRowHeight);
+    }
+
+    private double CalculateDesiredContentWidth()
+    {
+        int longestNameLength = ViewModel.Profiles
+            .Select(profile => profile.DisplayName.Length)
+            .DefaultIfEmpty(ViewModel.NameColumnHeader.Length)
+            .Max();
+        int longestFolderLength = ViewModel.Profiles
+            .Select(profile => profile.FolderName.Length)
+            .DefaultIfEmpty(ViewModel.FolderColumnHeader.Length)
+            .Max();
+
+        double nameWidth = Math.Min(longestNameLength * AverageCharacterWidth, 420);
+        double folderWidth = Math.Min(longestFolderLength * AverageCharacterWidth, 460);
+        return SelectionColumnWidth + nameWidth + folderWidth + ColumnPaddingWidth;
     }
 }


### PR DESCRIPTION
## Summary
Adds Phase 16.C Autopilot Microsoft Graph tenant profile import to the WinUI app.

## Reason
Autopilot profiles should be downloadable from Intune/Microsoft Graph and imported into Foundry as offline Autopilot profile JSON content without moving Graph authentication into Foundry.Core.

## Main changes
- Added WinUI Graph tenant profile download service with InteractiveBrowserCredential, token cache, environment variable overrides, organization lookup, paged deployment profile retrieval, and offline profile conversion.
- Added a WinUI ContentDialog for selecting downloaded profiles with default selection, select all, clear, selected count, disabled import when empty, and cancel handling.
- Wired the Autopilot page download command through the blocking operation overlay, then closes the overlay before profile selection.
- Refactored Autopilot profile settings creation into a Core factory while keeping Azure Identity and Graph HTTP logic out of Foundry.Core.
- Updated Phase 16.C plan checklist.

## Testing notes
- `dotnet build src\Foundry\Foundry.csproj --no-restore` passed with 0 warnings and 0 errors.
- `dotnet test src\Foundry.Core.Tests\Foundry.Core.Tests.csproj` passed: 163/163.
- `dotnet test src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj` passed: 49/49.
- `git diff --check` passed.
- Searched Foundry.Core and Foundry.Core.Tests for Azure Identity / Graph references; no matches.