### PR TITLE
feat(telemetry): update PostHog event taxonomy

### DIFF
--- a/src/Foundry.Connect.Tests/MainWindowViewModelTelemetryTests.cs
+++ b/src/Foundry.Connect.Tests/MainWindowViewModelTelemetryTests.cs
@@ -1,0 +1,247 @@
+using Foundry.Connect.Models;
+using Foundry.Connect.Models.Configuration;
+using Foundry.Connect.Models.Network;
+using Foundry.Connect.Services.ApplicationLifetime;
+using Foundry.Connect.Services.ApplicationShell;
+using Foundry.Connect.Services.Configuration;
+using Foundry.Connect.Services.Localization;
+using Foundry.Connect.Services.Network;
+using Foundry.Connect.Services.Theme;
+using Foundry.Connect.ViewModels;
+using Foundry.Telemetry;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Connect.Tests;
+
+public sealed class MainWindowViewModelTelemetryTests
+{
+    [Fact]
+    public async Task InitializeAsync_WhenNetworkIsReady_DoesNotTrackSessionReadyImmediately()
+    {
+        var telemetry = new RecordingTelemetryService();
+        MainWindowViewModel viewModel = CreateViewModel(
+            telemetry,
+            new QueueNetworkStatusService(CreateReadySnapshot()));
+
+        await viewModel.InitializeAsync();
+        viewModel.Dispose();
+
+        Assert.Empty(telemetry.Events);
+    }
+
+    [Fact]
+    public async Task ContinueBootstrapCommand_WhenNetworkIsReady_TracksSessionReadyBeforeSuccessfulExit()
+    {
+        var telemetry = new RecordingTelemetryService();
+        var lifetime = new RecordingApplicationLifetimeService(telemetry);
+        MainWindowViewModel viewModel = CreateViewModel(
+            telemetry,
+            new QueueNetworkStatusService(CreateReadySnapshot()),
+            lifetime);
+
+        await viewModel.InitializeAsync();
+
+        viewModel.ContinueBootstrapCommand.Execute(null);
+        viewModel.Dispose();
+
+        TelemetryEvent telemetryEvent = Assert.Single(telemetry.Events);
+        Assert.Equal(TelemetryEvents.ConnectSessionReady, telemetryEvent.Name);
+        Assert.True((bool)telemetryEvent.Properties["success"]!);
+        Assert.Equal("ethernet", telemetryEvent.Properties["connection_type"]);
+        Assert.Equal("ethernet_wifi", telemetryEvent.Properties["layout_mode"]);
+        Assert.Equal("none", telemetryEvent.Properties["wifi_security"]);
+        Assert.Equal("none", telemetryEvent.Properties["wifi_source"]);
+        Assert.True((bool)telemetryEvent.Properties["wifi_provisioned"]!);
+        Assert.True((bool)telemetryEvent.Properties["wired_dot1x_enabled"]!);
+        Assert.Equal(FoundryConnectExitCode.Success, lifetime.ExitCode);
+        Assert.True(telemetry.CallsCompletedBeforeExit);
+    }
+
+    [Fact]
+    public async Task ContinueBootstrapCommand_WhenExecutedTwice_TracksSessionReadyOnce()
+    {
+        var telemetry = new RecordingTelemetryService();
+        var lifetime = new RecordingApplicationLifetimeService(telemetry);
+        MainWindowViewModel viewModel = CreateViewModel(
+            telemetry,
+            new QueueNetworkStatusService(CreateReadySnapshot()),
+            lifetime);
+
+        await viewModel.InitializeAsync();
+
+        viewModel.ContinueBootstrapCommand.Execute(null);
+        viewModel.ContinueBootstrapCommand.Execute(null);
+        viewModel.Dispose();
+
+        Assert.Single(telemetry.Events);
+    }
+
+    private static MainWindowViewModel CreateViewModel(
+        RecordingTelemetryService telemetryService,
+        INetworkStatusService networkStatusService,
+        RecordingApplicationLifetimeService? lifetimeService = null)
+    {
+        lifetimeService ??= new RecordingApplicationLifetimeService(telemetryService);
+        var configuration = new FoundryConnectConfiguration
+        {
+            Capabilities = new NetworkCapabilitiesOptions { WifiProvisioned = true },
+            Wifi = new WifiSettings
+            {
+                IsEnabled = true,
+                SecurityType = "WPA2-Personal",
+                Ssid = "Foundry"
+            },
+            Dot1x = new Dot1xSettings { IsEnabled = true }
+        };
+
+        return new MainWindowViewModel(
+            new FakeThemeService(),
+            new LocalizationService(),
+            new FakeApplicationShellService(),
+            lifetimeService,
+            new FakeConnectConfigurationService(configuration),
+            configuration,
+            new FakeNetworkBootstrapService(),
+            networkStatusService,
+            telemetryService,
+            NullLogger<MainWindowViewModel>.Instance);
+    }
+
+    private static NetworkStatusSnapshot CreateReadySnapshot()
+    {
+        return new NetworkStatusSnapshot
+        {
+            LayoutMode = NetworkLayoutMode.EthernetWifi,
+            HasInternetAccess = true,
+            HasEthernetAdapter = true,
+            IsEthernetConnected = true,
+            HasEthernetIpv4 = true,
+            HasDhcpLease = true,
+            IsWifiRuntimeAvailable = true,
+            HasWirelessAdapter = true,
+            EthernetStatusText = "Connected",
+            WifiNetworks =
+            [
+                new WifiNetworkSummary
+                {
+                    Ssid = "Foundry",
+                    Authentication = "WPA2-Personal",
+                    Encryption = "AES",
+                    SignalStrengthPercent = 100
+                }
+            ]
+        };
+    }
+
+    private sealed class RecordingTelemetryService : ITelemetryService
+    {
+        public List<TelemetryEvent> Events { get; } = [];
+
+        public bool CallsCompletedBeforeExit { get; private set; }
+
+        public bool HasExitHappened { get; set; }
+
+        public Task TrackAsync(string eventName, IReadOnlyDictionary<string, object?> properties, CancellationToken cancellationToken = default)
+        {
+            Events.Add(new TelemetryEvent(eventName, new Dictionary<string, object?>(properties)));
+            CallsCompletedBeforeExit = !HasExitHappened;
+            return Task.CompletedTask;
+        }
+
+        public Task FlushAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingApplicationLifetimeService : IApplicationLifetimeService
+    {
+        private readonly RecordingTelemetryService? telemetryService;
+
+        public RecordingApplicationLifetimeService()
+        {
+        }
+
+        public RecordingApplicationLifetimeService(RecordingTelemetryService telemetryService)
+        {
+            this.telemetryService = telemetryService;
+        }
+
+        public bool IsExitRequested { get; private set; }
+
+        public FoundryConnectExitCode ExitCode { get; private set; }
+
+        public void Exit(FoundryConnectExitCode exitCode)
+        {
+            telemetryService?.HasExitHappened = true;
+            ExitCode = exitCode;
+            IsExitRequested = true;
+        }
+    }
+
+    private sealed class QueueNetworkStatusService(params NetworkStatusSnapshot[] snapshots) : INetworkStatusService
+    {
+        private readonly Queue<NetworkStatusSnapshot> snapshots = new(snapshots);
+
+        public Task<NetworkStatusSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(snapshots.Count > 1 ? snapshots.Dequeue() : snapshots.Peek());
+        }
+    }
+
+    private sealed class FakeThemeService : IThemeService
+    {
+        public ThemeMode CurrentTheme => ThemeMode.System;
+
+        public void SetTheme(ThemeMode theme)
+        {
+        }
+    }
+
+    private sealed class FakeApplicationShellService : IApplicationShellService
+    {
+        public void ShowAbout()
+        {
+        }
+    }
+
+    private sealed class FakeConnectConfigurationService(FoundryConnectConfiguration configuration) : IConnectConfigurationService
+    {
+        public string? ConfigurationPath => null;
+
+        public bool IsLoadedFromDisk => false;
+
+        public FoundryConnectConfiguration Load()
+        {
+            return configuration;
+        }
+    }
+
+    private sealed class FakeNetworkBootstrapService : INetworkBootstrapService
+    {
+        public Task<string> ApplyProvisionedSettingsAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(string.Empty);
+        }
+
+        public Task<string> ConnectConfiguredWifiAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(string.Empty);
+        }
+
+        public Task<string> ConnectWifiNetworkAsync(
+            string ssid,
+            string? ssidHex,
+            string authentication,
+            string? passphrase,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(string.Empty);
+        }
+
+        public Task<string> DisconnectWifiAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(string.Empty);
+        }
+    }
+}

