### PR TITLE
fix(deploy): localize runtime UI messages

### DIFF
--- a/src/Foundry.Deploy.Tests/DeploymentLaunchPreparationServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentLaunchPreparationServiceTests.cs
@@ -1,6 +1,7 @@
 using Foundry.Deploy.Models;
 using Foundry.Deploy.Services.ApplicationShell;
 using Foundry.Deploy.Services.Deployment;
+using System.Globalization;
 
 namespace Foundry.Deploy.Tests;
 
@@ -94,6 +95,36 @@ public sealed class DeploymentLaunchPreparationServiceTests
         Assert.Same(autopilotProfile, result.Context?.SelectedAutopilotProfile);
     }
 
+    [Fact]
+    public void Prepare_WhenConfirmationIsShown_UsesLocalizedWarningText()
+    {
+        CultureInfo originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo originalUiCulture = CultureInfo.CurrentUICulture;
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+        CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
+
+        try
+        {
+            var shell = new FakeApplicationShellService { ConfirmationResult = true };
+            var service = new DeploymentLaunchPreparationService(shell);
+
+            TargetDiskInfo targetDisk = CreateDisk(sizeBytes: 0);
+
+            service.Prepare(CreateRequest(selectedTargetDisk: targetDisk));
+
+            Assert.Equal("Confirmer l’effacement du disque", shell.LastConfirmationTitle);
+            Assert.Contains("Cette opération va EFFACER le disque sélectionné et appliquer un nouveau système d’exploitation.", shell.LastConfirmationMessage);
+            Assert.Contains("Disque : 3", shell.LastConfirmationMessage);
+            Assert.Contains("Taille : Taille inconnue", shell.LastConfirmationMessage);
+            Assert.Contains("Continuer ?", shell.LastConfirmationMessage);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
+    }
+
     private static DeploymentLaunchRequest CreateRequest(
         TargetDiskInfo? selectedTargetDisk,
         string targetComputerName = "LAB-01",
@@ -131,14 +162,14 @@ public sealed class DeploymentLaunchPreparationServiceTests
         };
     }
 
-    private static TargetDiskInfo CreateDisk(bool isSelectable = true, string selectionWarning = "")
+    private static TargetDiskInfo CreateDisk(bool isSelectable = true, string selectionWarning = "", ulong sizeBytes = 256UL * 1024UL * 1024UL * 1024UL)
     {
         return new TargetDiskInfo
         {
             DiskNumber = 3,
             FriendlyName = "NVMe Disk",
             BusType = "NVMe",
-            SizeBytes = 256UL * 1024UL * 1024UL * 1024UL,
+            SizeBytes = sizeBytes,
             IsSelectable = isSelectable,
             SelectionWarning = selectionWarning
         };
@@ -150,6 +181,10 @@ public sealed class DeploymentLaunchPreparationServiceTests
 
         public int ConfirmationCallCount { get; private set; }
 
+        public string LastConfirmationTitle { get; private set; } = string.Empty;
+
+        public string LastConfirmationMessage { get; private set; } = string.Empty;
+
         public void ShowAbout()
         {
         }
@@ -157,6 +192,8 @@ public sealed class DeploymentLaunchPreparationServiceTests
         public bool ConfirmWarning(string title, string message)
         {
             ConfirmationCallCount++;
+            LastConfirmationTitle = title;
+            LastConfirmationMessage = message;
             return ConfirmationResult;
         }
     }

--- a/src/Foundry.Deploy.Tests/DeploymentUiTextLocalizerTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentUiTextLocalizerTests.cs
@@ -1,0 +1,67 @@
+using System.Globalization;
+using Foundry.Deploy.Services.Localization;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class DeploymentUiTextLocalizerTests : IDisposable
+{
+    private readonly CultureInfo _originalCulture = CultureInfo.CurrentCulture;
+    private readonly CultureInfo _originalUiCulture = CultureInfo.CurrentUICulture;
+
+    [Theory]
+    [InlineData("Applying Windows drivers: 17,6%", "Application des pilotes Windows : 17,6 %")]
+    [InlineData("Mounting WinRE: 25%", "Montage de WinRE : 25 %")]
+    [InlineData("Applying WinRE drivers: 50%", "Application des pilotes WinRE : 50 %")]
+    [InlineData("Unmounting WinRE: 75%", "Démontage de WinRE : 75 %")]
+    [InlineData("Downloading: 10%", "Téléchargement : 10 %")]
+    [InlineData("Extracting: 25%", "Extraction : 25 %")]
+    [InlineData("Applying: 50%", "Application : 50 %")]
+    [InlineData("Staging: 75%", "Préparation : 75 %")]
+    public void LocalizeMessage_TranslatesGeneratedStepPercentLabels(string input, string expected)
+    {
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+        CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
+
+        Assert.Equal(expected, DeploymentUiTextLocalizer.LocalizeMessage(input));
+    }
+
+    [Theory]
+    [InlineData("Resolving cache location...", "Résolution de l’emplacement du cache...")]
+    [InlineData("Cache strategy resolved.", "Stratégie de cache résolue.")]
+    [InlineData("Cache strategy resolved (simulation).", "Stratégie de cache résolue (simulation).")]
+    [InlineData("Operating system image downloaded.", "Image système téléchargée.")]
+    [InlineData("Operating system image resolved from cache.", "Image système réutilisée depuis le cache.")]
+    [InlineData("Driver pack resolved from cache.", "Pack de pilotes réutilisé depuis le cache.")]
+    [InlineData("Driver pack prepared for deferred installation.", "Pack de pilotes préparé pour l’installation différée.")]
+    [InlineData("Driver pack source payload is unavailable for deferred staging.", "La charge utile source du pack de pilotes est indisponible pour la préparation différée.")]
+    [InlineData("Microsoft Update Catalog did not produce a driver payload.", "Microsoft Update Catalog n’a produit aucune charge utile de pilote.")]
+    [InlineData("Deferred driver pack staging was requested without a supported deferred command.", "La préparation différée du pack de pilotes a été demandée sans commande différée prise en charge.")]
+    [InlineData("Downloading Driver pack...", "Téléchargement du pack de pilotes...")]
+    [InlineData("System reboot", "Redémarrage système")]
+    [InlineData("Required reboot executable 'wpeutil.exe' was not found.", "L’exécutable de redémarrage requis 'wpeutil.exe' est introuvable.")]
+    public void LocalizeMessage_TranslatesDeploymentRuntimeMessages(string input, string expected)
+    {
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+        CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
+
+        Assert.Equal(expected, DeploymentUiTextLocalizer.LocalizeMessage(input));
+    }
+
+    [Theory]
+    [InlineData("Target disk 3 is no longer present.", "Le disque cible 3 n’est plus présent.")]
+    [InlineData("Target disk 3 is blocked: Blocked: system disk", "Le disque cible 3 est bloqué : Bloqué : disque système")]
+    [InlineData("12.5 MB downloaded", "12.5 MB téléchargés")]
+    public void LocalizeMessage_TranslatesDynamicDeploymentRuntimeMessages(string input, string expected)
+    {
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+        CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
+
+        Assert.Equal(expected, DeploymentUiTextLocalizer.LocalizeMessage(input));
+    }
+
+    public void Dispose()
+    {
+        CultureInfo.CurrentCulture = _originalCulture;
+        CultureInfo.CurrentUICulture = _originalUiCulture;
+    }
+}

