### PR TITLE
fix(release): generate Velopack delta packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,6 +224,7 @@ jobs:
       - name: Build release assets
         env:
           FoundryPostHogProjectToken: ${{ secrets.FoundryPostHogProjectToken }}
+          GITHUB_TOKEN: ${{ github.token }}
         shell: pwsh
         run: |
           if ([string]::IsNullOrWhiteSpace($env:FoundryPostHogProjectToken)) {

--- a/scripts/Publish-FoundryVelopack.ps1
+++ b/scripts/Publish-FoundryVelopack.ps1
@@ -11,6 +11,12 @@ param(
 
     [string]$VpkVersion = '0.0.1589-ga2c5a97',
 
+    [string]$VelopackFeedUrl = 'https://github.com/foundry-osd/foundry',
+
+    [string]$GitHubToken = $env:GITHUB_TOKEN,
+
+    [switch]$SkipPreviousReleaseDownload,
+
     [string]$ReleaseNotesPath
 )
 
@@ -75,7 +81,8 @@ Get-ChildItem -Path $releaseAssetsDir -File -ErrorAction SilentlyContinue |
         $_.Name -eq "assets.$velopackChannel.json" -or
         $_.Name -eq "releases.$velopackChannel.json" -or
         $_.Name -like "Foundry-*-$velopackChannel-full.nupkg" -or
-        $_.Name -match '^Foundry-\d+(\.\d+){2}-build\.\d+-full\.nupkg$'
+        $_.Name -like "Foundry-*-$velopackChannel-delta.nupkg" -or
+        $_.Name -match '^Foundry-\d+(\.\d+){2}-build\.\d+-(full|delta)\.nupkg$'
     } |
     Remove-Item -Force
 
@@ -89,6 +96,29 @@ else {
 
 if ($LASTEXITCODE -ne 0) {
     throw "Unable to install or update vpk $VpkVersion."
+}
+
+if (-not $SkipPreviousReleaseDownload) {
+    $downloadArgs = @(
+        'download',
+        'github',
+        '--repoUrl',
+        $VelopackFeedUrl,
+        '--channel',
+        $velopackChannel,
+        '--outputDir',
+        $releaseDir
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($GitHubToken)) {
+        $downloadArgs += @('--token', $GitHubToken)
+    }
+
+    & $vpkExe @downloadArgs
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Unable to download the previous Velopack release for $RuntimeIdentifier. Delta packages will not be generated."
+    }
 }
 
 # $installerInputPaths = @(
@@ -203,7 +233,7 @@ Get-ChildItem -Path $releaseDir -File |
         $_.Name -like 'RELEASES*' -or
         $_.Name -like 'assets.*.json' -or
         $_.Name -like 'releases.*.json' -or
-        $_.Extension -eq '.nupkg'
+        $_.Name -like "Foundry-$PackVersion-$velopackChannel-*.nupkg"
     } |
     Copy-Item -Destination $releaseAssetsDir -Force
 


### PR DESCRIPTION
## Summary
- Download the latest matching Velopack release before packaging so `vpk pack` can generate delta packages.
- Pass `GITHUB_TOKEN` to the release packaging step for authenticated GitHub release downloads.
- Keep copied release assets scoped to the current package version while preserving Velopack output metadata for upload.

## Reason
Velopack only creates delta packages when the previous full package is available in the packaging output directory. The release script cleared that directory before packing, so releases only produced full packages.

## Main changes
- Added optional previous-release download support to `Publish-FoundryVelopack.ps1`.
- Added `-SkipPreviousReleaseDownload` for local packaging scenarios that should not prefetch the latest release.
- Updated release asset cleanup/copy filters for both full and delta packages.
- Exposed `GITHUB_TOKEN` to the release asset build step.

## Testing notes
- Parsed `scripts/Publish-FoundryVelopack.ps1` with the PowerShell parser.
- Ran `git diff --check`.
- Generated local x64 Velopack assets for `26.5.16-build.2`; verified full, delta, and MSI outputs.
- Generated local arm64 Velopack assets for `26.5.16-build.2`; verified full, delta, and MSI outputs.
- Generated a local J-1 x64 MSI for `26.5.15-build.2` with `-SkipPreviousReleaseDownload`.