--- a/src/Foundry.Connect.Tests/NetworkTelemetryClassifierTests.cs
+++ b/src/Foundry.Connect.Tests/NetworkTelemetryClassifierTests.cs
@@ -1,3 +1,4 @@
+using Foundry.Connect.Models;
 using Foundry.Connect.Models.Network;
 using Foundry.Connect.Services.Network;
 
@@ -39,5 +40,13 @@ public sealed class NetworkTelemetryClassifierTests
         };
 
         Assert.Equal("wifi", NetworkTelemetryClassifier.ClassifyConnection(snapshot));
+    }
+
+    [Theory]
+    [InlineData(NetworkLayoutMode.EthernetOnly, "ethernet_only")]
+    [InlineData(NetworkLayoutMode.EthernetWifi, "ethernet_wifi")]
+    public void ClassifyLayout_ReturnsStableCategory(NetworkLayoutMode layoutMode, string expected)
+    {
+        Assert.Equal(expected, NetworkTelemetryClassifier.ClassifyLayout(layoutMode));
     }
 }

--- a/src/Foundry.Connect/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Connect/DependencyInjection/ServiceCollectionExtensions.cs
@@ -18,6 +18,8 @@ namespace Foundry.Connect.DependencyInjection;
 
 public static class ServiceCollectionExtensions
 {
+    private const string DeploymentModeEnvironmentVariable = "FOUNDRY_DEPLOYMENT_MODE";
+
     public static IServiceCollection AddFoundryConnectApplicationServices(this IServiceCollection services, string[] args)
     {
         services.AddSingleton<App>();
@@ -37,7 +39,7 @@ public static class ServiceCollectionExtensions
             ILogger<PostHogTelemetryService> logger = sp.GetRequiredService<ILogger<PostHogTelemetryService>>();
             logger.LogDebug(
                 "Configuring telemetry service. App={App}, IsEnabled={IsEnabled}, HasProjectToken={HasProjectToken}, HasInstallId={HasInstallId}, HostUrl={HostUrl}.",
-                "foundry-connect",
+                TelemetryApps.FoundryConnect,
                 options.IsEnabled,
                 !string.IsNullOrWhiteSpace(options.ProjectToken),
                 !string.IsNullOrWhiteSpace(options.InstallId),
@@ -76,14 +78,18 @@ public static class ServiceCollectionExtensions
     private static TelemetryContext CreateTelemetryContext(IServiceProvider serviceProvider)
     {
         FoundryConnectConfiguration configuration = serviceProvider.GetRequiredService<FoundryConnectConfiguration>();
+        string runtime = ConnectWorkspacePaths.IsWinPeRuntime() ? TelemetryRuntimeModes.WinPe : TelemetryRuntimeModes.Desktop;
         return new TelemetryContext(
-            "foundry-connect",
+            TelemetryApps.FoundryConnect,
             FoundryConnectApplicationInfo.Version,
             TelemetryBuildConfiguration.Current,
-            ConnectWorkspacePaths.IsWinPeRuntime() ? TelemetryRuntimeModes.WinPe : TelemetryRuntimeModes.Desktop,
+            runtime,
             string.IsNullOrWhiteSpace(configuration.Telemetry.RuntimePayloadSource)
                 ? TelemetryRuntimePayloadSources.Unknown
                 : configuration.Telemetry.RuntimePayloadSource,
+            TelemetryBootMediaTargetResolver.Resolve(
+                runtime,
+                Environment.GetEnvironmentVariable(DeploymentModeEnvironmentVariable)),
             RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant(),
             CultureInfo.CurrentUICulture.Name,
             Guid.NewGuid().ToString("D"));

--- a/src/Foundry.Connect/Services/Network/NetworkTelemetryClassifier.cs
+++ b/src/Foundry.Connect/Services/Network/NetworkTelemetryClassifier.cs
@@ -1,3 +1,4 @@
+using Foundry.Connect.Models;
 using Foundry.Connect.Models.Network;
 
 namespace Foundry.Connect.Services.Network;
@@ -20,6 +21,20 @@ internal static class NetworkTelemetryClassifier
         }
 
         return string.IsNullOrWhiteSpace(snapshot.ConnectedWifiSsid) ? "unknown" : "wifi";
+    }
+
+    /// <summary>
+    /// Classifies the runtime layout into a stable telemetry category.
+    /// </summary>
+    /// <param name="layoutMode">Detected Connect layout mode.</param>
+    /// <returns>A stable layout category.</returns>
+    public static string ClassifyLayout(NetworkLayoutMode layoutMode)
+    {
+        return layoutMode switch
+        {
+            NetworkLayoutMode.EthernetWifi => "ethernet_wifi",
+            _ => "ethernet_only"
+        };
     }
 
     /// <summary>

--- a/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
@@ -46,6 +46,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     private readonly ILogger<MainWindowViewModel> _logger;
     private readonly Dispatcher _dispatcher;
     private readonly SemaphoreSlim _refreshGate = new(1, 1);
+    private readonly SemaphoreSlim _successfulExitGate = new(1, 1);
     private readonly CancellationTokenSource _disposeCts = new();
     private readonly bool _isAutoCloseEnabled;
 
@@ -53,7 +54,8 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     private bool _isInitialized;
     private bool _isDisposed;
     private bool _isSyncingWifiNetworks;
-    private bool _hasTrackedNetworkReady;
+    private bool _hasTrackedSessionReady;
+    private NetworkStatusSnapshot? _lastNetworkReadySnapshot;
     private string? _lastSelectedWifiNetworkSsid;
     private DateTimeOffset? _lastConfiguredWifiConnectAttemptAt;
     private string? _connectedWifiSsid;
@@ -395,14 +397,9 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     }
 
     [RelayCommand(CanExecute = nameof(CanContinueBootstrap))]
-    private void ContinueBootstrap()
+    private async Task ContinueBootstrapAsync()
     {
-        if (_applicationLifetimeService.IsExitRequested)
-        {
-            return;
-        }
-
-        _applicationLifetimeService.Exit(FoundryConnectExitCode.Success);
+        await ContinueBootstrapSuccessfullyAsync(_disposeCts.Token).ConfigureAwait(false);
     }
 
     [RelayCommand(CanExecute = nameof(IsDebugMenuVisible))]
@@ -519,7 +516,6 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
                 snapshot.HasWirelessAdapter,
                 snapshot.WifiNetworks.Count);
             await RunOnUiAsync(() => ApplySnapshot(snapshot)).ConfigureAwait(false);
