### PR TITLE
fix(media): add USB size and cache space safeguards

### DIFF
--- a/src/Foundry.Core.Tests/Media/MediaPreflightServiceTests.cs
+++ b/src/Foundry.Core.Tests/Media/MediaPreflightServiceTests.cs
@@ -39,6 +39,32 @@ public sealed class MediaPreflightServiceTests
     }
 
     [Fact]
+    public void Evaluate_WhenUsbCandidateIsBelowMinimumSize_BlocksUsbCreationOnly()
+    {
+        MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(
+            CreateReadyOptions() with
+            {
+                SelectedUsbDisk = new WinPeUsbDiskCandidate
+                {
+                    DiskNumber = 3,
+                    FriendlyName = "Small USB",
+                    SerialNumber = "USB123",
+                    UniqueId = "USB-ID",
+                    BusType = "USB",
+                    IsRemovable = true,
+                    SizeBytes = 15UL * 1024UL * 1024UL * 1024UL
+                },
+                IsFinalExecutionEnabled = true
+            });
+
+        Assert.True(evaluation.CanCreateIso);
+        Assert.False(evaluation.CanGenerateUsbSummary);
+        Assert.False(evaluation.CanCreateUsb);
+        Assert.Contains(MediaPreflightBlockingReason.UsbTargetBelowMinimumSize, evaluation.UsbBlockingReasons);
+        Assert.DoesNotContain(MediaPreflightBlockingReason.UsbTargetBelowMinimumSize, evaluation.IsoBlockingReasons);
+    }
+
+    [Fact]
     public void Evaluate_WhenFinalExecutionIsEnabled_AllowsMediaCreationWithoutRuntimePayloadChecks()
     {
         MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(

--- a/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
@@ -70,7 +70,8 @@ public sealed class WinPeUsbMediaServiceTests
                 SerialNumber = "SERIAL-2",
                 UniqueId = "UNIQUE-2",
                 BusType = "USB",
-                IsRemovable = true
+                IsRemovable = true,
+                Size = 64UL * 1024UL * 1024UL * 1024UL
             });
 
         Assert.False(result.IsSuccess);
@@ -93,6 +94,28 @@ public sealed class WinPeUsbMediaServiceTests
                 BusType = "USB",
                 IsRemovable = true,
                 IsBoot = true
