### PR TITLE
fix(winpe): provision USB partitions with storage cmdlets

### DIFF
--- a/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
@@ -163,40 +163,98 @@ public sealed class WinPeUsbMediaServiceTests
     }
 
     [Fact]
-    public void BuildDiskPartScript_WhenGptQuickFormat_CreatesBootAndCachePartitionsWithoutActive()
+    public void BuildPowerShellProvisioningScript_WhenGptQuickFormat_CreatesBootAndCachePartitionsWithoutActive()
     {
-        IReadOnlyList<string> script = WinPeUsbMediaService.BuildDiskPartScript(
+        string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(
             diskNumber: 7,
             partitionStyle: UsbPartitionStyle.Gpt,
             formatMode: UsbFormatMode.Quick,
             bootDriveLetter: 'S',
             cacheDriveLetter: 'T');
 
-        Assert.Contains("select disk 7", script);
-        Assert.Contains("convert mbr noerr", script);
-        Assert.Contains("convert gpt", script);
-        Assert.Contains("create partition primary size=4096", script);
-        Assert.Contains("format fs=fat32 quick label=BOOT", script);
-        Assert.Contains("format fs=ntfs quick label=\"Foundry Cache\"", script);
-        Assert.DoesNotContain("active", script);
+        Assert.Contains("$diskNumber = 7", script, StringComparison.Ordinal);
+        Assert.Contains("$partitionStyle = 'GPT'", script, StringComparison.Ordinal);
+        Assert.Contains("Initialize-Disk -Number $diskNumber -PartitionStyle $partitionStyle", script, StringComparison.Ordinal);
+        Assert.Contains("New-Partition -DiskNumber $diskNumber -Size 4096MB -DriveLetter $bootDriveLetter", script, StringComparison.Ordinal);
+        Assert.Contains("FileSystem = 'FAT32'", script, StringComparison.Ordinal);
+        Assert.Contains("NewFileSystemLabel = 'BOOT'", script, StringComparison.Ordinal);
+        Assert.Contains("New-Partition -DiskNumber $diskNumber -UseMaximumSize -DriveLetter $cacheDriveLetter", script, StringComparison.Ordinal);
+        Assert.Contains("FileSystem = 'NTFS'", script, StringComparison.Ordinal);
+        Assert.Contains("NewFileSystemLabel = 'Foundry Cache'", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("-IsActive $true", script, StringComparison.Ordinal);
+        Assert.Contains("$fullFormat = $false", script, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void BuildDiskPartScript_WhenMbrCompleteFormat_MarksBootPartitionActiveWithoutQuickFormat()
+    public void BuildPowerShellProvisioningScript_WhenFormattingFreshPartitions_FormatsByExplicitDriveLetter()
     {
-        IReadOnlyList<string> script = WinPeUsbMediaService.BuildDiskPartScript(
+        string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(
+            diskNumber: 7,
+            partitionStyle: UsbPartitionStyle.Gpt,
+            formatMode: UsbFormatMode.Quick,
+            bootDriveLetter: 'S',
+            cacheDriveLetter: 'T');
+
+        Assert.DoesNotContain("diskpart", script, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("select partition", script, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("select volume", script, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("$bootDriveLetter = 'S'", script, StringComparison.Ordinal);
+        Assert.Contains("$cacheDriveLetter = 'T'", script, StringComparison.Ordinal);
+        Assert.Contains("DriveLetter = $bootDriveLetter", script, StringComparison.Ordinal);
+        Assert.Contains("DriveLetter = $cacheDriveLetter", script, StringComparison.Ordinal);
+        Assert.Contains("Format-Volume @bootFormatArguments", script, StringComparison.Ordinal);
+        Assert.Contains("Format-Volume @cacheFormatArguments", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildPowerShellProvisioningScript_WhenFormattingUsb_EmitsProgressMarkers()
+    {
+        string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(
+            diskNumber: 7,
+            partitionStyle: UsbPartitionStyle.Gpt,
+            formatMode: UsbFormatMode.Quick,
+            bootDriveLetter: 'S',
+            cacheDriveLetter: 'T');
+
+        Assert.Contains("FOUNDRY_USB_PROGRESS|", script, StringComparison.Ordinal);
+        Assert.Contains("Write-FoundryUsbProgress 26 'Clearing USB partition table.'", script, StringComparison.Ordinal);
+        Assert.Contains("Write-FoundryUsbProgress 44 'Formatting BOOT partition.'", script, StringComparison.Ordinal);
+        Assert.Contains("Write-FoundryUsbProgress 53 'Formatting cache partition.'", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildPowerShellProvisioningScript_WhenFormattingUsb_EmitsVerboseMarkers()
+    {
+        string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(
+            diskNumber: 7,
+            partitionStyle: UsbPartitionStyle.Gpt,
+            formatMode: UsbFormatMode.Quick,
+            bootDriveLetter: 'S',
+            cacheDriveLetter: 'T');
+
+        Assert.Contains("FOUNDRY_USB_VERBOSE|", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("Write-Verbose", script, StringComparison.Ordinal);
+        Assert.Contains("Write-FoundryUsbVerbose \"Disk opened.", script, StringComparison.Ordinal);
+        Assert.Contains("Write-FoundryUsbVerbose \"BOOT partition created.", script, StringComparison.Ordinal);
+        Assert.Contains("Write-FoundryUsbVerbose \"Cache partition formatted.", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildPowerShellProvisioningScript_WhenMbrCompleteFormat_MarksBootPartitionActiveAndFullFormat()
+    {
+        string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(
             diskNumber: 8,
             partitionStyle: UsbPartitionStyle.Mbr,
             formatMode: UsbFormatMode.Complete,
             bootDriveLetter: 'U',
             cacheDriveLetter: 'V');
 
-        Assert.Contains("convert mbr", script);
-        Assert.DoesNotContain("convert mbr noerr", script);
-        Assert.DoesNotContain("convert gpt", script);
-        Assert.Contains("format fs=fat32 label=BOOT", script);
-        Assert.Contains("active", script);
-        Assert.Contains("format fs=ntfs label=\"Foundry Cache\"", script);
+        Assert.Contains("$diskNumber = 8", script, StringComparison.Ordinal);
+        Assert.Contains("$partitionStyle = 'MBR'", script, StringComparison.Ordinal);
+        Assert.Contains("$fullFormat = $true", script, StringComparison.Ordinal);
+        Assert.Contains("Set-Partition -DiskNumber $diskNumber -PartitionNumber $bootPartition.PartitionNumber -IsActive $true", script, StringComparison.Ordinal);
+        Assert.Contains("if ($fullFormat) { $bootFormatArguments['Full'] = $true }", script, StringComparison.Ordinal);
+        Assert.Contains("if ($fullFormat) { $cacheFormatArguments['Full'] = $true }", script, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -314,7 +372,79 @@ public sealed class WinPeUsbMediaServiceTests
         Assert.Contains("EncodedCommand", runner.Executions[0].Arguments, StringComparison.Ordinal);
     }
 
-    private sealed class FakeRunner(string output) : IWinPeProcessRunner
+    [Fact]
+    public async Task ProvisionAndPopulateAsync_WhenPartitioningUsb_UsesPowerShellStorageProvisioning()
+    {
+        string payload = """
+                         {"Number":9,"FriendlyName":"Safe USB","SerialNumber":"SERIAL","UniqueId":"UNIQUE","BusType":"USB","IsRemovable":true,"IsSystem":false,"IsBoot":false,"Size":64000000000}
+                         """;
+        var runner = new FakeRunner(payload);
+        using TempWorkspace workspace = TempWorkspace.Create();
+        var service = new WinPeUsbMediaService(runner);
+
+        await service.ProvisionAndPopulateAsync(
+            new UsbOutputOptions
+            {
+                TargetDiskNumber = 9,
+                ExpectedDiskFriendlyName = "Safe USB",
+                PartitionStyle = UsbPartitionStyle.Gpt,
+                FormatMode = UsbFormatMode.Quick
+            },
+            new WinPeBuildArtifact
+            {
+                WorkingDirectoryPath = workspace.RootPath,
+                MediaDirectoryPath = Path.Combine(workspace.RootPath, "media"),
+                Architecture = WinPeArchitecture.X64
+            },
+            new WinPeToolPaths { PowerShellPath = "pwsh.exe" },
+            useBootEx: false,
+            CancellationToken.None);
+
+        Assert.DoesNotContain("diskpart.exe", runner.Executions.Select(execution => execution.FileName));
+        Assert.Equal(2, runner.Executions.Count(execution => execution.FileName == "pwsh.exe"));
+    }
+
+    [Fact]
+    public async Task ProvisionAndPopulateAsync_WhenProvisioningStreamsOutput_ReportsProvisioningSubstepsAndVerboseDetails()
+    {
+        string payload = """
+                         {"Number":9,"FriendlyName":"Safe USB","SerialNumber":"SERIAL","UniqueId":"UNIQUE","BusType":"USB","IsRemovable":true,"IsSystem":false,"IsBoot":false,"Size":64000000000}
+                         """;
+        var runner = new FakeOutputRunner(payload);
+        var progress = new RecordingProgress();
+        using TempWorkspace workspace = TempWorkspace.Create();
+        var service = new WinPeUsbMediaService(runner);
+
+        await service.ProvisionAndPopulateAsync(
+            new UsbOutputOptions
+            {
+                TargetDiskNumber = 9,
+                ExpectedDiskFriendlyName = "Safe USB",
+                PartitionStyle = UsbPartitionStyle.Gpt,
+                FormatMode = UsbFormatMode.Quick,
+                Progress = progress
+            },
+            new WinPeBuildArtifact
+            {
+                WorkingDirectoryPath = workspace.RootPath,
+                MediaDirectoryPath = Path.Combine(workspace.RootPath, "media"),
+                Architecture = WinPeArchitecture.X64
+            },
+            new WinPeToolPaths { PowerShellPath = "pwsh.exe" },
+            useBootEx: false,
+            CancellationToken.None);
+
+        Assert.Contains(progress.Reports, report => report is { Percent: 26, Status: "Clearing USB partition table." });
+        Assert.Contains(progress.Reports, report => report is { Percent: 44, Status: "Formatting BOOT partition." });
+        Assert.Contains(progress.Reports, report => report is { Percent: 53, Status: "Formatting cache partition." });
+        Assert.Contains(
+            progress.Reports,
+            report => report.Percent == 44 &&
+                      report.Status == "Formatting BOOT partition." &&
+                      report.LogDetail == "BOOT partition formatted. DriveLetter=S, FileSystem=FAT32, Label=BOOT.");
+    }
+
+    private class FakeRunner(string output) : IWinPeProcessRunner
     {
         public List<WinPeProcessExecution> Executions { get; } = [];
 
@@ -353,6 +483,36 @@ public sealed class WinPeUsbMediaServiceTests
             CancellationToken cancellationToken)
         {
             throw new NotSupportedException();
+        }
+    }
+
+    private sealed class FakeOutputRunner(string output) : FakeRunner(output), IWinPeProcessOutputRunner
+    {
+        public Task<WinPeProcessExecution> RunWithOutputAsync(
+            string fileName,
+            string arguments,
+            string workingDirectory,
+            Action<string>? onOutputData,
+            Action<string>? onErrorData,
+            CancellationToken cancellationToken,
+            IReadOnlyDictionary<string, string>? environmentOverrides = null)
+        {
+            onOutputData?.Invoke("FOUNDRY_USB_PROGRESS|26|Clearing USB partition table.");
+            onOutputData?.Invoke("FOUNDRY_USB_PROGRESS|44|Formatting BOOT partition.");
+            onOutputData?.Invoke("FOUNDRY_USB_VERBOSE|BOOT partition formatted. DriveLetter=S, FileSystem=FAT32, Label=BOOT.");
+            onOutputData?.Invoke("FOUNDRY_USB_PROGRESS|53|Formatting cache partition.");
+
+            return RunAsync(fileName, arguments, workingDirectory, cancellationToken, environmentOverrides);
+        }
+    }
+
+    private sealed class RecordingProgress : IProgress<WinPeMediaProgress>
+    {
+        public List<WinPeMediaProgress> Reports { get; } = [];
+
+        public void Report(WinPeMediaProgress value)
+        {
+            Reports.Add(value);
         }
     }
 

--- a/src/Foundry.Core/Services/WinPe/WinPeMediaProgress.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMediaProgress.cs
@@ -4,4 +4,5 @@ public sealed record WinPeMediaProgress
 {
     public int Percent { get; init; }
     public string Status { get; init; } = string.Empty;
+    public string LogDetail { get; init; } = string.Empty;
 }

--- a/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
@@ -5,6 +5,9 @@ namespace Foundry.Core.Services.WinPe;
 
 public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
 {
+    private const string UsbProvisioningProgressPrefix = "FOUNDRY_USB_PROGRESS|";
+    private const string UsbProvisioningVerbosePrefix = "FOUNDRY_USB_VERBOSE|";
+
     private readonly IWinPeProcessRunner _processRunner;
     private readonly IWinPeRuntimePayloadProvisioningService _runtimePayloadProvisioningService;
 
@@ -126,6 +129,7 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(artifact);
+        ArgumentNullException.ThrowIfNull(tools);
 
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -181,7 +185,9 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
             options.FormatMode,
             bootDriveLetter,
             cacheDriveLetter,
+            tools,
             artifact.WorkingDirectoryPath,
+            options.Progress,
             cancellationToken).ConfigureAwait(false);
         if (!provisioningResult.IsSuccess)
         {
@@ -320,42 +326,102 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
         return exitCode is >= 0 and <= 7;
     }
 
-    internal static IReadOnlyList<string> BuildDiskPartScript(
+    internal static string BuildPowerShellProvisioningScript(
         int diskNumber,
         UsbPartitionStyle partitionStyle,
         UsbFormatMode formatMode,
         char bootDriveLetter,
         char cacheDriveLetter)
     {
-        string[] conversionLines = partitionStyle == UsbPartitionStyle.Gpt
-            ? ["convert mbr noerr", "convert gpt"]
-            : ["convert mbr"];
-        string activeLine = partitionStyle == UsbPartitionStyle.Mbr ? "active" : string.Empty;
-        string formatSuffix = formatMode == UsbFormatMode.Quick ? " quick" : string.Empty;
+        string partitionStyleText = partitionStyle == UsbPartitionStyle.Gpt ? "GPT" : "MBR";
+        string fullFormatValue = formatMode == UsbFormatMode.Complete ? "$true" : "$false";
+        char normalizedBootDriveLetter = char.ToUpperInvariant(bootDriveLetter);
+        char normalizedCacheDriveLetter = char.ToUpperInvariant(cacheDriveLetter);
+        string activeLine = partitionStyle == UsbPartitionStyle.Mbr
+            ? "Set-Partition -DiskNumber $diskNumber -PartitionNumber $bootPartition.PartitionNumber -IsActive $true -ErrorAction Stop"
+            : string.Empty;
 
         string[] scriptLines =
         [
-            $"select disk {diskNumber}",
-            "online disk noerr",
-            "attributes disk clear readonly noerr",
-            "clean",
-            ..conversionLines,
-            "create partition primary size=4096",
-            "select partition 1",
-            $"assign letter={bootDriveLetter}",
-            $"select volume={bootDriveLetter}",
-            $"format fs=fat32{formatSuffix} label=BOOT",
+            "$ErrorActionPreference = 'Stop'",
+            "Import-Module Storage",
+            "function Write-FoundryUsbProgress([int]$Percent, [string]$Status) {",
+            "    Write-Output (\"FOUNDRY_USB_PROGRESS|{0}|{1}\" -f $Percent, $Status)",
+            "}",
+            "function Write-FoundryUsbVerbose([string]$Message) {",
+            "    Write-Output (\"FOUNDRY_USB_VERBOSE|{0}\" -f $Message)",
+            "}",
+            $"$diskNumber = {diskNumber}",
+            $"$partitionStyle = '{partitionStyleText}'",
+            $"$fullFormat = {fullFormatValue}",
+            $"$bootDriveLetter = '{normalizedBootDriveLetter}'",
+            $"$cacheDriveLetter = '{normalizedCacheDriveLetter}'",
+            "Write-FoundryUsbVerbose \"Provisioning disk $diskNumber. PartitionStyle=$partitionStyle, FullFormat=$fullFormat, BootDriveLetter=$bootDriveLetter, CacheDriveLetter=$cacheDriveLetter.\"",
+            "Write-FoundryUsbProgress 21 'Opening USB disk.'",
+            "$disk = Get-Disk -Number $diskNumber -ErrorAction Stop",
+            "Write-FoundryUsbVerbose \"Disk opened. Number=$($disk.Number), FriendlyName=$($disk.FriendlyName), PartitionStyle=$($disk.PartitionStyle), Size=$($disk.Size), IsOffline=$($disk.IsOffline), IsReadOnly=$($disk.IsReadOnly).\"",
+            "Write-FoundryUsbProgress 23 'Preparing USB disk attributes.'",
+            "if ($disk.IsOffline) { Set-Disk -Number $diskNumber -IsOffline $false -ErrorAction Stop }",
+            "if ($disk.IsReadOnly) { Set-Disk -Number $diskNumber -IsReadOnly $false -ErrorAction Stop }",
+            "Write-FoundryUsbVerbose 'USB disk attributes prepared.'",
+            "Write-FoundryUsbProgress 26 'Clearing USB partition table.'",
+            "Clear-Disk -Number $diskNumber -RemoveData -RemoveOEM -Confirm:$false -ErrorAction Stop",
+            "Update-HostStorageCache -ErrorAction SilentlyContinue",
+            "Write-FoundryUsbVerbose 'USB partition table cleared and host storage cache refreshed.'",
+            "Write-FoundryUsbProgress 32 'Initializing USB partition table.'",
+            "$disk = Get-Disk -Number $diskNumber -ErrorAction Stop",
+            "if ($disk.PartitionStyle -eq 'RAW') {",
+            "    Initialize-Disk -Number $diskNumber -PartitionStyle $partitionStyle -ErrorAction Stop",
+            "} elseif ([string]$disk.PartitionStyle -ne $partitionStyle) {",
+            "    throw \"Disk $diskNumber could not be reset to $partitionStyle. Current partition style: $($disk.PartitionStyle).\"",
+            "}",
+            "$disk = Get-Disk -Number $diskNumber -ErrorAction Stop",
+            "Write-FoundryUsbVerbose \"USB partition table initialized. CurrentPartitionStyle=$($disk.PartitionStyle).\"",
+            "Write-FoundryUsbProgress 38 'Creating BOOT partition.'",
+            "$bootPartition = New-Partition -DiskNumber $diskNumber -Size 4096MB -DriveLetter $bootDriveLetter -ErrorAction Stop",
+            "Write-FoundryUsbVerbose \"BOOT partition created. PartitionNumber=$($bootPartition.PartitionNumber), DriveLetter=$($bootPartition.DriveLetter), Size=$($bootPartition.Size).\"",
             activeLine,
-            "create partition primary",
-            "select partition 2",
-            $"assign letter={cacheDriveLetter}",
-            $"select volume={cacheDriveLetter}",
-            $"format fs=ntfs{formatSuffix} label=\"Foundry Cache\""
+            "if ($partitionStyle -eq 'MBR') { Write-FoundryUsbVerbose \"BOOT partition marked active. PartitionNumber=$($bootPartition.PartitionNumber).\" }",
+            "Write-FoundryUsbProgress 44 'Formatting BOOT partition.'",
+            "$bootFormatArguments = @{",
+            "    DriveLetter = $bootDriveLetter",
+            "    FileSystem = 'FAT32'",
+            "    NewFileSystemLabel = 'BOOT'",
+            "    Confirm = $false",
+            "    Force = $true",
+            "    ErrorAction = 'Stop'",
+            "}",
+            "if ($fullFormat) { $bootFormatArguments['Full'] = $true }",
+            "Format-Volume @bootFormatArguments | Out-Null",
+            "Write-FoundryUsbVerbose \"BOOT partition formatted. DriveLetter=$bootDriveLetter, FileSystem=FAT32, Label=BOOT.\"",
+            "Write-FoundryUsbProgress 49 'Creating cache partition.'",
+            "$cachePartition = New-Partition -DiskNumber $diskNumber -UseMaximumSize -DriveLetter $cacheDriveLetter -ErrorAction Stop",
+            "Write-FoundryUsbVerbose \"Cache partition created. PartitionNumber=$($cachePartition.PartitionNumber), DriveLetter=$($cachePartition.DriveLetter), Size=$($cachePartition.Size).\"",
+            "Write-FoundryUsbProgress 53 'Formatting cache partition.'",
+            "$cacheFormatArguments = @{",
+            "    DriveLetter = $cacheDriveLetter",
+            "    FileSystem = 'NTFS'",
+            "    NewFileSystemLabel = 'Foundry Cache'",
+            "    Confirm = $false",
+            "    Force = $true",
+            "    ErrorAction = 'Stop'",
+            "}",
+            "if ($fullFormat) { $cacheFormatArguments['Full'] = $true }",
+            "Format-Volume @cacheFormatArguments | Out-Null",
+            "Write-FoundryUsbVerbose \"Cache partition formatted. DriveLetter=$cacheDriveLetter, FileSystem=NTFS, Label=Foundry Cache.\"",
+            "Write-FoundryUsbProgress 55 'USB partitions formatted.'",
+            "[pscustomobject]@{",
+            "    DiskNumber = $diskNumber",
+            "    BootDriveLetter = \"$bootDriveLetter`:\"",
+            "    CacheDriveLetter = \"$cacheDriveLetter`:\"",
+            "} | ConvertTo-Json -Compress"
         ];
 
-        return scriptLines
+        return string.Join(
+            Environment.NewLine,
+            scriptLines
             .Where(line => !string.IsNullOrWhiteSpace(line))
-            .ToArray();
+            .ToArray());
     }
 
     internal static void InitializeCachePartitionDirectories(string cacheRootPath)
@@ -470,25 +536,35 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
         UsbFormatMode formatMode,
         char bootDriveLetter,
         char cacheDriveLetter,
+        WinPeToolPaths tools,
         string workingDirectoryPath,
+        IProgress<WinPeMediaProgress>? progress,
         CancellationToken cancellationToken)
     {
-        IReadOnlyList<string> diskPartScript = BuildDiskPartScript(
+        string script = BuildPowerShellProvisioningScript(
             diskNumber,
             partitionStyle,
             formatMode,
             bootDriveLetter,
             cacheDriveLetter);
 
-        string scriptPath = Path.Combine(workingDirectoryPath, "diskpart-usb.txt");
         Directory.CreateDirectory(workingDirectoryPath);
-        await File.WriteAllLinesAsync(scriptPath, diskPartScript, cancellationToken).ConfigureAwait(false);
-
-        WinPeProcessExecution execution = await _processRunner.RunAsync(
-            "diskpart.exe",
-            $"/s {WinPeProcessRunner.Quote(scriptPath)}",
-            workingDirectoryPath,
-            cancellationToken).ConfigureAwait(false);
+        string encodedScript = Convert.ToBase64String(Encoding.Unicode.GetBytes(script));
+        string arguments = $"-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand {encodedScript}";
+        var provisioningOutput = new UsbProvisioningOutputForwarder(progress);
+        WinPeProcessExecution execution = _processRunner is IWinPeProcessOutputRunner outputRunner
+            ? await outputRunner.RunWithOutputAsync(
+                tools.PowerShellPath,
+                arguments,
+                workingDirectoryPath,
+                provisioningOutput.Report,
+                null,
+                cancellationToken).ConfigureAwait(false)
+            : await _processRunner.RunAsync(
+                tools.PowerShellPath,
+                arguments,
+                workingDirectoryPath,
+                cancellationToken).ConfigureAwait(false);
 
         if (execution.IsSuccess)
         {
@@ -497,8 +573,8 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
 
         string diagnostic = $"{execution.ToDiagnosticText()}{Environment.NewLine}" +
                             $"PartitionStyle: {partitionStyle}{Environment.NewLine}" +
-                            "DiskPartScript:" + Environment.NewLine +
-                            string.Join(Environment.NewLine, diskPartScript);
+                            "PowerShellProvisioningScript:" + Environment.NewLine +
+                            script;
         return WinPeResult.Failure(
             WinPeErrorCodes.UsbProvisioningFailed,
             "Failed to partition and format the USB disk.",
@@ -544,6 +620,46 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
             Percent = Math.Clamp(percent, 0, 100),
             Status = status
         });
+    }
+
+    private sealed class UsbProvisioningOutputForwarder(IProgress<WinPeMediaProgress>? progress)
+    {
+        private int currentPercent = 20;
+        private string currentStatus = "Partitioning and formatting USB target.";
+
+        public void Report(string line)
+        {
+            if (progress is null)
+            {
+                return;
+            }
+
+            if (line.StartsWith(UsbProvisioningProgressPrefix, StringComparison.Ordinal))
+            {
+                string payload = line[UsbProvisioningProgressPrefix.Length..];
+                string[] parts = payload.Split('|', 2);
+                if (parts.Length != 2 || !int.TryParse(parts[0], out int percent))
+                {
+                    return;
+                }
+
+                currentPercent = percent;
+                currentStatus = parts[1];
+                ReportProgress(progress, currentPercent, currentStatus);
+                return;
+            }
+
+            string verboseLine = line.StartsWith(UsbProvisioningVerbosePrefix, StringComparison.Ordinal)
+                ? line[UsbProvisioningVerbosePrefix.Length..]
+                : line;
+
+            progress.Report(new WinPeMediaProgress
+            {
+                Percent = currentPercent,
+                Status = currentStatus,
+                LogDetail = verboseLine
+            });
+        }
     }
 
     private async Task<WinPeResult<WinPeUsbDiskIdentity>> GetDiskIdentityAsync(

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -726,6 +726,33 @@
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Partitioning and formatting USB target.</value>
   </data>
+  <data name="StartMedia.Operation.OpeningUsbDisk" xml:space="preserve">
+    <value>Opening USB disk.</value>
+  </data>
+  <data name="StartMedia.Operation.PreparingUsbDiskAttributes" xml:space="preserve">
+    <value>Preparing USB disk attributes.</value>
+  </data>
+  <data name="StartMedia.Operation.ClearingUsbPartitionTable" xml:space="preserve">
+    <value>Clearing USB partition table.</value>
+  </data>
+  <data name="StartMedia.Operation.InitializingUsbPartitionTable" xml:space="preserve">
+    <value>Initializing USB partition table.</value>
+  </data>
+  <data name="StartMedia.Operation.CreatingUsbBootPartition" xml:space="preserve">
+    <value>Creating BOOT partition.</value>
+  </data>
+  <data name="StartMedia.Operation.FormattingUsbBootPartition" xml:space="preserve">
+    <value>Formatting BOOT partition.</value>
+  </data>
+  <data name="StartMedia.Operation.CreatingUsbCachePartition" xml:space="preserve">
+    <value>Creating cache partition.</value>
+  </data>
+  <data name="StartMedia.Operation.FormattingUsbCachePartition" xml:space="preserve">
+    <value>Formatting cache partition.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbPartitionsFormatted" xml:space="preserve">
+    <value>USB partitions formatted.</value>
+  </data>
   <data name="StartMedia.Operation.CopyingUsbMedia" xml:space="preserve">
     <value>Copying WinPE media to USB.</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -726,6 +726,33 @@
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Partitionnement et formatage de la cible USB.</value>
   </data>
+  <data name="StartMedia.Operation.OpeningUsbDisk" xml:space="preserve">
+    <value>Ouverture du disque USB.</value>
+  </data>
+  <data name="StartMedia.Operation.PreparingUsbDiskAttributes" xml:space="preserve">
+    <value>Préparation des attributs du disque USB.</value>
+  </data>
+  <data name="StartMedia.Operation.ClearingUsbPartitionTable" xml:space="preserve">
+    <value>Effacement de la table de partitions USB.</value>
+  </data>
+  <data name="StartMedia.Operation.InitializingUsbPartitionTable" xml:space="preserve">
+    <value>Initialisation de la table de partitions USB.</value>
+  </data>
+  <data name="StartMedia.Operation.CreatingUsbBootPartition" xml:space="preserve">
+    <value>Création de la partition BOOT.</value>
+  </data>
+  <data name="StartMedia.Operation.FormattingUsbBootPartition" xml:space="preserve">
+    <value>Formatage de la partition BOOT.</value>
+  </data>
+  <data name="StartMedia.Operation.CreatingUsbCachePartition" xml:space="preserve">
+    <value>Création de la partition cache.</value>
+  </data>
+  <data name="StartMedia.Operation.FormattingUsbCachePartition" xml:space="preserve">
+    <value>Formatage de la partition cache.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbPartitionsFormatted" xml:space="preserve">
+    <value>Partitions USB formatées.</value>
+  </data>
   <data name="StartMedia.Operation.CopyingUsbMedia" xml:space="preserve">
     <value>Copie du média WinPE vers l'USB.</value>
   </data>

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -779,10 +779,11 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             : LocalizeFinalMediaStatus(progress.Status);
 
         logger.Debug(
-            "Final media output progress changed. CoreStatus={CoreStatus}, Percent={Percent}, NormalizedProgress={NormalizedProgress}",
+            "Final media output progress changed. CoreStatus={CoreStatus}, Percent={Percent}, NormalizedProgress={NormalizedProgress}, LogDetail={LogDetail}",
             progress.Status,
             progress.Percent,
-            normalizedProgress);
+            normalizedProgress,
+            progress.LogDetail);
         operationProgressService.Report(normalizedProgress, status);
     }
 
@@ -890,6 +891,15 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             "Validating USB target." => "StartMedia.Operation.ValidatingUsbTarget",
             "Checking USB target safety." => "StartMedia.Operation.CheckingUsbTargetSafety",
             "Partitioning and formatting USB target." => "StartMedia.Operation.PartitioningUsbTarget",
+            "Opening USB disk." => "StartMedia.Operation.OpeningUsbDisk",
+            "Preparing USB disk attributes." => "StartMedia.Operation.PreparingUsbDiskAttributes",
+            "Clearing USB partition table." => "StartMedia.Operation.ClearingUsbPartitionTable",
+            "Initializing USB partition table." => "StartMedia.Operation.InitializingUsbPartitionTable",
+            "Creating BOOT partition." => "StartMedia.Operation.CreatingUsbBootPartition",
+            "Formatting BOOT partition." => "StartMedia.Operation.FormattingUsbBootPartition",
+            "Creating cache partition." => "StartMedia.Operation.CreatingUsbCachePartition",
+            "Formatting cache partition." => "StartMedia.Operation.FormattingUsbCachePartition",
+            "USB partitions formatted." => "StartMedia.Operation.UsbPartitionsFormatted",
             "Copying WinPE media to USB." => "StartMedia.Operation.CopyingUsbMedia",
             "Configuring USB boot files." => "StartMedia.Operation.ConfiguringUsbBootFiles",
             "Verifying USB boot media." => "StartMedia.Operation.VerifyingUsbMedia",


### PR DESCRIPTION
## Summary
Fix USB boot media provisioning by replacing the DiskPart partitioning script with PowerShell Storage cmdlets and restoring detailed provisioning diagnostics in the media logs.

Fixes #165.

## Reason
DiskPart can create a partition without reliably keeping a usable volume selected on fresh or inconsistent removable media. The original issue failed after `select volume=<letter>`, and the later USB test showed the same class of failure when `format` ran without an explicitly selected volume.

Using Storage cmdlets lets Foundry create partitions with explicit drive letters and format those volumes directly by drive letter, without depending on DiskPart focus state. The Storage cmdlets are quiet on success, so the script emits Foundry progress markers plus clean provisioning diagnostics that are streamed back into `Foundry.log` through the existing media progress pipeline. Native PowerShell verbose/progress streams are not forwarded because Windows PowerShell 5.1 serializes them as CLIXML in redirected streams.

## Main changes
- Replaced USB provisioning via `diskpart.exe` with an encoded PowerShell Storage script.
- Clears, initializes, partitions, assigns drive letters, and formats BOOT/cache volumes through explicit Storage cmdlet calls.
- Preserves GPT/MBR behavior, quick/full formatting, and MBR active partition handling.
- Emits detailed USB provisioning progress for disk open, attribute prep, clear, initialize, BOOT creation/format, cache creation/format, and completion.
- Logs clean provisioning diagnostics on successful runs via `LogDetail`, while keeping the visible operation status readable.
- Added en-US and fr-FR translations for the new USB provisioning substeps.
- Added regression coverage proving provisioning no longer invokes DiskPart, formats by explicit drive letter, reports streamed provisioning substeps, and forwards clean verbose details.

## Testing notes
- Verified the new regression test failed before the fix while provisioning still invoked `diskpart.exe`.
- Ran `dotnet test src\Foundry.Core.Tests\Foundry.Core.Tests.csproj --filter "FullyQualifiedName~WinPeUsbMediaServiceTests" --logger "console;verbosity=normal"`: 23 passed.
- Ran `dotnet build src\Foundry\Foundry.csproj --no-restore`: succeeded, 0 warnings, 0 errors.
- Ran `dotnet test src\Foundry.Core.Tests\Foundry.Core.Tests.csproj --logger "console;verbosity=normal"`: 178 passed.
- Ran `git diff --check`: clean, with Windows line-ending warnings only.