### PR TITLE
feat(app): start Foundry maximized

### DIFF
--- a/src/Foundry/Views/MainWindow.xaml.cs
+++ b/src/Foundry/Views/MainWindow.xaml.cs
@@ -43,6 +43,11 @@ namespace Foundry.Views
             ExtendsContentIntoTitleBar = true;
             SetTitleBar(AppTitleBar);
             AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Tall;
+            if (AppWindow.Presenter is OverlappedPresenter presenter)
+            {
+                presenter.Maximize();
+            }
+
             InitializeNavigation();
             ApplyLocalizedShellText();
             ApplyShellNavigationState();


### PR DESCRIPTION
## Summary
Start the Foundry WinUI shell maximized when the application opens.

## Reason
The default startup window was too small for the main authoring workflow.

## Main changes
- Maximize the WinUI `MainWindow` through its `OverlappedPresenter` during startup.
- Leave existing title bar, navigation, and sizing behavior otherwise unchanged.

## Testing notes
- `dotnet build src\Foundry\Foundry.csproj --configuration Debug`