-            await TrackNetworkReadyAsync(snapshot, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -550,6 +546,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         IsWifiRuntimeAvailable = snapshot.IsWifiRuntimeAvailable;
         HasWirelessAdapter = snapshot.HasWirelessAdapter;
         _connectedWifiSsid = snapshot.ConnectedWifiSsid;
+        _lastNetworkReadySnapshot = snapshot.HasInternetAccess ? snapshot : null;
 
         EthernetGlyph = ResolveEthernetGlyph(snapshot);
         EthernetStatusText = snapshot.EthernetStatusText;
@@ -588,14 +585,14 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         }
     }
 
-    private async Task TrackNetworkReadyAsync(NetworkStatusSnapshot snapshot, CancellationToken cancellationToken)
+    private async Task TrackSessionReadyAsync(NetworkStatusSnapshot snapshot, CancellationToken cancellationToken)
     {
-        if (_hasTrackedNetworkReady || !snapshot.HasInternetAccess)
+        if (_hasTrackedSessionReady || !snapshot.HasInternetAccess)
         {
             return;
         }
 
-        _hasTrackedNetworkReady = true;
+        _hasTrackedSessionReady = true;
         string connectionType = NetworkTelemetryClassifier.ClassifyConnection(snapshot);
         string wifiSecurity = ResolveWifiSecurity(snapshot, connectionType);
         string wifiSource = ResolveWifiSource(snapshot, connectionType);
@@ -603,6 +600,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
             {
                 ["success"] = true,
                 ["connection_type"] = connectionType,
+                ["layout_mode"] = NetworkTelemetryClassifier.ClassifyLayout(snapshot.LayoutMode),
                 ["wifi_security"] = wifiSecurity,
                 ["wifi_source"] = wifiSource,
                 ["wired_dot1x_enabled"] = _configuration.Dot1x.IsEnabled,
@@ -610,15 +608,42 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
             };
 
         _logger.LogDebug(
-            "Tracking network-ready telemetry event. ConnectionType={ConnectionType}, WifiSecurity={WifiSecurity}, WifiSource={WifiSource}, WiredDot1xEnabled={WiredDot1xEnabled}, WifiProvisioned={WifiProvisioned}.",
+            "Tracking Connect session-ready telemetry event. ConnectionType={ConnectionType}, LayoutMode={LayoutMode}, WifiSecurity={WifiSecurity}, WifiSource={WifiSource}, WiredDot1xEnabled={WiredDot1xEnabled}, WifiProvisioned={WifiProvisioned}.",
             connectionType,
+            properties["layout_mode"],
             wifiSecurity,
             wifiSource,
             _configuration.Dot1x.IsEnabled,
             HasProvisionedWifiProfile);
 
-        await _telemetryService.TrackAsync("connect_network_ready", properties, cancellationToken).ConfigureAwait(false);
-        _logger.LogDebug("Network-ready telemetry event queued. ConnectionType={ConnectionType}.", connectionType);
+        await _telemetryService.TrackAsync(TelemetryEvents.ConnectSessionReady, properties, cancellationToken).ConfigureAwait(false);
+        _logger.LogDebug("Connect session-ready telemetry event queued. ConnectionType={ConnectionType}.", connectionType);
+    }
+
+    private async Task ContinueBootstrapSuccessfullyAsync(CancellationToken cancellationToken)
+    {
+        await _successfulExitGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            if (_applicationLifetimeService.IsExitRequested)
+            {
+                return;
+            }
+
+            NetworkStatusSnapshot? snapshot = _lastNetworkReadySnapshot;
+            if (snapshot is null || !snapshot.HasInternetAccess)
+            {
+                return;
+            }
+
+            await TrackSessionReadyAsync(snapshot, cancellationToken).ConfigureAwait(false);
+            _applicationLifetimeService.Exit(FoundryConnectExitCode.Success);
+        }
+        finally
+        {
+            _successfulExitGate.Release();
+        }
     }
 
     private string ResolveWifiSecurity(NetworkStatusSnapshot snapshot, string connectionType)
@@ -715,7 +740,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
             if (!_applicationLifetimeService.IsExitRequested)
             {
                 _logger.LogInformation("Internet validation remained stable through the countdown. Exiting successfully.");
-                _applicationLifetimeService.Exit(FoundryConnectExitCode.Success);
+                await ContinueBootstrapSuccessfullyAsync(cancellationToken).ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException)
@@ -897,6 +922,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         _countdownCts?.Dispose();
         _disposeCts.Dispose();
         _refreshGate.Dispose();
+        _successfulExitGate.Dispose();
         base.Dispose();
         _isDisposed = true;
     }

--- a/src/Foundry.Deploy.Tests/DeploymentOrchestratorTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentOrchestratorTests.cs
@@ -82,7 +82,7 @@ public sealed class DeploymentOrchestratorTests
         });
 
         TelemetryEvent telemetryEvent = Assert.Single(telemetryService.Events);