--- a/src/Foundry.Deploy.Tests/OperatingSystemDisplayFormatterTests.cs
+++ b/src/Foundry.Deploy.Tests/OperatingSystemDisplayFormatterTests.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+using Foundry.Deploy.Converters;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class OperatingSystemDisplayFormatterTests : IDisposable
+{
+    private readonly CultureInfo _originalCulture = CultureInfo.CurrentCulture;
+    private readonly CultureInfo _originalUiCulture = CultureInfo.CurrentUICulture;
+
+    [Theory]
+    [InlineData("RET", "Détail")]
+    [InlineData("VOL", "Volume")]
+    public void FormatLicenseChannel_UsesCurrentUiCulture(string input, string expected)
+    {
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+        CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
+
+        Assert.Equal(expected, OperatingSystemDisplayFormatter.FormatLicenseChannel(input));
+    }
+
+    [Theory]
+    [InlineData("Home", "Famille")]
+    [InlineData("Home N", "Famille N")]
+    [InlineData("Home Single Language", "Famille unilingue")]
+    [InlineData("Education", "Éducation")]
+    [InlineData("Enterprise", "Entreprise")]
+    [InlineData("Pro", "Professionnel")]
+    public void FormatEdition_UsesCurrentUiCultureForKnownEditions(string input, string expected)
+    {
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+        CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
+
+        Assert.Equal(expected, OperatingSystemDisplayFormatter.FormatEdition(input));
+    }
+
+    public void Dispose()
+    {
+        CultureInfo.CurrentCulture = _originalCulture;
+        CultureInfo.CurrentUICulture = _originalUiCulture;
+    }
+}

--- a/src/Foundry.Deploy/Converters/OperatingSystemDisplayFormatter.cs
+++ b/src/Foundry.Deploy/Converters/OperatingSystemDisplayFormatter.cs
@@ -1,24 +1,56 @@
+using Foundry.Deploy.Services.Localization;
+
 namespace Foundry.Deploy.Converters;
 
+/// <summary>
+/// Formats operating system catalog values for display without changing the invariant filter values.
+/// </summary>
 internal static class OperatingSystemDisplayFormatter
 {
+    /// <summary>
+    /// Normalizes a Windows release label from catalog metadata.
+    /// </summary>
+    /// <param name="value">The catalog release value.</param>
+    /// <returns>The trimmed release label.</returns>
     public static string FormatWindowsRelease(string value)
     {
         return value.Trim();
     }
 
+    /// <summary>
+    /// Converts known license channel codes to culture-specific display labels.
+    /// </summary>
+    /// <param name="channel">The catalog license channel code or label.</param>
+    /// <returns>The localized display label for known channel codes, otherwise the trimmed source value.</returns>
     public static string FormatLicenseChannel(string channel)
     {
         return channel.Trim().ToUpperInvariant() switch
         {
-            "RET" => "Retail",
-            "VOL" => "Volume",
+            "RET" => LocalizationText.GetString("Catalog.LicenseChannelRetail"),
+            "VOL" => LocalizationText.GetString("Catalog.LicenseChannelVolume"),
             _ => channel.Trim()
         };
     }
 
+    /// <summary>
+    /// Converts known Windows edition names to culture-specific display labels.
+    /// </summary>
+    /// <param name="edition">The catalog edition name.</param>
+    /// <returns>The localized display label for known editions, otherwise the trimmed source value.</returns>
     public static string FormatEdition(string edition)
     {
-        return edition.Trim();
+        return edition.Trim() switch
+        {
+            "Home" => LocalizationText.GetString("Catalog.EditionHome"),
+            "Home N" => LocalizationText.GetString("Catalog.EditionHomeN"),
+            "Home Single Language" => LocalizationText.GetString("Catalog.EditionHomeSingleLanguage"),
+            "Education" => LocalizationText.GetString("Catalog.EditionEducation"),
+            "Education N" => LocalizationText.GetString("Catalog.EditionEducationN"),
+            "Pro" => LocalizationText.GetString("Catalog.EditionPro"),
+            "Pro N" => LocalizationText.GetString("Catalog.EditionProN"),
+            "Enterprise" => LocalizationText.GetString("Catalog.EditionEnterprise"),
+            "Enterprise N" => LocalizationText.GetString("Catalog.EditionEnterpriseN"),
+            _ => edition.Trim()
+        };
     }
 }

--- a/src/Foundry.Deploy/Resources/AppStrings.fr-FR.resx
+++ b/src/Foundry.Deploy/Resources/AppStrings.fr-FR.resx
@@ -68,6 +68,17 @@
   <data name="Catalog.Loading" xml:space="preserve"><value>Chargement des catalogues...</value></data>
   <data name="Catalog.LoadedFormat" xml:space="preserve"><value>Catalogues chargés : {0} entrée(s) OS, {1} pack(s) de pilotes.</value></data>
   <data name="Catalog.LoadFailedFormat" xml:space="preserve"><value>Échec du chargement du catalogue : {0}</value></data>
