### PR TITLE
docs(readme): fix MSI asset links

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Foundry replaces legacy imaging scripts with Foundry OSD, a clean, fully-guided 
 Get started by downloading the latest Foundry OSD MSI installer for your workstation architecture.
 
 <p align="center">
-  <a href="https://github.com/foundry-osd/foundry/releases/latest/download/FoundrySetup-x64.msi"><img src="https://img.shields.io/badge/Download-Windows_x64-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Download x64"></a>
+  <a href="https://github.com/foundry-osd/foundry/releases/latest/download/Foundry-win-x64.msi"><img src="https://img.shields.io/badge/Download-Windows_x64-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Download x64"></a>
   &nbsp;&nbsp;&nbsp;
-  <a href="https://github.com/foundry-osd/foundry/releases/latest/download/FoundrySetup-arm64.msi"><img src="https://img.shields.io/badge/Download-Windows_ARM64-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Download ARM64"></a>
+  <a href="https://github.com/foundry-osd/foundry/releases/latest/download/Foundry-win-arm64.msi"><img src="https://img.shields.io/badge/Download-Windows_ARM64-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Download ARM64"></a>
 </p>
 
 > 💡 **Next steps:** For prerequisites (like the Windows ADK) and how to configure your first deployment, check out our [Quick Start guide](https://foundry-osd.github.io/docs/start/quick-start).


### PR DESCRIPTION
## Summary
- Update README download badge links to the current MSI asset names.

## Reason
The latest release publishes `Foundry-win-x64.msi` and `Foundry-win-arm64.msi`, while the README still pointed to the old `FoundrySetup-*` names.

## Main Changes
- Replace x64 MSI link with `Foundry-win-x64.msi`.
- Replace ARM64 MSI link with `Foundry-win-arm64.msi`.

## Testing Notes
- Verified README no longer references the old MSI asset names.

## Merge Notes
Do not auto-merge.