-        Assert.Equal("deployment_completed", telemetryEvent.Name);
+        Assert.Equal(TelemetryEvents.DeploySessionFinished, telemetryEvent.Name);
         Assert.False((bool)telemetryEvent.Properties["success"]!);
         Assert.False((bool)telemetryEvent.Properties["cancelled"]!);
         Assert.Equal(DeploymentStepNames.DownloadOperatingSystemImage, telemetryEvent.Properties["failed_step_name"]);

--- a/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
@@ -30,6 +30,8 @@ namespace Foundry.Deploy.DependencyInjection;
 
 public static class ServiceCollectionExtensions
 {
+    private const string DeploymentModeEnvironmentVariable = "FOUNDRY_DEPLOYMENT_MODE";
+
     public static IServiceCollection AddFoundryDeployApplicationServices(this IServiceCollection services)
     {
         services.AddSingleton<App>();
@@ -53,7 +55,7 @@ public static class ServiceCollectionExtensions
             ILogger<PostHogTelemetryService> logger = sp.GetRequiredService<ILogger<PostHogTelemetryService>>();
             logger.LogDebug(
                 "Configuring telemetry service. App={App}, IsEnabled={IsEnabled}, HasProjectToken={HasProjectToken}, HasInstallId={HasInstallId}, HostUrl={HostUrl}.",
-                "foundry-deploy",
+                TelemetryApps.FoundryDeploy,
                 options.IsEnabled,
                 !string.IsNullOrWhiteSpace(options.ProjectToken),
                 !string.IsNullOrWhiteSpace(options.InstallId),
@@ -129,14 +131,18 @@ public static class ServiceCollectionExtensions
     private static TelemetryContext CreateTelemetryContext(IServiceProvider serviceProvider)
     {
         TelemetrySettings settings = LoadTelemetrySettings(serviceProvider);
+        string runtime = WinPeRuntimeDetector.IsWinPeRuntime() ? TelemetryRuntimeModes.WinPe : TelemetryRuntimeModes.Desktop;
         return new TelemetryContext(
-            "foundry-deploy",
+            TelemetryApps.FoundryDeploy,
             FoundryDeployApplicationInfo.Version,
             TelemetryBuildConfiguration.Current,
-            WinPeRuntimeDetector.IsWinPeRuntime() ? TelemetryRuntimeModes.WinPe : TelemetryRuntimeModes.Desktop,
+            runtime,
             string.IsNullOrWhiteSpace(settings.RuntimePayloadSource)
                 ? TelemetryRuntimePayloadSources.Unknown
                 : settings.RuntimePayloadSource,
+            TelemetryBootMediaTargetResolver.Resolve(
+                runtime,
+                Environment.GetEnvironmentVariable(DeploymentModeEnvironmentVariable)),
             RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant(),
             CultureInfo.CurrentUICulture.Name,
             Guid.NewGuid().ToString("D"));

--- a/src/Foundry.Deploy/Program.cs
+++ b/src/Foundry.Deploy/Program.cs
@@ -47,9 +47,6 @@ public static class Program
 
             using IHost host = BuildHost(args);
             ITelemetryService telemetryService = host.Services.GetRequiredService<ITelemetryService>();
-            Log.Debug("Tracking Foundry.Deploy startup telemetry event.");
-            telemetryService.TrackAsync("app_started", new Dictionary<string, object?>()).GetAwaiter().GetResult();
-            Log.Debug("Foundry.Deploy startup telemetry event queued.");
 
             App app = host.Services.GetRequiredService<App>();
             app.DispatcherUnhandledException += OnDispatcherUnhandledException;

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentOrchestrator.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentOrchestrator.cs
@@ -299,7 +299,7 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
             properties["driver_pack_vendor"],
             properties["driver_pack_model"]);
 
-        return _telemetryService.TrackAsync("deployment_completed", properties, cancellationToken);
+        return _telemetryService.TrackAsync(TelemetryEvents.DeploySessionFinished, properties, cancellationToken);
     }
 
     private static string ResolveFailedStepName(DeploymentRuntimeState runtimeState)

--- a/src/Foundry.Telemetry.Tests/PostHogTelemetryServiceTests.cs
+++ b/src/Foundry.Telemetry.Tests/PostHogTelemetryServiceTests.cs
@@ -12,7 +12,7 @@ public sealed class PostHogTelemetryServiceTests
         using var httpClient = new HttpClient(new RecordingHttpMessageHandler { ThrowOnSend = true });
         var service = CreateService(httpClient);
 
-        await service.TrackAsync("boot_media_created", new Dictionary<string, object?> { ["target"] = "iso" });
+        await service.TrackAsync(TelemetryEvents.OsdBootMediaFinished, new Dictionary<string, object?> { ["boot_media_target"] = "iso" });
     }
 
     [Fact]
@@ -23,7 +23,7 @@ public sealed class PostHogTelemetryServiceTests
         var options = new TelemetryOptions(false, TelemetryDefaults.PostHogEuHost, "project-token", "install-id");
         var service = CreateService(httpClient, options);
 
-        await service.TrackAsync("boot_media_created", new Dictionary<string, object?> { ["target"] = "iso" });
+        await service.TrackAsync(TelemetryEvents.OsdBootMediaFinished, new Dictionary<string, object?> { ["boot_media_target"] = "iso" });
 
         Assert.Equal(0, handler.SendCount);
     }
@@ -36,10 +36,11 @@ public sealed class PostHogTelemetryServiceTests
         var service = CreateService(httpClient);
 
         await service.TrackAsync(
-            "boot_media_created",
+            TelemetryEvents.OsdBootMediaFinished,
             new Dictionary<string, object?>
             {
-                ["target"] = "iso",
+                ["boot_media_target"] = "iso",
+                ["boot_media_architecture"] = "arm64",
                 ["ssid"] = "CorpWifi"
             });
 
@@ -47,18 +48,33 @@ public sealed class PostHogTelemetryServiceTests
 
         JsonElement root = handler.ReadJson();
         Assert.Equal("project-token", root.GetProperty("api_key").GetString());
-        Assert.Equal("boot_media_created", root.GetProperty("event").GetString());
+        Assert.Equal(TelemetryEvents.OsdBootMediaFinished, root.GetProperty("event").GetString());
         Assert.Equal("install-id", root.GetProperty("distinct_id").GetString());
         Assert.False(root.TryGetProperty("timestamp", out _));
 
         JsonElement properties = root.GetProperty("properties");
         Assert.False(properties.TryGetProperty("timestamp", out _));
-        Assert.Equal("iso", properties.GetProperty("target").GetString());
+        Assert.Equal("iso", properties.GetProperty("boot_media_target").GetString());
+        Assert.Equal("arm64", properties.GetProperty("boot_media_architecture").GetString());
         Assert.False(properties.TryGetProperty("ssid", out _));
