### PR TITLE
fix(deploy): use provisioned WinPE 7-Zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,4 +146,4 @@ This project uses parts of the 7-Zip program (`7za.exe`) from the 7-Zip Extra pa
 
 - Upstream: [https://www.7-zip.org/](https://www.7-zip.org/)
 - License: GNU LGPL with additional BSD 2-clause and BSD 3-clause notices for portions of `7za.exe`
-- Included license files: `src/Foundry/Assets/7z/License.txt`, `src/Foundry/Assets/7z/readme.txt`
+- Included license files: `src/Foundry.Core/Assets/7z/License.txt`, `src/Foundry.Core/Assets/7z/readme.txt`

--- a/src/Foundry.Deploy.Tests/ArchiveExtractionServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/ArchiveExtractionServiceTests.cs
@@ -1,0 +1,106 @@
+using System.Runtime.InteropServices;
+using Foundry.Deploy.Services.System;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class ArchiveExtractionServiceTests
+{
+    [Fact]
+    public void ResolveSevenZipExecutablePath_WhenWinPeToolingExists_UsesProvisionedRuntimeTool()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            string systemDirectory = Path.Combine(root, "X", "Windows", "System32");
+            string expectedPath = Path.Combine(
+                root,
+                "X",
+                "Foundry",
+                "Tools",
+                "7zip",
+                ExpectedRuntimeFolder,
+                "7za.exe");
+            Directory.CreateDirectory(Path.GetDirectoryName(expectedPath)!);
+            File.WriteAllText(expectedPath, "7za");
+
+            string resolvedPath = ArchiveExtractionService.ResolveSevenZipExecutablePath(systemDirectory);
+
+            Assert.Equal(expectedPath, resolvedPath);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveSevenZipExecutablePath_WhenOnlySystem32CopyExists_Throws()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            string systemDirectory = Path.Combine(root, "X", "Windows", "System32");
+            string system32Path = Path.Combine(systemDirectory, "7za.exe");
+            Directory.CreateDirectory(systemDirectory);
+            File.WriteAllText(system32Path, "7za");
+
+            Assert.Throws<FileNotFoundException>(
+                () => ArchiveExtractionService.ResolveSevenZipExecutablePath(systemDirectory));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveSevenZipExecutablePath_WhenOnlyAppLocalAssetExists_Throws()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            string baseDirectory = Path.Combine(root, "app");
+            string systemDirectory = Path.Combine(root, "X", "Windows", "System32");
+            string appLocalPath = Path.Combine(baseDirectory, "Assets", "7z", ExpectedRuntimeFolder, "7za.exe");
+            Directory.CreateDirectory(Path.GetDirectoryName(appLocalPath)!);
+            File.WriteAllText(appLocalPath, "7za");
+
+            Assert.Throws<FileNotFoundException>(
+                () => ArchiveExtractionService.ResolveSevenZipExecutablePath(systemDirectory));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveSevenZipExecutablePath_WhenNoCandidateExists_ReportsProvisionedToolPath()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            string systemDirectory = Path.Combine(root, "X", "Windows", "System32");
+
+            FileNotFoundException exception = Assert.Throws<FileNotFoundException>(
+                () => ArchiveExtractionService.ResolveSevenZipExecutablePath(systemDirectory));
+
+            Assert.Contains(@"Foundry\Tools\7zip", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static string ExpectedRuntimeFolder => RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+        ? "arm64"
+        : "x64";
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "Foundry.Deploy.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/src/Foundry.Deploy/Foundry.Deploy.csproj
+++ b/src/Foundry.Deploy/Foundry.Deploy.csproj
@@ -41,13 +41,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\Foundry\Assets\7z\**\*">
-      <Link>Assets\7z\%(RecursiveDir)%(Filename)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="Assets\Icons\app.ico">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>

--- a/src/Foundry.Deploy/Services/System/ArchiveExtractionService.cs
+++ b/src/Foundry.Deploy/Services/System/ArchiveExtractionService.cs
@@ -3,6 +3,9 @@ using System.Runtime.InteropServices;
 
 namespace Foundry.Deploy.Services.System;
 
+/// <summary>
+/// Runs archive extraction for deployment payloads through the 7-Zip executable provisioned in the WinPE image.
+/// </summary>
 public sealed class ArchiveExtractionService : IArchiveExtractionService
 {
     private readonly IProcessRunner _processRunner;
@@ -12,6 +15,7 @@ public sealed class ArchiveExtractionService : IArchiveExtractionService
         _processRunner = processRunner;
     }
 
+    /// <inheritdoc />
     public async Task ExtractWithSevenZipAsync(
         string archivePath,
         string extractedPath,
@@ -68,33 +72,46 @@ public sealed class ArchiveExtractionService : IArchiveExtractionService
 
     private static string ResolveSevenZipExecutablePath()
     {
-        string winPePath = Path.Combine(Environment.SystemDirectory, "7za.exe");
-        if (File.Exists(winPePath))
-        {
-            return winPePath;
-        }
+        return ResolveSevenZipExecutablePath(Environment.SystemDirectory);
+    }
 
+    /// <summary>
+    /// Resolves the single supported 7-Zip executable location for Foundry.Deploy in WinPE.
+    /// </summary>
+    /// <param name="systemDirectory">The WinPE system directory used to derive the boot image root.</param>
+    /// <returns>The architecture-specific executable under <c>Foundry\Tools\7zip</c>.</returns>
+    /// <exception cref="FileNotFoundException">
+    /// Thrown when the boot image was not provisioned with the expected Foundry 7-Zip tool.
+    /// </exception>
+    internal static string ResolveSevenZipExecutablePath(string systemDirectory)
+    {
         string runtimeFolder = RuntimeInformation.ProcessArchitecture switch
         {
             Architecture.Arm64 => "arm64",
             _ => "x64"
         };
 
-        string architectureSpecific = Path.Combine(AppContext.BaseDirectory, "Assets", "7z", runtimeFolder, "7za.exe");
-        if (File.Exists(architectureSpecific))
+        string? provisionedPath = null;
+        string? winPeRoot = ResolveWindowsRoot(systemDirectory);
+        if (!string.IsNullOrWhiteSpace(winPeRoot))
         {
-            return architectureSpecific;
-        }
-
-        string bundledPath = Path.Combine(AppContext.BaseDirectory, "Assets", "7z", "7za.exe");
-        if (File.Exists(bundledPath))
-        {
-            return bundledPath;
+            provisionedPath = Path.Combine(winPeRoot, "Foundry", "Tools", "7zip", runtimeFolder, "7za.exe");
+            if (File.Exists(provisionedPath))
+            {
+                return provisionedPath;
+            }
         }
 
         throw new FileNotFoundException(
-            "No usable 7-Zip executable was found. Expected a WinPE copy in System32 or the bundled Assets\\7z payload.",
-            architectureSpecific);
+            $"No usable 7-Zip executable was found. Expected the provisioned WinPE tool at '{provisionedPath}'.",
+            provisionedPath);
+    }
+
+    private static string? ResolveWindowsRoot(string systemDirectory)
+    {
+        DirectoryInfo? windowsDirectoryInfo = Directory.GetParent(systemDirectory);
+        DirectoryInfo? windowsRootInfo = windowsDirectoryInfo?.Parent;
+        return windowsRootInfo?.FullName;
     }
 
     private static string ToDiagnostic(ProcessExecutionResult execution)

--- a/src/Foundry.Deploy/Services/System/IArchiveExtractionService.cs
+++ b/src/Foundry.Deploy/Services/System/IArchiveExtractionService.cs
@@ -1,7 +1,18 @@
 namespace Foundry.Deploy.Services.System;
 
+/// <summary>
+/// Extracts archive payloads during WinPE deployment using the 7-Zip tooling provisioned into the boot image.
+/// </summary>
 public interface IArchiveExtractionService
 {
+    /// <summary>
+    /// Extracts an archive into the specified directory and reports 7-Zip progress when available.
+    /// </summary>
+    /// <param name="archivePath">The archive file to extract.</param>
+    /// <param name="extractedPath">The destination directory for extracted files.</param>
+    /// <param name="workingDirectory">The working directory used to launch the 7-Zip process.</param>
+    /// <param name="cancellationToken">A token used to cancel process execution.</param>
+    /// <param name="progress">Optional progress receiver for deployment step reporting.</param>
     Task ExtractWithSevenZipAsync(
         string archivePath,
         string extractedPath,


### PR DESCRIPTION
## Summary
- Make Foundry.Deploy use only the 7-Zip executable provisioned in the WinPE image under `Foundry\Tools\7zip\<arch>\7za.exe`.
- Remove the bundled 7-Zip payload from the Foundry.Deploy publish output.
- Add regression coverage for the strict WinPE tool resolution contract.
- Update the README 7-Zip license path to the current Core asset location.

## Reason
Foundry.Deploy could fail driver-pack extraction because it looked for app-local bundled 7-Zip assets instead of the tool already provisioned into the boot image. Keeping a single WinPE-provisioned tool path avoids duplicate packaging and makes deployment behavior explicit.

## Main changes
- `ArchiveExtractionService` now resolves only the architecture-specific WinPE provisioned 7-Zip path.
- `Foundry.Deploy.csproj` no longer includes `Assets\7z` content.
- `IArchiveExtractionService` and the resolver now document the WinPE-only 7-Zip contract.
- Added tests proving System32 and app-local 7-Zip copies are not accepted.

## Testing notes
- `dotnet test` for all `*.Tests.csproj` projects: 31 + 173 + 66 + 12 tests passed, 0 failed.
- `powershell -ExecutionPolicy Bypass -File scripts\Publish-FoundryDeploy.ps1 -Configuration Debug -RuntimeIdentifier win-x64` passed.
- Verified the `Foundry.Deploy` publish output contains no `7z` / `7za` files.