+  <data name="Catalog.LicenseChannelRetail" xml:space="preserve"><value>Détail</value></data>
+  <data name="Catalog.LicenseChannelVolume" xml:space="preserve"><value>Volume</value></data>
+  <data name="Catalog.EditionHome" xml:space="preserve"><value>Famille</value></data>
+  <data name="Catalog.EditionHomeN" xml:space="preserve"><value>Famille N</value></data>
+  <data name="Catalog.EditionHomeSingleLanguage" xml:space="preserve"><value>Famille unilingue</value></data>
+  <data name="Catalog.EditionEducation" xml:space="preserve"><value>Éducation</value></data>
+  <data name="Catalog.EditionEducationN" xml:space="preserve"><value>Éducation N</value></data>
+  <data name="Catalog.EditionPro" xml:space="preserve"><value>Professionnel</value></data>
+  <data name="Catalog.EditionProN" xml:space="preserve"><value>Professionnel N</value></data>
+  <data name="Catalog.EditionEnterprise" xml:space="preserve"><value>Entreprise</value></data>
+  <data name="Catalog.EditionEnterpriseN" xml:space="preserve"><value>Entreprise N</value></data>
   <data name="OperatingSystem.Windows11" xml:space="preserve"><value>Windows 11</value></data>
   <data name="DriverPack.Source" xml:space="preserve"><value>Source des pilotes</value></data>
   <data name="DriverPack.Model" xml:space="preserve"><value>Modèle</value></data>
@@ -100,7 +111,6 @@
 ErrorCode=0x80070005
 Détails : accès refusé lors du montage de l’image sur le chemin cible.
 Action : vérifiez les attributs du disque puis relancez le déploiement.</value></data>
