### PR TITLE
chore(ui): update navigation glyphs and labels

### DIFF
--- a/src/Foundry/Assets/NavViewMenu/AppData.json
+++ b/src/Foundry/Assets/NavViewMenu/AppData.json
@@ -21,7 +21,7 @@
           "Title": "Home",
           "LocalizeId": "Nav_HomeKey",
           "UsexUid": true,
-          "ImagePath": "ms-appx:///Assets/AppIcon.png",
+          "IconGlyph": "E80F",
           "HideItem": true,
           "IsNew": false,
           "IsUpdated": false
@@ -31,7 +31,7 @@
           "Title": "ADK",
           "LocalizeId": "Nav_AdkKey",
           "UsexUid": true,
-          "IconGlyph": "E946",
+          "IconGlyph": "EC7A",
           "HideItem": true,
           "IsNew": false,
           "IsUpdated": false
@@ -74,21 +74,21 @@
       "ShowItemsWithoutGroup": true,
       "Items": [
         {
-          "UniqueId": "Foundry.Views.NetworkPage",
-          "Title": "Network",
-          "LocalizeId": "Nav_NetworkKey",
+          "UniqueId": "Foundry.Views.LocalizationPage",
+          "Title": "Localization",
+          "LocalizeId": "Nav_LocalizationKey",
           "UsexUid": true,
-          "IconGlyph": "E968",
+          "IconGlyph": "F2B7",
           "HideItem": true,
           "IsNew": false,
           "IsUpdated": false
         },
         {
-          "UniqueId": "Foundry.Views.LocalizationPage",
-          "Title": "Localization",
-          "LocalizeId": "Nav_LocalizationKey",
+          "UniqueId": "Foundry.Views.NetworkPage",
+          "Title": "Network",
+          "LocalizeId": "Nav_NetworkKey",
           "UsexUid": true,
-          "IconGlyph": "E909",
+          "IconGlyph": "E774",
           "HideItem": true,
           "IsNew": false,
           "IsUpdated": false
@@ -98,7 +98,7 @@
           "Title": "Autopilot",
           "LocalizeId": "Nav_AutopilotKey",
           "UsexUid": true,
-          "IconGlyph": "E7C1",
+          "IconGlyph": "E753",
           "HideItem": true,
           "IsNew": false,
           "IsUpdated": false
@@ -108,7 +108,7 @@
           "Title": "Customization",
           "LocalizeId": "Nav_CustomizationKey",
           "UsexUid": true,
-          "IconGlyph": "E771",
+          "IconGlyph": "EB3C",
           "HideItem": true,
           "IsNew": false,
           "IsUpdated": false

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -277,7 +277,7 @@
     <value>Open documentation</value>
   </data>
   <data name="Customization.MachineNamingHeader" xml:space="preserve">
-    <value>Machine naming</value>
+    <value>Computer name</value>
   </data>
   <data name="Customization.MachineNamingDescription" xml:space="preserve">
     <value>Control how the deployed computer name is generated in WinPE.</value>
@@ -307,7 +307,7 @@
     <value>Prefix must use 1 to 15 characters from A-Z, a-z, 0-9, or -.</value>
   </data>
   <data name="Home.Action.ConfigureMedia.Description" xml:space="preserve">
-    <value>Choose architecture, ISO, WinPE language, USB layout, and driver options.</value>
+    <value>Choose the architecture, boot image language, and drivers to inject into the boot image.</value>
   </data>
   <data name="Home.Action.ConfigureMedia.Title" xml:space="preserve">
     <value>Configure media</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -277,7 +277,7 @@
     <value>Ouvrir la documentation</value>
   </data>
   <data name="Customization.MachineNamingHeader" xml:space="preserve">
-    <value>Nommage machine</value>
+    <value>Nom de l'ordinateur</value>
   </data>
   <data name="Customization.MachineNamingDescription" xml:space="preserve">
     <value>Contrôler la génération du nom d'ordinateur déployé dans WinPE.</value>
@@ -307,7 +307,7 @@
     <value>Le préfixe doit utiliser 1 à 15 caractères parmi A-Z, a-z, 0-9 ou -.</value>
   </data>
   <data name="Home.Action.ConfigureMedia.Description" xml:space="preserve">
-    <value>Choisir l'architecture, l'ISO, la langue WinPE, la disposition USB et les pilotes.</value>
+    <value>Choisir l'architecture, la langue de l'image de démarrage et les pilotes à injecter dans cette image.</value>
   </data>
   <data name="Home.Action.ConfigureMedia.Title" xml:space="preserve">
     <value>Configurer le média</value>

--- a/src/Foundry/Views/AdkPage.xaml
+++ b/src/Foundry/Views/AdkPage.xaml
@@ -24,7 +24,7 @@
                               Header="{x:Bind ViewModel.SetupActionTitle, Mode=OneWay}"
                               Visibility="{x:Bind ViewModel.IsSetupActionVisible, Mode=OneWay}">
                 <wct:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE946;" />
+                    <FontIcon Glyph="&#xEC7A;" />
                 </wct:SettingsCard.HeaderIcon>
                 <StackPanel Orientation="Horizontal"
                             Spacing="{ThemeResource FoundryInlineControlSpacing}">
@@ -45,7 +45,7 @@
 
             <wct:SettingsCard Header="{x:Bind ViewModel.ReadinessDetailsTitle, Mode=OneWay}">
                 <wct:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE946;" />
+                    <FontIcon Glyph="&#xEC7A;" />
                 </wct:SettingsCard.HeaderIcon>
                 <Grid ColumnSpacing="{ThemeResource FoundrySpace24}"
                       RowSpacing="{ThemeResource FoundrySpace8}">

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -18,7 +18,7 @@
             <wct:SettingsCard Header="{x:Bind ViewModel.AutopilotHeader, Mode=OneWay}"
                               Description="{x:Bind ViewModel.AutopilotDescription, Mode=OneWay}">
                 <wct:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE7BF;" />
+                    <FontIcon Glyph="&#xE753;" />
                 </wct:SettingsCard.HeaderIcon>
                 <ToggleSwitch AutomationProperties.Name="{x:Bind ViewModel.EnableAutopilotText, Mode=OneWay}"
                               IsOn="{x:Bind ViewModel.IsAutopilotEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
@@ -28,7 +28,7 @@
                               HorizontalContentAlignment="Stretch"
                               IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
                 <wct:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE8B7;" />
+                    <FontIcon Glyph="&#xEF58;" />
                 </wct:SettingsCard.HeaderIcon>
                 <Grid ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}">
                     <Grid.ColumnDefinitions>
@@ -66,7 +66,7 @@
             <wct:SettingsCard Header="{x:Bind ViewModel.DefaultProfileLabel, Mode=OneWay}"
                               IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
                 <wct:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE8D7;" />
+                    <FontIcon Glyph="&#xECA7;" />
                 </wct:SettingsCard.HeaderIcon>
                 <ComboBox Width="{ThemeResource FoundryWideInputMinWidth}"
                           DisplayMemberPath="DisplayName"
@@ -78,7 +78,7 @@
                               HorizontalContentAlignment="Stretch"
                               IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
                 <wct:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE8A5;" />
+                    <FontIcon Glyph="&#xE716;" />
                 </wct:SettingsCard.HeaderIcon>
                 <StackPanel Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
                     <TextBlock Text="{x:Bind ViewModel.EmptyProfilesText, Mode=OneWay}"

--- a/src/Foundry/Views/CustomizationPage.xaml
+++ b/src/Foundry/Views/CustomizationPage.xaml
@@ -18,7 +18,7 @@
                                   Description="{x:Bind ViewModel.MachineNamingDescription, Mode=OneWay}"
                                   IsExpanded="{x:Bind ViewModel.IsMachineNamingExpanded, Mode=TwoWay}">
                 <wct:SettingsExpander.HeaderIcon>
-                    <FontIcon Glyph="&#xE8D4;" />
+                    <FontIcon Glyph="&#xE8AC;" />
                 </wct:SettingsExpander.HeaderIcon>
                 <ToggleSwitch AutomationProperties.Name="{x:Bind ViewModel.MachineNamingEnableText, Mode=OneWay}"
                               IsOn="{x:Bind ViewModel.IsMachineNamingEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml
@@ -18,7 +18,7 @@
 
             <wct:SettingsCard x:Name="ArchitectureCard">
                 <wct:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE7F4;" />
+                    <FontIcon Glyph="&#xE770;" />
                 </wct:SettingsCard.HeaderIcon>
                 <StackPanel Orientation="Horizontal"
                             Spacing="{ThemeResource FoundryInlineControlSpacing}">
@@ -33,7 +33,7 @@
 
             <wct:SettingsCard x:Name="WinPeLanguageCard">
                 <wct:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE8AB;" />
+                    <FontIcon Glyph="&#xF2B7;" />
                 </wct:SettingsCard.HeaderIcon>
                 <StackPanel Spacing="{ThemeResource FoundryCompactStackSpacing}">
                     <ComboBox x:Name="WinPeLanguageComboBox"

--- a/src/Foundry/Views/HomeLandingPage.xaml
+++ b/src/Foundry/Views/HomeLandingPage.xaml
@@ -21,7 +21,7 @@
                                 Title="{x:Bind ViewModel.OpenAdkTitle, Mode=OneWay}">
                     <dev:HeaderTile.Source>
                         <FontIcon FontSize="{ThemeResource FoundryIconSizeHero}"
-                                  Glyph="&#xE946;" />
+                                  Glyph="&#xEC7A;" />
                     </dev:HeaderTile.Source>
                 </dev:HeaderTile>
                 <dev:HeaderTile AutomationProperties.Name="{x:Bind ViewModel.ConfigureMediaTitle, Mode=OneWay}"

--- a/src/Foundry/Views/LocalizationPage.xaml
+++ b/src/Foundry/Views/LocalizationPage.xaml
@@ -18,13 +18,14 @@
             <wct:SettingsCard Header="{x:Bind ViewModel.VisibleLanguagesHeader, Mode=OneWay}"
                               HorizontalContentAlignment="Right">
                 <wct:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE8AB;" />
+                    <FontIcon Glyph="&#xF2B7;" />
                 </wct:SettingsCard.HeaderIcon>
                 <ItemsRepeater HorizontalAlignment="Right"
                                MaxWidth="{ThemeResource FoundryLanguageGridMaxWidth}"
                                ItemsSource="{x:Bind ViewModel.AvailableLanguages, Mode=OneWay}">
                     <ItemsRepeater.Layout>
-                        <UniformGridLayout MinColumnSpacing="{ThemeResource FoundrySpace12}"
+                        <UniformGridLayout MaximumRowsOrColumns="2"
+                                           MinColumnSpacing="{ThemeResource FoundrySpace12}"
                                            MinItemWidth="{ThemeResource FoundryCheckboxGridItemMinWidth}"
                                            MinRowSpacing="{ThemeResource FoundrySpace4}" />
                     </ItemsRepeater.Layout>
@@ -49,7 +50,7 @@
 
             <wct:SettingsCard Header="{x:Bind ViewModel.TimeZoneHeader, Mode=OneWay}">
                 <wct:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE916;" />
+                    <FontIcon Glyph="&#xE823;" />
                 </wct:SettingsCard.HeaderIcon>
                 <ComboBox Width="{ThemeResource FoundryWideInputMinWidth}"
                           DisplayMemberPath="DisplayName"

--- a/src/Foundry/Views/Settings/GeneralSettingPage.xaml
+++ b/src/Foundry/Views/Settings/GeneralSettingPage.xaml
@@ -47,7 +47,7 @@
             <wct:SettingsExpander x:Name="DiagnosticsCard"
                                    x:Uid="GeneralSetting_DiagnosticsCard">
                 <wct:SettingsExpander.HeaderIcon>
-                    <FontIcon Glyph="&#xE9D9;" />
+                    <FontIcon Glyph="&#xEC7A;" />
                 </wct:SettingsExpander.HeaderIcon>
                 <ToggleSwitch x:Name="DiagnosticsToggle"
                                IsOn="{x:Bind ViewModel.IsDeveloperMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />

--- a/src/Foundry/Views/StartPage.xaml
+++ b/src/Foundry/Views/StartPage.xaml
@@ -78,7 +78,7 @@
                     <wct:SettingsExpander x:Name="ReadinessPrerequisitesCard"
                                           IsExpanded="{x:Bind ViewModel.IsPrerequisiteReadinessExpanded, Mode=TwoWay}">
                         <wct:SettingsExpander.HeaderIcon>
-                            <FontIcon Glyph="&#xE946;" />
+                            <FontIcon Glyph="&#xE9D5;" />
                         </wct:SettingsExpander.HeaderIcon>
                         <wct:SettingsExpander.ItemsHeader>
                             <Grid Padding="{ThemeResource FoundryDefaultContentPadding}">
@@ -120,7 +120,7 @@
                         Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
                 <wct:SettingsCard x:Name="IsoPathCard">
                     <wct:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xE8A5;" />
+                        <FontIcon Glyph="&#xE958;" />
                     </wct:SettingsCard.HeaderIcon>
                     <StackPanel Orientation="Horizontal"
                                 Spacing="{ThemeResource FoundryInlineControlSpacing}">
@@ -165,7 +165,7 @@
 
                 <wct:SettingsCard x:Name="FinalCommandsCard">
                     <wct:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xE7C1;" />
+                        <FontIcon Glyph="&#xE768;" />
                     </wct:SettingsCard.HeaderIcon>
                     <StackPanel Orientation="Horizontal"
                                 Spacing="{ThemeResource FoundryInlineControlSpacing}">


### PR DESCRIPTION
## Summary
- Updates Foundry navigation and page glyphs for the refreshed UI pass.
- Clarifies Home and Customization labels in English and French.
- Changes the Localization language picker to display at most two columns.

## Reason
These small UI corrections keep the navigation, cards, and localized copy aligned with the current Foundry OSD workflow.

## Main changes
- Replaced the ADK glyph across the navigation entry, ADK page cards, and Home ADK tile.
- Updated related page/card glyphs for navigation, Start, General, Localization, Autopilot, Customization, and diagnostics surfaces.
- Updated the Configure media description to mention only architecture, boot image language, and injected drivers.
- Renamed the Customization card title from Machine naming to Computer name / Nom de l'ordinateur.
- Limited the Localization visible language list to two columns.

## Testing notes
- `dotnet build src\Foundry\Foundry.csproj --no-restore`
- `dotnet test src\Foundry.slnx --no-restore`
