### PR TITLE
feat(autopilot): wire start readiness

### DIFF
--- a/docs/migration/phases/06-business-workflows.md
+++ b/docs/migration/phases/06-business-workflows.md
@@ -270,16 +270,16 @@ git commit -m "feat(network): wire connect preflight readiness"
     - [x] Cancel returns no imported profiles.
   - [x] **16.C.6** Do not show tenant tokens or raw Graph response bodies in UI, summaries, logs, or diagnostics.
 
-- [ ] **16.D** Wire Autopilot/customization readiness into `Start` preflight and finish Phase 16 validation.
-  - [ ] **16.D.1** Do not block media creation when Autopilot is disabled.
-  - [ ] **16.D.2** Block or warn when Autopilot is enabled but no valid default profile is selected.
-  - [ ] **16.D.3** Show selected Autopilot profile metadata without exposing tenant tokens or Graph response bodies.
-  - [ ] **16.D.4** Keep final ISO/USB execution disabled until the final media enablement PR.
-  - [ ] **16.D.5** Preserve generated Deploy config and Autopilot profile path contracts across the final Phase 16 state.
-  - [ ] **16.D.6** Update `Foundry.Deploy` Autopilot startup behavior so generated Deploy config is the source of truth:
-    - [ ] Respect `autopilot.isEnabled=false` even when embedded Autopilot profiles exist.
-    - [ ] Select/use a default Autopilot profile only when `autopilot.isEnabled=true`.
-    - [ ] Remove any automatic enablement based only on profile presence.
+- [x] **16.D** Wire Autopilot/customization readiness into `Start` preflight and finish Phase 16 validation.
+  - [x] **16.D.1** Do not block media creation when Autopilot is disabled.
+  - [x] **16.D.2** Block or warn when Autopilot is enabled but no valid default profile is selected.
+  - [x] **16.D.3** Show selected Autopilot profile metadata without exposing tenant tokens or Graph response bodies.
+  - [x] **16.D.4** Keep final ISO/USB execution disabled until the final media enablement PR.
+  - [x] **16.D.5** Preserve generated Deploy config and Autopilot profile path contracts across the final Phase 16 state.
+  - [x] **16.D.6** Update `Foundry.Deploy` Autopilot startup behavior so generated Deploy config is the source of truth:
+    - [x] Respect `autopilot.isEnabled=false` even when embedded Autopilot profiles exist.
+    - [x] Select/use a default Autopilot profile only when `autopilot.isEnabled=true`.
+    - [x] Remove any automatic enablement based only on profile presence.
 
 - [ ] **16.6** Commit each split independently:
 
@@ -299,5 +299,6 @@ git commit -m "feat(autopilot): wire start readiness"
 - [x] **16.11** Manual Autopilot JSON import rejects empty, invalid, or non-ASCII JSON.
 - [x] **16.12** Manual Autopilot JSON import preserves WPF-compatible profile ID, display name, folder name, merge, sort, and default-profile fallback behavior.
 - [x] **16.13** Graph tenant import downloads profiles through a cancellable WinUI `ContentDialog` and imports selected profiles through a separate WinUI `ContentDialog`.
-- [ ] **16.14** Autopilot disabled does not block `Start` preflight.
-- [ ] **16.15** Autopilot enabled without a valid default profile blocks or warns in `Start` preflight.
+- [x] **16.14** Autopilot disabled does not block `Start` preflight.
+- [x] **16.15** Autopilot enabled without a valid default profile blocks or warns in `Start` preflight.
+- [ ] **16.16** Deferred until final media generation is enabled: boot generated media into `Foundry.Deploy` with Autopilot enabled but no embedded profile, and confirm the Autopilot section remains visible so the operator can disable it.

--- a/src/Foundry.Core.Tests/Media/MediaPreflightServiceTests.cs
+++ b/src/Foundry.Core.Tests/Media/MediaPreflightServiceTests.cs
@@ -39,6 +39,38 @@ public sealed class MediaPreflightServiceTests
     }
 
     [Fact]