-  <data name="Debug.ApplyingImageProgressFormat" xml:space="preserve"><value>Application de l’image : {0}%</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Actualiser</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Version : {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Précédent</value></data>
@@ -137,6 +147,18 @@ Action : vérifiez les attributs du disque puis relancez le déploiement.</value
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Bloqué : hors ligne</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>CIBLE VIRTUELLE DBG</value></data>
   <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Disque sélectionné bloqué : {0}</value></data>
+  <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Le disque cible {0} n’est plus présent.</value></data>
+  <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Le disque cible {0} est bloqué : {1}</value></data>
+  <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Confirmer l’effacement du disque</value></data>
+  <data name="Launch.ConfirmDiskEraseMessageFormat" xml:space="preserve"><value>Cette opération va EFFACER le disque sélectionné et appliquer un nouveau système d’exploitation.
+
+Disque : {0}
+Modèle : {1}
+Bus : {2}
+Taille : {3}
+
+OS : {4}
+Continuer ?</value></data>
   <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Sélectionnez un système d’exploitation.</value></data>
   <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Saisissez un nom d’ordinateur valide.</value></data>
   <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Sélectionnez un disque cible.</value></data>
@@ -171,6 +193,8 @@ Action : vérifiez les attributs du disque puis relancez le déploiement.</value
   <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>La commande de redémarrage a échoué : {0}</value></data>
   <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Impossible d’ouvrir le fichier journal : {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe a échoué avec le code de sortie {0}. {1}</value></data>
+  <data name="Status.SystemReboot" xml:space="preserve"><value>Redémarrage système</value></data>
+  <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>L’exécutable de redémarrage requis 'wpeutil.exe' est introuvable.</value></data>
   <data name="Status.UnknownStep" xml:space="preserve"><value>Étape inconnue</value></data>
   <data name="Status.NoErrorDetails" xml:space="preserve"><value>Aucun détail d’erreur n’a été fourni.</value></data>
   <data name="Step.GatherDeploymentVariables" xml:space="preserve"><value>Collecte des variables de déploiement</value></data>
@@ -210,7 +234,10 @@ Action : vérifiez les attributs du disque puis relancez le déploiement.</value
   <data name="StepResult.TargetConfigurationValidated" xml:space="preserve"><value>Configuration cible validée.</value></data>
   <data name="StepResult.TargetConfigurationValidatedSimulation" xml:space="preserve"><value>Configuration cible validée (simulation).</value></data>
   <data name="StepMessage.ResolvingCacheStrategy" xml:space="preserve"><value>Résolution de la stratégie de cache...</value></data>
+  <data name="StepMessage.ResolvingCacheLocation" xml:space="preserve"><value>Résolution de l’emplacement du cache...</value></data>
   <data name="StepMessage.CheckingCacheDiskConflict" xml:space="preserve"><value>Vérification des conflits disque/cache...</value></data>
+  <data name="StepResult.CacheStrategyResolved" xml:space="preserve"><value>Stratégie de cache résolue.</value></data>
+  <data name="StepResult.CacheStrategyResolvedSimulation" xml:space="preserve"><value>Stratégie de cache résolue (simulation).</value></data>
   <data name="StepMessage.PreparingTargetDiskLayout" xml:space="preserve"><value>Préparation du partitionnement cible...</value></data>
   <data name="StepMessage.PartitioningTargetDisk" xml:space="preserve"><value>Partitionnement du disque cible...</value></data>
   <data name="StepMessage.PreparingTargetWorkspace" xml:space="preserve"><value>Préparation de l’espace de travail cible...</value></data>
@@ -222,6 +249,8 @@ Action : vérifiez les attributs du disque puis relancez le déploiement.</value
   <data name="StepMessage.CheckingCache" xml:space="preserve"><value>Vérification du cache...</value></data>
   <data name="StepResult.OperatingSystemImageReadySimulation" xml:space="preserve"><value>Image système prête (simulation).</value></data>
   <data name="StepResult.OperatingSystemImageNotDownloaded" xml:space="preserve"><value>L’image système n’a pas été téléchargée.</value></data>
+  <data name="StepResult.OperatingSystemImageDownloaded" xml:space="preserve"><value>Image système téléchargée.</value></data>
+  <data name="StepResult.OperatingSystemImageResolvedFromCache" xml:space="preserve"><value>Image système réutilisée depuis le cache.</value></data>
   <data name="StepMessage.ApplyingOperatingSystemImage" xml:space="preserve"><value>Application de l’image OS...</value></data>
   <data name="StepMessage.InspectingImage" xml:space="preserve"><value>Inspection de l’image...</value></data>
   <data name="StepMessage.ApplyingImage" xml:space="preserve"><value>Application de l’image...</value></data>
@@ -246,20 +275,31 @@ Action : vérifiez les attributs du disque puis relancez le déploiement.</value
   <data name="StepResult.OemDriverPackMissing" xml:space="preserve"><value>Le mode pack de pilotes OEM est sélectionné mais aucun pack de pilotes n’a été fourni.</value></data>
   <data name="StepResult.DriverPackDownloaded" xml:space="preserve"><value>Pack de pilotes téléchargé.</value></data>
   <data name="StepResult.DriverPackDownloadedSimulation" xml:space="preserve"><value>Pack de pilotes téléchargé (simulation).</value></data>
+  <data name="StepResult.DriverPackResolvedFromCache" xml:space="preserve"><value>Pack de pilotes réutilisé depuis le cache.</value></data>
   <data name="StepMessage.ExtractingDriverPack" xml:space="preserve"><value>Extraction du pack de pilotes...</value></data>
   <data name="StepResult.DriverPackNotDownloaded" xml:space="preserve"><value>Le pack de pilotes n’a pas été téléchargé.</value></data>
   <data name="StepResult.DriverPackExtracted" xml:space="preserve"><value>Pack de pilotes extrait.</value></data>
   <data name="StepResult.DriverPackExtractedSimulation" xml:space="preserve"><value>Pack de pilotes extrait (simulation).</value></data>
+  <data name="StepResult.DriverPackPreparedForDeferredInstallation" xml:space="preserve"><value>Pack de pilotes préparé pour l’installation différée.</value></data>
   <data name="StepResult.NoDriverPackOperationRequired" xml:space="preserve"><value>Aucune opération sur le pack de pilotes n’est requise.</value></data>
   <data name="StepResult.UnsupportedDriverPackInstallMode" xml:space="preserve"><value>Mode d’installation du pack de pilotes non pris en charge.</value></data>
   <data name="StepResult.NoExtractedInfDriverPayload" xml:space="preserve"><value>Aucune charge utile INF extraite n’est disponible.</value></data>
+  <data name="StepResult.DriverPackSourcePayloadUnavailableForDeferredStaging" xml:space="preserve"><value>La charge utile source du pack de pilotes est indisponible pour la préparation différée.</value></data>
+  <data name="StepResult.MicrosoftUpdateCatalogDriverPayloadMissing" xml:space="preserve"><value>Microsoft Update Catalog n’a produit aucune charge utile de pilote.</value></data>
+  <data name="StepResult.DeferredDriverPackStagingUnsupportedCommand" xml:space="preserve"><value>La préparation différée du pack de pilotes a été demandée sans commande différée prise en charge.</value></data>
   <data name="StepMessage.ApplyingDriverPack" xml:space="preserve"><value>Application du pack de pilotes...</value></data>
   <data name="StepMessage.ApplyingWindowsDrivers" xml:space="preserve"><value>Application des pilotes Windows...</value></data>
   <data name="StepMessage.MountingWinRe" xml:space="preserve"><value>Montage de WinRE...</value></data>
   <data name="StepMessage.ApplyingWinReDrivers" xml:space="preserve"><value>Application des pilotes WinRE...</value></data>
   <data name="StepMessage.UnmountingWinRe" xml:space="preserve"><value>Démontage de WinRE...</value></data>
-  <data name="StepMessage.StagingPackage" xml:space="preserve"><value>Staging du package...</value></data>
-  <data name="StepMessage.UpdatingSetupCompleteHook" xml:space="preserve"><value>Mise à jour du hook SetupComplete...</value></data>
+  <data name="StepMessage.StagingPackage" xml:space="preserve"><value>Préparation du package...</value></data>
+  <data name="StepMessage.UpdatingSetupCompleteHook" xml:space="preserve"><value>Mise à jour du point d’ancrage SetupComplete...</value></data>
+  <data name="StepProgress.PercentFormat" xml:space="preserve"><value>{0} : {1} %</value></data>
+  <data name="StepProgress.Downloading" xml:space="preserve"><value>Téléchargement</value></data>
+  <data name="StepProgress.Extracting" xml:space="preserve"><value>Extraction</value></data>
+  <data name="StepProgress.Applying" xml:space="preserve"><value>Application</value></data>
+  <data name="StepProgress.Staging" xml:space="preserve"><value>Préparation</value></data>
+  <data name="StepProgress.DownloadedBytesFormat" xml:space="preserve"><value>{0} téléchargés</value></data>
   <data name="StepResult.DriverPackApplied" xml:space="preserve"><value>Pack de pilotes appliqué.</value></data>
   <data name="StepResult.DriverPackStagedForFirstBoot" xml:space="preserve"><value>Pack de pilotes préparé pour le premier démarrage.</value></data>
   <data name="StepResult.DriverPackAppliedSimulation" xml:space="preserve"><value>Pack de pilotes appliqué (simulation).</value></data>

--- a/src/Foundry.Deploy/Resources/AppStrings.resx
+++ b/src/Foundry.Deploy/Resources/AppStrings.resx
@@ -68,6 +68,17 @@
   <data name="Catalog.Loading" xml:space="preserve"><value>Loading catalogs...</value></data>
   <data name="Catalog.LoadedFormat" xml:space="preserve"><value>Catalogs loaded: {0} OS entries, {1} driver packs.</value></data>
   <data name="Catalog.LoadFailedFormat" xml:space="preserve"><value>Catalog load failed: {0}</value></data>
+  <data name="Catalog.LicenseChannelRetail" xml:space="preserve"><value>Retail</value></data>
+  <data name="Catalog.LicenseChannelVolume" xml:space="preserve"><value>Volume</value></data>
+  <data name="Catalog.EditionHome" xml:space="preserve"><value>Home</value></data>
+  <data name="Catalog.EditionHomeN" xml:space="preserve"><value>Home N</value></data>
+  <data name="Catalog.EditionHomeSingleLanguage" xml:space="preserve"><value>Home Single Language</value></data>
+  <data name="Catalog.EditionEducation" xml:space="preserve"><value>Education</value></data>
+  <data name="Catalog.EditionEducationN" xml:space="preserve"><value>Education N</value></data>
+  <data name="Catalog.EditionPro" xml:space="preserve"><value>Pro</value></data>
+  <data name="Catalog.EditionProN" xml:space="preserve"><value>Pro N</value></data>
+  <data name="Catalog.EditionEnterprise" xml:space="preserve"><value>Enterprise</value></data>
+  <data name="Catalog.EditionEnterpriseN" xml:space="preserve"><value>Enterprise N</value></data>
   <data name="OperatingSystem.Windows11" xml:space="preserve"><value>Windows 11</value></data>
   <data name="DriverPack.Source" xml:space="preserve"><value>Driver Source</value></data>
   <data name="DriverPack.Model" xml:space="preserve"><value>Model</value></data>
@@ -100,7 +111,6 @@
 ErrorCode=0x80070005
 Details: Access denied while mounting image to target path.
 Action: Verify disk attributes and retry deployment.</value></data>
-  <data name="Debug.ApplyingImageProgressFormat" xml:space="preserve"><value>Applying image: {0}%</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Refresh</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Version: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Previous</value></data>
@@ -137,6 +147,18 @@ Action: Verify disk attributes and retry deployment.</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Blocked: offline</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>DEBUG VIRTUAL TARGET</value></data>
   <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Selected disk blocked: {0}</value></data>
+  <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Target disk {0} is no longer present.</value></data>
+  <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Target disk {0} is blocked: {1}</value></data>
+  <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Confirm Disk Erase</value></data>
+  <data name="Launch.ConfirmDiskEraseMessageFormat" xml:space="preserve"><value>This operation will ERASE the selected disk and apply a new operating system.
+
+Disk: {0}
+Model: {1}
+Bus: {2}
+Size: {3}
+
+OS: {4}
+Continue?</value></data>
   <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Select an operating system.</value></data>
   <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Enter a valid computer name.</value></data>
   <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Select a target disk.</value></data>
@@ -171,6 +193,8 @@ Action: Verify disk attributes and retry deployment.</value></data>
   <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Reboot command failed: {0}</value></data>
   <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Unable to open log file: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe failed with exit code {0}. {1}</value></data>
+  <data name="Status.SystemReboot" xml:space="preserve"><value>System reboot</value></data>
+  <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Required reboot executable 'wpeutil.exe' was not found.</value></data>
   <data name="Status.UnknownStep" xml:space="preserve"><value>Unknown step</value></data>
   <data name="Status.NoErrorDetails" xml:space="preserve"><value>No error details were provided.</value></data>
   <data name="Step.GatherDeploymentVariables" xml:space="preserve"><value>Gather deployment variables</value></data>
@@ -210,7 +234,10 @@ Action: Verify disk attributes and retry deployment.</value></data>
   <data name="StepResult.TargetConfigurationValidated" xml:space="preserve"><value>Target configuration validated.</value></data>
   <data name="StepResult.TargetConfigurationValidatedSimulation" xml:space="preserve"><value>Target configuration validated (simulation).</value></data>
   <data name="StepMessage.ResolvingCacheStrategy" xml:space="preserve"><value>Resolving cache strategy...</value></data>
+  <data name="StepMessage.ResolvingCacheLocation" xml:space="preserve"><value>Resolving cache location...</value></data>
   <data name="StepMessage.CheckingCacheDiskConflict" xml:space="preserve"><value>Checking cache disk conflict...</value></data>
+  <data name="StepResult.CacheStrategyResolved" xml:space="preserve"><value>Cache strategy resolved.</value></data>
+  <data name="StepResult.CacheStrategyResolvedSimulation" xml:space="preserve"><value>Cache strategy resolved (simulation).</value></data>
   <data name="StepMessage.PreparingTargetDiskLayout" xml:space="preserve"><value>Preparing target disk layout...</value></data>
   <data name="StepMessage.PartitioningTargetDisk" xml:space="preserve"><value>Partitioning target disk...</value></data>
   <data name="StepMessage.PreparingTargetWorkspace" xml:space="preserve"><value>Preparing target workspace...</value></data>
@@ -222,6 +249,8 @@ Action: Verify disk attributes and retry deployment.</value></data>
   <data name="StepMessage.CheckingCache" xml:space="preserve"><value>Checking cache...</value></data>
   <data name="StepResult.OperatingSystemImageReadySimulation" xml:space="preserve"><value>Operating system image ready (simulation).</value></data>
   <data name="StepResult.OperatingSystemImageNotDownloaded" xml:space="preserve"><value>Operating system image was not downloaded.</value></data>
+  <data name="StepResult.OperatingSystemImageDownloaded" xml:space="preserve"><value>Operating system image downloaded.</value></data>
+  <data name="StepResult.OperatingSystemImageResolvedFromCache" xml:space="preserve"><value>Operating system image resolved from cache.</value></data>
   <data name="StepMessage.ApplyingOperatingSystemImage" xml:space="preserve"><value>Applying OS image...</value></data>
   <data name="StepMessage.InspectingImage" xml:space="preserve"><value>Inspecting image...</value></data>
   <data name="StepMessage.ApplyingImage" xml:space="preserve"><value>Applying image...</value></data>
@@ -246,13 +275,18 @@ Action: Verify disk attributes and retry deployment.</value></data>
   <data name="StepResult.OemDriverPackMissing" xml:space="preserve"><value>OEM driver pack mode selected but no driver pack was provided.</value></data>
   <data name="StepResult.DriverPackDownloaded" xml:space="preserve"><value>Driver pack downloaded.</value></data>
   <data name="StepResult.DriverPackDownloadedSimulation" xml:space="preserve"><value>Driver pack downloaded (simulation).</value></data>
+  <data name="StepResult.DriverPackResolvedFromCache" xml:space="preserve"><value>Driver pack resolved from cache.</value></data>
   <data name="StepMessage.ExtractingDriverPack" xml:space="preserve"><value>Extracting driver pack...</value></data>
   <data name="StepResult.DriverPackNotDownloaded" xml:space="preserve"><value>Driver pack was not downloaded.</value></data>
   <data name="StepResult.DriverPackExtracted" xml:space="preserve"><value>Driver pack extracted.</value></data>
   <data name="StepResult.DriverPackExtractedSimulation" xml:space="preserve"><value>Driver pack extracted (simulation).</value></data>
+  <data name="StepResult.DriverPackPreparedForDeferredInstallation" xml:space="preserve"><value>Driver pack prepared for deferred installation.</value></data>
   <data name="StepResult.NoDriverPackOperationRequired" xml:space="preserve"><value>No driver pack operation is required.</value></data>
   <data name="StepResult.UnsupportedDriverPackInstallMode" xml:space="preserve"><value>Unsupported driver pack install mode.</value></data>
   <data name="StepResult.NoExtractedInfDriverPayload" xml:space="preserve"><value>No extracted INF driver payload is available.</value></data>
+  <data name="StepResult.DriverPackSourcePayloadUnavailableForDeferredStaging" xml:space="preserve"><value>Driver pack source payload is unavailable for deferred staging.</value></data>
+  <data name="StepResult.MicrosoftUpdateCatalogDriverPayloadMissing" xml:space="preserve"><value>Microsoft Update Catalog did not produce a driver payload.</value></data>
+  <data name="StepResult.DeferredDriverPackStagingUnsupportedCommand" xml:space="preserve"><value>Deferred driver pack staging was requested without a supported deferred command.</value></data>
   <data name="StepMessage.ApplyingDriverPack" xml:space="preserve"><value>Applying driver pack...</value></data>
   <data name="StepMessage.ApplyingWindowsDrivers" xml:space="preserve"><value>Applying Windows drivers...</value></data>
   <data name="StepMessage.MountingWinRe" xml:space="preserve"><value>Mounting WinRE...</value></data>
@@ -260,6 +294,12 @@ Action: Verify disk attributes and retry deployment.</value></data>
   <data name="StepMessage.UnmountingWinRe" xml:space="preserve"><value>Unmounting WinRE...</value></data>
   <data name="StepMessage.StagingPackage" xml:space="preserve"><value>Staging package...</value></data>
   <data name="StepMessage.UpdatingSetupCompleteHook" xml:space="preserve"><value>Updating SetupComplete hook...</value></data>
+  <data name="StepProgress.PercentFormat" xml:space="preserve"><value>{0}: {1}%</value></data>
+  <data name="StepProgress.Downloading" xml:space="preserve"><value>Downloading</value></data>
+  <data name="StepProgress.Extracting" xml:space="preserve"><value>Extracting</value></data>
+  <data name="StepProgress.Applying" xml:space="preserve"><value>Applying</value></data>
+  <data name="StepProgress.Staging" xml:space="preserve"><value>Staging</value></data>
+  <data name="StepProgress.DownloadedBytesFormat" xml:space="preserve"><value>{0} downloaded</value></data>
   <data name="StepResult.DriverPackApplied" xml:space="preserve"><value>Driver pack applied.</value></data>
   <data name="StepResult.DriverPackStagedForFirstBoot" xml:space="preserve"><value>Driver pack staged for first boot.</value></data>
   <data name="StepResult.DriverPackAppliedSimulation" xml:space="preserve"><value>Driver pack applied (simulation).</value></data>

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchPreparationService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchPreparationService.cs
@@ -1,9 +1,13 @@
 using Foundry.Deploy.Models;
 using Foundry.Deploy.Services.ApplicationShell;
+using Foundry.Deploy.Services.Localization;
 using Foundry.Deploy.Validation;
 
 namespace Foundry.Deploy.Services.Deployment;
 
+/// <summary>
+/// Validates launch selections and asks the shell for destructive deployment confirmation before creating a deployment context.
+/// </summary>
 public sealed class DeploymentLaunchPreparationService : IDeploymentLaunchPreparationService
 {
     private readonly IApplicationShellService _applicationShellService;
@@ -13,6 +17,11 @@ public sealed class DeploymentLaunchPreparationService : IDeploymentLaunchPrepar
         _applicationShellService = applicationShellService;
     }
 
+    /// <summary>
+    /// Builds a deployment context when the request is valid and the user confirms disk erasure.
+    /// </summary>
+    /// <param name="request">The wizard selections and launch options to validate.</param>
+    /// <returns>The normalized launch result, including a deployment context when startup can continue.</returns>
     public DeploymentLaunchPreparationResult Prepare(DeploymentLaunchRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -91,23 +100,26 @@ public sealed class DeploymentLaunchPreparationService : IDeploymentLaunchPrepar
             context);
     }
 
+    /// <summary>
+    /// Shows the final warning that live deployments erase the selected target disk.
+    /// </summary>
+    /// <param name="targetDisk">The disk that will be repartitioned.</param>
+    /// <param name="operatingSystem">The operating system image that will be applied.</param>
+    /// <returns><see langword="true"/> when the user confirms the destructive operation.</returns>
     private bool ConfirmDestructiveDeployment(TargetDiskInfo targetDisk, OperatingSystemCatalogItem operatingSystem)
     {
         string sizeGiB = targetDisk.SizeBytes > 0
             ? $"{(targetDisk.SizeBytes / 1024d / 1024d / 1024d):0.0} GiB"
-            : "Unknown size";
+            : LocalizationText.GetString("Disk.UnknownSize");
 
-        string message =
-            "This operation will ERASE the selected disk and apply a new operating system." + Environment.NewLine +
-            Environment.NewLine +
-            $"Disk: {targetDisk.DiskNumber}" + Environment.NewLine +
-            $"Model: {targetDisk.FriendlyName}" + Environment.NewLine +
-            $"Bus: {targetDisk.BusType}" + Environment.NewLine +
-            $"Size: {sizeGiB}" + Environment.NewLine +
-            Environment.NewLine +
-            $"OS: {operatingSystem.DisplayLabel}" + Environment.NewLine +
-            "Continue?";
+        string message = LocalizationText.Format(
+            "Launch.ConfirmDiskEraseMessageFormat",
+            targetDisk.DiskNumber,
+            targetDisk.FriendlyName,
+            targetDisk.BusType,
+            sizeGiB,
+            operatingSystem.DisplayLabel);
 
-        return _applicationShellService.ConfirmWarning("Confirm Disk Erase", message);
+        return _applicationShellService.ConfirmWarning(LocalizationText.GetString("Launch.ConfirmDiskEraseTitle"), message);
     }
 }

