### PR TITLE
feat(media): enable final iso and usb commands

### DIFF
--- a/docs/migration/01-workflow.md
+++ b/docs/migration/01-workflow.md
@@ -97,7 +97,7 @@ Use the numeric phase IDs for stable prompts, but execute the work in dependency
 - [ ] **Final media enablement lane**
   - [ ] Phase 16.E: enable final ISO/USB commands after Deploy, Connect, network, secret, runtime payload, and optional Autopilot readiness are real.
 - [ ] **Cutover lane**
-  - [ ] Phase 17: `Foundry.Connect` and `Foundry.Deploy` compatibility pass.
+  - [ ] Phase 17: end-to-end generated media validation through `Foundry.Connect` and `Foundry.Deploy`.
   - [ ] Phase 18: Foundry UI/UX review and control rationalization.
   - [ ] Phase 19: cleanup and dependency review.
   - [ ] Phase 20: documentation update.

--- a/docs/migration/phases/06-business-workflows.md
+++ b/docs/migration/phases/06-business-workflows.md
@@ -309,7 +309,7 @@ git commit -m "feat(autopilot): wire start readiness"
 
 **Goal:** turn the `Start` page from readiness-only mode into the real ISO/USB execution entry point after Deploy, Connect, network, secret, runtime payload, and optional Autopilot/customization readiness are all real.
 
-**Prerequisites and boundary:** Phases 14, 15, and 16 must be complete. Phase 16.E owns final media command enablement and must absorb deferred real-media validations from Phases 12, 13, 14, 15, and 16. Phase 16.E should not perform the broader Connect/Deploy compatibility pass; that remains Phase 17 after media can be generated from WinUI.
+**Prerequisites and boundary:** Phases 14, 15, and 16 must be complete. Phase 16.E owns final media command enablement and generated-media creation from WinUI. The broader generated-media boot validation through `Foundry.Connect` and `Foundry.Deploy` belongs to Phase 17 after media can be generated from WinUI.
 
 - [x] **16.E.1** Replace remaining final media placeholders in `Start` preflight:
   - [x] Runtime payload readiness is real, not hardcoded.
@@ -351,23 +351,23 @@ git commit -m "feat(media): enable final iso and usb commands"
 
 **Validation**
 
-- [ ] **16.E.7** Complete deferred Phase 12 generated media validation:
+- [ ] **16.E.7** Complete deferred Phase 12 generated media validation during Phase 17:
   - [ ] **12.20** ISO creation works on a test machine with ADK through the final `Start` page command.
   - [ ] **12.21** USB creation works on a disposable test drive through the final `Start` page command when hardware is available.
   - [ ] **12.22** Generated ISO/USB media matches the documented layout from the final `Start` page workflow.
-- [ ] **16.E.8** Complete deferred Phase 13 command gate validation:
+- [ ] **16.E.8** Complete deferred Phase 13 command gate validation during Phase 17:
   - [ ] **13.18.1** ISO/USB creation is blocked when required Connect configuration is incomplete.
   - [ ] **13.18.1** ISO/USB creation is blocked when required Deploy configuration is incomplete.
   - [ ] **13.18.1** ISO/USB creation is blocked when encrypted secret-key provisioning is required but unavailable.
   - [ ] **13.18.1** ISO/USB creation is blocked when runtime payloads are unavailable.
   - [ ] **13.18.1** ISO/USB creation is blocked or warned when Autopilot is enabled without a valid embedded profile.
-- [ ] **16.E.9** Complete deferred Phase 14 generated-media validation:
+- [ ] **16.E.9** Complete deferred Phase 14 generated-media validation during Phase 17:
   - [ ] **14.13** Generated media contains `foundry.deploy.config.json`.
   - [ ] **14.13** `Foundry.Deploy` can load the generated Deploy config from generated media.
-- [ ] **16.E.10** Complete deferred Phase 15 generated-media validation:
+- [ ] **16.E.10** Complete deferred Phase 15 generated-media validation during Phase 17:
   - [ ] **15.14** `Foundry.Connect` can decrypt embedded `aes-gcm-v1` secrets from generated boot media.
   - [ ] **15.15** `Foundry.Connect` decrypts embedded secrets from generated boot media without prompting the operator for a decryption key.
-- [ ] **16.E.11** Complete deferred Phase 16 generated-media validation:
+- [ ] **16.E.11** Complete deferred Phase 16 generated-media validation during Phase 17:
   - [ ] **16.16** Boot generated media into `Foundry.Deploy` with Autopilot enabled but no embedded profile, and confirm the Autopilot section remains visible so the operator can disable it.
   - [ ] Generated media embeds selected Autopilot profiles under `Foundry\Config\Autopilot\<FolderName>\AutopilotConfigurationFile.json`.
   - [ ] Generated Deploy config stores the selected/default Autopilot profile folder name, not a full path.

--- a/docs/migration/phases/06-business-workflows.md
+++ b/docs/migration/phases/06-business-workflows.md
@@ -343,7 +343,7 @@ git commit -m "feat(autopilot): wire start readiness"
   - [x] Never log media secret keys.
   - [x] Never show plaintext secrets or media keys in summaries, validation errors, or operation output.
   - [x] Create `media-secrets.key` only when generated media contains encrypted secret envelopes.
-- [ ] **16.E.6** Commit:
+- [x] **16.E.6** Commit:
 
 ```powershell
 git commit -m "feat(media): enable final iso and usb commands"
@@ -374,7 +374,7 @@ git commit -m "feat(media): enable final iso and usb commands"
 - [ ] **16.E.12** Logs are readable in `C:\ProgramData\Foundry\Logs\Foundry.log` and include final ISO/USB start, progress, completion, pre-format cancellation, and failure events without exposing secrets.
   - [x] Add debug coverage for WinPE tool resolution, workspace build, provisioning payload generation, preparation stages, image customization progress, ISO/USB service completion, and workspace cleanup.
   - [ ] Re-run ISO/USB creation and confirm the new debug events appear without plaintext Wi-Fi passphrases or media keys.
-- [ ] **16.E.13** Improve long-running media progress UX:
-  - [ ] Show the current overall operation percentage beside the primary progress bar when progress is determinate.
-  - [ ] Extend the progress contract to support optional nested progress for internet downloads.
-  - [ ] Show a secondary progress bar only while a download exposes nested byte-level progress.
+- [x] **16.E.13** Improve long-running media progress UX:
+  - [x] Show the current overall operation percentage beside the primary progress bar when progress is determinate.
+  - [x] Extend the progress contract to support optional nested progress for internet downloads and DISM operations.
+  - [x] Show a secondary progress bar only while a download or DISM operation exposes nested progress.

--- a/docs/migration/phases/06-business-workflows.md
+++ b/docs/migration/phases/06-business-workflows.md
@@ -328,12 +328,14 @@ git commit -m "feat(autopilot): wire start readiness"
   - [x] Call the core ISO media service from an app-level orchestration service or view model command, not from page code-behind.
   - [x] Generate the complete effective Deploy and Connect configuration files during media provisioning.
   - [x] Provision runtime payloads, network assets, encrypted secret keys, Autopilot profiles, customization settings, drivers, and boot-language assets into the generated media layout.
+  - [x] Select the WinRE Wi-Fi boot image source whenever Wi-Fi provisioning is enabled, matching the WPF workflow.
   - [x] Clean temporary WinPE workspaces after the ISO operation exits.
 - [x] **16.E.4** Wire `Create USB` execution from WinUI:
   - [x] Require an explicit destructive USB confirmation dialog.
   - [x] Default the destructive confirmation to cancel.
   - [x] Keep destructive confirmation content readable with wrapping and a wider dialog content area.
   - [x] Revalidate selected USB disk identity immediately before formatting.
+  - [x] Select the WinRE Wi-Fi boot image source whenever Wi-Fi provisioning is enabled, matching the WPF workflow.
   - [x] Use the existing operation overlay contract for progress, completion, and failure; cancellation is limited to the pre-format confirmation step until the operation overlay supports cancellation.
   - [x] Clean temporary WinPE workspaces after the USB operation exits.
 - [x] **16.E.5** Keep secrets safe during final execution:
@@ -372,3 +374,7 @@ git commit -m "feat(media): enable final iso and usb commands"
 - [ ] **16.E.12** Logs are readable in `C:\ProgramData\Foundry\Logs\Foundry.log` and include final ISO/USB start, progress, completion, pre-format cancellation, and failure events without exposing secrets.
   - [x] Add debug coverage for WinPE tool resolution, workspace build, provisioning payload generation, preparation stages, image customization progress, ISO/USB service completion, and workspace cleanup.
   - [ ] Re-run ISO/USB creation and confirm the new debug events appear without plaintext Wi-Fi passphrases or media keys.
+- [ ] **16.E.13** Improve long-running media progress UX:
+  - [ ] Show the current overall operation percentage beside the primary progress bar when progress is determinate.
+  - [ ] Extend the progress contract to support optional nested progress for internet downloads.
+  - [ ] Show a secondary progress bar only while a download exposes nested byte-level progress.

--- a/docs/migration/phases/06-business-workflows.md
+++ b/docs/migration/phases/06-business-workflows.md
@@ -323,14 +323,19 @@ git commit -m "feat(autopilot): wire start readiness"
   - [x] Keep command state readable in the global summary.
 - [x] **16.E.3** Wire `Create ISO` execution from WinUI:
   - [x] Use the existing operation overlay contract for progress, completion, and failure; the current overlay has no in-operation cancel affordance.
+  - [x] Localize app-visible WinPE provisioning progress, including mounted-image customization statuses emitted by core services.
+  - [x] Keep the operation dialog readable with WinUI spacing guidance for progress/status content.
   - [x] Call the core ISO media service from an app-level orchestration service or view model command, not from page code-behind.
   - [x] Generate the complete effective Deploy and Connect configuration files during media provisioning.
   - [x] Provision runtime payloads, network assets, encrypted secret keys, Autopilot profiles, customization settings, drivers, and boot-language assets into the generated media layout.
+  - [x] Clean temporary WinPE workspaces after the ISO operation exits.
 - [x] **16.E.4** Wire `Create USB` execution from WinUI:
   - [x] Require an explicit destructive USB confirmation dialog.
   - [x] Default the destructive confirmation to cancel.
+  - [x] Keep destructive confirmation content readable with wrapping and a wider dialog content area.
   - [x] Revalidate selected USB disk identity immediately before formatting.
   - [x] Use the existing operation overlay contract for progress, completion, and failure; cancellation is limited to the pre-format confirmation step until the operation overlay supports cancellation.
+  - [x] Clean temporary WinPE workspaces after the USB operation exits.
 - [x] **16.E.5** Keep secrets safe during final execution:
   - [x] Never log plaintext Wi-Fi/network secrets.
   - [x] Never log media secret keys.
@@ -365,3 +370,5 @@ git commit -m "feat(media): enable final iso and usb commands"
   - [ ] Generated media embeds selected Autopilot profiles under `Foundry\Config\Autopilot\<FolderName>\AutopilotConfigurationFile.json`.
   - [ ] Generated Deploy config stores the selected/default Autopilot profile folder name, not a full path.
 - [ ] **16.E.12** Logs are readable in `C:\ProgramData\Foundry\Logs\Foundry.log` and include final ISO/USB start, progress, completion, pre-format cancellation, and failure events without exposing secrets.
+  - [x] Add debug coverage for WinPE tool resolution, workspace build, provisioning payload generation, preparation stages, image customization progress, ISO/USB service completion, and workspace cleanup.
+  - [ ] Re-run ISO/USB creation and confirm the new debug events appear without plaintext Wi-Fi passphrases or media keys.

--- a/docs/migration/phases/06-business-workflows.md
+++ b/docs/migration/phases/06-business-workflows.md
@@ -311,31 +311,31 @@ git commit -m "feat(autopilot): wire start readiness"
 
 **Prerequisites and boundary:** Phases 14, 15, and 16 must be complete. Phase 16.E owns final media command enablement and must absorb deferred real-media validations from Phases 12, 13, 14, 15, and 16. Phase 16.E should not perform the broader Connect/Deploy compatibility pass; that remains Phase 17 after media can be generated from WinUI.
 
-- [ ] **16.E.1** Replace remaining final media placeholders in `Start` preflight:
-  - [ ] Runtime payload readiness is real, not hardcoded.
-  - [ ] `Foundry.Connect` runtime payload availability is checked for the selected RID.
-  - [ ] `Foundry.Deploy` runtime payload availability is checked for the selected RID.
-  - [ ] Blocking reasons identify missing runtime payloads separately from Deploy, Connect, network, secret, or Autopilot readiness.
-- [ ] **16.E.2** Wire final ISO/USB command enablement:
-  - [ ] Enable `Create ISO` only when ADK, ISO path, architecture, Deploy, Connect, network, required secrets, runtime payloads, and optional Autopilot readiness pass.
-  - [ ] Enable `Create USB` only when all ISO requirements pass and a stable USB target is selected.
-  - [ ] Keep USB creation disabled when no USB target is selected without blocking ISO creation.
-  - [ ] Keep command state readable in the global summary.
-- [ ] **16.E.3** Wire `Create ISO` execution from WinUI:
-  - [ ] Use the existing operation overlay contract for progress, cancellation, completion, and failure.
-  - [ ] Call the core ISO media service from an app-level orchestration service or view model command, not from page code-behind.
-  - [ ] Generate the complete effective Deploy and Connect configuration files during media provisioning.
-  - [ ] Provision runtime payloads, network assets, encrypted secret keys, Autopilot profiles, customization settings, drivers, and boot-language assets into the generated media layout.
-- [ ] **16.E.4** Wire `Create USB` execution from WinUI:
-  - [ ] Require an explicit destructive USB confirmation dialog.
-  - [ ] Default the destructive confirmation to cancel.
-  - [ ] Revalidate selected USB disk identity immediately before formatting.
-  - [ ] Use the existing operation overlay contract for progress, cancellation, completion, and failure.
-- [ ] **16.E.5** Keep secrets safe during final execution:
-  - [ ] Never log plaintext Wi-Fi/network secrets.
-  - [ ] Never log media secret keys.
-  - [ ] Never show plaintext secrets or media keys in summaries, validation errors, or operation output.
-  - [ ] Create `media-secrets.key` only when generated media contains encrypted secret envelopes.
+- [x] **16.E.1** Replace remaining final media placeholders in `Start` preflight:
+  - [x] Runtime payload readiness is real, not hardcoded.
+  - [x] `Foundry.Connect` runtime payload availability is checked for the selected RID.
+  - [x] `Foundry.Deploy` runtime payload availability is checked for the selected RID.
+  - [x] Blocking reasons identify missing runtime payloads separately from Deploy, Connect, network, secret, or Autopilot readiness.
+- [x] **16.E.2** Wire final ISO/USB command enablement:
+  - [x] Enable `Create ISO` only when ADK, ISO path, architecture, Deploy, Connect, network, required secrets, runtime payloads, and optional Autopilot readiness pass.
+  - [x] Enable `Create USB` only when all ISO requirements pass and a stable USB target is selected.
+  - [x] Keep USB creation disabled when no USB target is selected without blocking ISO creation.
+  - [x] Keep command state readable in the global summary.
+- [x] **16.E.3** Wire `Create ISO` execution from WinUI:
+  - [x] Use the existing operation overlay contract for progress, completion, and failure; the current overlay has no in-operation cancel affordance.
+  - [x] Call the core ISO media service from an app-level orchestration service or view model command, not from page code-behind.
+  - [x] Generate the complete effective Deploy and Connect configuration files during media provisioning.
+  - [x] Provision runtime payloads, network assets, encrypted secret keys, Autopilot profiles, customization settings, drivers, and boot-language assets into the generated media layout.
+- [x] **16.E.4** Wire `Create USB` execution from WinUI:
+  - [x] Require an explicit destructive USB confirmation dialog.
+  - [x] Default the destructive confirmation to cancel.
+  - [x] Revalidate selected USB disk identity immediately before formatting.
+  - [x] Use the existing operation overlay contract for progress, completion, and failure; cancellation is limited to the pre-format confirmation step until the operation overlay supports cancellation.
+- [x] **16.E.5** Keep secrets safe during final execution:
+  - [x] Never log plaintext Wi-Fi/network secrets.
+  - [x] Never log media secret keys.
+  - [x] Never show plaintext secrets or media keys in summaries, validation errors, or operation output.
+  - [x] Create `media-secrets.key` only when generated media contains encrypted secret envelopes.
 - [ ] **16.E.6** Commit:
 
 ```powershell
@@ -364,4 +364,4 @@ git commit -m "feat(media): enable final iso and usb commands"
   - [ ] **16.16** Boot generated media into `Foundry.Deploy` with Autopilot enabled but no embedded profile, and confirm the Autopilot section remains visible so the operator can disable it.
   - [ ] Generated media embeds selected Autopilot profiles under `Foundry\Config\Autopilot\<FolderName>\AutopilotConfigurationFile.json`.
   - [ ] Generated Deploy config stores the selected/default Autopilot profile folder name, not a full path.
-- [ ] **16.E.12** Logs are readable in `C:\ProgramData\Foundry\Logs\Foundry.log` and include final ISO/USB start, progress, completion, cancellation, and failure events without exposing secrets.
+- [ ] **16.E.12** Logs are readable in `C:\ProgramData\Foundry\Logs\Foundry.log` and include final ISO/USB start, progress, completion, pre-format cancellation, and failure events without exposing secrets.

--- a/docs/migration/phases/07-compatibility-cleanup-cutover.md
+++ b/docs/migration/phases/07-compatibility-cleanup-cutover.md
@@ -1,33 +1,79 @@
 # Compatibility, UI Review, Cleanup, And Cutover Phases
 
-## Phase 17: Foundry.Connect And Foundry.Deploy Compatibility Pass
+## Phase 17: End-To-End Generated Media Validation
 
 **Priority:** high before cutover.
 
-**Goal:** prove the migrated WinUI app still produces runtime artifacts consumed by WPF Connect/Deploy.
+**Goal:** prove the full Foundry solution works from WinUI configuration through ISO/USB generation, WinPE boot, `Foundry.Connect` execution, and `Foundry.Deploy` execution.
 
-**Prerequisites and boundary:** Run Phase 17 after Phase 16.E final media command enablement is complete. Phase 17 should prove compatibility; only commit targeted fixes when the smoke tests expose a concrete incompatibility.
+**Prerequisites and boundary:** Run Phase 17 after Phase 16.E final media command enablement is complete and merged. Phase 17 is an end-to-end validation phase, not a broad refactor phase. Only commit targeted fixes when the generated-media tests expose a concrete incompatibility in configuration contracts, media layout, bootstrapping, Connect, Deploy, logging, or operator flow. Do not add backward-compatibility fallbacks for obsolete WPF-era paths or schemas; fix the generated contract and runtime consumers directly.
 
