### PR TITLE
feat(autopilot): add provisioning mode configuration

### DIFF
--- a/docs/implementation/autopilot-hardware-hash-upload.md
+++ b/docs/implementation/autopilot-hardware-hash-upload.md
@@ -38,7 +38,7 @@ Use this table as the cross-phase implementation status board. Detailed task, au
 | Phase | Branch created | Implementation complete | Verification complete | Manual checks complete | PR opened | Merged back |
 | --- | --- | --- | --- | --- | --- | --- |
 | 0 Foundation | [x] | [x] | [x] | [x] | [ ] | [ ] |
-| 1 Configuration model | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| 1 Configuration model | [x] | [x] | [x] | [x] | [ ] | [ ] |
 | 2 Security and tenant onboarding | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
 | 3 Autopilot page UX | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
 | 4 Media build and WinPE assets | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |

--- a/docs/implementation/autopilot-hardware-hash-upload.md
+++ b/docs/implementation/autopilot-hardware-hash-upload.md
@@ -38,7 +38,7 @@ Use this table as the cross-phase implementation status board. Detailed task, au
 | Phase | Branch created | Implementation complete | Verification complete | Manual checks complete | PR opened | Merged back |
 | --- | --- | --- | --- | --- | --- | --- |
 | 0 Foundation | [x] | [x] | [x] | [x] | [ ] | [ ] |
-| 1 Configuration model | [x] | [x] | [x] | [x] | [ ] | [ ] |
+| 1 Configuration model | [x] | [x] | [x] | [x] | [x] | [ ] |
 | 2 Security and tenant onboarding | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
 | 3 Autopilot page UX | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
 | 4 Media build and WinPE assets | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -32,36 +32,36 @@ Manual checks:
 PR title: `feat(autopilot): add provisioning mode configuration`
 
 Implementation progress:
-- [ ] Phase branch created from `feature/autopilot-hash-upload-foundation`.
-- [ ] Implementation checklist complete.
-- [ ] Automated tests complete.
-- [ ] Manual checks complete or explicitly deferred.
+- [x] Phase branch created from `feature/autopilot-hash-upload-foundation`.
+- [x] Implementation checklist complete.
+- [x] Automated tests complete.
+- [x] Manual checks complete or explicitly deferred.
 - [ ] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
-- [ ] Add `AutopilotProvisioningMode`.
-- [ ] Extend `AutopilotSettings` with mode and hardware hash upload settings.
-- [ ] Extend `DeployAutopilotSettings` with reduced runtime mode and upload settings.
-- [ ] Add active certificate metadata: Graph `keyId`, thumbprint, expiration, and display name.
-- [ ] Add tenant app registration identity, service principal identity, known group tags, and default group tag settings.
-- [ ] Update schema version handling if needed.
-- [ ] Keep old configurations backward compatible as JSON profile mode.
-- [ ] Update sanitization in `ExpertDeployConfigurationStateService`.
-- [ ] Update `DeployConfigurationGenerator`.
-- [ ] Add XML documentation comments to new public configuration records, enums, and service contracts when they clarify the behavior.
+- [x] Add `AutopilotProvisioningMode`.
+- [x] Extend `AutopilotSettings` with mode and hardware hash upload settings.
+- [x] Extend `DeployAutopilotSettings` with reduced runtime mode and upload settings.
+- [x] Add active certificate metadata: Graph `keyId`, thumbprint, expiration, and display name.
+- [x] Add tenant app registration identity, service principal identity, known group tags, and default group tag settings.
+- [x] Update schema version handling if needed.
+- [x] Keep old configurations backward compatible as JSON profile mode.
+- [x] Update sanitization in `ExpertDeployConfigurationStateService`.
+- [x] Update `DeployConfigurationGenerator`.
+- [x] Add XML documentation comments to new public configuration records, enums, and service contracts when they clarify the behavior.
 
 Automated tests:
-- [ ] Existing JSON profile config serializes and generates the same deploy output.
-- [ ] Enabled JSON mode requires a selected profile.
-- [ ] Enabled hash upload mode does not require a selected profile.
-- [ ] Capture-and-upload mode requires tenant ID, application object ID, client ID, active certificate `keyId`, active certificate thumbprint, and unexpired certificate metadata.
-- [ ] Invalid certificate settings make Autopilot configuration not ready.
-- [ ] Expired certificate settings make OSD media generation not ready for hardware hash upload.
-- [ ] Persistent OSD settings never serialize PFX bytes, PFX password, decrypted private key material, or access tokens.
+- [x] Existing JSON profile config serializes and generates the same deploy output.
+- [x] Enabled JSON mode requires a selected profile.
+- [x] Enabled hash upload mode does not require a selected profile.
+- [x] Capture-and-upload mode requires tenant ID, application object ID, client ID, active certificate `keyId`, active certificate thumbprint, and unexpired certificate metadata.
+- [x] Invalid certificate settings make Autopilot configuration not ready.
+- [x] Expired certificate settings make OSD media generation not ready for hardware hash upload.
+- [x] Persistent OSD settings never serialize PFX bytes, PFX password, decrypted private key material, or access tokens.
 
 Manual checks:
-- [ ] Start Foundry with existing user config and confirm JSON profile mode is selected.
-- [ ] Disable Autopilot and confirm no profile or hash settings are required.
+- [ ] Deferred to the Phase 3 UI validation pass: start Foundry with existing user config and confirm JSON profile mode is selected.
+- [ ] Deferred to the Phase 3 UI validation pass: disable Autopilot and confirm no profile or hash settings are required.
 
 ### Phase 2: Security And Tenant Onboarding
 PR title: `feat(autopilot): add secure tenant upload onboarding`

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -36,7 +36,7 @@ Implementation progress:
 - [x] Implementation checklist complete.
 - [x] Automated tests complete.
 - [x] Manual checks complete or explicitly deferred.
-- [ ] PR opened with the planned title.
+- [x] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
 - [x] Add `AutopilotProvisioningMode`.