--- a/src/Foundry.Deploy/Services/Localization/DeploymentUiTextLocalizer.cs
+++ b/src/Foundry.Deploy/Services/Localization/DeploymentUiTextLocalizer.cs
@@ -2,8 +2,16 @@ using System.Text.RegularExpressions;
 
 namespace Foundry.Deploy.Services.Localization;
 
+/// <summary>
+/// Translates deployment status values emitted by runtime services before they are shown by the WPF shell.
+/// </summary>
 public static partial class DeploymentUiTextLocalizer
 {
+    /// <summary>
+    /// Localizes an invariant deployment step name while preserving unknown labels from external sources.
+    /// </summary>
+    /// <param name="value">The invariant step name produced by the deployment pipeline.</param>
+    /// <returns>The localized step name, or a localized status message when the value is not a known step.</returns>
     public static string LocalizeStepName(string value)
     {
         return value switch
@@ -29,6 +37,11 @@ public static partial class DeploymentUiTextLocalizer
         };
     }
 
+    /// <summary>
+    /// Localizes invariant deployment messages and generated progress labels for the active UI culture.
+    /// </summary>
+    /// <param name="value">The invariant message emitted by services, progress reporters, or view models.</param>
+    /// <returns>The localized message, or the original value when no safe mapping exists.</returns>
     public static string LocalizeMessage(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -90,7 +103,10 @@ public static partial class DeploymentUiTextLocalizer
             "Target configuration validated." => LocalizationText.GetString("StepResult.TargetConfigurationValidated"),
             "Target configuration validated (simulation)." => LocalizationText.GetString("StepResult.TargetConfigurationValidatedSimulation"),
             "Resolving cache strategy..." => LocalizationText.GetString("StepMessage.ResolvingCacheStrategy"),
+            "Resolving cache location..." => LocalizationText.GetString("StepMessage.ResolvingCacheLocation"),
             "Checking cache disk conflict..." => LocalizationText.GetString("StepMessage.CheckingCacheDiskConflict"),
+            "Cache strategy resolved." => LocalizationText.GetString("StepResult.CacheStrategyResolved"),
+            "Cache strategy resolved (simulation)." => LocalizationText.GetString("StepResult.CacheStrategyResolvedSimulation"),
             "Preparing target disk layout..." => LocalizationText.GetString("StepMessage.PreparingTargetDiskLayout"),
             "Partitioning target disk..." => LocalizationText.GetString("StepMessage.PartitioningTargetDisk"),
             "Preparing target workspace..." => LocalizationText.GetString("StepMessage.PreparingTargetWorkspace"),
@@ -102,6 +118,8 @@ public static partial class DeploymentUiTextLocalizer
             "Checking cache..." => LocalizationText.GetString("StepMessage.CheckingCache"),
             "Operating system image ready (simulation)." => LocalizationText.GetString("StepResult.OperatingSystemImageReadySimulation"),
             "Operating system image was not downloaded." => LocalizationText.GetString("StepResult.OperatingSystemImageNotDownloaded"),
+            "Operating system image downloaded." => LocalizationText.GetString("StepResult.OperatingSystemImageDownloaded"),
+            "Operating system image resolved from cache." => LocalizationText.GetString("StepResult.OperatingSystemImageResolvedFromCache"),
             "Applying OS image..." => LocalizationText.GetString("StepMessage.ApplyingOperatingSystemImage"),
             "Inspecting image..." => LocalizationText.GetString("StepMessage.InspectingImage"),
             "Applying image..." => LocalizationText.GetString("StepMessage.ApplyingImage"),
@@ -126,13 +144,19 @@ public static partial class DeploymentUiTextLocalizer
             "OEM driver pack mode selected but no driver pack was provided." => LocalizationText.GetString("StepResult.OemDriverPackMissing"),
             "Driver pack downloaded." => LocalizationText.GetString("StepResult.DriverPackDownloaded"),
             "Driver pack downloaded (simulation)." => LocalizationText.GetString("StepResult.DriverPackDownloadedSimulation"),
+            "Driver pack resolved from cache." => LocalizationText.GetString("StepResult.DriverPackResolvedFromCache"),
+            "Downloading Driver pack..." => LocalizationText.GetString("StepMessage.DownloadingDriverPack"),
             "Extracting driver pack..." => LocalizationText.GetString("StepMessage.ExtractingDriverPack"),
             "Driver pack was not downloaded." => LocalizationText.GetString("StepResult.DriverPackNotDownloaded"),
             "Driver pack extracted." => LocalizationText.GetString("StepResult.DriverPackExtracted"),
             "Driver pack extracted (simulation)." => LocalizationText.GetString("StepResult.DriverPackExtractedSimulation"),
+            "Driver pack prepared for deferred installation." => LocalizationText.GetString("StepResult.DriverPackPreparedForDeferredInstallation"),
             "No driver pack operation is required." => LocalizationText.GetString("StepResult.NoDriverPackOperationRequired"),
             "Unsupported driver pack install mode." => LocalizationText.GetString("StepResult.UnsupportedDriverPackInstallMode"),
             "No extracted INF driver payload is available." => LocalizationText.GetString("StepResult.NoExtractedInfDriverPayload"),
+            "Driver pack source payload is unavailable for deferred staging." => LocalizationText.GetString("StepResult.DriverPackSourcePayloadUnavailableForDeferredStaging"),
+            "Microsoft Update Catalog did not produce a driver payload." => LocalizationText.GetString("StepResult.MicrosoftUpdateCatalogDriverPayloadMissing"),
+            "Deferred driver pack staging was requested without a supported deferred command." => LocalizationText.GetString("StepResult.DeferredDriverPackStagingUnsupportedCommand"),
             "Applying driver pack..." => LocalizationText.GetString("StepMessage.ApplyingDriverPack"),
             "Applying Windows drivers..." => LocalizationText.GetString("StepMessage.ApplyingWindowsDrivers"),
             "Mounting WinRE..." => LocalizationText.GetString("StepMessage.MountingWinRe"),
@@ -172,13 +196,23 @@ public static partial class DeploymentUiTextLocalizer
             "Autopilot profile staged (simulation)." => LocalizationText.GetString("StepResult.AutopilotProfileStagedSimulation"),
             "Rebooting now..." => LocalizationText.GetString("Status.RebootingNow"),
             "Reboot command failed." => LocalizationText.GetString("Status.RebootCommandFailed"),
+            "System reboot" => LocalizationText.GetString("Status.SystemReboot"),
+            "Required reboot executable 'wpeutil.exe' was not found." => LocalizationText.GetString("Status.RequiredRebootExecutableMissing"),
             "Unknown step" => LocalizationText.GetString("Status.UnknownStep"),
             "No error details were provided." => LocalizationText.GetString("Status.NoErrorDetails"),
             "N/A" => LocalizationText.GetString("Common.NotAvailable"),
             "Unavailable" => LocalizationText.GetString("Common.Unavailable"),
             "None" => LocalizationText.GetString("Common.None"),
+            "Blocked: system disk" => LocalizationText.GetString("Disk.BlockedSystemDisk"),
+            "Blocked: boot disk" => LocalizationText.GetString("Disk.BlockedBootDisk"),
+            "Blocked: read-only" => LocalizationText.GetString("Disk.BlockedReadOnly"),
+            "Blocked: offline" => LocalizationText.GetString("Disk.BlockedOffline"),
             "Microsoft Update Catalog" => LocalizationText.GetString("DriverPack.MicrosoftUpdateCatalog"),
             "OEM Driver Pack" => LocalizationText.GetString("DriverPack.OemDriverPack"),
+            "Downloading" => LocalizationText.GetString("StepProgress.Downloading"),
+            "Extracting" => LocalizationText.GetString("StepProgress.Extracting"),
+            "Applying" => LocalizationText.GetString("StepProgress.Applying"),
+            "Staging" => LocalizationText.GetString("StepProgress.Staging"),
             _ => LocalizeDynamicMessage(value)
         };
     }