-        Assert.Equal("foundry", properties.GetProperty("app").GetString());
+        Assert.Equal(TelemetryApps.FoundryOsd, properties.GetProperty("app").GetString());
         Assert.Equal("1.2.3", properties.GetProperty("app_version").GetString());
+        Assert.Equal("x64", properties.GetProperty("runtime_architecture").GetString());
+        Assert.False(properties.TryGetProperty("architecture", out _));
         Assert.False(properties.GetProperty("$process_person_profile").GetBoolean());
         Assert.False(properties.GetProperty("$geoip_disable").GetBoolean());
+    }
+
+    [Fact]
+    public async Task TrackAsync_WhenEventNameIsUnknown_DoesNotSend()
+    {
+        var handler = new RecordingHttpMessageHandler();
+        using var httpClient = new HttpClient(handler);
+        var service = CreateService(httpClient);
+
+        await service.TrackAsync("unknown_event", new Dictionary<string, object?> { ["success"] = true });
+
+        Assert.Equal(0, handler.SendCount);
     }
 
     [Fact]
@@ -78,7 +94,7 @@ public sealed class PostHogTelemetryServiceTests
     {
         var service = new NullTelemetryService();
 
-        await service.TrackAsync("boot_media_created", new Dictionary<string, object?> { ["target"] = "iso" });
+        await service.TrackAsync(TelemetryEvents.OsdBootMediaFinished, new Dictionary<string, object?> { ["boot_media_target"] = "iso" });
         await service.FlushAsync();
     }
 
@@ -86,11 +102,12 @@ public sealed class PostHogTelemetryServiceTests
     {
         options ??= new TelemetryOptions(true, TelemetryDefaults.PostHogEuHost, "project-token", "install-id");
         var context = new TelemetryContext(
-            "foundry",
+            TelemetryApps.FoundryOsd,
             "1.2.3",
             "debug",
             TelemetryRuntimeModes.Desktop,
             TelemetryRuntimePayloadSources.None,
+            TelemetryBootMediaTargets.Usb,
             "x64",
             "en-US",
             "session-id");

--- a/src/Foundry.Telemetry.Tests/TelemetryBootMediaTargetResolverTests.cs
+++ b/src/Foundry.Telemetry.Tests/TelemetryBootMediaTargetResolverTests.cs
@@ -1,0 +1,21 @@
+using Foundry.Telemetry;
+
+namespace Foundry.Telemetry.Tests;
+
+public sealed class TelemetryBootMediaTargetResolverTests
+{
+    [Theory]
+    [InlineData(TelemetryRuntimeModes.Desktop, null, TelemetryBootMediaTargets.None)]
+    [InlineData(TelemetryRuntimeModes.Desktop, "Usb", TelemetryBootMediaTargets.None)]
+    [InlineData(TelemetryRuntimeModes.WinPe, "Usb", TelemetryBootMediaTargets.Usb)]
+    [InlineData(TelemetryRuntimeModes.WinPe, "Iso", TelemetryBootMediaTargets.Iso)]
+    [InlineData(TelemetryRuntimeModes.WinPe, "usb", TelemetryBootMediaTargets.Usb)]
+    [InlineData(TelemetryRuntimeModes.WinPe, "iso", TelemetryBootMediaTargets.Iso)]
+    [InlineData(TelemetryRuntimeModes.WinPe, null, TelemetryBootMediaTargets.Unknown)]
+    [InlineData(TelemetryRuntimeModes.WinPe, "", TelemetryBootMediaTargets.Unknown)]
+    [InlineData(TelemetryRuntimeModes.WinPe, "Foundry Cache", TelemetryBootMediaTargets.Unknown)]
+    public void Resolve_ReturnsTargetFromExplicitRuntimeModeOnly(string runtime, string? deploymentMode, string expected)
+    {
+        Assert.Equal(expected, TelemetryBootMediaTargetResolver.Resolve(runtime, deploymentMode));
+    }
+}

--- a/src/Foundry.Telemetry.Tests/TelemetryDailyActivityGateTests.cs
+++ b/src/Foundry.Telemetry.Tests/TelemetryDailyActivityGateTests.cs
@@ -1,0 +1,44 @@
+using Foundry.Telemetry;
+
+namespace Foundry.Telemetry.Tests;
+
+public sealed class TelemetryDailyActivityGateTests
+{
+    [Fact]
+    public void ShouldTrack_WhenNoDateWasPersisted_ReturnsTrue()
+    {
+        Assert.True(TelemetryDailyActivityGate.ShouldTrack(DateOnly.FromDateTime(new DateTime(2026, 5, 14)), null));
+    }
+
+    [Fact]
+    public void ShouldTrack_WhenPersistedDateIsToday_ReturnsFalse()
+    {
+        DateOnly today = DateOnly.FromDateTime(new DateTime(2026, 5, 14));
+
+        Assert.False(TelemetryDailyActivityGate.ShouldTrack(today, "2026-05-14"));
+    }
+
+    [Fact]
+    public void ShouldTrack_WhenPersistedDateIsOlder_ReturnsTrue()
+    {
+        DateOnly today = DateOnly.FromDateTime(new DateTime(2026, 5, 14));
+
+        Assert.True(TelemetryDailyActivityGate.ShouldTrack(today, "2026-05-13"));
+    }
+
+    [Fact]
+    public void ShouldTrack_WhenPersistedDateIsInvalid_ReturnsTrue()
+    {
+        DateOnly today = DateOnly.FromDateTime(new DateTime(2026, 5, 14));
+
+        Assert.True(TelemetryDailyActivityGate.ShouldTrack(today, "invalid"));
+    }
+
+    [Fact]
+    public void FormatDate_ReturnsIsoLocalDate()
+    {
+        DateOnly today = DateOnly.FromDateTime(new DateTime(2026, 5, 14));
+
+        Assert.Equal("2026-05-14", TelemetryDailyActivityGate.FormatDate(today));
+    }
+}

--- a/src/Foundry.Telemetry.Tests/TelemetryEventPropertyPolicyTests.cs
+++ b/src/Foundry.Telemetry.Tests/TelemetryEventPropertyPolicyTests.cs
@@ -5,28 +5,30 @@ namespace Foundry.Telemetry.Tests;
 public sealed class TelemetryEventPropertyPolicyTests
 {
     [Fact]
-    public void Sanitize_DropsPropertiesOutsideEventAllowlist()
+    public void Sanitize_ForBootMediaFinished_DropsPropertiesOutsideEventAllowlist()
     {
         Dictionary<string, object?> input = new()
         {
-            ["target"] = "iso",
+            ["boot_media_target"] = "iso",
             ["success"] = true,
             ["duration_seconds"] = 12.5,
+            ["boot_media_architecture"] = "x64",
             ["ssid"] = "CorpWifi",
             ["iso_output_path"] = @"C:\Temp\Foundry.iso"
         };
 
-        IReadOnlyDictionary<string, object?> result = TelemetryEventPropertyPolicy.Sanitize("boot_media_created", input);
+        IReadOnlyDictionary<string, object?> result = TelemetryEventPropertyPolicy.Sanitize(TelemetryEvents.OsdBootMediaFinished, input);
 
-        Assert.Equal("iso", result["target"]);
+        Assert.Equal("iso", result["boot_media_target"]);
         Assert.True((bool)result["success"]!);
         Assert.Equal(12.5, result["duration_seconds"]);
+        Assert.Equal("x64", result["boot_media_architecture"]);
         Assert.False(result.ContainsKey("ssid"));
         Assert.False(result.ContainsKey("iso_output_path"));
     }
 
     [Fact]
-    public void Sanitize_DropsKnownDeploySensitiveValues()
+    public void Sanitize_ForDeploySessionFinished_DropsKnownDeploySensitiveValues()
     {
         Dictionary<string, object?> input = new()
         {
@@ -41,7 +43,7 @@ public sealed class TelemetryEventPropertyPolicyTests
             ["exception"] = @"C:\Temp\failure.log"
         };
 
-        IReadOnlyDictionary<string, object?> result = TelemetryEventPropertyPolicy.Sanitize("deployment_completed", input);
+        IReadOnlyDictionary<string, object?> result = TelemetryEventPropertyPolicy.Sanitize(TelemetryEvents.DeploySessionFinished, input);
 
         Assert.Equal(false, result["success"]);
         Assert.Equal("ApplyOperatingSystemImage", result["failed_step_name"]);
@@ -49,5 +51,39 @@ public sealed class TelemetryEventPropertyPolicyTests
         Assert.False(result.ContainsKey("driver_pack_url"));
         Assert.False(result.ContainsKey("target_computer_name"));
         Assert.False(result.ContainsKey("exception"));
+    }
+
+    [Fact]
+    public void Sanitize_ForConnectSessionReady_AllowsLayoutMode()
+    {
+        Dictionary<string, object?> input = new()
+        {
+            ["success"] = true,
+            ["connection_type"] = "ethernet",
+            ["layout_mode"] = "ethernet_wifi",
+            ["adapter_name"] = "Ethernet 1"
+        };
+
+        IReadOnlyDictionary<string, object?> result = TelemetryEventPropertyPolicy.Sanitize(TelemetryEvents.ConnectSessionReady, input);
+
+        Assert.True((bool)result["success"]!);
+        Assert.Equal("ethernet", result["connection_type"]);
+        Assert.Equal("ethernet_wifi", result["layout_mode"]);
+        Assert.False(result.ContainsKey("adapter_name"));
+    }
+
+    [Fact]
+    public void IsKnownEvent_ReturnsFalseForOldAndUnknownEventNames()
+    {
+        Assert.True(TelemetryEventPropertyPolicy.IsKnownEvent(TelemetryEvents.AppDailyActive));
+        Assert.True(TelemetryEventPropertyPolicy.IsKnownEvent(TelemetryEvents.OsdBootMediaFinished));
+        Assert.True(TelemetryEventPropertyPolicy.IsKnownEvent(TelemetryEvents.ConnectSessionReady));
+        Assert.True(TelemetryEventPropertyPolicy.IsKnownEvent(TelemetryEvents.DeploySessionFinished));
+
+        Assert.False(TelemetryEventPropertyPolicy.IsKnownEvent("app_started"));
+        Assert.False(TelemetryEventPropertyPolicy.IsKnownEvent("boot_media_created"));
+        Assert.False(TelemetryEventPropertyPolicy.IsKnownEvent("connect_network_ready"));
+        Assert.False(TelemetryEventPropertyPolicy.IsKnownEvent("deployment_completed"));
+        Assert.False(TelemetryEventPropertyPolicy.IsKnownEvent("unknown_event"));
     }
 }

--- a/src/Foundry.Telemetry/PostHogTelemetryService.cs
+++ b/src/Foundry.Telemetry/PostHogTelemetryService.cs
@@ -51,6 +51,12 @@ public sealed class PostHogTelemetryService : ITelemetryService
             return;
         }
 
