### PR TITLE
fix(winpe): use storage-assigned USB drive letters

### DIFF
--- a/src/Foundry.Core.Tests/WinPe/WinPeEmbeddedAssetServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeEmbeddedAssetServiceTests.cs
@@ -26,8 +26,9 @@ public sealed class WinPeEmbeddedAssetServiceTests
         Assert.Contains("Clear-Disk -Number $diskNumber", content, StringComparison.Ordinal);
         Assert.Contains("{{DISK_NUMBER}}", content, StringComparison.Ordinal);
         Assert.Contains("{{PARTITION_STYLE}}", content, StringComparison.Ordinal);
-        Assert.Contains("{{BOOT_DRIVE_LETTER}}", content, StringComparison.Ordinal);
-        Assert.Contains("{{CACHE_DRIVE_LETTER}}", content, StringComparison.Ordinal);
+        Assert.Contains("AssignDriveLetter = $true", content, StringComparison.Ordinal);
+        Assert.Contains("$bootDriveLetter = $bootPartition.DriveLetter", content, StringComparison.Ordinal);
+        Assert.Contains("$cacheDriveLetter = $cachePartition.DriveLetter", content, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
@@ -191,9 +191,7 @@ public sealed class WinPeUsbMediaServiceTests
         string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(
             diskNumber: 7,
             partitionStyle: UsbPartitionStyle.Gpt,
-            formatMode: UsbFormatMode.Quick,
-            bootDriveLetter: 'S',
-            cacheDriveLetter: 'T');
+            formatMode: UsbFormatMode.Quick);
 
         Assert.Contains("$diskNumber = 7", script, StringComparison.Ordinal);
         Assert.Contains("$partitionStyle = 'GPT'", script, StringComparison.Ordinal);
@@ -216,9 +214,7 @@ public sealed class WinPeUsbMediaServiceTests
         string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(
             diskNumber: 7,
             partitionStyle: UsbPartitionStyle.Gpt,
-            formatMode: UsbFormatMode.Quick,
-            bootDriveLetter: 'S',
-            cacheDriveLetter: 'T');
+            formatMode: UsbFormatMode.Quick);
 
         Assert.Contains("& diskpart.exe /s $diskPartResetScriptPath", script, StringComparison.Ordinal);
         Assert.Contains("'clean'", script, StringComparison.Ordinal);
@@ -229,46 +225,43 @@ public sealed class WinPeUsbMediaServiceTests
     }
 
     [Fact]