+    public void Evaluate_WhenAutopilotIsDisabled_DoesNotBlockDryRun()
+    {
+        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(
+            CreateReadyOptions() with
+            {
+                IsAutopilotEnabled = false,
+                IsAutopilotConfigurationReady = false
+            });
+
+        Assert.True(evaluation.CanGenerateIsoSummary);
+        Assert.True(evaluation.CanGenerateUsbSummary);
+        Assert.DoesNotContain(MediaPreflightBlockingReason.AutopilotConfigurationNotReady, evaluation.IsoBlockingReasons);
+        Assert.DoesNotContain(MediaPreflightBlockingReason.AutopilotConfigurationNotReady, evaluation.UsbBlockingReasons);
+    }
+
+    [Fact]
+    public void Evaluate_WhenAutopilotDefaultProfileIsMissing_BlocksDryRun()
+    {
+        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(
+            CreateReadyOptions() with
+            {
+                IsAutopilotEnabled = true,
+                IsAutopilotConfigurationReady = false
+            });
+
+        Assert.False(evaluation.CanGenerateIsoSummary);
+        Assert.False(evaluation.CanGenerateUsbSummary);
+        Assert.Contains(MediaPreflightBlockingReason.AutopilotConfigurationNotReady, evaluation.IsoBlockingReasons);
+        Assert.Contains(MediaPreflightBlockingReason.AutopilotConfigurationNotReady, evaluation.UsbBlockingReasons);
+    }
+
+    [Fact]
     public void Evaluate_WhenWinPeLanguageIsNotAvailableForArchitecture_BlocksDryRun()
     {
         MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(

--- a/src/Foundry.Core/Services/Media/MediaPreflightBlockingReason.cs
+++ b/src/Foundry.Core/Services/Media/MediaPreflightBlockingReason.cs
@@ -11,6 +11,7 @@ public enum MediaPreflightBlockingReason
     DeployConfigurationNotReady,
     ConnectProvisioningNotReady,
     RequiredSecretsNotReady,
+    AutopilotConfigurationNotReady,
     NoUsbTarget,
     Arm64RequiresGpt,
     CustomDriverDirectoryNotFound,

--- a/src/Foundry.Core/Services/Media/MediaPreflightOptions.cs
+++ b/src/Foundry.Core/Services/Media/MediaPreflightOptions.cs
@@ -10,6 +10,10 @@ public sealed record MediaPreflightOptions
     public bool IsDeployConfigurationReady { get; init; }
     public bool IsConnectProvisioningReady { get; init; }
     public bool AreRequiredSecretsReady { get; init; }
+    public bool IsAutopilotEnabled { get; init; }
+    public bool IsAutopilotConfigurationReady { get; init; } = true;
+    public string? AutopilotProfileDisplayName { get; init; }
+    public string? AutopilotProfileFolderName { get; init; }
     public bool IsFinalExecutionEnabled { get; init; }
     public string IsoOutputPath { get; init; } = string.Empty;
     public WinPeArchitecture Architecture { get; init; } = WinPeArchitecture.X64;

--- a/src/Foundry.Core/Services/Media/MediaPreflightService.cs
+++ b/src/Foundry.Core/Services/Media/MediaPreflightService.cs
@@ -93,6 +93,11 @@ public static class MediaPreflightService
             reasons.Add(MediaPreflightBlockingReason.RequiredSecretsNotReady);
         }
 
+        if (options.IsAutopilotEnabled && !options.IsAutopilotConfigurationReady)
+        {
+            reasons.Add(MediaPreflightBlockingReason.AutopilotConfigurationNotReady);
+        }
+
         if (string.IsNullOrWhiteSpace(options.WinPeLanguage))
         {
             reasons.Add(MediaPreflightBlockingReason.MissingWinPeLanguage);

--- a/src/Foundry.Deploy.Tests/DeploymentPreparationViewModelTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentPreparationViewModelTests.cs
@@ -11,7 +11,7 @@ namespace Foundry.Deploy.Tests;
 public sealed class DeploymentPreparationViewModelTests
 {
     [Fact]
-    public void ApplyAutopilotConfiguration_WhenProfilesExist_EnablesAutopilotByDefault()
+    public void ApplyAutopilotConfiguration_WhenProfilesExistButConfigIsDisabled_KeepsAutopilotDisabled()
     {
         using DeploymentPreparationViewModel viewModel = CreateViewModel();
         AutopilotProfileCatalogItem profile = CreateProfile("default", "Default Profile");
@@ -19,9 +19,10 @@ public sealed class DeploymentPreparationViewModelTests
         viewModel.ApplyAutopilotConfiguration(new DeployAutopilotSettings(), [profile]);
 
         Assert.True(viewModel.HasAutopilotProfiles);
-        Assert.True(viewModel.IsAutopilotEnabled);
-        Assert.True(viewModel.IsAutopilotProfileSelectionEnabled);
-        Assert.Same(profile, viewModel.SelectedAutopilotProfile);
+        Assert.True(viewModel.IsAutopilotSectionVisible);
+        Assert.False(viewModel.IsAutopilotEnabled);
+        Assert.False(viewModel.IsAutopilotProfileSelectionEnabled);
+        Assert.Null(viewModel.SelectedAutopilotProfile);
     }
 
     [Fact]
@@ -32,7 +33,7 @@ public sealed class DeploymentPreparationViewModelTests
         AutopilotProfileCatalogItem defaultProfile = CreateProfile("default", "Default Profile");
 
         viewModel.ApplyAutopilotConfiguration(
-            new DeployAutopilotSettings { DefaultProfileFolderName = "default" },
+            new DeployAutopilotSettings { IsEnabled = true, DefaultProfileFolderName = "default" },
             [firstProfile, defaultProfile]);
 
         Assert.True(viewModel.IsAutopilotEnabled);
@@ -40,17 +41,35 @@ public sealed class DeploymentPreparationViewModelTests
     }
 
     [Fact]
-    public void ApplyAutopilotConfiguration_WhenProfilesAreMissing_DisablesAutopilot()
+    public void ApplyAutopilotConfiguration_WhenEnabledDefaultProfileIsMissing_DoesNotFallbackToFirstProfile()
+    {
+        using DeploymentPreparationViewModel viewModel = CreateViewModel();
+        AutopilotProfileCatalogItem firstProfile = CreateProfile("first", "First Profile");
+
+        viewModel.ApplyAutopilotConfiguration(
+            new DeployAutopilotSettings { IsEnabled = true, DefaultProfileFolderName = "missing" },
+            [firstProfile]);
+
+        Assert.True(viewModel.HasAutopilotProfiles);
+        Assert.True(viewModel.IsAutopilotEnabled);
+        Assert.True(viewModel.IsAutopilotSectionVisible);
+        Assert.True(viewModel.IsAutopilotProfileSelectionEnabled);
+        Assert.Null(viewModel.SelectedAutopilotProfile);
+    }
+
+    [Fact]
+    public void ApplyAutopilotConfiguration_WhenEnabledProfileIsMissing_KeepsAutopilotEnabledWithoutSelection()
     {
         using DeploymentPreparationViewModel viewModel = CreateViewModel();
 
         viewModel.ApplyAutopilotConfiguration(new DeployAutopilotSettings { IsEnabled = true }, []);
 
         Assert.False(viewModel.HasAutopilotProfiles);
-        Assert.False(viewModel.IsAutopilotEnabled);
+        Assert.True(viewModel.IsAutopilotEnabled);
+        Assert.True(viewModel.IsAutopilotSectionVisible);
         Assert.False(viewModel.IsAutopilotProfileSelectionEnabled);
         Assert.Null(viewModel.SelectedAutopilotProfile);
-        Assert.Equal(string.Empty, viewModel.AutopilotProfileHint);
+        Assert.NotEqual(string.Empty, viewModel.AutopilotProfileHint);
     }
 
     [Fact]
@@ -59,10 +78,13 @@ public sealed class DeploymentPreparationViewModelTests
         using DeploymentPreparationViewModel viewModel = CreateViewModel();
         AutopilotProfileCatalogItem profile = CreateProfile("default", "Default Profile");
 
-        viewModel.ApplyAutopilotConfiguration(new DeployAutopilotSettings(), [profile]);
+        viewModel.ApplyAutopilotConfiguration(
+            new DeployAutopilotSettings { IsEnabled = true, DefaultProfileFolderName = "default" },
+            [profile]);
         viewModel.IsAutopilotEnabled = false;
 
         Assert.False(viewModel.IsAutopilotProfileSelectionEnabled);
+        Assert.True(viewModel.IsAutopilotSectionVisible);
 
         viewModel.IsAutopilotEnabled = true;
 

--- a/src/Foundry.Deploy/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry.Deploy/Resources/AppStrings.fr-FR.resx
@@ -48,6 +48,7 @@
   <data name="Preparation.AutopilotEnable" xml:space="preserve"><value>Autopilot : activer la préparation hors ligne du profil.</value></data>
   <data name="Preparation.AutopilotProfile" xml:space="preserve"><value>Profil Autopilot</value></data>
   <data name="Preparation.AutopilotProfilesAvailableFormat" xml:space="preserve"><value>Profils disponibles : {0}</value></data>
+  <data name="Preparation.AutopilotProfilesMissing" xml:space="preserve"><value>Autopilot est activé, mais aucun profil intégré n'a été trouvé.</value></data>
   <data name="Preparation.DetectingHardware" xml:space="preserve"><value>Détection du matériel...</value></data>
   <data name="Preparation.HardwareDetectionFailed" xml:space="preserve"><value>Échec de la détection matérielle.</value></data>
   <data name="Preparation.HardwareDetectionFailedFormat" xml:space="preserve"><value>Échec de la détection matérielle : {0}</value></data>

--- a/src/Foundry.Deploy/Resources/AppStrings.resx
+++ b/src/Foundry.Deploy/Resources/AppStrings.resx
@@ -48,6 +48,7 @@
   <data name="Preparation.AutopilotEnable" xml:space="preserve"><value>Autopilot: Enable offline profile staging.</value></data>
   <data name="Preparation.AutopilotProfile" xml:space="preserve"><value>Autopilot Profile</value></data>
   <data name="Preparation.AutopilotProfilesAvailableFormat" xml:space="preserve"><value>Profiles available: {0}</value></data>
+  <data name="Preparation.AutopilotProfilesMissing" xml:space="preserve"><value>Autopilot is enabled, but no embedded profiles were found.</value></data>
   <data name="Preparation.DetectingHardware" xml:space="preserve"><value>Detecting hardware...</value></data>
   <data name="Preparation.HardwareDetectionFailed" xml:space="preserve"><value>Hardware detection failed.</value></data>
   <data name="Preparation.HardwareDetectionFailedFormat" xml:space="preserve"><value>Hardware detection failed: {0}</value></data>

--- a/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
@@ -83,6 +83,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
 
     public bool IsFirmwareUpdatesOptionEnabled => _detectedHardware?.IsVirtualMachine != true;
     public bool HasAutopilotProfiles => AutopilotProfiles.Count > 0;
+    public bool IsAutopilotSectionVisible => IsAutopilotEnabled || HasAutopilotProfiles;
     public bool IsAutopilotProfileSelectionEnabled => IsAutopilotEnabled && HasAutopilotProfiles;
     public string TargetDiskSelectionHint => !string.IsNullOrWhiteSpace(SelectedTargetDisk?.SelectionWarning)
         ? SelectedTargetDisk.SelectionWarning
@@ -90,6 +91,8 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
     public string AutopilotProfileHint =>
         HasAutopilotProfiles
             ? Format("Preparation.AutopilotProfilesAvailableFormat", AutopilotProfiles.Count)
+            : IsAutopilotEnabled
+                ? GetString("Preparation.AutopilotProfilesMissing")
             : string.Empty;
 
     public bool HasTargetComputerNameValidationError => !string.IsNullOrWhiteSpace(TargetComputerNameValidationMessage);
@@ -190,11 +193,14 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         }
 
         OnPropertyChanged(nameof(HasAutopilotProfiles));
+        OnPropertyChanged(nameof(IsAutopilotSectionVisible));
         OnPropertyChanged(nameof(IsAutopilotProfileSelectionEnabled));
         OnPropertyChanged(nameof(AutopilotProfileHint));
 
-        SelectedAutopilotProfile = ResolveDefaultAutopilotProfile(settings.DefaultProfileFolderName);
-        IsAutopilotEnabled = SelectedAutopilotProfile is not null;
+        SelectedAutopilotProfile = settings.IsEnabled
+            ? ResolveDefaultAutopilotProfile(settings.DefaultProfileFolderName)
+            : null;
+        IsAutopilotEnabled = settings.IsEnabled;
 
         RaiseStateChanged();
     }