--- a/src/Foundry.Core.Tests/Configuration/AutopilotConfigurationValidatorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/AutopilotConfigurationValidatorTests.cs
@@ -1,0 +1,197 @@
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Configuration;
+
+namespace Foundry.Core.Tests.Configuration;
+
+public sealed class AutopilotConfigurationValidatorTests
+{
+    private static readonly DateTimeOffset EvaluationTimeUtc = new(2026, 5, 15, 0, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void IsReady_WhenAutopilotIsDisabled_ReturnsTrueWithoutProfileOrHashSettings()
+    {
+        var settings = new AutopilotSettings
+        {
+            IsEnabled = false,
+            ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload
+        };
+
+        Assert.True(AutopilotConfigurationValidator.IsReady(settings, EvaluationTimeUtc));
+    }
+
+    [Fact]
+    public void IsReady_WhenJsonProfileModeHasSelectedProfile_ReturnsTrue()
+    {
+        var settings = new AutopilotSettings
+        {
+            IsEnabled = true,
+            ProvisioningMode = AutopilotProvisioningMode.JsonProfile,
+            DefaultProfileId = "profile-a",
+            Profiles = [CreateProfile("profile-a")]
+        };
+
+        Assert.True(AutopilotConfigurationValidator.IsReady(settings, EvaluationTimeUtc));
+    }
+
+    [Fact]
+    public void IsReady_WhenJsonProfileModeHasNoSelectedProfile_ReturnsFalse()
+    {
+        var settings = new AutopilotSettings
+        {
+            IsEnabled = true,
+            ProvisioningMode = AutopilotProvisioningMode.JsonProfile
+        };
+
+        Assert.False(AutopilotConfigurationValidator.IsReady(settings, EvaluationTimeUtc));
+    }
+
+    [Fact]
+    public void IsReady_WhenHardwareHashModeHasCompleteUnexpiredSettings_ReturnsTrue()
+    {
+        var settings = new AutopilotSettings
+        {
+            IsEnabled = true,
+            ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+            HardwareHashUpload = CreateCompleteHardwareHashSettings(EvaluationTimeUtc.AddMonths(6))
+        };
+
+        Assert.True(AutopilotConfigurationValidator.IsReady(settings, EvaluationTimeUtc));
+    }
+
+    [Theory]
+    [InlineData("", "application-object-id", "client-id", "certificate-key-id", "ABCDEF123456")]
+    [InlineData("tenant-id", "", "client-id", "certificate-key-id", "ABCDEF123456")]
+    [InlineData("tenant-id", "application-object-id", "", "certificate-key-id", "ABCDEF123456")]
+    [InlineData("tenant-id", "application-object-id", "client-id", "", "ABCDEF123456")]
+    [InlineData("tenant-id", "application-object-id", "client-id", "certificate-key-id", "")]
+    public void IsReady_WhenHardwareHashModeHasMissingRequiredMetadata_ReturnsFalse(
+        string tenantId,
+        string applicationObjectId,
+        string clientId,
+        string keyId,
+        string thumbprint)
+    {
+        var settings = new AutopilotSettings
+        {
+            IsEnabled = true,
+            ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+            HardwareHashUpload = CreateCompleteHardwareHashSettings(
+                EvaluationTimeUtc.AddMonths(6),
+                tenantId,
+                applicationObjectId,
+                clientId,
+                keyId,
+                thumbprint)
+        };
+
+        Assert.False(AutopilotConfigurationValidator.IsReady(settings, EvaluationTimeUtc));
+    }
+
+    [Fact]
+    public void IsReady_WhenHardwareHashCertificateIsExpired_ReturnsFalse()
+    {
+        var settings = new AutopilotSettings
+        {
+            IsEnabled = true,
+            ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+            HardwareHashUpload = CreateCompleteHardwareHashSettings(EvaluationTimeUtc.AddTicks(-1))
+        };
+
+        Assert.False(AutopilotConfigurationValidator.IsReady(settings, EvaluationTimeUtc));
+    }
+
+    [Fact]
+    public void IsReady_WhenProvisioningModeIsUnsupported_ReturnsFalse()
+    {
+        var settings = new AutopilotSettings
+        {
+            IsEnabled = true,
+            ProvisioningMode = (AutopilotProvisioningMode)999
+        };
+
+        Assert.False(AutopilotConfigurationValidator.IsReady(settings, EvaluationTimeUtc));
+    }
+
+    [Fact]
+    public void IsReady_WhenHardwareHashUploadSettingsAreNull_ReturnsFalse()
+    {
+        var settings = new AutopilotSettings
+        {
+            IsEnabled = true,
+            ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+            HardwareHashUpload = null!
+        };
+
+        Assert.False(AutopilotConfigurationValidator.IsReady(settings, EvaluationTimeUtc));
+    }
+
+    [Fact]
+    public void IsReady_WhenHardwareHashTenantSettingsAreNull_ReturnsFalse()
+    {
+        var settings = new AutopilotSettings
+        {
+            IsEnabled = true,
+            ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+            HardwareHashUpload = CreateCompleteHardwareHashSettings(EvaluationTimeUtc.AddMonths(6)) with
+            {
+                Tenant = null!
+            }
+        };
+
+        Assert.False(AutopilotConfigurationValidator.IsReady(settings, EvaluationTimeUtc));
+    }
+
+    [Fact]
+    public void ThrowIfNotReady_WhenProvisioningModeIsUnsupported_ThrowsInvalidOperationException()
+    {
+        var settings = new AutopilotSettings
+        {
+            IsEnabled = true,
+            ProvisioningMode = (AutopilotProvisioningMode)999
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => AutopilotConfigurationValidator.ThrowIfNotReady(settings, EvaluationTimeUtc));
+        Assert.Contains("unsupported", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static AutopilotProfileSettings CreateProfile(string id)
+    {
+        return new AutopilotProfileSettings
+        {
+            Id = id,
+            DisplayName = id,
+            FolderName = id,
+            Source = "import",
+            ImportedAtUtc = EvaluationTimeUtc,
+            JsonContent = "{}"
+        };
+    }
+
+    private static AutopilotHardwareHashUploadSettings CreateCompleteHardwareHashSettings(
+        DateTimeOffset expiration,
+        string tenantId = "tenant-id",
+        string applicationObjectId = "application-object-id",
+        string clientId = "client-id",
+        string keyId = "certificate-key-id",
+        string thumbprint = "ABCDEF123456")
+    {
+        return new AutopilotHardwareHashUploadSettings
+        {
+            Tenant = new AutopilotTenantRegistrationSettings
+            {
+                TenantId = tenantId,
+                ApplicationObjectId = applicationObjectId,
+                ClientId = clientId,
+                ServicePrincipalObjectId = "service-principal-object-id"
+            },
+            ActiveCertificate = new AutopilotCertificateMetadata
+            {
+                KeyId = keyId,
+                Thumbprint = thumbprint,
+                DisplayName = "Foundry OSD Autopilot Registration",
+                ExpiresOnUtc = expiration
+            }
+        };
+    }
+}

--- a/src/Foundry.Core.Tests/Configuration/ConnectConfigurationGeneratorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/ConnectConfigurationGeneratorTests.cs
@@ -25,6 +25,8 @@ public sealed class ConnectConfigurationGeneratorTests
         Assert.True(root.TryGetProperty("wifi", out _));
         Assert.True(root.TryGetProperty("internetProbe", out JsonElement internetProbe));
         Assert.False(capabilities.GetProperty("wifiProvisioned").GetBoolean());
+        Assert.Equal(JsonValueKind.Number, root.GetProperty("dot1x").GetProperty("authenticationMode").ValueKind);
+        Assert.Equal(JsonValueKind.Number, root.GetProperty("wifi").GetProperty("enterpriseAuthenticationMode").ValueKind);
         Assert.Equal(5, internetProbe.GetProperty("timeoutSeconds").GetInt32());
         Assert.NotEmpty(internetProbe.GetProperty("probeUris").EnumerateArray());
         Assert.Empty(bundle.AssetFiles);

--- a/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
@@ -114,6 +114,106 @@ public sealed class DeployConfigurationGeneratorTests
         Assert.Equal("profile-b-folder", result.Autopilot.DefaultProfileFolderName);
     }
 
+    [Fact]
+    public void Generate_WhenJsonProfileModeHasNoSelectedProfile_ThrowsInvalidOperationException()
+    {
+        var generator = new DeployConfigurationGenerator();
+        var document = new FoundryExpertConfigurationDocument
+        {
+            Autopilot = new AutopilotSettings
+            {
+                IsEnabled = true,
+                ProvisioningMode = AutopilotProvisioningMode.JsonProfile
+            }
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => generator.Generate(document));
+        Assert.Contains("JSON", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Generate_WhenHardwareHashModeIsEnabled_DoesNotRequireSelectedProfile()
+    {
+        var generator = new DeployConfigurationGenerator();
+        DateTimeOffset expiration = DateTimeOffset.UtcNow.AddMonths(6);
+        var document = new FoundryExpertConfigurationDocument
+        {
+            Autopilot = new AutopilotSettings
+            {
+                IsEnabled = true,
+                ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+                HardwareHashUpload = CreateCompleteHardwareHashSettings(expiration)
+            }
+        };
+
+        var result = generator.Generate(document);
+
+        Assert.True(result.Autopilot.IsEnabled);
+        Assert.Equal(AutopilotProvisioningMode.HardwareHashUpload, result.Autopilot.ProvisioningMode);
+        Assert.Null(result.Autopilot.DefaultProfileFolderName);
+        Assert.Equal("tenant-id", result.Autopilot.HardwareHashUpload.TenantId);
+        Assert.Equal("client-id", result.Autopilot.HardwareHashUpload.ClientId);
+        Assert.Equal("certificate-key-id", result.Autopilot.HardwareHashUpload.ActiveCertificateKeyId);
+        Assert.Equal("ABCDEF123456", result.Autopilot.HardwareHashUpload.ActiveCertificateThumbprint);
+        Assert.Equal(expiration, result.Autopilot.HardwareHashUpload.ActiveCertificateExpiresOnUtc);
+        Assert.Equal("Sales", result.Autopilot.HardwareHashUpload.DefaultGroupTag);
+    }
+
+    [Fact]
+    public void Generate_WhenHardwareHashCertificateIsExpired_ThrowsInvalidOperationException()
+    {
+        var generator = new DeployConfigurationGenerator();
+        var document = new FoundryExpertConfigurationDocument
+        {
+            Autopilot = new AutopilotSettings
+            {
+                IsEnabled = true,
+                ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+                HardwareHashUpload = CreateCompleteHardwareHashSettings(DateTimeOffset.UtcNow.AddDays(-1))
+            }
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => generator.Generate(document));
+        Assert.Contains("certificate", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Generate_WhenAutopilotIsDisabledWithNullHardwareHashSettings_DoesNotThrow()
+    {
+        var generator = new DeployConfigurationGenerator();
+        var document = new FoundryExpertConfigurationDocument
+        {
+            Autopilot = new AutopilotSettings
+            {
+                IsEnabled = false,
+                HardwareHashUpload = null!
+            }
+        };
+
+        var result = generator.Generate(document);
+
+        Assert.False(result.Autopilot.IsEnabled);
+        Assert.Equal(AutopilotProvisioningMode.JsonProfile, result.Autopilot.ProvisioningMode);
+        Assert.NotNull(result.Autopilot.HardwareHashUpload);
+    }
+
+    [Fact]
+    public void Generate_WhenProvisioningModeIsUnsupported_ThrowsInvalidOperationException()
+    {
+        var generator = new DeployConfigurationGenerator();
+        var document = new FoundryExpertConfigurationDocument
+        {
+            Autopilot = new AutopilotSettings
+            {
+                IsEnabled = true,
+                ProvisioningMode = (AutopilotProvisioningMode)999
+            }
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => generator.Generate(document));
+        Assert.Contains("unsupported", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static AutopilotProfileSettings CreateProfile(string id, string folderName)
     {
         return new AutopilotProfileSettings
@@ -124,6 +224,29 @@ public sealed class DeployConfigurationGeneratorTests
             Source = "import",
             ImportedAtUtc = DateTimeOffset.UtcNow,
             JsonContent = "{}"
+        };
+    }
+
+    private static AutopilotHardwareHashUploadSettings CreateCompleteHardwareHashSettings(DateTimeOffset expiration)
+    {
+        return new AutopilotHardwareHashUploadSettings
+        {
+            Tenant = new AutopilotTenantRegistrationSettings
+            {
+                TenantId = "tenant-id",
+                ApplicationObjectId = "application-object-id",
+                ClientId = "client-id",
+                ServicePrincipalObjectId = "service-principal-object-id"
+            },
+            ActiveCertificate = new AutopilotCertificateMetadata
+            {
+                KeyId = "certificate-key-id",
+                Thumbprint = "ABCDEF123456",
+                DisplayName = "Foundry OSD Autopilot Registration",
+                ExpiresOnUtc = expiration
+            },
+            KnownGroupTags = ["Sales", "Engineering"],
+            DefaultGroupTag = "Sales"
         };
     }
 }

--- a/src/Foundry.Core.Tests/Configuration/ExpertConfigurationServiceTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/ExpertConfigurationServiceTests.cs
@@ -68,4 +68,60 @@ public sealed class ExpertConfigurationServiceTests
         Assert.False(document.Network.WifiProvisioned);
         Assert.False(document.Autopilot.IsEnabled);
     }
+
+    [Fact]
+    public void Deserialize_WhenAutopilotProvisioningModeIsMissing_DefaultsToJsonProfile()
+    {
+        var service = new ExpertConfigurationService();
+
+        FoundryExpertConfigurationDocument document = service.Deserialize("""
+            {
+              "schemaVersion": 4,
+              "autopilot": {
+                "isEnabled": true
+              }
+            }
+            """);
+
+        Assert.Equal(AutopilotProvisioningMode.JsonProfile, document.Autopilot.ProvisioningMode);
+    }
+
+    [Fact]
+    public void Serialize_WhenHardwareHashSettingsArePersisted_DoesNotWritePrivateMaterial()
+    {
+        var service = new ExpertConfigurationService();
+        var document = new FoundryExpertConfigurationDocument
+        {
+            Autopilot = new AutopilotSettings
+            {
+                IsEnabled = true,
+                ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+                HardwareHashUpload = new AutopilotHardwareHashUploadSettings
+                {
+                    Tenant = new AutopilotTenantRegistrationSettings
+                    {
+                        TenantId = "tenant-id",
+                        ApplicationObjectId = "application-object-id",
+                        ClientId = "client-id",
+                        ServicePrincipalObjectId = "service-principal-object-id"
+                    },
+                    ActiveCertificate = new AutopilotCertificateMetadata
+                    {
+                        KeyId = "certificate-key-id",
+                        Thumbprint = "ABCDEF123456",
+                        DisplayName = "Foundry OSD Autopilot Registration",
+                        ExpiresOnUtc = DateTimeOffset.UtcNow.AddMonths(6)
+                    }
+                }
+            }
+        };
+
+        string json = service.Serialize(document);
+
+        Assert.Contains("\"provisioningMode\": \"hardwareHashUpload\"", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("pfx", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("password", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("privateKey", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("accessToken", json, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
@@ -170,7 +170,10 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
 
         Assert.True(result.IsSuccess, result.Error?.Details);
         string deployConfigurationJson = await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.deploy.config.json"));
-        Assert.Contains("\"schemaVersion\": 2", deployConfigurationJson, StringComparison.Ordinal);
+        Assert.Contains(
+            $"\"schemaVersion\": {Foundry.Core.Models.Configuration.Deploy.FoundryDeployConfigurationDocument.CurrentSchemaVersion}",
+            deployConfigurationJson,
+            StringComparison.Ordinal);
         Assert.Contains("\"localization\":", deployConfigurationJson, StringComparison.Ordinal);
         Assert.Contains("\"customization\":", deployConfigurationJson, StringComparison.Ordinal);
         Assert.Contains("\"autopilot\":", deployConfigurationJson, StringComparison.Ordinal);

--- a/src/Foundry.Core/Models/Configuration/AutopilotCertificateMetadata.cs
+++ b/src/Foundry.Core/Models/Configuration/AutopilotCertificateMetadata.cs
@@ -1,0 +1,27 @@
+namespace Foundry.Core.Models.Configuration;
+
+/// <summary>
+/// Identifies the active certificate credential selected on the managed Autopilot app registration.
+/// </summary>
+public sealed record AutopilotCertificateMetadata
+{
+    /// <summary>
+    /// Gets the Microsoft Graph key credential identifier for the selected certificate.
+    /// </summary>
+    public string? KeyId { get; init; }
+
+    /// <summary>
+    /// Gets the certificate thumbprint used to validate the operator-provided PFX during media generation.
+    /// </summary>
+    public string? Thumbprint { get; init; }
+
+    /// <summary>
+    /// Gets the operator-facing certificate display name.
+    /// </summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>
+    /// Gets the UTC expiration time after which media generation must reject hardware hash upload mode.
+    /// </summary>
+    public DateTimeOffset? ExpiresOnUtc { get; init; }
+}

--- a/src/Foundry.Core/Models/Configuration/AutopilotHardwareHashUploadSettings.cs
+++ b/src/Foundry.Core/Models/Configuration/AutopilotHardwareHashUploadSettings.cs
@@ -1,0 +1,32 @@
+namespace Foundry.Core.Models.Configuration;
+
+/// <summary>
+/// Stores persistent metadata for WinPE Autopilot hardware hash upload without private key material.
+/// </summary>
+public sealed record AutopilotHardwareHashUploadSettings
+{
+    /// <summary>
+    /// Gets the display name used for the managed Foundry app registration in Microsoft Entra ID.
+    /// </summary>
+    public const string ManagedAppRegistrationDisplayName = "Foundry OSD Autopilot Registration";
+
+    /// <summary>
+    /// Gets the tenant and managed app registration identities.
+    /// </summary>
+    public AutopilotTenantRegistrationSettings Tenant { get; init; } = new();
+
+    /// <summary>
+    /// Gets the currently selected app registration certificate credential metadata.
+    /// </summary>
+    public AutopilotCertificateMetadata? ActiveCertificate { get; init; }
+
+    /// <summary>
+    /// Gets the group tags discovered from Intune for default selection in Foundry.Deploy.
+    /// </summary>
+    public IReadOnlyList<string> KnownGroupTags { get; init; } = [];
+
+    /// <summary>
+    /// Gets the default Autopilot group tag selected during media generation.
+    /// </summary>
+    public string? DefaultGroupTag { get; init; }
+}

--- a/src/Foundry.Core/Models/Configuration/AutopilotProvisioningMode.cs
+++ b/src/Foundry.Core/Models/Configuration/AutopilotProvisioningMode.cs
@@ -1,8 +1,11 @@
+using System.Text.Json.Serialization;
+
 namespace Foundry.Core.Models.Configuration;
 
 /// <summary>
 /// Defines how Foundry provisions Autopilot data during OS deployment.
 /// </summary>
+[JsonConverter(typeof(AutopilotProvisioningModeJsonConverter))]
 public enum AutopilotProvisioningMode
 {
     /// <summary>

--- a/src/Foundry.Core/Models/Configuration/AutopilotProvisioningMode.cs
+++ b/src/Foundry.Core/Models/Configuration/AutopilotProvisioningMode.cs
@@ -1,0 +1,17 @@
+namespace Foundry.Core.Models.Configuration;
+
+/// <summary>
+/// Defines how Foundry provisions Autopilot data during OS deployment.
+/// </summary>
+public enum AutopilotProvisioningMode
+{
+    /// <summary>
+    /// Stages an offline Autopilot profile JSON file into the applied Windows image.
+    /// </summary>
+    JsonProfile,
+
+    /// <summary>
+    /// Captures and uploads the device hardware hash from WinPE using the configured tenant app registration.
+    /// </summary>
+    HardwareHashUpload
+}

--- a/src/Foundry.Core/Models/Configuration/AutopilotProvisioningModeJsonConverter.cs
+++ b/src/Foundry.Core/Models/Configuration/AutopilotProvisioningModeJsonConverter.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Foundry.Core.Models.Configuration;
+
+/// <summary>
+/// Preserves readable Autopilot provisioning mode values without changing every enum in shared configuration JSON.
+/// </summary>
+public sealed class AutopilotProvisioningModeJsonConverter : JsonConverter<AutopilotProvisioningMode>
+{
+    /// <inheritdoc />
+    public override AutopilotProvisioningMode Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out int numericValue))
+        {
+            return Enum.IsDefined(typeof(AutopilotProvisioningMode), numericValue)
+                ? (AutopilotProvisioningMode)numericValue
+                : throw new JsonException($"Unsupported Autopilot provisioning mode value '{numericValue}'.");
+        }
+
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            throw new JsonException("Autopilot provisioning mode must be a string or numeric enum value.");
+        }
+
+        return reader.GetString() switch
+        {
+            "jsonProfile" or "JsonProfile" => AutopilotProvisioningMode.JsonProfile,
+            "hardwareHashUpload" or "HardwareHashUpload" => AutopilotProvisioningMode.HardwareHashUpload,
+            string value => throw new JsonException($"Unsupported Autopilot provisioning mode value '{value}'."),
+            null => throw new JsonException("Autopilot provisioning mode cannot be null.")
+        };
+    }
+
+    /// <inheritdoc />
+    public override void Write(
+        Utf8JsonWriter writer,
+        AutopilotProvisioningMode value,
+        JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value switch
+        {
+            AutopilotProvisioningMode.JsonProfile => "jsonProfile",
+            AutopilotProvisioningMode.HardwareHashUpload => "hardwareHashUpload",
+            _ => throw new JsonException($"Unsupported Autopilot provisioning mode value '{value}'.")
+        });
+    }
+}

--- a/src/Foundry.Core/Models/Configuration/AutopilotSettings.cs
+++ b/src/Foundry.Core/Models/Configuration/AutopilotSettings.cs
@@ -1,14 +1,19 @@
 namespace Foundry.Core.Models.Configuration;
 
 /// <summary>
-/// Describes Autopilot profiles selected for staging into a deployed Windows image.
+/// Describes the selected Autopilot provisioning method and its persistent settings.
 /// </summary>
 public sealed record AutopilotSettings
 {
     /// <summary>
-    /// Gets whether Autopilot staging is enabled.
+    /// Gets whether Autopilot provisioning is enabled.
     /// </summary>
     public bool IsEnabled { get; init; }
+
+    /// <summary>
+    /// Gets the provisioning method used when Autopilot is enabled.
+    /// </summary>
+    public AutopilotProvisioningMode ProvisioningMode { get; init; } = AutopilotProvisioningMode.JsonProfile;
 
     /// <summary>
     /// Gets the profile ID selected as the default staged profile.
@@ -19,4 +24,9 @@ public sealed record AutopilotSettings
     /// Gets the available imported or downloaded Autopilot profiles.
     /// </summary>
     public IReadOnlyList<AutopilotProfileSettings> Profiles { get; init; } = [];
+
+    /// <summary>
+    /// Gets tenant app registration metadata used by hardware hash upload mode.
+    /// </summary>
+    public AutopilotHardwareHashUploadSettings HardwareHashUpload { get; init; } = new();
 }

--- a/src/Foundry.Core/Models/Configuration/AutopilotTenantRegistrationSettings.cs
+++ b/src/Foundry.Core/Models/Configuration/AutopilotTenantRegistrationSettings.cs
@@ -1,0 +1,27 @@
+namespace Foundry.Core.Models.Configuration;
+
+/// <summary>
+/// Stores the tenant and managed app registration identities used for Autopilot hardware hash upload.
+/// </summary>
+public sealed record AutopilotTenantRegistrationSettings
+{
+    /// <summary>
+    /// Gets the Microsoft Entra tenant ID used by the managed app registration.
+    /// </summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>
+    /// Gets the application object ID for the managed app registration.
+    /// </summary>
+    public string? ApplicationObjectId { get; init; }
+
+    /// <summary>
+    /// Gets the application client ID used for certificate-based Graph authentication in WinPE.
+    /// </summary>
+    public string? ClientId { get; init; }
+
+    /// <summary>
+    /// Gets the service principal object ID created for the managed app registration.
+    /// </summary>
+    public string? ServicePrincipalObjectId { get; init; }
+}

--- a/src/Foundry.Core/Models/Configuration/Deploy/DeployAutopilotHardwareHashUploadSettings.cs
+++ b/src/Foundry.Core/Models/Configuration/Deploy/DeployAutopilotHardwareHashUploadSettings.cs
@@ -1,0 +1,37 @@
+namespace Foundry.Core.Models.Configuration.Deploy;
+
+/// <summary>
+/// Carries non-secret tenant and certificate metadata needed by the WinPE hardware hash upload workflow.
+/// </summary>
+public sealed record DeployAutopilotHardwareHashUploadSettings
+{
+    /// <summary>
+    /// Gets the Microsoft Entra tenant ID used for Graph authentication.
+    /// </summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>
+    /// Gets the application client ID used for certificate-based Graph authentication.
+    /// </summary>
+    public string? ClientId { get; init; }
+
+    /// <summary>
+    /// Gets the selected app registration certificate credential identifier for diagnostics.
+    /// </summary>
+    public string? ActiveCertificateKeyId { get; init; }
+
+    /// <summary>
+    /// Gets the selected certificate thumbprint expected from the encrypted media certificate.
+    /// </summary>
+    public string? ActiveCertificateThumbprint { get; init; }
+
+    /// <summary>
+    /// Gets the selected certificate expiration time used by Deploy to skip expired media without blocking OS deployment.
+    /// </summary>
+    public DateTimeOffset? ActiveCertificateExpiresOnUtc { get; init; }
+
+    /// <summary>
+    /// Gets the default group tag offered by Foundry.Deploy for hardware hash upload.
+    /// </summary>
+    public string? DefaultGroupTag { get; init; }
+}

--- a/src/Foundry.Core/Models/Configuration/Deploy/DeployAutopilotSettings.cs
+++ b/src/Foundry.Core/Models/Configuration/Deploy/DeployAutopilotSettings.cs
@@ -1,17 +1,29 @@
+using Foundry.Core.Models.Configuration;
+
 namespace Foundry.Core.Models.Configuration.Deploy;
 
 /// <summary>
-/// Describes Autopilot profile staging settings consumed by Foundry.Deploy.
+/// Describes the reduced Autopilot runtime settings consumed by Foundry.Deploy.
 /// </summary>
 public sealed record DeployAutopilotSettings
 {
     /// <summary>
-    /// Gets whether Autopilot staging is enabled.
+    /// Gets whether Autopilot provisioning is enabled.
     /// </summary>
     public bool IsEnabled { get; init; }
+
+    /// <summary>
+    /// Gets the provisioning method selected by Foundry OSD.
+    /// </summary>
+    public AutopilotProvisioningMode ProvisioningMode { get; init; } = AutopilotProvisioningMode.JsonProfile;
 
     /// <summary>
     /// Gets the profile folder name selected for staging.
     /// </summary>
     public string? DefaultProfileFolderName { get; init; }
+
+    /// <summary>
+    /// Gets runtime metadata required for hardware hash upload mode.
+    /// </summary>
+    public DeployAutopilotHardwareHashUploadSettings HardwareHashUpload { get; init; } = new();
 }

--- a/src/Foundry.Core/Models/Configuration/Deploy/FoundryDeployConfigurationDocument.cs
+++ b/src/Foundry.Core/Models/Configuration/Deploy/FoundryDeployConfigurationDocument.cs
@@ -10,7 +10,7 @@ public sealed record FoundryDeployConfigurationDocument
     /// <summary>
     /// Gets the current schema version for Foundry.Deploy configuration documents.
     /// </summary>
-    public const int CurrentSchemaVersion = 2;
+    public const int CurrentSchemaVersion = 3;
 
     /// <summary>
     /// Gets the schema version of this deployment configuration document.
@@ -28,7 +28,7 @@ public sealed record FoundryDeployConfigurationDocument
     public DeployCustomizationSettings Customization { get; init; } = new();
 
     /// <summary>
-    /// Gets Autopilot profile staging settings.
+    /// Gets Autopilot provisioning settings.
     /// </summary>
     public DeployAutopilotSettings Autopilot { get; init; } = new();
 

--- a/src/Foundry.Core/Models/Configuration/FoundryExpertConfigurationDocument.cs
+++ b/src/Foundry.Core/Models/Configuration/FoundryExpertConfigurationDocument.cs
@@ -10,7 +10,7 @@ public sealed record FoundryExpertConfigurationDocument
     /// <summary>
     /// Gets the current schema version for Expert Deploy configuration documents.
     /// </summary>
-    public const int CurrentSchemaVersion = 4;
+    public const int CurrentSchemaVersion = 5;
 
     /// <summary>
     /// Gets the schema version of this configuration document.
@@ -38,7 +38,7 @@ public sealed record FoundryExpertConfigurationDocument
     public CustomizationSettings Customization { get; init; } = new();
 
     /// <summary>
-    /// Gets Autopilot profile settings staged for OOBE.
+    /// Gets Autopilot provisioning settings used during deployment.
     /// </summary>
     public AutopilotSettings Autopilot { get; init; } = new();
 

--- a/src/Foundry.Core/Services/Configuration/AutopilotConfigurationValidator.cs
+++ b/src/Foundry.Core/Services/Configuration/AutopilotConfigurationValidator.cs
@@ -1,0 +1,87 @@
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Core.Services.Configuration;
+
+/// <summary>
+/// Evaluates whether persistent Autopilot settings are complete enough to generate deployment media.
+/// </summary>
+public static class AutopilotConfigurationValidator
+{
+    /// <summary>
+    /// Determines whether Autopilot settings are ready for media generation.
+    /// </summary>
+    /// <param name="settings">Autopilot settings to evaluate.</param>
+    /// <param name="currentTimeUtc">Current UTC time used for certificate expiration checks.</param>
+    /// <returns><see langword="true"/> when the selected Autopilot mode is ready for output.</returns>
+    public static bool IsReady(AutopilotSettings settings, DateTimeOffset currentTimeUtc)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        if (!settings.IsEnabled)
+        {
+            return true;
+        }
+
+        return settings.ProvisioningMode switch
+        {
+            AutopilotProvisioningMode.JsonProfile => GetSelectedJsonProfile(settings) is not null,
+            AutopilotProvisioningMode.HardwareHashUpload => IsHardwareHashUploadReady(settings.HardwareHashUpload, currentTimeUtc),
+            _ => false
+        };
+    }
+
+    internal static void ThrowIfNotReady(AutopilotSettings settings, DateTimeOffset currentTimeUtc)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        if (!settings.IsEnabled)
+        {
+            return;
+        }
+
+        if (settings.ProvisioningMode == AutopilotProvisioningMode.JsonProfile && GetSelectedJsonProfile(settings) is null)
+        {
+            throw new InvalidOperationException("Autopilot JSON profile mode requires a selected profile.");
+        }
+
+        if (settings.ProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload &&
+            !IsHardwareHashUploadReady(settings.HardwareHashUpload, currentTimeUtc))
+        {
+            throw new InvalidOperationException("Autopilot hardware hash upload mode requires complete tenant and unexpired certificate metadata.");
+        }
+
+        if (!Enum.IsDefined(settings.ProvisioningMode))
+        {
+            throw new InvalidOperationException($"Unsupported Autopilot provisioning mode '{settings.ProvisioningMode}'.");
+        }
+    }
+
+    private static AutopilotProfileSettings? GetSelectedJsonProfile(AutopilotSettings settings)
+    {
+        if (string.IsNullOrWhiteSpace(settings.DefaultProfileId))
+        {
+            return null;
+        }
+
+        return settings.Profiles.FirstOrDefault(profile =>
+            string.Equals(profile.Id, settings.DefaultProfileId, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsHardwareHashUploadReady(
+        AutopilotHardwareHashUploadSettings? settings,
+        DateTimeOffset currentTimeUtc)
+    {
+        if (settings?.Tenant is null)
+        {
+            return false;
+        }
+
+        return !string.IsNullOrWhiteSpace(settings.Tenant.TenantId) &&
+               !string.IsNullOrWhiteSpace(settings.Tenant.ApplicationObjectId) &&
+               !string.IsNullOrWhiteSpace(settings.Tenant.ClientId) &&
+               !string.IsNullOrWhiteSpace(settings.ActiveCertificate?.KeyId) &&
+               !string.IsNullOrWhiteSpace(settings.ActiveCertificate.Thumbprint) &&
+               settings.ActiveCertificate.ExpiresOnUtc is { } expiresOnUtc &&
+               expiresOnUtc > currentTimeUtc;
+    }
+}

--- a/src/Foundry.Core/Services/Configuration/ConfigurationJsonDefaults.cs
+++ b/src/Foundry.Core/Services/Configuration/ConfigurationJsonDefaults.cs
@@ -9,6 +9,7 @@ internal static class ConfigurationJsonDefaults
     {
         WriteIndented = true,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
     };
 }

--- a/src/Foundry.Core/Services/Configuration/ConfigurationJsonDefaults.cs
+++ b/src/Foundry.Core/Services/Configuration/ConfigurationJsonDefaults.cs
@@ -9,7 +9,6 @@ internal static class ConfigurationJsonDefaults
     {
         WriteIndented = true,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 }

--- a/src/Foundry.Core/Services/Configuration/DeployConfigurationGenerator.cs
+++ b/src/Foundry.Core/Services/Configuration/DeployConfigurationGenerator.cs
@@ -13,6 +13,7 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
     public FoundryDeployConfigurationDocument Generate(FoundryExpertConfigurationDocument document)
     {
         ArgumentNullException.ThrowIfNull(document);
+        AutopilotConfigurationValidator.ThrowIfNotReady(document.Autopilot, DateTimeOffset.UtcNow);
 
         string[] visibleLanguageCodes = CanonicalizeLanguageCodes(document.Localization.VisibleLanguageCodes);
         string? defaultLanguageCodeOverride = CanonicalizeOptionalLanguageCode(document.Localization.DefaultLanguageCodeOverride);
@@ -50,9 +51,13 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
             Autopilot = new DeployAutopilotSettings
             {
                 IsEnabled = document.Autopilot.IsEnabled,
-                DefaultProfileFolderName = document.Autopilot.Profiles
-                    .FirstOrDefault(profile => string.Equals(profile.Id, document.Autopilot.DefaultProfileId, StringComparison.OrdinalIgnoreCase))
-                    ?.FolderName
+                ProvisioningMode = document.Autopilot.ProvisioningMode,
+                DefaultProfileFolderName = document.Autopilot.ProvisioningMode == AutopilotProvisioningMode.JsonProfile
+                    ? document.Autopilot.Profiles
+                        .FirstOrDefault(profile => string.Equals(profile.Id, document.Autopilot.DefaultProfileId, StringComparison.OrdinalIgnoreCase))
+                        ?.FolderName
+                    : null,
+                HardwareHashUpload = CreateDeployHardwareHashUploadSettings(document.Autopilot.HardwareHashUpload)
             },
             Telemetry = document.Telemetry
         };
@@ -90,5 +95,24 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
     {
         string canonicalCode = LanguageCodeUtility.Canonicalize(languageCode);
         return string.IsNullOrWhiteSpace(canonicalCode) ? null : canonicalCode;
+    }
+
+    private static DeployAutopilotHardwareHashUploadSettings CreateDeployHardwareHashUploadSettings(
+        AutopilotHardwareHashUploadSettings? settings)
+    {
+        if (settings?.Tenant is null)
+        {
+            return new DeployAutopilotHardwareHashUploadSettings();
+        }
+
+        return new DeployAutopilotHardwareHashUploadSettings
+        {
+            TenantId = settings.Tenant.TenantId,
+            ClientId = settings.Tenant.ClientId,
+            ActiveCertificateKeyId = settings.ActiveCertificate?.KeyId,
+            ActiveCertificateThumbprint = settings.ActiveCertificate?.Thumbprint,
+            ActiveCertificateExpiresOnUtc = settings.ActiveCertificate?.ExpiresOnUtc,
+            DefaultGroupTag = settings.DefaultGroupTag
+        };
     }
 }

--- a/src/Foundry.Core/Services/Media/MediaPreflightOptions.cs
+++ b/src/Foundry.Core/Services/Media/MediaPreflightOptions.cs
@@ -33,12 +33,12 @@ public sealed record MediaPreflightOptions
     public bool AreRequiredSecretsReady { get; init; }
 
     /// <summary>
-    /// Gets a value indicating whether Autopilot staging is enabled.
+    /// Gets a value indicating whether Autopilot provisioning is enabled.
     /// </summary>
     public bool IsAutopilotEnabled { get; init; }
 
     /// <summary>
-    /// Gets a value indicating whether the selected Autopilot profile is valid.
+    /// Gets a value indicating whether the selected Autopilot provisioning mode is valid.
     /// </summary>
     public bool IsAutopilotConfigurationReady { get; init; } = true;
 

--- a/src/Foundry.Deploy.Tests/ExpertDeployConfigurationModelTests.cs
+++ b/src/Foundry.Deploy.Tests/ExpertDeployConfigurationModelTests.cs
@@ -79,7 +79,6 @@ public sealed class ExpertDeployConfigurationModelTests
             PropertyNameCaseInsensitive = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
-        options.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
 
         FoundryDeployConfigurationDocument? document = JsonSerializer.Deserialize<FoundryDeployConfigurationDocument>(json, options);
 
@@ -113,7 +112,6 @@ public sealed class ExpertDeployConfigurationModelTests
             PropertyNameCaseInsensitive = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
-        options.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
 
         FoundryDeployConfigurationDocument? document = JsonSerializer.Deserialize<FoundryDeployConfigurationDocument>(json, options);
 

--- a/src/Foundry.Deploy.Tests/ExpertDeployConfigurationModelTests.cs
+++ b/src/Foundry.Deploy.Tests/ExpertDeployConfigurationModelTests.cs
@@ -61,4 +61,69 @@ public sealed class ExpertDeployConfigurationModelTests
         Assert.Equal("project-token", document.Telemetry.ProjectToken);
         Assert.Equal(TelemetryRuntimePayloadSources.Release, document.Telemetry.RuntimePayloadSource);
     }
+
+    [Fact]
+    public void Deserialize_WhenAutopilotProvisioningModeIsMissing_DefaultsToJsonProfile()
+    {
+        const string json = """
+            {
+              "schemaVersion": 2,
+              "autopilot": {
+                "isEnabled": true
+              }
+            }
+            """;
+
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+        options.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+
+        FoundryDeployConfigurationDocument? document = JsonSerializer.Deserialize<FoundryDeployConfigurationDocument>(json, options);
+
+        Assert.NotNull(document);
+        Assert.Equal(AutopilotProvisioningMode.JsonProfile, document.Autopilot.ProvisioningMode);
+    }
+
+    [Fact]
+    public void Deserialize_WhenHardwareHashSettingsAreConfigured_PreservesRuntimeMetadata()
+    {
+        const string json = """
+            {
+              "schemaVersion": 2,
+              "autopilot": {
+                "isEnabled": true,
+                "provisioningMode": "hardwareHashUpload",
+                "hardwareHashUpload": {
+                  "tenantId": "tenant-id",
+                  "clientId": "client-id",
+                  "activeCertificateKeyId": "certificate-key-id",
+                  "activeCertificateThumbprint": "ABCDEF123456",
+                  "activeCertificateExpiresOnUtc": "2026-12-01T00:00:00+00:00",
+                  "defaultGroupTag": "Sales"
+                }
+              }
+            }
+            """;
+
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+        options.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+
+        FoundryDeployConfigurationDocument? document = JsonSerializer.Deserialize<FoundryDeployConfigurationDocument>(json, options);
+
+        Assert.NotNull(document);
+        Assert.Equal(AutopilotProvisioningMode.HardwareHashUpload, document.Autopilot.ProvisioningMode);
+        Assert.Equal("tenant-id", document.Autopilot.HardwareHashUpload.TenantId);
+        Assert.Equal("client-id", document.Autopilot.HardwareHashUpload.ClientId);
+        Assert.Equal("certificate-key-id", document.Autopilot.HardwareHashUpload.ActiveCertificateKeyId);
+        Assert.Equal("ABCDEF123456", document.Autopilot.HardwareHashUpload.ActiveCertificateThumbprint);
+        Assert.Equal(DateTimeOffset.Parse("2026-12-01T00:00:00+00:00"), document.Autopilot.HardwareHashUpload.ActiveCertificateExpiresOnUtc);
+        Assert.Equal("Sales", document.Autopilot.HardwareHashUpload.DefaultGroupTag);
+    }
 }

--- a/src/Foundry.Deploy/Models/Configuration/AutopilotProvisioningMode.cs
+++ b/src/Foundry.Deploy/Models/Configuration/AutopilotProvisioningMode.cs
@@ -1,0 +1,17 @@
+namespace Foundry.Deploy.Models.Configuration;
+
+/// <summary>
+/// Defines how Foundry.Deploy should provision Autopilot data during OS deployment.
+/// </summary>
+public enum AutopilotProvisioningMode
+{
+    /// <summary>
+    /// Stages an offline Autopilot profile JSON file into the applied Windows image.
+    /// </summary>
+    JsonProfile,
+
+    /// <summary>
+    /// Captures and uploads the device hardware hash from WinPE.
+    /// </summary>
+    HardwareHashUpload
+}

--- a/src/Foundry.Deploy/Models/Configuration/AutopilotProvisioningMode.cs
+++ b/src/Foundry.Deploy/Models/Configuration/AutopilotProvisioningMode.cs
@@ -1,8 +1,11 @@
+using System.Text.Json.Serialization;
+
 namespace Foundry.Deploy.Models.Configuration;
 
 /// <summary>
 /// Defines how Foundry.Deploy should provision Autopilot data during OS deployment.
 /// </summary>
+[JsonConverter(typeof(AutopilotProvisioningModeJsonConverter))]
 public enum AutopilotProvisioningMode
 {
     /// <summary>

--- a/src/Foundry.Deploy/Models/Configuration/AutopilotProvisioningModeJsonConverter.cs
+++ b/src/Foundry.Deploy/Models/Configuration/AutopilotProvisioningModeJsonConverter.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Foundry.Deploy.Models.Configuration;
+
+/// <summary>
+/// Reads and writes Autopilot provisioning mode strings without changing unrelated Deploy enum serialization.
+/// </summary>
+public sealed class AutopilotProvisioningModeJsonConverter : JsonConverter<AutopilotProvisioningMode>
+{
+    /// <inheritdoc />
+    public override AutopilotProvisioningMode Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out int numericValue))
+        {
+            return Enum.IsDefined(typeof(AutopilotProvisioningMode), numericValue)
+                ? (AutopilotProvisioningMode)numericValue
+                : throw new JsonException($"Unsupported Autopilot provisioning mode value '{numericValue}'.");
+        }
+
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            throw new JsonException("Autopilot provisioning mode must be a string or numeric enum value.");
+        }
+
+        return reader.GetString() switch
+        {
+            "jsonProfile" or "JsonProfile" => AutopilotProvisioningMode.JsonProfile,
+            "hardwareHashUpload" or "HardwareHashUpload" => AutopilotProvisioningMode.HardwareHashUpload,
+            string value => throw new JsonException($"Unsupported Autopilot provisioning mode value '{value}'."),
+            null => throw new JsonException("Autopilot provisioning mode cannot be null.")
+        };
+    }
+
+    /// <inheritdoc />
+    public override void Write(
+        Utf8JsonWriter writer,
+        AutopilotProvisioningMode value,
+        JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value switch
+        {
+            AutopilotProvisioningMode.JsonProfile => "jsonProfile",
+            AutopilotProvisioningMode.HardwareHashUpload => "hardwareHashUpload",
+            _ => throw new JsonException($"Unsupported Autopilot provisioning mode value '{value}'.")
+        });
+    }
+}

