### PR TITLE
fix(telemetry): track boot media failure step

### DIFF
--- a/src/Foundry.Telemetry.Tests/PostHogTelemetryServiceTests.cs
+++ b/src/Foundry.Telemetry.Tests/PostHogTelemetryServiceTests.cs
@@ -41,6 +41,7 @@ public sealed class PostHogTelemetryServiceTests
             {
                 ["boot_media_target"] = "iso",
                 ["boot_media_architecture"] = "arm64",
+                ["failed_step_name"] = "Customize boot image",
                 ["ssid"] = "CorpWifi"
             });
 
@@ -56,6 +57,7 @@ public sealed class PostHogTelemetryServiceTests
         Assert.False(properties.TryGetProperty("timestamp", out _));
         Assert.Equal("iso", properties.GetProperty("boot_media_target").GetString());
         Assert.Equal("arm64", properties.GetProperty("boot_media_architecture").GetString());
+        Assert.Equal("Customize boot image", properties.GetProperty("failed_step_name").GetString());
         Assert.False(properties.TryGetProperty("ssid", out _));
         Assert.Equal(TelemetryApps.FoundryOsd, properties.GetProperty("app").GetString());
         Assert.Equal("1.2.3", properties.GetProperty("app_version").GetString());

--- a/src/Foundry.Telemetry.Tests/TelemetryEventPropertyPolicyTests.cs
+++ b/src/Foundry.Telemetry.Tests/TelemetryEventPropertyPolicyTests.cs
@@ -13,6 +13,7 @@ public sealed class TelemetryEventPropertyPolicyTests
             ["success"] = true,
             ["duration_seconds"] = 12.5,
             ["boot_media_architecture"] = "x64",
+            ["failed_step_name"] = "Prepare WinPE workspace",
             ["ssid"] = "CorpWifi",
             ["iso_output_path"] = @"C:\Temp\Foundry.iso"
         };
@@ -23,6 +24,7 @@ public sealed class TelemetryEventPropertyPolicyTests
         Assert.True((bool)result["success"]!);
         Assert.Equal(12.5, result["duration_seconds"]);
         Assert.Equal("x64", result["boot_media_architecture"]);
+        Assert.Equal("Prepare WinPE workspace", result["failed_step_name"]);
         Assert.False(result.ContainsKey("ssid"));
         Assert.False(result.ContainsKey("iso_output_path"));
     }

--- a/src/Foundry.Telemetry/TelemetryEventPropertyPolicy.cs
+++ b/src/Foundry.Telemetry/TelemetryEventPropertyPolicy.cs
@@ -39,6 +39,7 @@ public static class TelemetryEventPropertyPolicy
                 "boot_media_target",
                 "success",
                 "duration_seconds",
+                "failed_step_name",
                 "boot_media_architecture",
                 "winpe_language",
                 "boot_image_source",