@@ -319,7 +325,9 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
 
     partial void OnIsAutopilotEnabledChanged(bool value)
     {
+        OnPropertyChanged(nameof(IsAutopilotSectionVisible));
         OnPropertyChanged(nameof(IsAutopilotProfileSelectionEnabled));
+        OnPropertyChanged(nameof(AutopilotProfileHint));
         RaiseStateChanged();
     }
 
@@ -477,7 +485,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
             }
         }
 
-        return AutopilotProfiles.FirstOrDefault();
+        return null;
     }
 
     private void RaiseStateChanged()

--- a/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
@@ -125,7 +125,7 @@
                             Margin="0"
                             Padding="16"
                             Style="{StaticResource SectionCardBorderStyle}"
-                            Visibility="{Binding HasAutopilotProfiles, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            Visibility="{Binding IsAutopilotSectionVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
                             <StackPanel>
                                 <TextBlock
                                     Margin="0,0,0,16"

--- a/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
@@ -55,6 +55,18 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
 
     public bool AreRequiredSecretsReady => EvaluateNetworkMediaReadiness().AreRequiredSecretsReady;
 
+    public bool IsAutopilotEnabled => Current.Autopilot.IsEnabled;
+
+    public bool IsAutopilotConfigurationReady => !Current.Autopilot.IsEnabled || GetSelectedAutopilotProfile() is not null;
+
+    public string? SelectedAutopilotProfileDisplayName => Current.Autopilot.IsEnabled
+        ? GetSelectedAutopilotProfile()?.DisplayName
+        : null;
+
+    public string? SelectedAutopilotProfileFolderName => Current.Autopilot.IsEnabled
+        ? GetSelectedAutopilotProfile()?.FolderName
+        : null;
+
     public void UpdateLocalization(LocalizationSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
@@ -188,6 +200,17 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
     private NetworkMediaReadinessEvaluation EvaluateNetworkMediaReadiness()
     {
         return NetworkMediaReadinessEvaluator.Evaluate(Current.Network, networkSecretStateService.PersonalWifiPassphrase);
+    }
+
+    private AutopilotProfileSettings? GetSelectedAutopilotProfile()
+    {
+        if (string.IsNullOrWhiteSpace(Current.Autopilot.DefaultProfileId))
+        {
+            return null;
+        }
+
+        return Current.Autopilot.Profiles.FirstOrDefault(profile =>
+            string.Equals(profile.Id, Current.Autopilot.DefaultProfileId, StringComparison.OrdinalIgnoreCase));
     }
 
     private void TryMoveInvalidState(string backupPath, Exception originalException)

--- a/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
@@ -16,6 +16,14 @@ public interface IExpertDeployConfigurationStateService
 
     bool AreRequiredSecretsReady { get; }
 
+    bool IsAutopilotEnabled { get; }
+
+    bool IsAutopilotConfigurationReady { get; }
+
+    string? SelectedAutopilotProfileDisplayName { get; }
+
+    string? SelectedAutopilotProfileFolderName { get; }
+
     void UpdateNetwork(NetworkSettings settings);
 
     void UpdateLocalization(LocalizationSettings settings);

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -519,6 +519,15 @@
   <data name="StartMedia.Field.Secrets" xml:space="preserve">
     <value>Media secrets</value>
   </data>
+  <data name="StartMedia.Field.Autopilot" xml:space="preserve">
+    <value>Autopilot</value>
+  </data>
+  <data name="StartMedia.Autopilot.ProfileFormat" xml:space="preserve">
+    <value>Enabled: {0} ({1})</value>
+  </data>
+  <data name="StartMedia.Autopilot.NotReady" xml:space="preserve">
+    <value>Enabled; default profile missing</value>
+  </data>
   <data name="StartMedia.BlockingReason.AdkNotReady" xml:space="preserve">
     <value>ADK or WinPE Add-on is not ready.</value>
   </data>
@@ -545,6 +554,9 @@
   </data>
   <data name="StartMedia.BlockingReason.RequiredSecretsNotReady" xml:space="preserve">
     <value>Required media secrets are not ready.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.AutopilotConfigurationNotReady" xml:space="preserve">
+    <value>Autopilot is enabled but no valid default profile is selected.</value>
   </data>
   <data name="StartMedia.BlockingReason.NoUsbTarget" xml:space="preserve">
     <value>No USB target is selected.</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -519,6 +519,15 @@
   <data name="StartMedia.Field.Secrets" xml:space="preserve">
     <value>Secrets média</value>
   </data>
+  <data name="StartMedia.Field.Autopilot" xml:space="preserve">
+    <value>Autopilot</value>
+  </data>
+  <data name="StartMedia.Autopilot.ProfileFormat" xml:space="preserve">
+    <value>Activé : {0} ({1})</value>
+  </data>
+  <data name="StartMedia.Autopilot.NotReady" xml:space="preserve">
+    <value>Activé ; profil par défaut manquant</value>
+  </data>
   <data name="StartMedia.BlockingReason.AdkNotReady" xml:space="preserve">
     <value>L'ADK ou le module complémentaire WinPE n'est pas prêt.</value>
   </data>
@@ -545,6 +554,9 @@
   </data>
   <data name="StartMedia.BlockingReason.RequiredSecretsNotReady" xml:space="preserve">
     <value>Les secrets média requis ne sont pas prêts.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.AutopilotConfigurationNotReady" xml:space="preserve">
+    <value>Autopilot est activé mais aucun profil par défaut valide n'est sélectionné.</value>
   </data>
   <data name="StartMedia.BlockingReason.NoUsbTarget" xml:space="preserve">
     <value>Aucune cible USB n'est sélectionnée.</value>

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -296,6 +296,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             IsDeployConfigurationReady = expertDeployConfigurationStateService.IsDeployConfigurationReady,
             IsConnectProvisioningReady = expertDeployConfigurationStateService.IsConnectProvisioningReady,
             AreRequiredSecretsReady = expertDeployConfigurationStateService.AreRequiredSecretsReady,
+            IsAutopilotEnabled = expertDeployConfigurationStateService.IsAutopilotEnabled,
+            IsAutopilotConfigurationReady = expertDeployConfigurationStateService.IsAutopilotConfigurationReady,
+            AutopilotProfileDisplayName = expertDeployConfigurationStateService.SelectedAutopilotProfileDisplayName,
+            AutopilotProfileFolderName = expertDeployConfigurationStateService.SelectedAutopilotProfileFolderName,
             IsFinalExecutionEnabled = false,
             IsoOutputPath = IsoOutputPath,
             Architecture = SelectedArchitecture?.Value ?? WinPeArchitecture.X64,
@@ -339,6 +343,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Deploy")}: {FormatReady(options.IsDeployConfigurationReady)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Connect")}: {FormatReady(options.IsConnectProvisioningReady)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Secrets")}: {FormatReady(options.AreRequiredSecretsReady)}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Autopilot")}: {FormatAutopilot(options)}");
         builder.AppendLine();
         builder.AppendLine(localizationService.GetString("StartMedia.FinalExecution.Deferred"));
 
