### PR TITLE
fix: improve Lenovo driver pack provisioning

### DIFF
--- a/src/Foundry.Deploy.Tests/DriverPackSelectionServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DriverPackSelectionServiceTests.cs
@@ -42,7 +42,7 @@ public sealed class DriverPackSelectionServiceTests
         DriverPackSelectionResult result = service.SelectBest([olderExactMatch, newerGeneric], hardware, operatingSystem);
 
         Assert.Equal("exact", result.DriverPack?.Id);
-        Assert.Equal("Matched by hardware model/product and latest release date.", result.SelectionReason);
+        Assert.Equal("Matched by hardware model/product and compatible OS release.", result.SelectionReason);
     }
 
     [Fact]
@@ -81,7 +81,91 @@ public sealed class DriverPackSelectionServiceTests
         DriverPackSelectionResult result = service.SelectBest([olderCandidate, newerCandidate], hardware, operatingSystem);
 
         Assert.Equal("newer", result.DriverPack?.Id);
-        Assert.Equal("No model exact match; selected newest manufacturer candidate.", result.SelectionReason);
+        Assert.Equal("No model exact match; selected newest compatible manufacturer candidate.", result.SelectionReason);
+    }
+
+    [Fact]
+    public void SelectBest_WhenTargetReleaseIsUnavailable_PrefersNewestCompatibleExactModelRelease()
+    {
+        var service = new DriverPackSelectionService(NullLogger<DriverPackSelectionService>.Instance);
+        HardwareProfile hardware = new()
+        {
+            Manufacturer = "Lenovo",
+            Model = "ThinkPad X13 Yoga Gen 3 Type 21AW 21AX",
+            Product = "21AW"
+        };
+        OperatingSystemCatalogItem operatingSystem = new()
+        {
+            WindowsRelease = "11",
+            ReleaseId = "25H2",
+            Architecture = "x64"
+        };
+        DateTimeOffset catalogDate = new(2024, 06, 13, 0, 0, 0, TimeSpan.Zero);
+
+        DriverPackCatalogItem win11_21H2 = CreateCatalogItem(
+            id: "21h2",
+            manufacturer: "Lenovo",
+            releaseId: "21H2",
+            architecture: "x64",
+            releaseDate: catalogDate,
+            modelNames: ["ThinkPad X13 Yoga Gen 3 Type 21AW 21AX"]);
+        DriverPackCatalogItem win11_22H2 = CreateCatalogItem(
+            id: "22h2",
+            manufacturer: "Lenovo",
+            releaseId: "22H2",
+            architecture: "x64",
+            releaseDate: catalogDate,
+            modelNames: ["ThinkPad X13 Yoga Gen 3 Type 21AW 21AX"]);
+        DriverPackCatalogItem win11_23H2 = CreateCatalogItem(
+            id: "23h2",
+            manufacturer: "Lenovo",
+            releaseId: "23H2",
+            architecture: "x64",
+            releaseDate: catalogDate,
+            modelNames: ["ThinkPad X13 Yoga Gen 3 Type 21AW 21AX"]);
+
+        DriverPackSelectionResult result = service.SelectBest([win11_21H2, win11_22H2, win11_23H2], hardware, operatingSystem);
+
+        Assert.Equal("23h2", result.DriverPack?.Id);
+        Assert.Equal("Matched by hardware model/product and compatible OS release.", result.SelectionReason);
+    }
+
+    [Fact]
+    public void SelectBest_WhenNewerCompatibleReleaseExistsForDifferentModel_PrefersExactModel()
+    {
+        var service = new DriverPackSelectionService(NullLogger<DriverPackSelectionService>.Instance);
+        HardwareProfile hardware = new()
+        {
+            Manufacturer = "Lenovo",
+            Model = "ThinkPad X13 Yoga Gen 3 Type 21AW 21AX",
+            Product = "21AW"
+        };
+        OperatingSystemCatalogItem operatingSystem = new()
+        {
+            WindowsRelease = "11",
+            ReleaseId = "25H2",
+            Architecture = "x64"
+        };
+
+        DriverPackCatalogItem exactModel = CreateCatalogItem(
+            id: "exact-23h2",
+            manufacturer: "Lenovo",
+            releaseId: "23H2",
+            architecture: "x64",
+            releaseDate: new DateTimeOffset(2024, 06, 13, 0, 0, 0, TimeSpan.Zero),
+            modelNames: ["ThinkPad X13 Yoga Gen 3 Type 21AW 21AX"]);
+        DriverPackCatalogItem otherModel = CreateCatalogItem(
+            id: "other-24h2",
+            manufacturer: "Lenovo",
+            releaseId: "24H2",
+            architecture: "x64",
+            releaseDate: new DateTimeOffset(2025, 01, 01, 0, 0, 0, TimeSpan.Zero),
+            modelNames: ["ThinkPad T14 Gen 5"]);
+
+        DriverPackSelectionResult result = service.SelectBest([exactModel, otherModel], hardware, operatingSystem);
+
+        Assert.Equal("exact-23h2", result.DriverPack?.Id);
+        Assert.Equal("Matched by hardware model/product and compatible OS release.", result.SelectionReason);
     }
 
     private static DriverPackCatalogItem CreateCatalogItem(

--- a/src/Foundry.Deploy.Tests/DriverPackSelectionViewModelTests.cs
+++ b/src/Foundry.Deploy.Tests/DriverPackSelectionViewModelTests.cs
@@ -1,0 +1,67 @@
+using Foundry.Deploy.Models;
+using Foundry.Deploy.Services.DriverPacks;
+using Foundry.Deploy.Services.Localization;
+using Foundry.Deploy.ViewModels;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class DriverPackSelectionViewModelTests
+{
+    [Fact]
+    public void ResolveEffectiveSelection_WhenLenovoPacksShareReleaseDate_SelectsNewestCompatibleRelease()
+    {
+        var viewModel = new DriverPackSelectionViewModel(
+            new DriverPackSelectionService(NullLogger<DriverPackSelectionService>.Instance),
+            new LocalizationService(),
+            "x64");
+        HardwareProfile hardware = new()
+        {
+            Manufacturer = "Lenovo",
+            Model = "ThinkPad X13 Yoga Gen 3 Type 21AW 21AX",
+            Product = "21AW"
+        };
+        OperatingSystemCatalogItem operatingSystem = new()
+        {
+            WindowsRelease = "11",
+            ReleaseId = "25H2",
+            Architecture = "x64"
+        };
+        DateTimeOffset catalogDate = new(2024, 06, 13, 0, 0, 0, TimeSpan.Zero);
+
+        viewModel.UpdateSelectionContext(hardware, operatingSystem, "x64");
+        viewModel.ApplyCatalog(
+        [
+            CreateCatalogItem("21h2", "21H2", catalogDate),
+            CreateCatalogItem("22h2", "22H2", catalogDate),
+            CreateCatalogItem("23h2", "23H2", catalogDate)
+        ]);
+
+        DriverPackCatalogItem? selected = viewModel.ResolveEffectiveSelection();
+
+        Assert.Equal(DriverPackSelectionKind.OemCatalog, viewModel.EffectiveSelectionKind);
+        Assert.Equal("ThinkPad X13 Yoga Gen 3 Type 21AW 21AX", viewModel.SelectedDriverPackModel);
+        Assert.Contains("23H2", viewModel.SelectedDriverPackVersion, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("23h2", selected?.Id);
+    }
+
+    private static DriverPackCatalogItem CreateCatalogItem(
+        string id,
+        string releaseId,
+        DateTimeOffset releaseDate)
+    {
+        return new DriverPackCatalogItem
+        {
+            Id = id,
+            Manufacturer = "Lenovo",
+            Name = $"ThinkPad X13 Yoga Gen 3 {releaseId}",
+            FileName = $"tp_x13_yoga_g3_w11_{releaseId}.exe",
+            DownloadUrl = $"https://example.test/{id}.exe",
+            OsName = "Windows 11",
+            OsReleaseId = releaseId,
+            OsArchitecture = "x64",
+            ReleaseDate = releaseDate,
+            ModelNames = ["ThinkPad X13 Yoga Gen 3 Type 21AW 21AX"]
+        };
+    }
+}

--- a/src/Foundry.Deploy.Tests/PreOobeScriptProvisioningServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/PreOobeScriptProvisioningServiceTests.cs
@@ -104,6 +104,10 @@ public sealed class PreOobeScriptProvisioningServiceTests
         Assert.Contains("'C:\\DRIVERS'", stagedScript);
         Assert.Contains("'C:\\Drivers'", stagedScript);
         Assert.Contains("Remove-RootFolder", stagedScript);
+        Assert.Contains("Start-Transcript -Path $TranscriptPath -Force", stagedScript);
+        Assert.Contains("Cleanup-PreOobe.transcript.log", stagedScript);
+        Assert.Contains("Write-FoundryLog", stagedScript);
+        Assert.Contains("$elapsed = $now - $script:ScriptStartedAt", stagedScript);
     }
 
     [Fact]
@@ -137,6 +141,56 @@ public sealed class PreOobeScriptProvisioningServiceTests
 
         Assert.DoesNotContain("Remove-Item -Path 'C:\\Drivers'", driverScript);
         Assert.Contains("'C:\\Drivers'", cleanupScript);
+    }
+
+    [Fact]
+    public void Provision_StagesDriverPackScriptWithTranscriptAndWaitedProcesses()
+    {
+        string windowsRoot = CreateWindowsRoot();
+        var service = new PreOobeScriptProvisioningService(new SetupCompleteScriptService());
+
+        PreOobeScriptProvisioningResult result = service.Provision(
+            windowsRoot,
+            [
+                new PreOobeScriptDefinition
+                {
+                    Id = "driver-pack",
+                    FileName = "Install-DriverPack.ps1",
+                    ResourceName = PreOobeScriptResources.InstallDriverPack,
+                    Priority = PreOobeScriptPriority.DriverProvisioning
+                }
+            ]);
+
+        string stagedScriptPath = Assert.Single(result.StagedScriptPaths);
+        string stagedScript = File.ReadAllText(stagedScriptPath);
+
+        Assert.Contains("Install-DriverPack.transcript.log", stagedScript);
+        Assert.Contains("Start-Transcript -Path $TranscriptPath -Force", stagedScript);
+        Assert.Contains("Write-FoundryLog", stagedScript);
+        Assert.Contains("$operationDuration = [DateTimeOffset]::Now - $operationStartedAt", stagedScript);
+        Assert.Contains("Start-Process -FilePath $FilePath -ArgumentList $ArgumentList -Wait -PassThru", stagedScript);
+        Assert.Contains("-FilePath $ResolvedPackagePath", stagedScript);
+        Assert.Contains("-FilePath 'reg.exe'", stagedScript);
+        Assert.Contains("-FilePath 'pnpunattend.exe'", stagedScript);
+        Assert.DoesNotContain("& $ResolvedPackagePath", stagedScript);
+        Assert.DoesNotContain("pnpunattend.exe AuditSystem /L", stagedScript);
+    }
+
+    [Fact]
+    public void Provision_RunnerReliesOnScriptTranscriptsInsteadOfPerScriptRedirectLogs()
+    {
+        string windowsRoot = CreateWindowsRoot();
+        var service = new PreOobeScriptProvisioningService(new SetupCompleteScriptService());
+
+        PreOobeScriptProvisioningResult result = service.Provision(
+            windowsRoot,
+            [CreateScript("driver-pack", "Install-DriverPack.ps1", PreOobeScriptPriority.DriverProvisioning)]);
+
+        string runner = File.ReadAllText(result.RunnerPath);
+
+        Assert.Contains("$name.transcript.log", runner);
+        Assert.DoesNotContain("$name.log", runner);
+        Assert.DoesNotContain("*> $logPath", runner);
     }
 
     [Fact]