--- a/src/Foundry/ViewModels/MediaCreationTelemetryProgressTracker.cs
+++ b/src/Foundry/ViewModels/MediaCreationTelemetryProgressTracker.cs
@@ -1,0 +1,317 @@
+using Foundry.Core.Services.WinPe;
+
+namespace Foundry.ViewModels;
+
+/// <summary>
+/// Tracks the active low-cardinality media creation stage while preserving existing UI progress forwarding.
+/// </summary>
+internal sealed class MediaCreationTelemetryProgressTracker
+{
+    /// <summary>
+    /// Gets the last media creation stage reported before the operation completed or failed.
+    /// </summary>
+    public string CurrentStepName { get; private set; } = MediaCreationStepNames.Unknown;
+
+    /// <summary>
+    /// Sets the active media creation stage for synchronous orchestration boundaries that do not report progress.
+    /// </summary>
+    public void SetCurrentStep(string stepName)
+    {
+        CurrentStepName = string.IsNullOrWhiteSpace(stepName) ? MediaCreationStepNames.Unknown : stepName;
+    }
+
+    /// <summary>
+    /// Creates a progress adapter that captures WinPE workspace preparation stages before forwarding progress.
+    /// </summary>
+    public IProgress<WinPeWorkspacePreparationStage> CreateWorkspacePreparationProgress(
+        IProgress<WinPeWorkspacePreparationStage> uiProgress)
+    {
+        return new TrackingProgress<WinPeWorkspacePreparationStage>(
+            this,
+            uiProgress,
+            ResolveFailedStepName);
+    }
+
+    /// <summary>
+    /// Creates a progress adapter that captures mounted boot image customization stages before forwarding progress.
+    /// </summary>
+    public IProgress<WinPeMountedImageCustomizationProgress> CreateCustomizationProgress(
+        IProgress<WinPeMountedImageCustomizationProgress> uiProgress)
+    {
+        return new TrackingProgress<WinPeMountedImageCustomizationProgress>(
+            this,
+            uiProgress,
+            ResolveFailedStepName);
+    }
+
+    /// <summary>
+    /// Creates a progress adapter that captures dependency download stages without preserving path, URL, or byte-count details.
+    /// </summary>
+    public IProgress<WinPeDownloadProgress> CreateDownloadProgress(IProgress<WinPeDownloadProgress> uiProgress)
+    {
+        return new TrackingProgress<WinPeDownloadProgress>(
+            this,
+            uiProgress,
+            ResolveFailedStepName);
+    }
+
+    /// <summary>
+    /// Creates a progress adapter that captures final ISO or USB media creation stages before forwarding progress.
+    /// </summary>
+    public IProgress<WinPeMediaProgress> CreateFinalMediaProgress(IProgress<WinPeMediaProgress> uiProgress)
+    {
+        return new TrackingProgress<WinPeMediaProgress>(
+            this,
+            uiProgress,
+            ResolveFailedStepName);
+    }
+
+    private static string ResolveFailedStepName(WinPeWorkspacePreparationStage stage)
+    {
+        return stage switch
+        {
+            WinPeWorkspacePreparationStage.ResolvingDrivers => MediaCreationStepNames.ResolveWinPeDrivers,
+            WinPeWorkspacePreparationStage.CustomizingImage => MediaCreationStepNames.CustomizeBootImage,
+            WinPeWorkspacePreparationStage.EvaluatingSignaturePolicy => MediaCreationStepNames.EvaluateSignaturePolicy,
+            _ => MediaCreationStepNames.PrepareWinPeWorkspace
+        };
+    }
+
+    private static string ResolveFailedStepName(WinPeMountedImageCustomizationProgress progress)
+    {
+        string status = progress.Status;
+        if (status.StartsWith("Resolving WinRE source catalog", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.ResolveWinReSourceCatalog;
+        }
+
+        if (status.StartsWith("Selected WinRE source package", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.SelectWinReSourcePackage;
+        }
+
+        if (status.StartsWith("Preparing WinRE source package", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.PrepareWinReSourcePackage;
+        }
+
+        if (status.StartsWith("Resolving WinRE image index", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.ResolveWinReImageIndex;
+        }
+
+        if (status.StartsWith("Exporting Windows image", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.ExportWinReSourceImage;
+        }
+
+        if (status.StartsWith("Mounting WinRE source image", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.MountWinReSourceImage;
+        }
+
+        if (status.StartsWith("Staging WinRE Wi-Fi dependencies", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.StageWinReWifiDependencies;
+        }
+
+        if (status.StartsWith("Replacing boot image with WinRE", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.ReplaceBootImageWithWinRe;
+        }
+
+        if (status.StartsWith("Preparing boot image customization", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.CustomizeBootImage;
+        }
+
+        if (status.StartsWith("Mounting boot image", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.MountBootImage;
+        }
+
+        if (status.StartsWith("Injecting drivers", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.InjectDriversIntoBootImage;
+        }
+
+        if (status.StartsWith("Applying language", StringComparison.OrdinalIgnoreCase) ||
+            status.StartsWith("Applying optional components", StringComparison.OrdinalIgnoreCase) ||
+            status.StartsWith("Applying international settings", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.ApplyLanguageAndOptionalComponents;
+        }
+
+        if (status.StartsWith("Provisioning Foundry boot assets", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.ProvisionBootAssets;
+        }
+
+        if (status.StartsWith("Provisioning Foundry runtime payloads", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.ProvisionRuntimePayloads;
+        }
+
+        if (status.StartsWith("Committing image changes", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.CommitBootImageChanges;
+        }
+
+        return MediaCreationStepNames.CustomizeBootImage;
+    }
+
+    private static string ResolveFailedStepName(WinPeDownloadProgress progress)
+    {
+        string status = progress.Status;
+        if (status.StartsWith("Downloading driver package", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.DownloadWinPeDriverPackage;
+        }
+
+        if (status.StartsWith("Downloading WinRE source package", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.DownloadWinReSourcePackage;
+        }
+
+        if (status.StartsWith("Downloading Foundry.Connect runtime payload", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.DownloadConnectRuntimePayload;
+        }
+
+        if (status.StartsWith("Downloading Foundry.Deploy runtime payload", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.DownloadDeployRuntimePayload;
+        }
+
+        return MediaCreationStepNames.DownloadMediaDependency;
+    }
+
+    private static string ResolveFailedStepName(WinPeMediaProgress progress)
+    {
+        string status = progress.Status;
+        if (status.StartsWith("Preparing ISO output path", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.PrepareIsoOutputPath;
+        }
+
+        if (status.StartsWith("Preparing ISO workspace", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.PrepareIsoWorkspace;
+        }
+
+        if (status.StartsWith("Running MakeWinPEMedia for ISO", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.RunMakeWinPeMediaForIso;
+        }
+
+        if (status.StartsWith("Finalizing ISO output", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.FinalizeIsoOutput;
+        }
+
+        if (status.StartsWith("Validating USB target", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.ValidateUsbTarget;
+        }
+
+        if (status.StartsWith("Checking USB target safety", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.CheckUsbTargetSafety;
+        }
+
+        if (status.StartsWith("Partitioning and formatting USB target", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.PartitionAndFormatUsbTarget;
+        }
+
+        if (status.StartsWith("Copying WinPE media to USB", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.CopyWinPeMediaToUsb;
+        }
+
+        if (status.StartsWith("Configuring USB boot files", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.ConfigureUsbBootFiles;
+        }
+
+        if (status.StartsWith("Verifying USB boot media", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.VerifyUsbBootMedia;
+        }
+
+        if (status.StartsWith("Preparing USB cache partition", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.PrepareUsbCachePartition;
+        }
+
+        if (status.StartsWith("Provisioning USB runtime payloads", StringComparison.OrdinalIgnoreCase))
+        {
+            return MediaCreationStepNames.ProvisionUsbRuntimePayloads;
+        }
+
+        return MediaCreationStepNames.CreateFinalMedia;
+    }
+
+    private sealed class TrackingProgress<T>(
+        MediaCreationTelemetryProgressTracker owner,
+        IProgress<T> uiProgress,
+        Func<T, string> resolveStepName) : IProgress<T>
+    {
+        public void Report(T value)
+        {
+            owner.SetCurrentStep(resolveStepName(value));
+            uiProgress.Report(value);
+        }
+    }
+}
+
+/// <summary>
+/// Defines stable boot media creation step names used by telemetry.
+/// </summary>
+internal static class MediaCreationStepNames
+{
+    public const string Unknown = "unknown";
+    public const string ValidateUsbTarget = "Validate USB target";
+    public const string ResolveWinPeTools = "Resolve WinPE tools";
+    public const string PrepareRuntimePayloads = "Prepare runtime payloads";
+    public const string CleanStaleWorkspaces = "Clean stale WinPE workspaces";
+    public const string BuildWinPeWorkspace = "Build WinPE workspace";
+    public const string GenerateProvisioningPayloads = "Generate provisioning payloads";
+    public const string PrepareWinPeWorkspace = "Prepare WinPE workspace";
+    public const string ResolveWinPeDrivers = "Resolve WinPE drivers";
+    public const string CustomizeBootImage = "Customize boot image";
+    public const string EvaluateSignaturePolicy = "Evaluate signature policy";
+    public const string ResolveWinReSourceCatalog = "Resolve WinRE source catalog";
+    public const string SelectWinReSourcePackage = "Select WinRE source package";
+    public const string PrepareWinReSourcePackage = "Prepare WinRE source package";
+    public const string DownloadWinReSourcePackage = "Download WinRE source package";
+    public const string ResolveWinReImageIndex = "Resolve WinRE image index";
+    public const string ExportWinReSourceImage = "Export WinRE source image";
+    public const string MountWinReSourceImage = "Mount WinRE source image";
+    public const string StageWinReWifiDependencies = "Stage WinRE Wi-Fi dependencies";
+    public const string ReplaceBootImageWithWinRe = "Replace boot image with WinRE";
+    public const string MountBootImage = "Mount boot image";
+    public const string DownloadWinPeDriverPackage = "Download WinPE driver package";
+    public const string InjectDriversIntoBootImage = "Inject drivers into boot image";
+    public const string ApplyLanguageAndOptionalComponents = "Apply language and optional components";
+    public const string ProvisionBootAssets = "Provision boot assets";
+    public const string ProvisionRuntimePayloads = "Provision runtime payloads";
+    public const string DownloadConnectRuntimePayload = "Download Connect runtime payload";
+    public const string DownloadDeployRuntimePayload = "Download Deploy runtime payload";
+    public const string CommitBootImageChanges = "Commit boot image changes";
+    public const string DownloadMediaDependency = "Download media dependency";
+    public const string PrepareIsoOutputPath = "Prepare ISO output path";
+    public const string PrepareIsoWorkspace = "Prepare ISO workspace";
+    public const string RunMakeWinPeMediaForIso = "Run MakeWinPEMedia for ISO";
+    public const string FinalizeIsoOutput = "Finalize ISO output";
+    public const string CheckUsbTargetSafety = "Check USB target safety";
+    public const string PartitionAndFormatUsbTarget = "Partition and format USB target";
+    public const string CopyWinPeMediaToUsb = "Copy WinPE media to USB";
+    public const string ConfigureUsbBootFiles = "Configure USB boot files";
+    public const string VerifyUsbBootMedia = "Verify USB boot media";
+    public const string PrepareUsbCachePartition = "Prepare USB cache partition";
+    public const string ProvisionUsbRuntimePayloads = "Provision USB runtime payloads";
+    public const string CreateFinalMedia = "Create final media";
+    public const string CreateIsoMedia = "Create ISO media";
+    public const string CreateUsbMedia = "Create USB media";
+}

--- a/src/Foundry/ViewModels/MediaCreationTelemetryProgressTracker.cs
+++ b/src/Foundry/ViewModels/MediaCreationTelemetryProgressTracker.cs
@@ -7,6 +7,51 @@ namespace Foundry.ViewModels;
 /// </summary>
 internal sealed class MediaCreationTelemetryProgressTracker
 {
+    private static readonly IReadOnlyList<StatusStepMapping> CustomizationStatusMappings =
+    [
+        new("Resolving WinRE source catalog", MediaCreationStepNames.ResolveWinReSourceCatalog),
+        new("Selected WinRE source package", MediaCreationStepNames.SelectWinReSourcePackage),
+        new("Preparing WinRE source package", MediaCreationStepNames.PrepareWinReSourcePackage),
+        new("Resolving WinRE image index", MediaCreationStepNames.ResolveWinReImageIndex),
+        new("Exporting Windows image", MediaCreationStepNames.ExportWinReSourceImage),
+        new("Mounting WinRE source image", MediaCreationStepNames.MountWinReSourceImage),
+        new("Staging WinRE Wi-Fi dependencies", MediaCreationStepNames.StageWinReWifiDependencies),
+        new("Replacing boot image with WinRE", MediaCreationStepNames.ReplaceBootImageWithWinRe),
+        new("Preparing boot image customization", MediaCreationStepNames.CustomizeBootImage),
+        new("Mounting boot image", MediaCreationStepNames.MountBootImage),
+        new("Injecting drivers", MediaCreationStepNames.InjectDriversIntoBootImage),
+        new("Applying language", MediaCreationStepNames.ApplyLanguageAndOptionalComponents),
+        new("Applying optional components", MediaCreationStepNames.ApplyLanguageAndOptionalComponents),
+        new("Applying international settings", MediaCreationStepNames.ApplyLanguageAndOptionalComponents),
+        new("Provisioning Foundry boot assets", MediaCreationStepNames.ProvisionBootAssets),
+        new("Provisioning Foundry runtime payloads", MediaCreationStepNames.ProvisionRuntimePayloads),
+        new("Committing image changes", MediaCreationStepNames.CommitBootImageChanges)
+    ];
+
+    private static readonly IReadOnlyList<StatusStepMapping> DownloadStatusMappings =
+    [
+        new("Downloading driver package", MediaCreationStepNames.DownloadWinPeDriverPackage),
+        new("Downloading WinRE source package", MediaCreationStepNames.DownloadWinReSourcePackage),
+        new("Downloading Foundry.Connect runtime payload", MediaCreationStepNames.DownloadConnectRuntimePayload),
+        new("Downloading Foundry.Deploy runtime payload", MediaCreationStepNames.DownloadDeployRuntimePayload)
+    ];
+
+    private static readonly IReadOnlyList<StatusStepMapping> FinalMediaStatusMappings =
+    [
+        new("Preparing ISO output path", MediaCreationStepNames.PrepareIsoOutputPath),
+        new("Preparing ISO workspace", MediaCreationStepNames.PrepareIsoWorkspace),
+        new("Running MakeWinPEMedia for ISO", MediaCreationStepNames.RunMakeWinPeMediaForIso),
+        new("Finalizing ISO output", MediaCreationStepNames.FinalizeIsoOutput),
+        new("Validating USB target", MediaCreationStepNames.ValidateUsbTarget),
+        new("Checking USB target safety", MediaCreationStepNames.CheckUsbTargetSafety),
+        new("Partitioning and formatting USB target", MediaCreationStepNames.PartitionAndFormatUsbTarget),
+        new("Copying WinPE media to USB", MediaCreationStepNames.CopyWinPeMediaToUsb),
+        new("Configuring USB boot files", MediaCreationStepNames.ConfigureUsbBootFiles),
+        new("Verifying USB boot media", MediaCreationStepNames.VerifyUsbBootMedia),
+        new("Preparing USB cache partition", MediaCreationStepNames.PrepareUsbCachePartition),
+        new("Provisioning USB runtime payloads", MediaCreationStepNames.ProvisionUsbRuntimePayloads)
+    ];
+
     /// <summary>
     /// Gets the last media creation stage reported before the operation completed or failed.
     /// </summary>
@@ -79,177 +124,33 @@ internal sealed class MediaCreationTelemetryProgressTracker
 
     private static string ResolveFailedStepName(WinPeMountedImageCustomizationProgress progress)
     {
-        string status = progress.Status;
-        if (status.StartsWith("Resolving WinRE source catalog", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.ResolveWinReSourceCatalog;
-        }
-
-        if (status.StartsWith("Selected WinRE source package", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.SelectWinReSourcePackage;
-        }
-
-        if (status.StartsWith("Preparing WinRE source package", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.PrepareWinReSourcePackage;
-        }
-
-        if (status.StartsWith("Resolving WinRE image index", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.ResolveWinReImageIndex;
-        }
-
-        if (status.StartsWith("Exporting Windows image", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.ExportWinReSourceImage;
-        }
-
-        if (status.StartsWith("Mounting WinRE source image", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.MountWinReSourceImage;
-        }
-
-        if (status.StartsWith("Staging WinRE Wi-Fi dependencies", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.StageWinReWifiDependencies;
-        }
-
-        if (status.StartsWith("Replacing boot image with WinRE", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.ReplaceBootImageWithWinRe;
-        }
-
-        if (status.StartsWith("Preparing boot image customization", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.CustomizeBootImage;
-        }
-
-        if (status.StartsWith("Mounting boot image", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.MountBootImage;
-        }
-
-        if (status.StartsWith("Injecting drivers", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.InjectDriversIntoBootImage;
-        }
-
-        if (status.StartsWith("Applying language", StringComparison.OrdinalIgnoreCase) ||
-            status.StartsWith("Applying optional components", StringComparison.OrdinalIgnoreCase) ||
-            status.StartsWith("Applying international settings", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.ApplyLanguageAndOptionalComponents;
-        }
-
-        if (status.StartsWith("Provisioning Foundry boot assets", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.ProvisionBootAssets;
-        }
-
-        if (status.StartsWith("Provisioning Foundry runtime payloads", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.ProvisionRuntimePayloads;
-        }
-
-        if (status.StartsWith("Committing image changes", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.CommitBootImageChanges;
-        }
-
-        return MediaCreationStepNames.CustomizeBootImage;
+        return ResolveStatusStepName(progress.Status, CustomizationStatusMappings, MediaCreationStepNames.CustomizeBootImage);
     }
 
     private static string ResolveFailedStepName(WinPeDownloadProgress progress)
     {
-        string status = progress.Status;
-        if (status.StartsWith("Downloading driver package", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.DownloadWinPeDriverPackage;
-        }
-
-        if (status.StartsWith("Downloading WinRE source package", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.DownloadWinReSourcePackage;
-        }
-
-        if (status.StartsWith("Downloading Foundry.Connect runtime payload", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.DownloadConnectRuntimePayload;
-        }
-
-        if (status.StartsWith("Downloading Foundry.Deploy runtime payload", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.DownloadDeployRuntimePayload;
-        }
-
-        return MediaCreationStepNames.DownloadMediaDependency;
+        return ResolveStatusStepName(progress.Status, DownloadStatusMappings, MediaCreationStepNames.DownloadMediaDependency);
     }
 
     private static string ResolveFailedStepName(WinPeMediaProgress progress)
     {
-        string status = progress.Status;
-        if (status.StartsWith("Preparing ISO output path", StringComparison.OrdinalIgnoreCase))
+        return ResolveStatusStepName(progress.Status, FinalMediaStatusMappings, MediaCreationStepNames.CreateFinalMedia);
+    }
+
+    private static string ResolveStatusStepName(
+        string status,
+        IReadOnlyList<StatusStepMapping> mappings,
+        string fallback)
+    {
+        foreach (StatusStepMapping mapping in mappings)
         {
-            return MediaCreationStepNames.PrepareIsoOutputPath;
+            if (status.StartsWith(mapping.StatusPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return mapping.StepName;
+            }
         }
 
-        if (status.StartsWith("Preparing ISO workspace", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.PrepareIsoWorkspace;
-        }
-
-        if (status.StartsWith("Running MakeWinPEMedia for ISO", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.RunMakeWinPeMediaForIso;
-        }
-
-        if (status.StartsWith("Finalizing ISO output", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.FinalizeIsoOutput;
-        }
-
-        if (status.StartsWith("Validating USB target", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.ValidateUsbTarget;
-        }
-
-        if (status.StartsWith("Checking USB target safety", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.CheckUsbTargetSafety;
-        }
-
-        if (status.StartsWith("Partitioning and formatting USB target", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.PartitionAndFormatUsbTarget;
-        }
-
-        if (status.StartsWith("Copying WinPE media to USB", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.CopyWinPeMediaToUsb;
-        }
-
-        if (status.StartsWith("Configuring USB boot files", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.ConfigureUsbBootFiles;
-        }
-
-        if (status.StartsWith("Verifying USB boot media", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.VerifyUsbBootMedia;
-        }
-
-        if (status.StartsWith("Preparing USB cache partition", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.PrepareUsbCachePartition;
-        }
-
-        if (status.StartsWith("Provisioning USB runtime payloads", StringComparison.OrdinalIgnoreCase))
-        {
-            return MediaCreationStepNames.ProvisionUsbRuntimePayloads;
-        }
-
-        return MediaCreationStepNames.CreateFinalMedia;
+        return fallback;
     }
 
     private sealed class TrackingProgress<T>(
@@ -263,6 +164,8 @@ internal sealed class MediaCreationTelemetryProgressTracker
             uiProgress.Report(value);
         }
     }
+
+    private sealed record StatusStepMapping(string StatusPrefix, string StepName);
 }
 
 /// <summary>

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -2045,6 +2045,13 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         public string CurrentStepName { get; set; } = MediaCreationStepNames.Unknown;
     }
 
+    /// <summary>
+    /// Updates the active telemetry stage synchronously before forwarding workspace preparation progress to the UI.
+    /// </summary>
+    /// <remarks>
+    /// The synchronous telemetry update avoids losing the failing stage when a workspace preparation error is returned
+    /// before the UI progress callback has been dispatched.
+    /// </remarks>
     private sealed class MediaCreationWorkspacePreparationProgress(
         MediaCreationTelemetryState telemetryState,
         IProgress<WinPeWorkspacePreparationStage> uiProgress) : IProgress<WinPeWorkspacePreparationStage>

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -391,7 +391,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         string? successMessage = null;
         Stopwatch stopwatch = Stopwatch.StartNew();
         bool success = false;
-        var telemetryState = new MediaCreationTelemetryState();
+        var telemetryProgressTracker = new MediaCreationTelemetryProgressTracker();
 
         try
         {
@@ -411,12 +411,12 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
             if (target == FinalMediaTarget.Iso)
             {
-                _ = await CreateIsoMediaAsync(options, telemetryState, CancellationToken.None);
+                _ = await CreateIsoMediaAsync(options, telemetryProgressTracker, CancellationToken.None);
                 successMessage = localizationService.GetString("StartMedia.Operation.IsoSuccessMessage");
             }
             else
             {
-                WinPeUsbProvisionResult usbResult = await CreateUsbMediaAsync(options, telemetryState, CancellationToken.None);
+                WinPeUsbProvisionResult usbResult = await CreateUsbMediaAsync(options, telemetryProgressTracker, CancellationToken.None);
                 successMessage = string.Format(
                     CultureInfo.CurrentCulture,
                     localizationService.GetString("StartMedia.Operation.UsbSuccessMessage"),
@@ -440,7 +440,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 ex,
                 "Final media creation failed. Target={Target}, FailedStepName={FailedStepName}",
                 target,
-                telemetryState.CurrentStepName);
+                telemetryProgressTracker.CurrentStepName);
         }
         finally
         {
@@ -448,7 +448,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 target,
                 options,
                 success,
-                success ? null : telemetryState.CurrentStepName,
+                success ? null : telemetryProgressTracker.CurrentStepName,
                 stopwatch.Elapsed,
                 CancellationToken.None);
             shellNavigationGuardService.SetState(adkService.CurrentStatus.CanCreateMedia
@@ -462,7 +462,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private async Task<string> CreateIsoMediaAsync(
         MediaPreflightOptions options,
-        MediaCreationTelemetryState telemetryState,
+        MediaCreationTelemetryProgressTracker telemetryProgressTracker,
         CancellationToken cancellationToken)
     {
         PreparedMediaWorkspace? workspace = null;
@@ -472,10 +472,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             workspace = await PrepareMediaWorkspaceAsync(
                 options,
                 includeRuntimePayloadInImage: true,
-                telemetryState: telemetryState,
+                telemetryProgressTracker: telemetryProgressTracker,
                 cancellationToken);
 
-            telemetryState.CurrentStepName = MediaCreationStepNames.CreateIsoMedia;
+            telemetryProgressTracker.SetCurrentStep(MediaCreationStepNames.CreateIsoMedia);
             logger.Debug(
                 "Creating ISO media. OutputIsoPath={OutputIsoPath}, MediaDirectoryPath={MediaDirectoryPath}, UseBootEx={UseBootEx}",
                 options.IsoOutputPath,
@@ -488,7 +488,8 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                     PreparedWorkspace = workspace.PreparedWorkspace,
                     OutputIsoPath = options.IsoOutputPath,
                     IsoTempDirectoryPath = Path.Combine(Constants.TempDirectoryPath, "Iso"),
-                    Progress = new Progress<WinPeMediaProgress>(ReportFinalMediaProgress)
+                    Progress = telemetryProgressTracker.CreateFinalMediaProgress(
+                        new Progress<WinPeMediaProgress>(ReportFinalMediaProgress))
                 },
                 cancellationToken);
 
@@ -504,10 +505,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private async Task<WinPeUsbProvisionResult> CreateUsbMediaAsync(
         MediaPreflightOptions options,
-        MediaCreationTelemetryState telemetryState,
+        MediaCreationTelemetryProgressTracker telemetryProgressTracker,
         CancellationToken cancellationToken)
     {
-        telemetryState.CurrentStepName = MediaCreationStepNames.ValidateUsbTarget;
+        telemetryProgressTracker.SetCurrentStep(MediaCreationStepNames.ValidateUsbTarget);
         if (options.SelectedUsbDisk is null)
         {
             throw new InvalidOperationException(localizationService.GetString("StartMedia.BlockingReason.NoUsbTarget"));
@@ -520,11 +521,11 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             workspace = await PrepareMediaWorkspaceAsync(
                 options,
                 includeRuntimePayloadInImage: false,
-                telemetryState: telemetryState,
+                telemetryProgressTracker: telemetryProgressTracker,
                 cancellationToken);
 
             WinPeUsbDiskCandidate selectedDisk = options.SelectedUsbDisk;
-            telemetryState.CurrentStepName = MediaCreationStepNames.CreateUsbMedia;
+            telemetryProgressTracker.SetCurrentStep(MediaCreationStepNames.CreateUsbMedia);
             logger.Debug(
                 "Creating USB media. DiskNumber={DiskNumber}, DiskName={DiskName}, PartitionStyle={PartitionStyle}, FormatMode={FormatMode}, MediaDirectoryPath={MediaDirectoryPath}, UseBootEx={UseBootEx}",
                 selectedDisk.DiskNumber,
@@ -544,8 +545,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                     PartitionStyle = options.UsbPartitionStyle,
                     FormatMode = options.UsbFormatMode,
                     RuntimePayloadProvisioning = workspace.RuntimePayloadProvisioning,
-                    DownloadProgress = new Progress<WinPeDownloadProgress>(ReportDownloadProgress),
-                    Progress = new Progress<WinPeMediaProgress>(ReportFinalMediaProgress)
+                    DownloadProgress = telemetryProgressTracker.CreateDownloadProgress(
+                        new Progress<WinPeDownloadProgress>(ReportDownloadProgress)),
+                    Progress = telemetryProgressTracker.CreateFinalMediaProgress(
+                        new Progress<WinPeMediaProgress>(ReportFinalMediaProgress))
                 },
                 workspace.PreparedWorkspace.Artifact,
                 workspace.Tools,
@@ -569,14 +572,14 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     private async Task<PreparedMediaWorkspace> PrepareMediaWorkspaceAsync(
         MediaPreflightOptions options,
         bool includeRuntimePayloadInImage,
-        MediaCreationTelemetryState telemetryState,
+        MediaCreationTelemetryProgressTracker telemetryProgressTracker,
         CancellationToken cancellationToken)
     {
         WinPeBuildArtifact? artifact = null;
 
         try
         {
-            telemetryState.CurrentStepName = MediaCreationStepNames.ResolveWinPeTools;
+            telemetryProgressTracker.SetCurrentStep(MediaCreationStepNames.ResolveWinPeTools);
             WinPeToolPaths tools = ResolveWinPeToolsOrThrow();
             logger.Debug(
                 "Resolved WinPE tools. KitsRootPath={KitsRootPath}, DismPath={DismPath}, MakeWinPeMediaPath={MakeWinPeMediaPath}",
@@ -584,7 +587,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 tools.DismPath,
                 tools.MakeWinPeMediaPath);
 
-            telemetryState.CurrentStepName = MediaCreationStepNames.PrepareRuntimePayloads;
+            telemetryProgressTracker.SetCurrentStep(MediaCreationStepNames.PrepareRuntimePayloads);
             WinPeRuntimePayloadProvisioningOptions runtimePayloadProvisioning = CreateRuntimePayloadProvisioningOptions(
                 options.Architecture,
                 Constants.WinPeWorkspaceDirectoryPath,
@@ -609,10 +612,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 runtimePayloadProvisioning.Deploy.IsEnabled,
                 ResolveProvisioningSource(runtimePayloadProvisioning.Deploy));
 
-            telemetryState.CurrentStepName = MediaCreationStepNames.CleanStaleWorkspaces;
+            telemetryProgressTracker.SetCurrentStep(MediaCreationStepNames.CleanStaleWorkspaces);
             CleanupStaleWinPeWorkspaces();
 
-            telemetryState.CurrentStepName = MediaCreationStepNames.BuildWinPeWorkspace;
+            telemetryProgressTracker.SetCurrentStep(MediaCreationStepNames.BuildWinPeWorkspace);
             operationProgressService.Report(10, localizationService.GetString("StartMedia.Operation.BuildingWorkspace"));
             WinPeResult<WinPeBuildArtifact> buildResult = await buildService.BuildAsync(
                 new WinPeBuildOptions
@@ -633,7 +636,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 artifact.MountDirectoryPath,
                 artifact.BootWimPath);
 
-            telemetryState.CurrentStepName = MediaCreationStepNames.GenerateProvisioningPayloads;
+            telemetryProgressTracker.SetCurrentStep(MediaCreationStepNames.GenerateProvisioningPayloads);
             FoundryConnectProvisioningBundle connectBundle = expertDeployConfigurationStateService.GenerateConnectProvisioningBundle(
                 Path.Combine(artifact.WorkingDirectoryPath, "Provisioning"),
                 connectTelemetrySettings);
@@ -650,10 +653,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 UsbCacheRootPath = string.Empty
             };
 
-            telemetryState.CurrentStepName = MediaCreationStepNames.PrepareWinPeWorkspace;
-            var workspacePreparationProgress = new MediaCreationWorkspacePreparationProgress(
-                telemetryState,
-                new Progress<WinPeWorkspacePreparationStage>(ReportWorkspacePreparationStage));
+            telemetryProgressTracker.SetCurrentStep(MediaCreationStepNames.PrepareWinPeWorkspace);
+            IProgress<WinPeWorkspacePreparationStage> workspacePreparationProgress =
+                telemetryProgressTracker.CreateWorkspacePreparationProgress(
+                    new Progress<WinPeWorkspacePreparationStage>(ReportWorkspacePreparationStage));
 
             operationProgressService.Report(25, localizationService.GetString("StartMedia.Operation.PreparingWorkspace"));
             WinPeResult<WinPeWorkspacePreparationResult> preparationResult = await workspacePreparationService.PrepareAsync(
@@ -671,8 +674,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                     RuntimePayloadProvisioning = includeRuntimePayloadInImage ? artifactRuntimePayloadProvisioning : null,
                     WinReCacheDirectoryPath = Constants.WinReTempDirectoryPath,
                     Progress = workspacePreparationProgress,
-                    DownloadProgress = new Progress<WinPeDownloadProgress>(ReportDownloadProgress),
-                    CustomizationProgress = new Progress<WinPeMountedImageCustomizationProgress>(ReportCustomizationProgress)
+                    DownloadProgress = telemetryProgressTracker.CreateDownloadProgress(
+                        new Progress<WinPeDownloadProgress>(ReportDownloadProgress)),
+                    CustomizationProgress = telemetryProgressTracker.CreateCustomizationProgress(
+                        new Progress<WinPeMountedImageCustomizationProgress>(ReportCustomizationProgress))
                 },
                 cancellationToken);
             EnsureSuccess(preparationResult);
@@ -1296,17 +1301,6 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
         await telemetryService.TrackAsync(TelemetryEvents.OsdBootMediaFinished, properties, cancellationToken);
         logger.Debug("Media telemetry event queued. Target={Target}, Success={Success}.", properties["boot_media_target"], success);
-    }
-
-    private static string ResolveMediaCreationFailedStepName(WinPeWorkspacePreparationStage stage)
-    {
-        return stage switch
-        {
-            WinPeWorkspacePreparationStage.ResolvingDrivers => MediaCreationStepNames.ResolveWinPeDrivers,
-            WinPeWorkspacePreparationStage.CustomizingImage => MediaCreationStepNames.CustomizeBootImage,
-            WinPeWorkspacePreparationStage.EvaluatingSignaturePolicy => MediaCreationStepNames.EvaluateSignaturePolicy,
-            _ => MediaCreationStepNames.PrepareWinPeWorkspace
-        };
     }
 
     private string BuildStatusText(MediaPreflightEvaluation evaluation)
@@ -2039,44 +2033,4 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         WinPeWorkspacePreparationResult PreparedWorkspace,
         WinPeToolPaths Tools,
         WinPeRuntimePayloadProvisioningOptions RuntimePayloadProvisioning);
-
-    private sealed class MediaCreationTelemetryState
-    {
-        public string CurrentStepName { get; set; } = MediaCreationStepNames.Unknown;
-    }
-
-    /// <summary>
-    /// Updates the active telemetry stage synchronously before forwarding workspace preparation progress to the UI.
-    /// </summary>
-    /// <remarks>
-    /// The synchronous telemetry update avoids losing the failing stage when a workspace preparation error is returned
-    /// before the UI progress callback has been dispatched.
-    /// </remarks>
-    private sealed class MediaCreationWorkspacePreparationProgress(
-        MediaCreationTelemetryState telemetryState,
-        IProgress<WinPeWorkspacePreparationStage> uiProgress) : IProgress<WinPeWorkspacePreparationStage>
-    {
-        public void Report(WinPeWorkspacePreparationStage value)
-        {
-            telemetryState.CurrentStepName = ResolveMediaCreationFailedStepName(value);
-            uiProgress.Report(value);
-        }
-    }
-
-    private static class MediaCreationStepNames
-    {
-        public const string Unknown = "unknown";
-        public const string ValidateUsbTarget = "Validate USB target";
-        public const string ResolveWinPeTools = "Resolve WinPE tools";
-        public const string PrepareRuntimePayloads = "Prepare runtime payloads";
-        public const string CleanStaleWorkspaces = "Clean stale WinPE workspaces";
-        public const string BuildWinPeWorkspace = "Build WinPE workspace";
-        public const string GenerateProvisioningPayloads = "Generate provisioning payloads";
-        public const string PrepareWinPeWorkspace = "Prepare WinPE workspace";
-        public const string ResolveWinPeDrivers = "Resolve WinPE drivers";
-        public const string CustomizeBootImage = "Customize boot image";
-        public const string EvaluateSignaturePolicy = "Evaluate signature policy";
-        public const string CreateIsoMedia = "Create ISO media";
-        public const string CreateUsbMedia = "Create USB media";
-    }
 }

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -391,6 +391,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         string? successMessage = null;
         Stopwatch stopwatch = Stopwatch.StartNew();
         bool success = false;
+        var telemetryState = new MediaCreationTelemetryState();
 
         try
         {
@@ -410,12 +411,12 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
             if (target == FinalMediaTarget.Iso)
             {
-                _ = await CreateIsoMediaAsync(options, CancellationToken.None);
+                _ = await CreateIsoMediaAsync(options, telemetryState, CancellationToken.None);
                 successMessage = localizationService.GetString("StartMedia.Operation.IsoSuccessMessage");
             }
             else
             {
-                WinPeUsbProvisionResult usbResult = await CreateUsbMediaAsync(options, CancellationToken.None);
+                WinPeUsbProvisionResult usbResult = await CreateUsbMediaAsync(options, telemetryState, CancellationToken.None);
                 successMessage = string.Format(
                     CultureInfo.CurrentCulture,
                     localizationService.GetString("StartMedia.Operation.UsbSuccessMessage"),
@@ -435,11 +436,21 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 ? failedStatus
                 : $"{failedStatus} {ex.Message}";
             operationProgressService.Report(100, terminalStatus);
-            logger.Error(ex, "Final media creation failed. Target={Target}", target);
+            logger.Error(
+                ex,
+                "Final media creation failed. Target={Target}, FailedStepName={FailedStepName}",
+                target,
+                telemetryState.CurrentStepName);
         }
         finally
         {
-            await TrackMediaCreatedAsync(target, options, success, stopwatch.Elapsed, CancellationToken.None);
+            await TrackMediaCreatedAsync(
+                target,
+                options,
+                success,
+                success ? null : telemetryState.CurrentStepName,
+                stopwatch.Elapsed,
+                CancellationToken.None);
             shellNavigationGuardService.SetState(adkService.CurrentStatus.CanCreateMedia
                 ? ShellNavigationState.Ready
                 : ShellNavigationState.AdkBlocked);
@@ -449,7 +460,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         }
     }
 
-    private async Task<string> CreateIsoMediaAsync(MediaPreflightOptions options, CancellationToken cancellationToken)
+    private async Task<string> CreateIsoMediaAsync(
+        MediaPreflightOptions options,
+        MediaCreationTelemetryState telemetryState,
+        CancellationToken cancellationToken)
     {
         PreparedMediaWorkspace? workspace = null;
 
@@ -458,8 +472,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             workspace = await PrepareMediaWorkspaceAsync(
                 options,
                 includeRuntimePayloadInImage: true,
+                telemetryState: telemetryState,
                 cancellationToken);
 
+            telemetryState.CurrentStepName = MediaCreationStepNames.CreateIsoMedia;
             logger.Debug(
                 "Creating ISO media. OutputIsoPath={OutputIsoPath}, MediaDirectoryPath={MediaDirectoryPath}, UseBootEx={UseBootEx}",
                 options.IsoOutputPath,
@@ -486,8 +502,12 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         }
     }
 
-    private async Task<WinPeUsbProvisionResult> CreateUsbMediaAsync(MediaPreflightOptions options, CancellationToken cancellationToken)
+    private async Task<WinPeUsbProvisionResult> CreateUsbMediaAsync(
+        MediaPreflightOptions options,
+        MediaCreationTelemetryState telemetryState,
+        CancellationToken cancellationToken)
     {
+        telemetryState.CurrentStepName = MediaCreationStepNames.ValidateUsbTarget;
         if (options.SelectedUsbDisk is null)
         {
             throw new InvalidOperationException(localizationService.GetString("StartMedia.BlockingReason.NoUsbTarget"));
@@ -500,9 +520,11 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             workspace = await PrepareMediaWorkspaceAsync(
                 options,
                 includeRuntimePayloadInImage: false,
+                telemetryState: telemetryState,
                 cancellationToken);
 
             WinPeUsbDiskCandidate selectedDisk = options.SelectedUsbDisk;
+            telemetryState.CurrentStepName = MediaCreationStepNames.CreateUsbMedia;
             logger.Debug(
                 "Creating USB media. DiskNumber={DiskNumber}, DiskName={DiskName}, PartitionStyle={PartitionStyle}, FormatMode={FormatMode}, MediaDirectoryPath={MediaDirectoryPath}, UseBootEx={UseBootEx}",
                 selectedDisk.DiskNumber,
@@ -547,12 +569,14 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     private async Task<PreparedMediaWorkspace> PrepareMediaWorkspaceAsync(
         MediaPreflightOptions options,
         bool includeRuntimePayloadInImage,
+        MediaCreationTelemetryState telemetryState,
         CancellationToken cancellationToken)
     {
         WinPeBuildArtifact? artifact = null;
 
         try
         {
+            telemetryState.CurrentStepName = MediaCreationStepNames.ResolveWinPeTools;
             WinPeToolPaths tools = ResolveWinPeToolsOrThrow();
             logger.Debug(
                 "Resolved WinPE tools. KitsRootPath={KitsRootPath}, DismPath={DismPath}, MakeWinPeMediaPath={MakeWinPeMediaPath}",
@@ -560,6 +584,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 tools.DismPath,
                 tools.MakeWinPeMediaPath);
 
+            telemetryState.CurrentStepName = MediaCreationStepNames.PrepareRuntimePayloads;
             WinPeRuntimePayloadProvisioningOptions runtimePayloadProvisioning = CreateRuntimePayloadProvisioningOptions(
                 options.Architecture,
                 Constants.WinPeWorkspaceDirectoryPath,
@@ -584,8 +609,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 runtimePayloadProvisioning.Deploy.IsEnabled,
                 ResolveProvisioningSource(runtimePayloadProvisioning.Deploy));
 
+            telemetryState.CurrentStepName = MediaCreationStepNames.CleanStaleWorkspaces;
             CleanupStaleWinPeWorkspaces();
 
+            telemetryState.CurrentStepName = MediaCreationStepNames.BuildWinPeWorkspace;
             operationProgressService.Report(10, localizationService.GetString("StartMedia.Operation.BuildingWorkspace"));
             WinPeResult<WinPeBuildArtifact> buildResult = await buildService.BuildAsync(
                 new WinPeBuildOptions
@@ -606,6 +633,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 artifact.MountDirectoryPath,
                 artifact.BootWimPath);
 
+            telemetryState.CurrentStepName = MediaCreationStepNames.GenerateProvisioningPayloads;
             FoundryConnectProvisioningBundle connectBundle = expertDeployConfigurationStateService.GenerateConnectProvisioningBundle(
                 Path.Combine(artifact.WorkingDirectoryPath, "Provisioning"),
                 connectTelemetrySettings);
@@ -622,6 +650,11 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 UsbCacheRootPath = string.Empty
             };
 
+            telemetryState.CurrentStepName = MediaCreationStepNames.PrepareWinPeWorkspace;
+            var workspacePreparationProgress = new MediaCreationWorkspacePreparationProgress(
+                telemetryState,
+                new Progress<WinPeWorkspacePreparationStage>(ReportWorkspacePreparationStage));
+
             operationProgressService.Report(25, localizationService.GetString("StartMedia.Operation.PreparingWorkspace"));
             WinPeResult<WinPeWorkspacePreparationResult> preparationResult = await workspacePreparationService.PrepareAsync(
                 new WinPeWorkspacePreparationOptions
@@ -637,7 +670,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                     AssetProvisioning = CreateAssetProvisioningOptions(options, connectBundle, runtimePayloadProvisioning, deployTelemetrySettings),
                     RuntimePayloadProvisioning = includeRuntimePayloadInImage ? artifactRuntimePayloadProvisioning : null,
                     WinReCacheDirectoryPath = Constants.WinReTempDirectoryPath,
-                    Progress = new Progress<WinPeWorkspacePreparationStage>(ReportWorkspacePreparationStage),
+                    Progress = workspacePreparationProgress,
                     DownloadProgress = new Progress<WinPeDownloadProgress>(ReportDownloadProgress),
                     CustomizationProgress = new Progress<WinPeMountedImageCustomizationProgress>(ReportCustomizationProgress)
                 },
@@ -1210,6 +1243,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         FinalMediaTarget target,
         MediaPreflightOptions options,
         bool success,
+        string? failedStepName,
         TimeSpan duration,
         CancellationToken cancellationToken)
     {
@@ -1226,6 +1260,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                     : TelemetryBootMediaTargets.Usb,
                 ["success"] = success,
                 ["duration_seconds"] = Math.Round(duration.TotalSeconds, 2),
+                ["failed_step_name"] = failedStepName,
                 ["boot_media_architecture"] = options.Architecture.ToString().ToLowerInvariant(),
                 ["winpe_language"] = NormalizeCultureName(options.WinPeLanguage).ToLowerInvariant(),
                 ["boot_image_source"] = options.BootImageSource.ToString().ToLowerInvariant(),
@@ -1248,9 +1283,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             };
 
         logger.Debug(
-            "Tracking media telemetry event. Target={Target}, Success={Success}, DurationSeconds={DurationSeconds}, Architecture={Architecture}, BootImageSource={BootImageSource}, SignatureMode={SignatureMode}, ConnectRuntimePayloadSource={ConnectRuntimePayloadSource}, DeployRuntimePayloadSource={DeployRuntimePayloadSource}.",
+            "Tracking media telemetry event. Target={Target}, Success={Success}, FailedStepName={FailedStepName}, DurationSeconds={DurationSeconds}, Architecture={Architecture}, BootImageSource={BootImageSource}, SignatureMode={SignatureMode}, ConnectRuntimePayloadSource={ConnectRuntimePayloadSource}, DeployRuntimePayloadSource={DeployRuntimePayloadSource}.",
             properties["boot_media_target"],
             success,
+            failedStepName,
             properties["duration_seconds"],
             properties["boot_media_architecture"],
             properties["boot_image_source"],
@@ -1260,6 +1296,17 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
         await telemetryService.TrackAsync(TelemetryEvents.OsdBootMediaFinished, properties, cancellationToken);
         logger.Debug("Media telemetry event queued. Target={Target}, Success={Success}.", properties["boot_media_target"], success);
+    }
+
+    private static string ResolveMediaCreationFailedStepName(WinPeWorkspacePreparationStage stage)
+    {
+        return stage switch
+        {
+            WinPeWorkspacePreparationStage.ResolvingDrivers => MediaCreationStepNames.ResolveWinPeDrivers,
+            WinPeWorkspacePreparationStage.CustomizingImage => MediaCreationStepNames.CustomizeBootImage,
+            WinPeWorkspacePreparationStage.EvaluatingSignaturePolicy => MediaCreationStepNames.EvaluateSignaturePolicy,
+            _ => MediaCreationStepNames.PrepareWinPeWorkspace
+        };
     }
 
     private string BuildStatusText(MediaPreflightEvaluation evaluation)
@@ -1992,4 +2039,37 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         WinPeWorkspacePreparationResult PreparedWorkspace,
         WinPeToolPaths Tools,
         WinPeRuntimePayloadProvisioningOptions RuntimePayloadProvisioning);
+
+    private sealed class MediaCreationTelemetryState
+    {
+        public string CurrentStepName { get; set; } = MediaCreationStepNames.Unknown;
+    }
+
+    private sealed class MediaCreationWorkspacePreparationProgress(
+        MediaCreationTelemetryState telemetryState,
+        IProgress<WinPeWorkspacePreparationStage> uiProgress) : IProgress<WinPeWorkspacePreparationStage>
+    {
+        public void Report(WinPeWorkspacePreparationStage value)
+        {
+            telemetryState.CurrentStepName = ResolveMediaCreationFailedStepName(value);
+            uiProgress.Report(value);
+        }
+    }
+
+    private static class MediaCreationStepNames
+    {
+        public const string Unknown = "unknown";
+        public const string ValidateUsbTarget = "Validate USB target";
+        public const string ResolveWinPeTools = "Resolve WinPE tools";
+        public const string PrepareRuntimePayloads = "Prepare runtime payloads";
+        public const string CleanStaleWorkspaces = "Clean stale WinPE workspaces";
+        public const string BuildWinPeWorkspace = "Build WinPE workspace";
+        public const string GenerateProvisioningPayloads = "Generate provisioning payloads";
+        public const string PrepareWinPeWorkspace = "Prepare WinPE workspace";
+        public const string ResolveWinPeDrivers = "Resolve WinPE drivers";
+        public const string CustomizeBootImage = "Customize boot image";
+        public const string EvaluateSignaturePolicy = "Evaluate signature policy";
+        public const string CreateIsoMedia = "Create ISO media";
+        public const string CreateUsbMedia = "Create USB media";
+    }
 }


### PR DESCRIPTION
## Summary
Adds a `failed_step_name` telemetry property to failed Foundry OSD boot media creation events.

## Reason
When boot image or media creation failed, telemetry only indicated that the operation failed. It did not identify which media creation stage was active when the failure occurred.

## Main changes
- Tracks the current media creation step across WinPE tool resolution, workspace build, provisioning generation, workspace preparation, ISO creation, and USB creation.
- Maps WinPE workspace preparation progress to stable failure step names such as `Resolve WinPE drivers`, `Customize boot image`, and `Evaluate signature policy`.
- Allows `failed_step_name` on the `osd:boot_media_finished` telemetry event and verifies it reaches the PostHog payload.

## Testing notes
- `dotnet test src\Foundry.Telemetry.Tests\Foundry.Telemetry.Tests.csproj -v:minimal`
- `dotnet build src\Foundry\Foundry.csproj -v:minimal`
- `dotnet test src\Foundry.slnx -v:minimal`