### PR TITLE
fix(winpe): update USB partition layout

### DIFF
--- a/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
@@ -199,6 +199,7 @@ public sealed class WinPeUsbMediaServiceTests
         Assert.Contains("$partitionStyle = 'GPT'", script, StringComparison.Ordinal);
         Assert.Contains("Initialize-Disk -Number $diskNumber -PartitionStyle $partitionStyle", script, StringComparison.Ordinal);
         Assert.Contains("if ($partitionStyle -eq 'GPT')", script, StringComparison.Ordinal);
+        Assert.Contains("Size = 2048MB", script, StringComparison.Ordinal);
         Assert.Contains("$bootPartitionArguments['GptType'] = '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'", script, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("FileSystem = 'FAT32'", script, StringComparison.Ordinal);
         Assert.Contains("NewFileSystemLabel = 'BOOT'", script, StringComparison.Ordinal);
@@ -316,6 +317,7 @@ public sealed class WinPeUsbMediaServiceTests
         Assert.Contains("$diskNumber = 8", script, StringComparison.Ordinal);
         Assert.Contains("$partitionStyle = 'MBR'", script, StringComparison.Ordinal);
         Assert.Contains("$fullFormat = $true", script, StringComparison.Ordinal);
+        Assert.Contains("Size = 2048MB", script, StringComparison.Ordinal);
         Assert.Contains("$bootPartitionArguments['MbrType'] = 'FAT32'", script, StringComparison.Ordinal);
         Assert.Contains("$bootPartitionArguments['IsActive'] = $true", script, StringComparison.Ordinal);
         Assert.Contains("$cachePartitionArguments['MbrType'] = 'IFS'", script, StringComparison.Ordinal);

--- a/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
@@ -186,7 +186,7 @@ public sealed class WinPeUsbMediaServiceTests
     }
 
     [Fact]