@@ -372,7 +377,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         IReadOnlyList<MediaPreflightBlockingReason> reasons = GetGlobalBlockingReasons(evaluation);
 
         logger.Information(
-            "Media preflight summary refreshed. Architecture={Architecture}, WinPeLanguage={WinPeLanguage}, BootImageSource={BootImageSource}, IsoOutputPath={IsoOutputPath}, UsbTargetSelected={UsbTargetSelected}, DiskNumber={DiskNumber}, DiskName={DiskName}, RuntimeReady={RuntimeReady}, NetworkReady={NetworkReady}, DeployReady={DeployReady}, ConnectReady={ConnectReady}, SecretsReady={SecretsReady}, SummaryReady={SummaryReady}, BlockingReasons={BlockingReasons}",
+            "Media preflight summary refreshed. Architecture={Architecture}, WinPeLanguage={WinPeLanguage}, BootImageSource={BootImageSource}, IsoOutputPath={IsoOutputPath}, UsbTargetSelected={UsbTargetSelected}, DiskNumber={DiskNumber}, DiskName={DiskName}, RuntimeReady={RuntimeReady}, NetworkReady={NetworkReady}, DeployReady={DeployReady}, ConnectReady={ConnectReady}, SecretsReady={SecretsReady}, AutopilotEnabled={AutopilotEnabled}, AutopilotReady={AutopilotReady}, AutopilotProfile={AutopilotProfile}, AutopilotFolder={AutopilotFolder}, SummaryReady={SummaryReady}, BlockingReasons={BlockingReasons}",
             options.Architecture,
             NormalizeCultureName(options.WinPeLanguage),
             options.BootImageSource,
@@ -385,6 +390,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             options.IsDeployConfigurationReady,
             options.IsConnectProvisioningReady,
             options.AreRequiredSecretsReady,
+            options.IsAutopilotEnabled,
+            options.IsAutopilotConfigurationReady,
+            options.AutopilotProfileDisplayName,
+            options.AutopilotProfileFolderName,
             evaluation.CanGenerateIsoSummary || evaluation.CanGenerateUsbSummary,
             string.Join(",", reasons));
     }