-    public void BuildPowerShellProvisioningScript_WhenFormattingFreshPartitions_FormatsByExplicitDriveLetter()
+    public void BuildPowerShellProvisioningScript_WhenFormattingFreshPartitions_UsesStorageAssignedDriveLetters()
     {
         string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(
             diskNumber: 7,
             partitionStyle: UsbPartitionStyle.Gpt,
-            formatMode: UsbFormatMode.Quick,
-            bootDriveLetter: 'S',
-            cacheDriveLetter: 'T');
+            formatMode: UsbFormatMode.Quick);
 
         Assert.DoesNotContain("select partition", script, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("select volume", script, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("create partition", script, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("format fs=", script, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("$bootDriveLetter = 'S'", script, StringComparison.Ordinal);
-        Assert.Contains("$cacheDriveLetter = 'T'", script, StringComparison.Ordinal);
-        Assert.Contains("DriveLetter = $bootDriveLetter", script, StringComparison.Ordinal);
-        Assert.Contains("DriveLetter = $cacheDriveLetter", script, StringComparison.Ordinal);
+        Assert.Contains("AssignDriveLetter = $true", script, StringComparison.Ordinal);
+        Assert.Contains("$bootDriveLetter = $bootPartition.DriveLetter", script, StringComparison.Ordinal);
+        Assert.Contains("$cacheDriveLetter = $cachePartition.DriveLetter", script, StringComparison.Ordinal);
+        Assert.True(
+            script.IndexOf("$bootDriveLetter = $bootPartition.DriveLetter", StringComparison.Ordinal) <
+            script.IndexOf("$bootFormatArguments", StringComparison.Ordinal));
+        Assert.True(
+            script.IndexOf("$cacheDriveLetter = $cachePartition.DriveLetter", StringComparison.Ordinal) <
+            script.IndexOf("$cacheFormatArguments", StringComparison.Ordinal));
         Assert.Contains("Format-Volume @bootFormatArguments", script, StringComparison.Ordinal);
         Assert.Contains("Format-Volume @cacheFormatArguments", script, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void BuildPowerShellProvisioningScript_WhenRecreatingUsb_ReleasesTargetDriveLettersBeforeClearingDisk()
+    public void BuildPowerShellProvisioningScript_WhenRecreatingUsb_ReleasesTargetAccessPathsBeforeClearingDisk()
     {
         string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(
             diskNumber: 7,
             partitionStyle: UsbPartitionStyle.Gpt,
-            formatMode: UsbFormatMode.Quick,
-            bootDriveLetter: 'S',
-            cacheDriveLetter: 'T');
+            formatMode: UsbFormatMode.Quick);
 
-        Assert.Contains("function Clear-FoundryUsbDriveLetter", script, StringComparison.Ordinal);
-        Assert.Contains("Clear-FoundryUsbDriveLetter -DriveLetter $bootDriveLetter", script, StringComparison.Ordinal);
-        Assert.Contains("Clear-FoundryUsbDriveLetter -DriveLetter $cacheDriveLetter", script, StringComparison.Ordinal);
+        Assert.Contains("function Clear-FoundryUsbTargetAccessPaths", script, StringComparison.Ordinal);
+        Assert.Contains("$partition.AccessPaths", script, StringComparison.Ordinal);
         Assert.Contains("Remove-PartitionAccessPath", script, StringComparison.Ordinal);
         Assert.True(
-            script.IndexOf("Clear-FoundryUsbDriveLetter -DriveLetter $bootDriveLetter", StringComparison.Ordinal) <
-            script.IndexOf("Clear-Disk -Number $diskNumber", StringComparison.Ordinal));
-        Assert.True(
-            script.IndexOf("Clear-FoundryUsbDriveLetter -DriveLetter $cacheDriveLetter", StringComparison.Ordinal) <
+            script.IndexOf("Clear-FoundryUsbTargetAccessPaths", StringComparison.Ordinal) <
             script.IndexOf("Clear-Disk -Number $diskNumber", StringComparison.Ordinal));
         Assert.True(
             script.IndexOf("Clear-Disk -Number $diskNumber", StringComparison.Ordinal) <
@@ -281,9 +274,7 @@ public sealed class WinPeUsbMediaServiceTests
         string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(
             diskNumber: 7,
             partitionStyle: UsbPartitionStyle.Gpt,
-            formatMode: UsbFormatMode.Quick,
-            bootDriveLetter: 'S',
-            cacheDriveLetter: 'T');
+            formatMode: UsbFormatMode.Quick);
 
         Assert.Contains("function Wait-FoundryUsbVolume", script, StringComparison.Ordinal);
         Assert.Contains("Wait-FoundryUsbVolume -DriveLetter $bootDriveLetter -VolumeName 'BOOT'", script, StringComparison.Ordinal);
@@ -302,9 +293,7 @@ public sealed class WinPeUsbMediaServiceTests
         string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(
             diskNumber: 7,
             partitionStyle: UsbPartitionStyle.Gpt,
-            formatMode: UsbFormatMode.Quick,
-            bootDriveLetter: 'S',
-            cacheDriveLetter: 'T');
+            formatMode: UsbFormatMode.Quick);
 
         Assert.Contains("FOUNDRY_USB_PROGRESS|", script, StringComparison.Ordinal);
         Assert.Contains("Write-FoundryUsbProgress 26 'Clearing USB partition table.'", script, StringComparison.Ordinal);
@@ -318,9 +307,7 @@ public sealed class WinPeUsbMediaServiceTests
         string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(
             diskNumber: 7,
             partitionStyle: UsbPartitionStyle.Gpt,
-            formatMode: UsbFormatMode.Quick,
-            bootDriveLetter: 'S',
-            cacheDriveLetter: 'T');
+            formatMode: UsbFormatMode.Quick);
 
         Assert.Contains("FOUNDRY_USB_VERBOSE|", script, StringComparison.Ordinal);
         Assert.DoesNotContain("Write-Verbose", script, StringComparison.Ordinal);
@@ -335,9 +322,7 @@ public sealed class WinPeUsbMediaServiceTests
         string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(
             diskNumber: 8,
             partitionStyle: UsbPartitionStyle.Mbr,
-            formatMode: UsbFormatMode.Complete,
-            bootDriveLetter: 'U',
-            cacheDriveLetter: 'V');
+            formatMode: UsbFormatMode.Complete);
 
         Assert.Contains("$diskNumber = 8", script, StringComparison.Ordinal);
         Assert.Contains("$partitionStyle = 'MBR'", script, StringComparison.Ordinal);
@@ -499,6 +484,44 @@ public sealed class WinPeUsbMediaServiceTests
     }
 
     [Fact]
+    public async Task ProvisionAndPopulateAsync_WhenProvisioningAssignsDriveLetters_UsesReturnedLetters()
+    {
+        string diskIdentity = """
+                              {"Number":9,"FriendlyName":"Safe USB","SerialNumber":"SERIAL","UniqueId":"UNIQUE","BusType":"USB","IsRemovable":true,"IsSystem":false,"IsBoot":false,"Size":64000000000}
+                              """;
+        string provisioningResult = """
+                                    FOUNDRY_USB_PROGRESS|55|USB partitions formatted.
+                                    {"DiskNumber":9,"BootDriveLetter":"Y:","CacheDriveLetter":"Z:"}
+                                    """;
+        var runner = new FakeSequenceRunner(diskIdentity, provisioningResult, string.Empty);
+        using TempWorkspace workspace = TempWorkspace.Create();
+        var service = new WinPeUsbMediaService(runner);
+
+        await service.ProvisionAndPopulateAsync(
+            new UsbOutputOptions
+            {
+                TargetDiskNumber = 9,
+                ExpectedDiskFriendlyName = "Safe USB",
+                PartitionStyle = UsbPartitionStyle.Gpt,
+                FormatMode = UsbFormatMode.Quick
+            },
+            new WinPeBuildArtifact
+            {
+                WorkingDirectoryPath = workspace.RootPath,
+                MediaDirectoryPath = Path.Combine(workspace.RootPath, "media"),
+                Architecture = WinPeArchitecture.X64
+            },
+            new WinPeToolPaths { PowerShellPath = "pwsh.exe" },
+            useBootEx: false,
+            CancellationToken.None);
+
+        WinPeProcessExecution copyExecution = Assert.Single(
+            runner.Executions,
+            execution => execution.FileName.EndsWith("robocopy.exe", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains("Y:\\", copyExecution.Arguments, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ProvisionAndPopulateAsync_WhenProvisioningStreamsOutput_ReportsProvisioningSubstepsAndVerboseDetails()
     {
         string payload = """
@@ -556,6 +579,50 @@ public sealed class WinPeUsbMediaServiceTests
                 WorkingDirectory = workingDirectory,
                 ExitCode = 0,
                 StandardOutput = output
+            };
+            Executions.Add(execution);
+            return Task.FromResult(execution);
+        }
+
+        public Task<WinPeProcessExecution> RunCmdScriptAsync(
+            string scriptPath,
+            string scriptArguments,
+            string workingDirectory,
+            CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<WinPeProcessExecution> RunCmdScriptDirectAsync(
+            string scriptPath,
+            string scriptArguments,
+            string workingDirectory,
+            CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed class FakeSequenceRunner(params string[] outputs) : IWinPeProcessRunner
+    {
+        private readonly Queue<string> _outputs = new(outputs);
+
+        public List<WinPeProcessExecution> Executions { get; } = [];
+
+        public Task<WinPeProcessExecution> RunAsync(
+            string fileName,
+            string arguments,
+            string workingDirectory,
+            CancellationToken cancellationToken,
+            IReadOnlyDictionary<string, string>? environmentOverrides = null)
+        {
+            var execution = new WinPeProcessExecution
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                WorkingDirectory = workingDirectory,
+                ExitCode = 0,
+                StandardOutput = _outputs.Count > 0 ? _outputs.Dequeue() : string.Empty
             };
             Executions.Add(execution);
             return Task.FromResult(execution);

--- a/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
@@ -251,6 +251,31 @@ public sealed class WinPeUsbMediaServiceTests
     }
 
     [Fact]
+    public void BuildPowerShellProvisioningScript_WhenRecreatingUsb_ReleasesTargetDriveLettersBeforeClearingDisk()
+    {
+        string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(
+            diskNumber: 7,
+            partitionStyle: UsbPartitionStyle.Gpt,
+            formatMode: UsbFormatMode.Quick,
+            bootDriveLetter: 'S',
+            cacheDriveLetter: 'T');
+
+        Assert.Contains("function Clear-FoundryUsbDriveLetter", script, StringComparison.Ordinal);
+        Assert.Contains("Clear-FoundryUsbDriveLetter -DriveLetter $bootDriveLetter", script, StringComparison.Ordinal);
+        Assert.Contains("Clear-FoundryUsbDriveLetter -DriveLetter $cacheDriveLetter", script, StringComparison.Ordinal);
+        Assert.Contains("Remove-PartitionAccessPath", script, StringComparison.Ordinal);
+        Assert.True(
+            script.IndexOf("Clear-FoundryUsbDriveLetter -DriveLetter $bootDriveLetter", StringComparison.Ordinal) <
+            script.IndexOf("Clear-Disk -Number $diskNumber", StringComparison.Ordinal));
+        Assert.True(
+            script.IndexOf("Clear-FoundryUsbDriveLetter -DriveLetter $cacheDriveLetter", StringComparison.Ordinal) <
+            script.IndexOf("Clear-Disk -Number $diskNumber", StringComparison.Ordinal));
+        Assert.True(
+            script.IndexOf("Clear-Disk -Number $diskNumber", StringComparison.Ordinal) <
+            script.IndexOf("$bootPartition = New-Partition @bootPartitionArguments", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void BuildPowerShellProvisioningScript_WhenCreatingPartitions_WaitsForVolumesBeforeFormatting()
     {
         string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(

--- a/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
@@ -454,10 +454,13 @@ public sealed class WinPeUsbMediaServiceTests
     [Fact]
     public async Task ProvisionAndPopulateAsync_WhenPartitioningUsb_UsesPowerShellStorageProvisioning()
     {
-        string payload = """
-                         {"Number":9,"FriendlyName":"Safe USB","SerialNumber":"SERIAL","UniqueId":"UNIQUE","BusType":"USB","IsRemovable":true,"IsSystem":false,"IsBoot":false,"Size":64000000000}
-                         """;
-        var runner = new FakeRunner(payload);
+        string diskIdentity = """
+                              {"Number":9,"FriendlyName":"Safe USB","SerialNumber":"SERIAL","UniqueId":"UNIQUE","BusType":"USB","IsRemovable":true,"IsSystem":false,"IsBoot":false,"Size":64000000000}
+                              """;
+        string provisioningResult = """
+                                    {"DiskNumber":9,"BootDriveLetter":"Y:","CacheDriveLetter":"Z:"}
+                                    """;
+        var runner = new FakeSequenceRunner(diskIdentity, provisioningResult, string.Empty);
         using TempWorkspace workspace = TempWorkspace.Create();
         var service = new WinPeUsbMediaService(runner);
 
@@ -481,6 +484,7 @@ public sealed class WinPeUsbMediaServiceTests
 
         Assert.DoesNotContain("diskpart.exe", runner.Executions.Select(execution => execution.FileName));
         Assert.Equal(2, runner.Executions.Count(execution => execution.FileName == "pwsh.exe"));
+        Assert.Contains(runner.Executions, execution => execution.FileName.EndsWith("robocopy.exe", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -527,7 +531,11 @@ public sealed class WinPeUsbMediaServiceTests
         string payload = """
                          {"Number":9,"FriendlyName":"Safe USB","SerialNumber":"SERIAL","UniqueId":"UNIQUE","BusType":"USB","IsRemovable":true,"IsSystem":false,"IsBoot":false,"Size":64000000000}
                          """;
-        var runner = new FakeOutputRunner(payload);
+        string provisioningResult = """
+                                    FOUNDRY_USB_PROGRESS|55|USB partitions formatted.
+                                    {"DiskNumber":9,"BootDriveLetter":"S:","CacheDriveLetter":"T:"}
+                                    """;
+        var runner = new FakeOutputRunner(payload, provisioningResult);
         var progress = new RecordingProgress();
         using TempWorkspace workspace = TempWorkspace.Create();
         var service = new WinPeUsbMediaService(runner);
@@ -559,6 +567,7 @@ public sealed class WinPeUsbMediaServiceTests
             report => report.Percent == 44 &&
                       report.Status == "Formatting BOOT partition." &&
                       report.LogDetail == "BOOT partition formatted. DriveLetter=S, FileSystem=FAT32, Label=BOOT.");
+        Assert.DoesNotContain(progress.Reports, report => report.LogDetail?.StartsWith('{') == true);
     }
 
     private class FakeRunner(string output) : IWinPeProcessRunner
@@ -647,7 +656,7 @@ public sealed class WinPeUsbMediaServiceTests
         }
     }
 
-    private sealed class FakeOutputRunner(string output) : FakeRunner(output), IWinPeProcessOutputRunner
+    private sealed class FakeOutputRunner(string output, string provisioningOutput) : FakeRunner(output), IWinPeProcessOutputRunner
     {
         public Task<WinPeProcessExecution> RunWithOutputAsync(
             string fileName,
@@ -662,8 +671,18 @@ public sealed class WinPeUsbMediaServiceTests
             onOutputData?.Invoke("FOUNDRY_USB_PROGRESS|44|Formatting BOOT partition.");
             onOutputData?.Invoke("FOUNDRY_USB_VERBOSE|BOOT partition formatted. DriveLetter=S, FileSystem=FAT32, Label=BOOT.");
             onOutputData?.Invoke("FOUNDRY_USB_PROGRESS|53|Formatting cache partition.");
+            onOutputData?.Invoke("""{"DiskNumber":9,"BootDriveLetter":"S:","CacheDriveLetter":"T:"}""");
 
-            return RunAsync(fileName, arguments, workingDirectory, cancellationToken, environmentOverrides);
+            var execution = new WinPeProcessExecution
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                WorkingDirectory = workingDirectory,
+                ExitCode = 0,
+                StandardOutput = provisioningOutput
+            };
+            Executions.Add(execution);
+            return Task.FromResult(execution);
         }
     }
 

--- a/src/Foundry.Core/Assets/WinPe/ProvisionUsbDisk.ps1
+++ b/src/Foundry.Core/Assets/WinPe/ProvisionUsbDisk.ps1
@@ -27,26 +27,26 @@ function Wait-FoundryUsbVolume([char]$DriveLetter, [string]$VolumeName) {
     throw "Timed out waiting for $VolumeName volume $DriveLetter`: to become available."
 }
 
-function Clear-FoundryUsbDriveLetter([char]$DriveLetter) {
-    $accessPath = ('{0}:\' -f $DriveLetter)
-    $partitions = @(
-        Get-Partition -DiskNumber $diskNumber -ErrorAction SilentlyContinue |
-            Where-Object { $_.DriveLetter -eq $DriveLetter }
-    )
+function Clear-FoundryUsbTargetAccessPaths {
+    $partitions = @(Get-Partition -DiskNumber $diskNumber -ErrorAction SilentlyContinue)
 
     foreach ($partition in $partitions) {
-        Write-FoundryUsbVerbose "Removing existing USB drive letter $DriveLetter`: from partition $($partition.PartitionNumber)."
-        Remove-PartitionAccessPath -DiskNumber $diskNumber -PartitionNumber $partition.PartitionNumber -AccessPath $accessPath -ErrorAction Stop
+        foreach ($accessPath in @($partition.AccessPaths)) {
+            if ([string]::IsNullOrWhiteSpace($accessPath) -or $accessPath -notmatch '^[A-Z]:\\$') {
+                continue
+            }
+
+            Write-FoundryUsbVerbose "Removing existing USB access path $accessPath from partition $($partition.PartitionNumber)."
+            Remove-PartitionAccessPath -DiskNumber $diskNumber -PartitionNumber $partition.PartitionNumber -AccessPath $accessPath -ErrorAction Stop
+        }
     }
 }
 
 $diskNumber = {{DISK_NUMBER}}
 $partitionStyle = '{{PARTITION_STYLE}}'
 $fullFormat = {{FULL_FORMAT}}
-$bootDriveLetter = '{{BOOT_DRIVE_LETTER}}'
-$cacheDriveLetter = '{{CACHE_DRIVE_LETTER}}'
 
-Write-FoundryUsbVerbose "Provisioning disk $diskNumber. PartitionStyle=$partitionStyle, FullFormat=$fullFormat, BootDriveLetter=$bootDriveLetter, CacheDriveLetter=$cacheDriveLetter."
+Write-FoundryUsbVerbose "Provisioning disk $diskNumber. PartitionStyle=$partitionStyle, FullFormat=$fullFormat."
 
 Write-FoundryUsbProgress 21 'Opening USB disk.'
 $disk = Get-Disk -Number $diskNumber -ErrorAction Stop
@@ -55,8 +55,7 @@ Write-FoundryUsbVerbose "Disk opened. Number=$($disk.Number), FriendlyName=$($di
 Write-FoundryUsbProgress 23 'Preparing USB disk attributes.'
 if ($disk.IsOffline) { Set-Disk -Number $diskNumber -IsOffline $false -ErrorAction Stop }
 if ($disk.IsReadOnly) { Set-Disk -Number $diskNumber -IsReadOnly $false -ErrorAction Stop }
-Clear-FoundryUsbDriveLetter -DriveLetter $bootDriveLetter
-Clear-FoundryUsbDriveLetter -DriveLetter $cacheDriveLetter
+Clear-FoundryUsbTargetAccessPaths
 Update-HostStorageCache -ErrorAction SilentlyContinue
 Update-Disk -Number $diskNumber -ErrorAction SilentlyContinue
 Write-FoundryUsbVerbose 'USB disk attributes prepared.'
@@ -100,7 +99,7 @@ Write-FoundryUsbProgress 38 'Creating BOOT partition.'
 $bootPartitionArguments = @{
     DiskNumber = $diskNumber
     Size = 2048MB
-    DriveLetter = $bootDriveLetter
+    AssignDriveLetter = $true
     ErrorAction = 'Stop'
 }
 if ($partitionStyle -eq 'GPT') {
@@ -110,6 +109,8 @@ if ($partitionStyle -eq 'GPT') {
     $bootPartitionArguments['IsActive'] = $true
 }
 $bootPartition = New-Partition @bootPartitionArguments
+$bootDriveLetter = $bootPartition.DriveLetter
+if ($null -eq $bootDriveLetter) { throw 'BOOT partition was created without a drive letter.' }
 Write-FoundryUsbVerbose "BOOT partition created. PartitionNumber=$($bootPartition.PartitionNumber), DriveLetter=$($bootPartition.DriveLetter), Size=$($bootPartition.Size)."
 if ($partitionStyle -eq 'MBR') { Write-FoundryUsbVerbose "BOOT partition marked active. PartitionNumber=$($bootPartition.PartitionNumber)." }
 Wait-FoundryUsbVolume -DriveLetter $bootDriveLetter -VolumeName 'BOOT'
@@ -131,7 +132,7 @@ Write-FoundryUsbProgress 49 'Creating cache partition.'
 $cachePartitionArguments = @{
     DiskNumber = $diskNumber
     UseMaximumSize = $true
-    DriveLetter = $cacheDriveLetter
+    AssignDriveLetter = $true
     ErrorAction = 'Stop'
 }
 if ($partitionStyle -eq 'GPT') {
@@ -140,6 +141,8 @@ if ($partitionStyle -eq 'GPT') {
     $cachePartitionArguments['MbrType'] = 'IFS'
 }
 $cachePartition = New-Partition @cachePartitionArguments
+$cacheDriveLetter = $cachePartition.DriveLetter
+if ($null -eq $cacheDriveLetter) { throw 'Cache partition was created without a drive letter.' }
 Write-FoundryUsbVerbose "Cache partition created. PartitionNumber=$($cachePartition.PartitionNumber), DriveLetter=$($cachePartition.DriveLetter), Size=$($cachePartition.Size)."
 Wait-FoundryUsbVolume -DriveLetter $cacheDriveLetter -VolumeName 'cache'
 

--- a/src/Foundry.Core/Assets/WinPe/ProvisionUsbDisk.ps1
+++ b/src/Foundry.Core/Assets/WinPe/ProvisionUsbDisk.ps1
@@ -27,6 +27,19 @@ function Wait-FoundryUsbVolume([char]$DriveLetter, [string]$VolumeName) {
     throw "Timed out waiting for $VolumeName volume $DriveLetter`: to become available."
 }
 
+function Clear-FoundryUsbDriveLetter([char]$DriveLetter) {
+    $accessPath = ('{0}:\' -f $DriveLetter)
+    $partitions = @(
+        Get-Partition -DiskNumber $diskNumber -ErrorAction SilentlyContinue |
+            Where-Object { $_.DriveLetter -eq $DriveLetter }
+    )
+
+    foreach ($partition in $partitions) {
+        Write-FoundryUsbVerbose "Removing existing USB drive letter $DriveLetter`: from partition $($partition.PartitionNumber)."
+        Remove-PartitionAccessPath -DiskNumber $diskNumber -PartitionNumber $partition.PartitionNumber -AccessPath $accessPath -ErrorAction Stop
+    }
+}
+
 $diskNumber = {{DISK_NUMBER}}
 $partitionStyle = '{{PARTITION_STYLE}}'
 $fullFormat = {{FULL_FORMAT}}
@@ -42,6 +55,10 @@ Write-FoundryUsbVerbose "Disk opened. Number=$($disk.Number), FriendlyName=$($di
 Write-FoundryUsbProgress 23 'Preparing USB disk attributes.'
 if ($disk.IsOffline) { Set-Disk -Number $diskNumber -IsOffline $false -ErrorAction Stop }
 if ($disk.IsReadOnly) { Set-Disk -Number $diskNumber -IsReadOnly $false -ErrorAction Stop }
+Clear-FoundryUsbDriveLetter -DriveLetter $bootDriveLetter
+Clear-FoundryUsbDriveLetter -DriveLetter $cacheDriveLetter
+Update-HostStorageCache -ErrorAction SilentlyContinue
+Update-Disk -Number $diskNumber -ErrorAction SilentlyContinue
 Write-FoundryUsbVerbose 'USB disk attributes prepared.'
 
 Write-FoundryUsbProgress 26 'Clearing USB partition table.'

--- a/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
@@ -603,6 +603,10 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
             string verboseLine = line.StartsWith(UsbProvisioningVerbosePrefix, StringComparison.Ordinal)
                 ? line[UsbProvisioningVerbosePrefix.Length..]
                 : line;
+            if (verboseLine.Length > 0 && verboseLine[0] == '{')
+            {
+                return;
+            }
 
             progress.Report(new WinPeMediaProgress
             {

--- a/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
@@ -161,31 +161,11 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
             return WinPeResult<WinPeUsbProvisionResult>.Failure(safetyValidation.Error!);
         }
 
-        char bootDriveLetter = FindAvailableDriveLetter('\0');
-        if (bootDriveLetter == '\0')
-        {
-            return WinPeResult<WinPeUsbProvisionResult>.Failure(
-                WinPeErrorCodes.UsbProvisioningFailed,
-                "No free drive letter is available for the BOOT partition.",
-                "Free at least two drive letters between D: and Z: and retry.");
-        }
-
-        char cacheDriveLetter = FindAvailableDriveLetter(bootDriveLetter);
-        if (cacheDriveLetter == '\0')
-        {
-            return WinPeResult<WinPeUsbProvisionResult>.Failure(
-                WinPeErrorCodes.UsbProvisioningFailed,
-                "No free drive letter is available for the cache partition.",
-                "Free at least one drive letter between D: and Z: and retry.");
-        }
-
         ReportProgress(options.Progress, 20, "Partitioning and formatting USB target.");
-        WinPeResult provisioningResult = await ProvisionDiskAsync(
+        WinPeResult<WinPeUsbProvisionResult> provisioningResult = await ProvisionDiskAsync(
             diskNumber,
             options.PartitionStyle,
             options.FormatMode,
-            bootDriveLetter,
-            cacheDriveLetter,
             tools,
             artifact.WorkingDirectoryPath,
             options.Progress,
@@ -195,8 +175,9 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
             return WinPeResult<WinPeUsbProvisionResult>.Failure(provisioningResult.Error!);
         }
 
-        string bootRootPath = $"{bootDriveLetter}:\\";
-        string cacheRootPath = $"{cacheDriveLetter}:\\";
+        WinPeUsbProvisionResult provisionedUsb = provisioningResult.Value!;
+        string bootRootPath = $"{provisionedUsb.BootDriveLetter}\\";
+        string cacheRootPath = $"{provisionedUsb.CacheDriveLetter}\\";
         ReportProgress(options.Progress, 55, "Copying WinPE media to USB.");
         WinPeResult copyResult = await CopyMediaAsync(
             artifact.MediaDirectoryPath,
@@ -249,11 +230,7 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
         }
 
         ReportProgress(options.Progress, 100, "USB media completed.");
-        return WinPeResult<WinPeUsbProvisionResult>.Success(new WinPeUsbProvisionResult
-        {
-            BootDriveLetter = $"{bootDriveLetter}:",
-            CacheDriveLetter = $"{cacheDriveLetter}:"
-        });
+        return WinPeResult<WinPeUsbProvisionResult>.Success(provisionedUsb);
     }
 
     internal static WinPeResult ValidateDiskSafety(UsbOutputOptions options, WinPeUsbDiskIdentity disk)
@@ -338,22 +315,16 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
     internal static string BuildPowerShellProvisioningScript(
         int diskNumber,
         UsbPartitionStyle partitionStyle,
-        UsbFormatMode formatMode,
-        char bootDriveLetter,
-        char cacheDriveLetter)
+        UsbFormatMode formatMode)
     {
         string template = WinPeEmbeddedAssetService.ReadEmbeddedText(WinPeEmbeddedAssetService.UsbProvisioningScriptResourceName);
         string partitionStyleText = partitionStyle == UsbPartitionStyle.Gpt ? "GPT" : "MBR";
         string fullFormatValue = formatMode == UsbFormatMode.Complete ? "$true" : "$false";
-        char normalizedBootDriveLetter = char.ToUpperInvariant(bootDriveLetter);
-        char normalizedCacheDriveLetter = char.ToUpperInvariant(cacheDriveLetter);
 
         return template
             .Replace("{{DISK_NUMBER}}", diskNumber.ToString())
             .Replace("{{PARTITION_STYLE}}", partitionStyleText)
             .Replace("{{FULL_FORMAT}}", fullFormatValue)
-            .Replace("{{BOOT_DRIVE_LETTER}}", normalizedBootDriveLetter.ToString())
-            .Replace("{{CACHE_DRIVE_LETTER}}", normalizedCacheDriveLetter.ToString())
             .ReplaceLineEndings(Environment.NewLine);
     }
 
@@ -463,12 +434,10 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
         return WinPeResult.Success();
     }
 
-    private async Task<WinPeResult> ProvisionDiskAsync(
+    private async Task<WinPeResult<WinPeUsbProvisionResult>> ProvisionDiskAsync(
         int diskNumber,
         UsbPartitionStyle partitionStyle,
         UsbFormatMode formatMode,
-        char bootDriveLetter,
-        char cacheDriveLetter,
         WinPeToolPaths tools,
         string workingDirectoryPath,
         IProgress<WinPeMediaProgress>? progress,
@@ -477,9 +446,7 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
         string script = BuildPowerShellProvisioningScript(
             diskNumber,
             partitionStyle,
-            formatMode,
-            bootDriveLetter,
-            cacheDriveLetter);
+            formatMode);
 
         Directory.CreateDirectory(workingDirectoryPath);
         string encodedScript = Convert.ToBase64String(Encoding.Unicode.GetBytes(script));
@@ -501,17 +468,68 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
 
         if (execution.IsSuccess)
         {
-            return WinPeResult.Success();
+            return ParseUsbProvisionResult(execution);
         }
 
         string diagnostic = $"{execution.ToDiagnosticText()}{Environment.NewLine}" +
                             $"PartitionStyle: {partitionStyle}{Environment.NewLine}" +
                             "PowerShellProvisioningScript:" + Environment.NewLine +
                             script;
-        return WinPeResult.Failure(
+        return WinPeResult<WinPeUsbProvisionResult>.Failure(
             WinPeErrorCodes.UsbProvisioningFailed,
             "Failed to partition and format the USB disk.",
             diagnostic);
+    }
+
+    private static WinPeResult<WinPeUsbProvisionResult> ParseUsbProvisionResult(WinPeProcessExecution execution)
+    {
+        string[] lines = execution.StandardOutput.Split(
+            [Environment.NewLine, "\n"],
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        foreach (string line in lines.Reverse())
+        {
+            if (!line.StartsWith('{'))
+            {
+                continue;
+            }
+
+            try
+            {
+                WinPeUsbProvisionResult? result = JsonSerializer.Deserialize<WinPeUsbProvisionResult>(
+                    line,
+                    new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                if (result is null)
+                {
+                    break;
+                }
+
+                string bootDriveLetter = NormalizeDriveLetter(result.BootDriveLetter);
+                string cacheDriveLetter = NormalizeDriveLetter(result.CacheDriveLetter);
+                if (string.IsNullOrWhiteSpace(bootDriveLetter) || string.IsNullOrWhiteSpace(cacheDriveLetter))
+                {
+                    break;
+                }
+
+                return WinPeResult<WinPeUsbProvisionResult>.Success(result with
+                {
+                    BootDriveLetter = bootDriveLetter,
+                    CacheDriveLetter = cacheDriveLetter
+                });
+            }
+            catch (JsonException ex)
+            {
+                return WinPeResult<WinPeUsbProvisionResult>.Failure(
+                    WinPeErrorCodes.UsbProvisioningFailed,
+                    "Failed to parse USB provisioning result.",
+                    ex.Message);
+            }
+        }
+
+        return WinPeResult<WinPeUsbProvisionResult>.Failure(
+            WinPeErrorCodes.UsbProvisioningFailed,
+            "USB provisioning did not return assigned drive letters.",
+            execution.ToDiagnosticText());
     }
 
     private async Task<WinPeResult> CopyMediaAsync(
@@ -645,28 +663,6 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
                 "Failed to parse target USB disk details.",
                 ex.Message);
         }
-    }
-
-    private static char FindAvailableDriveLetter(char excludedLetter)
-    {
-        HashSet<char> usedLetters = DriveInfo.GetDrives()
-            .Select(drive => char.ToUpperInvariant(drive.Name[0]))
-            .ToHashSet();
-
-        for (char letter = 'D'; letter <= 'Z'; letter++)
-        {
-            if (letter == char.ToUpperInvariant(excludedLetter))
-            {
-                continue;
-            }
-
-            if (!usedLetters.Contains(letter))
-            {
-                return letter;
-            }
-        }
-
-        return '\0';
     }
 
     private async Task<WinPeResult<string>> RunPowerShellAsync(
@@ -832,5 +828,23 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
     private static bool ContainsIgnoreCase(string source, string expectedFragment)
     {
         return source.IndexOf(expectedFragment, StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static string NormalizeDriveLetter(string value)
+    {
+        string normalizedValue = value.Trim();
+        if (normalizedValue.Length == 1 && char.IsLetter(normalizedValue[0]))
+        {
+            return $"{char.ToUpperInvariant(normalizedValue[0])}:";
+        }
+
+        if (normalizedValue.Length == 2 &&
+            char.IsLetter(normalizedValue[0]) &&
+            normalizedValue[1] == ':')
+        {
+            return $"{char.ToUpperInvariant(normalizedValue[0])}:";
+        }
+
+        return string.Empty;
     }
 }


### PR DESCRIPTION
## Summary
- Release existing drive-letter access paths from all partitions on the target USB disk before clearing it.
- Let the Storage module assign BOOT/cache drive letters during `New-Partition` instead of preselecting them in .NET.
- Parse the provisioning script JSON result and use the actual assigned letters for copy, verification, cache setup, and the returned USB result.

## Reason
Recreating a USB key on the same device can leave stale or Storage-reserved access paths that are invisible to `DriveInfo.GetDrives()`. Preselecting letters in .NET can therefore pass a letter that `New-Partition -DriveLetter` rejects with `The requested access path is already in use`.

## Main changes
- Replaced selected-letter cleanup with target-disk access-path cleanup.
- Switched partition creation to `AssignDriveLetter = $true`.
- Changed USB provisioning to return and consume the actual script-assigned drive letters.
- Removed the obsolete .NET drive-letter preselection path.
- Added regression coverage for script generation and the C# returned-letter flow.

## Testing
- `dotnet test src\Foundry.Core.Tests\Foundry.Core.Tests.csproj --filter WinPeUsbMediaServiceTests`
- All `*.Tests.csproj` projects with `dotnet test --no-restore`