@@ -219,6 +253,21 @@ public static partial class DeploymentUiTextLocalizer
             return localized;
         }
 
+        match = TargetDiskMissingRegex().Match(value);
+        if (match.Success)
+        {
+            return LocalizationText.Format("Disk.TargetMissingFormat", int.Parse(match.Groups["disk"].Value));
+        }
+
+        match = TargetDiskBlockedRegex().Match(value);
+        if (match.Success)
+        {
+            return LocalizationText.Format(
+                "Disk.TargetBlockedFormat",
+                int.Parse(match.Groups["disk"].Value),
+                LocalizeMessage(match.Groups["warning"].Value));
+        }
+
         if (TryLocalizeSingleSuffix(value, "Deployment failed: ", "Status.DeploymentFailedFormat", out localized))
         {
             return localized;
@@ -237,6 +286,23 @@ public static partial class DeploymentUiTextLocalizer
         if (value.StartsWith("Debug preview: DISM apply failed because the target partition is read-only.", StringComparison.Ordinal))
         {
             return LocalizationText.GetString("Debug.ErrorPreviewMessage");
+        }
+
+        match = StepPercentLabelRegex().Match(value);
+        if (match.Success)
+        {
+            string rawLabel = match.Groups["label"].Value;
+            string localizedLabel = LocalizeProgressLabel(rawLabel);
+            if (!localizedLabel.Equals(rawLabel, StringComparison.Ordinal))
+            {
+                return LocalizationText.Format("StepProgress.PercentFormat", localizedLabel, match.Groups["percent"].Value);
+            }
+        }
+
+        match = DownloadedBytesRegex().Match(value);
+        if (match.Success)
+        {
+            return LocalizationText.Format("StepProgress.DownloadedBytesFormat", match.Groups["size"].Value);
         }
 
         match = ProfilesAvailableRegex().Match(value);
@@ -272,12 +338,6 @@ public static partial class DeploymentUiTextLocalizer
             return LocalizationText.Format("Status.StartingStepSubProgressFormat", LocalizeStepName(match.Groups["step"].Value));
         }
 