-    public void BuildPowerShellProvisioningScript_WhenGptQuickFormat_CreatesBootAndCachePartitionsWithoutActive()
+    public void BuildPowerShellProvisioningScript_WhenGptQuickFormat_CreatesBootAndCachePartitionsWithExplicitTypesWithoutActive()
     {
         string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(
             diskNumber: 7,
@@ -198,10 +198,11 @@ public sealed class WinPeUsbMediaServiceTests
         Assert.Contains("$diskNumber = 7", script, StringComparison.Ordinal);
         Assert.Contains("$partitionStyle = 'GPT'", script, StringComparison.Ordinal);
         Assert.Contains("Initialize-Disk -Number $diskNumber -PartitionStyle $partitionStyle", script, StringComparison.Ordinal);
-        Assert.Contains("New-Partition -DiskNumber $diskNumber -Size 4096MB -DriveLetter $bootDriveLetter", script, StringComparison.Ordinal);
+        Assert.Contains("if ($partitionStyle -eq 'GPT')", script, StringComparison.Ordinal);
+        Assert.Contains("$bootPartitionArguments['GptType'] = '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'", script, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("FileSystem = 'FAT32'", script, StringComparison.Ordinal);
         Assert.Contains("NewFileSystemLabel = 'BOOT'", script, StringComparison.Ordinal);
-        Assert.Contains("New-Partition -DiskNumber $diskNumber -UseMaximumSize -DriveLetter $cacheDriveLetter", script, StringComparison.Ordinal);
+        Assert.Contains("$cachePartitionArguments['GptType'] = '{ebd0a0a2-b9e5-4433-87c0-68b6b72699c7}'", script, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("FileSystem = 'NTFS'", script, StringComparison.Ordinal);
         Assert.Contains("NewFileSystemLabel = 'Foundry Cache'", script, StringComparison.Ordinal);
         Assert.DoesNotContain("-IsActive $true", script, StringComparison.Ordinal);
@@ -315,7 +316,10 @@ public sealed class WinPeUsbMediaServiceTests
         Assert.Contains("$diskNumber = 8", script, StringComparison.Ordinal);
         Assert.Contains("$partitionStyle = 'MBR'", script, StringComparison.Ordinal);
         Assert.Contains("$fullFormat = $true", script, StringComparison.Ordinal);
-        Assert.Contains("Set-Partition -DiskNumber $diskNumber -PartitionNumber $bootPartition.PartitionNumber -IsActive $true", script, StringComparison.Ordinal);
+        Assert.Contains("$bootPartitionArguments['MbrType'] = 'FAT32'", script, StringComparison.Ordinal);
+        Assert.Contains("$bootPartitionArguments['IsActive'] = $true", script, StringComparison.Ordinal);
+        Assert.Contains("$cachePartitionArguments['MbrType'] = 'IFS'", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("Set-Partition -DiskNumber $diskNumber -PartitionNumber $bootPartition.PartitionNumber -IsActive $true", script, StringComparison.Ordinal);
         Assert.Contains("if ($fullFormat) { $bootFormatArguments['Full'] = $true }", script, StringComparison.Ordinal);
         Assert.Contains("if ($fullFormat) { $cacheFormatArguments['Full'] = $true }", script, StringComparison.Ordinal);
     }

--- a/src/Foundry.Core/Assets/WinPe/ProvisionUsbDisk.ps1
+++ b/src/Foundry.Core/Assets/WinPe/ProvisionUsbDisk.ps1
@@ -80,9 +80,20 @@ if ([string]$disk.PartitionStyle -ne $partitionStyle) {
 Write-FoundryUsbVerbose "USB partition table initialized. CurrentPartitionStyle=$($disk.PartitionStyle)."
 
 Write-FoundryUsbProgress 38 'Creating BOOT partition.'
-$bootPartition = New-Partition -DiskNumber $diskNumber -Size 4096MB -DriveLetter $bootDriveLetter -ErrorAction Stop
+$bootPartitionArguments = @{
+    DiskNumber = $diskNumber
+    Size = 4096MB
+    DriveLetter = $bootDriveLetter
+    ErrorAction = 'Stop'
+}
+if ($partitionStyle -eq 'GPT') {
+    $bootPartitionArguments['GptType'] = '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'
+} else {
+    $bootPartitionArguments['MbrType'] = 'FAT32'
+    $bootPartitionArguments['IsActive'] = $true
+}
+$bootPartition = New-Partition @bootPartitionArguments
 Write-FoundryUsbVerbose "BOOT partition created. PartitionNumber=$($bootPartition.PartitionNumber), DriveLetter=$($bootPartition.DriveLetter), Size=$($bootPartition.Size)."
-{{ACTIVE_BOOT_PARTITION}}
 if ($partitionStyle -eq 'MBR') { Write-FoundryUsbVerbose "BOOT partition marked active. PartitionNumber=$($bootPartition.PartitionNumber)." }
 Wait-FoundryUsbVolume -DriveLetter $bootDriveLetter -VolumeName 'BOOT'
 
@@ -100,7 +111,18 @@ Format-Volume @bootFormatArguments | Out-Null
 Write-FoundryUsbVerbose "BOOT partition formatted. DriveLetter=$bootDriveLetter, FileSystem=FAT32, Label=BOOT."
 
 Write-FoundryUsbProgress 49 'Creating cache partition.'
-$cachePartition = New-Partition -DiskNumber $diskNumber -UseMaximumSize -DriveLetter $cacheDriveLetter -ErrorAction Stop
+$cachePartitionArguments = @{
+    DiskNumber = $diskNumber
+    UseMaximumSize = $true
+    DriveLetter = $cacheDriveLetter
+    ErrorAction = 'Stop'
+}
+if ($partitionStyle -eq 'GPT') {
+    $cachePartitionArguments['GptType'] = '{ebd0a0a2-b9e5-4433-87c0-68b6b72699c7}'
+} else {
+    $cachePartitionArguments['MbrType'] = 'IFS'
+}
+$cachePartition = New-Partition @cachePartitionArguments
 Write-FoundryUsbVerbose "Cache partition created. PartitionNumber=$($cachePartition.PartitionNumber), DriveLetter=$($cachePartition.DriveLetter), Size=$($cachePartition.Size)."
 Wait-FoundryUsbVolume -DriveLetter $cacheDriveLetter -VolumeName 'cache'
 

--- a/src/Foundry.Core/Assets/WinPe/ProvisionUsbDisk.ps1
+++ b/src/Foundry.Core/Assets/WinPe/ProvisionUsbDisk.ps1
@@ -82,7 +82,7 @@ Write-FoundryUsbVerbose "USB partition table initialized. CurrentPartitionStyle=
 Write-FoundryUsbProgress 38 'Creating BOOT partition.'
 $bootPartitionArguments = @{
     DiskNumber = $diskNumber
-    Size = 4096MB
+    Size = 2048MB
     DriveLetter = $bootDriveLetter
     ErrorAction = 'Stop'
 }

--- a/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
@@ -347,9 +347,6 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
         string fullFormatValue = formatMode == UsbFormatMode.Complete ? "$true" : "$false";
         char normalizedBootDriveLetter = char.ToUpperInvariant(bootDriveLetter);
         char normalizedCacheDriveLetter = char.ToUpperInvariant(cacheDriveLetter);
-        string activeLine = partitionStyle == UsbPartitionStyle.Mbr
-            ? "Set-Partition -DiskNumber $diskNumber -PartitionNumber $bootPartition.PartitionNumber -IsActive $true -ErrorAction Stop"
-            : string.Empty;
 
         return template
             .Replace("{{DISK_NUMBER}}", diskNumber.ToString())
@@ -357,7 +354,6 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
             .Replace("{{FULL_FORMAT}}", fullFormatValue)
             .Replace("{{BOOT_DRIVE_LETTER}}", normalizedBootDriveLetter.ToString())
             .Replace("{{CACHE_DRIVE_LETTER}}", normalizedCacheDriveLetter.ToString())
-            .Replace("{{ACTIVE_BOOT_PARTITION}}", activeLine)
             .ReplaceLineEndings(Environment.NewLine);
     }
 

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -1093,7 +1093,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
         appSettingsService.Current.Media.UsbPartitionStyle = value.Value.ToString();
         appSettingsService.Save();
-        RefreshEvaluation();
+        RefreshEvaluation(loadConfigurationFromSettings: false);
     }
 
     partial void OnSelectedFormatModeChanged(SelectionOption<UsbFormatMode>? value)
@@ -1110,7 +1110,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private void OnAdkStatusChanged(object? sender, AdkStatusChangedEventArgs e)
     {
-        if (!appDispatcher.TryEnqueue(RefreshEvaluation))
+        if (!appDispatcher.TryEnqueue(() => RefreshEvaluation()))
         {
             logger.Warning("Failed to enqueue Start page ADK status refresh. IsReady={IsReady}", e.Status.CanCreateMedia);
         }
@@ -1118,7 +1118,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private void OnExpertDeployConfigurationStateChanged(object? sender, EventArgs e)
     {
-        if (!appDispatcher.TryEnqueue(RefreshEvaluation))
+        if (!appDispatcher.TryEnqueue(() => RefreshEvaluation()))
         {
             logger.Warning("Failed to enqueue Start page Expert Deploy configuration refresh.");
         }
@@ -1146,16 +1146,19 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         RebuildUsbCandidateDisplayNames();
     }
 
-    private void RefreshEvaluation()
+    private void RefreshEvaluation(bool loadConfigurationFromSettings = true)
     {
-        isLoadingConfiguration = true;
-        try
+        if (loadConfigurationFromSettings)
         {
-            LoadConfigurationFromSettings();
-        }
-        finally
-        {
-            isLoadingConfiguration = false;
+            isLoadingConfiguration = true;
+            try
+            {
+                LoadConfigurationFromSettings();
+            }
+            finally
+            {
+                isLoadingConfiguration = false;
+            }
         }
 
         WinPeLanguage = NormalizeCultureName(appSettingsService.Current.Media.WinPeLanguage);


### PR DESCRIPTION
## Summary

Make WinPE USB provisioning create BOOT and cache partitions with explicit partition types, reduce the BOOT partition from 4 GB to 2 GB, and keep the Start page USB partition style selector stable when switching between GPT and MBR.

## Reason

The previous USB layout relied on implicit partition types. Explicit types make the USB layout more predictable across firmware, diagnostic tools, and future maintenance. The BOOT partition only stores WinPE boot content, so 2 GB is sufficient while leaving more space for the cache partition.

The Start page selector rebuilt its partition style options while the ComboBox selection was being committed, which could leave the displayed selection blank and keep the effective target on GPT after choosing MBR.

## Main changes

- Set the GPT BOOT partition type to EFI System Partition.
- Set the GPT cache partition type to Microsoft Basic Data.
- Set the MBR BOOT partition type to FAT32 and mark it active during creation.
- Set the MBR cache partition type to IFS.
- Reduce the BOOT partition size from 4096 MB to 2048 MB.
- Remove the old C# active-partition placeholder injection.
- Preserve the current Start page partition style selection during direct ComboBox changes.
- Update WinPE USB provisioning tests for explicit partition type and size behavior.

## Testing

- dotnet test src\Foundry.Core.Tests\Foundry.Core.Tests.csproj
- dotnet build src\Foundry\Foundry.csproj -p:Platform=x64
- Manual: GPT + quick format USB creation boots successfully on x64 UEFI.
- Manual: x64 + MBR + quick format USB creation boots successfully in BIOS mode.