--- a/src/Foundry.Deploy/Models/Configuration/DeployAutopilotHardwareHashUploadSettings.cs
+++ b/src/Foundry.Deploy/Models/Configuration/DeployAutopilotHardwareHashUploadSettings.cs
@@ -1,0 +1,37 @@
+namespace Foundry.Deploy.Models.Configuration;
+
+/// <summary>
+/// Carries non-secret tenant and certificate metadata needed by the WinPE hardware hash upload workflow.
+/// </summary>
+public sealed record DeployAutopilotHardwareHashUploadSettings
+{
+    /// <summary>
+    /// Gets the Microsoft Entra tenant ID used for Graph authentication.
+    /// </summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>
+    /// Gets the application client ID used for certificate-based Graph authentication.
+    /// </summary>
+    public string? ClientId { get; init; }
+
+    /// <summary>
+    /// Gets the selected app registration certificate credential identifier for diagnostics.
+    /// </summary>
+    public string? ActiveCertificateKeyId { get; init; }
+
+    /// <summary>
+    /// Gets the selected certificate thumbprint expected from the encrypted media certificate.
+    /// </summary>
+    public string? ActiveCertificateThumbprint { get; init; }
+
+    /// <summary>
+    /// Gets the selected certificate expiration time used to skip expired media without blocking OS deployment.
+    /// </summary>
+    public DateTimeOffset? ActiveCertificateExpiresOnUtc { get; init; }
+
+    /// <summary>
+    /// Gets the default group tag offered by Foundry.Deploy for hardware hash upload.
+    /// </summary>
+    public string? DefaultGroupTag { get; init; }
+}

