### PR TITLE
docs: add migration plan clearing gate

### DIFF
--- a/docs/migration/phases/07-compatibility-cleanup-cutover.md
+++ b/docs/migration/phases/07-compatibility-cleanup-cutover.md
@@ -503,6 +503,7 @@ git commit -m "chore: align release automation and app branding"
 ```
 
 - [ ] **21.7** Merge `feat/winui-migration` into `main`.
+  - [ ] Before the final merge, clear the migration plan so it no longer presents the completed WinUI migration as active work.
 - [ ] **21.8** Tag first WinUI release.
   - [ ] Use date-based tag format `vYY.M.D.Build`.
 - [ ] **21.9** Monitor the Tuesday scheduled release after the first successful WinUI release from `main`.


### PR DESCRIPTION
## Summary
- Add an explicit Phase 21 pre-merge gate to clear the migration plan before the final cutover merge.

## Reason
The final merge to main should not leave the completed WinUI migration plan presented as active work.

## Main Changes
- Adds a checklist item under the Phase 21 merge gate.

## Testing Notes
- Documentation-only change; no runtime tests required.