### PR TITLE
fix(release): remove Velopack setup assets after upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -341,9 +341,6 @@ jobs:
                   throw "Velopack release output was not created: '$velopackReleasePath'."
               }
 
-              Get-ChildItem -Path $velopackReleasePath -Filter '*-Setup.exe' -File |
-                  Remove-Item -Force
-
               & $vpkExecutable upload github `
                   --outputDir $velopackReleasePath `
                   --channel $runtimeIdentifier `
@@ -355,6 +352,19 @@ jobs:
 
               if ($LASTEXITCODE -ne 0) {
                   throw "Velopack GitHub upload failed for '$runtimeIdentifier'."
+              }
+
+              $setupAssetNames = gh release view $releaseTag --json assets --jq '.assets[].name' |
+                  Where-Object { $_ -like "*-$runtimeIdentifier-Setup.exe" }
+              if ($LASTEXITCODE -ne 0) {
+                  throw "Unable to inspect GitHub release assets for '$releaseTag'."
+              }
+
+              foreach ($setupAssetName in $setupAssetNames) {
+                  gh release delete-asset $releaseTag $setupAssetName --yes
+                  if ($LASTEXITCODE -ne 0) {
+                      throw "Unable to delete GitHub release asset '$setupAssetName'."
+                  }
               }
           }
 


### PR DESCRIPTION
## Summary
Remove Velopack setup executable assets from the GitHub release after Velopack upload completes.

## Reason
Velopack expects the generated release directory to stay intact during `vpk upload github`. Deleting `*-Setup.exe` before upload causes the CLI to fail with `FileNotFoundException`.

## Main changes
- Stop deleting `*-Setup.exe` from the local Velopack release directory before upload.
- After each runtime upload succeeds, inspect the GitHub release assets and delete the matching `*-Setup.exe` asset.

## Testing notes
- Ran a static PowerShell guard to verify setup executables are not removed before `vpk upload github` and are deleted afterward.
- Parsed the `Upload release assets` PowerShell block with placeholder GitHub expressions to verify syntax.
- Ran `git show --check --stat --oneline HEAD`.