### PR TITLE
chore(deps): schedule dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "10:00"
     groups:
       actions-deps:
         patterns:
@@ -13,6 +15,8 @@ updates:
     directory: "/src"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "10:00"
     groups:
       nuget-deps:
         patterns:


### PR DESCRIPTION
## Summary
- Schedule Dependabot checks to run weekly on Monday at 10:00 UTC.
- Apply the schedule to GitHub Actions and NuGet update blocks.

## Reason
- Keeps dependency update PR timing predictable.

## Main changes
- Added `day: "monday"` and `time: "10:00"` to each Dependabot schedule.

## Testing notes
- Ran `git diff --check -- .github/dependabot.yml`; only Git's LF-to-CRLF working copy warning was reported.