--- a/src/Foundry.Deploy/Models/Configuration/DeployAutopilotSettings.cs
+++ b/src/Foundry.Deploy/Models/Configuration/DeployAutopilotSettings.cs
@@ -1,7 +1,27 @@
 namespace Foundry.Deploy.Models.Configuration;
 
+/// <summary>
+/// Describes the reduced Autopilot runtime settings consumed by Foundry.Deploy.
+/// </summary>
 public sealed record DeployAutopilotSettings
 {
+    /// <summary>
+    /// Gets whether Autopilot provisioning is enabled.
+    /// </summary>
     public bool IsEnabled { get; init; }
+
+    /// <summary>
+    /// Gets the provisioning method selected by Foundry OSD.
+    /// </summary>
+    public AutopilotProvisioningMode ProvisioningMode { get; init; } = AutopilotProvisioningMode.JsonProfile;
+
+    /// <summary>
+    /// Gets the profile folder name selected for JSON profile staging.
+    /// </summary>
     public string? DefaultProfileFolderName { get; init; }
+
+    /// <summary>
+    /// Gets runtime metadata required for hardware hash upload mode.
+    /// </summary>
+    public DeployAutopilotHardwareHashUploadSettings HardwareHashUpload { get; init; } = new();
 }

--- a/src/Foundry.Deploy/Models/Configuration/FoundryDeployConfigurationDocument.cs
+++ b/src/Foundry.Deploy/Models/Configuration/FoundryDeployConfigurationDocument.cs
@@ -10,7 +10,7 @@ public sealed record FoundryDeployConfigurationDocument
     /// <summary>
     /// Gets the current configuration schema version.
     /// </summary>