+        if (!TelemetryEventPropertyPolicy.IsKnownEvent(eventName))
+        {
+            logger?.LogDebug("Telemetry event {EventName} skipped because it is not part of the approved taxonomy.", eventName);
+            return;
+        }
+
         try
         {
             Dictionary<string, object> finalProperties = BuildProperties(eventName, properties);
@@ -121,7 +127,8 @@ public sealed class PostHogTelemetryService : ITelemetryService
             ["build_configuration"] = context.BuildConfiguration,
             ["runtime"] = context.Runtime,
             ["runtime_payload_source"] = context.RuntimePayloadSource,
-            ["architecture"] = context.Architecture,
+            ["boot_media_target"] = context.BootMediaTarget,
+            ["runtime_architecture"] = context.RuntimeArchitecture,
             ["locale"] = context.Locale,
             ["session_id"] = context.SessionId,
             ["$process_person_profile"] = false,

--- a/src/Foundry.Telemetry/TelemetryApps.cs
+++ b/src/Foundry.Telemetry/TelemetryApps.cs
@@ -1,0 +1,11 @@
+namespace Foundry.Telemetry;
+
+/// <summary>
+/// Defines stable application identifiers used by the shared telemetry envelope.
+/// </summary>
+public static class TelemetryApps
+{
+    public const string FoundryOsd = "foundry_osd";
+    public const string FoundryConnect = "foundry_connect";
+    public const string FoundryDeploy = "foundry_deploy";
+}

--- a/src/Foundry.Telemetry/TelemetryBootMediaTargetResolver.cs
+++ b/src/Foundry.Telemetry/TelemetryBootMediaTargetResolver.cs
@@ -1,0 +1,28 @@
+namespace Foundry.Telemetry;
+
+/// <summary>
+/// Resolves the telemetry boot media target from the explicit WinPE deployment mode.
+/// </summary>
+public static class TelemetryBootMediaTargetResolver
+{
+    /// <summary>
+    /// Converts the resolved runtime mode into a low-cardinality telemetry value.
+    /// </summary>
+    /// <param name="runtime">Current telemetry runtime category.</param>
+    /// <param name="deploymentMode">Explicit value of FOUNDRY_DEPLOYMENT_MODE when running in WinPE.</param>
+    /// <returns>A stable boot media target value.</returns>
+    public static string Resolve(string runtime, string? deploymentMode)
+    {
+        if (!string.Equals(runtime, TelemetryRuntimeModes.WinPe, StringComparison.Ordinal))
+        {
+            return TelemetryBootMediaTargets.None;
+        }
+
+        return deploymentMode?.Trim().ToLowerInvariant() switch
+        {
+            "iso" => TelemetryBootMediaTargets.Iso,
+            "usb" => TelemetryBootMediaTargets.Usb,
+            _ => TelemetryBootMediaTargets.Unknown
+        };
+    }
+}

--- a/src/Foundry.Telemetry/TelemetryBootMediaTargets.cs
+++ b/src/Foundry.Telemetry/TelemetryBootMediaTargets.cs
@@ -1,0 +1,12 @@
+namespace Foundry.Telemetry;
+
+/// <summary>
+/// Defines stable boot media target categories used by OSD and WinPE runtimes.
+/// </summary>
+public static class TelemetryBootMediaTargets
+{
+    public const string Iso = "iso";
+    public const string Usb = "usb";
+    public const string None = "none";
+    public const string Unknown = "unknown";
+}

--- a/src/Foundry.Telemetry/TelemetryContext.cs
+++ b/src/Foundry.Telemetry/TelemetryContext.cs
@@ -8,7 +8,8 @@ namespace Foundry.Telemetry;
 /// <param name="BuildConfiguration">Compile-time build configuration of the running binary.</param>
 /// <param name="Runtime">Runtime environment category.</param>
 /// <param name="RuntimePayloadSource">Source of the Connect or Deploy runtime payload.</param>
-/// <param name="Architecture">Application or runtime architecture.</param>
+/// <param name="BootMediaTarget">Boot media target or explicit WinPE runtime mode.</param>
+/// <param name="RuntimeArchitecture">Application or runtime architecture.</param>
 /// <param name="Locale">Current UI or runtime culture.</param>
 /// <param name="SessionId">Random per-process identifier for grouping events from one run.</param>
 public sealed record TelemetryContext(
@@ -17,6 +18,7 @@ public sealed record TelemetryContext(
     string BuildConfiguration,
     string Runtime,
     string RuntimePayloadSource,
-    string Architecture,
+    string BootMediaTarget,
+    string RuntimeArchitecture,
     string Locale,
     string SessionId);

--- a/src/Foundry.Telemetry/TelemetryDailyActivityGate.cs
+++ b/src/Foundry.Telemetry/TelemetryDailyActivityGate.cs
@@ -1,0 +1,38 @@
+using System.Globalization;
+
+namespace Foundry.Telemetry;
+
+/// <summary>
+/// Applies the local-day throttle used by the persistent Foundry OSD activity event.
+/// </summary>
+public static class TelemetryDailyActivityGate
+{
+    private const string DateFormat = "yyyy-MM-dd";
+
+    /// <summary>
+    /// Determines whether an activity event should be sent for the supplied local date.
+    /// </summary>
+    /// <param name="today">Current local calendar date.</param>
+    /// <param name="lastTrackedDate">Persisted local date in ISO format.</param>
+    /// <returns><see langword="true"/> when no event has been recorded for <paramref name="today"/>.</returns>
+    public static bool ShouldTrack(DateOnly today, string? lastTrackedDate)
+    {
+        return !DateOnly.TryParseExact(
+            lastTrackedDate,
+            DateFormat,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out DateOnly parsedDate) ||
+            parsedDate != today;
+    }
+
+    /// <summary>
+    /// Formats a local date for persistence in application settings.
+    /// </summary>
+    /// <param name="date">Local calendar date.</param>
+    /// <returns>The ISO local date value.</returns>
+    public static string FormatDate(DateOnly date)
+    {
+        return date.ToString(DateFormat, CultureInfo.InvariantCulture);
+    }
+}

--- a/src/Foundry.Telemetry/TelemetryEventPropertyPolicy.cs
+++ b/src/Foundry.Telemetry/TelemetryEventPropertyPolicy.cs
@@ -33,13 +33,13 @@ public static class TelemetryEventPropertyPolicy
     private static readonly IReadOnlyDictionary<string, HashSet<string>> AllowedPropertiesByEvent =
         new Dictionary<string, HashSet<string>>(StringComparer.Ordinal)
         {
-            ["app_started"] = new(StringComparer.Ordinal),
-            ["boot_media_created"] = new(StringComparer.Ordinal)
+            [TelemetryEvents.AppDailyActive] = new(StringComparer.Ordinal),
+            [TelemetryEvents.OsdBootMediaFinished] = new(StringComparer.Ordinal)
             {
-                "target",
+                "boot_media_target",
                 "success",
                 "duration_seconds",
-                "architecture",
+                "boot_media_architecture",
                 "winpe_language",
                 "boot_image_source",
                 "signature_mode",
@@ -55,16 +55,17 @@ public static class TelemetryEventPropertyPolicy
                 "deploy_runtime_payload_source",
                 "autopilot_enabled"
             },
-            ["connect_network_ready"] = new(StringComparer.Ordinal)
+            [TelemetryEvents.ConnectSessionReady] = new(StringComparer.Ordinal)
             {
                 "success",
                 "connection_type",
+                "layout_mode",
                 "wifi_security",
                 "wifi_source",
                 "wired_dot1x_enabled",
                 "wifi_provisioned"
             },
-            ["deployment_completed"] = new(StringComparer.Ordinal)
+            [TelemetryEvents.DeploySessionFinished] = new(StringComparer.Ordinal)
             {
                 "success",
                 "cancelled",
@@ -88,6 +89,16 @@ public static class TelemetryEventPropertyPolicy
                 "autopilot_enabled"
             }
         };
+
+    /// <summary>
+    /// Returns whether the event name is part of the approved telemetry taxonomy.
+    /// </summary>
+    /// <param name="eventName">Telemetry event name to validate.</param>
+    /// <returns><see langword="true"/> when the event is allowed to leave the process.</returns>
+    public static bool IsKnownEvent(string eventName)
+    {
+        return AllowedPropertiesByEvent.ContainsKey(eventName);
+    }
 
     /// <summary>
     /// Returns only properties explicitly allowed for the supplied event.

--- a/src/Foundry.Telemetry/TelemetryEvents.cs
+++ b/src/Foundry.Telemetry/TelemetryEvents.cs
@@ -1,0 +1,12 @@
+namespace Foundry.Telemetry;
+
+/// <summary>
+/// Defines the low-volume PostHog event names emitted by Foundry products.
+/// </summary>
+public static class TelemetryEvents
+{
+    public const string AppDailyActive = "app:daily_active";
+    public const string OsdBootMediaFinished = "osd:boot_media_finished";
+    public const string ConnectSessionReady = "connect:session_ready";
+    public const string DeploySessionFinished = "deploy:session_finished";
+}

--- a/src/Foundry/App.xaml.cs
+++ b/src/Foundry/App.xaml.cs
@@ -137,10 +137,29 @@ namespace Foundry
             }
 
             await GetService<IStartupReadinessService>().InitializeAsync();
-            AppLogger.Debug("Tracking Foundry startup telemetry event.");
-            await GetService<ITelemetryService>().TrackAsync("app_started", new Dictionary<string, object?>());
-            AppLogger.Debug("Foundry startup telemetry event queued.");
+            await TrackDailyActiveAsync();
             AppLogger.Information("Foundry WinUI startup completed.");
+        }
+
+        private static async Task TrackDailyActiveAsync()
+        {
+            IAppSettingsService settingsService = GetService<IAppSettingsService>();
+            if (!settingsService.Current.Telemetry.IsEnabled)
+            {
+                return;
+            }
+
+            DateOnly today = DateOnly.FromDateTime(DateTime.Now);
+            if (!TelemetryDailyActivityGate.ShouldTrack(today, settingsService.Current.Telemetry.LastDailyActiveDate))
+            {
+                return;
+            }
+
+            AppLogger.Debug("Tracking Foundry daily-active telemetry event.");
+            await GetService<ITelemetryService>().TrackAsync(TelemetryEvents.AppDailyActive, new Dictionary<string, object?>());
+            settingsService.Current.Telemetry.LastDailyActiveDate = TelemetryDailyActivityGate.FormatDate(today);
+            settingsService.Save();
+            AppLogger.Debug("Foundry daily-active telemetry event queued.");
         }
 
         private void RegisterWinUiExceptionHandler()

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -49,11 +49,12 @@ public static class ServiceCollectionExtensions
                 settings.Telemetry.InstallId);
         });
         services.AddSingleton(_ => new TelemetryContext(
-            "foundry",
+            TelemetryApps.FoundryOsd,
             FoundryApplicationInfo.Version,
             TelemetryBuildConfiguration.Current,
             TelemetryRuntimeModes.Desktop,
             TelemetryRuntimePayloadSources.None,
+            TelemetryBootMediaTargets.None,
             RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant(),
             CultureInfo.CurrentUICulture.Name,
             Guid.NewGuid().ToString("D")));