--- a/src/Foundry.Deploy/Assets/PreOobe/Cleanup-PreOobe.ps1
+++ b/src/Foundry.Deploy/Assets/PreOobe/Cleanup-PreOobe.ps1
@@ -1,9 +1,36 @@
 $ErrorActionPreference = 'Stop'
+$LogDirectory = Join-Path $env:SystemRoot 'Temp\Foundry\Logs\PreOobe'
+$TranscriptPath = Join-Path $LogDirectory 'Cleanup-PreOobe.transcript.log'
+$TranscriptStarted = $false
+$ScriptStartedAt = [DateTimeOffset]::Now
 
 $RootFolders = @(
     'C:\DRIVERS',
     'C:\Drivers'
 )
+
+function Start-FoundryTranscript {
+    New-Item -Path $LogDirectory -ItemType Directory -Force | Out-Null
+    Start-Transcript -Path $TranscriptPath -Force | Out-Null
+    $script:TranscriptStarted = $true
+}
+
+function Stop-FoundryTranscript {
+    if ($script:TranscriptStarted) {
+        Stop-Transcript | Out-Null
+    }
+}
+
+function Write-FoundryLog {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    $now = [DateTimeOffset]::Now
+    $elapsed = $now - $script:ScriptStartedAt
+    Write-Host ("[{0}] [+{1:c}] {2}" -f $now.ToString('yyyy-MM-ddTHH:mm:ss'), $elapsed, $Message)
+}
 
 function Remove-RootFolder {
     param(
@@ -12,17 +39,31 @@ function Remove-RootFolder {
     )
 
     if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        Write-FoundryLog "Skipping missing folder: $Path"
         return
     }
 
+    $operationStartedAt = [DateTimeOffset]::Now
     try {
+        Write-FoundryLog "Removing folder: $Path"
         Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction Stop
+        $operationDuration = [DateTimeOffset]::Now - $operationStartedAt
+        Write-FoundryLog "Removed folder '$Path' after $($operationDuration.ToString('c'))."
     }
     catch {
-        Write-Warning "Unable to remove '$Path': $($_.Exception.Message)"
+        Write-FoundryLog "WARNING: Unable to remove '$Path': $($_.Exception.Message)"
     }
 }
 
