### PR TITLE
docs(foundry): document app contracts

### DIFF
--- a/src/Foundry/App.xaml.cs
+++ b/src/Foundry/App.xaml.cs
@@ -7,19 +7,55 @@ using Serilog;
 
 namespace Foundry
 {
+    /// <summary>
+    /// Owns the WinUI application lifetime and exposes the host services used by XAML pages.
+    /// </summary>
     public partial class App : Application
     {
         private static readonly ILogger AppLogger = Log.ForContext<App>();
         private bool isShuttingDown;
 
+        /// <summary>
+        /// Gets the active Foundry application instance.
+        /// </summary>
         public new static App Current => (App)Application.Current;
+
+        /// <summary>
+        /// Gets the main window once the application has launched.
+        /// </summary>
         public static Window MainWindow = Window.Current;
+
+        /// <summary>
+        /// Gets the native window handle used by WinUI-backed platform services.
+        /// </summary>
         public static IntPtr Hwnd => WinRT.Interop.WindowNative.GetWindowHandle(MainWindow);
+
+        /// <summary>
+        /// Gets the dependency injection host for the application.
+        /// </summary>
         public IHost Host { get; }
+
+        /// <summary>
+        /// Gets the service provider rooted in <see cref="Host"/>.
+        /// </summary>
         public IServiceProvider Services => Host.Services;
+
+        /// <summary>
+        /// Gets the navigation service registered by the app shell.
+        /// </summary>
         public IJsonNavigationService NavService => GetService<IJsonNavigationService>();
+
+        /// <summary>
+        /// Gets the theme service used to apply runtime theme changes.
+        /// </summary>
         public IThemeService ThemeService => GetService<IThemeService>();
 
+        /// <summary>
+        /// Resolves a required service from the application host.
+        /// </summary>
+        /// <typeparam name="T">The service contract type.</typeparam>
+        /// <returns>The registered service instance.</returns>
+        /// <exception cref="ArgumentException">Thrown when the requested service has not been registered.</exception>
         public static T GetService<T>() where T : class
         {
             if (Current.Services.GetService(typeof(T)) is not T service)
@@ -30,6 +66,9 @@ namespace Foundry
             return service;
         }
 
+        /// <summary>
+        /// Creates the application host, initializes settings and localization, and loads the XAML application.
+        /// </summary>
         public App()
         {
             Host = FoundryHost.Create();
@@ -41,6 +80,10 @@ namespace Foundry
             this.InitializeComponent();
         }
 
+        /// <summary>
+        /// Creates and activates the main window, then starts application readiness checks.
+        /// </summary>
+        /// <param name="args">Launch activation arguments provided by WinUI.</param>
         protected override async void OnLaunched(LaunchActivatedEventArgs args)
         {
             try

--- a/src/Foundry/Common/Constants.cs
+++ b/src/Foundry/Common/Constants.cs
@@ -1,9 +1,23 @@
 namespace Foundry.Common
 {
+    /// <summary>
+    /// Defines application-wide constants and well-known local storage paths.
+    /// </summary>
     public static partial class Constants
     {
+        /// <summary>
+        /// Gets the application folder and process identity name.
+        /// </summary>
         public const string ApplicationName = "Foundry";
+
+        /// <summary>
+        /// Gets the user-facing product display name.
+        /// </summary>
         public const string ApplicationDisplayName = "Foundry OSD";
+
+        /// <summary>
+        /// Gets the default update channel used by the update service.
+        /// </summary>
         public const string DefaultUpdateChannel = "stable";
 
         public static readonly string RootDirectoryPath = Path.Combine(
@@ -37,6 +51,9 @@ namespace Foundry.Common
         public const string LatestReleaseUrl = RepositoryUrl + "/releases/latest";
         public const string DefaultUpdateFeedUrl = RepositoryUrl;
 
+        /// <summary>
+        /// Creates all application data directories required before services read or write state.
+        /// </summary>
         public static void EnsureDataDirectories()
         {
             Directory.CreateDirectory(SettingsDirectoryPath);

--- a/src/Foundry/Common/LoggerSetup.cs
+++ b/src/Foundry/Common/LoggerSetup.cs
@@ -4,14 +4,23 @@ using Serilog.Events;
 
 namespace Foundry.Common
 {
+    /// <summary>
+    /// Configures process-wide Serilog logging and global exception capture for the WinUI app.
+    /// </summary>
     public static partial class LoggerSetup
     {
         private static readonly LoggingLevelSwitch MinimumLevelSwitch = new(LogEventLevel.Information);
         private static bool globalExceptionHandlersRegistered;
 
+        /// <summary>
+        /// Gets the active Serilog logger instance.
+        /// </summary>
         public static ILogger Logger { get; private set; } = Serilog.Core.Logger.None;
         private static ILogger SetupLogger => Log.ForContext("SourceContext", typeof(LoggerSetup).FullName);
 
+        /// <summary>
+        /// Initializes the Foundry log sinks and assigns <see cref="Log.Logger"/>.
+        /// </summary>
         public static void ConfigureLogger()
         {
             Directory.CreateDirectory(Constants.LogDirectoryPath);
@@ -30,6 +39,10 @@ namespace Foundry.Common
             Log.Logger = Logger;
         }
 
+        /// <summary>
+        /// Updates the minimum logging level used by runtime diagnostics.
+        /// </summary>
+        /// <param name="isEnabled">Whether developer diagnostics should enable debug logging.</param>
         public static void SetDeveloperModeEnabled(bool isEnabled)
         {
             LogEventLevel targetLevel = isEnabled ? LogEventLevel.Debug : LogEventLevel.Information;
@@ -42,6 +55,9 @@ namespace Foundry.Common
             SetupLogger.Information("Developer diagnostics logging level changed. DeveloperMode={DeveloperMode}, MinimumLevel={MinimumLevel}", isEnabled, targetLevel);
         }
 
+        /// <summary>
+        /// Registers process-wide exception handlers once for non-UI failures.
+        /// </summary>
         public static void RegisterGlobalExceptionHandlers()
         {
             if (globalExceptionHandlersRegistered)
@@ -73,6 +89,7 @@ namespace Foundry.Common
 
         private sealed class LogComponentEnricher : ILogEventEnricher
         {
+            /// <inheritdoc />
             public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
             {
                 string component = Constants.ApplicationName;

--- a/src/Foundry/Converters/BooleanToBrushConverter.cs
+++ b/src/Foundry/Converters/BooleanToBrushConverter.cs
@@ -3,37 +3,54 @@ using Microsoft.UI.Xaml.Media;
 
 namespace Foundry.Converters;
 
+/// <summary>
+/// Converts a Boolean value into one of two configured brushes for XAML bindings.
+/// </summary>
 public sealed partial class BooleanToBrushConverter : DependencyObject, IValueConverter
 {
+    /// <summary>
+    /// Identifies the <see cref="TrueBrush"/> dependency property.
+    /// </summary>
     public static readonly DependencyProperty TrueBrushProperty = DependencyProperty.Register(
         nameof(TrueBrush),
         typeof(Brush),
         typeof(BooleanToBrushConverter),
         new PropertyMetadata(default(Brush)));
 
+    /// <summary>
+    /// Identifies the <see cref="FalseBrush"/> dependency property.
+    /// </summary>
     public static readonly DependencyProperty FalseBrushProperty = DependencyProperty.Register(
         nameof(FalseBrush),
         typeof(Brush),
         typeof(BooleanToBrushConverter),
         new PropertyMetadata(default(Brush)));
 
+    /// <summary>
+    /// Gets or sets the brush returned for <see langword="true"/> values.
+    /// </summary>
     public Brush? TrueBrush
     {
         get => (Brush?)GetValue(TrueBrushProperty);
         set => SetValue(TrueBrushProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the brush returned for <see langword="false"/> values.
+    /// </summary>
     public Brush? FalseBrush
     {
         get => (Brush?)GetValue(FalseBrushProperty);
         set => SetValue(FalseBrushProperty, value);
     }
 
+    /// <inheritdoc />
     public object? Convert(object value, Type targetType, object parameter, string language)
     {
         return value is true ? TrueBrush : FalseBrush;
     }
 
+    /// <inheritdoc />
     public object ConvertBack(object value, Type targetType, object parameter, string language)
     {
         throw new NotSupportedException();

--- a/src/Foundry/DependencyInjection/FoundryHost.cs
+++ b/src/Foundry/DependencyInjection/FoundryHost.cs
@@ -2,8 +2,15 @@ using Microsoft.Extensions.Hosting;
 
 namespace Foundry.DependencyInjection;
 
+/// <summary>
+/// Creates the dependency injection host used by the WinUI application.
+/// </summary>
 public static class FoundryHost
 {
+    /// <summary>
+    /// Builds the application host and registers Foundry services.
+    /// </summary>
+    /// <returns>The configured host instance.</returns>
     public static IHost Create()
     {
         HostApplicationBuilder builder = Host.CreateApplicationBuilder();

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -17,8 +17,16 @@ using Serilog;
 
 namespace Foundry.DependencyInjection;
 
+/// <summary>
+/// Registers the Foundry WinUI composition root.
+/// </summary>
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Adds application services, view models, shell services, and Core service integrations.
+    /// </summary>
+    /// <param name="services">Service collection to update.</param>
+    /// <returns>The same service collection for chaining.</returns>
     public static IServiceCollection AddFoundryApplicationServices(this IServiceCollection services)
     {
         services.AddSingleton(Log.Logger);

--- a/src/Foundry/FoundryApplicationInfo.cs
+++ b/src/Foundry/FoundryApplicationInfo.cs
@@ -7,9 +7,6 @@ namespace Foundry;
 /// </summary>
 public static class FoundryApplicationInfo
 {
-    /// <summary>
-    /// Gets the product display name.
-    /// </summary>
     public const string AppName = Constants.ApplicationDisplayName;
 
     /// <summary>
@@ -17,9 +14,6 @@ public static class FoundryApplicationInfo
     /// </summary>
     public const string DocumentationUrl = "https://foundry-osd.github.io/docs/start";
 
-    /// <summary>
-    /// Gets the source repository URL.
-    /// </summary>
     public const string RepositoryUrl = Constants.RepositoryUrl;
 
     /// <summary>
@@ -42,9 +36,6 @@ public static class FoundryApplicationInfo
     /// </summary>
     public const string ReleasesUrl = Constants.RepositoryUrl + "/releases";
 
-    /// <summary>
-    /// Gets the latest release URL.
-    /// </summary>
     public const string LatestReleaseUrl = Constants.LatestReleaseUrl;
 
     /// <summary>

--- a/src/Foundry/FoundryApplicationInfo.cs
+++ b/src/Foundry/FoundryApplicationInfo.cs
@@ -2,18 +2,59 @@ using System.Reflection;
 
 namespace Foundry;
 
+/// <summary>
+/// Provides product metadata and public project links used by the shell and about dialogs.
+/// </summary>
 public static class FoundryApplicationInfo
 {
+    /// <summary>
+    /// Gets the product display name.
+    /// </summary>
     public const string AppName = Constants.ApplicationDisplayName;
+
+    /// <summary>
+    /// Gets the documentation entry URL.
+    /// </summary>
     public const string DocumentationUrl = "https://foundry-osd.github.io/docs/start";
+
+    /// <summary>
+    /// Gets the source repository URL.
+    /// </summary>
     public const string RepositoryUrl = Constants.RepositoryUrl;
+
+    /// <summary>
+    /// Gets the GitHub contributors API endpoint.
+    /// </summary>
     public const string ContributorsApiUrl = "https://api.github.com/repos/foundry-osd/foundry/contributors";
+
+    /// <summary>
+    /// Gets the issue tracker URL.
+    /// </summary>
     public const string IssuesUrl = Constants.RepositoryUrl + "/issues";
+
+    /// <summary>
+    /// Gets the license document URL.
+    /// </summary>
     public const string LicenseUrl = Constants.RepositoryUrl + "/blob/main/LICENSE";
+
+    /// <summary>
+    /// Gets the releases page URL.
+    /// </summary>
     public const string ReleasesUrl = Constants.RepositoryUrl + "/releases";
+
+    /// <summary>
+    /// Gets the latest release URL.
+    /// </summary>
     public const string LatestReleaseUrl = Constants.LatestReleaseUrl;
+
+    /// <summary>
+    /// Gets the support URL shown by user-facing dialogs.
+    /// </summary>
     public const string SupportUrl = IssuesUrl;
 
+    /// <summary>
+    /// Gets the application version resolved from assembly metadata.
+    /// </summary>
     public static string Version { get; } = ResolveVersion();
 
     private static string ResolveVersion()

--- a/src/Foundry/Program.cs
+++ b/src/Foundry/Program.cs
@@ -6,8 +6,15 @@ using Velopack;
 
 namespace Foundry;
 
+/// <summary>
+/// Provides the packaged WinUI application entry point.
+/// </summary>
 public static class Program
 {
+    /// <summary>
+    /// Initializes process-wide services, runs Velopack startup hooks, and starts the WinUI dispatcher.
+    /// </summary>
+    /// <param name="args">Command-line arguments passed to the packaged application.</param>
     [STAThread]
     public static void Main(string[] args)
     {

--- a/src/Foundry/Services/Adk/AdkService.cs
+++ b/src/Foundry/Services/Adk/AdkService.cs
@@ -6,6 +6,9 @@ using Serilog;
 
 namespace Foundry.Services.Adk;
 
+/// <summary>
+/// Coordinates Windows ADK detection and elevated installer execution for the main application.
+/// </summary>
 internal sealed class AdkService(
     IAdkInstallationProbe installationProbe,
     IOperationProgressService operationProgressService,
@@ -24,8 +27,10 @@ internal sealed class AdkService(
     private readonly ILogger logger = logger.ForContext<AdkService>();
     private readonly SemaphoreSlim operationLock = new(1, 1);
 
+    /// <inheritdoc />
     public event EventHandler<AdkStatusChangedEventArgs>? StatusChanged;
 
+    /// <inheritdoc />
     public AdkInstallationStatus CurrentStatus { get; private set; } = new(
         false,
         false,
@@ -34,6 +39,7 @@ internal sealed class AdkService(
         null,
         "Windows ADK 10.1.26100.2454+ with the latest ADK servicing patch");
 
+    /// <inheritdoc />
     public Task<AdkInstallationStatus> RefreshStatusAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -50,11 +56,13 @@ internal sealed class AdkService(
         return Task.FromResult(status);
     }
 
+    /// <inheritdoc />
     public Task<AdkInstallationStatus> InstallAsync(CancellationToken cancellationToken = default)
     {
         return RunInstallOperationAsync(OperationKind.AdkInstall, uninstallFirst: false, cancellationToken);
     }
 
+    /// <inheritdoc />
     public Task<AdkInstallationStatus> UpgradeAsync(CancellationToken cancellationToken = default)
     {
         return RunInstallOperationAsync(OperationKind.AdkUpgrade, uninstallFirst: true, cancellationToken);
@@ -65,6 +73,7 @@ internal sealed class AdkService(
         bool uninstallFirst,
         CancellationToken cancellationToken)
     {
+        // ADK setup changes machine-level state and may show UAC, so only one install or upgrade can run at a time.
         await operationLock.WaitAsync(cancellationToken);
         string terminalStatus = string.Empty;
 
@@ -162,6 +171,7 @@ internal sealed class AdkService(
 
     private async Task UninstallExistingBundlesAsync(CancellationToken cancellationToken)
     {
+        // Upgrade uses the registered uninstall commands instead of assuming a fixed ADK install location.
         IReadOnlyList<AdkUninstallCommand> uninstallCommands = AdkUninstallCommandSelector.SelectBundleUninstallCommands(
             installationProbe.GetInstalledProducts());
 

--- a/src/Foundry/Services/Adk/AdkStatusChangedEventArgs.cs
+++ b/src/Foundry/Services/Adk/AdkStatusChangedEventArgs.cs
@@ -2,7 +2,14 @@ using Foundry.Core.Services.Adk;
 
 namespace Foundry.Services.Adk;
 
+/// <summary>
+/// Carries the latest Windows ADK installation status to subscribers.
+/// </summary>
+/// <param name="status">Current ADK installation status.</param>
 public sealed class AdkStatusChangedEventArgs(AdkInstallationStatus status) : EventArgs
 {
+    /// <summary>
+    /// Gets the current ADK installation status.
+    /// </summary>
     public AdkInstallationStatus Status { get; } = status;
 }

--- a/src/Foundry/Services/Adk/IAdkService.cs
+++ b/src/Foundry/Services/Adk/IAdkService.cs
@@ -2,11 +2,39 @@ using Foundry.Core.Services.Adk;
 
 namespace Foundry.Services.Adk;
 
+/// <summary>
+/// Manages Windows ADK and WinPE add-on readiness for media creation workflows.
+/// </summary>
 public interface IAdkService
 {
+    /// <summary>
+    /// Occurs when the detected ADK installation status changes.
+    /// </summary>
     event EventHandler<AdkStatusChangedEventArgs>? StatusChanged;
+
+    /// <summary>
+    /// Gets the latest detected ADK installation status.
+    /// </summary>
     AdkInstallationStatus CurrentStatus { get; }
+
+    /// <summary>
+    /// Re-detects installed ADK components and publishes the resulting status.
+    /// </summary>
+    /// <param name="cancellationToken">Token that cancels detection.</param>
+    /// <returns>The refreshed installation status.</returns>
     Task<AdkInstallationStatus> RefreshStatusAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Installs missing ADK components required by Foundry media creation.
+    /// </summary>
+    /// <param name="cancellationToken">Token that cancels the install operation.</param>
+    /// <returns>The installation status after the operation.</returns>
     Task<AdkInstallationStatus> InstallAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Upgrades installed ADK components when the current versions are unsupported.
+    /// </summary>
+    /// <param name="cancellationToken">Token that cancels the upgrade operation.</param>
+    /// <returns>The installation status after the operation.</returns>
     Task<AdkInstallationStatus> UpgradeAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Foundry/Services/Application/WinUiAppDispatcher.cs
+++ b/src/Foundry/Services/Application/WinUiAppDispatcher.cs
@@ -3,10 +3,15 @@ using Microsoft.UI.Dispatching;
 
 namespace Foundry.Services.Application;
 
+/// <summary>
+/// Marshals work onto the WinUI dispatcher queue.
+/// </summary>
 public sealed class WinUiAppDispatcher : IAppDispatcher
 {
+    /// <inheritdoc />
     public bool HasThreadAccess => GetDispatcherQueue().HasThreadAccess;
 
+    /// <inheritdoc />
     public bool TryEnqueue(Action action)
     {
         ArgumentNullException.ThrowIfNull(action);
@@ -21,6 +26,7 @@ public sealed class WinUiAppDispatcher : IAppDispatcher
         return dispatcherQueue.TryEnqueue(() => action());
     }
 
+    /// <inheritdoc />
     public Task EnqueueAsync(Action action)
     {
         ArgumentNullException.ThrowIfNull(action);

--- a/src/Foundry/Services/Application/WinUiApplicationLifetimeService.cs
+++ b/src/Foundry/Services/Application/WinUiApplicationLifetimeService.cs
@@ -2,8 +2,12 @@ using Foundry.Core.Services.Application;
 
 namespace Foundry.Services.Application;
 
+/// <summary>
+/// Bridges application lifetime requests to the WinUI application instance.
+/// </summary>
 public sealed class WinUiApplicationLifetimeService : IApplicationLifetimeService
 {
+    /// <inheritdoc />
     public void Shutdown()
     {
         Microsoft.UI.Xaml.Application.Current.Exit();

--- a/src/Foundry/Services/Application/WinUiDialogService.cs
+++ b/src/Foundry/Services/Application/WinUiDialogService.cs
@@ -2,8 +2,12 @@ using Foundry.Core.Services.Application;
 
 namespace Foundry.Services.Application;
 
+/// <summary>
+/// Displays simple WinUI message and confirmation dialogs for application services and view models.
+/// </summary>
 public sealed class WinUiDialogService : IDialogService
 {
+    /// <inheritdoc />
     public async Task ShowMessageAsync(DialogRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -19,6 +23,7 @@ public sealed class WinUiDialogService : IDialogService
         await dialog.ShowAsync();
     }
 
+    /// <inheritdoc />
     public async Task<bool> ConfirmAsync(ConfirmationDialogRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);

--- a/src/Foundry/Services/Application/WinUiExternalProcessLauncher.cs
+++ b/src/Foundry/Services/Application/WinUiExternalProcessLauncher.cs
@@ -4,10 +4,14 @@ using Serilog;
 
 namespace Foundry.Services.Application;
 
+/// <summary>
+/// Opens URIs, folders, and files with the Windows shell from WinUI commands.
+/// </summary>
 public sealed class WinUiExternalProcessLauncher(ILogger logger) : IExternalProcessLauncher
 {
     private readonly ILogger logger = logger.ForContext<WinUiExternalProcessLauncher>();
 
+    /// <inheritdoc />
     public Task OpenUriAsync(Uri uri)
     {
         ArgumentNullException.ThrowIfNull(uri);
@@ -15,6 +19,7 @@ public sealed class WinUiExternalProcessLauncher(ILogger logger) : IExternalProc
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     public Task OpenFolderAsync(string folderPath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(folderPath);
@@ -32,6 +37,7 @@ public sealed class WinUiExternalProcessLauncher(ILogger logger) : IExternalProc
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     public Task OpenFileAsync(string filePath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
@@ -66,6 +72,7 @@ public sealed class WinUiExternalProcessLauncher(ILogger logger) : IExternalProc
             Fragment = string.Empty
         };
 
+        // Strip credentials and query strings before logging externally opened URIs.
         return builder.Uri.ToString().TrimEnd('/');
     }
 }

--- a/src/Foundry/Services/Application/WinUiFilePickerService.cs
+++ b/src/Foundry/Services/Application/WinUiFilePickerService.cs
@@ -3,8 +3,12 @@ using Microsoft.Windows.Storage.Pickers;
 
 namespace Foundry.Services.Application;
 
+/// <summary>
+/// Implements file and folder picking through WinUI picker controls bound to the main window.
+/// </summary>
 public sealed class WinUiFilePickerService : IFilePickerService
 {
+    /// <inheritdoc />
     public async Task<string?> PickOpenFileAsync(FileOpenPickerRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -23,6 +27,7 @@ public sealed class WinUiFilePickerService : IFilePickerService
         return result?.Path;
     }
 
+    /// <inheritdoc />
     public async Task<string?> PickSaveFileAsync(FileSavePickerRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -43,6 +48,7 @@ public sealed class WinUiFilePickerService : IFilePickerService
         return result?.Path;
     }
 
+    /// <inheritdoc />
     public async Task<string?> PickFolderAsync(FolderPickerRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);

--- a/src/Foundry/Services/Autopilot/AutopilotTenantProfileService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantProfileService.cs
@@ -24,6 +24,76 @@ public sealed class AutopilotTenantProfileService(ILogger logger) : IAutopilotTe
     private const string AutopilotProfilesRequestPath = "beta/deviceManagement/windowsAutopilotDeploymentProfiles";
     private const string TenantDownloadSource = "Tenant download";
 
+    /// <summary>
+    /// Offline Autopilot profile schema version expected by Windows OOBE.
+    /// </summary>
+    private const int OfflineAutopilotProfileVersion = 2049;
+
+    /// <summary>
+    /// Base OOBE bitmask used by generated offline Autopilot profiles.
+    /// </summary>
+    private const int OobeConfigBaseFlags = 8 + 256;
+
+    /// <summary>
+    /// OOBE bitmask flag for standard user account type.
+    /// </summary>
+    private const int OobeConfigStandardUserFlag = 2;
+
+    /// <summary>
+    /// OOBE bitmask flag for hiding privacy settings.
+    /// </summary>
+    private const int OobeConfigHidePrivacySettingsFlag = 4;
+
+    /// <summary>
+    /// OOBE bitmask flag for hiding the license page.
+    /// </summary>
+    private const int OobeConfigHideEulaFlag = 16;
+
+    /// <summary>
+    /// OOBE bitmask flag for skipping keyboard selection.
+    /// </summary>
+    private const int OobeConfigSkipKeyboardSelectionFlag = 1024;
+
+    /// <summary>
+    /// OOBE bitmask flags for shared device usage.
+    /// </summary>
+    private const int OobeConfigSharedDeviceFlags = 96;
+
+    /// <summary>
+    /// Offline Autopilot value that requires enrollment during OOBE.
+    /// </summary>
+    private const int ForcedEnrollmentEnabled = 1;
+
+    /// <summary>
+    /// Offline Autopilot value that allows enrollment escape during OOBE.
+    /// </summary>
+    private const int ForcedEnrollmentDisabled = 0;
+
+    /// <summary>
+    /// Offline Autopilot value for hybrid Microsoft Entra join profiles.
+    /// </summary>
+    private const int DomainJoinMethodHybridEntraJoin = 1;
+
+    /// <summary>
+    /// Offline Autopilot value for Microsoft Entra join profiles.
+    /// </summary>
+    private const int DomainJoinMethodEntraJoin = 0;
+
+    /// <summary>
+    /// Value used by offline profiles to disable Autopilot update during OOBE.
+    /// </summary>
+    private const int AutopilotUpdateDisabled = 1;
+
+    /// <summary>
+    /// Autopilot update timeout written to offline profiles, in milliseconds.
+    /// </summary>
+    private const int AutopilotUpdateTimeoutMilliseconds = 1800000;
+
+    /// <summary>
+    /// Offline Autopilot value that skips domain controller connectivity checks for hybrid join.
+    /// </summary>
+    private const int HybridJoinSkipDcConnectivityCheckEnabled = 1;
+
     private static readonly string[] GraphScopes =
     [
         "DeviceManagementServiceConfig.Read.All",
@@ -118,32 +188,32 @@ public sealed class AutopilotTenantProfileService(ILogger logger) : IAutopilotTe
         bool hidePrivacySettings = oobeSettings.HidePrivacySettings ?? oobeSettings.PrivacySettingsHidden ?? false;
         bool hideEula = oobeSettings.HideEula ?? oobeSettings.EulaHidden ?? false;
         bool skipKeyboardSelectionPage = oobeSettings.SkipKeyboardSelectionPage ?? oobeSettings.KeyboardSelectionPageSkipped ?? false;
-        int forcedEnrollment = hideEscapeLink ? 1 : 0;
-        int oobeConfig = 8 + 256;
+        int forcedEnrollment = hideEscapeLink ? ForcedEnrollmentEnabled : ForcedEnrollmentDisabled;
+        int oobeConfig = OobeConfigBaseFlags;
 
         if (string.Equals(oobeSettings.UserType, "standard", StringComparison.OrdinalIgnoreCase))
         {
-            oobeConfig += 2;
+            oobeConfig += OobeConfigStandardUserFlag;
         }
 
         if (hidePrivacySettings)
         {
-            oobeConfig += 4;
+            oobeConfig += OobeConfigHidePrivacySettingsFlag;
         }
 
         if (hideEula)
         {
-            oobeConfig += 16;
+            oobeConfig += OobeConfigHideEulaFlag;
         }
 
         if (skipKeyboardSelectionPage)
         {
-            oobeConfig += 1024;
+            oobeConfig += OobeConfigSkipKeyboardSelectionFlag;
         }
 
         if (string.Equals(oobeSettings.DeviceUsageType, "shared", StringComparison.OrdinalIgnoreCase))
         {
-            oobeConfig += 96;
+            oobeConfig += OobeConfigSharedDeviceFlags;
         }
 
         string aadServerData = JsonSerializer.Serialize(
@@ -157,19 +227,19 @@ public sealed class AutopilotTenantProfileService(ILogger logger) : IAutopilotTe
         var configuration = new OfflineAutopilotConfiguration
         {
             CommentFile = $"Profile {displayName}",
-            Version = 2049,
+            Version = OfflineAutopilotProfileVersion,
             ZtdCorrelationId = profile.Id ?? string.Empty,
             CloudAssignedDomainJoinMethod = string.Equals(
                 profile.ODataType,
                 "#microsoft.graph.activeDirectoryWindowsAutopilotDeploymentProfile",
-                StringComparison.OrdinalIgnoreCase) ? 1 : 0,
+                StringComparison.OrdinalIgnoreCase) ? DomainJoinMethodHybridEntraJoin : DomainJoinMethodEntraJoin,
             CloudAssignedOobeConfig = oobeConfig,
             CloudAssignedForcedEnrollment = forcedEnrollment,
             CloudAssignedTenantId = organization.Id,
             CloudAssignedTenantDomain = organization.DefaultDomain,
             CloudAssignedAadServerData = aadServerData,
-            CloudAssignedAutopilotUpdateDisabled = 1,
-            CloudAssignedAutopilotUpdateTimeout = 1800000
+            CloudAssignedAutopilotUpdateDisabled = AutopilotUpdateDisabled,
+            CloudAssignedAutopilotUpdateTimeout = AutopilotUpdateTimeoutMilliseconds
         };
 
         if (!string.IsNullOrWhiteSpace(profile.DeviceNameTemplate))
@@ -185,7 +255,7 @@ public sealed class AutopilotTenantProfileService(ILogger logger) : IAutopilotTe
 
         if (profile.HybridAzureAdJoinSkipConnectivityCheck == true)
         {
-            configuration.HybridJoinSkipDcConnectivityCheck = 1;
+            configuration.HybridJoinSkipDcConnectivityCheck = HybridJoinSkipDcConnectivityCheckEnabled;
         }
 
         return JsonSerializer.Serialize(

--- a/src/Foundry/Services/Autopilot/AutopilotTenantProfileService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantProfileService.cs
@@ -10,6 +10,9 @@ using Serilog;
 
 namespace Foundry.Services.Autopilot;
 
+/// <summary>
+/// Downloads Windows Autopilot deployment profiles from Microsoft Graph and converts them to offline profile JSON.
+/// </summary>
 public sealed class AutopilotTenantProfileService(ILogger logger) : IAutopilotTenantProfileService
 {
     private const string DefaultClientId = "83eb3a92-030d-49b7-881b-32a1eb3e110a";
@@ -34,6 +37,7 @@ public sealed class AutopilotTenantProfileService(ILogger logger) : IAutopilotTe
 
     private readonly ILogger logger = logger.ForContext<AutopilotTenantProfileService>();
 
+    /// <inheritdoc />
     public async Task<IReadOnlyList<AutopilotProfileSettings>> DownloadFromTenantAsync(CancellationToken cancellationToken = default)
     {
         TokenCredential credential = CreateCredential();
@@ -70,6 +74,7 @@ public sealed class AutopilotTenantProfileService(ILogger logger) : IAutopilotTe
             RedirectUri = new Uri(DefaultRedirectUri, UriKind.Absolute),
             TokenCachePersistenceOptions = new TokenCachePersistenceOptions
             {
+                // Keep Graph auth reusable for Foundry without sharing a token cache name with unrelated tools.
                 Name = "FoundryAutopilotGraph"
             }
         });
@@ -108,6 +113,7 @@ public sealed class AutopilotTenantProfileService(ILogger logger) : IAutopilotTe
         string displayName)
     {
         OutOfBoxExperienceSettings oobeSettings = profile.OutOfBoxExperienceSettings ?? new();
+        // Microsoft Graph has used both current and legacy property names for these OOBE flags.
         bool hideEscapeLink = oobeSettings.HideEscapeLink ?? oobeSettings.EscapeLinkHidden ?? false;
         bool hidePrivacySettings = oobeSettings.HidePrivacySettings ?? oobeSettings.PrivacySettingsHidden ?? false;
         bool hideEula = oobeSettings.HideEula ?? oobeSettings.EulaHidden ?? false;
@@ -233,6 +239,7 @@ public sealed class AutopilotTenantProfileService(ILogger logger) : IAutopilotTe
                     !string.IsNullOrWhiteSpace(profile.DisplayName)));
             }
 
+            // Graph pagination returns an absolute nextLink; HttpClient accepts it even with a configured base address.
             requestPath = response?.NextLink;
         }
 
@@ -277,8 +284,17 @@ public sealed class AutopilotTenantProfileService(ILogger logger) : IAutopilotTe
     }
 }
 
+/// <summary>
+/// Tenant identity information required to generate offline Autopilot JSON.
+/// </summary>
+/// <param name="Id">The Microsoft Entra tenant ID.</param>
+/// <param name="DefaultDomain">The tenant default verified domain.</param>
 internal sealed record OrganizationInfo(string Id, string DefaultDomain);
 
+/// <summary>
+/// Represents a Microsoft Graph collection response.
+/// </summary>
+/// <typeparam name="TItem">The collection item type.</typeparam>
 internal sealed record GraphCollectionResponse<TItem>
 {
     public List<TItem>? Value { get; init; }
@@ -287,18 +303,27 @@ internal sealed record GraphCollectionResponse<TItem>
     public string? NextLink { get; init; }
 }
 
+/// <summary>
+/// Represents the subset of organization data required by offline Autopilot generation.
+/// </summary>
 internal sealed record OrganizationResponse
 {
     public string? Id { get; init; }
     public List<VerifiedDomain>? VerifiedDomains { get; init; }
 }
 
+/// <summary>
+/// Represents a verified tenant domain returned by Microsoft Graph.
+/// </summary>
 internal sealed record VerifiedDomain
 {
     public string? Name { get; init; }
     public bool IsDefault { get; init; }
 }
 
+/// <summary>
+/// Represents the Microsoft Graph Autopilot deployment profile payload consumed by Foundry.
+/// </summary>
 internal sealed record AutopilotDeploymentProfile
 {
     [JsonPropertyName("@odata.type")]
@@ -315,6 +340,9 @@ internal sealed record AutopilotDeploymentProfile
     public OutOfBoxExperienceSettings? OutOfBoxExperienceSettings { get; init; }
 }
 
+/// <summary>
+/// Represents the OOBE-related flags returned on an Autopilot deployment profile.
+/// </summary>
 internal sealed record OutOfBoxExperienceSettings
 {
     public string? UserType { get; init; }
@@ -334,13 +362,26 @@ internal sealed record OutOfBoxExperienceSettings
     public bool? EscapeLinkHidden { get; init; }
 }
 
+/// <summary>
+/// Represents the nested Azure AD server data embedded in offline Autopilot JSON.
+/// </summary>
+/// <param name="ZeroTouchConfig">The zero-touch configuration payload.</param>
 internal sealed record CloudAssignedAadServerData(ZeroTouchConfig ZeroTouchConfig);
 
+/// <summary>
+/// Represents the tenant zero-touch configuration embedded in offline Autopilot JSON.
+/// </summary>
+/// <param name="CloudAssignedTenantDomain">The tenant domain assigned to the device.</param>
+/// <param name="CloudAssignedTenantUpn">The optional assigned user principal name.</param>
+/// <param name="ForcedEnrollment">Whether enrollment is forced during OOBE.</param>
 internal sealed record ZeroTouchConfig(
     string CloudAssignedTenantDomain,
     string CloudAssignedTenantUpn,
     int ForcedEnrollment);
 
+/// <summary>
+/// Represents the offline Autopilot configuration file staged for Windows OOBE.
+/// </summary>
 internal sealed record OfflineAutopilotConfiguration
 {
     [JsonPropertyName("Comment_File")]
@@ -364,6 +405,9 @@ internal sealed record OfflineAutopilotConfiguration
     public int? HybridJoinSkipDcConnectivityCheck { get; set; }
 }
 
+/// <summary>
+/// Provides source-generated JSON metadata for Microsoft Graph and offline Autopilot payloads.
+/// </summary>
 [JsonSourceGenerationOptions(
     PropertyNameCaseInsensitive = true,
     WriteIndented = true,

--- a/src/Foundry/Services/Autopilot/IAutopilotProfileSelectionDialogService.cs
+++ b/src/Foundry/Services/Autopilot/IAutopilotProfileSelectionDialogService.cs
@@ -2,8 +2,16 @@ using Foundry.Core.Models.Configuration;
 
 namespace Foundry.Services.Autopilot;
 
+/// <summary>
+/// Shows the Autopilot profile selection dialog used by expert deployment configuration.
+/// </summary>
 public interface IAutopilotProfileSelectionDialogService
 {
+    /// <summary>
+    /// Lets the user select one or more downloaded Autopilot profiles.
+    /// </summary>
+    /// <param name="availableProfiles">Profiles available for selection.</param>
+    /// <returns>Selected profiles, or <see langword="null"/> when the dialog is canceled.</returns>
     Task<IReadOnlyList<AutopilotProfileSettings>?> PickProfilesAsync(
         IReadOnlyList<AutopilotProfileSettings> availableProfiles);
 }

--- a/src/Foundry/Services/Autopilot/IAutopilotTenantDownloadDialogService.cs
+++ b/src/Foundry/Services/Autopilot/IAutopilotTenantDownloadDialogService.cs
@@ -2,8 +2,16 @@ using Foundry.Core.Models.Configuration;
 
 namespace Foundry.Services.Autopilot;
 
+/// <summary>
+/// Shows the tenant profile download dialog and coordinates cancellation with the download operation.
+/// </summary>
 public interface IAutopilotTenantDownloadDialogService
 {
+    /// <summary>
+    /// Runs a profile download through a modal dialog.
+    /// </summary>
+    /// <param name="downloadProfilesAsync">Delegate that downloads profiles using the dialog-owned cancellation token.</param>
+    /// <returns>Downloaded profiles, or <see langword="null"/> when the dialog is canceled.</returns>
     Task<IReadOnlyList<AutopilotProfileSettings>?> DownloadAsync(
         Func<CancellationToken, Task<IReadOnlyList<AutopilotProfileSettings>>> downloadProfilesAsync);
 }

--- a/src/Foundry/Services/Autopilot/IAutopilotTenantProfileService.cs
+++ b/src/Foundry/Services/Autopilot/IAutopilotTenantProfileService.cs
@@ -2,7 +2,15 @@ using Foundry.Core.Models.Configuration;
 
 namespace Foundry.Services.Autopilot;
 
+/// <summary>
+/// Downloads Windows Autopilot deployment profiles from the signed-in tenant.
+/// </summary>
 public interface IAutopilotTenantProfileService
 {
+    /// <summary>
+    /// Authenticates to Microsoft Graph and downloads available Autopilot profiles.
+    /// </summary>
+    /// <param name="cancellationToken">Token that cancels tenant access and download operations.</param>
+    /// <returns>The profiles converted to Foundry configuration settings.</returns>
     Task<IReadOnlyList<AutopilotProfileSettings>> DownloadFromTenantAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Foundry/Services/Autopilot/IAutopilotTenantProfileService.cs
+++ b/src/Foundry/Services/Autopilot/IAutopilotTenantProfileService.cs
@@ -8,9 +8,9 @@ namespace Foundry.Services.Autopilot;
 public interface IAutopilotTenantProfileService
 {
     /// <summary>
-    /// Authenticates to Microsoft Graph and downloads available Autopilot profiles.
+    /// Opens interactive Microsoft Graph sign-in when needed and downloads available Autopilot profiles.
     /// </summary>
-    /// <param name="cancellationToken">Token that cancels tenant access and download operations.</param>
+    /// <param name="cancellationToken">Token that cancels token acquisition and Graph download operations.</param>
     /// <returns>The profiles converted to Foundry configuration settings.</returns>
     Task<IReadOnlyList<AutopilotProfileSettings>> DownloadFromTenantAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
@@ -4,6 +4,13 @@ using Serilog;
 
 namespace Foundry.Services.Configuration;
 
+/// <summary>
+/// Maintains the user-facing Expert Deploy configuration state and generates deploy/connect payloads from it.
+/// </summary>
+/// <remarks>
+/// Secrets that should not be persisted are kept in <see cref="INetworkSecretStateService"/> and are only merged
+/// when a provisioning bundle is generated.
+/// </remarks>
 internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfigurationStateService
 {
     private readonly IExpertConfigurationService expertConfigurationService;
@@ -28,12 +35,16 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
         Save();
     }
 
+    /// <inheritdoc />
     public event EventHandler? StateChanged;
 
+    /// <inheritdoc />
     public FoundryExpertConfigurationDocument Current { get; private set; }
 
+    /// <inheritdoc />
     public bool IsNetworkConfigurationReady => EvaluateNetworkMediaReadiness().IsNetworkConfigurationReady;
 
+    /// <inheritdoc />
     public bool IsDeployConfigurationReady
     {
         get
@@ -51,22 +62,29 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
         }
     }
 
+    /// <inheritdoc />
     public bool IsConnectProvisioningReady => EvaluateNetworkMediaReadiness().IsConnectProvisioningReady;
 
+    /// <inheritdoc />
     public bool AreRequiredSecretsReady => EvaluateNetworkMediaReadiness().AreRequiredSecretsReady;
 
+    /// <inheritdoc />
     public bool IsAutopilotEnabled => Current.Autopilot.IsEnabled;
 
+    /// <inheritdoc />
     public bool IsAutopilotConfigurationReady => !Current.Autopilot.IsEnabled || GetSelectedAutopilotProfile() is not null;
 
+    /// <inheritdoc />
     public string? SelectedAutopilotProfileDisplayName => Current.Autopilot.IsEnabled
         ? GetSelectedAutopilotProfile()?.DisplayName
         : null;
 
+    /// <inheritdoc />
     public string? SelectedAutopilotProfileFolderName => Current.Autopilot.IsEnabled
         ? GetSelectedAutopilotProfile()?.FolderName
         : null;
 
+    /// <inheritdoc />
     public void UpdateLocalization(LocalizationSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
@@ -75,6 +93,7 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 
+    /// <inheritdoc />
     public void UpdateNetwork(NetworkSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
@@ -84,6 +103,7 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 
+    /// <inheritdoc />
     public void UpdateCustomization(CustomizationSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
@@ -92,6 +112,7 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 
+    /// <inheritdoc />
     public void UpdateAutopilot(AutopilotSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
@@ -100,11 +121,13 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 
+    /// <inheritdoc />
     public string GenerateDeployConfigurationJson()
     {
         return deployConfigurationGenerator.Serialize(deployConfigurationGenerator.Generate(Current));
     }
 
+    /// <inheritdoc />
     public FoundryConnectProvisioningBundle GenerateConnectProvisioningBundle(string stagingDirectoryPath)
     {
         FoundryExpertConfigurationDocument document = Current with
@@ -155,6 +178,7 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
 
     private static AutopilotSettings SanitizeAutopilotForPersistence(AutopilotSettings settings)
     {
+        // Keep persisted profiles deterministic because the selected profile is referenced by ID across sessions.
         AutopilotProfileSettings[] profiles = settings.Profiles
             .Where(profile =>
                 !string.IsNullOrWhiteSpace(profile.Id) &&
@@ -187,6 +211,7 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
 
         return settings with
         {
+            // Disabled machine naming must not leak a stale prefix into generated deployment JSON.
             MachineNaming = new MachineNamingSettings
             {
                 IsEnabled = settings.MachineNaming.IsEnabled,

--- a/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
@@ -5,6 +5,10 @@ namespace Foundry.Services.Configuration;
 /// <summary>
 /// Owns the mutable expert deployment configuration assembled by the Foundry UI.
 /// </summary>
+/// <remarks>
+/// <see cref="Current"/> is always safe to persist. Volatile network secrets are kept outside the document and
+/// merged only when <see cref="GenerateConnectProvisioningBundle"/> creates the Connect payload.
+/// </remarks>
 public interface IExpertDeployConfigurationStateService
 {
     /// <summary>
@@ -13,7 +17,7 @@ public interface IExpertDeployConfigurationStateService
     event EventHandler? StateChanged;
 
     /// <summary>
-    /// Gets the current expert configuration document.
+    /// Gets the current expert configuration document after removing values that must not be persisted.
     /// </summary>
     FoundryExpertConfigurationDocument Current { get; }
 
@@ -58,7 +62,7 @@ public interface IExpertDeployConfigurationStateService
     string? SelectedAutopilotProfileFolderName { get; }
 
     /// <summary>
-    /// Replaces the network configuration section.
+    /// Replaces the network configuration section and stores required secrets in volatile state.
     /// </summary>
     /// <param name="settings">New network settings.</param>
     void UpdateNetwork(NetworkSettings settings);
@@ -82,7 +86,7 @@ public interface IExpertDeployConfigurationStateService
     void UpdateAutopilot(AutopilotSettings settings);
 
     /// <summary>
-    /// Generates Connect provisioning files for the current expert configuration.
+    /// Generates Connect provisioning files after merging required volatile secrets back into the current network settings.
     /// </summary>
     /// <param name="stagingDirectoryPath">Directory where provisioning files should be staged.</param>
     /// <returns>The generated Connect provisioning bundle.</returns>

--- a/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
@@ -2,37 +2,95 @@ using Foundry.Core.Models.Configuration;
 
 namespace Foundry.Services.Configuration;
 
+/// <summary>
+/// Owns the mutable expert deployment configuration assembled by the Foundry UI.
+/// </summary>
 public interface IExpertDeployConfigurationStateService
 {
+    /// <summary>
+    /// Occurs after the expert deployment configuration changes.
+    /// </summary>
     event EventHandler? StateChanged;
 
+    /// <summary>
+    /// Gets the current expert configuration document.
+    /// </summary>
     FoundryExpertConfigurationDocument Current { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether network configuration can be emitted for Connect.
+    /// </summary>
     bool IsNetworkConfigurationReady { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether Deploy configuration can be emitted.
+    /// </summary>
     bool IsDeployConfigurationReady { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether Connect provisioning files can be generated.
+    /// </summary>
     bool IsConnectProvisioningReady { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether required in-memory secrets are available.
+    /// </summary>
     bool AreRequiredSecretsReady { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether Autopilot staging is enabled.
+    /// </summary>
     bool IsAutopilotEnabled { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether the selected Autopilot profiles are valid for output.
+    /// </summary>
     bool IsAutopilotConfigurationReady { get; }
 
+    /// <summary>
+    /// Gets the selected Autopilot profile display name when a single profile is selected.
+    /// </summary>
     string? SelectedAutopilotProfileDisplayName { get; }
 
+    /// <summary>
+    /// Gets the selected Autopilot profile folder name when a single profile is selected.
+    /// </summary>
     string? SelectedAutopilotProfileFolderName { get; }
 
+    /// <summary>
+    /// Replaces the network configuration section.
+    /// </summary>
+    /// <param name="settings">New network settings.</param>
     void UpdateNetwork(NetworkSettings settings);
 
+    /// <summary>
+    /// Replaces the localization configuration section.
+    /// </summary>
+    /// <param name="settings">New localization settings.</param>
     void UpdateLocalization(LocalizationSettings settings);
 
+    /// <summary>
+    /// Replaces the customization configuration section.
+    /// </summary>
+    /// <param name="settings">New customization settings.</param>
     void UpdateCustomization(CustomizationSettings settings);
 
+    /// <summary>
+    /// Replaces the Autopilot configuration section.
+    /// </summary>
+    /// <param name="settings">New Autopilot settings.</param>
     void UpdateAutopilot(AutopilotSettings settings);
 
+    /// <summary>
+    /// Generates Connect provisioning files for the current expert configuration.
+    /// </summary>
+    /// <param name="stagingDirectoryPath">Directory where provisioning files should be staged.</param>
+    /// <returns>The generated Connect provisioning bundle.</returns>
     FoundryConnectProvisioningBundle GenerateConnectProvisioningBundle(string stagingDirectoryPath);
 
+    /// <summary>
+    /// Generates the Deploy configuration JSON for the current expert configuration.
+    /// </summary>
+    /// <returns>Serialized Deploy configuration JSON.</returns>
     string GenerateDeployConfigurationJson();
 }

--- a/src/Foundry/Services/Configuration/INetworkSecretStateService.cs
+++ b/src/Foundry/Services/Configuration/INetworkSecretStateService.cs
@@ -2,13 +2,31 @@ using Foundry.Core.Models.Configuration;
 
 namespace Foundry.Services.Configuration;
 
+/// <summary>
+/// Keeps transient network secrets available without persisting them back to configuration JSON.
+/// </summary>
 public interface INetworkSecretStateService
 {
+    /// <summary>
+    /// Gets the in-memory personal Wi-Fi passphrase captured from the UI.
+    /// </summary>
     string? PersonalWifiPassphrase { get; }
 
+    /// <summary>
+    /// Captures required secrets from the current network settings.
+    /// </summary>
+    /// <param name="settings">Network settings to inspect.</param>
     void Update(NetworkSettings settings);
 
+    /// <summary>
+    /// Removes the in-memory personal Wi-Fi passphrase.
+    /// </summary>
     void ClearPersonalWifiPassphrase();
 
+    /// <summary>
+    /// Applies required in-memory secrets to a network settings document before provisioning output is generated.
+    /// </summary>
+    /// <param name="settings">Network settings that may need secret values restored.</param>
+    /// <returns>Network settings with required secrets applied.</returns>
     NetworkSettings ApplyRequiredSecrets(NetworkSettings settings);
 }

--- a/src/Foundry/Services/Configuration/NetworkSecretStateService.cs
+++ b/src/Foundry/Services/Configuration/NetworkSecretStateService.cs
@@ -3,22 +3,29 @@ using Foundry.Core.Services.Configuration;
 
 namespace Foundry.Services.Configuration;
 
+/// <summary>
+/// Holds volatile network secrets that are required during provisioning but should not be saved to disk.
+/// </summary>
 internal sealed class NetworkSecretStateService : INetworkSecretStateService
 {
     private readonly NetworkSecretState state = new();
 
+    /// <inheritdoc />
     public string? PersonalWifiPassphrase => state.PersonalWifiPassphrase;
 
+    /// <inheritdoc />
     public void Update(NetworkSettings settings)
     {
         state.Update(settings);
     }
 
+    /// <inheritdoc />
     public void ClearPersonalWifiPassphrase()
     {
         state.ClearPersonalWifiPassphrase();
     }
 
+    /// <inheritdoc />
     public NetworkSettings ApplyRequiredSecrets(NetworkSettings settings)
     {
         return state.ApplyRequiredSecrets(settings);

--- a/src/Foundry/Services/GitHub/GitHubRepositoryContributor.cs
+++ b/src/Foundry/Services/GitHub/GitHubRepositoryContributor.cs
@@ -1,5 +1,13 @@
 namespace Foundry.Services.GitHub;
 
+/// <summary>
+/// Represents a GitHub contributor shown in the Foundry about dialog.
+/// </summary>
+/// <param name="Login">GitHub login name.</param>
+/// <param name="DisplayName">Optional public profile display name.</param>
+/// <param name="ProfileUri">Contributor profile URL.</param>
+/// <param name="AvatarUri">Contributor avatar URL.</param>
+/// <param name="Contributions">Contribution count returned by the repository contributors API.</param>
 public sealed record GitHubRepositoryContributor(
     string Login,
     string? DisplayName,

--- a/src/Foundry/Services/GitHub/GitHubRepositoryContributorService.cs
+++ b/src/Foundry/Services/GitHub/GitHubRepositoryContributorService.cs
@@ -3,10 +3,14 @@ using System.Text.Json;
 
 namespace Foundry.Services.GitHub;
 
+/// <summary>
+/// Reads contributor metadata from the public GitHub REST API.
+/// </summary>
 public sealed class GitHubRepositoryContributorService : IGitHubRepositoryContributorService
 {
     private static readonly HttpClient HttpClient = CreateHttpClient();
 
+    /// <inheritdoc />
     public async Task<IReadOnlyList<GitHubRepositoryContributor>> GetContributorsAsync(CancellationToken cancellationToken = default)
     {
         using HttpRequestMessage request = new(HttpMethod.Get, FoundryApplicationInfo.ContributorsApiUrl);
@@ -35,6 +39,7 @@ public sealed class GitHubRepositoryContributorService : IGitHubRepositoryContri
                 continue;
             }
 
+            // The contributors endpoint omits profile display names, so each user is enriched separately.
             contributors.Add(await EnrichContributorAsync(contributor, cancellationToken).ConfigureAwait(false));
         }
 

--- a/src/Foundry/Services/GitHub/IGitHubRepositoryContributorService.cs
+++ b/src/Foundry/Services/GitHub/IGitHubRepositoryContributorService.cs
@@ -1,6 +1,14 @@
 namespace Foundry.Services.GitHub;
 
+/// <summary>
+/// Loads repository contributor metadata for the about dialog.
+/// </summary>
 public interface IGitHubRepositoryContributorService
 {
+    /// <summary>
+    /// Gets non-bot repository contributors sorted by contribution count.
+    /// </summary>
+    /// <param name="cancellationToken">Token that cancels GitHub API calls.</param>
+    /// <returns>Contributor metadata.</returns>
     Task<IReadOnlyList<GitHubRepositoryContributor>> GetContributorsAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Foundry/Services/Localization/ApplicationLanguageChangedEventArgs.cs
+++ b/src/Foundry/Services/Localization/ApplicationLanguageChangedEventArgs.cs
@@ -1,7 +1,19 @@
 namespace Foundry.Services.Localization;
 
+/// <summary>
+/// Describes an application language transition.
+/// </summary>
+/// <param name="oldLanguage">Previously active language code.</param>
+/// <param name="newLanguage">Newly active language code.</param>
 public sealed class ApplicationLanguageChangedEventArgs(string oldLanguage, string newLanguage) : EventArgs
 {
+    /// <summary>
+    /// Gets the previously active language code.
+    /// </summary>
     public string OldLanguage { get; } = oldLanguage;
+
+    /// <summary>
+    /// Gets the newly active language code.
+    /// </summary>
     public string NewLanguage { get; } = newLanguage;
 }

--- a/src/Foundry/Services/Localization/ApplicationLocalizationService.cs
+++ b/src/Foundry/Services/Localization/ApplicationLocalizationService.cs
@@ -8,6 +8,9 @@ using Windows.System.UserProfile;
 
 namespace Foundry.Services.Localization;
 
+/// <summary>
+/// Applies the selected UI language and resolves localized WinUI resource strings.
+/// </summary>
 internal sealed class ApplicationLocalizationService(
     IAppSettingsService appSettingsService,
     ILogger logger) : IApplicationLocalizationService
@@ -17,10 +20,13 @@ internal sealed class ApplicationLocalizationService(
     private ResourceContext? resourceContext;
     private string currentLanguage = SupportedCultureCatalog.DefaultCultureCode;
 
+    /// <inheritdoc />
     public string CurrentLanguage => currentLanguage;
 
+    /// <inheritdoc />
     public event EventHandler<ApplicationLanguageChangedEventArgs>? LanguageChanged;
 
+    /// <inheritdoc />
     public Task InitializeAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -53,6 +59,7 @@ internal sealed class ApplicationLocalizationService(
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     public Task SetLanguageAsync(string languageCode, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -93,6 +100,7 @@ internal sealed class ApplicationLocalizationService(
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     public string GetString(string key)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
@@ -135,11 +143,13 @@ internal sealed class ApplicationLocalizationService(
             ?? resourceMap.TryGetValue(resourceKey, resourceContext);
     }
 
+    /// <inheritdoc />
     public string FormatString(string key, params object[] args)
     {
         return string.Format(CultureInfo.CurrentCulture, GetString(key), args);
     }
 
+    /// <inheritdoc />
     public IReadOnlyList<SupportedCultureOption> CreateSupportedLanguageOptions()
     {
         CultureInfo currentCulture = CultureInfo.GetCultureInfo(currentLanguage);
@@ -152,6 +162,7 @@ internal sealed class ApplicationLocalizationService(
         CultureInfo.DefaultThreadCurrentCulture = culture;
         CultureInfo.DefaultThreadCurrentUICulture = culture;
 
+        // WinUI resource lookup uses the primary language override plus an explicit ResourceContext qualifier.
         ApplicationLanguages.PrimaryLanguageOverride = languageCode;
 
         resourceManager ??= new ResourceManager();

--- a/src/Foundry/Services/Localization/IApplicationLocalizationService.cs
+++ b/src/Foundry/Services/Localization/IApplicationLocalizationService.cs
@@ -2,13 +2,52 @@ using Foundry.Core.Localization;
 
 namespace Foundry.Services.Localization;
 
+/// <summary>
+/// Provides application language state, resource lookup, and culture option creation.
+/// </summary>
 public interface IApplicationLocalizationService
 {
+    /// <summary>
+    /// Gets the currently active application language code.
+    /// </summary>
     string CurrentLanguage { get; }
+
+    /// <summary>
+    /// Occurs after the application language changes.
+    /// </summary>
     event EventHandler<ApplicationLanguageChangedEventArgs>? LanguageChanged;
+
+    /// <summary>
+    /// Initializes localization from persisted settings.
+    /// </summary>
+    /// <param name="cancellationToken">Token that cancels initialization.</param>
     Task InitializeAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Changes the active application language and persists the preference.
+    /// </summary>
+    /// <param name="languageCode">Culture code to activate.</param>
+    /// <param name="cancellationToken">Token that cancels the change.</param>
     Task SetLanguageAsync(string languageCode, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a localized string by resource key.
+    /// </summary>
+    /// <param name="key">Resource key.</param>
+    /// <returns>The localized string, or a fallback when the key is missing.</returns>
     string GetString(string key);
+
+    /// <summary>
+    /// Gets and formats a localized string by resource key.
+    /// </summary>
+    /// <param name="key">Resource key.</param>
+    /// <param name="args">Format arguments.</param>
+    /// <returns>The formatted localized string.</returns>
     string FormatString(string key, params object[] args);
+
+    /// <summary>
+    /// Creates the supported language option list used by settings UI.
+    /// </summary>
+    /// <returns>Supported culture options sorted for display.</returns>
     IReadOnlyList<SupportedCultureOption> CreateSupportedLanguageOptions();
 }

--- a/src/Foundry/Services/Operations/IOperationProgressService.cs
+++ b/src/Foundry/Services/Operations/IOperationProgressService.cs
@@ -1,13 +1,57 @@
 namespace Foundry.Services.Operations;
 
+/// <summary>
+/// Publishes process-wide progress for long-running operations that temporarily block navigation.
+/// </summary>
 public interface IOperationProgressService
 {
+    /// <summary>
+    /// Occurs after the operation progress snapshot changes.
+    /// </summary>
     event EventHandler<OperationProgressChangedEventArgs>? StateChanged;
+
+    /// <summary>
+    /// Gets the latest operation progress snapshot.
+    /// </summary>
     OperationProgressState State { get; }
+
+    /// <summary>
+    /// Starts a new operation and resets primary and secondary progress.
+    /// </summary>
+    /// <param name="kind">Operation category that drives shell behavior.</param>
+    /// <param name="status">Initial user-visible status text.</param>
     void Start(OperationKind kind, string status);
+
+    /// <summary>
+    /// Updates primary operation progress and clears secondary progress.
+    /// </summary>
+    /// <param name="progress">Primary progress percentage.</param>
+    /// <param name="status">User-visible status text.</param>
     void Report(int progress, string status);
+
+    /// <summary>
+    /// Updates primary and nested operation progress.
+    /// </summary>
+    /// <param name="progress">Primary progress percentage.</param>
+    /// <param name="status">User-visible primary status text.</param>
+    /// <param name="secondaryProgress">Nested operation progress percentage, when available.</param>
+    /// <param name="secondaryStatus">User-visible nested operation status text.</param>
     void Report(int progress, string status, int? secondaryProgress, string secondaryStatus);
+
+    /// <summary>
+    /// Clears nested operation progress while preserving the active primary operation.
+    /// </summary>
     void ClearSecondary();
+
+    /// <summary>
+    /// Marks the active operation as fully progressed without returning the service to idle.
+    /// </summary>
+    /// <param name="status">Completion status text shown before the operation is reset.</param>
     void Complete(string status);
+
+    /// <summary>
+    /// Returns the service to the idle operation state.
+    /// </summary>
+    /// <param name="status">Optional idle status text retained by subscribers.</param>
     void Reset(string status = "");
 }

--- a/src/Foundry/Services/Operations/IOperationProgressService.cs
+++ b/src/Foundry/Services/Operations/IOperationProgressService.cs
@@ -18,35 +18,40 @@ public interface IOperationProgressService
     /// <summary>
     /// Starts a new operation and resets primary and secondary progress.
     /// </summary>
-    /// <param name="kind">Operation category that drives shell behavior.</param>
+    /// <param name="kind">Operation category that drives shell behavior. <see cref="OperationKind.None"/> is rejected.</param>
     /// <param name="status">Initial user-visible status text.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="kind"/> is <see cref="OperationKind.None"/>.</exception>
     void Start(OperationKind kind, string status);
 
     /// <summary>
-    /// Updates primary operation progress and clears secondary progress.
+    /// Updates primary operation progress and clears secondary progress when an operation is active.
     /// </summary>
-    /// <param name="progress">Primary progress percentage.</param>
+    /// <param name="progress">Primary progress percentage clamped to the <c>0..100</c> range.</param>
     /// <param name="status">User-visible status text.</param>
+    /// <remarks>No state is changed when the service is idle.</remarks>
     void Report(int progress, string status);
 
     /// <summary>
-    /// Updates primary and nested operation progress.
+    /// Updates primary and nested operation progress when an operation is active.
     /// </summary>
-    /// <param name="progress">Primary progress percentage.</param>
+    /// <param name="progress">Primary progress percentage clamped to the <c>0..100</c> range.</param>
     /// <param name="status">User-visible primary status text.</param>
-    /// <param name="secondaryProgress">Nested operation progress percentage, when available.</param>
+    /// <param name="secondaryProgress">Nested operation progress percentage, when available, clamped to the <c>0..100</c> range.</param>
     /// <param name="secondaryStatus">User-visible nested operation status text.</param>
+    /// <remarks>No state is changed when the service is idle.</remarks>
     void Report(int progress, string status, int? secondaryProgress, string secondaryStatus);
 
     /// <summary>
     /// Clears nested operation progress while preserving the active primary operation.
     /// </summary>
+    /// <remarks>No state is changed when the service is idle or no nested progress is active.</remarks>
     void ClearSecondary();
 
     /// <summary>
     /// Marks the active operation as fully progressed without returning the service to idle.
     /// </summary>
     /// <param name="status">Completion status text shown before the operation is reset.</param>
+    /// <remarks>No state is changed when the service is idle.</remarks>
     void Complete(string status);
 
     /// <summary>

--- a/src/Foundry/Services/Operations/OperationKind.cs
+++ b/src/Foundry/Services/Operations/OperationKind.cs
@@ -1,9 +1,27 @@
 namespace Foundry.Services.Operations;
 
+/// <summary>
+/// Identifies the long-running operation currently reported through the shared operation progress service.
+/// </summary>
 public enum OperationKind
 {
+    /// <summary>
+    /// No user-visible operation is active.
+    /// </summary>
     None,
+
+    /// <summary>
+    /// Windows ADK or WinPE add-on installation is running.
+    /// </summary>
     AdkInstall,
+
+    /// <summary>
+    /// Windows ADK or WinPE add-on upgrade is running.
+    /// </summary>
     AdkUpgrade,
+
+    /// <summary>
+    /// Boot media creation is running.
+    /// </summary>
     MediaCreation
 }

--- a/src/Foundry/Services/Operations/OperationProgressChangedEventArgs.cs
+++ b/src/Foundry/Services/Operations/OperationProgressChangedEventArgs.cs
@@ -1,6 +1,13 @@
 namespace Foundry.Services.Operations;
 
+/// <summary>
+/// Carries the latest operation progress snapshot to shell and view-model subscribers.
+/// </summary>
+/// <param name="state">Updated progress snapshot.</param>
 public sealed class OperationProgressChangedEventArgs(OperationProgressState state) : EventArgs
 {
+    /// <summary>
+    /// Gets the updated progress snapshot.
+    /// </summary>
     public OperationProgressState State { get; } = state;
 }

--- a/src/Foundry/Services/Operations/OperationProgressService.cs
+++ b/src/Foundry/Services/Operations/OperationProgressService.cs
@@ -1,11 +1,17 @@
 namespace Foundry.Services.Operations;
 
+/// <summary>
+/// Stores and broadcasts the current shell-level operation progress state.
+/// </summary>
 internal sealed class OperationProgressService : IOperationProgressService
 {
+    /// <inheritdoc />
     public event EventHandler<OperationProgressChangedEventArgs>? StateChanged;
 
+    /// <inheritdoc />
     public OperationProgressState State { get; private set; } = OperationProgressState.Idle;
 
+    /// <inheritdoc />
     public void Start(OperationKind kind, string status)
     {
         if (kind == OperationKind.None)
@@ -16,11 +22,13 @@ internal sealed class OperationProgressService : IOperationProgressService
         SetState(new(kind, 0, status, null, string.Empty));
     }
 
+    /// <inheritdoc />
     public void Report(int progress, string status)
     {
         Report(progress, status, null, string.Empty);
     }
 
+    /// <inheritdoc />
     public void Report(int progress, string status, int? secondaryProgress, string secondaryStatus)
     {
         if (!State.IsRunning)
@@ -39,6 +47,7 @@ internal sealed class OperationProgressService : IOperationProgressService
         });
     }
 
+    /// <inheritdoc />
     public void ClearSecondary()
     {
         if (!State.IsRunning || !State.HasSecondaryProgress)
@@ -49,6 +58,7 @@ internal sealed class OperationProgressService : IOperationProgressService
         SetState(State with { SecondaryProgress = null, SecondaryStatus = string.Empty });
     }
 
+    /// <inheritdoc />
     public void Complete(string status)
     {
         if (!State.IsRunning)
@@ -65,6 +75,7 @@ internal sealed class OperationProgressService : IOperationProgressService
         });
     }
 
+    /// <inheritdoc />
     public void Reset(string status = "")
     {
         SetState(OperationProgressState.Idle with { Status = status });

--- a/src/Foundry/Services/Operations/OperationProgressState.cs
+++ b/src/Foundry/Services/Operations/OperationProgressState.cs
@@ -1,5 +1,13 @@
 namespace Foundry.Services.Operations;
 
+/// <summary>
+/// Represents the immutable progress snapshot broadcast to shell-level operation UI.
+/// </summary>
+/// <param name="Kind">The active operation kind, or <see cref="OperationKind.None"/> when idle.</param>
+/// <param name="Progress">Primary operation progress clamped to the 0-100 range.</param>
+/// <param name="Status">Primary status text displayed to the user.</param>
+/// <param name="SecondaryProgress">Optional nested operation progress clamped to the 0-100 range.</param>
+/// <param name="SecondaryStatus">Optional nested operation status text.</param>
 public sealed record OperationProgressState(
     OperationKind Kind,
     int Progress,
@@ -7,7 +15,18 @@ public sealed record OperationProgressState(
     int? SecondaryProgress,
     string SecondaryStatus)
 {
+    /// <summary>
+    /// Gets the canonical idle operation state.
+    /// </summary>
     public static OperationProgressState Idle { get; } = new(OperationKind.None, 0, string.Empty, null, string.Empty);
+
+    /// <summary>
+    /// Gets a value indicating whether the snapshot represents an active operation.
+    /// </summary>
     public bool IsRunning => Kind != OperationKind.None;
+
+    /// <summary>
+    /// Gets a value indicating whether nested progress should be shown.
+    /// </summary>
     public bool HasSecondaryProgress => SecondaryProgress.HasValue || !string.IsNullOrWhiteSpace(SecondaryStatus);
 }

--- a/src/Foundry/Services/Settings/FoundryAppSettings.cs
+++ b/src/Foundry/Services/Settings/FoundryAppSettings.cs
@@ -1,47 +1,147 @@
 namespace Foundry.Services.Settings;
 
+/// <summary>
+/// Root document persisted to the user application settings file.
+/// </summary>
 public sealed class FoundryAppSettings
 {
+    /// <summary>
+    /// Gets or sets the persisted settings schema version used for future migrations.
+    /// </summary>
     public int SchemaVersion { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets visual appearance preferences.
+    /// </summary>
     public AppearanceSettings Appearance { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets application language preferences.
+    /// </summary>
     public LocalizationSettings Localization { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets media creation defaults.
+    /// </summary>
     public MediaSettings Media { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets application update preferences and check history.
+    /// </summary>
     public UpdateSettings Updates { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets diagnostic and developer-mode preferences.
+    /// </summary>
     public DiagnosticsSettings Diagnostics { get; set; } = new();
 }
 
+/// <summary>
+/// Stores visual appearance preferences for the WinUI shell.
+/// </summary>
 public sealed class AppearanceSettings
 {
+    /// <summary>
+    /// Gets or sets the theme identifier, such as <c>system</c>, <c>light</c>, or <c>dark</c>.
+    /// </summary>
     public string Theme { get; set; } = "system";
 }
 
+/// <summary>
+/// Stores localization preferences for the application shell.
+/// </summary>
 public sealed class LocalizationSettings
 {
+    /// <summary>
+    /// Gets or sets the culture code used by the application resource loader.
+    /// </summary>
     public string Language { get; set; } = "en-US";
 }
 
+/// <summary>
+/// Stores defaults used when creating WinPE boot media.
+/// </summary>
 public sealed class MediaSettings
 {
+    /// <summary>
+    /// Gets or sets the default ISO output path.
+    /// </summary>
     public string IsoOutputPath { get; set; } = Path.Combine(Constants.IsoWorkspaceDirectoryPath, "Foundry.iso");
+
+    /// <summary>
+    /// Gets or sets the selected WinPE architecture name.
+    /// </summary>
     public string Architecture { get; set; } = "X64";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the WinPE image should use the CA 2023 boot signature.
+    /// </summary>
     public bool UseCa2023Signature { get; set; }
+
+    /// <summary>
+    /// Gets or sets the USB partition style used for removable media creation.
+    /// </summary>
     public string UsbPartitionStyle { get; set; } = "Gpt";
+
+    /// <summary>
+    /// Gets or sets the USB formatting mode used for removable media creation.
+    /// </summary>
     public string UsbFormatMode { get; set; } = "Quick";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Dell WinPE drivers should be included.
+    /// </summary>
     public bool IncludeDellDrivers { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether HP WinPE drivers should be included.
+    /// </summary>
     public bool IncludeHpDrivers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional custom driver directory included in WinPE media.
+    /// </summary>
     public string? CustomDriverDirectoryPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional WinPE language code applied to generated media.
+    /// </summary>
     public string WinPeLanguage { get; set; } = string.Empty;
 }
 
+/// <summary>
+/// Stores application update preferences and the last successful check timestamp.
+/// </summary>
 public sealed class UpdateSettings
 {
+    /// <summary>
+    /// Gets or sets a value indicating whether update checks run during application startup.
+    /// </summary>
     public bool CheckOnStartup { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the update channel name passed to the update feed.
+    /// </summary>
     public string Channel { get; set; } = Constants.DefaultUpdateChannel;
+
+    /// <summary>
+    /// Gets or sets the update feed URL.
+    /// </summary>
     public string FeedUrl { get; set; } = Constants.DefaultUpdateFeedUrl;
+
+    /// <summary>
+    /// Gets or sets the last time an update check completed.
+    /// </summary>
     public DateTimeOffset? LastCheckedAt { get; set; }
 }
 
+/// <summary>
+/// Stores diagnostic preferences that affect logging and developer-only UI behavior.
+/// </summary>
 public sealed class DiagnosticsSettings
 {
+    /// <summary>
+    /// Gets or sets a value indicating whether developer diagnostics are enabled.
+    /// </summary>
     public bool DeveloperMode { get; set; }
 }

--- a/src/Foundry/Services/Settings/IAppSettingsService.cs
+++ b/src/Foundry/Services/Settings/IAppSettingsService.cs
@@ -1,8 +1,22 @@
 namespace Foundry.Services.Settings;
 
+/// <summary>
+/// Loads and persists application-scoped settings for the WinUI shell.
+/// </summary>
 public interface IAppSettingsService
 {
+    /// <summary>
+    /// Gets the current mutable settings document.
+    /// </summary>
     FoundryAppSettings Current { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the settings file was missing during service initialization.
+    /// </summary>
     bool IsFirstRun { get; }
+
+    /// <summary>
+    /// Persists the current settings document to disk.
+    /// </summary>
     void Save();
 }

--- a/src/Foundry/Services/Settings/JsonAppSettingsService.cs
+++ b/src/Foundry/Services/Settings/JsonAppSettingsService.cs
@@ -4,10 +4,20 @@ using Serilog;
 
 namespace Foundry.Services.Settings;
 
+/// <summary>
+/// Persists application settings as JSON under the Foundry settings directory.
+/// </summary>
+/// <remarks>
+/// Invalid settings files are moved aside with an <c>.invalid</c> suffix and replaced by defaults.
+/// </remarks>
 internal sealed partial class JsonAppSettingsService : IAppSettingsService
 {
     private readonly ILogger logger;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonAppSettingsService"/> class.
+    /// </summary>
+    /// <param name="logger">Logger used for persistence and recovery diagnostics.</param>
     public JsonAppSettingsService(ILogger logger)
     {
         this.logger = logger.ForContext<JsonAppSettingsService>();
@@ -16,9 +26,13 @@ internal sealed partial class JsonAppSettingsService : IAppSettingsService
         Save();
     }
 
+    /// <inheritdoc />
     public FoundryAppSettings Current { get; }
+
+    /// <inheritdoc />
     public bool IsFirstRun { get; }
 
+    /// <inheritdoc />
     public void Save()
     {
         try

--- a/src/Foundry/Services/Shell/IShellNavigationGuardService.cs
+++ b/src/Foundry/Services/Shell/IShellNavigationGuardService.cs
@@ -1,8 +1,23 @@
 namespace Foundry.Services.Shell;
 
+/// <summary>
+/// Coordinates shell navigation availability across startup checks and long-running operations.
+/// </summary>
 public interface IShellNavigationGuardService
 {
+    /// <summary>
+    /// Occurs when the navigation guard state changes.
+    /// </summary>
     event EventHandler? StateChanged;
+
+    /// <summary>
+    /// Gets the current navigation guard state.
+    /// </summary>
     ShellNavigationState State { get; }
+
+    /// <summary>
+    /// Applies a new navigation guard state and notifies subscribers when it changes.
+    /// </summary>
+    /// <param name="state">New shell navigation state.</param>
     void SetState(ShellNavigationState state);
 }

--- a/src/Foundry/Services/Shell/ShellNavigationGuardService.cs
+++ b/src/Foundry/Services/Shell/ShellNavigationGuardService.cs
@@ -2,14 +2,20 @@ using Serilog;
 
 namespace Foundry.Services.Shell;
 
+/// <summary>
+/// Centralizes route-blocking state for the shell so views do not infer availability independently.
+/// </summary>
 internal sealed class ShellNavigationGuardService(ILogger logger) : IShellNavigationGuardService
 {
     private readonly ILogger logger = logger.ForContext<ShellNavigationGuardService>();
 
+    /// <inheritdoc />
     public event EventHandler? StateChanged;
 
+    /// <inheritdoc />
     public ShellNavigationState State { get; private set; } = ShellNavigationState.AdkBlocked;
 
+    /// <inheritdoc />
     public void SetState(ShellNavigationState state)
     {
         if (!Enum.IsDefined(state))

--- a/src/Foundry/Services/Shell/ShellNavigationState.cs
+++ b/src/Foundry/Services/Shell/ShellNavigationState.cs
@@ -1,8 +1,22 @@
 namespace Foundry.Services.Shell;
 
+/// <summary>
+/// Describes which shell routes and actions are currently available.
+/// </summary>
 public enum ShellNavigationState
 {
+    /// <summary>
+    /// Navigation is blocked because required Windows ADK components are missing or invalid.
+    /// </summary>
     AdkBlocked,
+
+    /// <summary>
+    /// The shell can navigate normally.
+    /// </summary>
     Ready,
+
+    /// <summary>
+    /// Navigation is restricted while a long-running operation is active.
+    /// </summary>
     OperationRunning
 }

--- a/src/Foundry/Services/Startup/IStartupReadinessService.cs
+++ b/src/Foundry/Services/Startup/IStartupReadinessService.cs
@@ -1,6 +1,13 @@
 namespace Foundry.Services.Startup;
 
+/// <summary>
+/// Runs startup checks that prime application state before the main workflow is used.
+/// </summary>
 public interface IStartupReadinessService
 {
+    /// <summary>
+    /// Initializes startup readiness state, including ADK detection and shell navigation guards.
+    /// </summary>
+    /// <param name="cancellationToken">Token that cancels startup checks.</param>
     Task InitializeAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Foundry/Services/Startup/StartupReadinessService.cs
+++ b/src/Foundry/Services/Startup/StartupReadinessService.cs
@@ -6,6 +6,9 @@ using Serilog;
 
 namespace Foundry.Services.Startup;
 
+/// <summary>
+/// Initializes startup state that controls whether the shell can enter media creation workflows.
+/// </summary>
 internal sealed class StartupReadinessService(
     IAppSettingsService appSettingsService,
     IApplicationUpdateService updateService,
@@ -15,6 +18,7 @@ internal sealed class StartupReadinessService(
 {
     private readonly ILogger logger = logger.ForContext<StartupReadinessService>();
 
+    /// <inheritdoc />
     public async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -32,6 +36,7 @@ internal sealed class StartupReadinessService(
                 appSettingsService.Current.Updates.Channel);
 
             var adkStatus = await adkService.RefreshStatusAsync(cancellationToken);
+            // ADK readiness is the startup gate for every route that can create or modify boot media.
             shellNavigationGuardService.SetState(adkStatus.CanCreateMedia ? ShellNavigationState.Ready : ShellNavigationState.AdkBlocked);
 
             await updateService.InitializeAsync(cancellationToken);

--- a/src/Foundry/Services/Updates/ApplicationUpdateCheckResult.cs
+++ b/src/Foundry/Services/Updates/ApplicationUpdateCheckResult.cs
@@ -1,10 +1,20 @@
 namespace Foundry.Services.Updates;
 
+/// <summary>
+/// Represents the outcome of an application update check.
+/// </summary>
+/// <param name="Status">Lifecycle status produced by the check.</param>
+/// <param name="Message">User-visible status or failure message.</param>
+/// <param name="Version">Available release version, when an update exists.</param>
+/// <param name="ReleaseNotes">Release notes for the available update, when provided by the feed.</param>
 public sealed record ApplicationUpdateCheckResult(
     ApplicationUpdateStatus Status,
     string Message,
     string? Version = null,
     string? ReleaseNotes = null)
 {
+    /// <summary>
+    /// Gets a value indicating whether the check found a downloadable update.
+    /// </summary>
     public bool IsUpdateAvailable => Status == ApplicationUpdateStatus.UpdateAvailable;
 }

--- a/src/Foundry/Services/Updates/ApplicationUpdateDownloadResult.cs
+++ b/src/Foundry/Services/Updates/ApplicationUpdateDownloadResult.cs
@@ -1,5 +1,10 @@
 namespace Foundry.Services.Updates;
 
+/// <summary>
+/// Represents the outcome of downloading an available application update.
+/// </summary>
+/// <param name="Status">Lifecycle status after the download attempt.</param>
+/// <param name="Message">User-visible completion or failure message.</param>
 public sealed record ApplicationUpdateDownloadResult(
     ApplicationUpdateStatus Status,
     string Message);

--- a/src/Foundry/Services/Updates/ApplicationUpdateService.cs
+++ b/src/Foundry/Services/Updates/ApplicationUpdateService.cs
@@ -7,6 +7,9 @@ using Velopack.Sources;
 
 namespace Foundry.Services.Updates;
 
+/// <summary>
+/// Wraps Velopack update checks, downloads, and restart handoff for the WinUI shell.
+/// </summary>
 internal sealed class ApplicationUpdateService(
     IAppSettingsService appSettingsService,
     IApplicationLifetimeService applicationLifetimeService,
@@ -17,6 +20,7 @@ internal sealed class ApplicationUpdateService(
     private Velopack.UpdateInfo? pendingUpdate;
     private UpdateManager? pendingUpdateManager;
 
+    /// <inheritdoc />
     public Task InitializeAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -29,12 +33,14 @@ internal sealed class ApplicationUpdateService(
 
         if (appSettingsService.Current.Updates.CheckOnStartup)
         {
+            // Startup checks are intentionally fire-and-forget so update availability never blocks app launch.
             _ = Task.Run(() => RunStartupCheckAsync(CancellationToken.None), CancellationToken.None);
         }
 
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     public async Task<ApplicationUpdateCheckResult> CheckForUpdatesAsync(
         bool isStartupCheck = false,
         CancellationToken cancellationToken = default)
@@ -148,6 +154,7 @@ internal sealed class ApplicationUpdateService(
         }
     }
 
+    /// <inheritdoc />
     public async Task<ApplicationUpdateDownloadResult> DownloadUpdateAsync(
         IProgress<int>? progress = null,
         CancellationToken cancellationToken = default)
@@ -185,6 +192,7 @@ internal sealed class ApplicationUpdateService(
         }
     }
 
+    /// <inheritdoc />
     public void ApplyUpdateAndRestart()
     {
         if (pendingUpdate is null || pendingUpdateManager is null)
@@ -236,6 +244,7 @@ internal sealed class ApplicationUpdateService(
             GetFeedUrlLogValue(feedUrl),
             appSettingsService.Current.Updates.Channel);
 
+        // GitHub feeds use prerelease visibility as the channel selector; stable channels only see releases.
         GithubSource source = new(
             feedUrl,
             accessToken: string.Empty,

--- a/src/Foundry/Services/Updates/ApplicationUpdateStateChangedEventArgs.cs
+++ b/src/Foundry/Services/Updates/ApplicationUpdateStateChangedEventArgs.cs
@@ -1,6 +1,13 @@
 namespace Foundry.Services.Updates;
 
+/// <summary>
+/// Carries the latest published application update check result.
+/// </summary>
+/// <param name="currentResult">Current update result, or <see langword="null"/> before the first result is published.</param>
 public sealed class ApplicationUpdateStateChangedEventArgs(ApplicationUpdateCheckResult? currentResult) : EventArgs
 {
+    /// <summary>
+    /// Gets the current update result.
+    /// </summary>
     public ApplicationUpdateCheckResult? CurrentResult { get; } = currentResult;
 }

--- a/src/Foundry/Services/Updates/ApplicationUpdateStateService.cs
+++ b/src/Foundry/Services/Updates/ApplicationUpdateStateService.cs
@@ -2,14 +2,20 @@ using Serilog;
 
 namespace Foundry.Services.Updates;
 
+/// <summary>
+/// Stores the latest update check result and broadcasts it to shell subscribers.
+/// </summary>
 internal sealed class ApplicationUpdateStateService(ILogger logger) : IApplicationUpdateStateService
 {
     private readonly ILogger logger = logger.ForContext<ApplicationUpdateStateService>();
 
+    /// <inheritdoc />
     public event EventHandler<ApplicationUpdateStateChangedEventArgs>? StateChanged;
 
+    /// <inheritdoc />
     public ApplicationUpdateCheckResult? CurrentResult { get; private set; }
 
+    /// <inheritdoc />
     public void Publish(ApplicationUpdateCheckResult result)
     {
         CurrentResult = result;

--- a/src/Foundry/Services/Updates/ApplicationUpdateStatus.cs
+++ b/src/Foundry/Services/Updates/ApplicationUpdateStatus.cs
@@ -1,14 +1,52 @@
 namespace Foundry.Services.Updates;
 
+/// <summary>
+/// Describes the application update lifecycle state shown by the shell and settings UI.
+/// </summary>
 public enum ApplicationUpdateStatus
 {
+    /// <summary>
+    /// The update service is initialized and ready for checks.
+    /// </summary>
     Ready,
+
+    /// <summary>
+    /// Update checks are intentionally skipped while debugging.
+    /// </summary>
     SkippedInDebug,
+
+    /// <summary>
+    /// The application is not running from an installed package that supports in-place updates.
+    /// </summary>
     NotInstalled,
+
+    /// <summary>
+    /// An update check is in progress.
+    /// </summary>
     Checking,
+
+    /// <summary>
+    /// The current application version is up to date.
+    /// </summary>
     NoUpdate,
+
+    /// <summary>
+    /// A newer release is available for download.
+    /// </summary>
     UpdateAvailable,
+
+    /// <summary>
+    /// An available update is being downloaded.
+    /// </summary>
     Downloading,
+
+    /// <summary>
+    /// An update has been downloaded and can be applied by restarting.
+    /// </summary>
     ReadyToRestart,
+
+    /// <summary>
+    /// The latest update operation failed.
+    /// </summary>
     Failed
 }

--- a/src/Foundry/Services/Updates/ApplicationUpdateStatus.cs
+++ b/src/Foundry/Services/Updates/ApplicationUpdateStatus.cs
@@ -1,7 +1,7 @@
 namespace Foundry.Services.Updates;
 
 /// <summary>
-/// Describes the application update lifecycle state shown by the shell and settings UI.
+/// Describes update states emitted by the update service or synthesized by update UI workflows.
 /// </summary>
 public enum ApplicationUpdateStatus
 {

--- a/src/Foundry/Services/Updates/IApplicationUpdateService.cs
+++ b/src/Foundry/Services/Updates/IApplicationUpdateService.cs
@@ -6,13 +6,13 @@ namespace Foundry.Services.Updates;
 public interface IApplicationUpdateService
 {
     /// <summary>
-    /// Initializes the update subsystem before any checks are requested.
+    /// Logs update settings and starts the optional startup check without blocking application launch.
     /// </summary>
     /// <param name="cancellationToken">Token that cancels initialization.</param>
     Task InitializeAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Checks the configured update feed for a newer release.
+    /// Checks the configured update feed for a newer release and publishes the result to update state.
     /// </summary>
     /// <param name="isStartupCheck">Whether the check is part of startup and may be skipped by settings.</param>
     /// <param name="cancellationToken">Token that cancels the check.</param>
@@ -28,7 +28,8 @@ public interface IApplicationUpdateService
     Task<ApplicationUpdateDownloadResult> DownloadUpdateAsync(IProgress<int>? progress = null, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Applies the downloaded update and restarts the application.
+    /// Applies the downloaded update and restarts the application when a pending update exists.
     /// </summary>
+    /// <remarks>The call logs and returns when no update has been checked and downloaded.</remarks>
     void ApplyUpdateAndRestart();
 }

--- a/src/Foundry/Services/Updates/IApplicationUpdateService.cs
+++ b/src/Foundry/Services/Updates/IApplicationUpdateService.cs
@@ -7,8 +7,9 @@ public interface IApplicationUpdateService
 {
     /// <summary>
     /// Logs update settings and starts the optional startup check without blocking application launch.
+    /// The startup check runs in the background and is not canceled by the initialization token after it starts.
     /// </summary>
-    /// <param name="cancellationToken">Token that cancels initialization.</param>
+    /// <param name="cancellationToken">Token that cancels initialization before the background check is scheduled.</param>
     Task InitializeAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -28,8 +29,8 @@ public interface IApplicationUpdateService
     Task<ApplicationUpdateDownloadResult> DownloadUpdateAsync(IProgress<int>? progress = null, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Applies the downloaded update and restarts the application when a pending update exists.
+    /// Applies the pending downloaded update and requests application shutdown so Velopack can complete the handoff.
     /// </summary>
-    /// <remarks>The call logs and returns when no update has been checked and downloaded.</remarks>
+    /// <remarks>The call logs and returns when no pending update exists, and rethrows apply failures.</remarks>
     void ApplyUpdateAndRestart();
 }

--- a/src/Foundry/Services/Updates/IApplicationUpdateService.cs
+++ b/src/Foundry/Services/Updates/IApplicationUpdateService.cs
@@ -1,9 +1,34 @@
 namespace Foundry.Services.Updates;
 
+/// <summary>
+/// Coordinates application update discovery, download, and restart handoff.
+/// </summary>
 public interface IApplicationUpdateService
 {
+    /// <summary>
+    /// Initializes the update subsystem before any checks are requested.
+    /// </summary>
+    /// <param name="cancellationToken">Token that cancels initialization.</param>
     Task InitializeAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks the configured update feed for a newer release.
+    /// </summary>
+    /// <param name="isStartupCheck">Whether the check is part of startup and may be skipped by settings.</param>
+    /// <param name="cancellationToken">Token that cancels the check.</param>
+    /// <returns>The update check result.</returns>
     Task<ApplicationUpdateCheckResult> CheckForUpdatesAsync(bool isStartupCheck = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Downloads the update discovered by the last successful check.
+    /// </summary>
+    /// <param name="progress">Optional progress receiver for download percentage updates.</param>
+    /// <param name="cancellationToken">Token that cancels the download.</param>
+    /// <returns>The download result.</returns>
     Task<ApplicationUpdateDownloadResult> DownloadUpdateAsync(IProgress<int>? progress = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Applies the downloaded update and restarts the application.
+    /// </summary>
     void ApplyUpdateAndRestart();
 }

--- a/src/Foundry/Services/Updates/IApplicationUpdateStateService.cs
+++ b/src/Foundry/Services/Updates/IApplicationUpdateStateService.cs
@@ -1,8 +1,23 @@
 namespace Foundry.Services.Updates;
 
+/// <summary>
+/// Stores and broadcasts the current application update result for shell and settings views.
+/// </summary>
 public interface IApplicationUpdateStateService
 {
+    /// <summary>
+    /// Occurs after a new update result is published.
+    /// </summary>
     event EventHandler<ApplicationUpdateStateChangedEventArgs>? StateChanged;
+
+    /// <summary>
+    /// Gets the latest published update result.
+    /// </summary>
     ApplicationUpdateCheckResult? CurrentResult { get; }
+
+    /// <summary>
+    /// Publishes a new update result to subscribers.
+    /// </summary>
+    /// <param name="result">Result to store and broadcast.</param>
     void Publish(ApplicationUpdateCheckResult result);
 }

--- a/src/Foundry/ViewModels/AdkPageViewModel.cs
+++ b/src/Foundry/ViewModels/AdkPageViewModel.cs
@@ -8,6 +8,9 @@ using Serilog;
 
 namespace Foundry.ViewModels;
 
+/// <summary>
+/// Drives the ADK readiness page and install or upgrade actions.
+/// </summary>
 public sealed partial class AdkPageViewModel : ObservableObject, IDisposable
 {
     private readonly IAdkService adkService;
@@ -77,6 +80,9 @@ public sealed partial class AdkPageViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     public partial bool IsActionEnabled { get; set; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AdkPageViewModel"/> class.
+    /// </summary>
     public AdkPageViewModel(
         IAdkService adkService,
         IOperationProgressService operationProgressService,
@@ -117,6 +123,7 @@ public sealed partial class AdkPageViewModel : ObservableObject, IDisposable
         ApplyOperationState(operationProgressService.State);
     }
 
+    /// <inheritdoc />
     public void Dispose()
     {
         adkService.StatusChanged -= OnAdkStatusChanged;
@@ -138,6 +145,7 @@ public sealed partial class AdkPageViewModel : ObservableObject, IDisposable
 
     private async Task RunBlockingAdkOperationAsync(Func<CancellationToken, Task<AdkInstallationStatus>> operation)
     {
+        // ADK setup can display UAC and modifies machine-level components, so the shell blocks navigation while it runs.
         shellNavigationGuardService.SetState(ShellNavigationState.OperationRunning);
 
         try

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -12,6 +12,9 @@ using Serilog;
 
 namespace Foundry.ViewModels;
 
+/// <summary>
+/// Backs the Autopilot configuration page, including local imports, tenant downloads, selection, and persistence.
+/// </summary>
 public sealed partial class AutopilotConfigurationViewModel : ObservableObject, IDisposable
 {
     private readonly IExpertDeployConfigurationStateService configurationStateService;
@@ -57,7 +60,14 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         isApplyingState = false;
     }
 
+    /// <summary>
+    /// Gets the ordered Autopilot profiles available for deployment.
+    /// </summary>
     public ObservableCollection<AutopilotProfileEntryViewModel> Profiles { get; } = [];
+
+    /// <summary>
+    /// Gets the currently selected profile rows for bulk UI actions.
+    /// </summary>
     public ObservableCollection<AutopilotProfileEntryViewModel> SelectedProfiles { get; } = [];
 
     public bool IsAutopilotSectionEnabled => IsAutopilotEnabled;
@@ -163,6 +173,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     [NotifyPropertyChangedFor(nameof(BusyStatusVisibility))]
     public partial bool IsDownloading { get; set; }
 
+    /// <summary>
+    /// Releases subscriptions to localization, configuration state, and profile collections.
+    /// </summary>
     public void Dispose()
     {
         localizationService.LanguageChanged -= OnLanguageChanged;
@@ -332,6 +345,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
         foreach (AutopilotProfileSettings incomingProfile in incomingProfiles)
         {
+            // Tenant downloads and file imports are keyed by Graph profile ID so newer payloads replace older copies.
             mergedProfiles[incomingProfile.Id] = AutopilotProfileEntryViewModel.FromSettings(incomingProfile);
         }
 
@@ -431,6 +445,10 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         RemoveSelectedProfilesCommand.NotifyCanExecuteChanged();
     }
 
+    /// <summary>
+    /// Replaces the selected profile rows after a XAML selection change.
+    /// </summary>
+    /// <param name="profiles">The selected profile view models.</param>
     public void ReplaceSelectedProfiles(IEnumerable<AutopilotProfileEntryViewModel> profiles)
     {
         SelectedProfiles.Clear();

--- a/src/Foundry/ViewModels/AutopilotProfileEntryViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotProfileEntryViewModel.cs
@@ -3,6 +3,15 @@ using Foundry.Core.Models.Configuration;
 
 namespace Foundry.ViewModels;
 
+/// <summary>
+/// Represents an imported Autopilot profile as displayed and persisted by the Foundry UI.
+/// </summary>
+/// <param name="Id">The stable Autopilot profile identifier.</param>
+/// <param name="DisplayName">The profile display name.</param>
+/// <param name="FolderName">The folder-safe profile name used when staging the JSON file.</param>
+/// <param name="Source">The import source shown to the user.</param>
+/// <param name="ImportedAtUtc">The UTC timestamp when the profile was imported.</param>
+/// <param name="JsonContent">The offline Autopilot profile JSON content.</param>
 public sealed record AutopilotProfileEntryViewModel(
     string Id,
     string DisplayName,
@@ -11,8 +20,16 @@ public sealed record AutopilotProfileEntryViewModel(
     DateTimeOffset ImportedAtUtc,
     string JsonContent)
 {
+    /// <summary>
+    /// Gets the localized import timestamp shown in the profile grid.
+    /// </summary>
     public string ImportedAtDisplay => ImportedAtUtc.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
 
+    /// <summary>
+    /// Creates a profile entry from persisted configuration settings.
+    /// </summary>
+    /// <param name="settings">The persisted Autopilot profile settings.</param>
+    /// <returns>A profile entry view model.</returns>
     public static AutopilotProfileEntryViewModel FromSettings(AutopilotProfileSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
@@ -26,6 +43,10 @@ public sealed record AutopilotProfileEntryViewModel(
             settings.JsonContent);
     }
 
+    /// <summary>
+    /// Converts this profile entry back to persisted configuration settings.
+    /// </summary>
+    /// <returns>The persisted profile settings.</returns>
     public AutopilotProfileSettings ToSettings()
     {
         return new AutopilotProfileSettings

--- a/src/Foundry/ViewModels/AutopilotProfileSelectionDialogViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotProfileSelectionDialogViewModel.cs
@@ -5,6 +5,9 @@ using Foundry.Services.Localization;
 
 namespace Foundry.ViewModels;
 
+/// <summary>
+/// Backs the tenant profile picker shown after downloading Autopilot profiles from Microsoft Graph.
+/// </summary>
 public sealed partial class AutopilotProfileSelectionDialogViewModel : ObservableObject, IDisposable
 {
     private readonly IApplicationLocalizationService localizationService;
@@ -30,6 +33,9 @@ public sealed partial class AutopilotProfileSelectionDialogViewModel : Observabl
         localizationService.LanguageChanged += OnLanguageChanged;
     }
 
+    /// <summary>
+    /// Gets the available profiles with per-row selection state.
+    /// </summary>
     public ObservableCollection<SelectableAutopilotProfileEntryViewModel> Profiles { get; } = [];
 
     [ObservableProperty]
@@ -62,6 +68,10 @@ public sealed partial class AutopilotProfileSelectionDialogViewModel : Observabl
     [ObservableProperty]
     public partial bool HasSelectedProfiles { get; set; }
 
+    /// <summary>
+    /// Gets the selected Autopilot profile settings to import into the deployment configuration.
+    /// </summary>
+    /// <returns>The selected profile settings.</returns>
     public IReadOnlyList<AutopilotProfileSettings> GetSelectedProfiles()
     {
         return Profiles
@@ -70,6 +80,9 @@ public sealed partial class AutopilotProfileSelectionDialogViewModel : Observabl
             .ToArray();
     }
 
+    /// <summary>
+    /// Releases localization and row selection subscriptions.
+    /// </summary>
     public void Dispose()
     {
         localizationService.LanguageChanged -= OnLanguageChanged;
@@ -139,16 +152,34 @@ public sealed partial class AutopilotProfileSelectionDialogViewModel : Observabl
 
 }
 
+/// <summary>
+/// Wraps a tenant Autopilot profile with dialog selection state.
+/// </summary>
 public sealed partial class SelectableAutopilotProfileEntryViewModel : ObservableObject
 {
+    /// <summary>
+    /// Initializes a selectable profile row.
+    /// </summary>
+    /// <param name="profile">The downloaded profile represented by this row.</param>
     public SelectableAutopilotProfileEntryViewModel(AutopilotProfileSettings profile)
     {
         Profile = profile ?? throw new ArgumentNullException(nameof(profile));
         IsSelected = true;
     }
 
+    /// <summary>
+    /// Gets the downloaded profile represented by this row.
+    /// </summary>
     public AutopilotProfileSettings Profile { get; }
+
+    /// <summary>
+    /// Gets the display name shown in the profile picker.
+    /// </summary>
     public string DisplayName => Profile.DisplayName;
+
+    /// <summary>
+    /// Gets the staging folder name shown in the profile picker.
+    /// </summary>
     public string FolderName => Profile.FolderName;
 
     [ObservableProperty]

--- a/src/Foundry/ViewModels/CustomizationConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/CustomizationConfigurationViewModel.cs
@@ -6,6 +6,9 @@ using Microsoft.UI.Xaml;
 
 namespace Foundry.ViewModels;
 
+/// <summary>
+/// Backs deployment customization settings that are generated into the Expert Deploy configuration.
+/// </summary>
 public sealed partial class CustomizationConfigurationViewModel : ObservableObject, IDisposable
 {
     private readonly IExpertDeployConfigurationStateService configurationStateService;
@@ -28,9 +31,24 @@ public sealed partial class CustomizationConfigurationViewModel : ObservableObje
         isApplyingState = false;
     }
 
+    /// <summary>
+    /// Gets the maximum computer-name prefix length accepted by Windows naming rules.
+    /// </summary>
     public int MachineNamePrefixMaxLength => ComputerNameRules.MaxLength;
+
+    /// <summary>
+    /// Gets whether machine naming controls should be enabled.
+    /// </summary>
     public bool IsMachineNamingOptionsEnabled => IsMachineNamingEnabled;
+
+    /// <summary>
+    /// Gets whether the current machine-name prefix has a validation error.
+    /// </summary>
     public bool HasMachineNamePrefixValidationError => !string.IsNullOrWhiteSpace(MachineNamePrefixValidationMessage);
+
+    /// <summary>
+    /// Gets the visibility for the machine-name prefix validation message.
+    /// </summary>
     public Visibility MachineNamePrefixValidationVisibility => HasMachineNamePrefixValidationError
         ? Visibility.Visible
         : Visibility.Collapsed;
@@ -87,6 +105,9 @@ public sealed partial class CustomizationConfigurationViewModel : ObservableObje
     [ObservableProperty]
     public partial bool AllowManualSuffixEdit { get; set; } = true;
 
+    /// <summary>
+    /// Gets the localized validation message for the machine-name prefix.
+    /// </summary>
     public string MachineNamePrefixValidationMessage
     {
         get
@@ -102,6 +123,9 @@ public sealed partial class CustomizationConfigurationViewModel : ObservableObje
         }
     }
 
+    /// <summary>
+    /// Releases subscriptions to localization and shared configuration state.
+    /// </summary>
     public void Dispose()
     {
         localizationService.LanguageChanged -= OnLanguageChanged;
@@ -173,6 +197,7 @@ public sealed partial class CustomizationConfigurationViewModel : ObservableObje
         isSavingState = true;
         try
         {
+            // Disabled machine naming intentionally clears generated JSON fields instead of preserving stale UI values.
             configurationStateService.UpdateCustomization(new CustomizationSettings
             {
                 MachineNaming = new MachineNamingSettings

--- a/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
@@ -11,6 +11,9 @@ using Serilog;
 
 namespace Foundry.ViewModels;
 
+/// <summary>
+/// Backs the general media settings page and persists WinPE architecture, language, and driver-source choices.
+/// </summary>
 public sealed partial class GeneralConfigurationViewModel : ObservableObject
 {
     private readonly IAppSettingsService appSettingsService;
@@ -51,7 +54,14 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
         isInitializing = false;
     }
 
+    /// <summary>
+    /// Gets the WinPE architecture options supported by the media build workflow.
+    /// </summary>
     public ObservableCollection<SelectionOption<WinPeArchitecture>> Architectures { get; }
+
+    /// <summary>
+    /// Gets the WinPE language packs discovered from the installed ADK.
+    /// </summary>
     public ObservableCollection<string> AvailableWinPeLanguages { get; } = [];
 
     [ObservableProperty]
@@ -82,6 +92,9 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
     [ObservableProperty]
     public partial string WinPeLanguageUnavailableDescription { get; set; }
 
+    /// <summary>
+    /// Gets whether the WinPE language picker should be hidden because no language packs are available.
+    /// </summary>
     public Visibility WinPeLanguageUnavailableVisibility => HasWinPeLanguages ? Visibility.Collapsed : Visibility.Visible;
 
     [RelayCommand]
@@ -96,11 +109,17 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// Refreshes whether media creation is currently allowed by the detected ADK state.
+    /// </summary>
     public void RefreshAdkState()
     {
         CanCreateMedia = adkService.CurrentStatus.CanCreateMedia;
     }
 
+    /// <summary>
+    /// Reloads available WinPE languages from the ADK path matching the selected architecture.
+    /// </summary>
     public void RefreshWinPeLanguages()
     {
         RefreshAdkState();
@@ -156,6 +175,10 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
         appSettingsService.Save();
     }
 
+    /// <summary>
+    /// Persists the selected WinPE language after normalizing it to a culture name.
+    /// </summary>
+    /// <param name="selectedLanguage">The selected WinPE language.</param>
     public void SetWinPeLanguage(string? selectedLanguage)
     {
         if (string.IsNullOrWhiteSpace(selectedLanguage))
@@ -240,6 +263,7 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject
 
         if (ParseEnum(appSettingsService.Current.Media.UsbPartitionStyle, UsbPartitionStyle.Gpt) == UsbPartitionStyle.Mbr)
         {
+            // ARM64 boot media must remain GPT-compatible, so changing the architecture also repairs the persisted USB style.
             appSettingsService.Current.Media.UsbPartitionStyle = UsbPartitionStyle.Gpt.ToString();
         }
     }

--- a/src/Foundry/ViewModels/HomeLandingViewModel.cs
+++ b/src/Foundry/ViewModels/HomeLandingViewModel.cs
@@ -7,6 +7,9 @@ using Serilog;
 
 namespace Foundry.ViewModels;
 
+/// <summary>
+/// Provides localized home page content and ADK readiness status.
+/// </summary>
 public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
 {
     private readonly IAdkService adkService;
@@ -65,11 +68,29 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     public partial InfoBarSeverity AdkStatusSeverity { get; set; }
 
+    /// <summary>
+    /// Gets the documentation URL opened by the home page.
+    /// </summary>
     public string DocumentationUrl => FoundryApplicationInfo.DocumentationUrl;
+
+    /// <summary>
+    /// Gets the localized navigation title for the ADK page.
+    /// </summary>
     public string AdkNavigationTitle => localizationService.GetString("Adk.PageTitle");
+
+    /// <summary>
+    /// Gets the localized navigation title for general configuration.
+    /// </summary>
     public string GeneralNavigationTitle => localizationService.GetString("GeneralConfigurationPage_Title.Text");
+
+    /// <summary>
+    /// Gets the localized navigation title for media creation.
+    /// </summary>
     public string StartNavigationTitle => localizationService.GetString("StartPage_Title.Text");
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HomeLandingViewModel"/> class.
+    /// </summary>
     public HomeLandingViewModel(
         IAdkService adkService,
         IApplicationLocalizationService localizationService,
@@ -105,6 +126,7 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
         ApplyLocalizedText();
     }
 
+    /// <inheritdoc />
     public void Dispose()
     {
         adkService.StatusChanged -= OnAdkStatusChanged;

--- a/src/Foundry/ViewModels/MainViewModel.cs
+++ b/src/Foundry/ViewModels/MainViewModel.cs
@@ -5,6 +5,9 @@ using Serilog;
 
 namespace Foundry.ViewModels
 {
+    /// <summary>
+    /// Owns shell-level update banner state for the main window.
+    /// </summary>
     public sealed partial class MainViewModel : ObservableObject, IDisposable
     {
         private readonly IApplicationUpdateStateService updateStateService;
@@ -26,6 +29,9 @@ namespace Foundry.ViewModels
         [ObservableProperty]
         public partial string UpdateBannerActionText { get; set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MainViewModel"/> class.
+        /// </summary>
         public MainViewModel(
             IApplicationUpdateStateService updateStateService,
             IApplicationLocalizationService localizationService,
@@ -46,18 +52,25 @@ namespace Foundry.ViewModels
             ApplyUpdateState(updateStateService.CurrentResult);
         }
 
+        /// <summary>
+        /// Hides the update banner until a different update result is published.
+        /// </summary>
         public void DismissUpdateBanner()
         {
             isUpdateBannerDismissed = true;
             IsUpdateBannerOpen = false;
         }
 
+        /// <summary>
+        /// Marks the update banner action as handled and hides the banner.
+        /// </summary>
         public void MarkUpdateBannerActionOpened()
         {
             isUpdateBannerDismissed = true;
             IsUpdateBannerOpen = false;
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             updateStateService.StateChanged -= OnUpdateStateChanged;

--- a/src/Foundry/ViewModels/NetworkConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/NetworkConfigurationViewModel.cs
@@ -8,6 +8,13 @@ using Microsoft.UI.Xaml;
 
 namespace Foundry.ViewModels;
 
+/// <summary>
+/// Backs the network configuration page and keeps persisted 802.1X/Wi-Fi settings in sync with the UI.
+/// </summary>
+/// <remarks>
+/// Personal Wi-Fi passphrases are routed through <see cref="INetworkSecretStateService"/> so they can be used for
+/// provisioning without becoming durable application settings.
+/// </remarks>
 public sealed partial class NetworkConfigurationViewModel : ObservableObject, IDisposable
 {
     private readonly IExpertDeployConfigurationStateService configurationStateService;
@@ -37,6 +44,9 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
         isApplyingState = false;
     }
 
+    /// <summary>
+    /// Gets the Wi-Fi security type options shown by the network page.
+    /// </summary>
     public ObservableCollection<SelectionOption<string>> WifiSecurityTypes { get; } = [];
 
     [ObservableProperty]
@@ -277,6 +287,9 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
         NetworkConfigurationValidationCode.WifiEnterpriseCertificateMissing);
     public Visibility WifiCertificateValidationVisibility => ToVisibility(WifiCertificateValidationMessage);
 
+    /// <summary>
+    /// Releases subscriptions to localization and shared configuration state.
+    /// </summary>
     public void Dispose()
     {
         localizationService.LanguageChanged -= OnLanguageChanged;
@@ -485,6 +498,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
         isSavingState = true;
         try
         {
+            // Store only the sanitized network model; volatile secrets stay in the secret state service.
             configurationStateService.UpdateNetwork(BuildSettingsForValidation());
         }
         finally

--- a/src/Foundry/ViewModels/SelectionOption.cs
+++ b/src/Foundry/ViewModels/SelectionOption.cs
@@ -1,3 +1,9 @@
 namespace Foundry.ViewModels;
 
+/// <summary>
+/// Represents a typed value paired with display text for combo boxes and option selectors.
+/// </summary>
+/// <typeparam name="T">Type of the backing value.</typeparam>
+/// <param name="Value">Backing value used by the workflow.</param>
+/// <param name="DisplayName">User-facing option label.</param>
 public sealed record SelectionOption<T>(T Value, string DisplayName);

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -16,6 +16,9 @@ using Serilog;
 
 namespace Foundry.ViewModels;
 
+/// <summary>
+/// Coordinates media creation options, readiness evaluation, and final ISO or USB creation commands.
+/// </summary>
 public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 {
     private readonly IAppSettingsService appSettingsService;
@@ -38,6 +41,9 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     private UsbCandidateDiscoveryState usbCandidateDiscoveryState = UsbCandidateDiscoveryState.NotLoaded;
     private bool isLoadingConfiguration = true;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StartMediaViewModel"/> class.
+    /// </summary>
     public StartMediaViewModel(
         IAppSettingsService appSettingsService,
         IAdkService adkService,
@@ -98,12 +104,39 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         RefreshEvaluation();
     }
 
+    /// <summary>
+    /// Gets the available WinPE architecture options.
+    /// </summary>
     public ObservableCollection<SelectionOption<WinPeArchitecture>> Architectures { get; }
+
+    /// <summary>
+    /// Gets the USB partition style options valid for the selected architecture.
+    /// </summary>
     public ObservableCollection<SelectionOption<UsbPartitionStyle>> PartitionStyles { get; }
+
+    /// <summary>
+    /// Gets the USB formatting mode options.
+    /// </summary>
     public ObservableCollection<SelectionOption<UsbFormatMode>> FormatModes { get; }
+
+    /// <summary>
+    /// Gets removable USB disk candidates discovered for media creation.
+    /// </summary>
     public ObservableCollection<SelectionOption<WinPeUsbDiskCandidate>> UsbCandidates { get; } = [];
+
+    /// <summary>
+    /// Gets readiness items that describe prerequisite blockers.
+    /// </summary>
     public ObservableCollection<StartReadinessItemViewModel> PrerequisiteReadinessItems { get; } = [];
+
+    /// <summary>
+    /// Gets readiness items that describe ISO and USB output blockers.
+    /// </summary>
     public ObservableCollection<StartReadinessItemViewModel> MediaOutputReadinessItems { get; } = [];
+
+    /// <summary>
+    /// Gets readiness items that describe expert configuration blockers.
+    /// </summary>
     public ObservableCollection<StartReadinessItemViewModel> ExpertConfigurationReadinessItems { get; } = [];
 
     [ObservableProperty]
@@ -181,6 +214,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     public partial bool IsExpertConfigurationReadinessExpanded { get; set; }
 
+    /// <inheritdoc />
     public void Dispose()
     {
         adkService.StatusChanged -= OnAdkStatusChanged;
@@ -188,6 +222,9 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         localizationService.LanguageChanged -= OnLanguageChanged;
     }
 
+    /// <summary>
+    /// Refreshes readiness and disk candidates after the page is loaded.
+    /// </summary>
     public async Task InitializeAsync()
     {
         RefreshEvaluation();
@@ -340,6 +377,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
         IsMediaOperationRunning = true;
         RefreshEvaluation();
+        // Final media operations can format disks or overwrite ISO output, so the shell remains locked until completion.
         shellNavigationGuardService.SetState(ShellNavigationState.OperationRunning);
         string terminalStatus = string.Empty;
         string? successMessage = null;

--- a/src/Foundry/ViewModels/StartReadinessItemViewModel.cs
+++ b/src/Foundry/ViewModels/StartReadinessItemViewModel.cs
@@ -1,17 +1,56 @@
 namespace Foundry.ViewModels;
 
+/// <summary>
+/// Identifies the navigation target opened by a readiness item action.
+/// </summary>
 public enum StartReadinessNavigationTarget
 {
+    /// <summary>
+    /// No navigation action is available.
+    /// </summary>
     None,
+
+    /// <summary>
+    /// Navigate to the ADK readiness page.
+    /// </summary>
     Adk,
+
+    /// <summary>
+    /// Navigate to general media configuration.
+    /// </summary>
     General,
+
+    /// <summary>
+    /// Navigate to network configuration.
+    /// </summary>
     Network,
+
+    /// <summary>
+    /// Navigate to Autopilot configuration.
+    /// </summary>
     Autopilot,
+
+    /// <summary>
+    /// Navigate to deployment customization settings.
+    /// </summary>
     Customization
 }
 
+/// <summary>
+/// Represents one readiness row shown on the media start page.
+/// </summary>
 public sealed class StartReadinessItemViewModel
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StartReadinessItemViewModel"/> class.
+    /// </summary>
+    /// <param name="title">Readiness item title.</param>
+    /// <param name="description">Readiness item description.</param>
+    /// <param name="status">Current readiness status text.</param>
+    /// <param name="glyph">Icon glyph shown beside the item.</param>
+    /// <param name="expandsGroup">Whether activating the item expands a local readiness group.</param>
+    /// <param name="navigationTarget">Optional shell navigation target.</param>
+    /// <param name="actionText">Optional action button text.</param>
     public StartReadinessItemViewModel(
         string title,
         string description,
@@ -30,20 +69,44 @@ public sealed class StartReadinessItemViewModel
         ActionText = actionText;
     }
 
+    /// <summary>
+    /// Gets the readiness item title.
+    /// </summary>
     public string Title { get; }
 
+    /// <summary>
+    /// Gets the readiness item description.
+    /// </summary>
     public string Description { get; }
 
+    /// <summary>
+    /// Gets the current readiness status text.
+    /// </summary>
     public string Status { get; }
 
+    /// <summary>
+    /// Gets the icon glyph shown beside the item.
+    /// </summary>
     public string Glyph { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether the item expands a readiness group instead of navigating.
+    /// </summary>
     public bool ExpandsGroup { get; }
 
+    /// <summary>
+    /// Gets the target page opened by the action button.
+    /// </summary>
     public StartReadinessNavigationTarget NavigationTarget { get; }
 
+    /// <summary>
+    /// Gets the action button text.
+    /// </summary>
     public string ActionText { get; }
 
+    /// <summary>
+    /// Gets the action button visibility derived from <see cref="NavigationTarget"/>.
+    /// </summary>
     public Visibility ActionVisibility => NavigationTarget == StartReadinessNavigationTarget.None
         ? Visibility.Collapsed
         : Visibility.Visible;

--- a/src/Foundry/ViewModels/StartReadinessItemViewModel.cs
+++ b/src/Foundry/ViewModels/StartReadinessItemViewModel.cs
@@ -99,9 +99,6 @@ public sealed class StartReadinessItemViewModel
     /// </summary>
     public StartReadinessNavigationTarget NavigationTarget { get; }
 
-    /// <summary>
-    /// Gets the action button text.
-    /// </summary>
     public string ActionText { get; }
 
     /// <summary>

--- a/src/Foundry/Views/MainWindow.xaml.cs
+++ b/src/Foundry/Views/MainWindow.xaml.cs
@@ -9,6 +9,9 @@ using Serilog;
 
 namespace Foundry.Views
 {
+    /// <summary>
+    /// Hosts the main WinUI shell, navigation view, global operation dialog, and update banner.
+    /// </summary>
     public sealed partial class MainWindow : Window
     {
         private readonly IApplicationLocalizationService localizationService;
@@ -30,8 +33,14 @@ namespace Foundry.Views
         private TextBlock? operationSecondaryProgressPercentText;
         private bool operationDialogCanClose;
 
+        /// <summary>
+        /// Gets the shell view model.
+        /// </summary>
         public MainViewModel ViewModel { get; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MainWindow"/> class.
+        /// </summary>
         public MainWindow()
         {
             localizationService = App.GetService<IApplicationLocalizationService>();
@@ -263,6 +272,7 @@ namespace Foundry.Views
             bool isOperationRunning = state == ShellNavigationState.OperationRunning;
             UpdateOperationDialog(isOperationRunning);
 
+            // The navigation guard owns route availability so individual pages do not duplicate ADK or operation checks.
             ApplyNavigationItemsState(NavView.MenuItems, isFooter: false, state);
             ApplyNavigationItemsState(NavView.FooterMenuItems, isFooter: true, state);
 


### PR DESCRIPTION
## Summary
- Adds XML documentation to Foundry app services, state contracts, update flows, ADK integration, shell navigation, and key view models.
- Adds targeted inline comments for lifecycle, persistence, secret handling, and Graph/Autopilot conversion behavior.

## Reason
- Improve maintainability for the WinUI app layer before expanding the same documentation pass across the other projects.

## Main changes
- Documents public/internal service contracts and app bootstrap surfaces.
- Clarifies configuration persistence, volatile secret handling, and Autopilot profile flow.
- Documents operation progress, startup readiness, settings, localization, updates, and app adapter services.

## Testing notes
- `dotnet build src\Foundry\Foundry.csproj` passed with 0 warnings and 0 errors.
- `git diff --check` reported only CRLF normalization warnings.