-    public const int CurrentSchemaVersion = 2;
+    public const int CurrentSchemaVersion = 3;
 
     /// <summary>
     /// Gets the schema version of this configuration.
@@ -28,7 +28,7 @@ public sealed record FoundryDeployConfigurationDocument
     public DeployCustomizationSettings Customization { get; init; } = new();
 
     /// <summary>
-    /// Gets Autopilot profile staging settings.
+    /// Gets Autopilot provisioning settings.
     /// </summary>
     public DeployAutopilotSettings Autopilot { get; init; } = new();
 

--- a/src/Foundry.Deploy/Services/Configuration/ConfigurationJsonDefaults.cs
+++ b/src/Foundry.Deploy/Services/Configuration/ConfigurationJsonDefaults.cs
@@ -12,7 +12,6 @@ internal static class ConfigurationJsonDefaults
         PropertyNameCaseInsensitive = true,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         ReadCommentHandling = JsonCommentHandling.Skip,
-        WriteIndented = true,
-        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+        WriteIndented = true
     };
 }

--- a/src/Foundry.Deploy/Services/Configuration/ConfigurationJsonDefaults.cs
+++ b/src/Foundry.Deploy/Services/Configuration/ConfigurationJsonDefaults.cs
@@ -12,6 +12,7 @@ internal static class ConfigurationJsonDefaults
         PropertyNameCaseInsensitive = true,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         ReadCommentHandling = JsonCommentHandling.Skip,