-foreach ($RootFolder in $RootFolders) {
-    Remove-RootFolder -Path $RootFolder
+try {
+    Start-FoundryTranscript
+    Write-FoundryLog "Foundry pre-OOBE cleanup started."
+    foreach ($RootFolder in $RootFolders) {
+        Remove-RootFolder -Path $RootFolder
+    }
+
+    Write-FoundryLog "Foundry pre-OOBE cleanup completed."
+}
+finally {
+    Stop-FoundryTranscript
 }

--- a/src/Foundry.Deploy/Assets/PreOobe/Install-DriverPack.ps1
+++ b/src/Foundry.Deploy/Assets/PreOobe/Install-DriverPack.ps1
@@ -10,51 +10,130 @@ param(
 $ErrorActionPreference = 'Stop'
 $SuccessExitCodes = @(0, 3010)
 $ResolvedPackagePath = [Environment]::ExpandEnvironmentVariables($PackagePath)
+$LogDirectory = Join-Path $env:SystemRoot 'Temp\Foundry\Logs\PreOobe'
+$TranscriptPath = Join-Path $LogDirectory 'Install-DriverPack.transcript.log'
+$TranscriptStarted = $false
+$ScriptStartedAt = [DateTimeOffset]::Now
+$DriverPathRegistryKey = 'HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\UnattendSettings\PnPUnattend\DriverPaths\1'
 
-function Assert-SuccessExitCode {
+function Start-FoundryTranscript {
+    New-Item -Path $LogDirectory -ItemType Directory -Force | Out-Null
+    Start-Transcript -Path $TranscriptPath -Force | Out-Null
+    $script:TranscriptStarted = $true
+}
+
+function Stop-FoundryTranscript {
+    if ($script:TranscriptStarted) {
+        Stop-Transcript | Out-Null
+    }
+}
+
+function Write-FoundryLog {
     param(
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    $now = [DateTimeOffset]::Now
+    $elapsed = $now - $script:ScriptStartedAt
+    Write-Host ("[{0}] [+{1:c}] {2}" -f $now.ToString('yyyy-MM-ddTHH:mm:ss'), $elapsed, $Message)
+}
+
+function ConvertTo-ProcessArgument {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Value
+    )
+
+    if ($Value -notmatch '[\s"]') {
+        return $Value
+    }
+
+    return '"' + ($Value -replace '"', '\"') + '"'
+}
+
+function Invoke-ProcessAndWait {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [string[]]$ArgumentList = @(),
+
         [Parameter(Mandatory = $true)]
         [string]$OperationName
     )
 
-    if ($SuccessExitCodes -notcontains $LASTEXITCODE) {
-        throw "$OperationName failed with exit code $LASTEXITCODE."
+    Write-FoundryLog "Starting ${OperationName}: $FilePath $($ArgumentList -join ' ')"
+    $operationStartedAt = [DateTimeOffset]::Now
+    $process = Start-Process -FilePath $FilePath -ArgumentList $ArgumentList -Wait -PassThru
+    $operationDuration = [DateTimeOffset]::Now - $operationStartedAt
+    Write-FoundryLog "$OperationName exited with code $($process.ExitCode) after $($operationDuration.ToString('c'))."
+
+    if ($SuccessExitCodes -notcontains $process.ExitCode) {
+        throw "$OperationName failed with exit code $($process.ExitCode)."
     }
 }
 
 $DriverPathRegistered = $false
 
 try {
+    Start-FoundryTranscript
+    Write-FoundryLog "Foundry driver pack installation started."
+    Write-FoundryLog "CommandKind=$CommandKind"
+    Write-FoundryLog "PackagePath=$ResolvedPackagePath"
+
     if (-not (Test-Path -Path $ResolvedPackagePath -PathType Leaf)) {
         throw "Driver package was not found: $ResolvedPackagePath"
     }
 
     switch ($CommandKind) {
         'LenovoExecutable' {
-            & $ResolvedPackagePath /SILENT /SUPPRESSMSGBOXES
-            Assert-SuccessExitCode -OperationName 'Lenovo driver package'
+            Invoke-ProcessAndWait `
+                -FilePath $ResolvedPackagePath `
+                -ArgumentList @('/SILENT', '/SUPPRESSMSGBOXES') `
+                -OperationName 'Lenovo driver package'
 
-            reg add 'HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\UnattendSettings\PnPUnattend\DriverPaths\1' /v Path /t REG_SZ /d 'C:\Drivers' /f | Out-Null
+            Invoke-ProcessAndWait `
+                -FilePath 'reg.exe' `
+                -ArgumentList @('add', (ConvertTo-ProcessArgument -Value $DriverPathRegistryKey), '/v', 'Path', '/t', 'REG_SZ', '/d', 'C:\Drivers', '/f') `
+                -OperationName 'Register PnPUnattend driver path'
             $DriverPathRegistered = $true
-            pnpunattend.exe AuditSystem /L
-            Assert-SuccessExitCode -OperationName 'pnpunattend.exe'
+            Invoke-ProcessAndWait `
+                -FilePath 'pnpunattend.exe' `
+                -ArgumentList @('AuditSystem', '/L') `
+                -OperationName 'pnpunattend.exe'
         }
         'SurfaceMsi' {
             $logDirectory = Join-Path $env:SystemRoot 'Temp\Foundry\DriverPack'
             New-Item -Path $logDirectory -ItemType Directory -Force | Out-Null
 
             $logPath = Join-Path $logDirectory 'surface-driverpack.log'
-            & msiexec.exe /i $ResolvedPackagePath /qn /norestart /l*v $logPath
-            Assert-SuccessExitCode -OperationName 'Surface driver package'
+            Invoke-ProcessAndWait `
+                -FilePath 'msiexec.exe' `
+                -ArgumentList @('/i', (ConvertTo-ProcessArgument -Value $ResolvedPackagePath), '/qn', '/norestart', '/l*v', (ConvertTo-ProcessArgument -Value $logPath)) `
+                -OperationName 'Surface driver package'
         }
     }
+
+    Write-FoundryLog "Foundry driver pack installation completed."
 }
 finally {
     if ($DriverPathRegistered) {
-        reg delete 'HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\UnattendSettings\PnPUnattend\DriverPaths\1' /v Path /f | Out-Null
+        try {
+            Invoke-ProcessAndWait `
+                -FilePath 'reg.exe' `
+                -ArgumentList @('delete', (ConvertTo-ProcessArgument -Value $DriverPathRegistryKey), '/v', 'Path', '/f') `
+                -OperationName 'Remove PnPUnattend driver path'
+        }
+        catch {
+            Write-FoundryLog "WARNING: $($_.Exception.Message)"
+        }
     }
 
     if (Test-Path -Path $ResolvedPackagePath -PathType Leaf) {
+        Write-FoundryLog "Removing staged package: $ResolvedPackagePath"
         Remove-Item -Path $ResolvedPackagePath -Force
     }
+
+    Stop-FoundryTranscript
 }

--- a/src/Foundry.Deploy/Models/WindowsReleaseId.cs
+++ b/src/Foundry.Deploy/Models/WindowsReleaseId.cs
@@ -1,0 +1,18 @@
+namespace Foundry.Deploy.Models;
+
+internal static class WindowsReleaseId
+{
+    public static int GetSortRank(string releaseId)
+    {
+        string normalized = releaseId.Trim().ToLowerInvariant();
+        if (normalized.Length != 4 ||
+            !int.TryParse(normalized[..2], out int year) ||
+            normalized[2] != 'h' ||
+            !int.TryParse(normalized[3..], out int half))
+        {
+            return 0;
+        }
+
+        return year * 10 + half;
+    }
+}

--- a/src/Foundry.Deploy/Services/Deployment/PreOobe/PreOobeScriptProvisioningService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/PreOobe/PreOobeScriptProvisioningService.cs
@@ -155,8 +155,6 @@ public sealed class PreOobeScriptProvisioningService : IPreOobeScriptProvisionin
         builder.AppendLine("$ErrorActionPreference = 'Stop'");
         builder.AppendLine("$preOobeRoot = Join-Path $env:SystemRoot 'Temp\\Foundry\\PreOobe'");
         builder.AppendLine("$scriptsRoot = Join-Path $preOobeRoot 'Scripts'");
-        builder.AppendLine("$logRoot = Join-Path $env:SystemRoot 'Temp\\Foundry\\Logs\\PreOobe'");
-        builder.AppendLine("New-Item -Path $logRoot -ItemType Directory -Force | Out-Null");
         builder.AppendLine();
         builder.AppendLine("function Invoke-FoundryScript {");
         builder.AppendLine("    param(");
@@ -166,10 +164,11 @@ public sealed class PreOobeScriptProvisioningService : IPreOobeScriptProvisionin
         builder.AppendLine("    )");
         builder.AppendLine();
         builder.AppendLine("    $name = [System.IO.Path]::GetFileNameWithoutExtension($ScriptPath)");
-        builder.AppendLine("    $logPath = Join-Path $logRoot \"$name.log\"");
-        builder.AppendLine("    & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $ScriptPath @Arguments *> $logPath");
+        builder.AppendLine("    $logRoot = Join-Path $env:SystemRoot 'Temp\\Foundry\\Logs\\PreOobe'");
+        builder.AppendLine("    $transcriptPath = Join-Path $logRoot \"$name.transcript.log\"");
+        builder.AppendLine("    & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $ScriptPath @Arguments");
         builder.AppendLine("    if ($LASTEXITCODE -ne 0) {");
-        builder.AppendLine("        throw \"Pre-OOBE script '$ScriptPath' failed with exit code $LASTEXITCODE. See '$logPath'.\"");
+        builder.AppendLine("        throw \"Pre-OOBE script '$ScriptPath' failed with exit code $LASTEXITCODE. See '$transcriptPath'.\"");
         builder.AppendLine("    }");
         builder.AppendLine("}");
         builder.AppendLine();

--- a/src/Foundry.Deploy/Services/DriverPacks/DriverPackSelectionService.cs
+++ b/src/Foundry.Deploy/Services/DriverPacks/DriverPackSelectionService.cs
@@ -17,11 +17,12 @@ public sealed class DriverPackSelectionService : IDriverPackSelectionService
         HardwareProfile hardware,
         OperatingSystemCatalogItem operatingSystem)
     {
-        _logger.LogInformation("Selecting best driver pack. CatalogCount={CatalogCount}, Manufacturer={Manufacturer}, Model={Model}, OsRelease={OsRelease}, OsArchitecture={OsArchitecture}",
+        _logger.LogInformation("Selecting best driver pack. CatalogCount={CatalogCount}, Manufacturer={Manufacturer}, Model={Model}, WindowsRelease={WindowsRelease}, ReleaseId={ReleaseId}, OsArchitecture={OsArchitecture}",
             catalog.Count,
             hardware.Manufacturer,
             hardware.Model,
             operatingSystem.WindowsRelease,
+            operatingSystem.ReleaseId,
             operatingSystem.Architecture);
 
         if (catalog.Count == 0)
@@ -69,21 +70,12 @@ public sealed class DriverPackSelectionService : IDriverPackSelectionService
             };
         }
 
-        DriverPackCatalogItem[] releaseCandidates = candidates;
-        if (!string.IsNullOrWhiteSpace(targetReleaseId))
-        {
-            DriverPackCatalogItem[] releaseFiltered = candidates
-                .Where(item => IsReleaseIdMatch(item, targetReleaseId))
-                .ToArray();
-
-            if (releaseFiltered.Length > 0)
-            {
-                releaseCandidates = releaseFiltered;
-            }
-        }
-
-        DriverPackCatalogItem? exactModel = releaseCandidates
+        DriverPackCatalogItem[] modelCandidates = candidates
             .Where(item => item.ModelNames.Any(modelName => ContainsIgnoreCase(modelName, model) || ContainsIgnoreCase(modelName, product)))
+            .ToArray();
+        DriverPackCatalogItem[] modelReleaseCandidates = SelectReleaseCandidates(modelCandidates, targetReleaseId);
+
+        DriverPackCatalogItem? exactModel = modelReleaseCandidates
             .OrderByDescending(item => item.ReleaseDate ?? DateTimeOffset.MinValue)
             .FirstOrDefault();
 
@@ -93,10 +85,11 @@ public sealed class DriverPackSelectionService : IDriverPackSelectionService
             return new DriverPackSelectionResult
             {
                 DriverPack = exactModel,
-                SelectionReason = "Matched by hardware model/product and latest release date."
+                SelectionReason = "Matched by hardware model/product and compatible OS release."
             };
         }
 
+        DriverPackCatalogItem[] releaseCandidates = SelectReleaseCandidates(candidates, targetReleaseId);
         DriverPackCatalogItem latest = releaseCandidates
             .OrderByDescending(item => item.ReleaseDate ?? DateTimeOffset.MinValue)
             .First();
@@ -106,7 +99,7 @@ public sealed class DriverPackSelectionService : IDriverPackSelectionService
         return new DriverPackSelectionResult
         {
             DriverPack = latest,
-            SelectionReason = "No model exact match; selected newest manufacturer candidate."
+            SelectionReason = "No model exact match; selected newest compatible manufacturer candidate."
         };
     }
 
@@ -129,6 +122,47 @@ public sealed class DriverPackSelectionService : IDriverPackSelectionService
 
         return Normalize(item.Name).Contains(targetReleaseId, StringComparison.OrdinalIgnoreCase) ||
                Normalize(item.OsReleaseId).Contains(targetReleaseId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static DriverPackCatalogItem[] SelectReleaseCandidates(
+        IReadOnlyList<DriverPackCatalogItem> candidates,
+        string targetReleaseId)
+    {
+        if (candidates.Count == 0 || string.IsNullOrWhiteSpace(targetReleaseId))
+        {
+            return candidates.ToArray();
+        }
+
+        DriverPackCatalogItem[] releaseFiltered = candidates
+            .Where(item => IsReleaseIdMatch(item, targetReleaseId))
+            .ToArray();
+        if (releaseFiltered.Length > 0)
+        {
+            return releaseFiltered;
+        }
+
+        int targetReleaseRank = WindowsReleaseId.GetSortRank(targetReleaseId);
+        if (targetReleaseRank <= 0)
+        {
+            return candidates.ToArray();
+        }
+
+        DriverPackCatalogItem[] compatibleReleaseCandidates = candidates
+            .Where(item =>
+            {
+                int releaseRank = WindowsReleaseId.GetSortRank(item.OsReleaseId);
+                return releaseRank > 0 && releaseRank <= targetReleaseRank;
+            })
+            .ToArray();
+        if (compatibleReleaseCandidates.Length == 0)
+        {
+            return candidates.ToArray();
+        }
+
+        int bestReleaseRank = compatibleReleaseCandidates.Max(item => WindowsReleaseId.GetSortRank(item.OsReleaseId));
+        return compatibleReleaseCandidates
+            .Where(item => WindowsReleaseId.GetSortRank(item.OsReleaseId) == bestReleaseRank)
+            .ToArray();
     }
 
     private static string Normalize(string value)

--- a/src/Foundry.Deploy/ViewModels/DriverPackSelectionViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DriverPackSelectionViewModel.cs
@@ -192,9 +192,7 @@ public sealed partial class DriverPackSelectionViewModel : LocalizedViewModelBas
             ? versionCandidates
             : modelCandidates;
 
-        return finalCandidates
-            .OrderByDescending(item => item.ReleaseDate ?? DateTimeOffset.MinValue)
-            .ThenBy(item => item.Name, StringComparer.OrdinalIgnoreCase)
+        return SortDriverPackCandidates(finalCandidates, _selectedOperatingSystem?.ReleaseId ?? string.Empty)
             .FirstOrDefault();
     }
 
@@ -318,7 +316,7 @@ public sealed partial class DriverPackSelectionViewModel : LocalizedViewModelBas
         }
 
         DriverPackCatalogItem[] modelCandidates = FilterDriverPackCandidatesBySelectedModel(BuildSourceDriverPackCandidates());
-        DriverPackCatalogItem[] orderedCandidates = SortDriverPackCandidates(modelCandidates);
+        DriverPackCatalogItem[] orderedCandidates = SortDriverPackCandidates(modelCandidates, _selectedOperatingSystem?.ReleaseId ?? string.Empty);
 
         string[] versions = orderedCandidates
             .Select(GetDriverPackVersionDisplay)
@@ -397,11 +395,10 @@ public sealed partial class DriverPackSelectionViewModel : LocalizedViewModelBas
             return containsOptionMatch;
         }
 
-        DriverPackCatalogItem? bestPackMatch = sourceCandidates
+        DriverPackCatalogItem? bestPackMatch = SortDriverPackCandidates(sourceCandidates
             .Where(item => item.ModelNames.Any(modelName =>
-                hardwareTokens.Any(token => IsFuzzyModelMatch(modelName, token))))
-            .OrderByDescending(item => item.ReleaseDate ?? DateTimeOffset.MinValue)
-            .ThenBy(item => item.Name, StringComparer.OrdinalIgnoreCase)
+                hardwareTokens.Any(token => IsFuzzyModelMatch(modelName, token)))),
+            _selectedOperatingSystem?.ReleaseId ?? string.Empty)
             .FirstOrDefault();
 
         if (bestPackMatch is not null)
@@ -444,7 +441,7 @@ public sealed partial class DriverPackSelectionViewModel : LocalizedViewModelBas
         }
 
         DriverPackCatalogItem[] baseCandidates = query.ToArray();
-        return SortDriverPackCandidates(baseCandidates);
+        return SortDriverPackCandidates(baseCandidates, _selectedOperatingSystem?.ReleaseId ?? string.Empty);
     }
 
     private DriverPackOptionItem? ResolveDefaultDriverPackOption(IReadOnlyList<DriverPackOptionItem> options)
@@ -612,7 +609,10 @@ public sealed partial class DriverPackSelectionViewModel : LocalizedViewModelBas
 
         if (driverPack.ReleaseDate is not null)
         {
-            return driverPack.ReleaseDate.Value.ToLocalTime().ToString("d", CultureInfo.CurrentCulture);
+            string releaseDate = driverPack.ReleaseDate.Value.ToLocalTime().ToString("d", CultureInfo.CurrentCulture);
+            return string.IsNullOrWhiteSpace(driverPack.OsReleaseId)
+                ? releaseDate
+                : $"{releaseDate} ({driverPack.OsReleaseId.Trim()})";
         }
 
         if (!string.IsNullOrWhiteSpace(driverPack.PackageId))
@@ -694,13 +694,28 @@ public sealed partial class DriverPackSelectionViewModel : LocalizedViewModelBas
         return ContainsIgnoreCase(source, value) || ContainsIgnoreCase(value, source);
     }
 
-    private static DriverPackCatalogItem[] SortDriverPackCandidates(IEnumerable<DriverPackCatalogItem> candidates)
+    private static DriverPackCatalogItem[] SortDriverPackCandidates(
+        IEnumerable<DriverPackCatalogItem> candidates,
+        string targetReleaseId)
     {
+        int targetReleaseRank = WindowsReleaseId.GetSortRank(targetReleaseId);
         return candidates
-            .OrderByDescending(item => item.ReleaseDate ?? DateTimeOffset.MinValue)
+            .OrderByDescending(item => GetDriverPackReleaseSortRank(item, targetReleaseRank))
+            .ThenByDescending(item => item.ReleaseDate ?? DateTimeOffset.MinValue)
             .ThenBy(item => item.Manufacturer, StringComparer.OrdinalIgnoreCase)
             .ThenBy(item => item.Name, StringComparer.OrdinalIgnoreCase)
             .ToArray();
+    }
+
+    private static int GetDriverPackReleaseSortRank(DriverPackCatalogItem driverPack, int targetReleaseRank)
+    {
+        int releaseRank = WindowsReleaseId.GetSortRank(driverPack.OsReleaseId);
+        if (targetReleaseRank > 0 && releaseRank <= targetReleaseRank)
+        {
+            return releaseRank;
+        }
+
+        return 0;
     }
 
     private static bool IsArchitectureMatch(string osArchitecture, string driverArchitecture)


### PR DESCRIPTION
## Summary

Improves OEM driver pack selection and pre-OOBE driver installation diagnostics for Lenovo driver packs.

## Reason

Lenovo driver pack catalog entries can expose multiple Windows release packages for the same hardware while sharing the same release date. Foundry could therefore select or display an older compatible Lenovo package instead of the newest compatible exact-model release, and pre-OOBE logs were hard to diagnose because output could be empty or duplicated.

Closes #162

## Main changes

- Prefer the newest compatible Windows release for exact hardware model matches when the target release is not available.
- Keep exact model matching ahead of newer compatible releases for other models.
- Make manual OEM version choices distinguish same-date driver packs by release ID.
- Use transcript-only pre-OOBE logs with timestamped entries and elapsed timings.
- Run Lenovo, registry, pnpunattend, and MSI commands through waited Start-Process calls with exit-code checks.

## Testing notes

- dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj