### PR TITLE
fix(winpe): reduce BOOT partition size

### DIFF
--- a/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
@@ -198,7 +198,7 @@ public sealed class WinPeUsbMediaServiceTests
         Assert.Contains("$diskNumber = 7", script, StringComparison.Ordinal);
         Assert.Contains("$partitionStyle = 'GPT'", script, StringComparison.Ordinal);
         Assert.Contains("Initialize-Disk -Number $diskNumber -PartitionStyle $partitionStyle", script, StringComparison.Ordinal);
-        Assert.Contains("New-Partition -DiskNumber $diskNumber -Size 4096MB -DriveLetter $bootDriveLetter", script, StringComparison.Ordinal);
+        Assert.Contains("New-Partition -DiskNumber $diskNumber -Size 2048MB -DriveLetter $bootDriveLetter", script, StringComparison.Ordinal);
         Assert.Contains("FileSystem = 'FAT32'", script, StringComparison.Ordinal);
         Assert.Contains("NewFileSystemLabel = 'BOOT'", script, StringComparison.Ordinal);
         Assert.Contains("New-Partition -DiskNumber $diskNumber -UseMaximumSize -DriveLetter $cacheDriveLetter", script, StringComparison.Ordinal);

--- a/src/Foundry.Core/Assets/WinPe/ProvisionUsbDisk.ps1
+++ b/src/Foundry.Core/Assets/WinPe/ProvisionUsbDisk.ps1
@@ -80,7 +80,7 @@ if ([string]$disk.PartitionStyle -ne $partitionStyle) {
 Write-FoundryUsbVerbose "USB partition table initialized. CurrentPartitionStyle=$($disk.PartitionStyle)."
 
 Write-FoundryUsbProgress 38 'Creating BOOT partition.'
-$bootPartition = New-Partition -DiskNumber $diskNumber -Size 4096MB -DriveLetter $bootDriveLetter -ErrorAction Stop
+$bootPartition = New-Partition -DiskNumber $diskNumber -Size 2048MB -DriveLetter $bootDriveLetter -ErrorAction Stop
 Write-FoundryUsbVerbose "BOOT partition created. PartitionNumber=$($bootPartition.PartitionNumber), DriveLetter=$($bootPartition.DriveLetter), Size=$($bootPartition.Size)."
 {{ACTIVE_BOOT_PARTITION}}
 if ($partitionStyle -eq 'MBR') { Write-FoundryUsbVerbose "BOOT partition marked active. PartitionNumber=$($bootPartition.PartitionNumber)." }


### PR DESCRIPTION
## Summary
Reduce the WinPE USB BOOT partition from 4 GB to 2 GB.

## Reason
The generated USB layout should reserve less space for the BOOT partition and leave more room for the cache partition.

## Main changes
- Changed the BOOT partition creation size from `4096MB` to `2048MB` in the WinPE USB provisioning script.
- Updated the existing provisioning script assertion to expect the new 2 GB size.

## Testing notes
- `dotnet test src\Foundry.Core.Tests\Foundry.Core.Tests.csproj --logger "console;verbosity=minimal"`

## Merge notes
Do not squash this PR.