+            });
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(WinPeErrorCodes.UsbUnsafeTarget, result.Error?.Code);
+    }
+
+    [Fact]
+    public void ValidateDiskSafety_WhenTargetIsBelowMinimumSize_ReturnsUnsafeTarget()
+    {
+        WinPeResult result = WinPeUsbMediaService.ValidateDiskSafety(
+            new UsbOutputOptions
+            {
+                TargetDiskNumber = 3,
+                ExpectedDiskFriendlyName = "Small USB"
+            },
+            new WinPeUsbDiskIdentity
+            {
+                Number = 3,
+                FriendlyName = "Small USB",
+                BusType = "USB",
+                IsRemovable = true,
+                Size = 15UL * 1024UL * 1024UL * 1024UL
             });
 
         Assert.False(result.IsSuccess);

--- a/src/Foundry.Core/Services/Media/MediaPreflightBlockingReason.cs
+++ b/src/Foundry.Core/Services/Media/MediaPreflightBlockingReason.cs
@@ -12,6 +12,7 @@ public enum MediaPreflightBlockingReason
     RequiredSecretsNotReady,
     AutopilotConfigurationNotReady,
     NoUsbTarget,
+    UsbTargetBelowMinimumSize,
     Arm64RequiresGpt,
     CustomDriverDirectoryNotFound,
     CustomDriverDirectoryHasNoInfFiles,

--- a/src/Foundry.Core/Services/Media/MediaPreflightService.cs
+++ b/src/Foundry.Core/Services/Media/MediaPreflightService.cs
@@ -29,6 +29,10 @@ public static class MediaPreflightService
         {
             usbReasons.Add(MediaPreflightBlockingReason.NoUsbTarget);
         }
+        else if (options.SelectedUsbDisk.SizeBytes < WinPeUsbMediaService.MinimumUsbDiskSizeBytes)
+        {
+            usbReasons.Add(MediaPreflightBlockingReason.UsbTargetBelowMinimumSize);
+        }
 
         UsbPartitionStyle effectiveUsbPartitionStyle = options.UsbPartitionStyle;
         if (options.Architecture == WinPeArchitecture.Arm64 && options.UsbPartitionStyle == UsbPartitionStyle.Mbr)

--- a/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
@@ -5,6 +5,7 @@ namespace Foundry.Core.Services.WinPe;
 
 public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
 {
+    internal const ulong MinimumUsbDiskSizeBytes = 16UL * 1024UL * 1024UL * 1024UL;
     private const string UsbProvisioningProgressPrefix = "FOUNDRY_USB_PROGRESS|";
     private const string UsbProvisioningVerbosePrefix = "FOUNDRY_USB_VERBOSE|";
 
@@ -279,6 +280,14 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
                 WinPeErrorCodes.UsbUnsafeTarget,
                 "Refusing to modify a system or boot disk.",
                 $"Disk {disk.Number}: IsSystem={disk.IsSystem}, IsBoot={disk.IsBoot}.");
+        }
+
+        if (disk.Size < MinimumUsbDiskSizeBytes)
+        {
+            return WinPeResult.Failure(
+                WinPeErrorCodes.UsbUnsafeTarget,
+                "Target USB disk is below the minimum supported size.",
+                $"Disk {disk.Number} size is {disk.Size} bytes. Foundry OSD requires a USB disk of at least 16 GB.");
         }
 
         if (string.IsNullOrWhiteSpace(options.ExpectedDiskFriendlyName) &&

--- a/src/Foundry.Deploy.Tests/DeploymentPayloadCacheFallbackTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentPayloadCacheFallbackTests.cs
@@ -1,0 +1,290 @@
+using Foundry.Deploy.Models;
+using Foundry.Deploy.Services.Cache;
+using Foundry.Deploy.Services.Deployment;
+using Foundry.Deploy.Services.Deployment.Steps;
+using Foundry.Deploy.Services.Download;
+using Foundry.Deploy.Services.DriverPacks;
+using Foundry.Deploy.Services.Hardware;
+using Foundry.Deploy.Services.Logging;
+using Foundry.Deploy.Services.Operations;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class DeploymentPayloadCacheFallbackTests
+{
+    [Fact]
+    public async Task DownloadOperatingSystemImageStep_WhenUsbCacheHasInsufficientSpace_UsesTargetCache()
+    {
+        using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
+        var downloadService = new CapturingArtifactDownloadService();
+        DeploymentStepExecutionContext context = CreateExecutionContext(
+            workspace,
+            operatingSystemSizeBytes: long.MaxValue);
+        var step = new DownloadOperatingSystemImageStep(downloadService);
+
+        DeploymentStepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(DeploymentStepState.Succeeded, result.State);
+        Assert.Equal(
+            Path.Combine(workspace.TargetFoundryRoot, "Cache", "OperatingSystems", "install.wim"),
+            downloadService.DestinationPath);
+    }
+
+    [Fact]
+    public async Task DownloadOperatingSystemImageStep_WhenUsbCacheHasEnoughSpace_UsesUsbCache()
+    {
+        using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
+        var downloadService = new CapturingArtifactDownloadService();
+        DeploymentStepExecutionContext context = CreateExecutionContext(
+            workspace,
+            operatingSystemSizeBytes: 1);
+        var step = new DownloadOperatingSystemImageStep(downloadService);
+
+        DeploymentStepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(DeploymentStepState.Succeeded, result.State);
+        Assert.Equal(
+            Path.Combine(workspace.UsbCacheRoot, "Cache", "OperatingSystems", "install.wim"),
+            downloadService.DestinationPath);
+    }
+
+    [Fact]
+    public async Task DownloadDriverPackStep_WhenUsbCacheHasInsufficientSpace_UsesTargetCache()
+    {
+        using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
+        var downloadService = new CapturingArtifactDownloadService();
+        DeploymentStepExecutionContext context = CreateExecutionContext(
+            workspace,
+            driverPackSizeBytes: long.MaxValue);
+        var step = new DownloadDriverPackStep(new FakeMicrosoftUpdateCatalogDriverService(), downloadService);
+
+        DeploymentStepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(DeploymentStepState.Succeeded, result.State);
+        Assert.Equal(
+            Path.Combine(workspace.TargetFoundryRoot, "Cache", "DriverPacks", "Contoso", "drivers.cab"),
+            downloadService.DestinationPath);
+    }
+
+    [Fact]
+    public async Task DownloadDriverPackStep_WhenUsbCacheHasEnoughSpace_UsesUsbCache()
+    {
+        using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
+        var downloadService = new CapturingArtifactDownloadService();
+        DeploymentStepExecutionContext context = CreateExecutionContext(
+            workspace,
+            driverPackSizeBytes: 1);
+        var step = new DownloadDriverPackStep(new FakeMicrosoftUpdateCatalogDriverService(), downloadService);
+
+        DeploymentStepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(DeploymentStepState.Succeeded, result.State);
+        Assert.Equal(
+            Path.Combine(workspace.UsbCacheRoot, "Cache", "DriverPacks", "Contoso", "drivers.cab"),
+            downloadService.DestinationPath);
+    }
+
+    private static DeploymentStepExecutionContext CreateExecutionContext(
+        TempDeploymentWorkspace workspace,
+        long operatingSystemSizeBytes = 1,
+        long driverPackSizeBytes = 1)
+    {
+        var request = new DeploymentContext
+        {
+            Mode = DeploymentMode.Usb,
+            CacheRootPath = workspace.UsbRuntimeRoot,
+            TargetDiskNumber = 1,
+            TargetComputerName = "LAB01",
+            OperatingSystem = new OperatingSystemCatalogItem
+            {
+                FileName = "install.wim",
+                Url = "https://example.test/install.wim",
+                SizeBytes = operatingSystemSizeBytes
+            },
+            DriverPackSelectionKind = DriverPackSelectionKind.OemCatalog,
+            DriverPack = new DriverPackCatalogItem
+            {
+                Manufacturer = "Contoso",
+                Name = "Contoso Driver Pack",
+                FileName = "drivers.cab",
+                DownloadUrl = "https://example.test/drivers.cab",
+                SizeBytes = driverPackSizeBytes
+            },
+            IsDryRun = false
+        };
+
+        var runtimeState = new DeploymentRuntimeState
+        {
+            WorkspaceRoot = workspace.WorkspaceRoot,
+            Mode = DeploymentMode.Usb,
+            TargetFoundryRoot = workspace.TargetFoundryRoot,
+            ResolvedCache = new CacheResolution
+            {
+                RootPath = workspace.UsbRuntimeRoot,
+                Source = "test"
+            }
+        };
+
+        return new DeploymentStepExecutionContext(
+            request,
+            runtimeState,
+            [],
+            new FakeOperationProgressService(),
+            new FakeDeploymentLogService(),
+            new FakeTargetDiskService(),
+            _ => { });
+    }
+
+    private sealed class CapturingArtifactDownloadService : IArtifactDownloadService
+    {
+        public string? DestinationPath { get; private set; }
+
+        public Task<ArtifactDownloadResult> DownloadAsync(
+            string sourceUrl,
+            string destinationPath,
+            string? expectedHash = null,
+            CancellationToken cancellationToken = default,
+            IProgress<DownloadProgress>? progress = null)
+        {
+            DestinationPath = destinationPath;
+            return Task.FromResult(new ArtifactDownloadResult
+            {
+                DestinationPath = destinationPath,
+                Downloaded = true,
+                Method = "test",
+                SizeBytes = 1
+            });
+        }
+    }
+
+    private sealed class FakeMicrosoftUpdateCatalogDriverService : IMicrosoftUpdateCatalogDriverService
+    {
+        public Task<MicrosoftUpdateCatalogDriverResult> DownloadAsync(
+            HardwareProfile hardwareProfile,
+            OperatingSystemCatalogItem operatingSystem,
+            string destinationDirectory,
+            CancellationToken cancellationToken = default,
+            IProgress<double>? progress = null)
+        {
+            return Task.FromResult(new MicrosoftUpdateCatalogDriverResult
+            {
+                DestinationDirectory = destinationDirectory,
+                IsPayloadAvailable = false,
+                Message = "No Microsoft Update Catalog payload."
+            });
+        }
+
+        public Task<MicrosoftUpdateCatalogDriverResult> ExpandAsync(
+            string sourceDirectory,
+            string destinationDirectory,
+            CancellationToken cancellationToken = default,
+            IProgress<double>? progress = null)
+        {
+            return Task.FromResult(new MicrosoftUpdateCatalogDriverResult
+            {
+                DestinationDirectory = destinationDirectory,
+                IsPayloadAvailable = false,
+                Message = "No Microsoft Update Catalog payload."
+            });
+        }
+    }
+
+    private sealed class TempDeploymentWorkspace : IDisposable
+    {
+        private TempDeploymentWorkspace(string rootPath)
+        {
+            WorkspaceRoot = Path.Combine(rootPath, "Workspace");
+            UsbCacheRoot = Path.Combine(rootPath, "UsbCache");
+            UsbRuntimeRoot = Path.Combine(UsbCacheRoot, "Runtime");
+            TargetWindowsRoot = Path.Combine(rootPath, "TargetWindows");
+            TargetFoundryRoot = Path.Combine(TargetWindowsRoot, "Foundry");
+
+            Directory.CreateDirectory(WorkspaceRoot);
+            Directory.CreateDirectory(UsbRuntimeRoot);
+            Directory.CreateDirectory(TargetFoundryRoot);
+        }
+
+        public string WorkspaceRoot { get; }
+        public string UsbCacheRoot { get; }
+        public string UsbRuntimeRoot { get; }
+        public string TargetWindowsRoot { get; }
+        public string TargetFoundryRoot { get; }
+
+        public static TempDeploymentWorkspace Create()
+        {
+            string rootPath = Path.Combine(Path.GetTempPath(), $"foundry-deploy-cache-{Guid.NewGuid():N}");
+            return new TempDeploymentWorkspace(rootPath);
+        }
+
+        public void Dispose()
+        {
+            string rootPath = Directory.GetParent(WorkspaceRoot)?.FullName
+                ?? throw new InvalidOperationException("Unable to resolve test workspace root.");
+            Directory.Delete(rootPath, recursive: true);
+        }
+    }
+
+    private sealed class FakeDeploymentLogService : IDeploymentLogService
+    {
+        public DeploymentLogSession Initialize(string rootPath)
+        {
+            return new DeploymentLogSession
+            {
+                RootPath = rootPath,
+                LogsDirectoryPath = Path.Combine(rootPath, "Logs"),
+                StateDirectoryPath = Path.Combine(rootPath, "State"),
+                LogFilePath = Path.Combine(rootPath, "Logs", "FoundryDeploy.log"),
+                StateFilePath = Path.Combine(rootPath, "State", "deployment-state.json")
+            };
+        }
+
+        public Task AppendAsync(
+            DeploymentLogSession session,
+            DeploymentLogLevel level,
+            string message,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task SaveStateAsync<TState>(
+            DeploymentLogSession session,
+            TState state,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public void Release(DeploymentLogSession session)
+        {
+        }
+    }
+
+    private sealed class FakeOperationProgressService : IOperationProgressService
+    {
+        public bool IsOperationInProgress => false;
+        public int Progress => 0;
+        public string? Status => null;
+        public OperationKind? CurrentOperation => null;
+        public bool CanStartOperation => true;
+        public event EventHandler? ProgressChanged;
+        public bool TryStart(OperationKind kind, string initialStatus, int initialProgress = 0) => true;
+        public void Report(int progress, string? status = null) => ProgressChanged?.Invoke(this, EventArgs.Empty);
+        public void Complete(string? status = null) => ProgressChanged?.Invoke(this, EventArgs.Empty);
+        public void Fail(string status) => ProgressChanged?.Invoke(this, EventArgs.Empty);
+        public void ResetToIdle() => ProgressChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private sealed class FakeTargetDiskService : ITargetDiskService
+    {
+        public Task<IReadOnlyList<TargetDiskInfo>> GetDisksAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<TargetDiskInfo>>([]);
+        }
+
+        public Task<int?> GetDiskNumberForPathAsync(string path, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<int?>(null);
+        }
+    }
+}

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentStepExecutionContext.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentStepExecutionContext.cs
@@ -296,13 +296,17 @@ public sealed class DeploymentStepExecutionContext
     /// <returns>The operating system cache root.</returns>
     public string ResolveOperatingSystemCacheRoot()
     {
-        if (RuntimeState.Mode == DeploymentMode.Iso &&
-            !string.IsNullOrWhiteSpace(RuntimeState.TargetFoundryRoot))
-        {
-            return Path.Combine(RuntimeState.TargetFoundryRoot, CacheFolderName, OperatingSystemsFolderName);
-        }
+        return ResolvePayloadCacheRoot(OperatingSystemsFolderName, requiredBytes: 0);
+    }
 
-        return Path.Combine(EnsureCacheBaseRoot(), CacheFolderName, OperatingSystemsFolderName);
+    /// <summary>
+    /// Resolves the operating system cache root and falls back to the target workspace when the USB cache is too small.
+    /// </summary>
+    /// <param name="requiredBytes">Expected payload size in bytes.</param>
+    /// <returns>The operating system cache root.</returns>
+    public string ResolveOperatingSystemCacheRoot(long requiredBytes)
+    {
+        return ResolvePayloadCacheRoot(OperatingSystemsFolderName, requiredBytes);
     }
 
     /// <summary>
@@ -311,13 +315,17 @@ public sealed class DeploymentStepExecutionContext
     /// <returns>The driver pack cache root.</returns>
     public string ResolveDriverPackCacheRoot()
     {
-        if (RuntimeState.Mode == DeploymentMode.Iso &&
-            !string.IsNullOrWhiteSpace(RuntimeState.TargetFoundryRoot))
-        {
-            return Path.Combine(RuntimeState.TargetFoundryRoot, CacheFolderName, DriverPacksFolderName);
-        }
+        return ResolvePayloadCacheRoot(DriverPacksFolderName, requiredBytes: 0);
+    }
 
-        return Path.Combine(EnsureCacheBaseRoot(), CacheFolderName, DriverPacksFolderName);
+    /// <summary>
+    /// Resolves the driver pack cache root and falls back to the target workspace when the USB cache is too small.
+    /// </summary>
+    /// <param name="requiredBytes">Expected payload size in bytes.</param>
+    /// <returns>The driver pack cache root.</returns>
+    public string ResolveDriverPackCacheRoot(long requiredBytes)
+    {
+        return ResolvePayloadCacheRoot(DriverPacksFolderName, requiredBytes);
     }
 
     /// <summary>
@@ -487,6 +495,45 @@ public sealed class DeploymentStepExecutionContext
     private string EnsureCacheBaseRoot()
     {
         return ResolveCacheBaseRoot(EnsureResolvedCache());
+    }
+
+    private string ResolvePayloadCacheRoot(string payloadFolderName, long requiredBytes)
+    {
+        if (RuntimeState.Mode == DeploymentMode.Iso &&
+            !string.IsNullOrWhiteSpace(RuntimeState.TargetFoundryRoot))
+        {
+            return Path.Combine(RuntimeState.TargetFoundryRoot, CacheFolderName, payloadFolderName);
+        }
+
+        string cacheRoot = Path.Combine(EnsureCacheBaseRoot(), CacheFolderName, payloadFolderName);
+        if (RuntimeState.Mode == DeploymentMode.Usb &&
+            requiredBytes > 0 &&
+            !string.IsNullOrWhiteSpace(RuntimeState.TargetFoundryRoot) &&
+            !HasAvailableSpace(cacheRoot, requiredBytes))
+        {
+            return Path.Combine(RuntimeState.TargetFoundryRoot, CacheFolderName, payloadFolderName);
+        }
+
+        return cacheRoot;
+    }
+
+    private static bool HasAvailableSpace(string path, long requiredBytes)
+    {
+        try
+        {
+            string rootPath = Path.GetPathRoot(Path.GetFullPath(path)) ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(rootPath))
+            {
+                return true;
+            }
+
+            var drive = new DriveInfo(rootPath);
+            return drive.IsReady && drive.AvailableFreeSpace >= requiredBytes;
+        }
+        catch
+        {
+            return true;
+        }
     }
 
     private static string ResolveWorkspaceRoot(DeploymentRuntimeState runtimeState)

--- a/src/Foundry.Deploy/Services/Deployment/Steps/DownloadDriverPackStep.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Steps/DownloadDriverPackStep.cs
@@ -79,7 +79,7 @@ public sealed class DownloadDriverPackStep : DeploymentStepBase
                 context.RuntimeState.DriverPackUrl = driverPack.DownloadUrl;
 
                 string driverPackDirectory = Path.Combine(
-                    context.ResolveDriverPackCacheRoot(),
+                    context.ResolveDriverPackCacheRoot(driverPack.SizeBytes),
                     DeploymentStepExecutionContext.SanitizePathSegment(driverPack.Manufacturer));
                 Directory.CreateDirectory(driverPackDirectory);
 

--- a/src/Foundry.Deploy/Services/Deployment/Steps/DownloadOperatingSystemImageStep.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Steps/DownloadOperatingSystemImageStep.cs
@@ -19,7 +19,7 @@ public sealed class DownloadOperatingSystemImageStep : DeploymentStepBase
 
     protected override async Task<DeploymentStepResult> ExecuteLiveAsync(DeploymentStepExecutionContext context, CancellationToken cancellationToken)
     {
-        string osDirectory = context.ResolveOperatingSystemCacheRoot();
+        string osDirectory = context.ResolveOperatingSystemCacheRoot(context.Request.OperatingSystem.SizeBytes);
         Directory.CreateDirectory(osDirectory);
         const string stepMessage = "Downloading OS image...";
 

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -990,6 +990,9 @@
   <data name="StartMedia.BlockingReason.NoUsbTarget" xml:space="preserve">
     <value>No USB target is selected.</value>
   </data>
+  <data name="StartMedia.BlockingReason.UsbTargetBelowMinimumSize" xml:space="preserve">
+    <value>The selected USB target is too small. Use a USB key of at least 16 GB.</value>
+  </data>
   <data name="StartMedia.BlockingReason.Arm64RequiresGpt" xml:space="preserve">
     <value>ARM64 media requires GPT partition style.</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -990,6 +990,9 @@
   <data name="StartMedia.BlockingReason.NoUsbTarget" xml:space="preserve">
     <value>Aucune cible USB n'est sélectionnée.</value>
   </data>
+  <data name="StartMedia.BlockingReason.UsbTargetBelowMinimumSize" xml:space="preserve">
+    <value>La cible USB sélectionnée est trop petite. Utilisez une clé USB d'au moins 16 Go.</value>
+  </data>
   <data name="StartMedia.BlockingReason.Arm64RequiresGpt" xml:space="preserve">
     <value>Le média ARM64 exige le style de partition GPT.</value>
   </data>

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -1322,7 +1322,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             MediaOutputReadinessItems,
             [
                 BuildIsoOutputReadinessItem(options, evaluation),
-                BuildUsbTargetReadinessItem(options),
+                BuildUsbTargetReadinessItem(options, evaluation),
                 BuildUsbLayoutReadinessItem(options, evaluation)
             ]);
 
@@ -1391,17 +1391,21 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 : FormatValue(options.IsoOutputPath));
     }
 
