### PR TITLE
fix(winpe): defer unused boot folder creation

### DIFF
--- a/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
@@ -113,18 +113,19 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
             CancellationToken.None);
 
         Assert.True(result.IsSuccess, result.Error?.Details);
-        Assert.True(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Network", "Wired", "Profiles")));
         Assert.Equal("{\"schemaVersion\":1}", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.connect.config.json")));
         Assert.Equal("{\"schemaVersion\":2}", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.deploy.config.json")));
         Assert.Equal("debug", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.connect.provisioning-source.txt")));
         Assert.Equal("release", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.deploy.provisioning-source.txt")));
         Assert.Equal("{\"zones\":[]}", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "iana-windows-timezones.json")));
         Assert.Equal("<WLANProfile />", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Network", "Wifi", "Profiles", "profile.xml")));
+        Assert.False(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Network", "Wired")));
+        Assert.False(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Network", "Certificates")));
         Assert.Equal("{\"profile\":1}", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Autopilot", "Profile1", "AutopilotConfigurationFile.json")));
     }
 
     [Fact]
-    public async Task ProvisionAsync_CreatesRuntimeLogAndTempDirectories()
+    public async Task ProvisionAsync_DoesNotCreateRuntimeOwnedLogTempOrNetworkDirectories()
     {
         using TempMountedImage image = TempMountedImage.Create();
         string curlSourcePath = Path.Combine(image.RootPath, "curl.exe");
@@ -144,8 +145,9 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
             CancellationToken.None);
 
         Assert.True(result.IsSuccess, result.Error?.Details);
-        Assert.True(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Logs")));
-        Assert.True(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Temp")));
+        Assert.False(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Logs")));
+        Assert.False(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Temp")));
+        Assert.False(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Network")));
     }
 
     [Fact]

--- a/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
@@ -337,7 +337,7 @@ public sealed class WinPeUsbMediaServiceTests
     }
 
     [Fact]
-    public void InitializeCachePartitionDirectories_CreatesUsbCacheLayoutWithoutLogs()
+    public void InitializeCachePartitionDirectories_CreatesOnlyMediaCreationCacheLayout()
     {
         using TempWorkspace workspace = TempWorkspace.Create();
 
@@ -347,8 +347,8 @@ public sealed class WinPeUsbMediaServiceTests
         Assert.True(Directory.Exists(Path.Combine(workspace.RootPath, "Cache", "OperatingSystems")));
         Assert.True(Directory.Exists(Path.Combine(workspace.RootPath, "Cache", "DriverPacks")));
         Assert.True(Directory.Exists(Path.Combine(workspace.RootPath, "Cache", "Firmware")));
-        Assert.True(Directory.Exists(Path.Combine(workspace.RootPath, "State")));
-        Assert.True(Directory.Exists(Path.Combine(workspace.RootPath, "Temp")));
+        Assert.False(Directory.Exists(Path.Combine(workspace.RootPath, "State")));
+        Assert.False(Directory.Exists(Path.Combine(workspace.RootPath, "Temp")));
         Assert.False(Directory.Exists(Path.Combine(workspace.RootPath, "Logs")));
     }
 

--- a/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningService.cs
@@ -33,8 +33,6 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
 
             Directory.CreateDirectory(system32Path);
             Directory.CreateDirectory(foundryConfigPath);
-            Directory.CreateDirectory(Path.Combine(foundryRootPath, "Logs"));
-            Directory.CreateDirectory(Path.Combine(foundryRootPath, "Temp"));
 
             await File.WriteAllTextAsync(
                 Path.Combine(system32Path, BootstrapFileName),
@@ -85,8 +83,6 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
         WinPeMountedImageAssetProvisioningOptions options,
         CancellationToken cancellationToken)
     {
-        CreateNetworkAssetDirectories(foundryConfigPath);
-
         string connectConfigurationJson = string.IsNullOrWhiteSpace(options.FoundryConnectConfigurationJson)
             ? CreateFallbackFoundryConnectConfigurationJson()
             : options.FoundryConnectConfigurationJson;
@@ -133,16 +129,6 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
 
         CopyConnectAssetFiles(mountedImagePath, options.FoundryConnectAssetFiles);
         await WriteAutopilotProfilesAsync(foundryConfigPath, options.AutopilotProfiles, cancellationToken).ConfigureAwait(false);
-    }
-
-    private static void CreateNetworkAssetDirectories(string foundryConfigPath)
-    {
-        string networkRoot = Path.Combine(foundryConfigPath, "Network");
-        Directory.CreateDirectory(Path.Combine(networkRoot, "Wired", "Profiles"));
-        Directory.CreateDirectory(Path.Combine(networkRoot, "Wifi", "Profiles"));
-        Directory.CreateDirectory(Path.Combine(networkRoot, "Certificates"));
-        Directory.CreateDirectory(Path.Combine(networkRoot, "Certificates", "Wired"));
-        Directory.CreateDirectory(Path.Combine(networkRoot, "Certificates", "Wifi"));
     }
 
     private static async Task WriteMediaSecretsKeyAsync(

--- a/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
@@ -334,8 +334,6 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
         Directory.CreateDirectory(Path.Combine(cacheRootPath, "Cache", "OperatingSystems"));
         Directory.CreateDirectory(Path.Combine(cacheRootPath, "Cache", "DriverPacks"));
         Directory.CreateDirectory(Path.Combine(cacheRootPath, "Cache", "Firmware"));
-        Directory.CreateDirectory(Path.Combine(cacheRootPath, "State"));
-        Directory.CreateDirectory(Path.Combine(cacheRootPath, "Temp"));
     }
 
     internal static WinPeRuntimePayloadProvisioningOptions CreateUsbRuntimePayloadOptions(

--- a/src/Foundry.Deploy.Tests/PrepareTargetDiskLayoutStepTests.cs
+++ b/src/Foundry.Deploy.Tests/PrepareTargetDiskLayoutStepTests.cs
@@ -1,0 +1,308 @@
+using Foundry.Deploy.Models;
+using Foundry.Deploy.Models.Configuration;
+using Foundry.Deploy.Services.Cache;
+using Foundry.Deploy.Services.Deployment;
+using Foundry.Deploy.Services.Deployment.Steps;
+using Foundry.Deploy.Services.Hardware;
+using Foundry.Deploy.Services.Logging;
+using Foundry.Deploy.Services.Operations;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class PrepareTargetDiskLayoutStepTests
+{
+    [Fact]
+    public async Task ExecuteAsync_WhenIsoMode_PreparesTargetWorkspaceWithoutEagerPayloadCacheFolders()
+    {
+        using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
+        var step = new PrepareTargetDiskLayoutStep(new FakeWindowsDeploymentService(workspace));
+        DeploymentStepExecutionContext context = CreateExecutionContext(workspace, DeploymentMode.Iso);
+
+        DeploymentStepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(DeploymentStepState.Succeeded, result.State);
+        string targetFoundryRoot = Path.Combine(workspace.WindowsRoot, "Foundry");
+        Assert.Equal(targetFoundryRoot, context.RuntimeState.TargetFoundryRoot);
+        Assert.True(Directory.Exists(Path.Combine(targetFoundryRoot, "Logs")));
+        Assert.True(Directory.Exists(Path.Combine(targetFoundryRoot, "State")));
+        Assert.False(Directory.Exists(Path.Combine(targetFoundryRoot, "Cache", "OperatingSystems")));
+        Assert.False(Directory.Exists(Path.Combine(targetFoundryRoot, "Cache", "DriverPacks")));
+    }
+
+    private static DeploymentStepExecutionContext CreateExecutionContext(
+        TempDeploymentWorkspace workspace,
+        DeploymentMode mode)
+    {
+        var request = new DeploymentContext
+        {
+            Mode = mode,
+            CacheRootPath = workspace.CacheRuntimeRoot,
+            TargetDiskNumber = 1,
+            TargetComputerName = "LAB01",
+            OperatingSystem = new OperatingSystemCatalogItem(),
+            DriverPackSelectionKind = DriverPackSelectionKind.None,
+            IsDryRun = false
+        };
+
+        var runtimeState = new DeploymentRuntimeState
+        {
+            WorkspaceRoot = workspace.WorkspaceRoot,
+            Mode = mode,
+            ResolvedCache = new CacheResolution
+            {
+                RootPath = workspace.CacheRuntimeRoot,
+                Source = "test"
+            }
+        };
+
+        return new DeploymentStepExecutionContext(
+            request,
+            runtimeState,
+            [],
+            new FakeOperationProgressService(),
+            new FakeDeploymentLogService(),
+            new FakeTargetDiskService(),
+            _ => { });
+    }
+
+    private sealed class FakeWindowsDeploymentService : IWindowsDeploymentService
+    {
+        private readonly TempDeploymentWorkspace _workspace;
+
+        public FakeWindowsDeploymentService(TempDeploymentWorkspace workspace)
+        {
+            _workspace = workspace;
+        }
+
+        public Task<DeploymentTargetLayout> PrepareTargetDiskAsync(
+            int diskNumber,
+            string workingDirectory,
+            CancellationToken cancellationToken = default)
+        {
+            Directory.CreateDirectory(workingDirectory);
+
+            return Task.FromResult(new DeploymentTargetLayout
+            {
+                DiskNumber = diskNumber,
+                SystemPartitionRoot = _workspace.SystemRoot,
+                WindowsPartitionRoot = _workspace.WindowsRoot,
+                RecoveryPartitionRoot = _workspace.RecoveryRoot,
+                RecoveryPartitionLetter = 'R'
+            });
+        }
+
+        public Task<int> ResolveImageIndexAsync(
+            string imagePath,
+            string requestedEdition,
+            string workingDirectory,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task ApplyImageAsync(
+            string imagePath,
+            int imageIndex,
+            string windowsPartitionRoot,
+            string scratchDirectory,
+            string workingDirectory,
+            CancellationToken cancellationToken = default,
+            IProgress<double>? progress = null)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<string?> GetAppliedWindowsEditionAsync(
+            string windowsPartitionRoot,
+            string workingDirectory,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task ConfigureOfflineComputerNameAsync(
+            string windowsPartitionRoot,
+            string computerName,
+            string processorArchitecture,
+            string? defaultTimeZoneId = null,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task ConfigureOfflineOobeAsync(
+            string windowsPartitionRoot,
+            DeployOobeSettings settings,
+            string processorArchitecture,
+            string workingDirectory,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task ConfigureRecoveryEnvironmentAsync(
+            string windowsPartitionRoot,
+            string recoveryPartitionRoot,
+            string workingDirectory,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task SealRecoveryPartitionAsync(
+            string recoveryPartitionRoot,
+            char recoveryPartitionLetter,
+            string workingDirectory,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task ApplyOfflineDriversAsync(
+            string windowsPartitionRoot,
+            string driverRoot,
+            string scratchDirectory,
+            string workingDirectory,
+            CancellationToken cancellationToken = default,
+            IProgress<double>? progress = null)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task ApplyRecoveryDriversAsync(
+            string recoveryPartitionRoot,
+            string driverRoot,
+            string scratchDirectory,
+            string workingDirectory,
+            CancellationToken cancellationToken = default,
+            IProgress<double>? mountProgress = null,
+            IProgress<double>? applyProgress = null,
+            IProgress<double>? unmountProgress = null,
+            Action? onMountStarted = null,
+            Action? onApplyStarted = null,
+            Action? onUnmountStarted = null)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task ConfigureBootAsync(
+            string windowsPartitionRoot,
+            string systemPartitionRoot,
+            int operatingSystemBuildMajor,
+            string workingDirectory,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed class FakeDeploymentLogService : IDeploymentLogService
+    {
+        public DeploymentLogSession Initialize(string rootPath)
+        {
+            string logsDirectory = Path.Combine(rootPath, "Logs");
+            string stateDirectory = Path.Combine(rootPath, "State");
+            Directory.CreateDirectory(logsDirectory);
+            Directory.CreateDirectory(stateDirectory);
+
+            return new DeploymentLogSession
+            {
+                RootPath = rootPath,
+                LogsDirectoryPath = logsDirectory,
+                StateDirectoryPath = stateDirectory,
+                LogFilePath = Path.Combine(logsDirectory, "FoundryDeploy.log"),
+                StateFilePath = Path.Combine(stateDirectory, "deployment-state.json")
+            };
+        }
+
+        public Task AppendAsync(
+            DeploymentLogSession session,
+            DeploymentLogLevel level,
+            string message,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task SaveStateAsync<TState>(
+            DeploymentLogSession session,
+            TState state,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public void Release(DeploymentLogSession session)
+        {
+        }
+    }
+
+    private sealed class FakeOperationProgressService : IOperationProgressService
+    {
+        public bool IsOperationInProgress => false;
+        public int Progress => 0;
+        public string? Status => null;
+        public OperationKind? CurrentOperation => null;
+        public bool CanStartOperation => true;
+        public event EventHandler? ProgressChanged;
+        public bool TryStart(OperationKind kind, string initialStatus, int initialProgress = 0) => true;
+        public void Report(int progress, string? status = null) => ProgressChanged?.Invoke(this, EventArgs.Empty);
+        public void Complete(string? status = null) => ProgressChanged?.Invoke(this, EventArgs.Empty);
+        public void Fail(string status) => ProgressChanged?.Invoke(this, EventArgs.Empty);
+        public void ResetToIdle() => ProgressChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private sealed class FakeTargetDiskService : ITargetDiskService
+    {
+        public Task<IReadOnlyList<TargetDiskInfo>> GetDisksAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<TargetDiskInfo>>(
+            [
+                new TargetDiskInfo
+                {
+                    DiskNumber = 1,
+                    FriendlyName = "Disk 1",
+                    IsSelectable = true
+                }
+            ]);
+        }
+
+        public Task<int?> GetDiskNumberForPathAsync(string path, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<int?>(null);
+        }
+    }
+
+    private sealed class TempDeploymentWorkspace : IDisposable
+    {
+        private TempDeploymentWorkspace(string rootPath)
+        {
+            RootPath = rootPath;
+            WorkspaceRoot = Path.Combine(rootPath, "Workspace");
+            CacheRuntimeRoot = Path.Combine(rootPath, "Foundry Cache", "Runtime");
+            SystemRoot = Path.Combine(rootPath, "System");
+            WindowsRoot = Path.Combine(rootPath, "Windows");
+            RecoveryRoot = Path.Combine(rootPath, "Recovery");
+            Directory.CreateDirectory(WorkspaceRoot);
+            Directory.CreateDirectory(CacheRuntimeRoot);
+        }
+
+        public string RootPath { get; }
+        public string WorkspaceRoot { get; }
+        public string CacheRuntimeRoot { get; }
+        public string SystemRoot { get; }
+        public string WindowsRoot { get; }
+        public string RecoveryRoot { get; }
+
+        public static TempDeploymentWorkspace Create()
+        {
+            string rootPath = Path.Combine(Path.GetTempPath(), $"foundry-prepare-target-{Guid.NewGuid():N}");
+            return new TempDeploymentWorkspace(rootPath);
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(RootPath, recursive: true);
+        }
+    }
+}

--- a/src/Foundry.Deploy/Services/Deployment/Steps/PrepareTargetDiskLayoutStep.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Steps/PrepareTargetDiskLayoutStep.cs
@@ -43,12 +43,6 @@ public sealed class PrepareTargetDiskLayoutStep : DeploymentStepBase
         context.RuntimeState.TargetRecoveryPartitionLetter = layout.RecoveryPartitionLetter;
         context.RuntimeState.TargetFoundryRoot = Path.Combine(layout.WindowsPartitionRoot, "Foundry");
 
-        if (context.RuntimeState.Mode == DeploymentMode.Iso)
-        {
-            Directory.CreateDirectory(Path.Combine(context.RuntimeState.TargetFoundryRoot, "Cache", "OperatingSystems"));
-            Directory.CreateDirectory(Path.Combine(context.RuntimeState.TargetFoundryRoot, "Cache", "DriverPacks"));
-        }
-
         context.EmitCurrentStepIndeterminate("Preparing target disk layout...", "Preparing target workspace...");
         await context.RebindLogSessionToTargetAsync(context.RuntimeState.TargetFoundryRoot, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
## Summary
- Stop creating unused USB cache `State` and `Temp` folders during media creation.
- Stop pre-creating runtime-owned `X:\Foundry\Logs` and `X:\Foundry\Temp` inside mounted WinPE images.
- Stop pre-creating empty `X:\Foundry\Config\Network` scaffolding when no network asset files are provided.
- Stop pre-creating ISO target payload cache folders under the target Foundry root before payload download steps need them.

## Reason
These folders are owned by later lifecycle stages. Creating them during boot image or target layout preparation leaves empty directories on media and target installations without a consumer at that stage.

## Main changes
- Removed eager USB cache `State` and `Temp` directory creation from `WinPeUsbMediaService`.
- Removed eager mounted-image `Logs`, `Temp`, and empty network asset directory creation from `WinPeMountedImageAssetProvisioningService`.
- Removed eager ISO target `Cache\OperatingSystems` and `Cache\DriverPacks` creation from `PrepareTargetDiskLayoutStep`.
- Updated and added regression tests for the reduced folder layouts.

## Testing
- `dotnet test src\Foundry.Core.Tests\Foundry.Core.Tests.csproj --no-restore --filter "FullyQualifiedName~WinPeMountedImageAssetProvisioningServiceTests" --logger "console;verbosity=minimal"`
- `dotnet test src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --no-restore --filter "FullyQualifiedName~PrepareTargetDiskLayoutStepTests.ExecuteAsync_WhenIsoMode_PreparesTargetWorkspaceWithoutEagerPayloadCacheFolders" --logger "console;verbosity=minimal"`
- `dotnet test src\Foundry.Core.Tests\Foundry.Core.Tests.csproj --no-restore --logger "console;verbosity=minimal"`
- `dotnet test src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --no-restore --logger "console;verbosity=minimal"`
- `dotnet test src\Foundry.Connect.Tests\Foundry.Connect.Tests.csproj --no-restore --logger "console;verbosity=minimal"`
- `dotnet test src\Foundry.Telemetry.Tests\Foundry.Telemetry.Tests.csproj --no-restore --logger "console;verbosity=minimal"`