-        WriteIndented = true
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
     };
 }

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentRuntimeState.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentRuntimeState.cs
@@ -195,7 +195,7 @@ public sealed record DeploymentRuntimeState
     public string? FirmwareUpdateTitle { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether Autopilot staging is enabled.
+    /// Gets or sets a value indicating whether Autopilot provisioning is enabled.
     /// </summary>
     public bool IsAutopilotEnabled { get; set; }
 

--- a/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/ExpertDeployConfigurationStateService.cs
@@ -73,15 +73,17 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
     public bool IsAutopilotEnabled => Current.Autopilot.IsEnabled;
 
     /// <inheritdoc />
-    public bool IsAutopilotConfigurationReady => !Current.Autopilot.IsEnabled || GetSelectedAutopilotProfile() is not null;
+    public bool IsAutopilotConfigurationReady => AutopilotConfigurationValidator.IsReady(Current.Autopilot, DateTimeOffset.UtcNow);
 
     /// <inheritdoc />
-    public string? SelectedAutopilotProfileDisplayName => Current.Autopilot.IsEnabled
+    public string? SelectedAutopilotProfileDisplayName => Current.Autopilot.IsEnabled &&
+                                                          Current.Autopilot.ProvisioningMode == AutopilotProvisioningMode.JsonProfile
         ? GetSelectedAutopilotProfile()?.DisplayName
         : null;
 
     /// <inheritdoc />
-    public string? SelectedAutopilotProfileFolderName => Current.Autopilot.IsEnabled
+    public string? SelectedAutopilotProfileFolderName => Current.Autopilot.IsEnabled &&
+                                                         Current.Autopilot.ProvisioningMode == AutopilotProvisioningMode.JsonProfile
         ? GetSelectedAutopilotProfile()?.FolderName
         : null;
 
@@ -213,7 +215,45 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
         return settings with
         {
             DefaultProfileId = defaultProfileId,
-            Profiles = profiles
+            Profiles = profiles,
+            HardwareHashUpload = SanitizeHardwareHashUploadSettings(settings.HardwareHashUpload)
+        };
+    }
+
+    private static AutopilotHardwareHashUploadSettings SanitizeHardwareHashUploadSettings(
+        AutopilotHardwareHashUploadSettings? settings)
+    {
+        if (settings?.Tenant is null)
+        {
+            return new AutopilotHardwareHashUploadSettings();
+        }
+
+        string[] knownGroupTags = (settings.KnownGroupTags ?? [])
+            .Select(groupTag => groupTag.Trim())
+            .Where(groupTag => !string.IsNullOrWhiteSpace(groupTag))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(groupTag => groupTag, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return settings with
+        {
+            Tenant = new AutopilotTenantRegistrationSettings
+            {
+                TenantId = NormalizeOptional(settings.Tenant.TenantId),
+                ApplicationObjectId = NormalizeOptional(settings.Tenant.ApplicationObjectId),
+                ClientId = NormalizeOptional(settings.Tenant.ClientId),
+                ServicePrincipalObjectId = NormalizeOptional(settings.Tenant.ServicePrincipalObjectId)
+            },
+            ActiveCertificate = settings.ActiveCertificate is null
+                ? null
+                : settings.ActiveCertificate with
+                {
+                    KeyId = NormalizeOptional(settings.ActiveCertificate.KeyId),
+                    Thumbprint = NormalizeOptional(settings.ActiveCertificate.Thumbprint)?.ToUpperInvariant(),
+                    DisplayName = NormalizeOptional(settings.ActiveCertificate.DisplayName)
+                },
+            KnownGroupTags = knownGroupTags,
+            DefaultGroupTag = NormalizeOptional(settings.DefaultGroupTag)
         };
     }
 
@@ -235,6 +275,12 @@ internal sealed class ExpertDeployConfigurationStateService : IExpertDeployConfi
                 AllowManualSuffixEdit = !settings.MachineNaming.IsEnabled || settings.MachineNaming.AllowManualSuffixEdit
             }
         };
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        string? trimmed = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
     }
 
     private NetworkMediaReadinessEvaluation EvaluateNetworkMediaReadiness()