@@ -64,7 +65,7 @@ public static class ServiceCollectionExtensions
                 sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<PostHogTelemetryService>>();
             logger.LogDebug(
                 "Configuring telemetry service. App={App}, IsEnabled={IsEnabled}, HasProjectToken={HasProjectToken}, HasInstallId={HasInstallId}, HostUrl={HostUrl}.",
-                "foundry",
+                TelemetryApps.FoundryOsd,
                 options.IsEnabled,
                 !string.IsNullOrWhiteSpace(options.ProjectToken),
                 !string.IsNullOrWhiteSpace(options.InstallId),

--- a/src/Foundry/Services/Settings/FoundryAppSettings.cs
+++ b/src/Foundry/Services/Settings/FoundryAppSettings.cs
@@ -165,4 +165,9 @@ public sealed class TelemetryAppSettings
     /// Gets or sets the random anonymous installation identifier used for telemetry.
     /// </summary>
     public string InstallId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the last local date where Foundry OSD activity telemetry was recorded.
+    /// </summary>
+    public string? LastDailyActiveDate { get; set; }
 }

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -1211,10 +1211,12 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
         var properties = new Dictionary<string, object?>
             {
-                ["target"] = target == FinalMediaTarget.Iso ? "iso" : "usb",
+                ["boot_media_target"] = target == FinalMediaTarget.Iso
+                    ? TelemetryBootMediaTargets.Iso
+                    : TelemetryBootMediaTargets.Usb,
                 ["success"] = success,
                 ["duration_seconds"] = Math.Round(duration.TotalSeconds, 2),
-                ["architecture"] = options.Architecture.ToString().ToLowerInvariant(),
+                ["boot_media_architecture"] = options.Architecture.ToString().ToLowerInvariant(),
                 ["winpe_language"] = NormalizeCultureName(options.WinPeLanguage).ToLowerInvariant(),
                 ["boot_image_source"] = options.BootImageSource.ToString().ToLowerInvariant(),
                 ["signature_mode"] = options.SignatureMode.ToString().ToLowerInvariant(),
@@ -1237,17 +1239,17 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
         logger.Debug(
             "Tracking media telemetry event. Target={Target}, Success={Success}, DurationSeconds={DurationSeconds}, Architecture={Architecture}, BootImageSource={BootImageSource}, SignatureMode={SignatureMode}, ConnectRuntimePayloadSource={ConnectRuntimePayloadSource}, DeployRuntimePayloadSource={DeployRuntimePayloadSource}.",
-            properties["target"],
+            properties["boot_media_target"],
             success,
             properties["duration_seconds"],
-            properties["architecture"],
+            properties["boot_media_architecture"],
             properties["boot_image_source"],
             properties["signature_mode"],
             properties["connect_runtime_payload_source"],
             properties["deploy_runtime_payload_source"]);
 
-        await telemetryService.TrackAsync("boot_media_created", properties, cancellationToken);
-        logger.Debug("Media telemetry event queued. Target={Target}, Success={Success}.", properties["target"], success);
+        await telemetryService.TrackAsync(TelemetryEvents.OsdBootMediaFinished, properties, cancellationToken);
+        logger.Debug("Media telemetry event queued. Target={Target}, Success={Success}.", properties["boot_media_target"], success);
     }
 
     private string BuildStatusText(MediaPreflightEvaluation evaluation)