-        match = ApplyingImageProgressRegex().Match(value);
-        if (match.Success)
-        {
-            return LocalizationText.Format("Debug.ApplyingImageProgressFormat", match.Groups["percent"].Value);
-        }
-
         match = WpeUtilFailureRegex().Match(value);
         if (match.Success)
         {
@@ -285,6 +345,32 @@ public static partial class DeploymentUiTextLocalizer
         }
 
         return value;
+    }
+
+    /// <summary>
+    /// Localizes the invariant prefix used by generated percentage labels such as driver or image progress.
+    /// </summary>
+    /// <param name="label">The label text without the trailing percentage.</param>
+    /// <returns>The localized label without a trailing ellipsis when a mapping exists.</returns>
+    private static string LocalizeProgressLabel(string label)
+    {
+        string localized = LocalizeMessage(label);
+        if (!localized.Equals(label, StringComparison.Ordinal))
+        {
+            return localized;
+        }
+
+        localized = LocalizeMessage($"{label}...");
+        return localized.Equals($"{label}...", StringComparison.Ordinal)
+            ? label
+            : TrimTrailingEllipsis(localized);
+    }
+
+    private static string TrimTrailingEllipsis(string value)
+    {
+        return value.EndsWith("...", StringComparison.Ordinal)
+            ? value[..^3]
+            : value;
     }
 
     private static bool TryLocalizeSingleSuffix(string value, string prefix, string key, out string localized)