@@ -468,6 +477,24 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     private string FormatReady(bool isReady)
     {
         return isReady ? localizationService.GetString("Common.Enabled") : localizationService.GetString("Common.Disabled");
+    }
+
+    private string FormatAutopilot(MediaPreflightOptions options)
+    {
+        if (!options.IsAutopilotEnabled)
+        {
+            return FormatReady(false);
+        }
+
+        if (!options.IsAutopilotConfigurationReady)
+        {
+            return localizationService.GetString("StartMedia.Autopilot.NotReady");
+        }
+
+        return string.Format(
+            localizationService.GetString("StartMedia.Autopilot.ProfileFormat"),
+            FormatValue(options.AutopilotProfileDisplayName),
+            FormatValue(options.AutopilotProfileFolderName));
     }
 
     private static string FormatValue(string? value)


### PR DESCRIPTION
## Summary
- Wires Autopilot readiness into Start media preflight and summary output.
- Makes Foundry.Deploy treat generated Autopilot config as the source of truth.
- Keeps the Deploy Autopilot section recoverable when config enables Autopilot but no embedded profile is available.

## Reason
Phase 16.D needs Start to reflect Autopilot readiness before final ISO/USB media execution is enabled, and Deploy must not infer Autopilot enablement from profile presence alone.

## Main changes
- Added Autopilot enabled/ready/profile metadata to media preflight options and blocking reasons.
- Surfaced selected Autopilot profile metadata in Start without Graph tokens or raw responses.
- Updated Deploy startup behavior to respect `autopilot.isEnabled` and avoid defaulting to the first available profile.
- Added localized strings and focused Core/Deploy regression coverage.
- Checked Phase 16.D and validations 16.14/16.15 in the migration plan.

## Testing
- `dotnet test src\Foundry.Core.Tests\Foundry.Core.Tests.csproj --no-restore`
- `dotnet test src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --no-restore`
- `dotnet build src\Foundry\Foundry.csproj --no-restore`