-- [ ] **17.1** Build `Foundry.Connect` as WPF.
-- [ ] **17.2** Build `Foundry.Deploy` as WPF.
-- [ ] **17.3** Generate WinPE media from WinUI `Foundry`.
-  - [ ] ISO media.
-  - [ ] USB media on a disposable drive when hardware is available.
-  - [ ] Standard workflow without optional Network/Autopilot settings.
-  - [ ] Expert workflow with deploy localization and generated Connect configuration.
-  - [ ] Expert workflow with Autopilot enabled when a test profile is available.
-- [ ] **17.4** Boot test media in a VM.
-- [ ] **17.5** Confirm `Foundry.Connect` starts in WinPE.
-- [ ] **17.6** Confirm `Foundry.Connect` reads generated network configuration.
-- [ ] **17.7** Confirm `Foundry.Deploy` can be launched from the runtime handoff.
-- [ ] **17.8** Confirm deployment configuration loads.
-- [ ] **17.8.1** Confirm `Foundry.Deploy` reads generated Autopilot configuration when Autopilot is enabled and a profile is embedded.
-- [ ] **17.8.2** Confirm `Foundry.Deploy` keeps Autopilot operator controls visible when Autopilot is enabled but no profile is embedded.
-- [ ] **17.9** Confirm both runtime agents use the normalized layout:
-  - [ ] `Runtime\Foundry.Connect\<rid>`.
-  - [ ] `Runtime\Foundry.Deploy\<rid>`.
-- [ ] **17.10** Confirm logs are written to expected locations.
-- [ ] **17.11** Commit compatibility or targeted shared-logic fixes only if required:
+- [ ] **17.1** Prepare a clean validation matrix:
+  - [ ] Record ADK and WinPE Add-on version, Windows host build, target architecture, signature mode, and generated media paths.
+  - [ ] Record whether each run uses ISO, USB, VM boot, physical boot, standard configuration, expert configuration, Wi-Fi/WinRE, secrets, Autopilot, and customization.
+  - [ ] Keep disposable generated artifacts and logs until the phase is reviewed.
+- [ ] **17.2** Build the full solution in the same configuration used by generated media:
+  - [ ] `Foundry`.
+  - [ ] `Foundry.Core`.
+  - [ ] `Foundry.Connect`.
+  - [ ] `Foundry.Deploy`.
+  - [ ] All available test projects.
+- [ ] **17.3** Generate baseline media from WinUI `Foundry`:
+  - [ ] ISO media with standard configuration and no optional expert features.
+  - [ ] USB media on a disposable drive with standard configuration when hardware is available.
+  - [ ] Confirm generated ISO/USB media matches the documented `X:\Foundry`, `Runtime`, `Config`, `Seed`, `Tools`, `OperatingSystem`, and `DriverPack` layout.
+  - [ ] Confirm `Runtime\Foundry.Connect\<rid>` and `Runtime\Foundry.Deploy\<rid>` are present in the expected ISO and USB locations.
+- [ ] **17.4** Generate complete expert media from WinUI `Foundry`:
+  - [ ] Deploy localization configured.
+  - [ ] Connect provisioning enabled.
+  - [ ] Network provisioning enabled.
+  - [ ] Encrypted media secrets enabled when required.
+  - [ ] WinRE Wi-Fi boot image selected when Wi-Fi provisioning is enabled.
+  - [ ] Autopilot enabled with an embedded default test profile.
+  - [ ] Customization enabled when test values are available.
+  - [ ] ISO media generated successfully.
+  - [ ] USB media generated successfully on a disposable drive when hardware is available.
+- [ ] **17.5** Validate generated boot image contents before boot:
+  - [ ] `boot.wim` contains `X:\Foundry` runtime, configuration, bootstrap, secrets, network assets, Autopilot assets, and tools expected for the selected workflow.
+  - [ ] `boot.wim` does not contain plaintext Wi-Fi passphrases, plaintext media secret keys, or host-only workspace artifacts.
+  - [ ] WinRE Wi-Fi media contains the expected WinRE-derived boot image and injected drivers/assets.
+  - [ ] Temporary WinPE workspaces under `C:\ProgramData\Foundry\Workspaces\WinPe` are cleaned after successful and failed runs.
+- [ ] **17.6** Boot generated ISO media in a VM:
+  - [ ] WinPE reaches Foundry bootstrap.
+  - [ ] `Foundry.Connect` starts automatically or through the expected bootstrap handoff.
+  - [ ] `Foundry.Connect` loads generated Connect configuration from `X:\Foundry\Config`.
+  - [ ] `Foundry.Connect` reads generated network assets when present.
+  - [ ] `Foundry.Connect` decrypts embedded `aes-gcm-v1` secrets without prompting for a decryption key.
+  - [ ] `Foundry.Connect` completes or reaches the expected operator state without schema or path errors.
+- [ ] **17.7** Boot generated USB media:
+  - [ ] Physical USB boot reaches Foundry bootstrap when hardware is available.
+  - [ ] USB BOOT partition remains minimal and bootable.
+  - [ ] USB cache partition keeps persistent runtime/cache data under the documented layout.
+  - [ ] `Foundry.Connect` resolves runtime/cache paths correctly from USB media.
+  - [ ] Logs stay under expected WinPE and deployment locations; USB cache does not become the boot log sink.
+- [ ] **17.8** Validate `Foundry.Deploy` handoff:
+  - [ ] `Foundry.Deploy` can be launched from the `Foundry.Connect` runtime handoff.
+  - [ ] `Foundry.Deploy` loads generated `foundry.deploy.config.json`.
+  - [ ] Deploy localization values are loaded and applied.
+  - [ ] Deployment storage, OS image, driver, and customization settings load without relying on missing-root defaults.
+  - [ ] Runtime errors are logged with enough context to troubleshoot media layout or schema issues.
+- [ ] **17.9** Validate Autopilot generated-media behavior:
+  - [ ] Generated media embeds selected Autopilot profiles under `Foundry\Config\Autopilot\<FolderName>\AutopilotConfigurationFile.json`.
+  - [ ] Generated Deploy config stores the selected/default Autopilot profile folder name, not a full path.
+  - [ ] `Foundry.Deploy` reads the embedded default Autopilot profile when Autopilot is enabled and a profile is embedded.
+  - [ ] `Foundry.Deploy` keeps Autopilot operator controls visible when Autopilot is enabled but no profile is embedded, so the operator can disable it.
+- [ ] **17.10** Validate negative command gates from WinUI `Start`:
+  - [ ] ISO/USB creation is blocked when required Connect configuration is incomplete.
+  - [ ] ISO/USB creation is blocked when required Deploy configuration is incomplete.
+  - [ ] ISO/USB creation is blocked when encrypted secret-key provisioning is required but unavailable.
+  - [ ] ISO/USB creation is blocked when runtime payloads are unavailable.
+  - [ ] ISO/USB creation is blocked or warned when Autopilot is enabled without a valid embedded profile.
+- [ ] **17.11** Validate operation logs:
+  - [ ] `C:\ProgramData\Foundry\Logs\Foundry.log` includes final ISO/USB start, progress, completion, pre-format cancellation, and failure events.
+  - [ ] Logs include WinPE tool resolution, workspace build, provisioning payload generation, preparation stages, image customization progress, ISO/USB service completion, workspace cleanup, and runtime handoff context.
+  - [ ] Logs do not expose plaintext Wi-Fi passphrases, media secret keys, or decrypted secret values.
+  - [ ] `Foundry.Connect` and `Foundry.Deploy` runtime logs are written to expected WinPE/deployment locations.
+- [ ] **17.12** Commit compatibility or targeted shared-logic fixes only if required:
 
 ```powershell
 git commit -m "fix: preserve winpe runtime compatibility"
@@ -35,12 +81,14 @@ git commit -m "fix: preserve winpe runtime compatibility"
 
 **Validation**
 
-- [ ] **17.12** VM smoke test completed.
-- [ ] **17.13** Physical USB smoke test completed if hardware is available.
-- [ ] **17.14** No schema-breaking changes found.
+- [ ] **17.13** ISO end-to-end smoke test completed in a VM.
+- [ ] **17.14** Physical USB end-to-end smoke test completed when hardware is available.
+- [ ] **17.15** Complete expert media smoke test completed through `Foundry.Connect` and `Foundry.Deploy`.
+- [ ] **17.16** No schema-breaking changes found.
   - [ ] Complete effective Deploy config remains accepted by `Foundry.Deploy`.
   - [ ] Complete effective Connect config remains accepted by `Foundry.Connect`.
   - [ ] Generated media does not rely on sparse missing-root defaults.
+- [ ] **17.17** Deferred validations from Phases 12, 13, 14, 15, and 16 are closed or explicitly moved to a later cutover checklist item with a reason.
 
 ## Phase 18: Foundry UI/UX Review And Control Rationalization
 

--- a/src/Foundry.Core.Tests/Media/MediaPreflightServiceTests.cs
+++ b/src/Foundry.Core.Tests/Media/MediaPreflightServiceTests.cs
@@ -39,6 +39,22 @@ public sealed class MediaPreflightServiceTests
     }
 
     [Fact]
+    public void Evaluate_WhenRuntimePayloadsAreMissing_ReportsConnectAndDeploySeparately()
+    {
+        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(
+            CreateReadyOptions() with
+            {
+                IsRuntimePayloadReady = false,
+                IsConnectRuntimePayloadReady = false,
+                IsDeployRuntimePayloadReady = false
+            });
+
+        Assert.Contains(MediaPreflightBlockingReason.ConnectRuntimePayloadNotReady, evaluation.IsoBlockingReasons);
+        Assert.Contains(MediaPreflightBlockingReason.DeployRuntimePayloadNotReady, evaluation.IsoBlockingReasons);
+        Assert.DoesNotContain(MediaPreflightBlockingReason.RuntimePayloadNotReady, evaluation.IsoBlockingReasons);
+    }
+
+    [Fact]
     public void Evaluate_WhenAutopilotIsDisabled_DoesNotBlockDryRun()
     {
         MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(

--- a/src/Foundry.Core.Tests/WinPe/WinPeDismProgressReporterTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeDismProgressReporterTests.cs
@@ -1,0 +1,54 @@
+using Foundry.Core.Services.WinPe;
+
+namespace Foundry.Core.Tests.WinPe;
+
+public sealed class WinPeDismProgressReporterTests
+{
+    [Fact]
+    public void HandleOutput_ReportsPercentProgress()
+    {
+        var progress = new CollectingProgress<WinPeDismProgress>();
+        var reporter = new WinPeDismProgressReporter("Applying DISM changes.", progress);
+
+        reporter.HandleOutput("[==========================50.0%==========================]");
+
+        WinPeDismProgress report = Assert.Single(progress.Reports);
+        Assert.Equal(50, report.Percent);
+        Assert.Equal("Applying DISM changes.", report.Status);
+    }
+
+    [Fact]
+    public void HandleOutput_ReportsFrenchOrdinalProgress()
+    {
+        var progress = new CollectingProgress<WinPeDismProgress>();
+        var reporter = new WinPeDismProgressReporter("Applying DISM changes.", progress);
+
+        reporter.HandleOutput("3 sur 4 operations completed");
+
+        WinPeDismProgress report = Assert.Single(progress.Reports);
+        Assert.Equal(75, report.Percent);
+    }
+
+    [Fact]
+    public void HandleOutput_IgnoresRegressingProgress()
+    {
+        var progress = new CollectingProgress<WinPeDismProgress>();
+        var reporter = new WinPeDismProgressReporter("Applying DISM changes.", progress);
+
+        reporter.HandleOutput("70%");
+        reporter.HandleOutput("20%");
+
+        WinPeDismProgress report = Assert.Single(progress.Reports);
+        Assert.Equal(70, report.Percent);
+    }
+
+    private sealed class CollectingProgress<T> : IProgress<T>
+    {
+        public List<T> Reports { get; } = [];
+
+        public void Report(T value)
+        {
+            Reports.Add(value);
+        }
+    }
+}

--- a/src/Foundry.Core.Tests/WinPe/WinPeDriverInjectionServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeDriverInjectionServiceTests.cs
@@ -61,7 +61,48 @@ public sealed class WinPeDriverInjectionServiceTests
         Assert.Equal(WinPeErrorCodes.ValidationFailed, result.Error?.Code);
     }
 
-    private sealed class FakeInjectionRunner : IWinPeProcessRunner
+    [Fact]
+    public async Task InjectAsync_ReportsDismProgressFromProcessOutput()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"foundry-driver-injection-{Guid.NewGuid():N}");
+        string mountedImagePath = Path.Combine(root, "mount");
+        string workingDirectory = Path.Combine(root, "work");
+        string driverDirectory = Path.Combine(root, "drivers");
+        Directory.CreateDirectory(mountedImagePath);
+        Directory.CreateDirectory(workingDirectory);
+        Directory.CreateDirectory(driverDirectory);
+
+        var runner = new FakeInjectionRunner(["25%", "100%"]);
+        var progress = new CollectingProgress<WinPeDismProgress>();
+        var service = new WinPeDriverInjectionService(runner);
+
+        try
+        {
+            WinPeResult result = await service.InjectAsync(
+                new WinPeDriverInjectionOptions
+                {
+                    MountedImagePath = mountedImagePath,
+                    WorkingDirectoryPath = workingDirectory,
+                    DriverPackagePaths = [driverDirectory],
+                    DismExecutablePath = "dism.exe",
+                    RecurseSubdirectories = true,
+                    DismProgress = progress
+                },
+                CancellationToken.None);
+
+            Assert.True(result.IsSuccess, result.Error?.Details);
+            Assert.Collection(
+                progress.Reports,
+                report => Assert.Equal(25, report.Percent),
+                report => Assert.Equal(100, report.Percent));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private sealed class FakeInjectionRunner(IReadOnlyList<string>? outputLines = null) : IWinPeProcessOutputRunner
     {
         public List<WinPeProcessExecution> Executions { get; } = [];
 
@@ -83,6 +124,23 @@ public sealed class WinPeDriverInjectionServiceTests
             return Task.FromResult(execution);
         }
 
+        public Task<WinPeProcessExecution> RunWithOutputAsync(
+            string fileName,
+            string arguments,
+            string workingDirectory,
+            Action<string>? onOutputData,
+            Action<string>? onErrorData,
+            CancellationToken cancellationToken,
+            IReadOnlyDictionary<string, string>? environmentOverrides = null)
+        {
+            foreach (string line in outputLines ?? [])
+            {
+                onOutputData?.Invoke(line);
+            }
+
+            return RunAsync(fileName, arguments, workingDirectory, cancellationToken, environmentOverrides);
+        }
+
         public Task<WinPeProcessExecution> RunCmdScriptAsync(
             string scriptPath,
             string scriptArguments,
@@ -99,6 +157,16 @@ public sealed class WinPeDriverInjectionServiceTests
             CancellationToken cancellationToken)
         {
             throw new NotSupportedException();
+        }
+    }
+
+    private sealed class CollectingProgress<T> : IProgress<T>
+    {
+        public List<T> Reports { get; } = [];
+
+        public void Report(T value)
+        {
+            Reports.Add(value);
         }
     }
 }

--- a/src/Foundry.Core.Tests/WinPe/WinPeDriverPackageServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeDriverPackageServiceTests.cs
@@ -37,6 +37,7 @@ public sealed class WinPeDriverPackageServiceTests
                 ],
                 downloadRoot,
                 extractRoot,
+                null,
                 CancellationToken.None);
 
             Assert.True(result.IsSuccess, result.Error?.Details);
@@ -75,6 +76,7 @@ public sealed class WinPeDriverPackageServiceTests
                 ],
                 Path.Combine(root, "downloads"),
                 Path.Combine(root, "extracted"),
+                null,
                 CancellationToken.None);
 
             Assert.False(result.IsSuccess);

--- a/src/Foundry.Core.Tests/WinPe/WinPeDriverResolutionServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeDriverResolutionServiceTests.cs
@@ -150,6 +150,7 @@ public sealed class WinPeDriverResolutionServiceTests
             IReadOnlyList<WinPeDriverCatalogEntry> packages,
             string downloadRootPath,
             string extractRootPath,
+            IProgress<WinPeDownloadProgress>? downloadProgress,
             CancellationToken cancellationToken)
         {
             PreparedPackages.AddRange(packages);

--- a/src/Foundry.Core/Services/Media/MediaPreflightBlockingReason.cs
+++ b/src/Foundry.Core/Services/Media/MediaPreflightBlockingReason.cs
@@ -7,6 +7,8 @@ public enum MediaPreflightBlockingReason
     MissingWinPeLanguage,
     WinPeLanguageUnavailable,
     RuntimePayloadNotReady,
+    ConnectRuntimePayloadNotReady,
+    DeployRuntimePayloadNotReady,
     NetworkConfigurationNotReady,
     DeployConfigurationNotReady,
     ConnectProvisioningNotReady,

--- a/src/Foundry.Core/Services/Media/MediaPreflightOptions.cs
+++ b/src/Foundry.Core/Services/Media/MediaPreflightOptions.cs
@@ -6,6 +6,8 @@ public sealed record MediaPreflightOptions
 {
     public bool IsAdkReady { get; init; }
     public bool IsRuntimePayloadReady { get; init; }
+    public bool? IsConnectRuntimePayloadReady { get; init; }
+    public bool? IsDeployRuntimePayloadReady { get; init; }
     public bool IsNetworkConfigurationReady { get; init; }
     public bool IsDeployConfigurationReady { get; init; }
     public bool IsConnectProvisioningReady { get; init; }

--- a/src/Foundry.Core/Services/Media/MediaPreflightService.cs
+++ b/src/Foundry.Core/Services/Media/MediaPreflightService.cs
@@ -68,7 +68,19 @@ public static class MediaPreflightService
             reasons.Add(MediaPreflightBlockingReason.AdkNotReady);
         }
 
-        if (!options.IsRuntimePayloadReady)
+        if (options.IsConnectRuntimePayloadReady.HasValue || options.IsDeployRuntimePayloadReady.HasValue)
+        {
+            if (options.IsConnectRuntimePayloadReady != true)
+            {
+                reasons.Add(MediaPreflightBlockingReason.ConnectRuntimePayloadNotReady);
+            }
+
+            if (options.IsDeployRuntimePayloadReady != true)
+            {
+                reasons.Add(MediaPreflightBlockingReason.DeployRuntimePayloadNotReady);
+            }
+        }
+        else if (!options.IsRuntimePayloadReady)
         {
             reasons.Add(MediaPreflightBlockingReason.RuntimePayloadNotReady);
         }
@@ -131,6 +143,8 @@ public static class MediaPreflightService
         return
         [
             MediaPreflightBlockingReason.RuntimePayloadNotReady,
+            MediaPreflightBlockingReason.ConnectRuntimePayloadNotReady,
+            MediaPreflightBlockingReason.DeployRuntimePayloadNotReady,
             MediaPreflightBlockingReason.NetworkConfigurationNotReady,
             MediaPreflightBlockingReason.DeployConfigurationNotReady,
             MediaPreflightBlockingReason.ConnectProvisioningNotReady,

--- a/src/Foundry.Core/Services/WinPe/IWinPeDriverPackageService.cs
+++ b/src/Foundry.Core/Services/WinPe/IWinPeDriverPackageService.cs
@@ -6,5 +6,6 @@ public interface IWinPeDriverPackageService
         IReadOnlyList<WinPeDriverCatalogEntry> packages,
         string downloadRootPath,
         string extractRootPath,
+        IProgress<WinPeDownloadProgress>? downloadProgress,
         CancellationToken cancellationToken);
 }

--- a/src/Foundry.Core/Services/WinPe/IWinPeProcessOutputRunner.cs
+++ b/src/Foundry.Core/Services/WinPe/IWinPeProcessOutputRunner.cs
@@ -1,0 +1,13 @@
+namespace Foundry.Core.Services.WinPe;
+
+internal interface IWinPeProcessOutputRunner : IWinPeProcessRunner
+{
+    Task<WinPeProcessExecution> RunWithOutputAsync(
+        string fileName,
+        string arguments,
+        string workingDirectory,
+        Action<string>? onOutputData,
+        Action<string>? onErrorData,
+        CancellationToken cancellationToken,
+        IReadOnlyDictionary<string, string>? environmentOverrides = null);
+}

--- a/src/Foundry.Core/Services/WinPe/UsbOutputOptions.cs
+++ b/src/Foundry.Core/Services/WinPe/UsbOutputOptions.cs
@@ -25,5 +25,6 @@ public sealed record UsbOutputOptions
     public string? ExpertDeployConfigurationJson { get; init; }
     public IReadOnlyList<AutopilotProfileSettings> AutopilotProfiles { get; init; } = [];
     public WinPeRuntimePayloadProvisioningOptions? RuntimePayloadProvisioning { get; init; }
+    public IProgress<WinPeMediaProgress>? Progress { get; init; }
     public bool PreserveBuildWorkspace { get; init; }
 }

--- a/src/Foundry.Core/Services/WinPe/WinPeDismProcessRunner.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeDismProcessRunner.cs
@@ -1,0 +1,32 @@
+namespace Foundry.Core.Services.WinPe;
+
+internal static class WinPeDismProcessRunner
+{
+    public static Task<WinPeProcessExecution> RunAsync(
+        IWinPeProcessRunner processRunner,
+        string dismPath,
+        string arguments,
+        string workingDirectory,
+        string progressStatus,
+        IProgress<WinPeDismProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        if (progress is not null && processRunner is IWinPeProcessOutputRunner outputRunner)
+        {
+            var reporter = new WinPeDismProgressReporter(progressStatus, progress);
+            return outputRunner.RunWithOutputAsync(
+                dismPath,
+                arguments,
+                workingDirectory,
+                reporter.HandleOutput,
+                reporter.HandleOutput,
+                cancellationToken);
+        }
+
+        return processRunner.RunAsync(
+            dismPath,
+            arguments,
+            workingDirectory,
+            cancellationToken);
+    }
+}

--- a/src/Foundry.Core/Services/WinPe/WinPeDismProgress.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeDismProgress.cs
@@ -1,0 +1,8 @@
+namespace Foundry.Core.Services.WinPe;
+
+public sealed record WinPeDismProgress
+{
+    public int Percent { get; init; }
+
+    public string Status { get; init; } = string.Empty;
+}

--- a/src/Foundry.Core/Services/WinPe/WinPeDismProgressForwarder.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeDismProgressForwarder.cs
@@ -1,0 +1,29 @@
+namespace Foundry.Core.Services.WinPe;
+
+internal sealed class WinPeDismProgressForwarder : IProgress<WinPeDismProgress>
+{
+    private readonly IProgress<WinPeMountedImageCustomizationProgress> _progress;
+    private readonly int _percent;
+    private readonly string _status;
+
+    public WinPeDismProgressForwarder(
+        IProgress<WinPeMountedImageCustomizationProgress> progress,
+        int percent,
+        string status)
+    {
+        _progress = progress;
+        _percent = percent;
+        _status = status;
+    }
+
+    public void Report(WinPeDismProgress value)
+    {
+        _progress.Report(new WinPeMountedImageCustomizationProgress
+        {
+            Percent = _percent,
+            Status = _status,
+            DetailPercent = value.Percent,
+            DetailStatus = value.Status
+        });
+    }
+}

--- a/src/Foundry.Core/Services/WinPe/WinPeDismProgressReporter.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeDismProgressReporter.cs
@@ -1,0 +1,116 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Foundry.Core.Services.WinPe;
+
+internal sealed class WinPeDismProgressReporter
+{
+    private static readonly Regex PercentageRegex = new(@"(?<percent>\d{1,3}(?:[.,]\d+)?)\s*%", RegexOptions.Compiled);
+    private static readonly Regex OrdinalProgressRegex = new(@"(?<!\d)(?<current>\d+)\s+(?:of|sur)\s+(?<total>\d+)(?!\d)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private readonly string _status;
+    private readonly IProgress<WinPeDismProgress> _progress;
+    private readonly object _sync = new();
+    private double _lastReportedPercent = double.NaN;
+
+    public WinPeDismProgressReporter(string status, IProgress<WinPeDismProgress> progress)
+    {
+        _status = status;
+        _progress = progress ?? throw new ArgumentNullException(nameof(progress));
+    }
+
+    public bool HasReportedProgress
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return !double.IsNaN(_lastReportedPercent);
+            }
+        }
+    }
+
+    public void HandleOutput(string line)
+    {
+        if (!TryParseProgress(line, out double percent))
+        {
+            return;
+        }
+
+        lock (_sync)
+        {
+            if (!double.IsNaN(_lastReportedPercent) && percent <= _lastReportedPercent)
+            {
+                return;
+            }
+
+            _lastReportedPercent = percent;
+        }
+
+        _progress.Report(new WinPeDismProgress
+        {
+            Percent = (int)Math.Round(percent, MidpointRounding.AwayFromZero),
+            Status = _status
+        });
+    }
+
+    private static bool TryParseProgress(string? line, out double percent)
+    {
+        if (TryParsePercent(line, out percent))
+        {
+            return true;
+        }
+
+        return TryParseOrdinalProgress(line, out percent);
+    }
+
+    private static bool TryParsePercent(string? line, out double percent)
+    {
+        percent = 0d;
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return false;
+        }
+
+        Match match = PercentageRegex.Match(line);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        string rawPercent = match.Groups["percent"].Value.Replace(',', '.');
+        if (!double.TryParse(rawPercent, NumberStyles.Float, CultureInfo.InvariantCulture, out double parsed))
+        {
+            return false;
+        }
+
+        percent = Math.Clamp(parsed, 0d, 100d);
+        return true;
+    }
+
+    private static bool TryParseOrdinalProgress(string? line, out double percent)
+    {
+        percent = 0d;
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return false;
+        }
+
+        Match match = OrdinalProgressRegex.Match(line);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        if (!int.TryParse(match.Groups["current"].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int current) ||
+            !int.TryParse(match.Groups["total"].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int total) ||
+            current <= 0 ||
+            total <= 0)
+        {
+            return false;
+        }
+
+        percent = Math.Clamp((double)current / total * 100d, 0d, 100d);
+        return true;
+    }
+}

--- a/src/Foundry.Core/Services/WinPe/WinPeDownloadProgress.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeDownloadProgress.cs
@@ -1,0 +1,8 @@
+namespace Foundry.Core.Services.WinPe;
+
+public sealed record WinPeDownloadProgress
+{
+    public int? Percent { get; init; }
+
+    public string Status { get; init; } = string.Empty;
+}

--- a/src/Foundry.Core/Services/WinPe/WinPeDriverInjectionOptions.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeDriverInjectionOptions.cs
@@ -7,4 +7,5 @@ public sealed record WinPeDriverInjectionOptions
     public bool RecurseSubdirectories { get; init; } = true;
     public string? DismExecutablePath { get; init; }
     public string WorkingDirectoryPath { get; init; } = string.Empty;
+    public IProgress<WinPeDismProgress>? DismProgress { get; init; }
 }

--- a/src/Foundry.Core/Services/WinPe/WinPeDriverInjectionService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeDriverInjectionService.cs
@@ -32,10 +32,13 @@ public sealed class WinPeDriverInjectionService : IWinPeDriverInjectionService
         foreach (string packagePath in options.DriverPackagePaths)
         {
             string normalizedPath = packagePath.Trim();
-            WinPeProcessExecution result = await _processRunner.RunAsync(
+            WinPeProcessExecution result = await WinPeDismProcessRunner.RunAsync(
+                _processRunner,
                 dismPath,
                 $"/Image:{WinPeProcessRunner.Quote(options.MountedImagePath)} /Add-Driver /Driver:{WinPeProcessRunner.Quote(normalizedPath)}{recurse}",
                 options.WorkingDirectoryPath,
+                "Injecting drivers with DISM.",
+                options.DismProgress,
                 cancellationToken).ConfigureAwait(false);
 
             if (!result.IsSuccess)

--- a/src/Foundry.Core/Services/WinPe/WinPeDriverPackageService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeDriverPackageService.cs
@@ -29,6 +29,7 @@ public sealed class WinPeDriverPackageService : IWinPeDriverPackageService
         IReadOnlyList<WinPeDriverCatalogEntry> packages,
         string downloadRootPath,
         string extractRootPath,
+        IProgress<WinPeDownloadProgress>? downloadProgress,
         CancellationToken cancellationToken)
     {
         Directory.CreateDirectory(downloadRootPath);
@@ -48,6 +49,9 @@ public sealed class WinPeDriverPackageService : IWinPeDriverPackageService
             WinPeResult downloadResult = await DownloadPackageAsync(
                 package.DownloadUri,
                 downloadPath,
+                index + 1,
+                packages.Count,
+                downloadProgress,
                 cancellationToken).ConfigureAwait(false);
 
             if (!downloadResult.IsSuccess)
@@ -131,6 +135,9 @@ public sealed class WinPeDriverPackageService : IWinPeDriverPackageService
     private async Task<WinPeResult> DownloadPackageAsync(
         string sourceUri,
         string destinationPath,
+        int packageNumber,
+        int packageCount,
+        IProgress<WinPeDownloadProgress>? progress,
         CancellationToken cancellationToken)
     {
         if (!Uri.TryCreate(sourceUri, UriKind.Absolute, out Uri? uri))
@@ -143,6 +150,9 @@ public sealed class WinPeDriverPackageService : IWinPeDriverPackageService
 
         try
         {
+            string status = BuildDriverDownloadStatus(destinationPath, packageNumber, packageCount);
+            ReportDownloadProgress(progress, 0, status);
+
             using HttpResponseMessage response = await _httpClient.GetAsync(
                 uri,
                 HttpCompletionOption.ResponseHeadersRead,
@@ -157,6 +167,7 @@ public sealed class WinPeDriverPackageService : IWinPeDriverPackageService
             }
 
             Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+            long? totalBytes = response.Content.Headers.ContentLength;
             await using Stream sourceStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
             await using FileStream destinationStream = new(
                 destinationPath,
@@ -166,7 +177,13 @@ public sealed class WinPeDriverPackageService : IWinPeDriverPackageService
                 81920,
                 useAsync: true);
 
-            await sourceStream.CopyToAsync(destinationStream, cancellationToken).ConfigureAwait(false);
+            await CopyDownloadToFileAsync(
+                sourceStream,
+                destinationStream,
+                totalBytes,
+                status,
+                progress,
+                cancellationToken).ConfigureAwait(false);
             return WinPeResult.Success();
         }
         catch (Exception ex) when (ex is HttpRequestException or IOException or UnauthorizedAccessException)
@@ -176,6 +193,93 @@ public sealed class WinPeDriverPackageService : IWinPeDriverPackageService
                 "Failed to download driver package.",
                 $"URI: '{sourceUri}'. Error: {ex.Message}");
         }
+    }
+
+    private static async Task CopyDownloadToFileAsync(
+        Stream sourceStream,
+        FileStream destinationStream,
+        long? totalBytes,
+        string status,
+        IProgress<WinPeDownloadProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        byte[] buffer = new byte[81920];
+        long bytesWritten = 0;
+        int lastReportedPercent = -1;
+
+        while (true)
+        {
+            int bytesRead = await sourceStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (bytesRead == 0)
+            {
+                break;
+            }
+
+            await destinationStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken).ConfigureAwait(false);
+            bytesWritten += bytesRead;
+
+            if (totalBytes is > 0)
+            {
+                int downloadPercent = (int)Math.Clamp(bytesWritten * 100 / totalBytes.Value, 0, 100);
+                if (downloadPercent == lastReportedPercent)
+                {
+                    continue;
+                }
+
+                lastReportedPercent = downloadPercent;
+                ReportDownloadProgress(
+                    progress,
+                    downloadPercent,
+                    $"{status} ({FormatBytes(bytesWritten)} / {FormatBytes(totalBytes.Value)})");
+            }
+            else
+            {
+                ReportDownloadProgress(
+                    progress,
+                    null,
+                    $"{status} ({FormatBytes(bytesWritten)} downloaded)");
+            }
+        }
+
+        ReportDownloadProgress(
+            progress,
+            100,
+            totalBytes is > 0
+                ? $"{status} ({FormatBytes(bytesWritten)} / {FormatBytes(totalBytes.Value)})"
+                : $"{status} ({FormatBytes(bytesWritten)} downloaded)");
+    }
+
+    private static string BuildDriverDownloadStatus(string destinationPath, int packageNumber, int packageCount)
+    {
+        return $"Downloading driver package {packageNumber} of {packageCount}: {Path.GetFileName(destinationPath)}.";
+    }
+
+    private static void ReportDownloadProgress(IProgress<WinPeDownloadProgress>? progress, int? percent, string status)
+    {
+        progress?.Report(new WinPeDownloadProgress
+        {
+            Percent = percent.HasValue
+                ? Math.Clamp(percent.Value, 0, 100)
+                : null,
+            Status = status
+        });
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        string[] units = ["B", "KB", "MB", "GB", "TB"];
+        double value = bytes;
+        int unitIndex = 0;
+
+        while (value >= 1024 && unitIndex < units.Length - 1)
+        {
+            value /= 1024;
+            unitIndex++;
+        }
+
+        return unitIndex == 0
+            ? $"{bytes} {units[unitIndex]}"
+            : $"{value:F1} {units[unitIndex]}";
     }
 
     private static async Task<WinPeResult> ValidateSha256Async(

--- a/src/Foundry.Core/Services/WinPe/WinPeDriverResolutionRequest.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeDriverResolutionRequest.cs
@@ -8,4 +8,5 @@ public sealed record WinPeDriverResolutionRequest
     public required IReadOnlyList<WinPeVendorSelection> DriverVendors { get; init; }
     public string? CustomDriverDirectoryPath { get; init; }
     public required WinPeBuildArtifact Artifact { get; init; }
+    public IProgress<WinPeDownloadProgress>? DownloadProgress { get; init; }
 }

--- a/src/Foundry.Core/Services/WinPe/WinPeDriverResolutionService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeDriverResolutionService.cs
@@ -67,6 +67,7 @@ public sealed class WinPeDriverResolutionService : IWinPeDriverResolutionService
                     selectedPackages,
                     Path.Combine(request.Artifact.DriverWorkspacePath, "downloads"),
                     Path.Combine(request.Artifact.DriverWorkspacePath, "extracted"),
+                    request.DownloadProgress,
                     cancellationToken).ConfigureAwait(false);
 
                 if (!prepared.IsSuccess)

--- a/src/Foundry.Core/Services/WinPe/WinPeImageInternationalizationOptions.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeImageInternationalizationOptions.cs
@@ -7,4 +7,5 @@ public sealed record WinPeImageInternationalizationOptions
     public WinPeToolPaths? Tools { get; init; }
     public string WinPeLanguage { get; init; } = string.Empty;
     public string WorkingDirectoryPath { get; init; } = string.Empty;
+    public IProgress<WinPeDismProgress>? DismProgress { get; init; }
 }

--- a/src/Foundry.Core/Services/WinPe/WinPeImageInternationalizationService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeImageInternationalizationService.cs
@@ -64,6 +64,7 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
             optionalComponentsRoot,
             normalizedLocale,
             options.WorkingDirectoryPath,
+            options.DismProgress,
             cancellationToken).ConfigureAwait(false);
 
         if (!packageResult.IsSuccess)
@@ -77,6 +78,7 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
             canonicalLocale,
             inputLocale,
             options.WorkingDirectoryPath,
+            options.DismProgress,
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -86,6 +88,7 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
         string optionalComponentsRoot,
         string normalizedLocale,
         string workingDirectoryPath,
+        IProgress<WinPeDismProgress>? dismProgress,
         CancellationToken cancellationToken)
     {
         string languagePackPath = Path.Combine(optionalComponentsRoot, normalizedLocale, "lp.cab");
@@ -103,6 +106,8 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
             languagePackPath,
             workingDirectoryPath,
             "Failed to add the selected WinPE language pack.",
+            "Applying language pack with DISM.",
+            dismProgress,
             cancellationToken).ConfigureAwait(false);
 
         if (!languagePackResult.IsSuccess)
@@ -123,6 +128,8 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
                     neutralPackagePath,
                     workingDirectoryPath,
                     $"Failed to add the '{component}' WinPE optional component.",
+                    "Applying optional components with DISM.",
+                    dismProgress,
                     cancellationToken).ConfigureAwait(false);
 
                 if (!neutralResult.IsSuccess)
@@ -140,6 +147,8 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
                     localizedPackagePath,
                     workingDirectoryPath,
                     $"Failed to add the localized '{component}' WinPE optional component.",
+                    "Applying optional components with DISM.",
+                    dismProgress,
                     cancellationToken).ConfigureAwait(false);
 
                 if (!localizedResult.IsSuccess)
@@ -163,12 +172,17 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
         string packagePath,
         string workingDirectoryPath,
         string failureMessage,
+        string progressStatus,
+        IProgress<WinPeDismProgress>? dismProgress,
         CancellationToken cancellationToken)
     {
-        WinPeProcessExecution execution = await _processRunner.RunAsync(
+        WinPeProcessExecution execution = await WinPeDismProcessRunner.RunAsync(
+            _processRunner,
             dismPath,
             $"/Image:{WinPeProcessRunner.Quote(mountedImagePath)} /Add-Package /PackagePath:{WinPeProcessRunner.Quote(packagePath)}",
             workingDirectoryPath,
+            progressStatus,
+            dismProgress,
             cancellationToken).ConfigureAwait(false);
 
         if (execution.IsSuccess || IsIgnorablePackageFailure(execution))
@@ -188,6 +202,7 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
         string canonicalLocale,
         string inputLocale,
         string workingDirectoryPath,
+        IProgress<WinPeDismProgress>? dismProgress,
         CancellationToken cancellationToken)
     {
         string[] arguments =
@@ -198,10 +213,13 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
 
         foreach (string args in arguments)
         {
-            WinPeProcessExecution execution = await _processRunner.RunAsync(
+            WinPeProcessExecution execution = await WinPeDismProcessRunner.RunAsync(
+                _processRunner,
                 dismPath,
                 args,
                 workingDirectoryPath,
+                "Applying international settings with DISM.",
+                dismProgress,
                 cancellationToken).ConfigureAwait(false);
 
             if (!execution.IsSuccess)

--- a/src/Foundry.Core/Services/WinPe/WinPeIsoMediaOptions.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeIsoMediaOptions.cs
@@ -6,4 +6,5 @@ public sealed record WinPeIsoMediaOptions
     public string OutputIsoPath { get; init; } = string.Empty;
     public string IsoTempDirectoryPath { get; init; } = string.Empty;
     public bool ForceOverwriteOutput { get; init; } = true;
+    public IProgress<WinPeMediaProgress>? Progress { get; init; }
 }

--- a/src/Foundry.Core/Services/WinPe/WinPeIsoMediaService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeIsoMediaService.cs
@@ -33,8 +33,10 @@ public sealed class WinPeIsoMediaService : IWinPeIsoMediaService
 
         try
         {
+            ReportProgress(options.Progress, 0, "Preparing ISO output path.");
             EnsureOutputDirectoryExists(requestedOutputPath);
             preparedOutputPath = PrepareOutputPath(requestedOutputPath, options.IsoTempDirectoryPath);
+            ReportProgress(options.Progress, 20, "Preparing ISO workspace.");
             string makeWinPeMediaWorkspacePath = PrepareWorkspacePath(
                 preparedWorkspace.Artifact.WorkingDirectoryPath,
                 options.IsoTempDirectoryPath,
@@ -49,6 +51,7 @@ public sealed class WinPeIsoMediaService : IWinPeIsoMediaService
                 $"/ISO /F {WinPeProcessRunner.Quote(makeWinPeMediaWorkspacePath)} {WinPeProcessRunner.Quote(preparedOutputPath)}" +
                 (preparedWorkspace.UseBootEx ? " /bootex" : string.Empty);
 
+            ReportProgress(options.Progress, 40, "Running MakeWinPEMedia for ISO.");
             WinPeProcessExecution execution = await _processRunner.RunCmdScriptAsync(
                 preparedWorkspace.Tools.MakeWinPeMediaPath,
                 arguments,
@@ -63,7 +66,9 @@ public sealed class WinPeIsoMediaService : IWinPeIsoMediaService
                     execution.ToDiagnosticText());
             }
 
+            ReportProgress(options.Progress, 90, "Finalizing ISO output.");
             FinalizeOutput(preparedOutputPath, requestedOutputPath);
+            ReportProgress(options.Progress, 100, "ISO media completed.");
             return WinPeResult.Success();
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -253,6 +258,15 @@ public sealed class WinPeIsoMediaService : IWinPeIsoMediaService
     private static bool ContainsNonAscii(string value)
     {
         return value.Any(character => character > 127);
+    }
+
+    private static void ReportProgress(IProgress<WinPeMediaProgress>? progress, int percent, string status)
+    {
+        progress?.Report(new WinPeMediaProgress
+        {
+            Percent = Math.Clamp(percent, 0, 100),
+            Status = status
+        });
     }
 
     private static string ToAsciiSafeFileName(string fileName)

--- a/src/Foundry.Core/Services/WinPe/WinPeMediaProgress.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMediaProgress.cs
@@ -1,0 +1,7 @@
+namespace Foundry.Core.Services.WinPe;
+
+public sealed record WinPeMediaProgress
+{
+    public int Percent { get; init; }
+    public string Status { get; init; } = string.Empty;
+}

--- a/src/Foundry.Core/Services/WinPe/WinPeMountSession.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountSession.cs
@@ -31,15 +31,19 @@ public sealed class WinPeMountSession : IAsyncDisposable
         string bootWimPath,
         string mountDirectoryPath,
         string workingDirectory,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IProgress<WinPeDismProgress>? dismProgress = null)
     {
         Directory.CreateDirectory(mountDirectoryPath);
 
         string args = $"/Mount-Image /ImageFile:{WinPeProcessRunner.Quote(bootWimPath)} /Index:1 /MountDir:{WinPeProcessRunner.Quote(mountDirectoryPath)}";
-        WinPeProcessExecution mountResult = await processRunner.RunAsync(
+        WinPeProcessExecution mountResult = await WinPeDismProcessRunner.RunAsync(
+            processRunner,
             dismPath,
             args,
             workingDirectory,
+            "Mounting image with DISM.",
+            dismProgress,
             cancellationToken).ConfigureAwait(false);
 
         if (!mountResult.IsSuccess)
@@ -58,17 +62,22 @@ public sealed class WinPeMountSession : IAsyncDisposable
             workingDirectory));
     }
 
-    public async Task<WinPeResult> CommitAsync(CancellationToken cancellationToken)
+    public async Task<WinPeResult> CommitAsync(
+        CancellationToken cancellationToken,
+        IProgress<WinPeDismProgress>? dismProgress = null)
     {
         if (!_isMounted)
         {
             return WinPeResult.Success();
         }
 
-        WinPeProcessExecution commitResult = await _processRunner.RunAsync(
+        WinPeProcessExecution commitResult = await WinPeDismProcessRunner.RunAsync(
+            _processRunner,
             _dismPath,
             $"/Unmount-Image /MountDir:{WinPeProcessRunner.Quote(MountDirectoryPath)} /Commit",
             _workingDirectory,
+            "Committing image changes with DISM.",
+            dismProgress,
             cancellationToken).ConfigureAwait(false);
 
         if (commitResult.IsSuccess)

--- a/src/Foundry.Core/Services/WinPe/WinPeMountedImageCustomizationOptions.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountedImageCustomizationOptions.cs
@@ -11,5 +11,6 @@ public sealed record WinPeMountedImageCustomizationOptions
     public WinPeRuntimePayloadProvisioningOptions? RuntimePayloadProvisioning { get; init; }
     public string WinReCacheDirectoryPath { get; init; } = string.Empty;
     public Uri? WinReCatalogUri { get; init; }
+    public IProgress<WinPeDownloadProgress>? DownloadProgress { get; init; }
     public IProgress<WinPeMountedImageCustomizationProgress>? Progress { get; init; }
 }

--- a/src/Foundry.Core/Services/WinPe/WinPeMountedImageCustomizationProgress.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountedImageCustomizationProgress.cs
@@ -4,4 +4,6 @@ public sealed record WinPeMountedImageCustomizationProgress
 {
     public int Percent { get; init; }
     public string Status { get; init; } = string.Empty;
+    public int? DetailPercent { get; init; }
+    public string DetailStatus { get; init; } = string.Empty;
 }

--- a/src/Foundry.Core/Services/WinPe/WinPeMountedImageCustomizationService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountedImageCustomizationService.cs
@@ -63,7 +63,9 @@ public sealed class WinPeMountedImageCustomizationService : IWinPeMountedImageCu
                         Tools = tools,
                         WinPeLanguage = options.WinPeLanguage,
                         CacheDirectoryPath = options.WinReCacheDirectoryPath,
-                        CatalogUri = options.WinReCatalogUri ?? WinReBootImagePreparationService.DefaultOperatingSystemCatalogUri
+                        CatalogUri = options.WinReCatalogUri ?? WinReBootImagePreparationService.DefaultOperatingSystemCatalogUri,
+                        DownloadProgress = options.DownloadProgress,
+                        Progress = options.Progress
                     },
                     cancellationToken).ConfigureAwait(false);
 

--- a/src/Foundry.Core/Services/WinPe/WinPeMountedImageCustomizationService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountedImageCustomizationService.cs
@@ -84,7 +84,8 @@ public sealed class WinPeMountedImageCustomizationService : IWinPeMountedImageCu
             artifact.BootWimPath,
             artifact.MountDirectoryPath,
             artifact.WorkingDirectoryPath,
-            cancellationToken).ConfigureAwait(false);
+            cancellationToken,
+            CreateDismProgress(options.Progress, 30, "Mounting boot image.")).ConfigureAwait(false);
 
         if (!mountResult.IsSuccess)
         {
@@ -119,6 +120,7 @@ public sealed class WinPeMountedImageCustomizationService : IWinPeMountedImageCu
             options.DriverPackagePaths,
             tools.DismPath,
             artifact.WorkingDirectoryPath,
+            options.Progress,
             cancellationToken).ConfigureAwait(false);
 
         if (!driverInjectionResult.IsSuccess)
@@ -134,7 +136,8 @@ public sealed class WinPeMountedImageCustomizationService : IWinPeMountedImageCu
                 Architecture = artifact.Architecture,
                 Tools = tools,
                 WinPeLanguage = options.WinPeLanguage,
-                WorkingDirectoryPath = artifact.WorkingDirectoryPath
+                WorkingDirectoryPath = artifact.WorkingDirectoryPath,
+                DismProgress = CreateDismProgress(options.Progress, 65, "Applying language and optional components.")
             },
             cancellationToken).ConfigureAwait(false);
 
@@ -178,7 +181,9 @@ public sealed class WinPeMountedImageCustomizationService : IWinPeMountedImageCu
         }
 
         ReportProgress(options.Progress, 90, "Committing image changes.");
-        WinPeResult commitResult = await session.CommitAsync(cancellationToken).ConfigureAwait(false);
+        WinPeResult commitResult = await session.CommitAsync(
+            cancellationToken,
+            CreateDismProgress(options.Progress, 90, "Committing image changes.")).ConfigureAwait(false);
         if (commitResult.IsSuccess)
         {
             ReportProgress(options.Progress, 100, "Image customization completed.");
@@ -192,6 +197,7 @@ public sealed class WinPeMountedImageCustomizationService : IWinPeMountedImageCu
         IReadOnlyList<string> driverPackagePaths,
         string dismPath,
         string workingDirectoryPath,
+        IProgress<WinPeMountedImageCustomizationProgress>? progress,
         CancellationToken cancellationToken)
     {
         if (driverPackagePaths.Count == 0)
@@ -206,7 +212,8 @@ public sealed class WinPeMountedImageCustomizationService : IWinPeMountedImageCu
                 DriverPackagePaths = driverPackagePaths,
                 RecurseSubdirectories = true,
                 DismExecutablePath = dismPath,
-                WorkingDirectoryPath = workingDirectoryPath
+                WorkingDirectoryPath = workingDirectoryPath,
+                DismProgress = CreateDismProgress(progress, 45, "Injecting drivers into mounted image.")
             },
             cancellationToken).ConfigureAwait(false);
     }
@@ -354,5 +361,13 @@ public sealed class WinPeMountedImageCustomizationService : IWinPeMountedImageCu
             Percent = percent,
             Status = status
         });
+    }
+
+    private static IProgress<WinPeDismProgress>? CreateDismProgress(
+        IProgress<WinPeMountedImageCustomizationProgress>? progress,
+        int percent,
+        string status)
+    {
+        return progress is null ? null : new WinPeDismProgressForwarder(progress, percent, status);
     }
 }

--- a/src/Foundry.Core/Services/WinPe/WinPeProcessRunner.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeProcessRunner.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace Foundry.Core.Services.WinPe;
 
-public sealed class WinPeProcessRunner : IWinPeProcessRunner
+public sealed class WinPeProcessRunner : IWinPeProcessOutputRunner
 {
     private const string InternalSetEnvKey = "FOUNDRY_ADK_SETENV_PATH";
 
@@ -11,6 +11,25 @@ public sealed class WinPeProcessRunner : IWinPeProcessRunner
         string fileName,
         string arguments,
         string workingDirectory,
+        CancellationToken cancellationToken,
+        IReadOnlyDictionary<string, string>? environmentOverrides = null)
+    {
+        return await RunWithOutputAsync(
+            fileName,
+            arguments,
+            workingDirectory,
+            null,
+            null,
+            cancellationToken,
+            environmentOverrides).ConfigureAwait(false);
+    }
+
+    public async Task<WinPeProcessExecution> RunWithOutputAsync(
+        string fileName,
+        string arguments,
+        string workingDirectory,
+        Action<string>? onOutputData,
+        Action<string>? onErrorData,
         CancellationToken cancellationToken,
         IReadOnlyDictionary<string, string>? environmentOverrides = null)
     {
@@ -58,6 +77,7 @@ public sealed class WinPeProcessRunner : IWinPeProcessRunner
         {
             if (args.Data is not null)
             {
+                onOutputData?.Invoke(args.Data);
                 stdoutBuilder.AppendLine(args.Data);
             }
         };
@@ -66,6 +86,7 @@ public sealed class WinPeProcessRunner : IWinPeProcessRunner
         {
             if (args.Data is not null)
             {
+                onErrorData?.Invoke(args.Data);
                 stderrBuilder.AppendLine(args.Data);
             }
         };

--- a/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
@@ -138,6 +138,7 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
         }
 
         int diskNumber = options.TargetDiskNumber.Value;
+        ReportProgress(options.Progress, 0, "Validating USB target.");
         WinPeResult<WinPeUsbDiskIdentity> diskResult = await GetDiskIdentityAsync(
             diskNumber,
             tools,
@@ -148,6 +149,7 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
             return WinPeResult<WinPeUsbProvisionResult>.Failure(diskResult.Error!);
         }
 
+        ReportProgress(options.Progress, 10, "Checking USB target safety.");
         WinPeResult safetyValidation = ValidateDiskSafety(options, diskResult.Value!);
         if (!safetyValidation.IsSuccess)
         {
@@ -172,6 +174,7 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
                 "Free at least one drive letter between D: and Z: and retry.");
         }
 
+        ReportProgress(options.Progress, 20, "Partitioning and formatting USB target.");
         WinPeResult provisioningResult = await ProvisionDiskAsync(
             diskNumber,
             options.PartitionStyle,
@@ -187,6 +190,7 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
 
         string bootRootPath = $"{bootDriveLetter}:\\";
         string cacheRootPath = $"{cacheDriveLetter}:\\";
+        ReportProgress(options.Progress, 55, "Copying WinPE media to USB.");
         WinPeResult copyResult = await CopyMediaAsync(
             artifact.MediaDirectoryPath,
             bootRootPath,
@@ -199,6 +203,7 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
 
         if (useBootEx)
         {
+            ReportProgress(options.Progress, 70, "Configuring USB boot files.");
             WinPeResult bootConfigurationResult = ConfigureBootFiles(bootRootPath, artifact);
             if (!bootConfigurationResult.IsSuccess)
             {
@@ -206,6 +211,7 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
             }
         }
 
+        ReportProgress(options.Progress, 78, "Verifying USB boot media.");
         WinPeResult verificationResult = VerifyBootArtifacts(bootRootPath, artifact.Architecture);
         if (!verificationResult.IsSuccess)
         {
@@ -218,10 +224,12 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
             return WinPeResult<WinPeUsbProvisionResult>.Failure(bootLayoutResult.Error!);
         }
 
+        ReportProgress(options.Progress, 85, "Preparing USB cache partition.");
         InitializeCachePartitionDirectories(cacheRootPath);
 
         if (options.RuntimePayloadProvisioning is not null)
         {
+            ReportProgress(options.Progress, 92, "Provisioning USB runtime payloads.");
             WinPeResult runtimePayloadResult = await _runtimePayloadProvisioningService.ProvisionAsync(
                 CreateUsbRuntimePayloadOptions(options.RuntimePayloadProvisioning, artifact, cacheRootPath),
                 cancellationToken).ConfigureAwait(false);
@@ -232,6 +240,7 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
             }
         }
 
+        ReportProgress(options.Progress, 100, "USB media completed.");
         return WinPeResult<WinPeUsbProvisionResult>.Success(new WinPeUsbProvisionResult
         {
             BootDriveLetter = $"{bootDriveLetter}:",
@@ -525,6 +534,15 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
             WinPeErrorCodes.UsbCopyFailed,
             "Failed to copy WinPE media files to USB BOOT partition.",
             execution.ToDiagnosticText());
+    }
+
+    private static void ReportProgress(IProgress<WinPeMediaProgress>? progress, int percent, string status)
+    {
+        progress?.Report(new WinPeMediaProgress
+        {
+            Percent = Math.Clamp(percent, 0, 100),
+            Status = status
+        });
     }
 
     private async Task<WinPeResult<WinPeUsbDiskIdentity>> GetDiskIdentityAsync(

--- a/src/Foundry.Core/Services/WinPe/WinPeWorkspacePreparationOptions.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeWorkspacePreparationOptions.cs
@@ -15,5 +15,6 @@ public sealed record WinPeWorkspacePreparationOptions
     public string WinReCacheDirectoryPath { get; init; } = string.Empty;
     public Uri? WinReCatalogUri { get; init; }
     public IProgress<WinPeWorkspacePreparationStage>? Progress { get; init; }
+    public IProgress<WinPeDownloadProgress>? DownloadProgress { get; init; }
     public IProgress<WinPeMountedImageCustomizationProgress>? CustomizationProgress { get; init; }
 }

--- a/src/Foundry.Core/Services/WinPe/WinPeWorkspacePreparationService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeWorkspacePreparationService.cs
@@ -52,9 +52,10 @@ public sealed class WinPeWorkspacePreparationService : IWinPeWorkspacePreparatio
                 BootImageSource = options.BootImageSource,
                 DriverVendors = options.DriverVendors,
                 CustomDriverDirectoryPath = options.CustomDriverDirectoryPath,
-                Artifact = artifact
+                Artifact = artifact,
+                DownloadProgress = options.DownloadProgress
             },
-            cancellationToken).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
 
         if (!drivers.IsSuccess)
         {
@@ -74,6 +75,7 @@ public sealed class WinPeWorkspacePreparationService : IWinPeWorkspacePreparatio
                 RuntimePayloadProvisioning = options.RuntimePayloadProvisioning,
                 WinReCacheDirectoryPath = options.WinReCacheDirectoryPath,
                 WinReCatalogUri = options.WinReCatalogUri,
+                DownloadProgress = options.DownloadProgress,
                 Progress = options.CustomizationProgress
             },
             cancellationToken).ConfigureAwait(false);

--- a/src/Foundry.Core/Services/WinPe/WinReBootImagePreparationOptions.cs
+++ b/src/Foundry.Core/Services/WinPe/WinReBootImagePreparationOptions.cs
@@ -7,4 +7,6 @@ public sealed record WinReBootImagePreparationOptions
     public required string WinPeLanguage { get; init; }
     public required string CacheDirectoryPath { get; init; }
     public Uri CatalogUri { get; init; } = WinReBootImagePreparationService.DefaultOperatingSystemCatalogUri;
+    public IProgress<WinPeDownloadProgress>? DownloadProgress { get; init; }
+    public IProgress<WinPeMountedImageCustomizationProgress>? Progress { get; init; }
 }

--- a/src/Foundry.Core/Services/WinPe/WinReBootImagePreparationService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinReBootImagePreparationService.cs
@@ -335,6 +335,7 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
                 sourcePathResult.Value!,
                 candidate.RequestedEdition,
                 options.Artifact.WorkingDirectoryPath,
+                CreateDismProgress(options.Progress, 16, "Resolving WinRE image index."),
                 cancellationToken).ConfigureAwait(false);
 
             if (!indexResult.IsSuccess)
@@ -343,10 +344,13 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
             }
 
             ReportProgress(options.Progress, 19, "Exporting Windows image for WinRE extraction.");
-            WinPeProcessExecution exportResult = await _processRunner.RunAsync(
+            WinPeProcessExecution exportResult = await WinPeDismProcessRunner.RunAsync(
+                _processRunner,
                 options.Tools.DismPath,
                 $"/Export-Image /SourceImageFile:{WinPeProcessRunner.Quote(sourcePathResult.Value!)} /SourceIndex:{indexResult.Value} /DestinationImageFile:{WinPeProcessRunner.Quote(installWimPath)} /Compress:max /CheckIntegrity",
                 options.Artifact.WorkingDirectoryPath,
+                "Exporting Windows image with DISM.",
+                CreateDismProgress(options.Progress, 19, "Exporting Windows image for WinRE extraction."),
                 cancellationToken).ConfigureAwait(false);
 
             if (!exportResult.IsSuccess || !File.Exists(installWimPath))
@@ -364,7 +368,8 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
                 installWimPath,
                 mountDirectory,
                 options.Artifact.WorkingDirectoryPath,
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken,
+                CreateDismProgress(options.Progress, 24, "Mounting WinRE source image.")).ConfigureAwait(false);
 
             if (!mountResult.IsSuccess)
             {
@@ -584,12 +589,16 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
         string sourceImagePath,
         string requestedEdition,
         string workingDirectory,
+        IProgress<WinPeDismProgress>? dismProgress,
         CancellationToken cancellationToken)
     {
-        WinPeProcessExecution imageInfoResult = await _processRunner.RunAsync(
+        WinPeProcessExecution imageInfoResult = await WinPeDismProcessRunner.RunAsync(
+            _processRunner,
             dismPath,
             $"/English /Get-ImageInfo /ImageFile:{WinPeProcessRunner.Quote(sourceImagePath)}",
             workingDirectory,
+            "Resolving WinRE image index with DISM.",
+            dismProgress,
             cancellationToken).ConfigureAwait(false);
 
         if (!imageInfoResult.IsSuccess)
@@ -717,6 +726,14 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
                 : null,
             Status = status
         });
+    }
+
+    private static IProgress<WinPeDismProgress>? CreateDismProgress(
+        IProgress<WinPeMountedImageCustomizationProgress>? progress,
+        int percent,
+        string status)
+    {
+        return progress is null ? null : new WinPeDismProgressForwarder(progress, percent, status);
     }
 
     private static string FormatBytes(long bytes)

--- a/src/Foundry.Core/Services/WinPe/WinReBootImagePreparationService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinReBootImagePreparationService.cs
@@ -41,6 +41,7 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
             return WinPeResult<WinReBootImagePreparationResult>.Failure(validationError);
         }
 
+        ReportProgress(options.Progress, 2, "Resolving WinRE source catalog.");
         WinPeResult<IReadOnlyList<WinReSourceCandidate>> candidatesResult = await SelectCatalogCandidatesAsync(
             options.CatalogUri,
             options.Artifact.Architecture,
@@ -52,6 +53,7 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
             return WinPeResult<WinReBootImagePreparationResult>.Failure(candidatesResult.Error!);
         }
 
+        ReportProgress(options.Progress, 4, "Selected WinRE source package.");
         var failures = new List<WinPeDiagnostic>();
         foreach (WinReSourceCandidate candidate in candidatesResult.Value!)
         {
@@ -314,10 +316,12 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
         {
             WinPeFileSystemHelper.EnsureDirectoryClean(sourceDirectory);
             Directory.CreateDirectory(exportDirectory);
+            ReportProgress(options.Progress, 5, "Preparing WinRE source package.");
 
             WinPeResult<string> sourcePathResult = await EnsureDownloadedAsync(
                 options.CacheDirectoryPath,
                 candidate.Source,
+                options.DownloadProgress,
                 cancellationToken).ConfigureAwait(false);
 
             if (!sourcePathResult.IsSuccess)
@@ -325,6 +329,7 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
                 return WinPeResult<WinReBootImagePreparationResult>.Failure(sourcePathResult.Error!);
             }
 
+            ReportProgress(options.Progress, 16, "Resolving WinRE image index.");
             WinPeResult<int> indexResult = await ResolveImageIndexAsync(
                 options.Tools.DismPath,
                 sourcePathResult.Value!,
@@ -337,6 +342,7 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
                 return WinPeResult<WinReBootImagePreparationResult>.Failure(indexResult.Error!);
             }
 
+            ReportProgress(options.Progress, 19, "Exporting Windows image for WinRE extraction.");
             WinPeProcessExecution exportResult = await _processRunner.RunAsync(
                 options.Tools.DismPath,
                 $"/Export-Image /SourceImageFile:{WinPeProcessRunner.Quote(sourcePathResult.Value!)} /SourceIndex:{indexResult.Value} /DestinationImageFile:{WinPeProcessRunner.Quote(installWimPath)} /Compress:max /CheckIntegrity",
@@ -351,6 +357,7 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
                     exportResult.ToDiagnosticText());
             }
 
+            ReportProgress(options.Progress, 24, "Mounting WinRE source image.");
             WinPeResult<WinPeMountSession> mountResult = await WinPeMountSession.MountAsync(
                 _processRunner,
                 options.Tools.DismPath,
@@ -377,6 +384,7 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
                     cancellationToken).ConfigureAwait(false);
             }
 
+            ReportProgress(options.Progress, 27, "Staging WinRE Wi-Fi dependencies.");
             WinPeResult<WinReBootImagePreparationResult> dependencyResult = PrepareWirelessDependencyFiles(
                 mountDirectory,
                 dependencyDirectory);
@@ -386,6 +394,7 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
                 return await FailWithDiscardAsync(dependencyResult.Error!, session, cancellationToken).ConfigureAwait(false);
             }
 
+            ReportProgress(options.Progress, 29, "Replacing boot image with WinRE.");
             Directory.CreateDirectory(Path.GetDirectoryName(options.Artifact.BootWimPath)!);
             File.Copy(winRePath, options.Artifact.BootWimPath, overwrite: true);
 
@@ -398,6 +407,7 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
 
             TryDeleteDirectory(exportDirectory);
             TryDeleteDirectory(mountDirectory);
+            ReportProgress(options.Progress, 30, "WinRE Wi-Fi boot image is ready.");
             return dependencyResult;
         }
         catch (Exception ex)
@@ -430,6 +440,7 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
     private async Task<WinPeResult<string>> EnsureDownloadedAsync(
         string cacheDirectoryPath,
         WinReCatalogItem source,
+        IProgress<WinPeDownloadProgress>? progress,
         CancellationToken cancellationToken)
     {
         string sourceCachePath = BuildCachedSourcePath(cacheDirectoryPath, source);
@@ -461,12 +472,14 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
 
         try
         {
+            ReportDownloadProgress(progress, 0, "Downloading WinRE source package.");
             using HttpResponseMessage response = await _httpClient.GetAsync(
                 sourceUri,
                 HttpCompletionOption.ResponseHeadersRead,
                 cancellationToken).ConfigureAwait(false);
 
             response.EnsureSuccessStatusCode();
+            long? totalBytes = response.Content.Headers.ContentLength;
             await using Stream sourceStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
             await using (FileStream destinationStream = new(
                              temporaryDownloadPath,
@@ -476,7 +489,12 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
                              81920,
                              useAsync: true))
             {
-                await sourceStream.CopyToAsync(destinationStream, cancellationToken).ConfigureAwait(false);
+                await CopyDownloadToFileAsync(
+                    sourceStream,
+                    destinationStream,
+                    totalBytes,
+                    progress,
+                    cancellationToken).ConfigureAwait(false);
             }
 
             File.Move(temporaryDownloadPath, sourceCachePath, overwrite: true);
@@ -507,6 +525,58 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
         }
 
         return WinPeResult<string>.Success(sourceCachePath);
+    }
+
+    private static async Task CopyDownloadToFileAsync(
+        Stream sourceStream,
+        FileStream destinationStream,
+        long? totalBytes,
+        IProgress<WinPeDownloadProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        byte[] buffer = new byte[81920];
+        long bytesWritten = 0;
+        int lastReportedPercent = -1;
+
+        while (true)
+        {
+            int bytesRead = await sourceStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (bytesRead == 0)
+            {
+                break;
+            }
+
+            await destinationStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken).ConfigureAwait(false);
+            bytesWritten += bytesRead;
+
+            if (totalBytes is > 0)
+            {
+                int downloadPercent = (int)Math.Clamp(bytesWritten * 100 / totalBytes.Value, 0, 100);
+                if (downloadPercent != lastReportedPercent)
+                {
+                    lastReportedPercent = downloadPercent;
+                    ReportDownloadProgress(
+                        progress,
+                        downloadPercent,
+                        $"Downloading WinRE source package ({FormatBytes(bytesWritten)} / {FormatBytes(totalBytes.Value)}).");
+                }
+            }
+            else
+            {
+                ReportDownloadProgress(
+                    progress,
+                    null,
+                    $"Downloading WinRE source package ({FormatBytes(bytesWritten)} downloaded).");
+            }
+        }
+
+        if (totalBytes is > 0)
+        {
+            ReportDownloadProgress(
+                progress,
+                100,
+                $"Downloading WinRE source package ({FormatBytes(bytesWritten)} / {FormatBytes(totalBytes.Value)}).");
+        }
     }
 
     private async Task<WinPeResult<int>> ResolveImageIndexAsync(
@@ -626,9 +696,51 @@ public sealed partial class WinReBootImagePreparationService : IWinReBootImagePr
         };
     }
 
+    private static void ReportProgress(
+        IProgress<WinPeMountedImageCustomizationProgress>? progress,
+        int percent,
+        string status)
+    {
+        progress?.Report(new WinPeMountedImageCustomizationProgress
+        {
+            Percent = Math.Clamp(percent, 0, 100),
+            Status = status
+        });
+    }
+
+    private static void ReportDownloadProgress(IProgress<WinPeDownloadProgress>? progress, int? percent, string status)
+    {
+        progress?.Report(new WinPeDownloadProgress
+        {
+            Percent = percent.HasValue
+                ? Math.Clamp(percent.Value, 0, 100)
+                : null,
+            Status = status
+        });
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        string[] units = ["B", "KB", "MB", "GB", "TB"];
+        double value = bytes;
+        int unitIndex = 0;
+
+        while (value >= 1024 && unitIndex < units.Length - 1)
+        {
+            value /= 1024;
+            unitIndex++;
+        }
+
+        return unitIndex == 0
+            ? $"{bytes} {units[unitIndex]}"
+            : $"{value:F1} {units[unitIndex]}";
+    }
+
     private static string ReadElement(XElement parent, string elementName)
     {
-        return (parent.Element(elementName)?.Value ?? string.Empty).Trim();
+        return (parent.Elements()
+            .FirstOrDefault(element => element.Name.LocalName.Equals(elementName, StringComparison.OrdinalIgnoreCase))
+            ?.Value ?? string.Empty).Trim();
     }
 
     private static void TryDeleteDirectory(string path)

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -37,6 +37,10 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<INetworkSecretStateService, NetworkSecretStateService>();
         services.AddSingleton<IExpertDeployConfigurationStateService, ExpertDeployConfigurationStateService>();
         services.AddSingleton<IWinPeLanguageDiscoveryService, WinPeLanguageDiscoveryService>();
+        services.AddSingleton<IWinPeEmbeddedAssetService, WinPeEmbeddedAssetService>();
+        services.AddSingleton<IWinPeBuildService, WinPeBuildService>();
+        services.AddSingleton<IWinPeWorkspacePreparationService, WinPeWorkspacePreparationService>();
+        services.AddSingleton<IWinPeIsoMediaService, WinPeIsoMediaService>();
         services.AddSingleton<IWinPeUsbMediaService, WinPeUsbMediaService>();
         services.AddSingleton<IOperationProgressService, OperationProgressService>();
         services.AddSingleton<IAdkService, AdkService>();

--- a/src/Foundry/Services/Application/WinUiDialogService.cs
+++ b/src/Foundry/Services/Application/WinUiDialogService.cs
@@ -11,7 +11,7 @@ public sealed class WinUiDialogService : IDialogService
         var dialog = new ContentDialog
         {
             Title = request.Title,
-            Content = request.Message,
+            Content = CreateMessageContent(request.Message),
             CloseButtonText = request.CloseButtonText,
             XamlRoot = GetXamlRoot()
         };
@@ -26,7 +26,7 @@ public sealed class WinUiDialogService : IDialogService
         var dialog = new ContentDialog
         {
             Title = request.Title,
-            Content = request.Message,
+            Content = CreateMessageContent(request.Message),
             PrimaryButtonText = request.PrimaryButtonText,
             CloseButtonText = request.CancelButtonText,
             XamlRoot = GetXamlRoot()
@@ -34,6 +34,16 @@ public sealed class WinUiDialogService : IDialogService
 
         ContentDialogResult result = await dialog.ShowAsync();
         return result == ContentDialogResult.Primary;
+    }
+
+    private static TextBlock CreateMessageContent(string message)
+    {
+        return new TextBlock
+        {
+            Text = message,
+            TextWrapping = TextWrapping.Wrap,
+            MaxWidth = 520
+        };
     }
 
     private static XamlRoot GetXamlRoot()

--- a/src/Foundry/Services/Application/WinUiDialogService.cs
+++ b/src/Foundry/Services/Application/WinUiDialogService.cs
@@ -42,7 +42,9 @@ public sealed class WinUiDialogService : IDialogService
         {
             Text = message,
             TextWrapping = TextWrapping.Wrap,
-            MaxWidth = 520
+            MinWidth = 360,
+            MaxWidth = 520,
+            Margin = new Thickness(0, 4, 0, 8)
         };
     }
 

--- a/src/Foundry/Services/Operations/IOperationProgressService.cs
+++ b/src/Foundry/Services/Operations/IOperationProgressService.cs
@@ -6,6 +6,8 @@ public interface IOperationProgressService
     OperationProgressState State { get; }
     void Start(OperationKind kind, string status);
     void Report(int progress, string status);
+    void Report(int progress, string status, int? secondaryProgress, string secondaryStatus);
+    void ClearSecondary();
     void Complete(string status);
     void Reset(string status = "");
 }

--- a/src/Foundry/Services/Operations/OperationKind.cs
+++ b/src/Foundry/Services/Operations/OperationKind.cs
@@ -4,5 +4,6 @@ public enum OperationKind
 {
     None,
     AdkInstall,
-    AdkUpgrade
+    AdkUpgrade,
+    MediaCreation
 }

--- a/src/Foundry/Services/Operations/OperationProgressService.cs
+++ b/src/Foundry/Services/Operations/OperationProgressService.cs
@@ -13,17 +13,40 @@ internal sealed class OperationProgressService : IOperationProgressService
             throw new ArgumentOutOfRangeException(nameof(kind), kind, "An operation kind is required.");
         }
 
-        SetState(new(kind, 0, status));
+        SetState(new(kind, 0, status, null, string.Empty));
     }
 
     public void Report(int progress, string status)
+    {
+        Report(progress, status, null, string.Empty);
+    }
+
+    public void Report(int progress, string status, int? secondaryProgress, string secondaryStatus)
     {
         if (!State.IsRunning)
         {
             return;
         }
 
-        SetState(State with { Progress = Math.Clamp(progress, 0, 100), Status = status });
+        SetState(State with
+        {
+            Progress = Math.Clamp(progress, 0, 100),
+            Status = status,
+            SecondaryProgress = secondaryProgress.HasValue
+                ? Math.Clamp(secondaryProgress.Value, 0, 100)
+                : null,
+            SecondaryStatus = secondaryStatus
+        });
+    }
+
+    public void ClearSecondary()
+    {
+        if (!State.IsRunning || !State.HasSecondaryProgress)
+        {
+            return;
+        }
+
+        SetState(State with { SecondaryProgress = null, SecondaryStatus = string.Empty });
     }
 
     public void Complete(string status)
@@ -33,7 +56,13 @@ internal sealed class OperationProgressService : IOperationProgressService
             return;
         }
 
-        SetState(State with { Progress = 100, Status = status });
+        SetState(State with
+        {
+            Progress = 100,
+            Status = status,
+            SecondaryProgress = null,
+            SecondaryStatus = string.Empty
+        });
     }
 
     public void Reset(string status = "")

--- a/src/Foundry/Services/Operations/OperationProgressState.cs
+++ b/src/Foundry/Services/Operations/OperationProgressState.cs
@@ -1,7 +1,13 @@
 namespace Foundry.Services.Operations;
 
-public sealed record OperationProgressState(OperationKind Kind, int Progress, string Status)
+public sealed record OperationProgressState(
+    OperationKind Kind,
+    int Progress,
+    string Status,
+    int? SecondaryProgress,
+    string SecondaryStatus)
 {
-    public static OperationProgressState Idle { get; } = new(OperationKind.None, 0, string.Empty);
+    public static OperationProgressState Idle { get; } = new(OperationKind.None, 0, string.Empty, null, string.Empty);
     public bool IsRunning => Kind != OperationKind.None;
+    public bool HasSecondaryProgress => SecondaryProgress.HasValue || !string.IsNullOrWhiteSpace(SecondaryStatus);
 }

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -474,6 +474,42 @@
   <data name="StartMedia.Operation.PreparingWorkspace" xml:space="preserve">
     <value>Preparing WinPE workspace.</value>
   </data>
+  <data name="StartMedia.Operation.ResolvingDrivers" xml:space="preserve">
+    <value>Resolving driver packages.</value>
+  </data>
+  <data name="StartMedia.Operation.CustomizingImage" xml:space="preserve">
+    <value>Customizing the boot image.</value>
+  </data>
+  <data name="StartMedia.Operation.EvaluatingSignaturePolicy" xml:space="preserve">
+    <value>Evaluating boot signature policy.</value>
+  </data>
+  <data name="StartMedia.Operation.PreparingBootImageCustomization" xml:space="preserve">
+    <value>Preparing boot image customization.</value>
+  </data>
+  <data name="StartMedia.Operation.MountingBootImage" xml:space="preserve">
+    <value>Mounting boot image.</value>
+  </data>
+  <data name="StartMedia.Operation.InjectingDrivers" xml:space="preserve">
+    <value>Injecting drivers into the boot image.</value>
+  </data>
+  <data name="StartMedia.Operation.ApplyingLanguageAndComponents" xml:space="preserve">
+    <value>Applying language and optional components.</value>
+  </data>
+  <data name="StartMedia.Operation.ProvisioningBootAssets" xml:space="preserve">
+    <value>Provisioning Foundry boot assets.</value>
+  </data>
+  <data name="StartMedia.Operation.ProvisioningRuntimePayloads" xml:space="preserve">
+    <value>Provisioning Foundry runtime payloads.</value>
+  </data>
+  <data name="StartMedia.Operation.CommittingImageChanges" xml:space="preserve">
+    <value>Committing boot image changes.</value>
+  </data>
+  <data name="StartMedia.Operation.ImageCustomizationCompleted" xml:space="preserve">
+    <value>Boot image customization completed.</value>
+  </data>
+  <data name="StartMedia.Operation.CleaningWorkspace" xml:space="preserve">
+    <value>Cleaning WinPE workspace.</value>
+  </data>
   <data name="StartMedia.Operation.CreatingIso" xml:space="preserve">
     <value>Creating ISO media.</value>
   </data>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -525,6 +525,102 @@
   <data name="StartMedia.Operation.FailedTitle" xml:space="preserve">
     <value>Media creation failed</value>
   </data>
+  <data name="StartMedia.Operation.Downloading" xml:space="preserve">
+    <value>Downloading.</value>
+  </data>
+  <data name="StartMedia.Operation.ResolvingWinReSourceCatalog" xml:space="preserve">
+    <value>Resolving WinRE source catalog.</value>
+  </data>
+  <data name="StartMedia.Operation.SelectedWinReSourcePackage" xml:space="preserve">
+    <value>Selected WinRE source package.</value>
+  </data>
+  <data name="StartMedia.Operation.PreparingWinReSourcePackage" xml:space="preserve">
+    <value>Preparing WinRE source package.</value>
+  </data>
+  <data name="StartMedia.Operation.ValidatingCachedWinReSourcePackage" xml:space="preserve">
+    <value>Validating cached WinRE source package.</value>
+  </data>
+  <data name="StartMedia.Operation.UsingCachedWinReSourcePackage" xml:space="preserve">
+    <value>Using cached WinRE source package.</value>
+  </data>
+  <data name="StartMedia.Operation.DownloadingWinReSourcePackage" xml:space="preserve">
+    <value>Downloading WinRE source package.</value>
+  </data>
+  <data name="StartMedia.Operation.DownloadingDriverPackage" xml:space="preserve">
+    <value>Downloading driver package</value>
+  </data>
+  <data name="StartMedia.Operation.ValidatingWinReSourcePackage" xml:space="preserve">
+    <value>Validating WinRE source package.</value>
+  </data>
+  <data name="StartMedia.Operation.ResolvingWinReImageIndex" xml:space="preserve">
+    <value>Resolving WinRE image index.</value>
+  </data>
+  <data name="StartMedia.Operation.ExportingWinReSourceImage" xml:space="preserve">
+    <value>Exporting Windows image for WinRE extraction.</value>
+  </data>
+  <data name="StartMedia.Operation.MountingWinReSourceImage" xml:space="preserve">
+    <value>Mounting WinRE source image.</value>
+  </data>
+  <data name="StartMedia.Operation.StagingWinReWifiDependencies" xml:space="preserve">
+    <value>Staging WinRE Wi-Fi dependencies.</value>
+  </data>
+  <data name="StartMedia.Operation.ReplacingBootImageWithWinRe" xml:space="preserve">
+    <value>Replacing boot image with WinRE.</value>
+  </data>
+  <data name="StartMedia.Operation.WinReWifiBootImageReady" xml:space="preserve">
+    <value>WinRE Wi-Fi boot image is ready.</value>
+  </data>
+  <data name="StartMedia.Operation.PreparingIsoOutput" xml:space="preserve">
+    <value>Preparing ISO output path.</value>
+  </data>
+  <data name="StartMedia.Operation.PreparingIsoWorkspace" xml:space="preserve">
+    <value>Preparing ISO workspace.</value>
+  </data>
+  <data name="StartMedia.Operation.RunningMakeWinPeMediaIso" xml:space="preserve">
+    <value>Running MakeWinPEMedia for ISO.</value>
+  </data>
+  <data name="StartMedia.Operation.FinalizingIsoOutput" xml:space="preserve">
+    <value>Finalizing ISO output.</value>
+  </data>
+  <data name="StartMedia.Operation.IsoMediaCompleted" xml:space="preserve">
+    <value>ISO media completed.</value>
+  </data>
+  <data name="StartMedia.Operation.ValidatingUsbTarget" xml:space="preserve">
+    <value>Validating USB target.</value>
+  </data>
+  <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
+    <value>Checking USB target safety.</value>
+  </data>
+  <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
+    <value>Partitioning and formatting USB target.</value>
+  </data>
+  <data name="StartMedia.Operation.CopyingUsbMedia" xml:space="preserve">
+    <value>Copying WinPE media to USB.</value>
+  </data>
+  <data name="StartMedia.Operation.ConfiguringUsbBootFiles" xml:space="preserve">
+    <value>Configuring USB boot files.</value>
+  </data>
+  <data name="StartMedia.Operation.VerifyingUsbMedia" xml:space="preserve">
+    <value>Verifying USB boot media.</value>
+  </data>
+  <data name="StartMedia.Operation.PreparingUsbCache" xml:space="preserve">
+    <value>Preparing USB cache partition.</value>
+  </data>
+  <data name="StartMedia.Operation.ProvisioningUsbRuntimePayloads" xml:space="preserve">
+    <value>Provisioning USB runtime payloads.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
+    <value>USB media completed.</value>
+  </data>
+  <data name="StartMedia.Operation.SuccessTitle" xml:space="preserve">
+    <value>Media creation completed</value>
+  </data>
+  <data name="StartMedia.Operation.IsoSuccessMessage" xml:space="preserve">
+    <value>ISO media was created successfully: {0}</value>
+  </data>
+  <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
+    <value>USB media was created successfully. Boot volume: {0}. Cache volume: {1}.</value>
+  </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Select ISO output path</value>
   </data>
@@ -557,6 +653,9 @@
   </data>
   <data name="StartMedia.Field.WinPeLanguage" xml:space="preserve">
     <value>WinPE boot language</value>
+  </data>
+  <data name="StartMedia.Field.BootImageSource" xml:space="preserve">
+    <value>Boot image source</value>
   </data>
   <data name="StartMedia.Field.Architecture" xml:space="preserve">
     <value>Architecture</value>
@@ -659,6 +758,12 @@
   </data>
   <data name="StartMedia.SignatureMode.Pca2023" xml:space="preserve">
     <value>PCA 2023</value>
+  </data>
+  <data name="StartMedia.BootImageSource.WinPe" xml:space="preserve">
+    <value>Standard WinPE</value>
+  </data>
+  <data name="StartMedia.BootImageSource.WinReWifi" xml:space="preserve">
+    <value>WinRE Wi-Fi image</value>
   </data>
   <data name="StartMedia.DriverVendor.Dell" xml:space="preserve">
     <value>Dell</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -433,7 +433,7 @@
     <value>Final media commands</value>
   </data>
   <data name="StartMedia.FinalCommands.Description" xml:space="preserve">
-    <value>Final ISO and USB execution stays disabled until the final media enablement phase.</value>
+    <value>Create the final ISO or USB media after all readiness checks pass.</value>
   </data>
   <data name="StartMedia.CreateIsoButton" xml:space="preserve">
     <value>Create ISO</value>
@@ -449,6 +449,45 @@
   </data>
   <data name="StartMedia.FinalExecution.Deferred" xml:space="preserve">
     <value>Final ISO/USB execution is deferred until the final media enablement phase.</value>
+  </data>
+  <data name="StartMedia.FinalExecution.Ready" xml:space="preserve">
+    <value>Final ISO/USB execution is enabled when all readiness checks pass.</value>
+  </data>
+  <data name="StartMedia.CreateIso.BlockedTitle" xml:space="preserve">
+    <value>ISO creation is blocked</value>
+  </data>
+  <data name="StartMedia.CreateUsb.BlockedTitle" xml:space="preserve">
+    <value>USB creation is blocked</value>
+  </data>
+  <data name="StartMedia.CreateUsb.ConfirmTitle" xml:space="preserve">
+    <value>Format USB target</value>
+  </data>
+  <data name="StartMedia.CreateUsb.ConfirmMessage" xml:space="preserve">
+    <value>This will erase disk {0}: {1} ({2}). Continue only if this is the intended disposable USB target.</value>
+  </data>
+  <data name="StartMedia.CreateUsb.ConfirmPrimary" xml:space="preserve">
+    <value>Format and create USB</value>
+  </data>
+  <data name="StartMedia.Operation.BuildingWorkspace" xml:space="preserve">
+    <value>Creating WinPE workspace.</value>
+  </data>
+  <data name="StartMedia.Operation.PreparingWorkspace" xml:space="preserve">
+    <value>Preparing WinPE workspace.</value>
+  </data>
+  <data name="StartMedia.Operation.CreatingIso" xml:space="preserve">
+    <value>Creating ISO media.</value>
+  </data>
+  <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
+    <value>Creating USB media.</value>
+  </data>
+  <data name="StartMedia.Operation.Completed" xml:space="preserve">
+    <value>Final media creation completed.</value>
+  </data>
+  <data name="StartMedia.Operation.Failed" xml:space="preserve">
+    <value>Final media creation failed.</value>
+  </data>
+  <data name="StartMedia.Operation.FailedTitle" xml:space="preserve">
+    <value>Media creation failed</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Select ISO output path</value>
@@ -542,6 +581,12 @@
   </data>
   <data name="StartMedia.BlockingReason.RuntimePayloadNotReady" xml:space="preserve">
     <value>Runtime payload readiness is deferred.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.ConnectRuntimePayloadNotReady" xml:space="preserve">
+    <value>Foundry.Connect runtime payload is not available for the selected architecture.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.DeployRuntimePayloadNotReady" xml:space="preserve">
+    <value>Foundry.Deploy runtime payload is not available for the selected architecture.</value>
   </data>
   <data name="StartMedia.BlockingReason.NetworkConfigurationNotReady" xml:space="preserve">
     <value>Network configuration is not ready.</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -612,11 +612,35 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB media completed.</value>
   </data>
+  <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
+    <value>Exporting Windows image with DISM.</value>
+  </data>
+  <data name="StartMedia.Operation.DismResolvingWinReImageIndex" xml:space="preserve">
+    <value>Resolving WinRE image index with DISM.</value>
+  </data>
+  <data name="StartMedia.Operation.DismMountingImage" xml:space="preserve">
+    <value>Mounting image with DISM.</value>
+  </data>
+  <data name="StartMedia.Operation.DismInjectingDrivers" xml:space="preserve">
+    <value>Injecting drivers with DISM.</value>
+  </data>
+  <data name="StartMedia.Operation.DismApplyingLanguagePack" xml:space="preserve">
+    <value>Applying language pack with DISM.</value>
+  </data>
+  <data name="StartMedia.Operation.DismApplyingOptionalComponents" xml:space="preserve">
+    <value>Applying optional components with DISM.</value>
+  </data>
+  <data name="StartMedia.Operation.DismApplyingInternationalSettings" xml:space="preserve">
+    <value>Applying international settings with DISM.</value>
+  </data>
+  <data name="StartMedia.Operation.DismCommittingImageChanges" xml:space="preserve">
+    <value>Committing image changes with DISM.</value>
+  </data>
   <data name="StartMedia.Operation.SuccessTitle" xml:space="preserve">
     <value>Media creation completed</value>
   </data>
   <data name="StartMedia.Operation.IsoSuccessMessage" xml:space="preserve">
-    <value>ISO media was created successfully: {0}</value>
+    <value>The ISO media was created successfully.</value>
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB media was created successfully. Boot volume: {0}. Cache volume: {1}.</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -474,6 +474,42 @@
   <data name="StartMedia.Operation.PreparingWorkspace" xml:space="preserve">
     <value>Préparation de l'espace de travail WinPE.</value>
   </data>
+  <data name="StartMedia.Operation.ResolvingDrivers" xml:space="preserve">
+    <value>Résolution des packages de pilotes.</value>
+  </data>
+  <data name="StartMedia.Operation.CustomizingImage" xml:space="preserve">
+    <value>Personnalisation de l'image de démarrage.</value>
+  </data>
+  <data name="StartMedia.Operation.EvaluatingSignaturePolicy" xml:space="preserve">
+    <value>Évaluation de la stratégie de signature de démarrage.</value>
+  </data>
+  <data name="StartMedia.Operation.PreparingBootImageCustomization" xml:space="preserve">
+    <value>Préparation de la personnalisation de l'image de démarrage.</value>
+  </data>
+  <data name="StartMedia.Operation.MountingBootImage" xml:space="preserve">
+    <value>Montage de l'image de démarrage.</value>
+  </data>
+  <data name="StartMedia.Operation.InjectingDrivers" xml:space="preserve">
+    <value>Injection des pilotes dans l'image de démarrage.</value>
+  </data>
+  <data name="StartMedia.Operation.ApplyingLanguageAndComponents" xml:space="preserve">
+    <value>Application de la langue et des composants optionnels.</value>
+  </data>
+  <data name="StartMedia.Operation.ProvisioningBootAssets" xml:space="preserve">
+    <value>Provisionnement des ressources de démarrage Foundry.</value>
+  </data>
+  <data name="StartMedia.Operation.ProvisioningRuntimePayloads" xml:space="preserve">
+    <value>Provisionnement des charges utiles d'exécution Foundry.</value>
+  </data>
+  <data name="StartMedia.Operation.CommittingImageChanges" xml:space="preserve">
+    <value>Validation des modifications de l'image de démarrage.</value>
+  </data>
+  <data name="StartMedia.Operation.ImageCustomizationCompleted" xml:space="preserve">
+    <value>Personnalisation de l'image de démarrage terminée.</value>
+  </data>
+  <data name="StartMedia.Operation.CleaningWorkspace" xml:space="preserve">
+    <value>Nettoyage de l'espace de travail WinPE.</value>
+  </data>
   <data name="StartMedia.Operation.CreatingIso" xml:space="preserve">
     <value>Création du média ISO.</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -433,7 +433,7 @@
     <value>Commandes média finales</value>
   </data>
   <data name="StartMedia.FinalCommands.Description" xml:space="preserve">
-    <value>L'exécution ISO et USB finale reste désactivée jusqu'à la phase d'activation finale des médias.</value>
+    <value>Crée le média ISO ou USB final après validation de tous les contrôles.</value>
   </data>
   <data name="StartMedia.CreateIsoButton" xml:space="preserve">
     <value>Créer l'ISO</value>
@@ -449,6 +449,45 @@
   </data>
   <data name="StartMedia.FinalExecution.Deferred" xml:space="preserve">
     <value>L'exécution ISO/USB finale est différée jusqu'à la phase d'activation finale des médias.</value>
+  </data>
+  <data name="StartMedia.FinalExecution.Ready" xml:space="preserve">
+    <value>L'exécution ISO/USB finale est activée quand tous les contrôles sont validés.</value>
+  </data>
+  <data name="StartMedia.CreateIso.BlockedTitle" xml:space="preserve">
+    <value>La création ISO est bloquée</value>
+  </data>
+  <data name="StartMedia.CreateUsb.BlockedTitle" xml:space="preserve">
+    <value>La création USB est bloquée</value>
+  </data>
+  <data name="StartMedia.CreateUsb.ConfirmTitle" xml:space="preserve">
+    <value>Formater la cible USB</value>
+  </data>
+  <data name="StartMedia.CreateUsb.ConfirmMessage" xml:space="preserve">
+    <value>Cette action va effacer le disque {0} : {1} ({2}). Continuez uniquement si c'est bien la cible USB jetable prévue.</value>
+  </data>
+  <data name="StartMedia.CreateUsb.ConfirmPrimary" xml:space="preserve">
+    <value>Formater et créer l'USB</value>
+  </data>
+  <data name="StartMedia.Operation.BuildingWorkspace" xml:space="preserve">
+    <value>Création de l'espace de travail WinPE.</value>
+  </data>
+  <data name="StartMedia.Operation.PreparingWorkspace" xml:space="preserve">
+    <value>Préparation de l'espace de travail WinPE.</value>
+  </data>
+  <data name="StartMedia.Operation.CreatingIso" xml:space="preserve">
+    <value>Création du média ISO.</value>
+  </data>
+  <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
+    <value>Création du média USB.</value>
+  </data>
+  <data name="StartMedia.Operation.Completed" xml:space="preserve">
+    <value>Création du média final terminée.</value>
+  </data>
+  <data name="StartMedia.Operation.Failed" xml:space="preserve">
+    <value>La création du média final a échoué.</value>
+  </data>
+  <data name="StartMedia.Operation.FailedTitle" xml:space="preserve">
+    <value>La création du média a échoué</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Sélectionner le chemin de sortie ISO</value>
@@ -542,6 +581,12 @@
   </data>
   <data name="StartMedia.BlockingReason.RuntimePayloadNotReady" xml:space="preserve">
     <value>La validation des payloads runtime est différée.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.ConnectRuntimePayloadNotReady" xml:space="preserve">
+    <value>Le payload runtime Foundry.Connect n'est pas disponible pour l'architecture sélectionnée.</value>
+  </data>
+  <data name="StartMedia.BlockingReason.DeployRuntimePayloadNotReady" xml:space="preserve">
+    <value>Le payload runtime Foundry.Deploy n'est pas disponible pour l'architecture sélectionnée.</value>
   </data>
   <data name="StartMedia.BlockingReason.NetworkConfigurationNotReady" xml:space="preserve">
     <value>La configuration réseau n'est pas prête.</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -525,6 +525,102 @@
   <data name="StartMedia.Operation.FailedTitle" xml:space="preserve">
     <value>La création du média a échoué</value>
   </data>
+  <data name="StartMedia.Operation.Downloading" xml:space="preserve">
+    <value>Téléchargement en cours.</value>
+  </data>
+  <data name="StartMedia.Operation.ResolvingWinReSourceCatalog" xml:space="preserve">
+    <value>Résolution du catalogue source WinRE.</value>
+  </data>
+  <data name="StartMedia.Operation.SelectedWinReSourcePackage" xml:space="preserve">
+    <value>Package source WinRE sélectionné.</value>
+  </data>
+  <data name="StartMedia.Operation.PreparingWinReSourcePackage" xml:space="preserve">
+    <value>Préparation du package source WinRE.</value>
+  </data>
+  <data name="StartMedia.Operation.ValidatingCachedWinReSourcePackage" xml:space="preserve">
+    <value>Validation du package source WinRE en cache.</value>
+  </data>
+  <data name="StartMedia.Operation.UsingCachedWinReSourcePackage" xml:space="preserve">
+    <value>Utilisation du package source WinRE en cache.</value>
+  </data>
+  <data name="StartMedia.Operation.DownloadingWinReSourcePackage" xml:space="preserve">
+    <value>Téléchargement du package source WinRE.</value>
+  </data>
+  <data name="StartMedia.Operation.DownloadingDriverPackage" xml:space="preserve">
+    <value>Téléchargement du package de pilotes</value>
+  </data>
+  <data name="StartMedia.Operation.ValidatingWinReSourcePackage" xml:space="preserve">
+    <value>Validation du package source WinRE.</value>
+  </data>
+  <data name="StartMedia.Operation.ResolvingWinReImageIndex" xml:space="preserve">
+    <value>Résolution de l'index de l'image WinRE.</value>
+  </data>
+  <data name="StartMedia.Operation.ExportingWinReSourceImage" xml:space="preserve">
+    <value>Export de l'image Windows pour l'extraction WinRE.</value>
+  </data>
+  <data name="StartMedia.Operation.MountingWinReSourceImage" xml:space="preserve">
+    <value>Montage de l'image source WinRE.</value>
+  </data>
+  <data name="StartMedia.Operation.StagingWinReWifiDependencies" xml:space="preserve">
+    <value>Préparation des dépendances Wi-Fi WinRE.</value>
+  </data>
+  <data name="StartMedia.Operation.ReplacingBootImageWithWinRe" xml:space="preserve">
+    <value>Remplacement de l'image de démarrage par WinRE.</value>
+  </data>
+  <data name="StartMedia.Operation.WinReWifiBootImageReady" xml:space="preserve">
+    <value>L'image de démarrage WinRE Wi-Fi est prête.</value>
+  </data>
+  <data name="StartMedia.Operation.PreparingIsoOutput" xml:space="preserve">
+    <value>Préparation du chemin de sortie ISO.</value>
+  </data>
+  <data name="StartMedia.Operation.PreparingIsoWorkspace" xml:space="preserve">
+    <value>Préparation de l'espace de travail ISO.</value>
+  </data>
+  <data name="StartMedia.Operation.RunningMakeWinPeMediaIso" xml:space="preserve">
+    <value>Exécution de MakeWinPEMedia pour l'ISO.</value>
+  </data>
+  <data name="StartMedia.Operation.FinalizingIsoOutput" xml:space="preserve">
+    <value>Finalisation de la sortie ISO.</value>
+  </data>
+  <data name="StartMedia.Operation.IsoMediaCompleted" xml:space="preserve">
+    <value>Média ISO terminé.</value>
+  </data>
+  <data name="StartMedia.Operation.ValidatingUsbTarget" xml:space="preserve">
+    <value>Validation de la cible USB.</value>
+  </data>
+  <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
+    <value>Contrôle de sécurité de la cible USB.</value>
+  </data>
+  <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
+    <value>Partitionnement et formatage de la cible USB.</value>
+  </data>
+  <data name="StartMedia.Operation.CopyingUsbMedia" xml:space="preserve">
+    <value>Copie du média WinPE vers l'USB.</value>
+  </data>
+  <data name="StartMedia.Operation.ConfiguringUsbBootFiles" xml:space="preserve">
+    <value>Configuration des fichiers de démarrage USB.</value>
+  </data>
+  <data name="StartMedia.Operation.VerifyingUsbMedia" xml:space="preserve">
+    <value>Vérification du média de démarrage USB.</value>
+  </data>
+  <data name="StartMedia.Operation.PreparingUsbCache" xml:space="preserve">
+    <value>Préparation de la partition cache USB.</value>
+  </data>
+  <data name="StartMedia.Operation.ProvisioningUsbRuntimePayloads" xml:space="preserve">
+    <value>Provisionnement des charges utiles d'exécution USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
+    <value>Média USB terminé.</value>
+  </data>
+  <data name="StartMedia.Operation.SuccessTitle" xml:space="preserve">
+    <value>Création du média terminée</value>
+  </data>
+  <data name="StartMedia.Operation.IsoSuccessMessage" xml:space="preserve">
+    <value>Le média ISO a été créé avec succès : {0}</value>
+  </data>
+  <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
+    <value>Le média USB a été créé avec succès. Volume de démarrage : {0}. Volume cache : {1}.</value>
+  </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Sélectionner le chemin de sortie ISO</value>
   </data>
@@ -557,6 +653,9 @@
   </data>
   <data name="StartMedia.Field.WinPeLanguage" xml:space="preserve">
     <value>Langue de démarrage WinPE</value>
+  </data>
+  <data name="StartMedia.Field.BootImageSource" xml:space="preserve">
+    <value>Source de l'image de démarrage</value>
   </data>
   <data name="StartMedia.Field.Architecture" xml:space="preserve">
     <value>Architecture</value>
@@ -659,6 +758,12 @@
   </data>
   <data name="StartMedia.SignatureMode.Pca2023" xml:space="preserve">
     <value>PCA 2023</value>
+  </data>
+  <data name="StartMedia.BootImageSource.WinPe" xml:space="preserve">
+    <value>WinPE standard</value>
+  </data>
+  <data name="StartMedia.BootImageSource.WinReWifi" xml:space="preserve">
+    <value>Image WinRE Wi-Fi</value>
   </data>
   <data name="StartMedia.DriverVendor.Dell" xml:space="preserve">
     <value>Dell</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -612,11 +612,35 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>Média USB terminé.</value>
   </data>
+  <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
+    <value>Export de l'image Windows avec DISM.</value>
+  </data>
+  <data name="StartMedia.Operation.DismResolvingWinReImageIndex" xml:space="preserve">
+    <value>Résolution de l'index de l'image WinRE avec DISM.</value>
+  </data>
+  <data name="StartMedia.Operation.DismMountingImage" xml:space="preserve">
+    <value>Montage de l'image avec DISM.</value>
+  </data>
+  <data name="StartMedia.Operation.DismInjectingDrivers" xml:space="preserve">
+    <value>Injection des pilotes avec DISM.</value>
+  </data>
+  <data name="StartMedia.Operation.DismApplyingLanguagePack" xml:space="preserve">
+    <value>Application du pack de langue avec DISM.</value>
+  </data>
+  <data name="StartMedia.Operation.DismApplyingOptionalComponents" xml:space="preserve">
+    <value>Application des composants optionnels avec DISM.</value>
+  </data>
+  <data name="StartMedia.Operation.DismApplyingInternationalSettings" xml:space="preserve">
+    <value>Application des paramètres régionaux avec DISM.</value>
+  </data>
+  <data name="StartMedia.Operation.DismCommittingImageChanges" xml:space="preserve">
+    <value>Validation des changements de l'image avec DISM.</value>
+  </data>
   <data name="StartMedia.Operation.SuccessTitle" xml:space="preserve">
     <value>Création du média terminée</value>
   </data>
   <data name="StartMedia.Operation.IsoSuccessMessage" xml:space="preserve">
-    <value>Le média ISO a été créé avec succès : {0}</value>
+    <value>Le média ISO a été créé avec succès.</value>
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>Le média USB a été créé avec succès. Volume de démarrage : {0}. Volume cache : {1}.</value>

--- a/src/Foundry/ViewModels/LocalizationConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/LocalizationConfigurationViewModel.cs
@@ -129,7 +129,7 @@ public sealed partial class LocalizationConfigurationViewModel : ObservableObjec
 
         ForceSingleVisibleLanguage = settings.ForceSingleVisibleLanguage;
         RefreshDefaultLanguageOptions(settings.DefaultLanguageCodeOverride);
-        SelectedTimeZone = SelectStringOption(TimeZoneOptions, settings.DefaultTimeZoneId);
+        SelectedTimeZone = SelectStringOption(TimeZoneOptions, settings.DefaultTimeZoneId) ?? TimeZoneOptions[0];
 
         isApplyingState = false;
     }

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -1,13 +1,17 @@
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
+using Foundry.Core.Models.Configuration;
 using Foundry.Core.Services.Application;
 using Foundry.Core.Services.Media;
 using Foundry.Core.Services.WinPe;
 using Foundry.Services.Adk;
 using Foundry.Services.Configuration;
 using Foundry.Services.Localization;
+using Foundry.Services.Operations;
 using Foundry.Services.Settings;
+using Foundry.Services.Shell;
 using Serilog;
 
 namespace Foundry.ViewModels;
@@ -17,8 +21,15 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     private readonly IAppSettingsService appSettingsService;
     private readonly IAdkService adkService;
     private readonly IWinPeLanguageDiscoveryService languageDiscoveryService;
+    private readonly IWinPeEmbeddedAssetService embeddedAssetService;
+    private readonly IWinPeBuildService buildService;
+    private readonly IWinPeWorkspacePreparationService workspacePreparationService;
+    private readonly IWinPeIsoMediaService isoMediaService;
     private readonly IWinPeUsbMediaService usbMediaService;
     private readonly IExpertDeployConfigurationStateService expertDeployConfigurationStateService;
+    private readonly IOperationProgressService operationProgressService;
+    private readonly IShellNavigationGuardService shellNavigationGuardService;
+    private readonly IDialogService dialogService;
     private readonly IApplicationLocalizationService localizationService;
     private readonly IAppDispatcher appDispatcher;
     private readonly ILogger logger;
@@ -28,8 +39,15 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         IAppSettingsService appSettingsService,
         IAdkService adkService,
         IWinPeLanguageDiscoveryService languageDiscoveryService,
+        IWinPeEmbeddedAssetService embeddedAssetService,
+        IWinPeBuildService buildService,
+        IWinPeWorkspacePreparationService workspacePreparationService,
+        IWinPeIsoMediaService isoMediaService,
         IWinPeUsbMediaService usbMediaService,
         IExpertDeployConfigurationStateService expertDeployConfigurationStateService,
+        IOperationProgressService operationProgressService,
+        IShellNavigationGuardService shellNavigationGuardService,
+        IDialogService dialogService,
         IApplicationLocalizationService localizationService,
         IAppDispatcher appDispatcher,
         ILogger logger)
@@ -37,8 +55,15 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         this.appSettingsService = appSettingsService;
         this.adkService = adkService;
         this.languageDiscoveryService = languageDiscoveryService;
+        this.embeddedAssetService = embeddedAssetService;
+        this.buildService = buildService;
+        this.workspacePreparationService = workspacePreparationService;
+        this.isoMediaService = isoMediaService;
         this.usbMediaService = usbMediaService;
         this.expertDeployConfigurationStateService = expertDeployConfigurationStateService;
+        this.operationProgressService = operationProgressService;
+        this.shellNavigationGuardService = shellNavigationGuardService;
+        this.dialogService = dialogService;
         this.localizationService = localizationService;
         this.appDispatcher = appDispatcher;
         this.logger = logger.ForContext<StartMediaViewModel>();
@@ -114,6 +139,15 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     [ObservableProperty]
     public partial bool CanGenerateUsbSummary { get; set; }
+
+    [ObservableProperty]
+    public partial bool CanCreateIso { get; set; }
+
+    [ObservableProperty]
+    public partial bool CanCreateUsb { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsMediaOperationRunning { get; set; }
 
     [ObservableProperty]
     public partial string StatusSummary { get; set; } = string.Empty;
@@ -205,6 +239,301 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         }
     }
 
+    [RelayCommand]
+    private async Task CreateIsoAsync()
+    {
+        MediaPreflightOptions options = CreatePreflightOptions();
+        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(options);
+        if (!evaluation.CanCreateIso)
+        {
+            await ShowBlockedDialogAsync("StartMedia.CreateIso.BlockedTitle", evaluation.IsoBlockingReasons);
+            return;
+        }
+
+        await RunFinalMediaOperationAsync(FinalMediaTarget.Iso, options);
+    }
+
+    [RelayCommand]
+    private async Task CreateUsbAsync()
+    {
+        MediaPreflightOptions options = CreatePreflightOptions();
+        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(options);
+        if (!evaluation.CanCreateUsb || options.SelectedUsbDisk is null)
+        {
+            await ShowBlockedDialogAsync("StartMedia.CreateUsb.BlockedTitle", evaluation.UsbBlockingReasons);
+            return;
+        }
+
+        WinPeUsbDiskCandidate selectedDisk = options.SelectedUsbDisk;
+        bool confirmed = await dialogService.ConfirmAsync(new ConfirmationDialogRequest(
+            localizationService.GetString("StartMedia.CreateUsb.ConfirmTitle"),
+            string.Format(
+                localizationService.GetString("StartMedia.CreateUsb.ConfirmMessage"),
+                selectedDisk.DiskNumber,
+                selectedDisk.FriendlyName,
+                FormatByteSize(selectedDisk.SizeBytes)),
+            localizationService.GetString("StartMedia.CreateUsb.ConfirmPrimary"),
+            localizationService.GetString("Common.Cancel")));
+
+        if (!confirmed)
+        {
+            logger.Information(
+                "Final USB media creation cancelled before formatting. DiskNumber={DiskNumber}, DiskName={DiskName}",
+                selectedDisk.DiskNumber,
+                selectedDisk.FriendlyName);
+            return;
+        }
+
+        await RunFinalMediaOperationAsync(FinalMediaTarget.Usb, options);
+    }
+
+    private async Task RunFinalMediaOperationAsync(FinalMediaTarget target, MediaPreflightOptions options)
+    {
+        if (IsMediaOperationRunning)
+        {
+            return;
+        }
+
+        IsMediaOperationRunning = true;
+        RefreshEvaluation();
+        shellNavigationGuardService.SetState(ShellNavigationState.OperationRunning);
+        string terminalStatus = string.Empty;
+        string? failureMessage = null;
+
+        try
+        {
+            string startStatus = target == FinalMediaTarget.Iso
+                ? localizationService.GetString("StartMedia.Operation.CreatingIso")
+                : localizationService.GetString("StartMedia.Operation.CreatingUsb");
+
+            operationProgressService.Start(OperationKind.MediaCreation, startStatus);
+            logger.Information(
+                "Final media creation started. Target={Target}, Architecture={Architecture}, WinPeLanguage={WinPeLanguage}, IsoOutputPath={IsoOutputPath}, UsbDiskNumber={UsbDiskNumber}, UsbDiskName={UsbDiskName}",
+                target,
+                options.Architecture,
+                NormalizeCultureName(options.WinPeLanguage),
+                target == FinalMediaTarget.Iso ? options.IsoOutputPath : null,
+                target == FinalMediaTarget.Usb ? options.SelectedUsbDisk?.DiskNumber : null,
+                target == FinalMediaTarget.Usb ? options.SelectedUsbDisk?.FriendlyName : null);
+
+            if (target == FinalMediaTarget.Iso)
+            {
+                await CreateIsoMediaAsync(options, CancellationToken.None);
+            }
+            else
+            {
+                await CreateUsbMediaAsync(options, CancellationToken.None);
+            }
+
+            terminalStatus = localizationService.GetString("StartMedia.Operation.Completed");
+            operationProgressService.Complete(terminalStatus);
+            logger.Information("Final media creation completed. Target={Target}", target);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            terminalStatus = localizationService.GetString("StartMedia.Operation.Failed");
+            operationProgressService.Report(100, terminalStatus);
+            failureMessage = ex.Message;
+            logger.Error(ex, "Final media creation failed. Target={Target}", target);
+        }
+        finally
+        {
+            shellNavigationGuardService.SetState(adkService.CurrentStatus.CanCreateMedia
+                ? ShellNavigationState.Ready
+                : ShellNavigationState.AdkBlocked);
+            operationProgressService.Reset(terminalStatus);
+            IsMediaOperationRunning = false;
+            RefreshEvaluation();
+        }
+
+        if (!string.IsNullOrWhiteSpace(failureMessage))
+        {
+            await dialogService.ShowMessageAsync(new DialogRequest(
+                localizationService.GetString("StartMedia.Operation.FailedTitle"),
+                failureMessage,
+                localizationService.GetString("Common.Close")));
+        }
+    }
+
+    private async Task CreateIsoMediaAsync(MediaPreflightOptions options, CancellationToken cancellationToken)
+    {
+        PreparedMediaWorkspace workspace = await PrepareMediaWorkspaceAsync(
+            options,
+            includeRuntimePayloadInImage: true,
+            cancellationToken);
+
+        operationProgressService.Report(90, localizationService.GetString("StartMedia.Operation.CreatingIso"));
+        WinPeResult result = await isoMediaService.CreateAsync(
+            new WinPeIsoMediaOptions
+            {
+                PreparedWorkspace = workspace.PreparedWorkspace,
+                OutputIsoPath = options.IsoOutputPath,
+                IsoTempDirectoryPath = Path.Combine(Constants.TempDirectoryPath, "Iso")
+            },
+            cancellationToken);
+
+        EnsureSuccess(result);
+    }
+
+    private async Task CreateUsbMediaAsync(MediaPreflightOptions options, CancellationToken cancellationToken)
+    {
+        if (options.SelectedUsbDisk is null)
+        {
+            throw new InvalidOperationException(localizationService.GetString("StartMedia.BlockingReason.NoUsbTarget"));
+        }
+
+        PreparedMediaWorkspace workspace = await PrepareMediaWorkspaceAsync(
+            options,
+            includeRuntimePayloadInImage: false,
+            cancellationToken);
+
+        WinPeUsbDiskCandidate selectedDisk = options.SelectedUsbDisk;
+        operationProgressService.Report(90, localizationService.GetString("StartMedia.Operation.CreatingUsb"));
+        WinPeResult<WinPeUsbProvisionResult> result = await usbMediaService.ProvisionAndPopulateAsync(
+            new UsbOutputOptions
+            {
+                TargetDiskNumber = selectedDisk.DiskNumber,
+                ExpectedDiskFriendlyName = selectedDisk.FriendlyName,
+                ExpectedDiskSerialNumber = selectedDisk.SerialNumber,
+                ExpectedDiskUniqueId = selectedDisk.UniqueId,
+                PartitionStyle = options.UsbPartitionStyle,
+                FormatMode = options.UsbFormatMode,
+                RuntimePayloadProvisioning = workspace.RuntimePayloadProvisioning
+            },
+            workspace.PreparedWorkspace.Artifact,
+            workspace.Tools,
+            workspace.PreparedWorkspace.UseBootEx,
+            cancellationToken);
+
+        EnsureSuccess(result);
+    }
+
+    private async Task<PreparedMediaWorkspace> PrepareMediaWorkspaceAsync(
+        MediaPreflightOptions options,
+        bool includeRuntimePayloadInImage,
+        CancellationToken cancellationToken)
+    {
+        WinPeToolPaths tools = ResolveWinPeToolsOrThrow();
+        WinPeRuntimePayloadProvisioningOptions runtimePayloadProvisioning = CreateRuntimePayloadProvisioningOptions(
+            options.Architecture,
+            Constants.WinPeWorkspaceDirectoryPath,
+            Constants.WinPeWorkspaceDirectoryPath,
+            Constants.WinPeWorkspaceDirectoryPath);
+
+        operationProgressService.Report(10, localizationService.GetString("StartMedia.Operation.BuildingWorkspace"));
+        WinPeResult<WinPeBuildArtifact> buildResult = await buildService.BuildAsync(
+            new WinPeBuildOptions
+            {
+                OutputDirectoryPath = Constants.WinPeWorkspaceDirectoryPath,
+                AdkRootPath = tools.KitsRootPath,
+                Architecture = options.Architecture,
+                SignatureMode = options.SignatureMode
+            },
+            cancellationToken);
+        EnsureSuccess(buildResult);
+
+        WinPeBuildArtifact artifact = buildResult.Value!;
+        FoundryConnectProvisioningBundle connectBundle = expertDeployConfigurationStateService.GenerateConnectProvisioningBundle(
+            Path.Combine(artifact.WorkingDirectoryPath, "Provisioning"));
+
+        WinPeRuntimePayloadProvisioningOptions artifactRuntimePayloadProvisioning = runtimePayloadProvisioning with
+        {
+            WorkingDirectoryPath = artifact.WorkingDirectoryPath,
+            MountedImagePath = artifact.MountDirectoryPath,
+            UsbCacheRootPath = string.Empty
+        };
+
+        operationProgressService.Report(25, localizationService.GetString("StartMedia.Operation.PreparingWorkspace"));
+        WinPeResult<WinPeWorkspacePreparationResult> preparationResult = await workspacePreparationService.PrepareAsync(
+            new WinPeWorkspacePreparationOptions
+            {
+                Artifact = artifact,
+                Tools = tools,
+                SignatureMode = options.SignatureMode,
+                BootImageSource = options.BootImageSource,
+                DriverCatalogUri = new WinPeDriverCatalogOptions().CatalogUri,
+                DriverVendors = options.DriverVendors,
+                CustomDriverDirectoryPath = options.CustomDriverDirectoryPath,
+                WinPeLanguage = options.WinPeLanguage,
+                AssetProvisioning = CreateAssetProvisioningOptions(options, connectBundle),
+                RuntimePayloadProvisioning = includeRuntimePayloadInImage ? artifactRuntimePayloadProvisioning : null,
+                WinReCacheDirectoryPath = Constants.WinReTempDirectoryPath,
+                Progress = new Progress<WinPeWorkspacePreparationStage>(ReportWorkspacePreparationStage),
+                CustomizationProgress = new Progress<WinPeMountedImageCustomizationProgress>(ReportCustomizationProgress)
+            },
+            cancellationToken);
+        EnsureSuccess(preparationResult);
+
+        return new PreparedMediaWorkspace(
+            preparationResult.Value!,
+            tools,
+            artifactRuntimePayloadProvisioning with
+            {
+                MountedImagePath = string.Empty,
+                UsbCacheRootPath = string.Empty
+            });
+    }
+
+    private WinPeMountedImageAssetProvisioningOptions CreateAssetProvisioningOptions(
+        MediaPreflightOptions options,
+        FoundryConnectProvisioningBundle connectBundle)
+    {
+        return new WinPeMountedImageAssetProvisioningOptions
+        {
+            BootstrapScriptContent = embeddedAssetService.GetBootstrapScriptContent(),
+            CurlExecutableSourcePath = ResolveCurlExecutablePath(),
+            SevenZipSourceDirectoryPath = embeddedAssetService.GetSevenZipSourceDirectoryPath(),
+            IanaWindowsTimeZoneMapJson = embeddedAssetService.GetIanaWindowsTimeZoneMapJson(),
+            FoundryConnectConfigurationJson = connectBundle.ConfigurationJson,
+            ExpertDeployConfigurationJson = expertDeployConfigurationStateService.GenerateDeployConfigurationJson(),
+            MediaSecretsKey = connectBundle.MediaSecretsKey,
+            FoundryConnectAssetFiles = connectBundle.AssetFiles,
+            AutopilotProfiles = options.IsAutopilotEnabled
+                ? expertDeployConfigurationStateService.Current.Autopilot.Profiles
+                : [],
+            ConnectProvisioningSource = WinPeProvisioningSource.Local,
+            DeployProvisioningSource = WinPeProvisioningSource.Local
+        };
+    }
+
+    private void ReportWorkspacePreparationStage(WinPeWorkspacePreparationStage stage)
+    {
+        int progress = stage switch
+        {
+            WinPeWorkspacePreparationStage.ResolvingDrivers => 35,
+            WinPeWorkspacePreparationStage.CustomizingImage => 45,
+            WinPeWorkspacePreparationStage.EvaluatingSignaturePolicy => 85,
+            _ => 45
+        };
+
+        operationProgressService.Report(progress, localizationService.GetString("StartMedia.Operation.PreparingWorkspace"));
+    }
+
+    private void ReportCustomizationProgress(WinPeMountedImageCustomizationProgress progress)
+    {
+        int normalizedProgress = Math.Clamp(45 + (progress.Percent * 35 / 100), 45, 80);
+        string status = string.IsNullOrWhiteSpace(progress.Status)
+            ? localizationService.GetString("StartMedia.Operation.PreparingWorkspace")
+            : progress.Status;
+
+        operationProgressService.Report(normalizedProgress, status);
+    }
+
+    private async Task ShowBlockedDialogAsync(
+        string titleResourceKey,
+        IReadOnlyList<MediaPreflightBlockingReason> blockingReasons)
+    {
+        IReadOnlyList<MediaPreflightBlockingReason> reasons = blockingReasons.Distinct().ToList();
+        string message = reasons.Count == 0
+            ? localizationService.GetString("StartMedia.Operation.Failed")
+            : string.Join(Environment.NewLine, reasons.Select(reason => $"- {GetBlockingReasonText(reason)}"));
+
+        await dialogService.ShowMessageAsync(new DialogRequest(
+            localizationService.GetString(titleResourceKey),
+            message,
+            localizationService.GetString("Common.Close")));
+    }
+
     partial void OnSelectedUsbDiskChanged(SelectionOption<WinPeUsbDiskCandidate>? value)
     {
         RefreshEvaluation();
@@ -244,7 +573,6 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     private void ApplyLocalizedText()
     {
         PageTitle = localizationService.GetString("StartPage_Title.Text");
-        FinalExecutionStatus = localizationService.GetString("StartMedia.FinalExecution.Deferred");
         RebuildFormatModes();
         RebuildUsbCandidateDisplayNames();
     }
@@ -258,6 +586,11 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(options);
         CanGenerateIsoSummary = evaluation.CanGenerateIsoSummary;
         CanGenerateUsbSummary = evaluation.CanGenerateUsbSummary;
+        CanCreateIso = evaluation.CanCreateIso && !IsMediaOperationRunning;
+        CanCreateUsb = evaluation.CanCreateUsb && !IsMediaOperationRunning;
+        FinalExecutionStatus = options.IsFinalExecutionEnabled
+            ? localizationService.GetString("StartMedia.FinalExecution.Ready")
+            : localizationService.GetString("StartMedia.FinalExecution.Deferred");
         StatusSummary = BuildStatusText(evaluation);
         GlobalSummary = BuildGlobalSummary(options, evaluation);
 
@@ -288,10 +621,19 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             vendors.Add(WinPeVendorSelection.Hp);
         }
 
+        RuntimePayloadReadiness runtimeReadiness = EvaluateRuntimePayloadReadiness(
+            CreateRuntimePayloadProvisioningOptions(
+                SelectedArchitecture?.Value ?? WinPeArchitecture.X64,
+                Constants.WinPeWorkspaceDirectoryPath,
+                Constants.WinPeWorkspaceDirectoryPath,
+                Constants.WinPeWorkspaceDirectoryPath));
+
         return new MediaPreflightOptions
         {
             IsAdkReady = adkService.CurrentStatus.CanCreateMedia,
-            IsRuntimePayloadReady = false,
+            IsRuntimePayloadReady = runtimeReadiness.IsReady,
+            IsConnectRuntimePayloadReady = runtimeReadiness.IsConnectReady,
+            IsDeployRuntimePayloadReady = runtimeReadiness.IsDeployReady,
             IsNetworkConfigurationReady = expertDeployConfigurationStateService.IsNetworkConfigurationReady,
             IsDeployConfigurationReady = expertDeployConfigurationStateService.IsDeployConfigurationReady,
             IsConnectProvisioningReady = expertDeployConfigurationStateService.IsConnectProvisioningReady,
@@ -300,7 +642,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             IsAutopilotConfigurationReady = expertDeployConfigurationStateService.IsAutopilotConfigurationReady,
             AutopilotProfileDisplayName = expertDeployConfigurationStateService.SelectedAutopilotProfileDisplayName,
             AutopilotProfileFolderName = expertDeployConfigurationStateService.SelectedAutopilotProfileFolderName,
-            IsFinalExecutionEnabled = false,
+            IsFinalExecutionEnabled = true,
             IsoOutputPath = IsoOutputPath,
             Architecture = SelectedArchitecture?.Value ?? WinPeArchitecture.X64,
             SignatureMode = UseCa2023Signature ? WinPeSignatureMode.Pca2023 : WinPeSignatureMode.Pca2011,
@@ -345,7 +687,9 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Secrets")}: {FormatReady(options.AreRequiredSecretsReady)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Autopilot")}: {FormatAutopilot(options)}");
         builder.AppendLine();
-        builder.AppendLine(localizationService.GetString("StartMedia.FinalExecution.Deferred"));
+        builder.AppendLine(options.IsFinalExecutionEnabled
+            ? localizationService.GetString("StartMedia.FinalExecution.Ready")
+            : localizationService.GetString("StartMedia.FinalExecution.Deferred"));
 
         AppendBlockingReasons(builder, reasons);
 
@@ -590,6 +934,98 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         return $"{size:0.#} {units[unitIndex]}";
     }
 
+    private WinPeToolPaths ResolveWinPeToolsOrThrow()
+    {
+        WinPeResult<WinPeToolPaths> result = new WinPeToolResolver().ResolveTools(adkService.CurrentStatus.KitsRootPath);
+        EnsureSuccess(result);
+        return result.Value!;
+    }
+
+    private WinPeRuntimePayloadProvisioningOptions CreateRuntimePayloadProvisioningOptions(
+        WinPeArchitecture architecture,
+        string workingDirectoryPath,
+        string mountedImagePath,
+        string usbCacheRootPath)
+    {
+        return WinPeRuntimePayloadProvisioningOptions.CreateDeveloperOptions(
+            architecture,
+            workingDirectoryPath,
+            mountedImagePath,
+            usbCacheRootPath,
+            Debugger.IsAttached,
+            projectDiscoveryStartPath: FindRepositoryRoot());
+    }
+
+    private static RuntimePayloadReadiness EvaluateRuntimePayloadReadiness(WinPeRuntimePayloadProvisioningOptions options)
+    {
+        bool connectReady = IsRuntimeApplicationReady(options.Connect);
+        bool deployReady = IsRuntimeApplicationReady(options.Deploy);
+        return new RuntimePayloadReadiness(connectReady, deployReady);
+    }
+
+    private static bool IsRuntimeApplicationReady(WinPeRuntimePayloadApplicationOptions options)
+    {
+        if (!options.IsEnabled)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.ArchivePath))
+        {
+            return File.Exists(options.ArchivePath);
+        }
+
+        return !string.IsNullOrWhiteSpace(options.ProjectPath) && File.Exists(options.ProjectPath);
+    }
+
+    private static string ResolveCurlExecutablePath()
+    {
+        string systemCurlPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.System),
+            "curl.exe");
+
+        return File.Exists(systemCurlPath) ? systemCurlPath : "curl.exe";
+    }
+
+    private static string? FindRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "src", "Foundry.Connect", "Foundry.Connect.csproj")) &&
+                File.Exists(Path.Combine(current.FullName, "src", "Foundry.Deploy", "Foundry.Deploy.csproj")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        return null;
+    }
+
+    private static void EnsureSuccess(WinPeResult result)
+    {
+        if (result.IsSuccess)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(FormatWinPeError(result.Error));
+    }
+
+    private static string FormatWinPeError(WinPeDiagnostic? diagnostic)
+    {
+        if (diagnostic is null)
+        {
+            return "WinPE operation failed.";
+        }
+
+        return string.IsNullOrWhiteSpace(diagnostic.Details)
+            ? diagnostic.Message
+            : $"{diagnostic.Message}{Environment.NewLine}{diagnostic.Details}";
+    }
+
     private static T ParseEnum<T>(string? value, T fallback)
         where T : struct, Enum
     {
@@ -600,4 +1036,20 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     {
         return options.FirstOrDefault(option => EqualityComparer<T>.Default.Equals(option.Value, value));
     }
+
+    private enum FinalMediaTarget
+    {
+        Iso,
+        Usb
+    }
+
+    private sealed record RuntimePayloadReadiness(bool IsConnectReady, bool IsDeployReady)
+    {
+        public bool IsReady => IsConnectReady && IsDeployReady;
+    }
+
+    private sealed record PreparedMediaWorkspace(
+        WinPeWorkspacePreparationResult PreparedWorkspace,
+        WinPeToolPaths Tools,
+        WinPeRuntimePayloadProvisioningOptions RuntimePayloadProvisioning);
 }

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -299,6 +299,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         shellNavigationGuardService.SetState(ShellNavigationState.OperationRunning);
         string terminalStatus = string.Empty;
         string? failureMessage = null;
+        string? successMessage = null;
 
         try
         {
@@ -318,11 +319,20 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
             if (target == FinalMediaTarget.Iso)
             {
-                await CreateIsoMediaAsync(options, CancellationToken.None);
+                string isoOutputPath = await CreateIsoMediaAsync(options, CancellationToken.None);
+                successMessage = string.Format(
+                    CultureInfo.CurrentCulture,
+                    localizationService.GetString("StartMedia.Operation.IsoSuccessMessage"),
+                    isoOutputPath);
             }
             else
             {
-                await CreateUsbMediaAsync(options, CancellationToken.None);
+                WinPeUsbProvisionResult usbResult = await CreateUsbMediaAsync(options, CancellationToken.None);
+                successMessage = string.Format(
+                    CultureInfo.CurrentCulture,
+                    localizationService.GetString("StartMedia.Operation.UsbSuccessMessage"),
+                    usbResult.BootDriveLetter,
+                    usbResult.CacheDriveLetter);
             }
 
             terminalStatus = localizationService.GetString("StartMedia.Operation.Completed");
@@ -353,9 +363,16 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 failureMessage,
                 localizationService.GetString("Common.Close")));
         }
+        else if (!string.IsNullOrWhiteSpace(successMessage))
+        {
+            await dialogService.ShowMessageAsync(new DialogRequest(
+                localizationService.GetString("StartMedia.Operation.SuccessTitle"),
+                successMessage,
+                localizationService.GetString("Common.Close")));
+        }
     }
 
-    private async Task CreateIsoMediaAsync(MediaPreflightOptions options, CancellationToken cancellationToken)
+    private async Task<string> CreateIsoMediaAsync(MediaPreflightOptions options, CancellationToken cancellationToken)
     {
         PreparedMediaWorkspace? workspace = null;
 
@@ -366,7 +383,6 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 includeRuntimePayloadInImage: true,
                 cancellationToken);
 
-            operationProgressService.Report(90, localizationService.GetString("StartMedia.Operation.CreatingIso"));
             logger.Debug(
                 "Creating ISO media. OutputIsoPath={OutputIsoPath}, MediaDirectoryPath={MediaDirectoryPath}, UseBootEx={UseBootEx}",
                 options.IsoOutputPath,
@@ -378,12 +394,14 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 {
                     PreparedWorkspace = workspace.PreparedWorkspace,
                     OutputIsoPath = options.IsoOutputPath,
-                    IsoTempDirectoryPath = Path.Combine(Constants.TempDirectoryPath, "Iso")
+                    IsoTempDirectoryPath = Path.Combine(Constants.TempDirectoryPath, "Iso"),
+                    Progress = new Progress<WinPeMediaProgress>(ReportFinalMediaProgress)
                 },
                 cancellationToken);
 
             EnsureSuccess(result);
             logger.Debug("ISO media service completed. OutputIsoPath={OutputIsoPath}", options.IsoOutputPath);
+            return options.IsoOutputPath;
         }
         finally
         {
@@ -391,7 +409,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         }
     }
 
-    private async Task CreateUsbMediaAsync(MediaPreflightOptions options, CancellationToken cancellationToken)
+    private async Task<WinPeUsbProvisionResult> CreateUsbMediaAsync(MediaPreflightOptions options, CancellationToken cancellationToken)
     {
         if (options.SelectedUsbDisk is null)
         {
@@ -408,7 +426,6 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 cancellationToken);
 
             WinPeUsbDiskCandidate selectedDisk = options.SelectedUsbDisk;
-            operationProgressService.Report(90, localizationService.GetString("StartMedia.Operation.CreatingUsb"));
             logger.Debug(
                 "Creating USB media. DiskNumber={DiskNumber}, DiskName={DiskName}, PartitionStyle={PartitionStyle}, FormatMode={FormatMode}, MediaDirectoryPath={MediaDirectoryPath}, UseBootEx={UseBootEx}",
                 selectedDisk.DiskNumber,
@@ -427,7 +444,8 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                     ExpectedDiskUniqueId = selectedDisk.UniqueId,
                     PartitionStyle = options.UsbPartitionStyle,
                     FormatMode = options.UsbFormatMode,
-                    RuntimePayloadProvisioning = workspace.RuntimePayloadProvisioning
+                    RuntimePayloadProvisioning = workspace.RuntimePayloadProvisioning,
+                    Progress = new Progress<WinPeMediaProgress>(ReportFinalMediaProgress)
                 },
                 workspace.PreparedWorkspace.Artifact,
                 workspace.Tools,
@@ -440,6 +458,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 selectedDisk.DiskNumber,
                 result.Value?.BootDriveLetter,
                 result.Value?.CacheDriveLetter);
+            return result.Value!;
         }
         finally
         {
@@ -536,6 +555,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                     RuntimePayloadProvisioning = includeRuntimePayloadInImage ? artifactRuntimePayloadProvisioning : null,
                     WinReCacheDirectoryPath = Constants.WinReTempDirectoryPath,
                     Progress = new Progress<WinPeWorkspacePreparationStage>(ReportWorkspacePreparationStage),
+                    DownloadProgress = new Progress<WinPeDownloadProgress>(ReportDownloadProgress),
                     CustomizationProgress = new Progress<WinPeMountedImageCustomizationProgress>(ReportCustomizationProgress)
                 },
                 cancellationToken);
@@ -588,10 +608,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     {
         int progress = stage switch
         {
-            WinPeWorkspacePreparationStage.ResolvingDrivers => 35,
-            WinPeWorkspacePreparationStage.CustomizingImage => 45,
-            WinPeWorkspacePreparationStage.EvaluatingSignaturePolicy => 85,
-            _ => 45
+            WinPeWorkspacePreparationStage.ResolvingDrivers => 30,
+            WinPeWorkspacePreparationStage.CustomizingImage => 35,
+            WinPeWorkspacePreparationStage.EvaluatingSignaturePolicy => 84,
+            _ => 35
         };
 
         string statusResourceKey = stage switch
@@ -608,13 +628,45 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private void ReportCustomizationProgress(WinPeMountedImageCustomizationProgress progress)
     {
-        int normalizedProgress = Math.Clamp(45 + (progress.Percent * 35 / 100), 45, 80);
+        int normalizedProgress = Math.Clamp(35 + (progress.Percent * 47 / 100), 35, 82);
         string status = string.IsNullOrWhiteSpace(progress.Status)
             ? localizationService.GetString("StartMedia.Operation.PreparingWorkspace")
             : LocalizeCustomizationStatus(progress.Status);
 
         logger.Debug(
             "WinPE image customization progress changed. CoreStatus={CoreStatus}, Percent={Percent}, NormalizedProgress={NormalizedProgress}",
+            progress.Status,
+            progress.Percent,
+            normalizedProgress);
+        operationProgressService.Report(normalizedProgress, status);
+    }
+
+    private void ReportDownloadProgress(WinPeDownloadProgress progress)
+    {
+        string status = string.IsNullOrWhiteSpace(progress.Status)
+            ? localizationService.GetString("StartMedia.Operation.Downloading")
+            : LocalizeDownloadStatus(progress.Status);
+
+        logger.Debug(
+            "Final media download progress changed. DownloadStatus={DownloadStatus}, DownloadPercent={DownloadPercent}",
+            progress.Status,
+            progress.Percent);
+        operationProgressService.Report(
+            operationProgressService.State.Progress,
+            operationProgressService.State.Status,
+            progress.Percent,
+            status);
+    }
+
+    private void ReportFinalMediaProgress(WinPeMediaProgress progress)
+    {
+        int normalizedProgress = Math.Clamp(88 + (progress.Percent * 10 / 100), 88, 98);
+        string status = string.IsNullOrWhiteSpace(progress.Status)
+            ? localizationService.GetString("StartMedia.Operation.CreatingIso")
+            : LocalizeFinalMediaStatus(progress.Status);
+
+        logger.Debug(
+            "Final media output progress changed. CoreStatus={CoreStatus}, Percent={Percent}, NormalizedProgress={NormalizedProgress}",
             progress.Status,
             progress.Percent,
             normalizedProgress);
@@ -633,6 +685,68 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             "Provisioning Foundry runtime payloads." => "StartMedia.Operation.ProvisioningRuntimePayloads",
             "Committing image changes." => "StartMedia.Operation.CommittingImageChanges",
             "Image customization completed." => "StartMedia.Operation.ImageCustomizationCompleted",
+            "Resolving WinRE source catalog." => "StartMedia.Operation.ResolvingWinReSourceCatalog",
+            "Selected WinRE source package." => "StartMedia.Operation.SelectedWinReSourcePackage",
+            "Preparing WinRE source package." => "StartMedia.Operation.PreparingWinReSourcePackage",
+            "Validating cached WinRE source package." => "StartMedia.Operation.ValidatingCachedWinReSourcePackage",
+            "Using cached WinRE source package." => "StartMedia.Operation.UsingCachedWinReSourcePackage",
+            "Downloading WinRE source package." => "StartMedia.Operation.DownloadingWinReSourcePackage",
+            "Validating WinRE source package." => "StartMedia.Operation.ValidatingWinReSourcePackage",
+            "Resolving WinRE image index." => "StartMedia.Operation.ResolvingWinReImageIndex",
+            "Exporting Windows image for WinRE extraction." => "StartMedia.Operation.ExportingWinReSourceImage",
+            "Mounting WinRE source image." => "StartMedia.Operation.MountingWinReSourceImage",
+            "Staging WinRE Wi-Fi dependencies." => "StartMedia.Operation.StagingWinReWifiDependencies",
+            "Replacing boot image with WinRE." => "StartMedia.Operation.ReplacingBootImageWithWinRe",
+            "WinRE Wi-Fi boot image is ready." => "StartMedia.Operation.WinReWifiBootImageReady",
+            _ => string.Empty
+        };
+
+        return string.IsNullOrWhiteSpace(resourceKey)
+            ? status
+            : localizationService.GetString(resourceKey);
+    }
+
+    private string LocalizeDownloadStatus(string status)
+    {
+        if (status.StartsWith("Downloading WinRE source package", StringComparison.Ordinal))
+        {
+            int suffixIndex = status.IndexOf('(', StringComparison.Ordinal);
+            string suffix = suffixIndex >= 0
+                ? $" {status[suffixIndex..]}"
+                : string.Empty;
+            return localizationService.GetString("StartMedia.Operation.DownloadingWinReSourcePackage") + suffix;
+        }
+
+        if (status.StartsWith("Downloading driver package", StringComparison.Ordinal))
+        {
+            int suffixIndex = status.IndexOf(':', StringComparison.Ordinal);
+            string suffix = suffixIndex >= 0
+                ? status[suffixIndex..]
+                : string.Empty;
+            return localizationService.GetString("StartMedia.Operation.DownloadingDriverPackage") + suffix;
+        }
+
+        return status;
+    }
+
+    private string LocalizeFinalMediaStatus(string status)
+    {
+        string resourceKey = status switch
+        {
+            "Preparing ISO output path." => "StartMedia.Operation.PreparingIsoOutput",
+            "Preparing ISO workspace." => "StartMedia.Operation.PreparingIsoWorkspace",
+            "Running MakeWinPEMedia for ISO." => "StartMedia.Operation.RunningMakeWinPeMediaIso",
+            "Finalizing ISO output." => "StartMedia.Operation.FinalizingIsoOutput",
+            "ISO media completed." => "StartMedia.Operation.IsoMediaCompleted",
+            "Validating USB target." => "StartMedia.Operation.ValidatingUsbTarget",
+            "Checking USB target safety." => "StartMedia.Operation.CheckingUsbTargetSafety",
+            "Partitioning and formatting USB target." => "StartMedia.Operation.PartitioningUsbTarget",
+            "Copying WinPE media to USB." => "StartMedia.Operation.CopyingUsbMedia",
+            "Configuring USB boot files." => "StartMedia.Operation.ConfiguringUsbBootFiles",
+            "Verifying USB boot media." => "StartMedia.Operation.VerifyingUsbMedia",
+            "Preparing USB cache partition." => "StartMedia.Operation.PreparingUsbCache",
+            "Provisioning USB runtime payloads." => "StartMedia.Operation.ProvisioningUsbRuntimePayloads",
+            "USB media completed." => "StartMedia.Operation.UsbMediaCompleted",
             _ => string.Empty
         };
 
@@ -704,7 +818,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         {
             if (reportProgress)
             {
-                operationProgressService.Report(95, localizationService.GetString("StartMedia.Operation.CleaningWorkspace"));
+                operationProgressService.Report(99, localizationService.GetString("StartMedia.Operation.CleaningWorkspace"));
             }
 
             logger.Debug("Cleaning WinPE workspace. WorkspacePath={WorkspacePath}", workspacePath);
@@ -866,7 +980,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             UsbFormatMode = SelectedFormatMode?.Value ?? UsbFormatMode.Quick,
             WinPeLanguage = WinPeLanguage,
             AvailableWinPeLanguages = availableWinPeLanguages,
-            BootImageSource = WinPeBootImageSource.WinPe,
+            BootImageSource = ResolveBootImageSource(),
             DriverVendors = vendors,
             CustomDriverDirectoryPath = CustomDriverDirectoryPath,
             SelectedUsbDisk = SelectedUsbDisk?.Value
@@ -889,6 +1003,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         var builder = new StringBuilder();
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Adk")}: {FormatReady(adkService.CurrentStatus.CanCreateMedia)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.WinPeLanguage")}: {FormatValue(NormalizeCultureName(options.WinPeLanguage))}");
+        builder.AppendLine($"{localizationService.GetString("StartMedia.Field.BootImageSource")}: {FormatBootImageSource(options.BootImageSource)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.Architecture")}: {FormatArchitecture(options.Architecture)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.IsoPath")}: {FormatValue(options.IsoOutputPath)}");
         builder.AppendLine($"{localizationService.GetString("StartMedia.Field.UsbTarget")}: {FormatUsbCandidate(options.SelectedUsbDisk)}");
@@ -1119,6 +1234,11 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         return localizationService.GetString($"StartMedia.SignatureMode.{signatureMode}");
     }
 
+    private string FormatBootImageSource(WinPeBootImageSource bootImageSource)
+    {
+        return localizationService.GetString($"StartMedia.BootImageSource.{bootImageSource}");
+    }
+
     private string FormatUsbFormatMode(UsbFormatMode formatMode)
     {
         return localizationService.GetString($"StartMedia.FormatMode.{formatMode}");
@@ -1155,6 +1275,14 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         WinPeResult<WinPeToolPaths> result = new WinPeToolResolver().ResolveTools(adkService.CurrentStatus.KitsRootPath);
         EnsureSuccess(result);
         return result.Value!;
+    }
+
+    private WinPeBootImageSource ResolveBootImageSource()
+    {
+        NetworkSettings network = expertDeployConfigurationStateService.Current.Network;
+        return network.WifiProvisioned || network.Wifi.IsEnabled
+            ? WinPeBootImageSource.WinReWifi
+            : WinPeBootImageSource.WinPe;
     }
 
     private WinPeRuntimePayloadProvisioningOptions CreateRuntimePayloadProvisioningOptions(

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -319,11 +319,8 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
             if (target == FinalMediaTarget.Iso)
             {
-                string isoOutputPath = await CreateIsoMediaAsync(options, CancellationToken.None);
-                successMessage = string.Format(
-                    CultureInfo.CurrentCulture,
-                    localizationService.GetString("StartMedia.Operation.IsoSuccessMessage"),
-                    isoOutputPath);
+                _ = await CreateIsoMediaAsync(options, CancellationToken.None);
+                successMessage = localizationService.GetString("StartMedia.Operation.IsoSuccessMessage");
             }
             else
             {
@@ -634,10 +631,23 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             : LocalizeCustomizationStatus(progress.Status);
 
         logger.Debug(
-            "WinPE image customization progress changed. CoreStatus={CoreStatus}, Percent={Percent}, NormalizedProgress={NormalizedProgress}",
+            "WinPE image customization progress changed. CoreStatus={CoreStatus}, Percent={Percent}, NormalizedProgress={NormalizedProgress}, DetailStatus={DetailStatus}, DetailPercent={DetailPercent}",
             progress.Status,
             progress.Percent,
-            normalizedProgress);
+            normalizedProgress,
+            progress.DetailStatus,
+            progress.DetailPercent);
+
+        if (progress.DetailPercent.HasValue || !string.IsNullOrWhiteSpace(progress.DetailStatus))
+        {
+            operationProgressService.Report(
+                normalizedProgress,
+                status,
+                progress.DetailPercent,
+                LocalizeDismProgressStatus(progress.DetailStatus));
+            return;
+        }
+
         operationProgressService.Report(normalizedProgress, status);
     }
 
@@ -727,6 +737,26 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         }
 
         return status;
+    }
+
+    private string LocalizeDismProgressStatus(string status)
+    {
+        string resourceKey = status switch
+        {
+            "Exporting Windows image with DISM." => "StartMedia.Operation.DismExportingWindowsImage",
+            "Resolving WinRE image index with DISM." => "StartMedia.Operation.DismResolvingWinReImageIndex",
+            "Mounting image with DISM." => "StartMedia.Operation.DismMountingImage",
+            "Injecting drivers with DISM." => "StartMedia.Operation.DismInjectingDrivers",
+            "Applying language pack with DISM." => "StartMedia.Operation.DismApplyingLanguagePack",
+            "Applying optional components with DISM." => "StartMedia.Operation.DismApplyingOptionalComponents",
+            "Applying international settings with DISM." => "StartMedia.Operation.DismApplyingInternationalSettings",
+            "Committing image changes with DISM." => "StartMedia.Operation.DismCommittingImageChanges",
+            _ => string.Empty
+        };
+
+        return string.IsNullOrWhiteSpace(resourceKey)
+            ? status
+            : localizationService.GetString(resourceKey);
     }
 
     private string LocalizeFinalMediaStatus(string status)

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -212,13 +212,13 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 Constants.UsbQueryTempDirectoryPath,
                 CancellationToken.None);
 
-                UsbCandidates.Clear();
-                if (result.IsSuccess && result.Value is not null)
+            UsbCandidates.Clear();
+            if (result.IsSuccess && result.Value is not null)
+            {
+                foreach (WinPeUsbDiskCandidate candidate in result.Value)
                 {
-                    foreach (WinPeUsbDiskCandidate candidate in result.Value)
-                    {
                     UsbCandidates.Add(CreateUsbDiskOption(candidate));
-                    }
+                }
 
                 SelectedUsbDisk = UsbCandidates.FirstOrDefault(option => option.Value.DiskNumber == SelectedUsbDisk?.Value.DiskNumber)
                     ?? UsbCandidates.FirstOrDefault();
@@ -357,22 +357,38 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private async Task CreateIsoMediaAsync(MediaPreflightOptions options, CancellationToken cancellationToken)
     {
-        PreparedMediaWorkspace workspace = await PrepareMediaWorkspaceAsync(
-            options,
-            includeRuntimePayloadInImage: true,
-            cancellationToken);
+        PreparedMediaWorkspace? workspace = null;
 
-        operationProgressService.Report(90, localizationService.GetString("StartMedia.Operation.CreatingIso"));
-        WinPeResult result = await isoMediaService.CreateAsync(
-            new WinPeIsoMediaOptions
-            {
-                PreparedWorkspace = workspace.PreparedWorkspace,
-                OutputIsoPath = options.IsoOutputPath,
-                IsoTempDirectoryPath = Path.Combine(Constants.TempDirectoryPath, "Iso")
-            },
-            cancellationToken);
+        try
+        {
+            workspace = await PrepareMediaWorkspaceAsync(
+                options,
+                includeRuntimePayloadInImage: true,
+                cancellationToken);
 
-        EnsureSuccess(result);
+            operationProgressService.Report(90, localizationService.GetString("StartMedia.Operation.CreatingIso"));
+            logger.Debug(
+                "Creating ISO media. OutputIsoPath={OutputIsoPath}, MediaDirectoryPath={MediaDirectoryPath}, UseBootEx={UseBootEx}",
+                options.IsoOutputPath,
+                workspace.PreparedWorkspace.Artifact.MediaDirectoryPath,
+                workspace.PreparedWorkspace.UseBootEx);
+
+            WinPeResult result = await isoMediaService.CreateAsync(
+                new WinPeIsoMediaOptions
+                {
+                    PreparedWorkspace = workspace.PreparedWorkspace,
+                    OutputIsoPath = options.IsoOutputPath,
+                    IsoTempDirectoryPath = Path.Combine(Constants.TempDirectoryPath, "Iso")
+                },
+                cancellationToken);
+
+            EnsureSuccess(result);
+            logger.Debug("ISO media service completed. OutputIsoPath={OutputIsoPath}", options.IsoOutputPath);
+        }
+        finally
+        {
+            CleanupPreparedWorkspace(workspace?.PreparedWorkspace.Artifact.WorkingDirectoryPath);
+        }
     }
 
     private async Task CreateUsbMediaAsync(MediaPreflightOptions options, CancellationToken cancellationToken)
@@ -382,30 +398,53 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             throw new InvalidOperationException(localizationService.GetString("StartMedia.BlockingReason.NoUsbTarget"));
         }
 
-        PreparedMediaWorkspace workspace = await PrepareMediaWorkspaceAsync(
-            options,
-            includeRuntimePayloadInImage: false,
-            cancellationToken);
+        PreparedMediaWorkspace? workspace = null;
 
-        WinPeUsbDiskCandidate selectedDisk = options.SelectedUsbDisk;
-        operationProgressService.Report(90, localizationService.GetString("StartMedia.Operation.CreatingUsb"));
-        WinPeResult<WinPeUsbProvisionResult> result = await usbMediaService.ProvisionAndPopulateAsync(
-            new UsbOutputOptions
-            {
-                TargetDiskNumber = selectedDisk.DiskNumber,
-                ExpectedDiskFriendlyName = selectedDisk.FriendlyName,
-                ExpectedDiskSerialNumber = selectedDisk.SerialNumber,
-                ExpectedDiskUniqueId = selectedDisk.UniqueId,
-                PartitionStyle = options.UsbPartitionStyle,
-                FormatMode = options.UsbFormatMode,
-                RuntimePayloadProvisioning = workspace.RuntimePayloadProvisioning
-            },
-            workspace.PreparedWorkspace.Artifact,
-            workspace.Tools,
-            workspace.PreparedWorkspace.UseBootEx,
-            cancellationToken);
+        try
+        {
+            workspace = await PrepareMediaWorkspaceAsync(
+                options,
+                includeRuntimePayloadInImage: false,
+                cancellationToken);
 
-        EnsureSuccess(result);
+            WinPeUsbDiskCandidate selectedDisk = options.SelectedUsbDisk;
+            operationProgressService.Report(90, localizationService.GetString("StartMedia.Operation.CreatingUsb"));
+            logger.Debug(
+                "Creating USB media. DiskNumber={DiskNumber}, DiskName={DiskName}, PartitionStyle={PartitionStyle}, FormatMode={FormatMode}, MediaDirectoryPath={MediaDirectoryPath}, UseBootEx={UseBootEx}",
+                selectedDisk.DiskNumber,
+                selectedDisk.FriendlyName,
+                options.UsbPartitionStyle,
+                options.UsbFormatMode,
+                workspace.PreparedWorkspace.Artifact.MediaDirectoryPath,
+                workspace.PreparedWorkspace.UseBootEx);
+
+            WinPeResult<WinPeUsbProvisionResult> result = await usbMediaService.ProvisionAndPopulateAsync(
+                new UsbOutputOptions
+                {
+                    TargetDiskNumber = selectedDisk.DiskNumber,
+                    ExpectedDiskFriendlyName = selectedDisk.FriendlyName,
+                    ExpectedDiskSerialNumber = selectedDisk.SerialNumber,
+                    ExpectedDiskUniqueId = selectedDisk.UniqueId,
+                    PartitionStyle = options.UsbPartitionStyle,
+                    FormatMode = options.UsbFormatMode,
+                    RuntimePayloadProvisioning = workspace.RuntimePayloadProvisioning
+                },
+                workspace.PreparedWorkspace.Artifact,
+                workspace.Tools,
+                workspace.PreparedWorkspace.UseBootEx,
+                cancellationToken);
+
+            EnsureSuccess(result);
+            logger.Debug(
+                "USB media service completed. DiskNumber={DiskNumber}, BootVolume={BootVolume}, CacheVolume={CacheVolume}",
+                selectedDisk.DiskNumber,
+                result.Value?.BootDriveLetter,
+                result.Value?.CacheDriveLetter);
+        }
+        finally
+        {
+            CleanupPreparedWorkspace(workspace?.PreparedWorkspace.Artifact.WorkingDirectoryPath);
+        }
     }
 
     private async Task<PreparedMediaWorkspace> PrepareMediaWorkspaceAsync(
@@ -413,65 +452,114 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         bool includeRuntimePayloadInImage,
         CancellationToken cancellationToken)
     {
-        WinPeToolPaths tools = ResolveWinPeToolsOrThrow();
-        WinPeRuntimePayloadProvisioningOptions runtimePayloadProvisioning = CreateRuntimePayloadProvisioningOptions(
-            options.Architecture,
-            Constants.WinPeWorkspaceDirectoryPath,
-            Constants.WinPeWorkspaceDirectoryPath,
-            Constants.WinPeWorkspaceDirectoryPath);
+        WinPeBuildArtifact? artifact = null;
 
-        operationProgressService.Report(10, localizationService.GetString("StartMedia.Operation.BuildingWorkspace"));
-        WinPeResult<WinPeBuildArtifact> buildResult = await buildService.BuildAsync(
-            new WinPeBuildOptions
-            {
-                OutputDirectoryPath = Constants.WinPeWorkspaceDirectoryPath,
-                AdkRootPath = tools.KitsRootPath,
-                Architecture = options.Architecture,
-                SignatureMode = options.SignatureMode
-            },
-            cancellationToken);
-        EnsureSuccess(buildResult);
-
-        WinPeBuildArtifact artifact = buildResult.Value!;
-        FoundryConnectProvisioningBundle connectBundle = expertDeployConfigurationStateService.GenerateConnectProvisioningBundle(
-            Path.Combine(artifact.WorkingDirectoryPath, "Provisioning"));
-
-        WinPeRuntimePayloadProvisioningOptions artifactRuntimePayloadProvisioning = runtimePayloadProvisioning with
+        try
         {
-            WorkingDirectoryPath = artifact.WorkingDirectoryPath,
-            MountedImagePath = artifact.MountDirectoryPath,
-            UsbCacheRootPath = string.Empty
-        };
+            WinPeToolPaths tools = ResolveWinPeToolsOrThrow();
+            logger.Debug(
+                "Resolved WinPE tools. KitsRootPath={KitsRootPath}, DismPath={DismPath}, MakeWinPeMediaPath={MakeWinPeMediaPath}",
+                tools.KitsRootPath,
+                tools.DismPath,
+                tools.MakeWinPeMediaPath);
 
-        operationProgressService.Report(25, localizationService.GetString("StartMedia.Operation.PreparingWorkspace"));
-        WinPeResult<WinPeWorkspacePreparationResult> preparationResult = await workspacePreparationService.PrepareAsync(
-            new WinPeWorkspacePreparationOptions
-            {
-                Artifact = artifact,
-                Tools = tools,
-                SignatureMode = options.SignatureMode,
-                BootImageSource = options.BootImageSource,
-                DriverCatalogUri = new WinPeDriverCatalogOptions().CatalogUri,
-                DriverVendors = options.DriverVendors,
-                CustomDriverDirectoryPath = options.CustomDriverDirectoryPath,
-                WinPeLanguage = options.WinPeLanguage,
-                AssetProvisioning = CreateAssetProvisioningOptions(options, connectBundle),
-                RuntimePayloadProvisioning = includeRuntimePayloadInImage ? artifactRuntimePayloadProvisioning : null,
-                WinReCacheDirectoryPath = Constants.WinReTempDirectoryPath,
-                Progress = new Progress<WinPeWorkspacePreparationStage>(ReportWorkspacePreparationStage),
-                CustomizationProgress = new Progress<WinPeMountedImageCustomizationProgress>(ReportCustomizationProgress)
-            },
-            cancellationToken);
-        EnsureSuccess(preparationResult);
+            WinPeRuntimePayloadProvisioningOptions runtimePayloadProvisioning = CreateRuntimePayloadProvisioningOptions(
+                options.Architecture,
+                Constants.WinPeWorkspaceDirectoryPath,
+                Constants.WinPeWorkspaceDirectoryPath,
+                Constants.WinPeWorkspaceDirectoryPath);
+            RuntimePayloadReadiness runtimeReadiness = EvaluateRuntimePayloadReadiness(runtimePayloadProvisioning);
 
-        return new PreparedMediaWorkspace(
-            preparationResult.Value!,
-            tools,
-            artifactRuntimePayloadProvisioning with
+            logger.Debug(
+                "Final media workspace preparation started. Architecture={Architecture}, WinPeLanguage={WinPeLanguage}, SignatureMode={SignatureMode}, BootImageSource={BootImageSource}, IncludeRuntimePayloadInImage={IncludeRuntimePayloadInImage}, DriverVendorCount={DriverVendorCount}, HasCustomDriverDirectory={HasCustomDriverDirectory}, IsAutopilotEnabled={IsAutopilotEnabled}, HasConnectRuntimePayload={HasConnectRuntimePayload}, HasDeployRuntimePayload={HasDeployRuntimePayload}",
+                options.Architecture,
+                NormalizeCultureName(options.WinPeLanguage),
+                options.SignatureMode,
+                options.BootImageSource,
+                includeRuntimePayloadInImage,
+                options.DriverVendors.Count,
+                !string.IsNullOrWhiteSpace(options.CustomDriverDirectoryPath),
+                options.IsAutopilotEnabled,
+                runtimeReadiness.IsConnectReady,
+                runtimeReadiness.IsDeployReady);
+
+            CleanupStaleWinPeWorkspaces();
+
+            operationProgressService.Report(10, localizationService.GetString("StartMedia.Operation.BuildingWorkspace"));
+            WinPeResult<WinPeBuildArtifact> buildResult = await buildService.BuildAsync(
+                new WinPeBuildOptions
+                {
+                    OutputDirectoryPath = Constants.WinPeWorkspaceDirectoryPath,
+                    AdkRootPath = tools.KitsRootPath,
+                    Architecture = options.Architecture,
+                    SignatureMode = options.SignatureMode
+                },
+                cancellationToken);
+            EnsureSuccess(buildResult);
+
+            artifact = buildResult.Value!;
+            logger.Debug(
+                "WinPE workspace created. WorkingDirectoryPath={WorkingDirectoryPath}, MediaDirectoryPath={MediaDirectoryPath}, MountDirectoryPath={MountDirectoryPath}, BootWimPath={BootWimPath}",
+                artifact.WorkingDirectoryPath,
+                artifact.MediaDirectoryPath,
+                artifact.MountDirectoryPath,
+                artifact.BootWimPath);
+
+            FoundryConnectProvisioningBundle connectBundle = expertDeployConfigurationStateService.GenerateConnectProvisioningBundle(
+                Path.Combine(artifact.WorkingDirectoryPath, "Provisioning"));
+            logger.Debug(
+                "Generated local provisioning payloads. ConnectAssetFileCount={ConnectAssetFileCount}, HasMediaSecretsKey={HasMediaSecretsKey}, AutopilotProfileCount={AutopilotProfileCount}",
+                connectBundle.AssetFiles.Count,
+                connectBundle.MediaSecretsKey is { Length: > 0 },
+                options.IsAutopilotEnabled ? expertDeployConfigurationStateService.Current.Autopilot.Profiles.Count : 0);
+
+            WinPeRuntimePayloadProvisioningOptions artifactRuntimePayloadProvisioning = runtimePayloadProvisioning with
             {
-                MountedImagePath = string.Empty,
+                WorkingDirectoryPath = artifact.WorkingDirectoryPath,
+                MountedImagePath = artifact.MountDirectoryPath,
                 UsbCacheRootPath = string.Empty
-            });
+            };
+
+            operationProgressService.Report(25, localizationService.GetString("StartMedia.Operation.PreparingWorkspace"));
+            WinPeResult<WinPeWorkspacePreparationResult> preparationResult = await workspacePreparationService.PrepareAsync(
+                new WinPeWorkspacePreparationOptions
+                {
+                    Artifact = artifact,
+                    Tools = tools,
+                    SignatureMode = options.SignatureMode,
+                    BootImageSource = options.BootImageSource,
+                    DriverCatalogUri = new WinPeDriverCatalogOptions().CatalogUri,
+                    DriverVendors = options.DriverVendors,
+                    CustomDriverDirectoryPath = options.CustomDriverDirectoryPath,
+                    WinPeLanguage = options.WinPeLanguage,
+                    AssetProvisioning = CreateAssetProvisioningOptions(options, connectBundle),
+                    RuntimePayloadProvisioning = includeRuntimePayloadInImage ? artifactRuntimePayloadProvisioning : null,
+                    WinReCacheDirectoryPath = Constants.WinReTempDirectoryPath,
+                    Progress = new Progress<WinPeWorkspacePreparationStage>(ReportWorkspacePreparationStage),
+                    CustomizationProgress = new Progress<WinPeMountedImageCustomizationProgress>(ReportCustomizationProgress)
+                },
+                cancellationToken);
+            EnsureSuccess(preparationResult);
+
+            logger.Debug(
+                "WinPE workspace prepared. UseBootEx={UseBootEx}, RuntimePayloadInImage={RuntimePayloadInImage}",
+                preparationResult.Value!.UseBootEx,
+                includeRuntimePayloadInImage);
+
+            return new PreparedMediaWorkspace(
+                preparationResult.Value!,
+                tools,
+                artifactRuntimePayloadProvisioning with
+                {
+                    MountedImagePath = string.Empty,
+                    UsbCacheRootPath = string.Empty
+                });
+        }
+        catch
+        {
+            CleanupPreparedWorkspace(artifact?.WorkingDirectoryPath);
+            throw;
+        }
     }
 
     private WinPeMountedImageAssetProvisioningOptions CreateAssetProvisioningOptions(
@@ -506,7 +594,16 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             _ => 45
         };
 
-        operationProgressService.Report(progress, localizationService.GetString("StartMedia.Operation.PreparingWorkspace"));
+        string statusResourceKey = stage switch
+        {
+            WinPeWorkspacePreparationStage.ResolvingDrivers => "StartMedia.Operation.ResolvingDrivers",
+            WinPeWorkspacePreparationStage.CustomizingImage => "StartMedia.Operation.CustomizingImage",
+            WinPeWorkspacePreparationStage.EvaluatingSignaturePolicy => "StartMedia.Operation.EvaluatingSignaturePolicy",
+            _ => "StartMedia.Operation.PreparingWorkspace"
+        };
+
+        logger.Debug("WinPE workspace preparation stage changed. Stage={Stage}, Progress={Progress}", stage, progress);
+        operationProgressService.Report(progress, localizationService.GetString(statusResourceKey));
     }
 
     private void ReportCustomizationProgress(WinPeMountedImageCustomizationProgress progress)
@@ -514,9 +611,128 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         int normalizedProgress = Math.Clamp(45 + (progress.Percent * 35 / 100), 45, 80);
         string status = string.IsNullOrWhiteSpace(progress.Status)
             ? localizationService.GetString("StartMedia.Operation.PreparingWorkspace")
-            : progress.Status;
+            : LocalizeCustomizationStatus(progress.Status);
 
+        logger.Debug(
+            "WinPE image customization progress changed. CoreStatus={CoreStatus}, Percent={Percent}, NormalizedProgress={NormalizedProgress}",
+            progress.Status,
+            progress.Percent,
+            normalizedProgress);
         operationProgressService.Report(normalizedProgress, status);
+    }
+
+    private string LocalizeCustomizationStatus(string status)
+    {
+        string resourceKey = status switch
+        {
+            "Preparing boot image customization." => "StartMedia.Operation.PreparingBootImageCustomization",
+            "Mounting boot image." => "StartMedia.Operation.MountingBootImage",
+            "Injecting drivers into mounted image." => "StartMedia.Operation.InjectingDrivers",
+            "Applying language and optional components." => "StartMedia.Operation.ApplyingLanguageAndComponents",
+            "Provisioning Foundry boot assets." => "StartMedia.Operation.ProvisioningBootAssets",
+            "Provisioning Foundry runtime payloads." => "StartMedia.Operation.ProvisioningRuntimePayloads",
+            "Committing image changes." => "StartMedia.Operation.CommittingImageChanges",
+            "Image customization completed." => "StartMedia.Operation.ImageCustomizationCompleted",
+            _ => string.Empty
+        };
+
+        return string.IsNullOrWhiteSpace(resourceKey)
+            ? status
+            : localizationService.GetString(resourceKey);
+    }
+
+    private void CleanupPreparedWorkspace(string? workingDirectoryPath)
+    {
+        if (string.IsNullOrWhiteSpace(workingDirectoryPath))
+        {
+            return;
+        }
+
+        string workspaceRoot = Path.GetFullPath(Constants.WinPeWorkspaceDirectoryPath);
+        string workspacePath = Path.GetFullPath(workingDirectoryPath);
+        string normalizedRoot = workspaceRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+
+        if (!workspacePath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            logger.Warning(
+                "Skipped WinPE workspace cleanup because the target is outside the workspace root. WorkspacePath={WorkspacePath}, WorkspaceRoot={WorkspaceRoot}",
+                workspacePath,
+                workspaceRoot);
+            return;
+        }
+
+        if (!Directory.Exists(workspacePath))
+        {
+            logger.Debug("Skipped WinPE workspace cleanup because the directory no longer exists. WorkspacePath={WorkspacePath}", workspacePath);
+            return;
+        }
+
+        DeleteWorkspaceDirectory(workspacePath, reportProgress: true);
+    }
+
+    private void CleanupStaleWinPeWorkspaces()
+    {
+        string workspaceRoot = Path.GetFullPath(Constants.WinPeWorkspaceDirectoryPath);
+        if (!Directory.Exists(workspaceRoot))
+        {
+            return;
+        }
+
+        foreach (string workspacePath in Directory.EnumerateDirectories(workspaceRoot))
+        {
+            DeleteWorkspaceDirectory(workspacePath, reportProgress: false);
+        }
+
+        foreach (string filePath in Directory.EnumerateFiles(workspaceRoot))
+        {
+            try
+            {
+                logger.Debug("Cleaning stale WinPE workspace file. FilePath={FilePath}", filePath);
+                File.Delete(filePath);
+            }
+            catch (Exception ex)
+            {
+                logger.Warning(ex, "Failed to clean stale WinPE workspace file. FilePath={FilePath}", filePath);
+            }
+        }
+    }
+
+    private void DeleteWorkspaceDirectory(string workspacePath, bool reportProgress)
+    {
+        try
+        {
+            if (reportProgress)
+            {
+                operationProgressService.Report(95, localizationService.GetString("StartMedia.Operation.CleaningWorkspace"));
+            }
+
+            logger.Debug("Cleaning WinPE workspace. WorkspacePath={WorkspacePath}", workspacePath);
+            NormalizeWorkspaceAttributes(workspacePath);
+            Directory.Delete(workspacePath, recursive: true);
+            logger.Debug("WinPE workspace cleaned. WorkspacePath={WorkspacePath}", workspacePath);
+        }
+        catch (Exception ex)
+        {
+            logger.Warning(ex, "Failed to clean WinPE workspace. WorkspacePath={WorkspacePath}", workspacePath);
+        }
+    }
+
+    private static void NormalizeWorkspaceAttributes(string workspacePath)
+    {
+        foreach (string filePath in Directory.EnumerateFiles(workspacePath, "*", SearchOption.AllDirectories))
+        {
+            File.SetAttributes(filePath, FileAttributes.Normal);
+        }
+
+        foreach (string directoryPath in Directory
+            .EnumerateDirectories(workspacePath, "*", SearchOption.AllDirectories)
+            .OrderByDescending(path => path.Length))
+        {
+            File.SetAttributes(directoryPath, FileAttributes.Directory);
+        }
+
+        File.SetAttributes(workspacePath, FileAttributes.Directory);
     }
 
     private async Task ShowBlockedDialogAsync(

--- a/src/Foundry/Views/MainWindow.xaml.cs
+++ b/src/Foundry/Views/MainWindow.xaml.cs
@@ -322,8 +322,8 @@ namespace Foundry.Views
                 Text = GetOperationDialogStatusText(),
                 TextWrapping = TextWrapping.Wrap,
                 MaxWidth = 440,
-                HorizontalAlignment = HorizontalAlignment.Center,
-                TextAlignment = TextAlignment.Center
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                TextAlignment = TextAlignment.Left
             };
 
             operationProgressBar = new ProgressBar
@@ -340,7 +340,9 @@ namespace Foundry.Views
             {
                 Text = GetSecondaryOperationDialogStatusText(),
                 TextWrapping = TextWrapping.Wrap,
-                MaxWidth = 440
+                MaxWidth = 440,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                TextAlignment = TextAlignment.Left
             };
 
             operationSecondaryProgressBar = new ProgressBar
@@ -369,7 +371,7 @@ namespace Foundry.Views
                 MinWidth = 420,
                 MaxWidth = 520,
                 Padding = new Thickness(0, 8, 0, 0),
-                Spacing = 20,
+                Spacing = 16,
                 Children =
                 {
                     new Microsoft.UI.Xaml.Controls.ProgressRing

--- a/src/Foundry/Views/MainWindow.xaml.cs
+++ b/src/Foundry/Views/MainWindow.xaml.cs
@@ -17,6 +17,11 @@ namespace Foundry.Views
         private JsonNavigationService? jsonNavigationService;
         private TextBlock? operationStatusText;
         private ProgressBar? operationProgressBar;
+        private TextBlock? operationProgressPercentText;
+        private StackPanel? operationSecondaryProgressPanel;
+        private TextBlock? operationSecondaryStatusText;
+        private ProgressBar? operationSecondaryProgressBar;
+        private TextBlock? operationSecondaryProgressPercentText;
 
         public MainViewModel ViewModel { get; }
 
@@ -326,8 +331,37 @@ namespace Foundry.Views
                 Minimum = 0,
                 Maximum = 100,
                 Value = operationProgressService.State.Progress,
+                Height = 4
+            };
+
+            operationProgressPercentText = CreatePercentText(operationProgressService.State.Progress);
+
+            operationSecondaryStatusText = new TextBlock
+            {
+                Text = GetSecondaryOperationDialogStatusText(),
+                TextWrapping = TextWrapping.Wrap,
+                MaxWidth = 440
+            };
+
+            operationSecondaryProgressBar = new ProgressBar
+            {
+                Minimum = 0,
+                Maximum = 100,
                 Height = 4,
-                Margin = new Thickness(0, 4, 0, 0)
+                Value = operationProgressService.State.SecondaryProgress ?? 0,
+                IsIndeterminate = !operationProgressService.State.SecondaryProgress.HasValue
+            };
+
+            operationSecondaryProgressPercentText = CreatePercentText(operationProgressService.State.SecondaryProgress);
+            operationSecondaryProgressPanel = new StackPanel
+            {
+                Spacing = 8,
+                Visibility = operationProgressService.State.HasSecondaryProgress ? Visibility.Visible : Visibility.Collapsed,
+                Children =
+                {
+                    operationSecondaryStatusText,
+                    CreateProgressRow(operationSecondaryProgressBar, operationSecondaryProgressPercentText)
+                }
             };
 
             return new StackPanel
@@ -335,7 +369,7 @@ namespace Foundry.Views
                 MinWidth = 420,
                 MaxWidth = 520,
                 Padding = new Thickness(0, 8, 0, 0),
-                Spacing = 24,
+                Spacing = 20,
                 Children =
                 {
                     new Microsoft.UI.Xaml.Controls.ProgressRing
@@ -346,8 +380,36 @@ namespace Foundry.Views
                         HorizontalAlignment = HorizontalAlignment.Center
                     },
                     operationStatusText,
-                    operationProgressBar
+                    CreateProgressRow(operationProgressBar, operationProgressPercentText),
+                    operationSecondaryProgressPanel
                 }
+            };
+        }
+
+        private static Grid CreateProgressRow(ProgressBar progressBar, TextBlock percentText)
+        {
+            var grid = new Grid
+            {
+                ColumnSpacing = 12
+            };
+
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            Grid.SetColumn(progressBar, 0);
+            Grid.SetColumn(percentText, 1);
+            grid.Children.Add(progressBar);
+            grid.Children.Add(percentText);
+            return grid;
+        }
+
+        private static TextBlock CreatePercentText(int? progress)
+        {
+            return new TextBlock
+            {
+                Text = FormatProgressPercent(progress),
+                MinWidth = 36,
+                TextAlignment = TextAlignment.Right,
+                VerticalAlignment = VerticalAlignment.Center
             };
         }
 
@@ -360,6 +422,11 @@ namespace Foundry.Views
 
             operationStatusText = null;
             operationProgressBar = null;
+            operationProgressPercentText = null;
+            operationSecondaryProgressPanel = null;
+            operationSecondaryStatusText = null;
+            operationSecondaryProgressBar = null;
+            operationSecondaryProgressPercentText = null;
             isClosingOperationDialog = true;
             operationDialog.Hide();
         }
@@ -419,6 +486,32 @@ namespace Foundry.Views
             {
                 operationProgressBar.Value = state.Progress;
             }
+
+            if (operationProgressPercentText is not null)
+            {
+                operationProgressPercentText.Text = FormatProgressPercent(state.Progress);
+            }
+
+            if (operationSecondaryProgressPanel is not null)
+            {
+                operationSecondaryProgressPanel.Visibility = state.HasSecondaryProgress ? Visibility.Visible : Visibility.Collapsed;
+            }
+
+            if (operationSecondaryStatusText is not null)
+            {
+                operationSecondaryStatusText.Text = GetSecondaryOperationDialogStatusText();
+            }
+
+            if (operationSecondaryProgressBar is not null)
+            {
+                operationSecondaryProgressBar.IsIndeterminate = !state.SecondaryProgress.HasValue;
+                operationSecondaryProgressBar.Value = state.SecondaryProgress ?? 0;
+            }
+
+            if (operationSecondaryProgressPercentText is not null)
+            {
+                operationSecondaryProgressPercentText.Text = FormatProgressPercent(state.SecondaryProgress);
+            }
         }
 
         private string GetOperationDialogStatusText()
@@ -426,6 +519,20 @@ namespace Foundry.Views
             return !string.IsNullOrWhiteSpace(operationProgressService.State.Status)
                 ? operationProgressService.State.Status
                 : localizationService.GetString("Shell.OperationRunning");
+        }
+
+        private string GetSecondaryOperationDialogStatusText()
+        {
+            return operationProgressService.State.HasSecondaryProgress
+                ? operationProgressService.State.SecondaryStatus
+                : string.Empty;
+        }
+
+        private static string FormatProgressPercent(int? progress)
+        {
+            return progress.HasValue
+                ? $"{Math.Clamp(progress.Value, 0, 100)}%"
+                : string.Empty;
         }
 
         private void SynchronizeSelectedNavigationItem(Type? pageType)

--- a/src/Foundry/Views/MainWindow.xaml.cs
+++ b/src/Foundry/Views/MainWindow.xaml.cs
@@ -316,6 +316,7 @@ namespace Foundry.Views
             {
                 Text = GetOperationDialogStatusText(),
                 TextWrapping = TextWrapping.Wrap,
+                MaxWidth = 440,
                 HorizontalAlignment = HorizontalAlignment.Center,
                 TextAlignment = TextAlignment.Center
             };
@@ -324,19 +325,23 @@ namespace Foundry.Views
             {
                 Minimum = 0,
                 Maximum = 100,
-                Value = operationProgressService.State.Progress
+                Value = operationProgressService.State.Progress,
+                Height = 4,
+                Margin = new Thickness(0, 4, 0, 0)
             };
 
             return new StackPanel
             {
-                MinWidth = 360,
-                Spacing = 16,
+                MinWidth = 420,
+                MaxWidth = 520,
+                Padding = new Thickness(0, 8, 0, 0),
+                Spacing = 24,
                 Children =
                 {
                     new Microsoft.UI.Xaml.Controls.ProgressRing
                     {
-                        Width = 48,
-                        Height = 48,
+                        Width = 56,
+                        Height = 56,
                         IsActive = true,
                         HorizontalAlignment = HorizontalAlignment.Center
                     },

--- a/src/Foundry/Views/StartPage.xaml
+++ b/src/Foundry/Views/StartPage.xaml
@@ -61,10 +61,12 @@
                             Spacing="10">
                     <Button x:Name="CreateIsoButton"
                             MinWidth="{StaticResource SettingActionControlMinWidth}"
-                            IsEnabled="False" />
+                            Command="{x:Bind ViewModel.CreateIsoCommand}"
+                            IsEnabled="{x:Bind ViewModel.CanCreateIso, Mode=OneWay}" />
                     <Button x:Name="CreateUsbButton"
                             MinWidth="{StaticResource SettingActionControlMinWidth}"
-                            IsEnabled="False" />
+                            Command="{x:Bind ViewModel.CreateUsbCommand}"
+                            IsEnabled="{x:Bind ViewModel.CanCreateUsb, Mode=OneWay}" />
                 </StackPanel>
             </dev:SettingsCard>
         </StackPanel>


### PR DESCRIPTION
## Summary
- Enable final Start page ISO and USB commands once full readiness checks pass.
- Add real Connect/Deploy runtime payload readiness gates with separate blocking reasons.
- Wire final media creation through existing WinPE build, preparation, ISO, and USB services.

## Reason
Phase 16.E turns the Start page from readiness-only mode into the final media execution entry point after Deploy, Connect, network, secrets, runtime payloads, and optional Autopilot readiness are implemented.

## Main changes
- Register the WinPE build, workspace preparation, embedded asset, and ISO media services in the app DI container.
- Add Start page Create ISO/Create USB commands, operation overlay progress, failure handling, USB destructive confirmation, and USB identity revalidation through the core USB service.
- Provision generated Deploy/Connect configs, Connect assets, encrypted media key when required, Autopilot profiles, bundled assets, drivers, boot language, and runtime payloads into generated media.
- Update the migration plan to reflect the implemented Phase 16.E scope and the current non-cancelable operation overlay contract.

## Testing notes
- `dotnet build .\src\Foundry.slnx -c Debug -p:Platform=x64`
- `dotnet test .\src\Foundry.Core.Tests\Foundry.Core.Tests.csproj -c Debug -p:Platform=x64 --filter FullyQualifiedName~MediaPreflightServiceTests`
- `dotnet test .\src\Foundry.Core.Tests\Foundry.Core.Tests.csproj -c Debug -p:Platform=x64 --filter FullyQualifiedName~WinPeRuntimePayloadProvisioningOptionsTests`
- `dotnet test .\src\Foundry.slnx -c Debug -p:Platform=x64`