### PR TITLE
fix(deploy): default VM driver source to none

### DIFF
--- a/src/Foundry.Deploy.Tests/DriverPackSelectionViewModelTests.cs
+++ b/src/Foundry.Deploy.Tests/DriverPackSelectionViewModelTests.cs
@@ -9,6 +9,33 @@ namespace Foundry.Deploy.Tests;
 public sealed class DriverPackSelectionViewModelTests
 {
     [Fact]
+    public void EffectiveSelectionKind_WhenDetectedHardwareIsVirtualMachine_DefaultsToNone()
+    {
+        var viewModel = new DriverPackSelectionViewModel(
+            new DriverPackSelectionService(NullLogger<DriverPackSelectionService>.Instance),
+            new LocalizationService(),
+            "x64");
+        HardwareProfile hardware = new()
+        {
+            Manufacturer = "Microsoft Corporation",
+            Model = "Virtual Machine",
+            Product = "Virtual Machine",
+            IsVirtualMachine = true
+        };
+        OperatingSystemCatalogItem operatingSystem = new()
+        {
+            WindowsRelease = "11",
+            ReleaseId = "25H2",
+            Architecture = "x64"
+        };
+
+        viewModel.UpdateSelectionContext(hardware, operatingSystem, "x64");
+        viewModel.ApplyCatalog([]);
+
+        Assert.Equal(DriverPackSelectionKind.None, viewModel.EffectiveSelectionKind);
+    }
+
+    [Fact]
     public void ResolveEffectiveSelection_WhenLenovoPacksShareReleaseDate_SelectsNewestCompatibleRelease()
     {
         var viewModel = new DriverPackSelectionViewModel(

--- a/src/Foundry.Deploy/ViewModels/DriverPackSelectionViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DriverPackSelectionViewModel.cs
@@ -453,7 +453,7 @@ public sealed partial class DriverPackSelectionViewModel : LocalizedViewModelBas
 
         if (_detectedHardware?.IsVirtualMachine == true)
         {
-            return options.FirstOrDefault(option => option.Kind == DriverPackSelectionKind.MicrosoftUpdateCatalog)
+            return options.FirstOrDefault(option => option.Kind == DriverPackSelectionKind.None)
                    ?? options[0];
         }
 


### PR DESCRIPTION
## Summary
Change the Foundry.Deploy default driver source for detected virtual machines from Microsoft Update Catalog to None.

## Reason
VM deployments should not automatically select Microsoft Update Catalog when the default driver source is resolved.

## Main changes
- Select the None driver pack option when detected hardware is a virtual machine.
- Add a regression test covering the VM default driver source.

## Testing
- `dotnet test src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --no-restore --filter "FullyQualifiedName~DriverPackSelectionViewModelTests" -v normal`
- `dotnet test src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --no-restore -v minimal`

## Merge note
Do not squash this PR.