--- a/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/IExpertDeployConfigurationStateService.cs
@@ -43,7 +43,7 @@ public interface IExpertDeployConfigurationStateService
     bool AreRequiredSecretsReady { get; }
 
     /// <summary>
-    /// Gets a value indicating whether Autopilot staging is enabled.
+    /// Gets a value indicating whether Autopilot provisioning is enabled.
     /// </summary>
     bool IsAutopilotEnabled { get; }
 


### PR DESCRIPTION
## Summary
- Add Autopilot provisioning mode configuration for JSON profile and hardware hash upload modes.
- Add persistent non-secret tenant/app/certificate metadata models and reduced Deploy runtime metadata.
- Add mode-aware readiness validation and deploy configuration projection while keeping legacy missing-mode JSON as JSON profile mode.
- Update Phase 1 progress tracking in the implementation plan.

## Reason
Phase 1 establishes the configuration contract required by later Autopilot hardware hash upload work without implementing tenant onboarding, UI, media staging, or WinPE runtime upload behavior yet.

## Main changes
- Adds `AutopilotProvisioningMode`, hardware hash upload metadata records, and schema version bumps.
- Adds string enum serialization for configuration JSON.
- Adds `AutopilotConfigurationValidator` and uses it in deploy config generation and OSD readiness.
- Mirrors the reduced runtime model in Foundry.Deploy configuration models.
- Adds tests for legacy defaults, hash mode readiness, invalid/expired certificate metadata, unsupported mode values, null malformed payloads, and Deploy model deserialization.

## Testing
- `dotnet test .\src\Foundry.Core.Tests\Foundry.Core.Tests.csproj --configuration Debug`
- `dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --configuration Debug`
- `dotnet build .\src\Foundry.slnx --configuration Debug`

## Notes
- UI-only manual checks are explicitly deferred to Phase 3.
- Runtime profile gating in Foundry.Deploy remains for Phase 5, where Deploy starts branching by provisioning mode.
- This PR must not be merged or squashed automatically; repository owner will handle the merge workflow.