### PR DESCRIPTION
## Summary
- Replace the previous PostHog event names with the new low-volume taxonomy.
- Add daily activity throttling for Foundry OSD and explicit WinPE boot media target context.
- Move Foundry Connect telemetry to the successful continue path and capture deployment outcomes with the updated schema.
- Add event/property allowlist coverage and focused regression tests.

## Reason
The previous telemetry model sent startup-oriented events and used names that did not clearly represent outcome-based analytics. This change keeps event volume low while supporting Foundry OSD, Connect, and Deploy product analytics.

## Main changes
- Adds stable telemetry constants for apps, events, and boot media target values.
- Adds app:daily_active, osd:boot_media_finished, connect:session_ready, and deploy:session_finished.
- Adds boot_media_target and runtime_architecture to the shared telemetry envelope.
- Keeps PostHog country enrichment enabled while preventing custom PII/location properties from being sent.
- Removes obsolete startup telemetry from Foundry Deploy.

## Testing
- dotnet test src\Foundry.Telemetry.Tests\Foundry.Telemetry.Tests.csproj --no-restore
- dotnet test src\Foundry.Connect.Tests\Foundry.Connect.Tests.csproj --no-restore
- dotnet test src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --no-restore
- dotnet build src\Foundry\Foundry.csproj --no-restore
- dotnet build src\Foundry.Connect\Foundry.Connect.csproj --no-restore
- dotnet build src\Foundry.Deploy\Foundry.Deploy.csproj --no-restore
- git diff --check