-    private StartReadinessItemViewModel BuildUsbTargetReadinessItem(MediaPreflightOptions options)
+    private StartReadinessItemViewModel BuildUsbTargetReadinessItem(MediaPreflightOptions options, MediaPreflightEvaluation evaluation)
     {
+        bool isBelowMinimumSize = HasReason(evaluation, MediaPreflightBlockingReason.UsbTargetBelowMinimumSize);
         StartReadinessState state = usbCandidateDiscoveryState switch
         {
             UsbCandidateDiscoveryState.Loading => StartReadinessState.Loading,
             UsbCandidateDiscoveryState.Empty => StartReadinessState.Warning,
             UsbCandidateDiscoveryState.Error => StartReadinessState.Warning,
+            _ when isBelowMinimumSize => StartReadinessState.Warning,
             _ => options.SelectedUsbDisk is null ? StartReadinessState.NotConfigured : StartReadinessState.Ready
         };
 
-        string description = state == StartReadinessState.Ready
+        string description = isBelowMinimumSize
+            ? GetBlockingReasonText(MediaPreflightBlockingReason.UsbTargetBelowMinimumSize)
+            : state == StartReadinessState.Ready
             ? FormatUsbCandidate(options.SelectedUsbDisk)
             : string.IsNullOrWhiteSpace(UsbCandidateStatus)
                 ? localizationService.GetString("StartMedia.Usb.NotLoaded")


### PR DESCRIPTION
## Summary

Add USB media safety checks and deployment cache fallback behavior.

## Reason

Foundry OSD should prevent creating boot media on USB keys smaller than 16 GB while still making the selected device and reason visible to the user. Foundry Deploy should avoid failing deployment downloads when the USB cache does not have enough free space.

## Main changes

- Keep small USB keys visible in Foundry OSD, but mark the USB target readiness row as a warning and block USB creation below 16 GB.
- Add a final destructive-operation guard before USB formatting.
- Fall back from USB cache to the target Windows partition cache for OS images and OEM driver packs when the USB cache has insufficient free space.
- Add regression tests for OSD preflight/USB validation and Deploy payload cache fallback.

## Testing notes

- `git diff --check`
- `dotnet test src\Foundry.Core.Tests\Foundry.Core.Tests.csproj --no-restore -m:1 -nr:false` (180 passed)
- `dotnet test src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --no-restore -m:1 -nr:false` (108 passed)
- `dotnet build src\Foundry\Foundry.csproj --no-restore -m:1 -nr:false` (0 warnings, 0 errors)