@@ -308,6 +394,18 @@ public static partial class DeploymentUiTextLocalizer
     [GeneratedRegex(@"^Target disks loaded: (?<count>\d+) detected\.$")]
     private static partial Regex TargetDisksLoadedRegex();
 
+    [GeneratedRegex(@"^Target disk (?<disk>\d+) is no longer present\.$")]
+    private static partial Regex TargetDiskMissingRegex();
+
+    [GeneratedRegex(@"^Target disk (?<disk>\d+) is blocked: (?<warning>.+)$")]
+    private static partial Regex TargetDiskBlockedRegex();
+
+    [GeneratedRegex(@"^(?<label>.+): (?<percent>\d+(?:[.,]\d+)?)%$")]
+    private static partial Regex StepPercentLabelRegex();
+
+    [GeneratedRegex(@"^(?<size>.+) downloaded$")]
+    private static partial Regex DownloadedBytesRegex();
+
     [GeneratedRegex(@"^Step: (?<current>\d+) of (?<total>\d+)$")]
     private static partial Regex StepCounterRegex();
 
@@ -316,9 +414,6 @@ public static partial class DeploymentUiTextLocalizer
 
     [GeneratedRegex(@"^Starting (?<step>.+)\.\.\.$")]
     private static partial Regex StartingStepSubProgressRegex();
-
-    [GeneratedRegex(@"^Applying image: (?<percent>\d+(?:[.,]\d+)?)%$")]
-    private static partial Regex ApplyingImageProgressRegex();
 
     [GeneratedRegex(@"^wpeutil\.exe failed with exit code (?<code>\d+)\. (?<diagnostic>.+)$")]
     private static partial Regex WpeUtilFailureRegex();


### PR DESCRIPTION
## Summary
- Localize Foundry.Deploy runtime progress/status messages that could appear in English under `fr-FR`.
- Localize the destructive disk erase confirmation dialog and OS catalog display labels.
- Add regression coverage for deployment UI message localization and OS display formatting.

## Reason
French deployments could still show mixed English/French text for generated progress labels, runtime status messages, disk validation errors, and confirmation dialogs.

## Main changes
- Extend `AppStrings` resource coverage for runtime deployment messages and catalog labels.
- Route generated progress labels through `DeploymentUiTextLocalizer`.
- Use localized resources for the disk erase confirmation warning.
- Remove obsolete image-progress-specific localization now covered by generic percent-label localization.

## Testing
- `dotnet test .\src\Foundry.slnx --logger "console;verbosity=minimal"`
