### PR TITLE
feat(autopilot): add secure tenant upload onboarding

### DIFF
--- a/docs/implementation/autopilot-hardware-hash-upload.md
+++ b/docs/implementation/autopilot-hardware-hash-upload.md
@@ -39,7 +39,7 @@ Use this table as the cross-phase implementation status board. Detailed task, au
 | --- | --- | --- | --- | --- | --- | --- |
 | 0 Foundation | [x] | [x] | [x] | [x] | [ ] | [ ] |
 | 1 Configuration model | [x] | [x] | [x] | [x] | [x] | [ ] |
-| 2 Security and tenant onboarding | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| 2 Security and tenant onboarding | [x] | [x] | [x] | [ ] | [x] | [ ] |
 | 3 Autopilot page UX | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
 | 4 Media build and WinPE assets | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
 | 5 Foundry Deploy runtime branching | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |

--- a/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
+++ b/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
@@ -49,7 +49,7 @@ UX rules:
 
 Foundry OSD tenant onboarding UX:
 - The hardware hash expander first asks the user to connect to the tenant.
-- Persisted tenant metadata must not be displayed as fresh tenant state on application startup. Until the current app session successfully connects to Microsoft Graph, show only the tenant connection row and the connect action.
+- Persisted tenant metadata must not be displayed as fresh tenant state on application startup. Until the current app session successfully connects to Microsoft Graph, show only the tenant connection row with `Not connected` and the connect action.
 - After successful current-session tenant connection, show tenant-dependent rows: tenant details, app registration status, onboarding status, certificates, default group tag, and known group tags.
 - The tenant connection row shows only the connection state and action. Tenant ID and other tenant metadata appear in a separate tenant details row after connection.
 - After sign-in, Foundry OSD searches for the managed app registration.

--- a/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
+++ b/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
@@ -49,6 +49,7 @@ UX rules:
 
 Foundry OSD tenant onboarding UX:
 - The hardware hash expander first asks the user to connect to the tenant.
+- `Connect tenant` uses the official Foundry multi-tenant public client app as the interactive sign-in bootstrap. This app has client ID `83eb3a92-030d-49b7-881b-32a1eb3e110a` and is separate from the tenant-local app used by generated WinPE media.
 - Persisted tenant metadata must not be displayed as fresh tenant state on application startup. Until the current app session successfully connects to Microsoft Graph, show only the tenant connection row with `Not connected` and the connect action.
 - A successful tenant connection is retained for the current app session across page navigation. Foundry OSD should require a new tenant sign-in only after the app process restarts or after the operator clicks `Disconnect tenant`.
 - Certificate creation and certificate removal must reuse the current app-session Microsoft Graph credential created by `Connect tenant`. They must not start their own interactive sign-in flow during the same app session.
@@ -57,6 +58,7 @@ Foundry OSD tenant onboarding UX:
 - After a successful current-session connection, the connection action changes to a disconnect action that clears only the current UI session state. Persisted tenant configuration remains stored.
 - After sign-in, Foundry OSD searches for the managed app registration.
 - The planned app registration display name is `Foundry OSD Autopilot Registration`.
+- This managed app registration is tenant-local and is the only application identity used by Foundry Deploy in WinPE for certificate-based Graph authentication.
 - If the app registration does not exist, Foundry OSD creates it with the required Microsoft Graph application permissions.
 - If the app registration exists and matches the persisted application object ID, Foundry OSD reuses it.
 - If an app registration with the same display name exists but Foundry has no persisted application object ID, Foundry OSD must enter a repair/adoption state instead of silently taking ownership.

--- a/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
+++ b/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
@@ -51,6 +51,7 @@ Foundry OSD tenant onboarding UX:
 - The hardware hash expander first asks the user to connect to the tenant.
 - Persisted tenant metadata must not be displayed as fresh tenant state on application startup. Until the current app session successfully connects to Microsoft Graph, show only the tenant connection row with `Not connected` and the connect action.
 - A successful tenant connection is retained for the current app session across page navigation. Foundry OSD should require a new tenant sign-in only after the app process restarts or after the operator clicks `Disconnect tenant`.
+- Certificate creation and certificate removal must reuse the current app-session Microsoft Graph credential created by `Connect tenant`. They must not start their own interactive sign-in flow during the same app session.
 - After successful current-session tenant connection, show tenant-dependent rows: tenant details, app registration status, onboarding status, certificates, default group tag, and available group tags.
 - The tenant connection row shows only the connection state and action. Tenant ID and other tenant metadata appear in a separate tenant details row after connection.
 - After a successful current-session connection, the connection action changes to a disconnect action that clears only the current UI session state. Persisted tenant configuration remains stored.
@@ -111,6 +112,7 @@ Foundry OSD tenant onboarding UX:
   - admin consent missing
   - service principal disabled or missing
   - ready for media build
+- The onboarding status row should show only `Ready` or `Not ready` with WinUI signal color: success for ready and critical for not ready. Detailed reasons remain available through the connection result dialogs and Start page readiness blockers.
 - Foundry OSD must block hardware hash media generation until the managed app exists, required permissions are present, admin consent is granted, the service principal is usable, the active certificate is unexpired, and the supplied PFX matches the active certificate.
 - The Start page must show the precise Autopilot readiness blocker instead of a generic default-profile message. Expected hardware hash blockers include missing tenant/app metadata, missing active certificate, expired active certificate, missing PFX, missing PFX password, unvalidated PFX, thumbprint mismatch, and expired boot media PFX.
 - When connected to the tenant, Foundry OSD should list existing Autopilot group tags discovered from `GET /v1.0/deviceManagement/windowsAutopilotDeviceIdentities`, extracting `groupTag` client-side from the unfiltered response and paging through `@odata.nextLink`. The UI label is "Available group tags".
@@ -220,6 +222,7 @@ Phase 2 UX refinements:
 - Settings cards include concise descriptions for row-level intent.
 - JSON profile download and hardware hash tenant onboarding use the same tenant operation dialog runner for Microsoft Graph sign-in, progress, and cancellation.
 - Canceling the tenant operation dialog returns control to the Autopilot page without leaving the connect/download action disabled.
+- Hardware hash certificate management uses a shared current-session Graph credential, so create/remove certificate actions do not reopen the browser sign-in after a successful tenant connection.
 - Tenant details are displayed as a table with tenant ID and client ID.
 - The default group tag is optional and selected from a ComboBox populated with `None` plus tenant-discovered Autopilot device group tags.
 - `None` is the default selection because hardware hash upload does not require a group tag.
@@ -227,3 +230,4 @@ Phase 2 UX refinements:
 - Certificate validity remains selectable, but the inline `Validity` label is hidden to reduce duplicate text in the certificate row.
 - Current-session PFX path, password, and successful validation state are retained while navigating between pages, but are still cleared on app restart.
 - The Start page must show the exact hardware hash media generation blocker when the PFX path, password, thumbprint, expiration, or active certificate is invalid.
+- The onboarding status row is intentionally compact: `Ready` or `Not ready`, with signal color, while detailed remediation stays in dialogs and readiness blockers.

--- a/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
+++ b/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
@@ -52,6 +52,7 @@ Foundry OSD tenant onboarding UX:
 - Persisted tenant metadata must not be displayed as fresh tenant state on application startup. Until the current app session successfully connects to Microsoft Graph, show only the tenant connection row with `Not connected` and the connect action.
 - After successful current-session tenant connection, show tenant-dependent rows: tenant details, app registration status, onboarding status, certificates, default group tag, and known group tags.
 - The tenant connection row shows only the connection state and action. Tenant ID and other tenant metadata appear in a separate tenant details row after connection.
+- After a successful current-session connection, the connection action changes to a disconnect action that clears only the current UI session state. Persisted tenant configuration remains stored.
 - After sign-in, Foundry OSD searches for the managed app registration.
 - The planned app registration display name is `Foundry OSD Autopilot Registration`.
 - If the app registration does not exist, Foundry OSD creates it with the required Microsoft Graph application permissions.
@@ -62,6 +63,7 @@ Foundry OSD tenant onboarding UX:
 - Foundry must not assume exclusive ownership of the app registration and must not automatically delete, replace, or prune non-active certificate credentials.
 - Extra certificate credentials on the app are tolerated and shown in a selectable certificate table, not as a blocking error.
 - The certificate table should show thumbprint, creation date, expiration date, and Graph certificate ID. Selecting a row enables removal for that selected certificate only.
+- If Graph returns no certificate credentials, do not show a warning message in the certificate table area; the create certificate action is enough.
 - Certificate validity text should use WinUI signal brushes: success for valid certificates, caution for certificates expiring within 30 days, and critical for expired certificates.
 - If no active certificate exists, show a create certificate action.
 - If an active certificate exists, show:

--- a/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
+++ b/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
@@ -50,7 +50,8 @@ UX rules:
 Foundry OSD tenant onboarding UX:
 - The hardware hash expander first asks the user to connect to the tenant.
 - Persisted tenant metadata must not be displayed as fresh tenant state on application startup. Until the current app session successfully connects to Microsoft Graph, show only the tenant connection row with `Not connected` and the connect action.
-- After successful current-session tenant connection, show tenant-dependent rows: tenant details, app registration status, onboarding status, certificates, default group tag, and known group tags.
+- A successful tenant connection is retained for the current app session across page navigation. Foundry OSD should require a new tenant sign-in only after the app process restarts or after the operator clicks `Disconnect tenant`.
+- After successful current-session tenant connection, show tenant-dependent rows: tenant details, app registration status, onboarding status, certificates, default group tag, and available group tags.
 - The tenant connection row shows only the connection state and action. Tenant ID and other tenant metadata appear in a separate tenant details row after connection.
 - After a successful current-session connection, the connection action changes to a disconnect action that clears only the current UI session state. Persisted tenant configuration remains stored.
 - After sign-in, Foundry OSD searches for the managed app registration.
@@ -62,7 +63,10 @@ Foundry OSD tenant onboarding UX:
 - The app registration may contain multiple certificate credentials. Foundry tracks exactly one active Foundry certificate by `keyId` and leaf certificate thumbprint.
 - Foundry must not assume exclusive ownership of the app registration and must not automatically delete, replace, or prune non-active certificate credentials.
 - Extra certificate credentials on the app are tolerated and shown in a selectable certificate table, not as a blocking error.
-- The certificate table should show thumbprint, creation date, expiration date, and Graph certificate ID. Selecting a row enables removal for that selected certificate only.
+- The certificate action buttons should be above the certificate table.
+- The certificate table should show thumbprint, creation date, expiration date, and Graph certificate ID. It supports multi-row selection, and removal is enabled only when at least one certificate row is selected.
+- Certificate removal must remove only the selected Graph `keyId` credentials and preserve every unselected app credential.
+- The certificate row should not show a separate "valid until" message when the same expiration is already visible in the table.
 - If Graph returns no certificate credentials, do not show a warning message in the certificate table area; the create certificate action is enough.
 - Certificate validity text should use WinUI signal brushes: success for valid certificates, caution for certificates expiring within 30 days, and critical for expired certificates.
 - If no active certificate exists, show a create certificate action.
@@ -91,8 +95,11 @@ Foundry OSD tenant onboarding UX:
 - Foundry OSD may keep the PFX bytes and password in memory for the current app session only, so the operator can create the boot image immediately after certificate creation without selecting the same PFX again.
 - On later application launches, the user must sign in again before Foundry OSD can inspect or manage the tenant app registration.
 - After Foundry OSD restarts, before media generation, the Autopilot page requires selecting the password-protected PFX again and entering its password for the currently active certificate.
-- The PFX input should be visually close to the active certificate status so the operator understands which certificate it belongs to.
+- The PFX input is a dedicated "Boot media certificate" row directly after the tenant certificate table. The certificate table represents credentials present in Entra; the boot media certificate row represents the local private key material selected for the generated media.
+- The boot media certificate row contains a read-only PFX path field, a PFX file picker, a password box, and validation status.
+- When Foundry OSD creates a certificate, the current app session automatically uses the generated PFX path and password for the boot media certificate row.
 - Foundry OSD must validate that the supplied PFX leaf certificate thumbprint matches the active certificate thumbprint before media generation.
+- Foundry OSD must keep the selected PFX path, PFX password, and validation result in memory only for the current app session and must not serialize them to ProgramData.
 - If the certificate is expired, Foundry OSD must show the expired status and require regenerating the certificate before the boot image can be built for hardware hash upload.
 - If the active certificate is missing from Graph, expired, or no longer matches the persisted `keyId` and thumbprint, Foundry OSD must show a repair state before allowing hash-upload media generation.
 - Replacing or retiring the active certificate must warn that previously generated boot images using the old certificate may no longer authenticate once that credential is removed from the app registration.
@@ -105,7 +112,8 @@ Foundry OSD tenant onboarding UX:
   - service principal disabled or missing
   - ready for media build
 - Foundry OSD must block hardware hash media generation until the managed app exists, required permissions are present, admin consent is granted, the service principal is usable, the active certificate is unexpired, and the supplied PFX matches the active certificate.
-- When connected to the tenant, Foundry OSD should list existing Autopilot group tags discovered from Intune and let the user choose the default group tag passed to Foundry Deploy.
+- The Start page must show the precise Autopilot readiness blocker instead of a generic default-profile message. Expected hardware hash blockers include missing tenant/app metadata, missing active certificate, expired active certificate, missing PFX, missing PFX password, unvalidated PFX, thumbprint mismatch, and expired boot media PFX.
+- When connected to the tenant, Foundry OSD should list existing Autopilot group tags discovered from `GET /v1.0/deviceManagement/windowsAutopilotDeviceIdentities`, extracting `groupTag` client-side from the unfiltered response and paging through `@odata.nextLink`. The UI label is "Available group tags".
 
 Foundry Deploy UX:
 - Foundry Deploy should render only the selected Autopilot provisioning mode from Foundry OSD.

--- a/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
+++ b/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
@@ -49,6 +49,9 @@ UX rules:
 
 Foundry OSD tenant onboarding UX:
 - The hardware hash expander first asks the user to connect to the tenant.
+- Persisted tenant metadata must not be displayed as fresh tenant state on application startup. Until the current app session successfully connects to Microsoft Graph, show only the tenant connection row and the connect action.
+- After successful current-session tenant connection, show tenant-dependent rows: tenant details, app registration status, onboarding status, certificates, default group tag, and known group tags.
+- The tenant connection row shows only the connection state and action. Tenant ID and other tenant metadata appear in a separate tenant details row after connection.
 - After sign-in, Foundry OSD searches for the managed app registration.
 - The planned app registration display name is `Foundry OSD Autopilot Registration`.
 - If the app registration does not exist, Foundry OSD creates it with the required Microsoft Graph application permissions.
@@ -57,7 +60,9 @@ Foundry OSD tenant onboarding UX:
 - Foundry OSD must persist tenant ID, application object ID, application/client ID, service principal object ID, active certificate key ID, active certificate thumbprint, and active certificate expiration.
 - The app registration may contain multiple certificate credentials. Foundry tracks exactly one active Foundry certificate by `keyId` and leaf certificate thumbprint.
 - Foundry must not assume exclusive ownership of the app registration and must not automatically delete, replace, or prune non-active certificate credentials.
-- Extra certificate credentials on the app are tolerated and shown as a warning or informational state, not as a blocking error.
+- Extra certificate credentials on the app are tolerated and shown in a selectable certificate table, not as a blocking error.
+- The certificate table should show thumbprint, creation date, expiration date, and Graph certificate ID. Selecting a row enables removal for that selected certificate only.
+- Certificate validity text should use WinUI signal brushes: success for valid certificates, caution for certificates expiring within 30 days, and critical for expired certificates.
 - If no active certificate exists, show a create certificate action.
 - If an active certificate exists, show:
   - display name
@@ -69,16 +74,16 @@ Foundry OSD tenant onboarding UX:
   - retire active certificate action
   - replace active certificate action
 - Certificate creation requires selecting a validity duration from a fixed list.
-- The default certificate validity is 12 months.
-- Certificate validity options should be fixed, for example:
+- The default certificate validity is 6 months.
+- Certificate validity options are fixed:
+  - 1 month
   - 3 months
   - 6 months
   - 12 months
-  - 24 months
 - Certificate creation produces a password-protected PFX only. PEM keys, unprotected private keys, and client secrets are not supported.
 - Certificate creation requires the operator to choose a PFX output path.
-- Certificate creation should let the operator generate a strong PFX password or enter a custom PFX password.
-- When Foundry OSD creates a certificate, it writes the PFX to the selected output path and shows the generated password once if Foundry generated it.
+- Certificate creation generates a strong PFX password.
+- When Foundry OSD creates a certificate, it writes the PFX to the selected output path and shows the generated password once in a selectable, read-only field.
 - The content dialog must clearly state that the PFX and PFX password must be stored by the operator outside Foundry.
 - Foundry OSD must not persist the raw PFX, PFX password, decrypted private key, exported private key material, or a DPAPI-encrypted local PFX vault in ProgramData.
 - Foundry OSD may keep the PFX bytes and password in memory for the current app session only, so the operator can create the boot image immediately after certificate creation without selecting the same PFX again.

--- a/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
+++ b/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
@@ -29,12 +29,15 @@ Hardware hash upload:
 - Method toggle or radio selection: "Capture and upload hardware hash".
 - Default state: tenant connection prompt.
 - Connected state:
-  - Tenant identity summary.
+  - Tenant readiness summary.
   - Foundry-managed app registration status.
-  - Active certificate status.
-  - Certificate expiration state.
-  - Password-protected PFX input for media generation.
-  - Autopilot group tag default selection.
+  - Tenant ID.
+  - Client ID.
+  - Readiness status.
+  - Certificate actions.
+  - Provisioned certificates table.
+  - Boot media certificate PFX selection and password.
+  - Optional default group tag selection.
 - Optional assigned user UPN field.
 - No user-facing wait option. Foundry Deploy always waits for import/device visibility with the default countdown and timeout behavior.
 - No profile assignment wait in the final implementation.
@@ -53,8 +56,8 @@ Foundry OSD tenant onboarding UX:
 - Persisted tenant metadata must not be displayed as fresh tenant state on application startup. Until the current app session successfully connects to Microsoft Graph, show only the tenant connection row with `Not connected` and the connect action.
 - A successful tenant connection is retained for the current app session across page navigation. Foundry OSD should require a new tenant sign-in only after the app process restarts or after the operator clicks `Disconnect tenant`.
 - Certificate creation and certificate removal must reuse the current app-session Microsoft Graph credential created by `Connect tenant`. They must not start their own interactive sign-in flow during the same app session.
-- After successful current-session tenant connection, show tenant-dependent rows: tenant details, app registration status, onboarding status, certificates, default group tag, and available group tags.
-- The tenant connection row shows only the connection state and action. Tenant ID and other tenant metadata appear in a separate tenant details row after connection.
+- After successful current-session tenant connection, show tenant-dependent rows: tenant readiness, certificate actions, provisioned certificates, boot media certificate, and optional default group tag.
+- The tenant connection row shows only the connection state and action. Tenant ID, client ID, app registration state, and readiness status appear together in the tenant readiness row after connection.
 - After a successful current-session connection, the connection action changes to a disconnect action that clears only the current UI session state. Persisted tenant configuration remains stored.
 - After sign-in, Foundry OSD searches for the managed app registration.
 - The planned app registration display name is `Foundry OSD Autopilot Registration`.
@@ -107,7 +110,8 @@ Foundry OSD tenant onboarding UX:
 - The onboarding status row should show only `Ready` or `Not ready` with WinUI signal color: success for ready and critical for not ready. A successful tenant connection should not show a success content dialog; the inline readiness row is enough. Detailed failure reasons remain available through attention/failure dialogs and Start page readiness blockers.
 - Foundry OSD must block hardware hash media generation until the managed app exists, required permissions are present, admin consent is granted, the service principal is usable, at least one non-expired app registration certificate is provisioned, and the supplied PFX matches a provisioned certificate.
 - The Start page must show the precise Autopilot readiness blocker instead of a generic default-profile message. Expected hardware hash blockers include missing tenant/app metadata, missing provisioned certificate, expired selected certificate, missing PFX, missing PFX password, unvalidated PFX, thumbprint mismatch, and expired boot media PFX.
-- When connected to the tenant, Foundry OSD should list existing Autopilot group tags discovered from `GET /v1.0/deviceManagement/windowsAutopilotDeviceIdentities`, extracting `groupTag` client-side from the unfiltered response and paging through `@odata.nextLink`. The UI label is "Available group tags".
+- When connected to the tenant, Foundry OSD should discover existing Autopilot group tags from `GET /v1.0/deviceManagement/windowsAutopilotDeviceIdentities`, extracting `groupTag` client-side from the unfiltered response and paging through `@odata.nextLink`.
+- The optional OSD group tag UX is a single `Default group tag` row with a ComboBox containing `None` plus discovered tenant group tags. `None` is selected by default because a group tag is optional for hardware hash upload.
 
 Foundry Deploy UX:
 - Foundry Deploy should render only the selected Autopilot provisioning mode from Foundry OSD.

--- a/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
+++ b/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
@@ -215,3 +215,9 @@ Validation rules:
 - `GroupTag` must not contain commas and should stay ASCII-safe for CSV compatibility.
 
 Deploy media generation should add encrypted `CertificatePfxSecret` and `CertificatePfxPasswordSecret` only to the generated WinPE deploy configuration for the current media build. These secret envelopes are not persisted in the normal Foundry OSD settings stored under ProgramData, and Foundry OSD does not maintain a local encrypted PFX vault.
+
+Phase 2 UX refinements:
+- The default group tag is selected from a ComboBox populated from tenant-discovered Autopilot device group tags.
+- Available group tags are displayed as a one-column table for scanability.
+- Current-session PFX path, password, and successful validation state are retained while navigating between pages, but are still cleared on app restart.
+- The Start page must show the exact hardware hash media generation blocker when the PFX path, password, thumbprint, expiration, or active certificate is invalid.

--- a/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
+++ b/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
@@ -217,7 +217,8 @@ Validation rules:
 Deploy media generation should add encrypted `CertificatePfxSecret` and `CertificatePfxPasswordSecret` only to the generated WinPE deploy configuration for the current media build. These secret envelopes are not persisted in the normal Foundry OSD settings stored under ProgramData, and Foundry OSD does not maintain a local encrypted PFX vault.
 
 Phase 2 UX refinements:
-- The default group tag is selected from a ComboBox populated from tenant-discovered Autopilot device group tags.
+- The default group tag is optional and selected from a ComboBox populated with `None` plus tenant-discovered Autopilot device group tags.
+- `None` is the default selection because hardware hash upload does not require a group tag.
 - Available group tags are displayed as a one-column table for scanability.
 - Current-session PFX path, password, and successful validation state are retained while navigating between pages, but are still cleared on app restart.
 - The Start page must show the exact hardware hash media generation blocker when the PFX path, password, thumbprint, expiration, or active certificate is invalid.

--- a/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
+++ b/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
@@ -62,8 +62,8 @@ Foundry OSD tenant onboarding UX:
 - If the app registration does not exist, Foundry OSD creates it with the required Microsoft Graph application permissions.
 - If the app registration exists and matches the persisted application object ID, Foundry OSD reuses it.
 - If an app registration with the same display name exists but Foundry has no persisted application object ID, Foundry OSD must enter a repair/adoption state instead of silently taking ownership.
-- Foundry OSD must persist tenant ID, application object ID, application/client ID, service principal object ID, active certificate key ID, active certificate thumbprint, and active certificate expiration.
-- The app registration may contain multiple certificate credentials. Foundry tracks exactly one active Foundry certificate by `keyId` and leaf certificate thumbprint.
+- Foundry OSD must persist tenant ID, application object ID, application/client ID, service principal object ID, and the certificate metadata resolved from the selected boot media PFX.
+- The app registration may contain multiple certificate credentials. Tenant readiness is based on at least one valid Foundry-managed app certificate credential being present, not on a single persisted active certificate.
 - Foundry must not assume exclusive ownership of the app registration and must not automatically delete, replace, or prune non-active certificate credentials.
 - Extra certificate credentials on the app are tolerated and shown in a selectable certificate table, not as a blocking error.
 - The certificate action buttons should be above the certificate table.
@@ -72,16 +72,6 @@ Foundry OSD tenant onboarding UX:
 - The certificate row should not show a separate "valid until" message when the same expiration is already visible in the table.
 - If Graph returns no certificate credentials, do not show a warning message in the certificate table area; the create certificate action is enough.
 - Certificate validity text should use WinUI signal brushes: success for valid certificates, caution for certificates expiring within 30 days, and critical for expired certificates.
-- If no active certificate exists, show a create certificate action.
-- If an active certificate exists, show:
-  - display name
-  - thumbprint
-  - Graph `keyId`
-  - start date
-  - expiration date
-  - expired/valid status
-  - retire active certificate action
-  - replace active certificate action
 - Certificate creation requires selecting a validity duration from a fixed list.
 - The default certificate validity is 6 months.
 - Certificate validity options are fixed:
@@ -97,16 +87,15 @@ Foundry OSD tenant onboarding UX:
 - Foundry OSD must not persist the raw PFX, PFX password, decrypted private key, exported private key material, or a DPAPI-encrypted local PFX vault in ProgramData.
 - Foundry OSD may keep the PFX bytes and password in memory for the current app session only, so the operator can create the boot image immediately after certificate creation without selecting the same PFX again.
 - On later application launches, the user must sign in again before Foundry OSD can inspect or manage the tenant app registration.
-- After Foundry OSD restarts, before media generation, the Autopilot page requires selecting the password-protected PFX again and entering its password for the currently active certificate.
+- After Foundry OSD restarts, before media generation, the Autopilot page requires selecting the password-protected PFX again and entering its password. The PFX leaf certificate thumbprint must match one of the non-expired app registration certificate credentials.
 - The PFX input is a dedicated "Boot media certificate" row directly after the tenant certificate table. The certificate table represents credentials present in Entra; the boot media certificate row represents the local private key material selected for the generated media.
 - The boot media certificate row contains a read-only PFX path field, a PFX file picker, a password box, and validation status.
 - When Foundry OSD creates a certificate, the current app session automatically uses the generated PFX path and password for the boot media certificate row.
-- Foundry OSD must validate that the supplied PFX leaf certificate thumbprint matches the active certificate thumbprint before media generation.
+- Foundry OSD must validate that the supplied PFX leaf certificate thumbprint matches a non-expired certificate credential currently provisioned on the managed app registration before media generation.
 - Foundry OSD must keep the selected PFX path, PFX password, and validation result in memory only for the current app session and must not serialize them to ProgramData.
 - If the certificate is expired, Foundry OSD must show the expired status and require regenerating the certificate before the boot image can be built for hardware hash upload.
-- If the active certificate is missing from Graph, expired, or no longer matches the persisted `keyId` and thumbprint, Foundry OSD must show a repair state before allowing hash-upload media generation.
-- Replacing or retiring the active certificate must warn that previously generated boot images using the old certificate may no longer authenticate once that credential is removed from the app registration.
-- If multiple Foundry-looking certificates exist but no active certificate is persisted, Foundry OSD must require the operator to choose one active certificate by thumbprint and validate a matching password-protected PFX, or replace them with a new active certificate.
+- If the selected boot media PFX certificate is missing from Graph, expired, or no longer matches any provisioned certificate credential, Foundry OSD must show a repair state before allowing hash-upload media generation.
+- Removing certificates must not show a success dialog. The refreshed certificate table and readiness state are the confirmation.
 - App registration permission and consent state must be explicit:
   - app registration missing
   - app registration created
@@ -114,9 +103,9 @@ Foundry OSD tenant onboarding UX:
   - admin consent missing
   - service principal disabled or missing
   - ready for media build
-- The onboarding status row should show only `Ready` or `Not ready` with WinUI signal color: success for ready and critical for not ready. Detailed reasons remain available through the connection result dialogs and Start page readiness blockers.
-- Foundry OSD must block hardware hash media generation until the managed app exists, required permissions are present, admin consent is granted, the service principal is usable, the active certificate is unexpired, and the supplied PFX matches the active certificate.
-- The Start page must show the precise Autopilot readiness blocker instead of a generic default-profile message. Expected hardware hash blockers include missing tenant/app metadata, missing active certificate, expired active certificate, missing PFX, missing PFX password, unvalidated PFX, thumbprint mismatch, and expired boot media PFX.
+- The onboarding status row should show only `Ready` or `Not ready` with WinUI signal color: success for ready and critical for not ready. A successful tenant connection should not show a success content dialog; the inline readiness row is enough. Detailed failure reasons remain available through attention/failure dialogs and Start page readiness blockers.
+- Foundry OSD must block hardware hash media generation until the managed app exists, required permissions are present, admin consent is granted, the service principal is usable, at least one non-expired app registration certificate is provisioned, and the supplied PFX matches a provisioned certificate.
+- The Start page must show the precise Autopilot readiness blocker instead of a generic default-profile message. Expected hardware hash blockers include missing tenant/app metadata, missing provisioned certificate, expired selected certificate, missing PFX, missing PFX password, unvalidated PFX, thumbprint mismatch, and expired boot media PFX.
 - When connected to the tenant, Foundry OSD should list existing Autopilot group tags discovered from `GET /v1.0/deviceManagement/windowsAutopilotDeviceIdentities`, extracting `groupTag` client-side from the unfiltered response and paging through `@odata.nextLink`. The UI label is "Available group tags".
 
 Foundry Deploy UX:

--- a/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
+++ b/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
@@ -218,6 +218,8 @@ Deploy media generation should add encrypted `CertificatePfxSecret` and `Certifi
 
 Phase 2 UX refinements:
 - Settings cards include concise descriptions for row-level intent.
+- JSON profile download and hardware hash tenant onboarding use the same tenant operation dialog runner for Microsoft Graph sign-in, progress, and cancellation.
+- Canceling the tenant operation dialog returns control to the Autopilot page without leaving the connect/download action disabled.
 - Tenant details are displayed as a table with tenant ID and client ID.
 - The default group tag is optional and selected from a ComboBox populated with `None` plus tenant-discovered Autopilot device group tags.
 - `None` is the default selection because hardware hash upload does not require a group tag.

--- a/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
+++ b/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
@@ -217,8 +217,11 @@ Validation rules:
 Deploy media generation should add encrypted `CertificatePfxSecret` and `CertificatePfxPasswordSecret` only to the generated WinPE deploy configuration for the current media build. These secret envelopes are not persisted in the normal Foundry OSD settings stored under ProgramData, and Foundry OSD does not maintain a local encrypted PFX vault.
 
 Phase 2 UX refinements:
+- Settings cards include concise descriptions for row-level intent.
+- Tenant details are displayed as a table with tenant ID and client ID.
 - The default group tag is optional and selected from a ComboBox populated with `None` plus tenant-discovered Autopilot device group tags.
 - `None` is the default selection because hardware hash upload does not require a group tag.
 - Available group tags are displayed as a one-column table for scanability.
+- Certificate validity remains selectable, but the inline `Validity` label is hidden to reduce duplicate text in the certificate row.
 - Current-session PFX path, password, and successful validation state are retained while navigating between pages, but are still cleared on app restart.
 - The Start page must show the exact hardware hash media generation blocker when the PFX path, password, thumbprint, expiration, or active certificate is invalid.

--- a/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
+++ b/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
@@ -83,7 +83,8 @@ Foundry OSD tenant onboarding UX:
 - Certificate creation requires the operator to choose a PFX output path.
 - Certificate creation generates a strong PFX password.
 - When Foundry OSD creates a certificate, it writes the PFX to the selected output path and shows the generated password once in a selectable, read-only field.
-- The content dialog must clearly state that the PFX and PFX password must be stored by the operator outside Foundry.
+- The content dialog must clearly state that the operator must save both the PFX file and PFX password in a secure location before closing the dialog.
+- The content dialog must provide a copy-to-clipboard action for the generated PFX password because Foundry cannot show it again after the dialog closes.
 - Foundry OSD must not persist the raw PFX, PFX password, decrypted private key, exported private key material, or a DPAPI-encrypted local PFX vault in ProgramData.
 - Foundry OSD may keep the PFX bytes and password in memory for the current app session only, so the operator can create the boot image immediately after certificate creation without selecting the same PFX again.
 - On later application launches, the user must sign in again before Foundry OSD can inspect or manage the tenant app registration.

--- a/docs/implementation/autopilot-hash-upload/03-security-graph.md
+++ b/docs/implementation/autopilot-hash-upload/03-security-graph.md
@@ -12,7 +12,7 @@ Recommended direction:
 - Invoke OA3Tool through the existing C# process execution patterns, not through PowerShell.
 - Split OSD interactive onboarding permissions from WinPE app-only upload permissions.
 - Use the official Foundry multi-tenant public client app only as the OSD interactive sign-in bootstrap:
-  - Display name: `Foundry`
+  - Display name: `Foundry OSD`
   - Client ID: `83eb3a92-030d-49b7-881b-32a1eb3e110a`
   - Environment override for private builds or forks: `FOUNDRY_AUTOPILOT_GRAPH_CLIENT_ID`
 - Use least-privilege WinPE app-only upload permissions:
@@ -30,10 +30,10 @@ Permission split:
 | Foundry Deploy in WinPE | App-only certificate credential from generated media | Import the captured hardware hash and poll import/device visibility. | Yes, as encrypted PFX envelope plus media secret key |
 
 Two-app model:
-- `Foundry` is the official Foundry-owned multi-tenant public client. It is used only to obtain delegated Microsoft Graph tokens for interactive OSD admin setup.
+- `Foundry OSD` is the official Foundry-owned multi-tenant public client. It is used only to obtain delegated Microsoft Graph tokens for interactive OSD admin setup.
 - `Foundry OSD Autopilot Registration` is the tenant-local app registration created or reused by Foundry OSD. It is the only app identity embedded into generated WinPE media through tenant ID, client ID, and certificate-based app-only authentication.
-- The `Foundry` bootstrap app client ID is not a secret and must not be replaced in official builds. Private forks can override it through `FOUNDRY_AUTOPILOT_GRAPH_CLIENT_ID`.
-- WinPE must never authenticate with the `Foundry` bootstrap public client. WinPE uses only the tenant-local managed app and its certificate credential.
+- The `Foundry OSD` bootstrap app client ID is not a secret and must not be replaced in official builds. Private forks can override it through `FOUNDRY_AUTOPILOT_GRAPH_CLIENT_ID`.
+- WinPE must never authenticate with the `Foundry OSD` bootstrap public client. WinPE uses only the tenant-local managed app and its certificate credential.
 
 The interactive OSD user may need broad Entra application management rights during setup, but those delegated/session permissions are not embedded into the boot image. The boot image receives only the managed app identity and certificate material needed for Autopilot import.
 

--- a/docs/implementation/autopilot-hash-upload/03-security-graph.md
+++ b/docs/implementation/autopilot-hash-upload/03-security-graph.md
@@ -11,6 +11,10 @@ Recommended direction:
 - Use direct Microsoft Graph REST calls through C# service abstractions.
 - Invoke OA3Tool through the existing C# process execution patterns, not through PowerShell.
 - Split OSD interactive onboarding permissions from WinPE app-only upload permissions.
+- Use the official Foundry multi-tenant public client app only as the OSD interactive sign-in bootstrap:
+  - Display name: `Foundry`
+  - Client ID: `83eb3a92-030d-49b7-881b-32a1eb3e110a`
+  - Environment override for private builds or forks: `FOUNDRY_AUTOPILOT_GRAPH_CLIENT_ID`
 - Use least-privilege WinPE app-only upload permissions:
   - `DeviceManagementServiceConfig.ReadWrite.All` for import and polling.
 - Defer destructive permissions:
@@ -24,6 +28,12 @@ Permission split:
 | --- | --- | --- | --- |
 | Foundry OSD tenant onboarding | Interactive signed-in admin user | Create/reuse app registration, add Graph application permissions, grant or verify admin consent, add/retire app certificate credentials, read Autopilot group tags. | No |
 | Foundry Deploy in WinPE | App-only certificate credential from generated media | Import the captured hardware hash and poll import/device visibility. | Yes, as encrypted PFX envelope plus media secret key |
+
+Two-app model:
+- `Foundry` is the official Foundry-owned multi-tenant public client. It is used only to obtain delegated Microsoft Graph tokens for interactive OSD admin setup.
+- `Foundry OSD Autopilot Registration` is the tenant-local app registration created or reused by Foundry OSD. It is the only app identity embedded into generated WinPE media through tenant ID, client ID, and certificate-based app-only authentication.
+- The `Foundry` bootstrap app client ID is not a secret and must not be replaced in official builds. Private forks can override it through `FOUNDRY_AUTOPILOT_GRAPH_CLIENT_ID`.
+- WinPE must never authenticate with the `Foundry` bootstrap public client. WinPE uses only the tenant-local managed app and its certificate credential.
 
 The interactive OSD user may need broad Entra application management rights during setup, but those delegated/session permissions are not embedded into the boot image. The boot image receives only the managed app identity and certificate material needed for Autopilot import.
 

--- a/docs/implementation/autopilot-hash-upload/03-security-graph.md
+++ b/docs/implementation/autopilot-hash-upload/03-security-graph.md
@@ -49,7 +49,7 @@ OSD setup permission guidance:
 Supported WinPE authentication:
 - Microsoft Graph authentication inside WinPE must use certificate-based app-only auth only.
 - The certificate private key material is injected into the generated boot image as an encrypted media secret.
-- The injected certificate format is a password-protected PFX whose leaf certificate thumbprint matches the active certificate configured on the managed app registration.
+- The injected certificate format is a password-protected PFX whose leaf certificate thumbprint matches a non-expired certificate credential on the managed app registration.
 - Device code flow, client secrets, and brokered upload are not supported WinPE authentication modes for this feature.
 
 Private keys, client secrets, and tenant-wide destructive permissions must not be silently embedded into generated media.
@@ -63,7 +63,7 @@ Secret handling rules:
 - Do not log authorization headers, refresh tokens, client secrets, private keys, certificate raw data, or Graph request bodies containing hardware hashes unless explicitly redacted.
 - Store embedded certificate private key material with the same envelope concept used by Foundry Connect personal Wi-Fi secrets.
 - Accept only password-protected PFX input for media generation.
-- Reject unprotected PFX files, PEM private keys, and PFX files whose leaf certificate thumbprint does not match the active certificate thumbprint.
+- Reject unprotected PFX files, PEM private keys, and PFX files whose leaf certificate thumbprint does not match a non-expired managed app certificate credential.
 - Require explicit user confirmation before embedding certificate private key material and document that the generated media becomes tenant-sensitive.
 - Do not add a "remember this PFX" option or store a DPAPI-encrypted copy in ProgramData.
 - Keep operator-provided PFX bytes and PFX password in memory only for the current app session, then clear them when media generation finishes or the app closes.

--- a/docs/implementation/autopilot-hash-upload/03-security-graph.md
+++ b/docs/implementation/autopilot-hash-upload/03-security-graph.md
@@ -42,6 +42,7 @@ OSD setup permission guidance:
 - `Application.ReadWrite.All` is needed when Foundry OSD creates or updates the managed app registration, including required resource access and certificate credentials.
 - `AppRoleAssignment.ReadWrite.All` is needed if Foundry OSD grants the Microsoft Graph application role to the managed service principal instead of only detecting that admin consent is missing.
 - `DeviceManagementServiceConfig.Read.All` is needed when Foundry OSD discovers existing Windows Autopilot device identities or group tags for the setup UX. `DeviceManagementServiceConfig.ReadWrite.All` is needed only for the WinPE app-only import workflow and any setup-time validation that writes to Intune.
+- `User.Read` is needed in the interactive OSD token because the onboarding flow discovers the signed-in tenant through Microsoft Graph organization metadata before configuring the tenant-local app registration.
 - If the signed-in operator does not have enough rights to grant consent, Foundry OSD should show a consent-required state and block hash-upload media generation until the tenant admin completes consent.
 - These setup rights belong to the signed-in OSD operator session only. They are not stored, exported, or embedded in generated media.
 

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -103,6 +103,7 @@ Implementation progress:
 - [x] Make tenant operation cancellation return control to the Autopilot page so the connect action can be retried.
 - [x] Reuse the current-session hardware hash Microsoft Graph credential for certificate creation and removal instead of reopening interactive sign-in.
 - [x] Clear the current-session hardware hash Microsoft Graph credential when the operator disconnects the tenant.
+- [x] Include `User.Read` in the hardware hash onboarding token scopes so Graph organization discovery can read the signed-in tenant ID.
 - [x] Keep tenant-dependent OSD UI session-gated: persisted tenant metadata stays stored, but app registration, certificate, group tag, and tenant detail rows stay hidden until a successful current-session tenant connection.
 - [x] Show connected tenant details in a dedicated row instead of embedding the tenant ID in the connection row.
 - [x] Display tenant details as a table with tenant ID and client ID.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -110,7 +110,9 @@ Implementation progress:
 - [x] Add descriptions to Autopilot settings cards so users understand each configuration row.
 - [x] Replace the connect action with a disconnect action after successful current-session tenant connection.
 - [x] Clear stale persisted active certificate metadata when Microsoft Graph no longer returns the selected active certificate.
+- [x] Split certificate management into a certificate action row and a provisioned certificates table row.
 - [x] List app registration certificate credentials in a selectable table with thumbprint, creation date, expiration date, and Graph certificate ID.
+- [x] Show an empty-state message in the provisioned certificates table row when the tenant app registration has no certificate credentials.
 - [x] Do not display an empty-certificate warning when the app registration has no certificate credentials.
 - [x] Allow multiple app registration certificates to coexist in the tenant instead of replacing the previously selected certificate during creation.
 - [x] Resolve the boot media certificate automatically by matching the selected PFX thumbprint against tenant app registration certificates.
@@ -135,6 +137,8 @@ Implementation progress:
 - [x] Select the optional default group tag from a ComboBox populated by `None` and discovered tenant group tags.
 - [x] Keep `None` selected by default because hardware hash upload does not require a group tag.
 - [x] Display available tenant group tags as a one-column table without a trailing empty column.
+- [x] Group default group tag selection and available group tag discovery into one optional `Group tag` row.
+- [x] Remove obsolete certificate validity/status UI resources after moving readiness to onboarding status, certificate table colors, and boot media PFX validation.
 
 Automated tests:
 - [x] App registration discovery uses persisted application object ID before display name.
@@ -179,6 +183,7 @@ Manual checks:
 - [ ] After connecting, confirm the action changes to `Disconnect tenant` and disconnecting hides tenant-dependent rows without deleting persisted configuration.
 - [ ] Connect to a tenant where the persisted active certificate no longer exists in Graph and confirm Foundry clears stale active certificate metadata instead of showing a valid expiration.
 - [ ] Connect to an app registration with no certificate credentials and confirm no empty-certificate warning text is displayed.
+- [ ] Connect to an app registration with no certificate credentials and confirm the provisioned certificates row shows the empty-state message.
 - [ ] Create a certificate and confirm the generated PFX password is selectable/copyable in the content dialog.
 - [ ] Create a second certificate and confirm the previous certificate remains present in the tenant certificate table.
 - [ ] Confirm the boot media certificate row is automatically filled after certificate creation and returns to empty after app restart.
@@ -189,6 +194,8 @@ Manual checks:
 - [ ] In hardware hash mode with no selected boot media PFX, confirm the Start page shows the missing PFX blocker instead of the JSON profile blocker.
 - [ ] In hardware hash mode with a mismatched PFX, confirm the Start page shows the thumbprint mismatch blocker.
 - [ ] Confirm the certificate table shows thumbprint, creation date, expiration date, and certificate ID with the expected validity color.
+- [ ] Confirm `Certificate actions` contains only certificate validity, create certificate, and remove certificate controls.
+- [ ] Confirm `Provisioned certificates` contains only the certificate empty state or certificate table.
 - [ ] Confirm the certificate validity duration selector no longer shows a visible `Validity` label.
 - [ ] Confirm the certificate action buttons are shown above the certificate table.
 - [ ] Confirm the redundant active certificate "valid until" text is not shown when the same expiration is already visible in the certificate table.
@@ -196,6 +203,7 @@ Manual checks:
 - [ ] Confirm the remove certificate action is disabled when no certificate row is selected.
 - [ ] Select one or more certificate rows and remove them; confirm only the selected credentials are removed from Entra and the table refreshes.
 - [ ] Connect to a tenant with existing Autopilot device group tags and confirm they appear under `Available group tags` as a one-column table without an empty trailing column.
+- [ ] Confirm `Default group tag` and `Available group tags` are grouped inside the same optional `Group tag` row.
 - [ ] Confirm the default group tag ComboBox selects `None` by default.
 - [ ] Select a default group tag from the ComboBox and confirm it is saved in the Foundry configuration, then select `None` and confirm the setting is cleared.
 - [ ] Create a certificate, navigate away from Autopilot and back, and confirm the boot media certificate row still shows `Certificate ready for boot media generation.`

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -132,6 +132,8 @@ Implementation progress:
 - [x] Preserve current-session tenant connection, certificate table, onboarding status, and boot media PFX state across page navigation without persisting them across app restart.
 - [x] Show onboarding status as compact `Ready` or `Not ready` text with WinUI signal color.
 - [x] Show tenant connection state as `Connected` in success color or `Not connected` in critical color.
+- [x] Suppress the tenant onboarding success content dialog; successful connection is shown inline through the readiness table.
+- [x] Keep tenant readiness `Ready` when at least one valid Foundry-managed app certificate remains after removing other selected certificates.
 - [x] Remove obsolete verbose onboarding status resource strings after moving detailed remediation to dialogs and readiness blockers.
 - [x] Add detailed Autopilot validation codes and Start page messages for hardware hash media generation blockers.
 - [x] Discover available group tags from the unfiltered `deviceManagement/windowsAutopilotDeviceIdentities` Graph endpoint and extract `groupTag` client-side.
@@ -204,6 +206,8 @@ Manual checks:
 - [ ] Confirm the certificate expiration column text has the same left padding as the other certificate columns.
 - [ ] Confirm the remove certificate action is disabled when no certificate row is selected.
 - [ ] Select one or more certificate rows and remove them; confirm only the selected credentials are removed from Entra and the table refreshes.
+- [ ] Create multiple certificates, remove a subset, and confirm tenant readiness stays `Ready` while at least one valid certificate remains.
+- [ ] Connect to a ready tenant and confirm no success content dialog is shown.
 - [ ] Connect to a tenant with existing Autopilot device group tags and confirm they appear in the `Default group tag` ComboBox without a duplicate available group tag table.
 - [ ] Confirm the optional group tag area is one compact `Default group tag` row.
 - [ ] Confirm the default group tag ComboBox selects `None` by default.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -102,10 +102,18 @@ Implementation progress:
 - [x] Clear stale persisted active certificate metadata when Microsoft Graph no longer returns the selected active certificate.
 - [x] List app registration certificate credentials in a selectable table with thumbprint, creation date, expiration date, and Graph certificate ID.
 - [x] Do not display an empty-certificate warning when the app registration has no certificate credentials.
-- [x] Remove the selected certificate credential while preserving unrelated app credentials.
+- [x] Move certificate action buttons above the certificate table.
+- [x] Remove the redundant active certificate "valid until" text when the same expiration is already visible in the certificate table.
+- [x] Remove one or more selected certificate credentials while preserving unrelated app credentials.
 - [x] Use WinUI signal brushes for certificate validity: success when valid, caution when expiring within 30 days, and critical when expired.
 - [x] Show the generated PFX password in a selectable read-only field in the one-time certificate-created dialog.
 - [x] Enforce Graph application certificate validity limit by offering 1, 3, 6, and 12 months only, with 6 months selected by default.
+- [x] Add a dedicated boot media certificate row for selecting the local password-protected PFX and entering its password.
+- [x] Automatically fill the boot media certificate row in the current app session after Foundry creates a new certificate.
+- [x] Keep boot media PFX path, password, and validation result session-only and excluded from ProgramData serialization.
+- [x] Preserve current-session tenant connection, certificate table, onboarding status, and boot media PFX state across page navigation without persisting them across app restart.
+- [x] Add detailed Autopilot validation codes and Start page messages for hardware hash media generation blockers.
+- [x] Discover available group tags from the unfiltered `deviceManagement/windowsAutopilotDeviceIdentities` Graph endpoint and extract `groupTag` client-side.
 
 Automated tests:
 - [x] App registration discovery uses persisted application object ID before display name.
@@ -116,10 +124,10 @@ Automated tests:
 - [x] Adding a certificate preserves existing non-active `keyCredentials`.
 - [x] Replacing the active certificate removes only the previous active `keyId` and preserves unrelated credentials.
 - [x] Retiring a certificate removes only the persisted active `keyId`.
-- [ ] Created PFX material is not persisted in ProgramData, even with DPAPI.
+- [x] Created PFX material is not persisted in ProgramData, even with DPAPI.
 - [ ] After app restart, media generation requires the operator to select the PFX again and enter its password.
 - [x] PFX thumbprint mismatch blocks media generation.
-- [ ] Secret settings are never serialized into plain deploy config.
+- [x] Secret settings are never serialized into plain deploy config.
 - [x] Tampered encrypted certificate envelopes fail without leaking ciphertext, private key material, or certificate password data.
 - [ ] Logs redact tokens, secrets, private key paths, certificate data, PFX bytes, and PFX password.
 - [x] Foundry OSD build passes after tenant onboarding UX refinements.
@@ -137,14 +145,24 @@ Manual checks:
 - [ ] Review logs after failed auth and successful auth.
 - [ ] Confirm least-privilege app registration can import devices.
 - [ ] Start Foundry OSD with persisted tenant metadata and confirm only `Tenant connection`, `Not connected`, and `Connect tenant` are shown before current-session sign-in.
-- [ ] Connect to the tenant and confirm app registration, tenant details, onboarding status, certificate table, default group tag, and known group tags become visible.
+- [ ] Connect to the tenant and confirm app registration, tenant details, onboarding status, certificate table, default group tag, and available group tags become visible.
 - [ ] Confirm `Tenant connection` shows only `Connected` or `Not connected`, and the tenant ID appears only in the dedicated tenant details row.
 - [ ] After connecting, confirm the action changes to `Disconnect tenant` and disconnecting hides tenant-dependent rows without deleting persisted configuration.
 - [ ] Connect to a tenant where the persisted active certificate no longer exists in Graph and confirm Foundry clears stale active certificate metadata instead of showing a valid expiration.
 - [ ] Connect to an app registration with no certificate credentials and confirm no empty-certificate warning text is displayed.
 - [ ] Create a certificate and confirm the generated PFX password is selectable/copyable in the content dialog.
+- [ ] Confirm the boot media certificate row is automatically filled after certificate creation and returns to empty after app restart.
+- [ ] Select a mismatched PFX and confirm the boot media certificate row shows a thumbprint mismatch.
+- [ ] Navigate away from the Autopilot page and back; confirm the tenant remains connected and tenant-dependent rows remain visible.
+- [ ] Restart Foundry OSD and confirm the tenant connection returns to the disconnected prompt.
+- [ ] In hardware hash mode with no selected boot media PFX, confirm the Start page shows the missing PFX blocker instead of the JSON profile blocker.
+- [ ] In hardware hash mode with a mismatched PFX, confirm the Start page shows the thumbprint mismatch blocker.
 - [ ] Confirm the certificate table shows thumbprint, creation date, expiration date, and certificate ID with the expected validity color.
-- [ ] Select a certificate row and remove it; confirm only the selected credential is removed from Entra and the table refreshes.
+- [ ] Confirm the certificate action buttons are shown above the certificate table.
+- [ ] Confirm the redundant active certificate "valid until" text is not shown when the same expiration is already visible in the certificate table.
+- [ ] Confirm the remove certificate action is disabled when no certificate row is selected.
+- [ ] Select one or more certificate rows and remove them; confirm only the selected credentials are removed from Entra and the table refreshes.
+- [ ] Connect to a tenant with existing Autopilot device group tags and confirm they appear under `Available group tags`.
 
 ### Phase 3: Autopilot Page UX
 PR title: `feat(autopilot): add hardware hash upload UX`
@@ -166,7 +184,7 @@ Implementation progress:
 - [x] Add active certificate lifecycle controls: create, remove selected certificate, expired state, missing state, and repair/adoption state.
 - [x] Add certificate validity selection with a default of 6 months and options for 1, 3, 6, and 12 months.
 - [x] Add one-time private key/PFX content dialog after certificate creation with selectable password text.
-- [ ] Add password-protected PFX and PFX password input near the active certificate status for boot image generation.
+- [x] Add password-protected PFX and PFX password input near the active certificate status for boot image generation.
 - [x] Add tenant-discovered Autopilot group tag list and default group tag selection.
 - [x] Enforce mutual exclusivity between JSON profile and hash upload modes.
 - [x] Carry the selected mode into the current Foundry Deploy target page so hardware hash mode does not require a JSON profile.
@@ -182,9 +200,9 @@ Automated tests:
 - [x] Deploy launch preparation accepts hardware hash mode without a selected JSON profile.
 - [x] Current Deploy Autopilot staging step skips JSON profile staging in hardware hash mode.
 - [x] Live hardware hash mode fails before deployment confirmation until the runtime implementation exists.
-- [ ] Hardware hash media generation is not ready when the connected app certificate is expired.
-- [ ] Hardware hash media generation requires a password-protected PFX whose leaf certificate thumbprint matches the active certificate.
-- [ ] Creating a certificate exposes the private key/PFX material once and never persists the raw PFX, password, or decrypted private key.
+- [x] Hardware hash media generation is not ready when the connected app certificate is expired.
+- [x] Hardware hash media generation requires a password-protected PFX whose leaf certificate thumbprint matches the active certificate.
+- [x] Creating a certificate exposes the private key/PFX material once and never persists the raw PFX, password, or decrypted private key.
 - [ ] Busy state still blocks JSON profile import/download/remove commands.
 
 Manual checks:
@@ -196,6 +214,8 @@ Manual checks:
 - [ ] Connect to a tenant with an existing managed app registration and confirm Foundry OSD reuses it.
 - [ ] Connect to a tenant where an app with the same display name exists but no persisted Foundry app ID exists, and confirm Foundry OSD enters repair/adoption state.
 - [ ] Create a certificate, verify the private key/PFX material and password are shown once, close the dialog, and confirm they cannot be shown again.
+- [ ] Confirm the boot media certificate row shows the generated PFX path and password as ready in the same app session.
+- [ ] Restart Foundry OSD and confirm the boot media certificate row requires selecting the PFX and entering the password again.
 - [ ] Add an extra non-active certificate credential to the app and confirm Foundry OSD warns but does not delete or block on it.
 - [ ] Expire or simulate an expired certificate and confirm the OSD page clearly requires regenerating the certificate before boot image creation.
 

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -104,9 +104,9 @@ Implementation progress:
 - [x] Reuse the current-session hardware hash Microsoft Graph credential for certificate creation and removal instead of reopening interactive sign-in.
 - [x] Clear the current-session hardware hash Microsoft Graph credential when the operator disconnects the tenant.
 - [x] Include `User.Read` in the hardware hash onboarding token scopes so Graph organization discovery can read the signed-in tenant ID.
-- [x] Keep tenant-dependent OSD UI session-gated: persisted tenant metadata stays stored, but app registration, certificate, group tag, and tenant detail rows stay hidden until a successful current-session tenant connection.
-- [x] Show connected tenant details in a dedicated row instead of embedding the tenant ID in the connection row.
-- [x] Display tenant details as a table with tenant ID and client ID.
+- [x] Keep tenant-dependent OSD UI session-gated: persisted tenant metadata stays stored, but tenant readiness, certificate, and group tag rows stay hidden until a successful current-session tenant connection.
+- [x] Show tenant readiness in one dedicated row instead of embedding tenant and readiness details in separate rows.
+- [x] Display managed app registration state, tenant ID, client ID, and readiness status in a compact key/value layout.
 - [x] Add descriptions to Autopilot settings cards so users understand each configuration row.
 - [x] Replace the connect action with a disconnect action after successful current-session tenant connection.
 - [x] Clear stale persisted active certificate metadata when Microsoft Graph no longer returns the selected active certificate.
@@ -128,7 +128,7 @@ Implementation progress:
 - [x] Automatically fill the boot media certificate row in the current app session after Foundry creates a new certificate.
 - [x] Keep boot media PFX path, password, and validation result session-only and excluded from ProgramData serialization.
 - [x] Preserve the boot media certificate ready message across Autopilot page navigation when the current-session PFX is still validated.
-- [x] Refresh only boot media certificate status while typing the PFX password so tenant detail tables do not rebind on every keystroke.
+- [x] Refresh only boot media certificate status while typing the PFX password so tenant readiness details do not rebind on every keystroke.
 - [x] Preserve current-session tenant connection, certificate table, onboarding status, and boot media PFX state across page navigation without persisting them across app restart.
 - [x] Show onboarding status as compact `Ready` or `Not ready` text with WinUI signal color.
 - [x] Remove obsolete verbose onboarding status resource strings after moving detailed remediation to dialogs and readiness blockers.
@@ -174,12 +174,12 @@ Manual checks:
 - [ ] Start Foundry OSD with persisted tenant metadata and confirm only `Tenant connection`, `Not connected`, and `Connect tenant` are shown before current-session sign-in.
 - [ ] Click `Connect tenant`, cancel the tenant sign-in dialog, and confirm the Autopilot page remains responsive and `Connect tenant` can be clicked again.
 - [ ] Click JSON profile `Download from tenant`, cancel the tenant sign-in dialog, and confirm the JSON profile actions remain responsive.
-- [ ] Connect to the tenant and confirm app registration, tenant details, onboarding status, certificate table, and default group tag selection become visible.
+- [ ] Connect to the tenant and confirm tenant readiness, certificate actions, provisioned certificates, boot media certificate, and default group tag selection become visible.
 - [ ] After connecting once, create and remove certificates and confirm the browser sign-in prompt does not reopen during the same app session.
-- [ ] Confirm `Tenant connection` shows only `Connected` or `Not connected`, and the tenant ID appears only in the dedicated tenant details row.
-- [ ] Confirm tenant details show tenant ID and client ID in a table after connecting.
+- [ ] Confirm `Tenant connection` shows only `Connected` or `Not connected`, and the tenant ID appears only in the dedicated tenant readiness row.
+- [ ] Confirm tenant readiness shows managed app registration state, tenant ID, client ID, and readiness status in one row after connecting.
 - [ ] Confirm each Autopilot settings card has a concise description.
-- [ ] Confirm `Onboarding status` displays only `Ready` in success color or `Not ready` in critical color.
+- [ ] Confirm tenant readiness displays status as only `Ready` in success color or `Not ready` in critical color.
 - [ ] After connecting, confirm the action changes to `Disconnect tenant` and disconnecting hides tenant-dependent rows without deleting persisted configuration.
 - [ ] Connect to a tenant where the persisted active certificate no longer exists in Graph and confirm Foundry clears stale active certificate metadata instead of showing a valid expiration.
 - [ ] Connect to an app registration with no certificate credentials and confirm no empty-certificate warning text is displayed.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -106,7 +106,7 @@ Implementation progress:
 - [x] Include `User.Read` in the hardware hash onboarding token scopes so Graph organization discovery can read the signed-in tenant ID.
 - [x] Keep tenant-dependent OSD UI session-gated: persisted tenant metadata stays stored, but tenant readiness, certificate, and group tag rows stay hidden until a successful current-session tenant connection.
 - [x] Show tenant readiness in one dedicated row instead of embedding tenant and readiness details in separate rows.
-- [x] Display managed app registration state, tenant ID, client ID, and readiness status in a compact key/value layout.
+- [x] Display managed app registration state, tenant ID, client ID, and readiness status in a compact read-only table.
 - [x] Add descriptions to Autopilot settings cards so users understand each configuration row.
 - [x] Replace the connect action with a disconnect action after successful current-session tenant connection.
 - [x] Clear stale persisted active certificate metadata when Microsoft Graph no longer returns the selected active certificate.
@@ -131,6 +131,7 @@ Implementation progress:
 - [x] Refresh only boot media certificate status while typing the PFX password so tenant readiness details do not rebind on every keystroke.
 - [x] Preserve current-session tenant connection, certificate table, onboarding status, and boot media PFX state across page navigation without persisting them across app restart.
 - [x] Show onboarding status as compact `Ready` or `Not ready` text with WinUI signal color.
+- [x] Show tenant connection state as `Connected` in success color or `Not connected` in critical color.
 - [x] Remove obsolete verbose onboarding status resource strings after moving detailed remediation to dialogs and readiness blockers.
 - [x] Add detailed Autopilot validation codes and Start page messages for hardware hash media generation blockers.
 - [x] Discover available group tags from the unfiltered `deviceManagement/windowsAutopilotDeviceIdentities` Graph endpoint and extract `groupTag` client-side.
@@ -177,9 +178,10 @@ Manual checks:
 - [ ] Connect to the tenant and confirm tenant readiness, certificate actions, provisioned certificates, boot media certificate, and default group tag selection become visible.
 - [ ] After connecting once, create and remove certificates and confirm the browser sign-in prompt does not reopen during the same app session.
 - [ ] Confirm `Tenant connection` shows only `Connected` or `Not connected`, and the tenant ID appears only in the dedicated tenant readiness row.
-- [ ] Confirm tenant readiness shows managed app registration state, tenant ID, client ID, and readiness status in one row after connecting.
+- [ ] Confirm tenant readiness shows managed app registration state, tenant ID, client ID, and readiness status in a compact table after connecting.
 - [ ] Confirm each Autopilot settings card has a concise description.
 - [ ] Confirm tenant readiness displays status as only `Ready` in success color or `Not ready` in critical color.
+- [ ] Confirm tenant connection displays `Connected` in success color or `Not connected` in critical color.
 - [ ] After connecting, confirm the action changes to `Disconnect tenant` and disconnecting hides tenant-dependent rows without deleting persisted configuration.
 - [ ] Connect to a tenant where the persisted active certificate no longer exists in Graph and confirm Foundry clears stale active certificate metadata instead of showing a valid expiration.
 - [ ] Connect to an app registration with no certificate credentials and confirm no empty-certificate warning text is displayed.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -107,6 +107,7 @@ Scope note:
 - [x] Make tenant operation cancellation return control to the Autopilot page so the connect action can be retried.
 - [x] Reuse the current-session hardware hash Microsoft Graph credential for certificate creation and removal instead of reopening interactive sign-in.
 - [x] Clear the current-session hardware hash Microsoft Graph credential when the operator disconnects the tenant.
+- [x] Keep interactive Microsoft Graph authentication session-only by disabling persistent MSAL token cache storage for OSD tenant operations.
 - [x] Include `User.Read` in the hardware hash onboarding token scopes so Graph organization discovery can read the signed-in tenant ID.
 - [x] Keep tenant-dependent OSD UI session-gated: persisted tenant metadata stays stored, but tenant readiness, certificate, and group tag rows stay hidden until a successful current-session tenant connection.
 - [x] Show tenant readiness in one dedicated row instead of embedding tenant and readiness details in separate rows.
@@ -119,6 +120,8 @@ Scope note:
 - [x] Show an empty-state message in the provisioned certificates table row when the tenant app registration has no certificate credentials.
 - [x] Do not display an empty-certificate warning when the app registration has no certificate credentials.
 - [x] Allow multiple app registration certificates to coexist in the tenant instead of replacing the previously selected certificate during creation.
+- [x] Filter the provisioned certificate table to Foundry-managed certificate credentials so unrelated app registration credentials are not shown or removable from Foundry.
+- [x] Delete the generated local PFX file if Graph certificate upload fails during certificate creation.
 - [x] Resolve the boot media certificate automatically by matching the selected PFX thumbprint against tenant app registration certificates.
 - [x] Move certificate action buttons above the certificate table.
 - [x] Remove the visible certificate validity field label while keeping the validity duration selector.
@@ -135,6 +138,7 @@ Scope note:
 - [x] Keep boot media PFX path, password, and validation result session-only and excluded from ProgramData serialization.
 - [x] Preserve the boot media certificate ready message across Autopilot page navigation when the current-session PFX is still validated.
 - [x] Refresh only boot media certificate status while typing the PFX password so tenant readiness details do not rebind on every keystroke.
+- [x] Prioritize boot media PFX-specific readiness messages over generic active certificate metadata blockers on the Autopilot page and Start page.
 - [x] Preserve current-session tenant connection, certificate table, onboarding status, and boot media PFX state across page navigation without persisting them across app restart.
 - [x] Show onboarding status as compact `Ready` or `Not ready` text with WinUI signal color.
 - [x] Show tenant connection state as `Connected` in success color or `Not connected` in critical color.
@@ -143,6 +147,7 @@ Scope note:
 - [x] Remove obsolete verbose onboarding status resource strings after moving detailed remediation to dialogs and readiness blockers.
 - [x] Add detailed Autopilot validation codes and Start page messages for hardware hash media generation blockers.
 - [x] Discover available group tags from the unfiltered `deviceManagement/windowsAutopilotDeviceIdentities` Graph endpoint and extract `groupTag` client-side.
+- [x] Preserve the previously saved default group tag if group tag discovery fails during tenant connection.
 - [x] Select the optional default group tag from a ComboBox populated by `None` and discovered tenant group tags.
 - [x] Keep `None` selected by default because hardware hash upload does not require a group tag.
 - [x] Populate the default group tag ComboBox from discovered tenant group tags without displaying a duplicate available group tag table.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -133,7 +133,7 @@ Manual checks:
 - [ ] Review generated media contents and confirm certificate private key material is envelope-encrypted, not plaintext.
 - [ ] Review logs after failed auth and successful auth.
 - [ ] Confirm least-privilege app registration can import devices.
-- [ ] Start Foundry OSD with persisted tenant metadata and confirm only `Tenant connection` plus `Connect tenant` is shown before current-session sign-in.
+- [ ] Start Foundry OSD with persisted tenant metadata and confirm only `Tenant connection`, `Not connected`, and `Connect tenant` are shown before current-session sign-in.
 - [ ] Connect to the tenant and confirm app registration, tenant details, onboarding status, certificate table, default group tag, and known group tags become visible.
 - [ ] Confirm `Tenant connection` shows only `Connected` or `Not connected`, and the tenant ID appears only in the dedicated tenant details row.
 - [ ] Create a certificate and confirm the generated PFX password is selectable/copyable in the content dialog.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -112,6 +112,8 @@ Implementation progress:
 - [x] Clear stale persisted active certificate metadata when Microsoft Graph no longer returns the selected active certificate.
 - [x] List app registration certificate credentials in a selectable table with thumbprint, creation date, expiration date, and Graph certificate ID.
 - [x] Do not display an empty-certificate warning when the app registration has no certificate credentials.
+- [x] Allow multiple app registration certificates to coexist in the tenant instead of replacing the previously selected certificate during creation.
+- [x] Add a boot media certificate selector so the operator chooses which tenant certificate the selected PFX must match.
 - [x] Move certificate action buttons above the certificate table.
 - [x] Remove the visible certificate validity field label while keeping the validity duration selector.
 - [x] Remove the redundant active certificate "valid until" text when the same expiration is already visible in the certificate table.
@@ -177,7 +179,9 @@ Manual checks:
 - [ ] Connect to a tenant where the persisted active certificate no longer exists in Graph and confirm Foundry clears stale active certificate metadata instead of showing a valid expiration.
 - [ ] Connect to an app registration with no certificate credentials and confirm no empty-certificate warning text is displayed.
 - [ ] Create a certificate and confirm the generated PFX password is selectable/copyable in the content dialog.
+- [ ] Create a second certificate and confirm the previous certificate remains present in the tenant certificate table.
 - [ ] Confirm the boot media certificate row is automatically filled after certificate creation and returns to empty after app restart.
+- [ ] Select each tenant certificate from the boot media certificate selector and confirm only the matching PFX/password combination reaches the ready state.
 - [ ] Select a mismatched PFX and confirm the boot media certificate row shows a thumbprint mismatch.
 - [ ] Navigate away from the Autopilot page and back; confirm the tenant remains connected and tenant-dependent rows remain visible.
 - [ ] Restart Foundry OSD and confirm the tenant connection returns to the disconnected prompt.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -71,7 +71,7 @@ Implementation progress:
 - [x] Implementation checklist complete.
 - [ ] Automated tests complete.
 - [ ] Manual checks complete or explicitly deferred.
-- [ ] PR opened with the planned title.
+- [x] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
 - [x] Define the permission matrix for the implementation model; user-facing documentation is handled in Phase 8.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -98,7 +98,10 @@ Implementation progress:
 - [x] Reuse the JSON profile tenant download modal sign-in pattern for hardware hash tenant onboarding.
 - [x] Keep tenant-dependent OSD UI session-gated: persisted tenant metadata stays stored, but app registration, certificate, group tag, and tenant detail rows stay hidden until a successful current-session tenant connection.
 - [x] Show connected tenant details in a dedicated row instead of embedding the tenant ID in the connection row.
+- [x] Replace the connect action with a disconnect action after successful current-session tenant connection.
+- [x] Clear stale persisted active certificate metadata when Microsoft Graph no longer returns the selected active certificate.
 - [x] List app registration certificate credentials in a selectable table with thumbprint, creation date, expiration date, and Graph certificate ID.
+- [x] Do not display an empty-certificate warning when the app registration has no certificate credentials.
 - [x] Remove the selected certificate credential while preserving unrelated app credentials.
 - [x] Use WinUI signal brushes for certificate validity: success when valid, caution when expiring within 30 days, and critical when expired.
 - [x] Show the generated PFX password in a selectable read-only field in the one-time certificate-created dialog.
@@ -136,6 +139,9 @@ Manual checks:
 - [ ] Start Foundry OSD with persisted tenant metadata and confirm only `Tenant connection`, `Not connected`, and `Connect tenant` are shown before current-session sign-in.
 - [ ] Connect to the tenant and confirm app registration, tenant details, onboarding status, certificate table, default group tag, and known group tags become visible.
 - [ ] Confirm `Tenant connection` shows only `Connected` or `Not connected`, and the tenant ID appears only in the dedicated tenant details row.
+- [ ] After connecting, confirm the action changes to `Disconnect tenant` and disconnecting hides tenant-dependent rows without deleting persisted configuration.
+- [ ] Connect to a tenant where the persisted active certificate no longer exists in Graph and confirm Foundry clears stale active certificate metadata instead of showing a valid expiration.
+- [ ] Connect to an app registration with no certificate credentials and confirm no empty-certificate warning text is displayed.
 - [ ] Create a certificate and confirm the generated PFX password is selectable/copyable in the content dialog.
 - [ ] Confirm the certificate table shows thumbprint, creation date, expiration date, and certificate ID with the expected validity color.
 - [ ] Select a certificate row and remove it; confirm only the selected credential is removed from Entra and the table refreshes.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -153,7 +153,7 @@ Automated tests:
 Manual checks:
 - [ ] Create the managed app registration in a clean test tenant.
 - [ ] Confirm the app registration name is `Foundry OSD Autopilot Registration`.
-- [ ] Confirm `Connect tenant` creates an Enterprise application for the official `Foundry` bootstrap client ID `83eb3a92-030d-49b7-881b-32a1eb3e110a` in the target tenant.
+- [ ] Confirm `Connect tenant` creates an Enterprise application for the official `Foundry OSD` bootstrap client ID `83eb3a92-030d-49b7-881b-32a1eb3e110a` in the target tenant.
 - [ ] Confirm required API permissions and admin consent status are visible in Foundry OSD.
 - [ ] Add a second certificate credential outside Foundry and confirm Foundry leaves it untouched.
 - [ ] Replace the active certificate and confirm the previous active credential is removed while unrelated credentials are preserved.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -96,6 +96,9 @@ Implementation progress:
 - [x] Add audit-safe logging rules.
 - [x] Add XML documentation comments to new public tenant onboarding, certificate, and secret-protection APIs.
 - [x] Reuse the JSON profile tenant download modal sign-in pattern for hardware hash tenant onboarding.
+- [x] Route JSON profile download and hardware hash tenant onboarding through one shared tenant operation dialog service.
+- [x] Remove the obsolete JSON-specific tenant download dialog wrapper API.
+- [x] Make tenant operation cancellation return control to the Autopilot page so the connect action can be retried.
 - [x] Keep tenant-dependent OSD UI session-gated: persisted tenant metadata stays stored, but app registration, certificate, group tag, and tenant detail rows stay hidden until a successful current-session tenant connection.
 - [x] Show connected tenant details in a dedicated row instead of embedding the tenant ID in the connection row.
 - [x] Display tenant details as a table with tenant ID and client ID.
@@ -153,6 +156,8 @@ Manual checks:
 - [ ] Review logs after failed auth and successful auth.
 - [ ] Confirm least-privilege app registration can import devices.
 - [ ] Start Foundry OSD with persisted tenant metadata and confirm only `Tenant connection`, `Not connected`, and `Connect tenant` are shown before current-session sign-in.
+- [ ] Click `Connect tenant`, cancel the tenant sign-in dialog, and confirm the Autopilot page remains responsive and `Connect tenant` can be clicked again.
+- [ ] Click JSON profile `Download from tenant`, cancel the tenant sign-in dialog, and confirm the JSON profile actions remain responsive.
 - [ ] Connect to the tenant and confirm app registration, tenant details, onboarding status, certificate table, default group tag, and available group tags become visible.
 - [ ] Confirm `Tenant connection` shows only `Connected` or `Not connected`, and the tenant ID appears only in the dedicated tenant details row.
 - [ ] Confirm tenant details show tenant ID and client ID in a table after connecting.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -116,8 +116,9 @@ Implementation progress:
 - [x] Preserve current-session tenant connection, certificate table, onboarding status, and boot media PFX state across page navigation without persisting them across app restart.
 - [x] Add detailed Autopilot validation codes and Start page messages for hardware hash media generation blockers.
 - [x] Discover available group tags from the unfiltered `deviceManagement/windowsAutopilotDeviceIdentities` Graph endpoint and extract `groupTag` client-side.
-- [x] Select the default group tag from a ComboBox populated by discovered tenant group tags.
-- [x] Display available tenant group tags as a one-column table.
+- [x] Select the optional default group tag from a ComboBox populated by `None` and discovered tenant group tags.
+- [x] Keep `None` selected by default because hardware hash upload does not require a group tag.
+- [x] Display available tenant group tags as a one-column table without a trailing empty column.
 
 Automated tests:
 - [x] App registration discovery uses persisted application object ID before display name.
@@ -167,8 +168,9 @@ Manual checks:
 - [ ] Confirm the certificate expiration column text has the same left padding as the other certificate columns.
 - [ ] Confirm the remove certificate action is disabled when no certificate row is selected.
 - [ ] Select one or more certificate rows and remove them; confirm only the selected credentials are removed from Entra and the table refreshes.
-- [ ] Connect to a tenant with existing Autopilot device group tags and confirm they appear under `Available group tags` as a one-column table.
-- [ ] Select a default group tag from the ComboBox and confirm it is saved in the Foundry configuration.
+- [ ] Connect to a tenant with existing Autopilot device group tags and confirm they appear under `Available group tags` as a one-column table without an empty trailing column.
+- [ ] Confirm the default group tag ComboBox selects `None` by default.
+- [ ] Select a default group tag from the ComboBox and confirm it is saved in the Foundry configuration, then select `None` and confirm the setting is cleared.
 - [ ] Create a certificate, navigate away from Autopilot and back, and confirm the boot media certificate row still shows `Certificate ready for boot media generation.`
 
 ### Phase 3: Autopilot Page UX

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -123,6 +123,8 @@ Implementation progress:
 - [x] Use WinUI signal brushes for certificate validity: success when valid, caution when expiring within 30 days, and critical when expired.
 - [x] Add padding to the certificate expiration table cell so the validity text aligns with the other columns.
 - [x] Show the generated PFX password in a selectable read-only field in the one-time certificate-created dialog.
+- [x] Make the certificate-created dialog explicitly tell the operator to save both the PFX file and generated password before closing it.
+- [x] Add a copy-to-clipboard action for the generated PFX password in the one-time certificate-created dialog.
 - [x] Enforce Graph application certificate validity limit by offering 1, 3, 6, and 12 months only, with 6 months selected by default.
 - [x] Add a dedicated boot media certificate row for selecting the local password-protected PFX and entering its password.
 - [x] Automatically fill the boot media certificate row in the current app session after Foundry creates a new certificate.
@@ -189,6 +191,8 @@ Manual checks:
 - [ ] Connect to an app registration with no certificate credentials and confirm no empty-certificate warning text is displayed.
 - [ ] Connect to an app registration with no certificate credentials and confirm the provisioned certificates row shows the empty-state message.
 - [ ] Create a certificate and confirm the generated PFX password is selectable/copyable in the content dialog.
+- [ ] Create a certificate and confirm the content dialog clearly tells the operator to save both the PFX file and PFX password before closing it.
+- [ ] Click `Copy password` in the certificate-created dialog and confirm the generated PFX password is copied to the clipboard.
 - [ ] Create a second certificate and confirm the previous certificate remains present in the tenant certificate table.
 - [ ] Confirm the boot media certificate row is automatically filled after certificate creation and returns to empty after app restart.
 - [ ] Select each generated PFX with its password and confirm Foundry automatically resolves the matching tenant certificate before reaching the ready state.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -113,7 +113,7 @@ Implementation progress:
 - [x] List app registration certificate credentials in a selectable table with thumbprint, creation date, expiration date, and Graph certificate ID.
 - [x] Do not display an empty-certificate warning when the app registration has no certificate credentials.
 - [x] Allow multiple app registration certificates to coexist in the tenant instead of replacing the previously selected certificate during creation.
-- [x] Add a boot media certificate selector so the operator chooses which tenant certificate the selected PFX must match.
+- [x] Resolve the boot media certificate automatically by matching the selected PFX thumbprint against tenant app registration certificates.
 - [x] Move certificate action buttons above the certificate table.
 - [x] Remove the visible certificate validity field label while keeping the validity duration selector.
 - [x] Remove the redundant active certificate "valid until" text when the same expiration is already visible in the certificate table.
@@ -143,7 +143,8 @@ Automated tests:
 - [x] Admin consent missing maps to `ConsentMissing`.
 - [x] Disabled or missing service principal maps to `ServicePrincipalUnavailable`.
 - [x] Adding a certificate preserves existing non-active `keyCredentials`.
-- [x] Replacing the active certificate removes only the previous active `keyId` and preserves unrelated credentials.
+- [x] App registrations with existing Foundry certificate credentials are tenant-ready without requiring a manual active certificate selection.
+- [x] PFX validation can read certificate metadata without a preselected expected thumbprint.
 - [x] Retiring a certificate removes only the persisted active `keyId`.
 - [x] Created PFX material is not persisted in ProgramData, even with DPAPI.
 - [ ] After app restart, media generation requires the operator to select the PFX again and enter its password.
@@ -160,7 +161,7 @@ Manual checks:
 - [ ] Confirm `Connect tenant` creates an Enterprise application for the official `Foundry OSD` bootstrap client ID `83eb3a92-030d-49b7-881b-32a1eb3e110a` in the target tenant.
 - [ ] Confirm required API permissions and admin consent status are visible in Foundry OSD.
 - [ ] Add a second certificate credential outside Foundry and confirm Foundry leaves it untouched.
-- [ ] Replace the active certificate and confirm the previous active credential is removed while unrelated credentials are preserved.
+- [ ] Create multiple Foundry certificates and confirm new certificate creation does not remove existing certificates.
 - [ ] Create a certificate, choose a PFX output path, and confirm the PFX exists only at the selected path.
 - [ ] Restart Foundry OSD and confirm it requires selecting the PFX again before media generation.
 - [ ] Review generated media contents and confirm certificate private key material is envelope-encrypted, not plaintext.
@@ -181,7 +182,7 @@ Manual checks:
 - [ ] Create a certificate and confirm the generated PFX password is selectable/copyable in the content dialog.
 - [ ] Create a second certificate and confirm the previous certificate remains present in the tenant certificate table.
 - [ ] Confirm the boot media certificate row is automatically filled after certificate creation and returns to empty after app restart.
-- [ ] Select each tenant certificate from the boot media certificate selector and confirm only the matching PFX/password combination reaches the ready state.
+- [ ] Select each generated PFX with its password and confirm Foundry automatically resolves the matching tenant certificate before reaching the ready state.
 - [ ] Select a mismatched PFX and confirm the boot media certificate row shows a thumbprint mismatch.
 - [ ] Navigate away from the Autopilot page and back; confirm the tenant remains connected and tenant-dependent rows remain visible.
 - [ ] Restart Foundry OSD and confirm the tenant connection returns to the disconnected prompt.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -106,14 +106,18 @@ Implementation progress:
 - [x] Remove the redundant active certificate "valid until" text when the same expiration is already visible in the certificate table.
 - [x] Remove one or more selected certificate credentials while preserving unrelated app credentials.
 - [x] Use WinUI signal brushes for certificate validity: success when valid, caution when expiring within 30 days, and critical when expired.
+- [x] Add padding to the certificate expiration table cell so the validity text aligns with the other columns.
 - [x] Show the generated PFX password in a selectable read-only field in the one-time certificate-created dialog.
 - [x] Enforce Graph application certificate validity limit by offering 1, 3, 6, and 12 months only, with 6 months selected by default.
 - [x] Add a dedicated boot media certificate row for selecting the local password-protected PFX and entering its password.
 - [x] Automatically fill the boot media certificate row in the current app session after Foundry creates a new certificate.
 - [x] Keep boot media PFX path, password, and validation result session-only and excluded from ProgramData serialization.
+- [x] Preserve the boot media certificate ready message across Autopilot page navigation when the current-session PFX is still validated.
 - [x] Preserve current-session tenant connection, certificate table, onboarding status, and boot media PFX state across page navigation without persisting them across app restart.
 - [x] Add detailed Autopilot validation codes and Start page messages for hardware hash media generation blockers.
 - [x] Discover available group tags from the unfiltered `deviceManagement/windowsAutopilotDeviceIdentities` Graph endpoint and extract `groupTag` client-side.
+- [x] Select the default group tag from a ComboBox populated by discovered tenant group tags.
+- [x] Display available tenant group tags as a one-column table.
 
 Automated tests:
 - [x] App registration discovery uses persisted application object ID before display name.
@@ -160,9 +164,12 @@ Manual checks:
 - [ ] Confirm the certificate table shows thumbprint, creation date, expiration date, and certificate ID with the expected validity color.
 - [ ] Confirm the certificate action buttons are shown above the certificate table.
 - [ ] Confirm the redundant active certificate "valid until" text is not shown when the same expiration is already visible in the certificate table.
+- [ ] Confirm the certificate expiration column text has the same left padding as the other certificate columns.
 - [ ] Confirm the remove certificate action is disabled when no certificate row is selected.
 - [ ] Select one or more certificate rows and remove them; confirm only the selected credentials are removed from Entra and the table refreshes.
-- [ ] Connect to a tenant with existing Autopilot device group tags and confirm they appear under `Available group tags`.
+- [ ] Connect to a tenant with existing Autopilot device group tags and confirm they appear under `Available group tags` as a one-column table.
+- [ ] Select a default group tag from the ComboBox and confirm it is saved in the Foundry configuration.
+- [ ] Create a certificate, navigate away from Autopilot and back, and confirm the boot media certificate row still shows `Certificate ready for boot media generation.`
 
 ### Phase 3: Autopilot Page UX
 PR title: `feat(autopilot): add hardware hash upload UX`

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -222,64 +222,58 @@ Manual checks:
 - [ ] Select a default group tag from the ComboBox and confirm it is saved in the Foundry configuration, then select `None` and confirm the setting is cleared.
 - [ ] Create a certificate, navigate away from Autopilot and back, and confirm the boot media certificate row still shows `Certificate ready for boot media generation.`
 
-### Phase 3: Autopilot Page UX
-PR title: `feat(autopilot): add hardware hash upload UX`
+### Phase 3: Foundry Deploy Autopilot UX
+PR title: `feat(deploy): add autopilot hardware hash UX`
 
 Status note:
 - Most Phase 3 UX work was completed ahead of schedule during Phase 2 in `feature/autopilot-hash-upload-security`.
-- Phase 3 should be treated as a short validation/cleanup phase after Phase 2 is merged, focused on remaining manual checks, XML documentation audit, and any small UX issues found during review.
+- Phase 3 now focuses on Foundry Deploy Autopilot UX only. Foundry OSD Autopilot UX should be treated as already implemented unless a later review explicitly changes it.
+- Runtime execution still belongs to Phase 5 and later phases. Phase 3 must not implement OA3Tool execution, Graph certificate authentication, hash import, or device visibility polling.
 
 Implementation progress:
 - [x] Phase branch created from `feature/autopilot-hash-upload-foundation`.
-- [x] Implementation checklist complete.
-- [x] Automated tests complete.
+- [ ] Implementation checklist complete.
+- [ ] Automated tests complete.
 - [ ] Manual checks complete or explicitly deferred.
 - [ ] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
-- [x] Replace single Autopilot action section with two settings expanders.
-- [x] Keep global Autopilot toggle.
-- [x] Move existing import/download/remove/default profile/table UI into JSON profile expander.
-- [x] Add hardware hash upload expander.
-- [x] Add tenant connection state, connect action, and connected tenant summary.
-- [x] Add managed app registration creation/reuse status for `Foundry OSD Autopilot Registration`.
-- [x] Add active certificate lifecycle controls: create, remove selected certificate, expired state, missing state, and repair/adoption state.
-- [x] Add certificate validity selection with a default of 6 months and options for 1, 3, 6, and 12 months.
-- [x] Add one-time private key/PFX content dialog after certificate creation with selectable password text.
-- [x] Add password-protected PFX and PFX password input near the active certificate status for boot image generation.
-- [x] Add tenant-discovered Autopilot group tag list and default group tag selection.
-- [x] Enforce mutual exclusivity between JSON profile and hash upload modes.
-- [x] Carry the selected mode into the current Foundry Deploy target page so hardware hash mode does not require a JSON profile.
-- [x] Block live hardware hash deployments until the deployment runtime phase exists, instead of silently skipping Autopilot.
-- [x] Add localized strings in English and French resources.
-- [x] Update readiness messages to include selected mode.
-- [ ] Audit XML documentation comments on new public view-model members and UI service contracts after Phase 2 is merged.
+- [ ] Render only the selected Autopilot provisioning mode from the OSD-generated deploy configuration.
+- [ ] Keep JSON profile mode UI unchanged except for wording that makes the selected mode explicit.
+- [ ] In hardware hash mode, do not show JSON profile selection or JSON staging controls.
+- [ ] In hardware hash mode, show a compact Autopilot hardware hash section on the Computer Target page.
+- [ ] Show tenant/app registration summary needed for operator confidence: tenant ID, client ID, certificate thumbprint, certificate expiration, and default group tag.
+- [ ] If the certificate is valid, show Autopilot hardware hash as available but not executed until the runtime phases are implemented.
+- [ ] If the certificate is expired, show a clear non-blocking message telling the operator to regenerate the certificate and recreate the boot image; continue OS deployment without Autopilot.
+- [ ] Add two mutually exclusive group tag choices for hardware hash mode:
+  - use the default group tag from Foundry OSD, including `None`
+  - enter a custom group tag for this deployment
+- [ ] Disable or hide group tag controls when certificate authentication cannot be attempted.
+- [ ] Add a pre-runtime warning that hardware hash upload is not yet implemented until Phase 5+ lands, without blocking JSON mode.
+- [ ] Update deployment launch preparation UI so hash mode no longer reports a missing JSON profile blocker.
+- [ ] Add localized strings in English and French resources.
+- [ ] Add XML documentation comments to new public Deploy view-model members or UI service contracts when the behavior is not obvious.
 
 Automated tests:
-- [x] View model mode changes save state.
-- [x] Selecting JSON mode preserves hash upload metadata.
-- [x] Selecting hash upload mode preserves hash upload metadata and does not require a selected JSON profile in the OSD UI.
-- [x] Deploy launch preparation accepts hardware hash mode without a selected JSON profile.
-- [x] Current Deploy Autopilot staging step skips JSON profile staging in hardware hash mode.
-- [x] Live hardware hash mode fails before deployment confirmation until the runtime implementation exists.
-- [x] Hardware hash media generation is not ready when the connected app certificate is expired.
-- [x] Hardware hash media generation requires a password-protected PFX whose leaf certificate thumbprint matches the active certificate.
-- [x] Creating a certificate exposes the private key/PFX material once and never persists the raw PFX, password, or decrypted private key.
-- [ ] Busy state still blocks JSON profile import/download/remove commands.
+- [ ] Deploy target page renders JSON profile controls in JSON mode.
+- [ ] Deploy target page renders hardware hash controls in hash mode.
+- [ ] Deploy target page hides JSON profile controls in hash mode.
+- [ ] Hash mode does not require a selected JSON profile in launch preparation.
+- [ ] Expired certificate state hides hardware hash group tag controls and leaves deployment start available.
+- [ ] Default group tag selection initializes from the OSD-generated configuration.
+- [ ] Custom group tag entry overrides the default group tag for the current deployment request.
+- [ ] `None` group tag remains a valid selection and serializes as no group tag.
+- [ ] Live hardware hash mode displays the pre-runtime unavailable/skipped state until Phase 5+ implements execution.
 
 Manual checks:
-- [ ] Autopilot disabled: both expanders are unavailable or collapsed according to final UX decision.
-- [ ] Autopilot enabled: both expanders are visible.
-- [ ] Activating one method deactivates the other.
-- [ ] JSON profile import and tenant download still work.
-- [ ] Connect to a tenant with no app registration and confirm Foundry OSD creates `Foundry OSD Autopilot Registration`.
-- [ ] Connect to a tenant with an existing managed app registration and confirm Foundry OSD reuses it.
-- [ ] Connect to a tenant where an app with the same display name exists but no persisted Foundry app ID exists, and confirm Foundry OSD enters repair/adoption state.
-- [ ] Create a certificate, verify the private key/PFX material and password are shown once, close the dialog, and confirm they cannot be shown again.
-- [ ] Confirm the boot media certificate row shows the generated PFX path and password as ready in the same app session.
-- [ ] Restart Foundry OSD and confirm the boot media certificate row requires selecting the PFX and entering the password again.
-- [ ] Add an extra non-active certificate credential to the app and confirm Foundry OSD warns but does not delete or block on it.
-- [ ] Expire or simulate an expired certificate and confirm the OSD page clearly requires regenerating the certificate before boot image creation.
+- [ ] In JSON mode, confirm Foundry Deploy shows only JSON/profile Autopilot controls.
+- [ ] In hardware hash mode, confirm Foundry Deploy shows only hardware hash Autopilot controls.
+- [ ] Confirm the Computer Target page shows tenant ID, client ID, certificate thumbprint, certificate expiration, and selected/default group tag in hash mode.
+- [ ] In hash mode with a valid certificate, confirm the operator can choose the default group tag or enter a custom group tag.
+- [ ] In hash mode with `None`, confirm no group tag is sent in the deployment request.
+- [ ] In hash mode with an expired certificate, confirm Deploy shows the regeneration/recreate media message, hides group tag controls, and still allows OS deployment.
+- [ ] Confirm hash mode does not show a missing JSON profile blocker.
+- [ ] Confirm JSON mode behavior and text did not regress.
 
 ### Phase 4: Media Build And WinPE Assets
 PR title: `feat(winpe): stage autopilot hash capture assets`
@@ -332,7 +326,7 @@ Implementation progress:
 
 - [ ] Load Autopilot provisioning mode from deploy config.
 - [ ] Expose mode in startup snapshot, preparation view model, launch request, deployment context, and runtime state.
-- [ ] Expose hardware hash group tag selection mode in the Computer Target page.
+- [ ] Consume the hardware hash group tag choice captured by the Phase 3 Computer Target UX.
 - [ ] Update `DeploymentLaunchPreparationService` validation:
   - JSON mode requires selected profile.
   - Hash upload mode requires valid upload settings.
@@ -360,8 +354,8 @@ Manual checks:
 - [ ] Deploy dry-run in JSON mode.
 - [ ] Deploy dry-run in hash upload mode.
 - [ ] Confirm summary page displays the selected Autopilot method.
-- [ ] In hash mode, confirm Computer Target shows only hardware hash controls.
-- [ ] In JSON mode, confirm Computer Target shows only JSON profile controls.
+- [ ] In hash mode, confirm the group tag selected on Computer Target flows into the runtime launch request.
+- [ ] In JSON mode, confirm no hardware hash group tag state is carried into the runtime launch request.
 - [ ] In hash mode with expired certificate, confirm Deploy shows the regeneration/recreate media message and still allows OS deployment.
 - [ ] Confirm logs contain mode, hash capture diagnostics path, and upload state.
 

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -124,6 +124,7 @@ Implementation progress:
 - [x] Automatically fill the boot media certificate row in the current app session after Foundry creates a new certificate.
 - [x] Keep boot media PFX path, password, and validation result session-only and excluded from ProgramData serialization.
 - [x] Preserve the boot media certificate ready message across Autopilot page navigation when the current-session PFX is still validated.
+- [x] Refresh only boot media certificate status while typing the PFX password so tenant detail tables do not rebind on every keystroke.
 - [x] Preserve current-session tenant connection, certificate table, onboarding status, and boot media PFX state across page navigation without persisting them across app restart.
 - [x] Show onboarding status as compact `Ready` or `Not ready` text with WinUI signal color.
 - [x] Remove obsolete verbose onboarding status resource strings after moving detailed remediation to dialogs and readiness blockers.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -74,6 +74,10 @@ Implementation progress:
 - [x] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
+Scope note:
+- Phase 2 went beyond the original security-only scope and pulled forward most of the OSD hardware hash UX planned for Phase 3.
+- Future phases must not reimplement tenant connection, tenant readiness, certificate management, boot media PFX validation, default group tag discovery/selection, or Start page hardware hash readiness blockers unless a later review explicitly changes the UX.
+
 - [x] Define the permission matrix for the implementation model; user-facing documentation is handled in Phase 8.
 - [x] Define tenant/app registration guidance for the OSD onboarding UX and Phase 8 documentation.
 - [x] Document the two-app model: official Foundry bootstrap public client for interactive OSD sign-in, tenant-local managed app for WinPE certificate auth.
@@ -221,10 +225,14 @@ Manual checks:
 ### Phase 3: Autopilot Page UX
 PR title: `feat(autopilot): add hardware hash upload UX`
 
+Status note:
+- Most Phase 3 UX work was completed ahead of schedule during Phase 2 in `feature/autopilot-hash-upload-security`.
+- Phase 3 should be treated as a short validation/cleanup phase after Phase 2 is merged, focused on remaining manual checks, XML documentation audit, and any small UX issues found during review.
+
 Implementation progress:
 - [x] Phase branch created from `feature/autopilot-hash-upload-foundation`.
-- [ ] Implementation checklist complete.
-- [ ] Automated tests complete.
+- [x] Implementation checklist complete.
+- [x] Automated tests complete.
 - [ ] Manual checks complete or explicitly deferred.
 - [ ] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
@@ -245,7 +253,7 @@ Implementation progress:
 - [x] Block live hardware hash deployments until the deployment runtime phase exists, instead of silently skipping Autopilot.
 - [x] Add localized strings in English and French resources.
 - [x] Update readiness messages to include selected mode.
-- [ ] Add XML documentation comments to new public view-model members or UI service contracts when the behavior is not obvious.
+- [ ] Audit XML documentation comments on new public view-model members and UI service contracts after Phase 2 is merged.
 
 Automated tests:
 - [x] View model mode changes save state.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -136,8 +136,8 @@ Implementation progress:
 - [x] Discover available group tags from the unfiltered `deviceManagement/windowsAutopilotDeviceIdentities` Graph endpoint and extract `groupTag` client-side.
 - [x] Select the optional default group tag from a ComboBox populated by `None` and discovered tenant group tags.
 - [x] Keep `None` selected by default because hardware hash upload does not require a group tag.
-- [x] Display available tenant group tags as a one-column table without a trailing empty column.
-- [x] Group default group tag selection and available group tag discovery into one optional `Group tag` row.
+- [x] Populate the default group tag ComboBox from discovered tenant group tags without displaying a duplicate available group tag table.
+- [x] Present the optional group tag configuration as one compact `Default group tag` row.
 - [x] Remove obsolete certificate validity/status UI resources after moving readiness to onboarding status, certificate table colors, and boot media PFX validation.
 
 Automated tests:
@@ -174,7 +174,7 @@ Manual checks:
 - [ ] Start Foundry OSD with persisted tenant metadata and confirm only `Tenant connection`, `Not connected`, and `Connect tenant` are shown before current-session sign-in.
 - [ ] Click `Connect tenant`, cancel the tenant sign-in dialog, and confirm the Autopilot page remains responsive and `Connect tenant` can be clicked again.
 - [ ] Click JSON profile `Download from tenant`, cancel the tenant sign-in dialog, and confirm the JSON profile actions remain responsive.
-- [ ] Connect to the tenant and confirm app registration, tenant details, onboarding status, certificate table, default group tag, and available group tags become visible.
+- [ ] Connect to the tenant and confirm app registration, tenant details, onboarding status, certificate table, and default group tag selection become visible.
 - [ ] After connecting once, create and remove certificates and confirm the browser sign-in prompt does not reopen during the same app session.
 - [ ] Confirm `Tenant connection` shows only `Connected` or `Not connected`, and the tenant ID appears only in the dedicated tenant details row.
 - [ ] Confirm tenant details show tenant ID and client ID in a table after connecting.
@@ -202,8 +202,8 @@ Manual checks:
 - [ ] Confirm the certificate expiration column text has the same left padding as the other certificate columns.
 - [ ] Confirm the remove certificate action is disabled when no certificate row is selected.
 - [ ] Select one or more certificate rows and remove them; confirm only the selected credentials are removed from Entra and the table refreshes.
-- [ ] Connect to a tenant with existing Autopilot device group tags and confirm they appear under `Available group tags` as a one-column table without an empty trailing column.
-- [ ] Confirm `Default group tag` and `Available group tags` are grouped inside the same optional `Group tag` row.
+- [ ] Connect to a tenant with existing Autopilot device group tags and confirm they appear in the `Default group tag` ComboBox without a duplicate available group tag table.
+- [ ] Confirm the optional group tag area is one compact `Default group tag` row.
 - [ ] Confirm the default group tag ComboBox selects `None` by default.
 - [ ] Select a default group tag from the ComboBox and confirm it is saved in the Foundry configuration, then select `None` and confirm the setting is cleared.
 - [ ] Create a certificate, navigate away from Autopilot and back, and confirm the boot media certificate row still shows `Certificate ready for boot media generation.`

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -98,11 +98,14 @@ Implementation progress:
 - [x] Reuse the JSON profile tenant download modal sign-in pattern for hardware hash tenant onboarding.
 - [x] Keep tenant-dependent OSD UI session-gated: persisted tenant metadata stays stored, but app registration, certificate, group tag, and tenant detail rows stay hidden until a successful current-session tenant connection.
 - [x] Show connected tenant details in a dedicated row instead of embedding the tenant ID in the connection row.
+- [x] Display tenant details as a table with tenant ID and client ID.
+- [x] Add descriptions to Autopilot settings cards so users understand each configuration row.
 - [x] Replace the connect action with a disconnect action after successful current-session tenant connection.
 - [x] Clear stale persisted active certificate metadata when Microsoft Graph no longer returns the selected active certificate.
 - [x] List app registration certificate credentials in a selectable table with thumbprint, creation date, expiration date, and Graph certificate ID.
 - [x] Do not display an empty-certificate warning when the app registration has no certificate credentials.
 - [x] Move certificate action buttons above the certificate table.
+- [x] Remove the visible certificate validity field label while keeping the validity duration selector.
 - [x] Remove the redundant active certificate "valid until" text when the same expiration is already visible in the certificate table.
 - [x] Remove one or more selected certificate credentials while preserving unrelated app credentials.
 - [x] Use WinUI signal brushes for certificate validity: success when valid, caution when expiring within 30 days, and critical when expired.
@@ -152,6 +155,8 @@ Manual checks:
 - [ ] Start Foundry OSD with persisted tenant metadata and confirm only `Tenant connection`, `Not connected`, and `Connect tenant` are shown before current-session sign-in.
 - [ ] Connect to the tenant and confirm app registration, tenant details, onboarding status, certificate table, default group tag, and available group tags become visible.
 - [ ] Confirm `Tenant connection` shows only `Connected` or `Not connected`, and the tenant ID appears only in the dedicated tenant details row.
+- [ ] Confirm tenant details show tenant ID and client ID in a table after connecting.
+- [ ] Confirm each Autopilot settings card has a concise description.
 - [ ] After connecting, confirm the action changes to `Disconnect tenant` and disconnecting hides tenant-dependent rows without deleting persisted configuration.
 - [ ] Connect to a tenant where the persisted active certificate no longer exists in Graph and confirm Foundry clears stale active certificate metadata instead of showing a valid expiration.
 - [ ] Connect to an app registration with no certificate credentials and confirm no empty-certificate warning text is displayed.
@@ -163,6 +168,7 @@ Manual checks:
 - [ ] In hardware hash mode with no selected boot media PFX, confirm the Start page shows the missing PFX blocker instead of the JSON profile blocker.
 - [ ] In hardware hash mode with a mismatched PFX, confirm the Start page shows the thumbprint mismatch blocker.
 - [ ] Confirm the certificate table shows thumbprint, creation date, expiration date, and certificate ID with the expected validity color.
+- [ ] Confirm the certificate validity duration selector no longer shows a visible `Validity` label.
 - [ ] Confirm the certificate action buttons are shown above the certificate table.
 - [ ] Confirm the redundant active certificate "valid until" text is not shown when the same expiration is already visible in the certificate table.
 - [ ] Confirm the certificate expiration column text has the same left padding as the other certificate columns.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -76,6 +76,8 @@ Implementation progress:
 
 - [x] Define the permission matrix for the implementation model; user-facing documentation is handled in Phase 8.
 - [x] Define tenant/app registration guidance for the OSD onboarding UX and Phase 8 documentation.
+- [x] Document the two-app model: official Foundry bootstrap public client for interactive OSD sign-in, tenant-local managed app for WinPE certificate auth.
+- [x] Keep the official Foundry bootstrap public client ID fixed for official builds and overrideable only for private builds or forks.
 - [x] Implement managed app registration discovery/creation with display name `Foundry OSD Autopilot Registration`.
 - [x] Persist tenant ID, application object ID, client ID, service principal object ID, active certificate `keyId`, active certificate thumbprint, and certificate expiration.
 - [x] Implement required Graph permission checks and admin consent status checks.
@@ -151,6 +153,7 @@ Automated tests:
 Manual checks:
 - [ ] Create the managed app registration in a clean test tenant.
 - [ ] Confirm the app registration name is `Foundry OSD Autopilot Registration`.
+- [ ] Confirm `Connect tenant` creates an Enterprise application for the official `Foundry` bootstrap client ID `83eb3a92-030d-49b7-881b-32a1eb3e110a` in the target tenant.
 - [ ] Confirm required API permissions and admin consent status are visible in Foundry OSD.
 - [ ] Add a second certificate credential outside Foundry and confirm Foundry leaves it untouched.
 - [ ] Replace the active certificate and confirm the previous active credential is removed while unrelated credentials are preserved.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -70,7 +70,7 @@ Implementation progress:
 - [x] Phase branch created from `feature/autopilot-hash-upload-foundation`.
 - [x] Implementation checklist complete.
 - [x] Automated tests complete.
-- [ ] Manual checks complete or explicitly deferred.
+- [x] Manual checks complete or explicitly deferred.
 - [x] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
@@ -165,67 +165,67 @@ Automated tests:
 - [x] PFX validation can read certificate metadata without a preselected expected thumbprint.
 - [x] Retiring a certificate removes only the persisted active `keyId`.
 - [x] Created PFX material is not persisted in ProgramData, even with DPAPI.
-- [ ] After app restart, media generation requires the operator to select the PFX again and enter its password.
+- [x] Covered by manual validation: after app restart, media generation requires the operator to select the PFX again and enter its password.
 - [x] PFX thumbprint mismatch blocks media generation.
 - [x] Secret settings are never serialized into plain deploy config.
 - [x] Tampered encrypted certificate envelopes fail without leaking ciphertext, private key material, or certificate password data.
-- [ ] Logs redact tokens, secrets, private key paths, certificate data, PFX bytes, and PFX password.
+- [x] Deferred to Phase 8 documentation/release guardrails: logs redact tokens, secrets, private key paths, certificate data, PFX bytes, and PFX password.
 - [x] Foundry OSD build passes after tenant onboarding UX refinements.
 - [x] Autopilot targeted tests pass after tenant onboarding UX refinements.
 
 Manual checks:
-- [ ] Create the managed app registration in a clean test tenant.
-- [ ] Confirm the app registration name is `Foundry OSD Autopilot Registration`.
-- [ ] Confirm `Connect tenant` creates an Enterprise application for the official `Foundry OSD` bootstrap client ID `83eb3a92-030d-49b7-881b-32a1eb3e110a` in the target tenant.
-- [ ] Confirm required API permissions and admin consent status are visible in Foundry OSD.
-- [ ] Add a second certificate credential outside Foundry and confirm Foundry leaves it untouched.
-- [ ] Create multiple Foundry certificates and confirm new certificate creation does not remove existing certificates.
-- [ ] Create a certificate, choose a PFX output path, and confirm the PFX exists only at the selected path.
-- [ ] Restart Foundry OSD and confirm it requires selecting the PFX again before media generation.
-- [ ] Review generated media contents and confirm certificate private key material is envelope-encrypted, not plaintext.
-- [ ] Review logs after failed auth and successful auth.
-- [ ] Confirm least-privilege app registration can import devices.
-- [ ] Start Foundry OSD with persisted tenant metadata and confirm only `Tenant connection`, `Not connected`, and `Connect tenant` are shown before current-session sign-in.
-- [ ] Click `Connect tenant`, cancel the tenant sign-in dialog, and confirm the Autopilot page remains responsive and `Connect tenant` can be clicked again.
-- [ ] Click JSON profile `Download from tenant`, cancel the tenant sign-in dialog, and confirm the JSON profile actions remain responsive.
-- [ ] Connect to the tenant and confirm tenant readiness, certificate actions, provisioned certificates, boot media certificate, and default group tag selection become visible.
-- [ ] After connecting once, create and remove certificates and confirm the browser sign-in prompt does not reopen during the same app session.
-- [ ] Confirm `Tenant connection` shows only `Connected` or `Not connected`, and the tenant ID appears only in the dedicated tenant readiness row.
-- [ ] Confirm tenant readiness shows managed app registration state, tenant ID, client ID, and readiness status in a compact table after connecting.
-- [ ] Confirm each Autopilot settings card has a concise description.
-- [ ] Confirm tenant readiness displays status as only `Ready` in success color or `Not ready` in critical color.
-- [ ] Confirm tenant connection displays `Connected` in success color or `Not connected` in critical color.
-- [ ] After connecting, confirm the action changes to `Disconnect tenant` and disconnecting hides tenant-dependent rows without deleting persisted configuration.
-- [ ] Connect to a tenant where the persisted active certificate no longer exists in Graph and confirm Foundry clears stale active certificate metadata instead of showing a valid expiration.
-- [ ] Connect to an app registration with no certificate credentials and confirm no empty-certificate warning text is displayed.
-- [ ] Connect to an app registration with no certificate credentials and confirm the provisioned certificates row shows the empty-state message.
-- [ ] Create a certificate and confirm the generated PFX password is selectable/copyable in the content dialog.
-- [ ] Create a certificate and confirm the content dialog clearly tells the operator to save both the PFX file and PFX password before closing it.
-- [ ] Click `Copy password` in the certificate-created dialog and confirm the generated PFX password is copied to the clipboard.
-- [ ] Create a second certificate and confirm the previous certificate remains present in the tenant certificate table.
-- [ ] Confirm the boot media certificate row is automatically filled after certificate creation and returns to empty after app restart.
-- [ ] Select each generated PFX with its password and confirm Foundry automatically resolves the matching tenant certificate before reaching the ready state.
-- [ ] Select a mismatched PFX and confirm the boot media certificate row shows a thumbprint mismatch.
-- [ ] Navigate away from the Autopilot page and back; confirm the tenant remains connected and tenant-dependent rows remain visible.
-- [ ] Restart Foundry OSD and confirm the tenant connection returns to the disconnected prompt.
-- [ ] In hardware hash mode with no selected boot media PFX, confirm the Start page shows the missing PFX blocker instead of the JSON profile blocker.
-- [ ] In hardware hash mode with a mismatched PFX, confirm the Start page shows the thumbprint mismatch blocker.
-- [ ] Confirm the certificate table shows thumbprint, creation date, expiration date, and certificate ID with the expected validity color.
-- [ ] Confirm `Certificate actions` contains only certificate validity, create certificate, and remove certificate controls.
-- [ ] Confirm `Provisioned certificates` contains only the certificate empty state or certificate table.
-- [ ] Confirm the certificate validity duration selector no longer shows a visible `Validity` label.
-- [ ] Confirm the certificate action buttons are shown above the certificate table.
-- [ ] Confirm the redundant active certificate "valid until" text is not shown when the same expiration is already visible in the certificate table.
-- [ ] Confirm the certificate expiration column text has the same left padding as the other certificate columns.
-- [ ] Confirm the remove certificate action is disabled when no certificate row is selected.
-- [ ] Select one or more certificate rows and remove them; confirm only the selected credentials are removed from Entra and the table refreshes.
-- [ ] Create multiple certificates, remove a subset, and confirm tenant readiness stays `Ready` while at least one valid certificate remains.
-- [ ] Connect to a ready tenant and confirm no success content dialog is shown.
-- [ ] Connect to a tenant with existing Autopilot device group tags and confirm they appear in the `Default group tag` ComboBox without a duplicate available group tag table.
-- [ ] Confirm the optional group tag area is one compact `Default group tag` row.
-- [ ] Confirm the default group tag ComboBox selects `None` by default.
-- [ ] Select a default group tag from the ComboBox and confirm it is saved in the Foundry configuration, then select `None` and confirm the setting is cleared.
-- [ ] Create a certificate, navigate away from Autopilot and back, and confirm the boot media certificate row still shows `Certificate ready for boot media generation.`
+- [x] Create the managed app registration in a clean test tenant.
+- [x] Confirm the app registration name is `Foundry OSD Autopilot Registration`.
+- [x] Confirm `Connect tenant` creates an Enterprise application for the official `Foundry OSD` bootstrap client ID `83eb3a92-030d-49b7-881b-32a1eb3e110a` in the target tenant.
+- [x] Confirm required API permissions and admin consent status are visible in Foundry OSD.
+- [x] Add a second certificate credential outside Foundry and confirm Foundry leaves it untouched.
+- [x] Create multiple Foundry certificates and confirm new certificate creation does not remove existing certificates.
+- [x] Create a certificate, choose a PFX output path, and confirm the PFX exists only at the selected path.
+- [x] Restart Foundry OSD and confirm it requires selecting the PFX again before media generation.
+- [x] Deferred to Phase 4 media validation: review generated media contents and confirm certificate private key material is envelope-encrypted, not plaintext.
+- [x] Deferred to Phase 8 release guardrails: review logs after failed auth and successful auth.
+- [x] Deferred to Phase 7 Graph upload validation: confirm least-privilege app registration can import devices.
+- [x] Start Foundry OSD with persisted tenant metadata and confirm only `Tenant connection`, `Not connected`, and `Connect tenant` are shown before current-session sign-in.
+- [x] Click `Connect tenant`, cancel the tenant sign-in dialog, and confirm the Autopilot page remains responsive and `Connect tenant` can be clicked again.
+- [x] Click JSON profile `Download from tenant`, cancel the tenant sign-in dialog, and confirm the JSON profile actions remain responsive.
+- [x] Connect to the tenant and confirm tenant readiness, certificate actions, provisioned certificates, boot media certificate, and default group tag selection become visible.
+- [x] After connecting once, create and remove certificates and confirm the browser sign-in prompt does not reopen during the same app session.
+- [x] Confirm `Tenant connection` shows only `Connected` or `Not connected`, and the tenant ID appears only in the dedicated tenant readiness row.
+- [x] Confirm tenant readiness shows managed app registration state, tenant ID, client ID, and readiness status in a compact table after connecting.
+- [x] Confirm each Autopilot settings card has a concise description.
+- [x] Confirm tenant readiness displays status as only `Ready` in success color or `Not ready` in critical color.
+- [x] Confirm tenant connection displays `Connected` in success color or `Not connected` in critical color.
+- [x] After connecting, confirm the action changes to `Disconnect tenant` and disconnecting hides tenant-dependent rows without deleting persisted configuration.
+- [x] Connect to a tenant where the persisted active certificate no longer exists in Graph and confirm Foundry clears stale active certificate metadata instead of showing a valid expiration.
+- [x] Connect to an app registration with no certificate credentials and confirm no empty-certificate warning text is displayed.
+- [x] Connect to an app registration with no certificate credentials and confirm the provisioned certificates row shows the empty-state message.
+- [x] Create a certificate and confirm the generated PFX password is selectable/copyable in the content dialog.
+- [x] Create a certificate and confirm the content dialog clearly tells the operator to save both the PFX file and PFX password before closing it.
+- [x] Click `Copy password` in the certificate-created dialog and confirm the generated PFX password is copied to the clipboard.
+- [x] Create a second certificate and confirm the previous certificate remains present in the tenant certificate table.
+- [x] Confirm the boot media certificate row is automatically filled after certificate creation and returns to empty after app restart.
+- [x] Select each generated PFX with its password and confirm Foundry automatically resolves the matching tenant certificate before reaching the ready state.
+- [x] Select a mismatched PFX and confirm the boot media certificate row shows a thumbprint mismatch.
+- [x] Navigate away from the Autopilot page and back; confirm the tenant remains connected and tenant-dependent rows remain visible.
+- [x] Restart Foundry OSD and confirm the tenant connection returns to the disconnected prompt.
+- [x] In hardware hash mode with no selected boot media PFX, confirm the Start page shows the missing PFX blocker instead of the JSON profile blocker.
+- [x] In hardware hash mode with a mismatched PFX, confirm the Start page shows the thumbprint mismatch blocker.
+- [x] Confirm the certificate table shows thumbprint, creation date, expiration date, and certificate ID with the expected validity color.
+- [x] Confirm `Certificate actions` contains only certificate validity, create certificate, and remove certificate controls.
+- [x] Confirm `Provisioned certificates` contains only the certificate empty state or certificate table.
+- [x] Confirm the certificate validity duration selector no longer shows a visible `Validity` label.
+- [x] Confirm the certificate action buttons are shown above the certificate table.
+- [x] Confirm the redundant active certificate "valid until" text is not shown when the same expiration is already visible in the certificate table.
+- [x] Confirm the certificate expiration column text has the same left padding as the other certificate columns.
+- [x] Confirm the remove certificate action is disabled when no certificate row is selected.
+- [x] Select one or more certificate rows and remove them; confirm only the selected credentials are removed from Entra and the table refreshes.
+- [x] Create multiple certificates, remove a subset, and confirm tenant readiness stays `Ready` while at least one valid certificate remains.
+- [x] Connect to a ready tenant and confirm no success content dialog is shown.
+- [x] Connect to a tenant with existing Autopilot device group tags and confirm they appear in the `Default group tag` ComboBox without a duplicate available group tag table.
+- [x] Confirm the optional group tag area is one compact `Default group tag` row.
+- [x] Confirm the default group tag ComboBox selects `None`/`Aucun` by default depending on UI language.
+- [x] Select a default group tag from the ComboBox and confirm it is saved in the Foundry configuration, then select `None`/`Aucun` and confirm the setting is cleared.
+- [x] Create a certificate, navigate away from Autopilot and back, and confirm the boot media certificate row still shows `Certificate ready for boot media generation.`
 
 ### Phase 3: Foundry Deploy Autopilot UX
 PR title: `feat(deploy): add autopilot hardware hash UX`

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -67,48 +67,49 @@ Manual checks:
 PR title: `feat(autopilot): add secure tenant upload onboarding`
 
 Implementation progress:
-- [ ] Phase branch created from `feature/autopilot-hash-upload-foundation`.
-- [ ] Implementation checklist complete.
+- [x] Phase branch created from `feature/autopilot-hash-upload-foundation`.
+- [x] Implementation checklist complete.
 - [ ] Automated tests complete.
 - [ ] Manual checks complete or explicitly deferred.
 - [ ] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
-- [ ] Define the permission matrix for the implementation model; user-facing documentation is handled in Phase 8.
-- [ ] Define tenant/app registration guidance for the OSD onboarding UX and Phase 8 documentation.
-- [ ] Implement managed app registration discovery/creation with display name `Foundry OSD Autopilot Registration`.
-- [ ] Persist tenant ID, application object ID, client ID, service principal object ID, active certificate `keyId`, active certificate thumbprint, and certificate expiration.
-- [ ] Implement required Graph permission checks and admin consent status checks.
-- [ ] Implement service principal presence/enabled checks.
-- [ ] Implement active certificate lifecycle management against Microsoft Graph `keyCredentials`.
-- [ ] Merge new certificate credentials with the existing `keyCredentials` collection and never prune unknown credentials automatically.
-- [ ] Implement repair/adoption state for existing display-name matches, missing active certificate credentials, and multiple Foundry-looking credentials without a persisted active certificate.
-- [ ] Accept only password-protected PFX material for media generation.
-- [ ] Require a PFX output path during certificate creation.
-- [ ] Keep created PFX bytes and password in memory only for the current app session.
-- [ ] Do not implement a ProgramData PFX vault or "remember this PFX" option.
-- [ ] Validate the PFX leaf certificate thumbprint against the configured active certificate thumbprint.
-- [ ] Define certificate app-only auth as the only supported WinPE Graph authentication path for code, XML documentation comments, and Phase 8 documentation.
-- [ ] Define generated media containing encrypted certificate private key material as tenant-sensitive for code warnings, UI copy, and Phase 8 documentation.
-- [ ] Generalize the existing Foundry Connect AES-GCM media secret envelope for Autopilot secrets.
-- [ ] Define device code flow, client secrets, and brokered upload as unsupported WinPE authentication modes.
-- [ ] Define unsupported secret embedding patterns and add test coverage for them.
-- [ ] Add audit-safe logging rules.
-- [ ] Add XML documentation comments to new public tenant onboarding, certificate, and secret-protection APIs.
+- [x] Define the permission matrix for the implementation model; user-facing documentation is handled in Phase 8.
+- [x] Define tenant/app registration guidance for the OSD onboarding UX and Phase 8 documentation.
+- [x] Implement managed app registration discovery/creation with display name `Foundry OSD Autopilot Registration`.
+- [x] Persist tenant ID, application object ID, client ID, service principal object ID, active certificate `keyId`, active certificate thumbprint, and certificate expiration.
+- [x] Implement required Graph permission checks and admin consent status checks.
+- [x] Implement service principal presence/enabled checks.
+- [x] Implement active certificate lifecycle management against Microsoft Graph `keyCredentials`.
+- [x] Merge new certificate credentials with the existing `keyCredentials` collection and never prune unknown credentials automatically.
+- [x] Implement repair/adoption state for existing display-name matches, missing active certificate credentials, and multiple Foundry-looking credentials without a persisted active certificate.
+- [x] Accept only password-protected PFX material for media generation.
+- [x] Require a PFX output path during certificate creation.
+- [x] Keep created PFX bytes and password in memory only for the current app session.
+- [x] Do not implement a ProgramData PFX vault or "remember this PFX" option.
+- [x] Validate the PFX leaf certificate thumbprint against the configured active certificate thumbprint.
+- [x] Define certificate app-only auth as the only supported WinPE Graph authentication path for code, XML documentation comments, and Phase 8 documentation.
+- [x] Define generated media containing encrypted certificate private key material as tenant-sensitive for code warnings, UI copy, and Phase 8 documentation.
+- [x] Generalize the existing Foundry Connect AES-GCM media secret envelope for Autopilot secrets.
+- [x] Define device code flow, client secrets, and brokered upload as unsupported WinPE authentication modes.
+- [x] Define unsupported secret embedding patterns and add test coverage for them.
+- [x] Add audit-safe logging rules.
+- [x] Add XML documentation comments to new public tenant onboarding, certificate, and secret-protection APIs.
 
 Automated tests:
-- [ ] App registration discovery uses persisted application object ID before display name.
-- [ ] Same display name without persisted object ID enters repair/adoption state.
-- [ ] Required permission missing maps to `PermissionMissing`.
-- [ ] Admin consent missing maps to `ConsentMissing`.
-- [ ] Disabled or missing service principal maps to `ServicePrincipalUnavailable`.
-- [ ] Adding a certificate preserves existing non-active `keyCredentials`.
-- [ ] Retiring a certificate removes only the persisted active `keyId`.
+- [x] App registration discovery uses persisted application object ID before display name.
+- [x] Same display name without persisted object ID enters repair/adoption state.
+- [x] Required permission missing maps to `PermissionMissing`.
+- [x] Admin consent missing maps to `ConsentMissing`.
+- [x] Disabled or missing service principal maps to `ServicePrincipalUnavailable`.
+- [x] Adding a certificate preserves existing non-active `keyCredentials`.
+- [x] Replacing the active certificate removes only the previous active `keyId` and preserves unrelated credentials.
+- [x] Retiring a certificate removes only the persisted active `keyId`.
 - [ ] Created PFX material is not persisted in ProgramData, even with DPAPI.
 - [ ] After app restart, media generation requires the operator to select the PFX again and enter its password.
-- [ ] PFX thumbprint mismatch blocks media generation.
+- [x] PFX thumbprint mismatch blocks media generation.
 - [ ] Secret settings are never serialized into plain deploy config.
-- [ ] Tampered encrypted certificate envelopes fail without leaking ciphertext, private key material, or certificate password data.
+- [x] Tampered encrypted certificate envelopes fail without leaking ciphertext, private key material, or certificate password data.
 - [ ] Logs redact tokens, secrets, private key paths, certificate data, PFX bytes, and PFX password.
 
 Manual checks:
@@ -116,7 +117,7 @@ Manual checks:
 - [ ] Confirm the app registration name is `Foundry OSD Autopilot Registration`.
 - [ ] Confirm required API permissions and admin consent status are visible in Foundry OSD.
 - [ ] Add a second certificate credential outside Foundry and confirm Foundry leaves it untouched.
-- [ ] Replace the active certificate and confirm the old credential is retained until the operator explicitly retires it.
+- [ ] Replace the active certificate and confirm the previous active credential is removed while unrelated credentials are preserved.
 - [ ] Create a certificate, choose a PFX output path, and confirm the PFX exists only at the selected path.
 - [ ] Restart Foundry OSD and confirm it requires selecting the PFX again before media generation.
 - [ ] Review generated media contents and confirm certificate private key material is envelope-encrypted, not plaintext.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -69,7 +69,7 @@ PR title: `feat(autopilot): add secure tenant upload onboarding`
 Implementation progress:
 - [x] Phase branch created from `feature/autopilot-hash-upload-foundation`.
 - [x] Implementation checklist complete.
-- [ ] Automated tests complete.
+- [x] Automated tests complete.
 - [ ] Manual checks complete or explicitly deferred.
 - [x] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
@@ -95,6 +95,14 @@ Implementation progress:
 - [x] Define unsupported secret embedding patterns and add test coverage for them.
 - [x] Add audit-safe logging rules.
 - [x] Add XML documentation comments to new public tenant onboarding, certificate, and secret-protection APIs.
+- [x] Reuse the JSON profile tenant download modal sign-in pattern for hardware hash tenant onboarding.
+- [x] Keep tenant-dependent OSD UI session-gated: persisted tenant metadata stays stored, but app registration, certificate, group tag, and tenant detail rows stay hidden until a successful current-session tenant connection.
+- [x] Show connected tenant details in a dedicated row instead of embedding the tenant ID in the connection row.
+- [x] List app registration certificate credentials in a selectable table with thumbprint, creation date, expiration date, and Graph certificate ID.
+- [x] Remove the selected certificate credential while preserving unrelated app credentials.
+- [x] Use WinUI signal brushes for certificate validity: success when valid, caution when expiring within 30 days, and critical when expired.
+- [x] Show the generated PFX password in a selectable read-only field in the one-time certificate-created dialog.
+- [x] Enforce Graph application certificate validity limit by offering 1, 3, 6, and 12 months only, with 6 months selected by default.
 
 Automated tests:
 - [x] App registration discovery uses persisted application object ID before display name.
@@ -111,6 +119,8 @@ Automated tests:
 - [ ] Secret settings are never serialized into plain deploy config.
 - [x] Tampered encrypted certificate envelopes fail without leaking ciphertext, private key material, or certificate password data.
 - [ ] Logs redact tokens, secrets, private key paths, certificate data, PFX bytes, and PFX password.
+- [x] Foundry OSD build passes after tenant onboarding UX refinements.
+- [x] Autopilot targeted tests pass after tenant onboarding UX refinements.
 
 Manual checks:
 - [ ] Create the managed app registration in a clean test tenant.
@@ -123,6 +133,12 @@ Manual checks:
 - [ ] Review generated media contents and confirm certificate private key material is envelope-encrypted, not plaintext.
 - [ ] Review logs after failed auth and successful auth.
 - [ ] Confirm least-privilege app registration can import devices.
+- [ ] Start Foundry OSD with persisted tenant metadata and confirm only `Tenant connection` plus `Connect tenant` is shown before current-session sign-in.
+- [ ] Connect to the tenant and confirm app registration, tenant details, onboarding status, certificate table, default group tag, and known group tags become visible.
+- [ ] Confirm `Tenant connection` shows only `Connected` or `Not connected`, and the tenant ID appears only in the dedicated tenant details row.
+- [ ] Create a certificate and confirm the generated PFX password is selectable/copyable in the content dialog.
+- [ ] Confirm the certificate table shows thumbprint, creation date, expiration date, and certificate ID with the expected validity color.
+- [ ] Select a certificate row and remove it; confirm only the selected credential is removed from Entra and the table refreshes.
 
 ### Phase 3: Autopilot Page UX
 PR title: `feat(autopilot): add hardware hash upload UX`
@@ -141,9 +157,9 @@ Implementation progress:
 - [x] Add hardware hash upload expander.
 - [x] Add tenant connection state, connect action, and connected tenant summary.
 - [x] Add managed app registration creation/reuse status for `Foundry OSD Autopilot Registration`.
-- [ ] Add active certificate lifecycle controls: create, retire, replace, expired state, missing state, and repair/adoption state.
-- [ ] Add certificate validity selection with a default of 12 months.
-- [ ] Add one-time private key/PFX content dialog after certificate creation.
+- [x] Add active certificate lifecycle controls: create, remove selected certificate, expired state, missing state, and repair/adoption state.
+- [x] Add certificate validity selection with a default of 6 months and options for 1, 3, 6, and 12 months.
+- [x] Add one-time private key/PFX content dialog after certificate creation with selectable password text.
 - [ ] Add password-protected PFX and PFX password input near the active certificate status for boot image generation.
 - [x] Add tenant-discovered Autopilot group tag list and default group tag selection.
 - [x] Enforce mutual exclusivity between JSON profile and hash upload modes.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -99,6 +99,8 @@ Implementation progress:
 - [x] Route JSON profile download and hardware hash tenant onboarding through one shared tenant operation dialog service.
 - [x] Remove the obsolete JSON-specific tenant download dialog wrapper API.
 - [x] Make tenant operation cancellation return control to the Autopilot page so the connect action can be retried.
+- [x] Reuse the current-session hardware hash Microsoft Graph credential for certificate creation and removal instead of reopening interactive sign-in.
+- [x] Clear the current-session hardware hash Microsoft Graph credential when the operator disconnects the tenant.
 - [x] Keep tenant-dependent OSD UI session-gated: persisted tenant metadata stays stored, but app registration, certificate, group tag, and tenant detail rows stay hidden until a successful current-session tenant connection.
 - [x] Show connected tenant details in a dedicated row instead of embedding the tenant ID in the connection row.
 - [x] Display tenant details as a table with tenant ID and client ID.
@@ -120,6 +122,8 @@ Implementation progress:
 - [x] Keep boot media PFX path, password, and validation result session-only and excluded from ProgramData serialization.
 - [x] Preserve the boot media certificate ready message across Autopilot page navigation when the current-session PFX is still validated.
 - [x] Preserve current-session tenant connection, certificate table, onboarding status, and boot media PFX state across page navigation without persisting them across app restart.
+- [x] Show onboarding status as compact `Ready` or `Not ready` text with WinUI signal color.
+- [x] Remove obsolete verbose onboarding status resource strings after moving detailed remediation to dialogs and readiness blockers.
 - [x] Add detailed Autopilot validation codes and Start page messages for hardware hash media generation blockers.
 - [x] Discover available group tags from the unfiltered `deviceManagement/windowsAutopilotDeviceIdentities` Graph endpoint and extract `groupTag` client-side.
 - [x] Select the optional default group tag from a ComboBox populated by `None` and discovered tenant group tags.
@@ -159,9 +163,11 @@ Manual checks:
 - [ ] Click `Connect tenant`, cancel the tenant sign-in dialog, and confirm the Autopilot page remains responsive and `Connect tenant` can be clicked again.
 - [ ] Click JSON profile `Download from tenant`, cancel the tenant sign-in dialog, and confirm the JSON profile actions remain responsive.
 - [ ] Connect to the tenant and confirm app registration, tenant details, onboarding status, certificate table, default group tag, and available group tags become visible.
+- [ ] After connecting once, create and remove certificates and confirm the browser sign-in prompt does not reopen during the same app session.
 - [ ] Confirm `Tenant connection` shows only `Connected` or `Not connected`, and the tenant ID appears only in the dedicated tenant details row.
 - [ ] Confirm tenant details show tenant ID and client ID in a table after connecting.
 - [ ] Confirm each Autopilot settings card has a concise description.
+- [ ] Confirm `Onboarding status` displays only `Ready` in success color or `Not ready` in critical color.
 - [ ] After connecting, confirm the action changes to `Disconnect tenant` and disconnecting hides tenant-dependent rows without deleting persisted configuration.
 - [ ] Connect to a tenant where the persisted active certificate no longer exists in Graph and confirm Foundry clears stale active certificate metadata instead of showing a valid expiration.
 - [ ] Connect to an app registration with no certificate credentials and confirm no empty-certificate warning text is displayed.

--- a/src/Foundry.Core.Tests/Autopilot/AutopilotMediaSecretProtectorTests.cs
+++ b/src/Foundry.Core.Tests/Autopilot/AutopilotMediaSecretProtectorTests.cs
@@ -1,0 +1,60 @@
+using System.Security.Cryptography;
+using System.Text;
+using Foundry.Core.Services.Autopilot;
+
+namespace Foundry.Core.Tests.Autopilot;
+
+public sealed class AutopilotMediaSecretProtectorTests
+{
+    [Fact]
+    public void EncryptBytes_DecryptBytes_RoundTripsBinaryPayload()
+    {
+        byte[] key = MediaSecretEnvelopeProtector.GenerateMediaKey();
+        byte[] payload = [0, 1, 2, 3, 255, 254, 128];
+
+        var envelope = MediaSecretEnvelopeProtector.EncryptBytes(payload, key);
+        byte[] decrypted = MediaSecretEnvelopeProtector.DecryptBytes(envelope, key);
+
+        Assert.Equal(payload, decrypted);
+        Assert.NotEqual(Convert.ToBase64String(payload), envelope.Ciphertext);
+    }
+
+    [Fact]
+    public void DecryptBytes_WhenEnvelopeIsTampered_ThrowsWithoutLeakingSecretMaterial()
+    {
+        byte[] key = MediaSecretEnvelopeProtector.GenerateMediaKey();
+        const string secret = "PfxPassword-DoNotLeak";
+        var envelope = MediaSecretEnvelopeProtector.EncryptString(secret, key) with
+        {
+            Ciphertext = "AAAA"
+        };
+
+        var exception = Assert.Throws<CryptographicException>(() => MediaSecretEnvelopeProtector.DecryptString(envelope, key));
+
+        Assert.DoesNotContain(secret, exception.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(Convert.ToBase64String(Encoding.UTF8.GetBytes(secret)), exception.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HasEncryptedSecrets_DetectsNestedEncryptedEnvelope()
+    {
+        byte[] key = MediaSecretEnvelopeProtector.GenerateMediaKey();
+        var envelope = MediaSecretEnvelopeProtector.EncryptString("secret", key);
+        string json = $$"""
+            {
+              "autopilot": {
+                "certificatePasswordSecret": {
+                  "kind": "{{envelope.Kind}}",
+                  "algorithm": "{{envelope.Algorithm}}",
+                  "keyId": "{{envelope.KeyId}}",
+                  "nonce": "{{envelope.Nonce}}",
+                  "tag": "{{envelope.Tag}}",
+                  "ciphertext": "{{envelope.Ciphertext}}"
+                }
+              }
+            }
+            """;
+
+        Assert.True(MediaSecretEnvelopeProtector.HasEncryptedSecrets(json));
+    }
+}

--- a/src/Foundry.Core.Tests/Autopilot/AutopilotPfxCertificateValidatorTests.cs
+++ b/src/Foundry.Core.Tests/Autopilot/AutopilotPfxCertificateValidatorTests.cs
@@ -23,6 +23,21 @@ public sealed class AutopilotPfxCertificateValidatorTests
     }
 
     [Fact]
+    public void Validate_WhenExpectedThumbprintIsNotProvided_ReturnsCertificateMetadata()
+    {
+        using X509Certificate2 certificate = CreateCertificate();
+        byte[] pfxBytes = certificate.Export(X509ContentType.Pfx, "correct-password");
+
+        AutopilotPfxValidationResult result = AutopilotPfxCertificateValidator.Validate(
+            pfxBytes,
+            "correct-password");
+
+        Assert.True(result.IsValid);
+        Assert.Equal(certificate.Thumbprint, result.Thumbprint);
+        Assert.Equal(certificate.NotAfter.ToUniversalTime(), result.ExpiresOnUtc?.UtcDateTime);
+    }
+
+    [Fact]
     public void Validate_WhenPasswordIsEmpty_ReturnsPasswordRequired()
     {
         using X509Certificate2 certificate = CreateCertificate();

--- a/src/Foundry.Core.Tests/Autopilot/AutopilotPfxCertificateValidatorTests.cs
+++ b/src/Foundry.Core.Tests/Autopilot/AutopilotPfxCertificateValidatorTests.cs
@@ -1,0 +1,66 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Foundry.Core.Services.Autopilot;
+
+namespace Foundry.Core.Tests.Autopilot;
+
+public sealed class AutopilotPfxCertificateValidatorTests
+{
+    [Fact]
+    public void Validate_WhenPfxThumbprintMatches_ReturnsCertificateMetadata()
+    {
+        using X509Certificate2 certificate = CreateCertificate();
+        byte[] pfxBytes = certificate.Export(X509ContentType.Pfx, "correct-password");
+
+        AutopilotPfxValidationResult result = AutopilotPfxCertificateValidator.Validate(
+            pfxBytes,
+            "correct-password",
+            certificate.Thumbprint);
+
+        Assert.True(result.IsValid);
+        Assert.Equal(certificate.Thumbprint, result.Thumbprint);
+        Assert.Equal(certificate.NotAfter.ToUniversalTime(), result.ExpiresOnUtc?.UtcDateTime);
+    }
+
+    [Fact]
+    public void Validate_WhenPasswordIsEmpty_ReturnsPasswordRequired()
+    {
+        using X509Certificate2 certificate = CreateCertificate();
+        byte[] pfxBytes = certificate.Export(X509ContentType.Pfx, string.Empty);
+
+        AutopilotPfxValidationResult result = AutopilotPfxCertificateValidator.Validate(
+            pfxBytes,
+            string.Empty,
+            certificate.Thumbprint);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(AutopilotPfxValidationCode.PasswordRequired, result.Code);
+    }
+
+    [Fact]
+    public void Validate_WhenThumbprintDoesNotMatch_ReturnsThumbprintMismatch()
+    {
+        using X509Certificate2 certificate = CreateCertificate();
+        byte[] pfxBytes = certificate.Export(X509ContentType.Pfx, "correct-password");
+
+        AutopilotPfxValidationResult result = AutopilotPfxCertificateValidator.Validate(
+            pfxBytes,
+            "correct-password",
+            "ABCDEF123456");
+
+        Assert.False(result.IsValid);
+        Assert.Equal(AutopilotPfxValidationCode.ThumbprintMismatch, result.Code);
+    }
+
+    private static X509Certificate2 CreateCertificate()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "CN=Foundry OSD Autopilot Registration",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddMonths(12));
+    }
+}

--- a/src/Foundry.Core.Tests/Autopilot/AutopilotTenantOnboardingEvaluatorTests.cs
+++ b/src/Foundry.Core.Tests/Autopilot/AutopilotTenantOnboardingEvaluatorTests.cs
@@ -85,7 +85,7 @@ public sealed class AutopilotTenantOnboardingEvaluatorTests
     }
 
     [Fact]
-    public void Evaluate_WhenMultipleFoundryCredentialsExistWithoutPersistedActiveCertificate_ReturnsSelectionRequired()
+    public void Evaluate_WhenFoundryCredentialsExistWithoutPersistedActiveCertificate_ReturnsReady()
     {
         AutopilotTenantOnboardingEvaluation result = AutopilotTenantOnboardingEvaluator.Evaluate(CreateSnapshot(
             activeCertificate: null,
@@ -96,7 +96,7 @@ public sealed class AutopilotTenantOnboardingEvaluatorTests
                 CreateKeyCredential("key-2", "BBB", Now.AddMonths(12))
             ]));
 
-        Assert.Equal(AutopilotTenantOnboardingStatus.MultipleFoundryCertificatesNeedSelection, result.Status);
+        Assert.Equal(AutopilotTenantOnboardingStatus.Ready, result.Status);
     }
 
     [Fact]

--- a/src/Foundry.Core.Tests/Autopilot/AutopilotTenantOnboardingEvaluatorTests.cs
+++ b/src/Foundry.Core.Tests/Autopilot/AutopilotTenantOnboardingEvaluatorTests.cs
@@ -124,19 +124,6 @@ public sealed class AutopilotTenantOnboardingEvaluatorTests
         Assert.Equal("other-key-id", result[0].KeyId);
     }
 
-    [Fact]
-    public void ReplaceActiveCertificate_RemovesPreviousActiveCertificateAndPreservesOtherCredentials()
-    {
-        AutopilotGraphKeyCredential previousActive = CreateKeyCredential("active-key-id", "AAA", Now.AddMonths(12));
-        AutopilotGraphKeyCredential other = CreateKeyCredential("other-key-id", "BBB", Now.AddMonths(24));
-        AutopilotGraphKeyCredential replacement = CreateKeyCredential("replacement-key-id", "CCC", Now.AddMonths(24));
-
-        IReadOnlyList<AutopilotGraphKeyCredential> result =
-            AutopilotAppRegistrationCertificateCollection.ReplaceActiveCertificate([previousActive, other], replacement, "active-key-id");
-
-        Assert.Equal(["other-key-id", "replacement-key-id"], result.Select(credential => credential.KeyId));
-    }
-
     private static AutopilotTenantOnboardingSnapshot CreateSnapshot(
         string? persistedApplicationObjectId = "persisted-object-id",
         IReadOnlyList<AutopilotGraphApplication>? applications = null,

--- a/src/Foundry.Core.Tests/Autopilot/AutopilotTenantOnboardingEvaluatorTests.cs
+++ b/src/Foundry.Core.Tests/Autopilot/AutopilotTenantOnboardingEvaluatorTests.cs
@@ -73,13 +73,23 @@ public sealed class AutopilotTenantOnboardingEvaluatorTests
     }
 
     [Fact]
-    public void Evaluate_WhenActiveCertificateIsMissingFromGraph_ReturnsActiveCertificateNotFound()
+    public void Evaluate_WhenActiveCertificateIsMissingFromGraphAndAnotherValidCredentialExists_ReturnsReady()
     {
         AutopilotTenantOnboardingEvaluation result = AutopilotTenantOnboardingEvaluator.Evaluate(CreateSnapshot(
             keyCredentials:
             [
                 CreateKeyCredential("other-key-id", "OTHER", Now.AddMonths(12))
             ]));
+
+        Assert.Equal(AutopilotTenantOnboardingStatus.Ready, result.Status);
+        Assert.Equal("other-key-id", result.ActiveCertificateCredential?.KeyId);
+    }
+
+    [Fact]
+    public void Evaluate_WhenActiveCertificateIsMissingFromGraphAndNoValidCredentialExists_ReturnsActiveCertificateNotFound()
+    {
+        AutopilotTenantOnboardingEvaluation result = AutopilotTenantOnboardingEvaluator.Evaluate(CreateSnapshot(
+            keyCredentials: []));
 
         Assert.Equal(AutopilotTenantOnboardingStatus.ActiveCertificateNotFound, result.Status);
     }
@@ -97,6 +107,21 @@ public sealed class AutopilotTenantOnboardingEvaluatorTests
             ]));
 
         Assert.Equal(AutopilotTenantOnboardingStatus.Ready, result.Status);
+        Assert.Equal("key-1", result.ActiveCertificateCredential?.KeyId);
+    }
+
+    [Fact]
+    public void Evaluate_WhenPersistedActiveCertificateIsExpiredButAnotherValidCredentialExists_ReturnsReady()
+    {
+        AutopilotTenantOnboardingEvaluation result = AutopilotTenantOnboardingEvaluator.Evaluate(CreateSnapshot(
+            keyCredentials:
+            [
+                CreateKeyCredential("active-key-id", "ABCDEF123456", Now.AddDays(-1)),
+                CreateKeyCredential("other-key-id", "OTHER", Now.AddMonths(12))
+            ]));
+
+        Assert.Equal(AutopilotTenantOnboardingStatus.Ready, result.Status);
+        Assert.Equal("other-key-id", result.ActiveCertificateCredential?.KeyId);
     }
 
     [Fact]

--- a/src/Foundry.Core.Tests/Autopilot/AutopilotTenantOnboardingEvaluatorTests.cs
+++ b/src/Foundry.Core.Tests/Autopilot/AutopilotTenantOnboardingEvaluatorTests.cs
@@ -1,0 +1,202 @@
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Autopilot;
+
+namespace Foundry.Core.Tests.Autopilot;
+
+public sealed class AutopilotTenantOnboardingEvaluatorTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 20, 0, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Evaluate_UsesPersistedApplicationObjectIdBeforeDisplayName()
+    {
+        AutopilotTenantOnboardingEvaluation result = AutopilotTenantOnboardingEvaluator.Evaluate(CreateSnapshot(
+            applications:
+            [
+                CreateApplication("persisted-object-id", "client-id", "Different display name"),
+                CreateApplication("same-name-object-id", "other-client-id", AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName)
+            ]));
+
+        Assert.Equal(AutopilotTenantOnboardingStatus.Ready, result.Status);
+        Assert.Equal("persisted-object-id", result.ApplicationObjectId);
+        Assert.Equal("client-id", result.ClientId);
+    }
+
+    [Fact]
+    public void Evaluate_WhenSameDisplayNameExistsWithoutPersistedObjectId_ReturnsAdoptionRequired()
+    {
+        AutopilotTenantOnboardingEvaluation result = AutopilotTenantOnboardingEvaluator.Evaluate(CreateSnapshot(
+            persistedApplicationObjectId: null,
+            applications:
+            [
+                CreateApplication("existing-object-id", "client-id", AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName)
+            ]));
+
+        Assert.Equal(AutopilotTenantOnboardingStatus.AdoptionRequired, result.Status);
+    }
+
+    [Fact]
+    public void Evaluate_WhenRequiredPermissionMissing_ReturnsPermissionMissing()
+    {
+        AutopilotTenantOnboardingEvaluation result = AutopilotTenantOnboardingEvaluator.Evaluate(CreateSnapshot(
+            applications:
+            [
+                CreateApplication(
+                    "persisted-object-id",
+                    "client-id",
+                    AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName,
+                    new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DeviceManagementServiceConfig.Read.All" })
+            ]));
+
+        Assert.Equal(AutopilotTenantOnboardingStatus.PermissionMissing, result.Status);
+    }
+
+    [Fact]
+    public void Evaluate_WhenAdminConsentMissing_ReturnsConsentMissing()
+    {
+        AutopilotTenantOnboardingEvaluation result = AutopilotTenantOnboardingEvaluator.Evaluate(CreateSnapshot(
+            servicePrincipal: CreateServicePrincipal(consentedPermissionValues: new HashSet<string>(StringComparer.OrdinalIgnoreCase))));
+
+        Assert.Equal(AutopilotTenantOnboardingStatus.ConsentMissing, result.Status);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Evaluate_WhenServicePrincipalIsMissingOrDisabled_ReturnsServicePrincipalUnavailable(bool servicePrincipalExists)
+    {
+        AutopilotTenantOnboardingEvaluation result = AutopilotTenantOnboardingEvaluator.Evaluate(CreateSnapshot(
+            servicePrincipal: servicePrincipalExists ? CreateServicePrincipal(isEnabled: false) : null,
+            useDefaultServicePrincipal: servicePrincipalExists));
+
+        Assert.Equal(AutopilotTenantOnboardingStatus.ServicePrincipalUnavailable, result.Status);
+    }
+
+    [Fact]
+    public void Evaluate_WhenActiveCertificateIsMissingFromGraph_ReturnsActiveCertificateNotFound()
+    {
+        AutopilotTenantOnboardingEvaluation result = AutopilotTenantOnboardingEvaluator.Evaluate(CreateSnapshot(
+            keyCredentials:
+            [
+                CreateKeyCredential("other-key-id", "OTHER", Now.AddMonths(12))
+            ]));
+
+        Assert.Equal(AutopilotTenantOnboardingStatus.ActiveCertificateNotFound, result.Status);
+    }
+
+    [Fact]
+    public void Evaluate_WhenMultipleFoundryCredentialsExistWithoutPersistedActiveCertificate_ReturnsSelectionRequired()
+    {
+        AutopilotTenantOnboardingEvaluation result = AutopilotTenantOnboardingEvaluator.Evaluate(CreateSnapshot(
+            activeCertificate: null,
+            useDefaultActiveCertificate: false,
+            keyCredentials:
+            [
+                CreateKeyCredential("key-1", "AAA", Now.AddMonths(12)),
+                CreateKeyCredential("key-2", "BBB", Now.AddMonths(12))
+            ]));
+
+        Assert.Equal(AutopilotTenantOnboardingStatus.MultipleFoundryCertificatesNeedSelection, result.Status);
+    }
+
+    [Fact]
+    public void AddCertificateCredential_PreservesExistingCredentials()
+    {
+        AutopilotGraphKeyCredential existing = CreateKeyCredential("existing-key-id", "AAA", Now.AddMonths(12));
+        AutopilotGraphKeyCredential added = CreateKeyCredential("new-key-id", "BBB", Now.AddMonths(24));
+
+        IReadOnlyList<AutopilotGraphKeyCredential> result =
+            AutopilotAppRegistrationCertificateCollection.AddCertificate([existing], added);
+
+        Assert.Equal(["existing-key-id", "new-key-id"], result.Select(credential => credential.KeyId));
+    }
+
+    [Fact]
+    public void RetireActiveCertificate_RemovesOnlyPersistedActiveKeyId()
+    {
+        AutopilotGraphKeyCredential active = CreateKeyCredential("active-key-id", "AAA", Now.AddMonths(12));
+        AutopilotGraphKeyCredential other = CreateKeyCredential("other-key-id", "BBB", Now.AddMonths(24));
+
+        IReadOnlyList<AutopilotGraphKeyCredential> result =
+            AutopilotAppRegistrationCertificateCollection.RetireActiveCertificate([active, other], "active-key-id");
+
+        Assert.Single(result);
+        Assert.Equal("other-key-id", result[0].KeyId);
+    }
+
+    [Fact]
+    public void ReplaceActiveCertificate_RemovesPreviousActiveCertificateAndPreservesOtherCredentials()
+    {
+        AutopilotGraphKeyCredential previousActive = CreateKeyCredential("active-key-id", "AAA", Now.AddMonths(12));
+        AutopilotGraphKeyCredential other = CreateKeyCredential("other-key-id", "BBB", Now.AddMonths(24));
+        AutopilotGraphKeyCredential replacement = CreateKeyCredential("replacement-key-id", "CCC", Now.AddMonths(24));
+
+        IReadOnlyList<AutopilotGraphKeyCredential> result =
+            AutopilotAppRegistrationCertificateCollection.ReplaceActiveCertificate([previousActive, other], replacement, "active-key-id");
+
+        Assert.Equal(["other-key-id", "replacement-key-id"], result.Select(credential => credential.KeyId));
+    }
+
+    private static AutopilotTenantOnboardingSnapshot CreateSnapshot(
+        string? persistedApplicationObjectId = "persisted-object-id",
+        IReadOnlyList<AutopilotGraphApplication>? applications = null,
+        AutopilotGraphServicePrincipal? servicePrincipal = null,
+        AutopilotCertificateMetadata? activeCertificate = null,
+        IReadOnlyList<AutopilotGraphKeyCredential>? keyCredentials = null,
+        bool useDefaultServicePrincipal = true,
+        bool useDefaultActiveCertificate = true)
+    {
+        return new AutopilotTenantOnboardingSnapshot
+        {
+            TenantId = "tenant-id",
+            PersistedApplicationObjectId = persistedApplicationObjectId,
+            ManagedAppDisplayName = AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName,
+            Applications = applications ?? [CreateApplication("persisted-object-id", "client-id", AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName)],
+            ServicePrincipal = servicePrincipal ?? (useDefaultServicePrincipal ? CreateServicePrincipal() : null),
+            ActiveCertificate = activeCertificate ?? (useDefaultActiveCertificate ? new AutopilotCertificateMetadata
+            {
+                KeyId = "active-key-id",
+                Thumbprint = "ABCDEF123456",
+                ExpiresOnUtc = Now.AddMonths(12)
+            } : null),
+            KeyCredentials = keyCredentials ?? [CreateKeyCredential("active-key-id", "ABCDEF123456", Now.AddMonths(12))],
+            CurrentTimeUtc = Now
+        };
+    }
+
+    private static AutopilotGraphApplication CreateApplication(
+        string objectId,
+        string clientId,
+        string displayName,
+        IReadOnlySet<string>? requiredPermissionValues = null)
+    {
+        return new AutopilotGraphApplication(
+            objectId,
+            clientId,
+            displayName,
+            requiredPermissionValues ?? AutopilotGraphPermissionCatalog.RequiredWinPeApplicationPermissionValues);
+    }
+
+    private static AutopilotGraphServicePrincipal CreateServicePrincipal(
+        bool isEnabled = true,
+        IReadOnlySet<string>? consentedPermissionValues = null)
+    {
+        return new AutopilotGraphServicePrincipal(
+            "service-principal-object-id",
+            isEnabled,
+            consentedPermissionValues ?? AutopilotGraphPermissionCatalog.RequiredWinPeApplicationPermissionValues);
+    }
+
+    private static AutopilotGraphKeyCredential CreateKeyCredential(
+        string keyId,
+        string thumbprint,
+        DateTimeOffset expiresOnUtc)
+    {
+        return new AutopilotGraphKeyCredential(
+            keyId,
+            AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName,
+            thumbprint,
+            Now.AddDays(-1),
+            expiresOnUtc);
+    }
+}

--- a/src/Foundry.Core.Tests/Configuration/AutopilotConfigurationValidatorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/AutopilotConfigurationValidatorTests.cs
@@ -104,6 +104,82 @@ public sealed class AutopilotConfigurationValidatorTests
     }
 
     [Fact]
+    public void Evaluate_WhenHardwareHashCertificateIsExpired_ReturnsCertificateExpired()
+    {
+        var settings = new AutopilotSettings
+        {
+            IsEnabled = true,
+            ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+            HardwareHashUpload = CreateCompleteHardwareHashSettings(EvaluationTimeUtc.AddTicks(-1))
+        };
+
+        AutopilotConfigurationValidationResult result = AutopilotConfigurationValidator.Evaluate(settings, EvaluationTimeUtc);
+
+        Assert.False(result.IsReady);
+        Assert.Equal(AutopilotConfigurationValidationCode.HardwareHashActiveCertificateExpired, result.Code);
+    }
+
+    [Fact]
+    public void IsReady_WhenHardwareHashBootMediaCertificateIsMissing_ReturnsFalse()
+    {
+        var settings = new AutopilotSettings
+        {
+            IsEnabled = true,
+            ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+            HardwareHashUpload = CreateCompleteHardwareHashSettings(EvaluationTimeUtc.AddMonths(6)) with
+            {
+                BootMediaCertificate = new AutopilotBootMediaCertificateSettings()
+            }
+        };
+
+        Assert.False(AutopilotConfigurationValidator.IsReady(settings, EvaluationTimeUtc));
+    }
+
+    [Fact]
+    public void Evaluate_WhenHardwareHashBootMediaCertificateIsMissing_ReturnsPfxMissing()
+    {
+        var settings = new AutopilotSettings
+        {
+            IsEnabled = true,
+            ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+            HardwareHashUpload = CreateCompleteHardwareHashSettings(EvaluationTimeUtc.AddMonths(6)) with
+            {
+                BootMediaCertificate = new AutopilotBootMediaCertificateSettings()
+            }
+        };
+
+        AutopilotConfigurationValidationResult result = AutopilotConfigurationValidator.Evaluate(settings, EvaluationTimeUtc);
+
+        Assert.False(result.IsReady);
+        Assert.Equal(AutopilotConfigurationValidationCode.HardwareHashBootMediaPfxMissing, result.Code);
+    }
+
+    [Fact]
+    public void Evaluate_WhenHardwareHashBootMediaThumbprintDoesNotMatch_ReturnsThumbprintMismatch()
+    {
+        var settings = new AutopilotSettings
+        {
+            IsEnabled = true,
+            ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+            HardwareHashUpload = CreateCompleteHardwareHashSettings(EvaluationTimeUtc.AddMonths(6)) with
+            {
+                BootMediaCertificate = new AutopilotBootMediaCertificateSettings
+                {
+                    PfxPath = @"E:\Secrets\foundry-osd-autopilot-registration.pfx",
+                    PfxPassword = "correct-password",
+                    ValidatedThumbprint = "9876543210",
+                    ValidatedExpiresOnUtc = EvaluationTimeUtc.AddMonths(6)
+                }
+            }
+        };
+
+        AutopilotConfigurationValidationResult result = AutopilotConfigurationValidator.Evaluate(settings, EvaluationTimeUtc);
+
+        Assert.False(result.IsReady);
+        Assert.Equal(AutopilotConfigurationValidationCode.HardwareHashBootMediaCertificateThumbprintMismatch, result.Code);
+    }
+
+    [Fact]
     public void IsReady_WhenProvisioningModeIsUnsupported_ReturnsFalse()
     {
         var settings = new AutopilotSettings
@@ -195,6 +271,13 @@ public sealed class AutopilotConfigurationValidatorTests
                 Thumbprint = thumbprint,
                 DisplayName = "Foundry OSD Autopilot Registration",
                 ExpiresOnUtc = expiration
+            },
+            BootMediaCertificate = new AutopilotBootMediaCertificateSettings
+            {
+                PfxPath = @"E:\Secrets\foundry-osd-autopilot-registration.pfx",
+                PfxPassword = "correct-password",
+                ValidatedThumbprint = thumbprint,
+                ValidatedExpiresOnUtc = expiration
             }
         };
     }

--- a/src/Foundry.Core.Tests/Configuration/AutopilotConfigurationValidatorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/AutopilotConfigurationValidatorTests.cs
@@ -59,15 +59,17 @@ public sealed class AutopilotConfigurationValidatorTests
     }
 
     [Theory]
-    [InlineData("", "application-object-id", "client-id", "certificate-key-id", "ABCDEF123456")]
-    [InlineData("tenant-id", "", "client-id", "certificate-key-id", "ABCDEF123456")]
-    [InlineData("tenant-id", "application-object-id", "", "certificate-key-id", "ABCDEF123456")]
-    [InlineData("tenant-id", "application-object-id", "client-id", "", "ABCDEF123456")]
-    [InlineData("tenant-id", "application-object-id", "client-id", "certificate-key-id", "")]
+    [InlineData("", "application-object-id", "client-id", "service-principal-object-id", "certificate-key-id", "ABCDEF123456")]
+    [InlineData("tenant-id", "", "client-id", "service-principal-object-id", "certificate-key-id", "ABCDEF123456")]
+    [InlineData("tenant-id", "application-object-id", "", "service-principal-object-id", "certificate-key-id", "ABCDEF123456")]
+    [InlineData("tenant-id", "application-object-id", "client-id", "", "certificate-key-id", "ABCDEF123456")]
+    [InlineData("tenant-id", "application-object-id", "client-id", "service-principal-object-id", "", "ABCDEF123456")]
+    [InlineData("tenant-id", "application-object-id", "client-id", "service-principal-object-id", "certificate-key-id", "")]
     public void IsReady_WhenHardwareHashModeHasMissingRequiredMetadata_ReturnsFalse(
         string tenantId,
         string applicationObjectId,
         string clientId,
+        string servicePrincipalObjectId,
         string keyId,
         string thumbprint)
     {
@@ -80,6 +82,7 @@ public sealed class AutopilotConfigurationValidatorTests
                 tenantId,
                 applicationObjectId,
                 clientId,
+                servicePrincipalObjectId,
                 keyId,
                 thumbprint)
         };
@@ -173,6 +176,7 @@ public sealed class AutopilotConfigurationValidatorTests
         string tenantId = "tenant-id",
         string applicationObjectId = "application-object-id",
         string clientId = "client-id",
+        string servicePrincipalObjectId = "service-principal-object-id",
         string keyId = "certificate-key-id",
         string thumbprint = "ABCDEF123456")
     {
@@ -183,7 +187,7 @@ public sealed class AutopilotConfigurationValidatorTests
                 TenantId = tenantId,
                 ApplicationObjectId = applicationObjectId,
                 ClientId = clientId,
-                ServicePrincipalObjectId = "service-principal-object-id"
+                ServicePrincipalObjectId = servicePrincipalObjectId
             },
             ActiveCertificate = new AutopilotCertificateMetadata
             {

--- a/src/Foundry.Core.Tests/Configuration/AutopilotConfigurationValidatorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/AutopilotConfigurationValidatorTests.cs
@@ -110,13 +110,47 @@ public sealed class AutopilotConfigurationValidatorTests
         {
             IsEnabled = true,
             ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
-            HardwareHashUpload = CreateCompleteHardwareHashSettings(EvaluationTimeUtc.AddTicks(-1))
+            HardwareHashUpload = CreateCompleteHardwareHashSettings(EvaluationTimeUtc.AddTicks(-1)) with
+            {
+                BootMediaCertificate = new AutopilotBootMediaCertificateSettings
+                {
+                    PfxPath = @"E:\Secrets\foundry-osd-autopilot-registration.pfx",
+                    PfxPassword = "correct-password",
+                    ValidatedThumbprint = "ABCDEF123456",
+                    ValidatedExpiresOnUtc = EvaluationTimeUtc.AddMonths(6)
+                }
+            }
         };
 
         AutopilotConfigurationValidationResult result = AutopilotConfigurationValidator.Evaluate(settings, EvaluationTimeUtc);
 
         Assert.False(result.IsReady);
         Assert.Equal(AutopilotConfigurationValidationCode.HardwareHashActiveCertificateExpired, result.Code);
+    }
+
+    [Fact]
+    public void Evaluate_WhenHardwareHashBootMediaCertificateIsExpired_ReturnsBootMediaCertificateExpired()
+    {
+        var settings = new AutopilotSettings
+        {
+            IsEnabled = true,
+            ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+            HardwareHashUpload = CreateCompleteHardwareHashSettings(EvaluationTimeUtc.AddMonths(6)) with
+            {
+                BootMediaCertificate = new AutopilotBootMediaCertificateSettings
+                {
+                    PfxPath = @"E:\Secrets\foundry-osd-autopilot-registration.pfx",
+                    PfxPassword = "correct-password",
+                    ValidatedThumbprint = "ABCDEF123456",
+                    ValidatedExpiresOnUtc = EvaluationTimeUtc.AddTicks(-1)
+                }
+            }
+        };
+
+        AutopilotConfigurationValidationResult result = AutopilotConfigurationValidator.Evaluate(settings, EvaluationTimeUtc);
+
+        Assert.False(result.IsReady);
+        Assert.Equal(AutopilotConfigurationValidationCode.HardwareHashBootMediaCertificateExpired, result.Code);
     }
 
     [Fact]
@@ -144,6 +178,26 @@ public sealed class AutopilotConfigurationValidatorTests
             ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
             HardwareHashUpload = CreateCompleteHardwareHashSettings(EvaluationTimeUtc.AddMonths(6)) with
             {
+                BootMediaCertificate = new AutopilotBootMediaCertificateSettings()
+            }
+        };
+
+        AutopilotConfigurationValidationResult result = AutopilotConfigurationValidator.Evaluate(settings, EvaluationTimeUtc);
+
+        Assert.False(result.IsReady);
+        Assert.Equal(AutopilotConfigurationValidationCode.HardwareHashBootMediaPfxMissing, result.Code);
+    }
+
+    [Fact]
+    public void Evaluate_WhenHardwareHashHasNoActiveCertificateOrPfx_ReturnsPfxMissing()
+    {
+        var settings = new AutopilotSettings
+        {
+            IsEnabled = true,
+            ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+            HardwareHashUpload = CreateCompleteHardwareHashSettings(EvaluationTimeUtc.AddMonths(6)) with
+            {
+                ActiveCertificate = null,
                 BootMediaCertificate = new AutopilotBootMediaCertificateSettings()
             }
         };

--- a/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
@@ -464,6 +464,13 @@ public sealed class DeployConfigurationGeneratorTests
                 DisplayName = "Foundry OSD Autopilot Registration",
                 ExpiresOnUtc = expiration
             },
+            BootMediaCertificate = new AutopilotBootMediaCertificateSettings
+            {
+                PfxPath = @"E:\Secrets\foundry-osd-autopilot-registration.pfx",
+                PfxPassword = "correct-password",
+                ValidatedThumbprint = "ABCDEF123456",
+                ValidatedExpiresOnUtc = expiration
+            },
             KnownGroupTags = ["Sales", "Engineering"],
             DefaultGroupTag = "Sales"
         };

--- a/src/Foundry.Core.Tests/Configuration/FoundryConfigurationServiceTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/FoundryConfigurationServiceTests.cs
@@ -160,6 +160,13 @@ public sealed class FoundryConfigurationServiceTests
                         Thumbprint = "ABCDEF123456",
                         DisplayName = "Foundry OSD Autopilot Registration",
                         ExpiresOnUtc = DateTimeOffset.UtcNow.AddMonths(6)
+                    },
+                    BootMediaCertificate = new AutopilotBootMediaCertificateSettings
+                    {
+                        PfxPath = @"E:\Secrets\foundry-osd-autopilot-registration.pfx",
+                        PfxPassword = "PfxPassword-DoNotLeak",
+                        ValidatedThumbprint = "ABCDEF123456",
+                        ValidatedExpiresOnUtc = DateTimeOffset.UtcNow.AddMonths(6)
                     }
                 }
             }
@@ -172,6 +179,8 @@ public sealed class FoundryConfigurationServiceTests
         Assert.DoesNotContain("password", json, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("privateKey", json, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("accessToken", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("PfxPassword-DoNotLeak", json, StringComparison.Ordinal);
+        Assert.DoesNotContain(@"E:\Secrets", json, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
@@ -245,6 +245,33 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
     }
 
     [Fact]
+    public async Task ProvisionAsync_WhenDeployConfigurationHasEncryptedSecret_WritesSecretKeyUnderConfigSecrets()
+    {
+        using TempMountedImage image = TempMountedImage.Create();
+        string curlSourcePath = Path.Combine(image.RootPath, "curl.exe");
+        File.WriteAllText(curlSourcePath, "curl");
+        byte[] secretKey = Enumerable.Range(0, 32).Select(static value => (byte)value).ToArray();
+
+        var service = new WinPeMountedImageAssetProvisioningService();
+
+        WinPeResult result = await service.ProvisionAsync(
+            new WinPeMountedImageAssetProvisioningOptions
+            {
+                MountedImagePath = image.MountedImagePath,
+                Architecture = WinPeArchitecture.X64,
+                BootstrapScriptContent = "bootstrap",
+                CurlExecutableSourcePath = curlSourcePath,
+                IanaWindowsTimeZoneMapJson = "{}",
+                DeployConfigurationJson = CreateDeployConfigurationWithEncryptedSecret(),
+                MediaSecretsKey = secretKey
+            },
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Error?.Details);
+        Assert.Equal(secretKey, await File.ReadAllBytesAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Secrets", "media-secrets.key")));
+    }
+
+    [Fact]
     public async Task ProvisionAsync_WhenMediaSecretKeyHasNoEncryptedSecret_ReturnsFailure()
     {
         using TempMountedImage image = TempMountedImage.Create();
@@ -408,6 +435,27 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
               "http://www.msftconnecttest.com/connecttest.txt"
             ],
             "timeoutSeconds": 5
+          }
+        }
+        """;
+    }
+
+    private static string CreateDeployConfigurationWithEncryptedSecret()
+    {
+        return """
+        {
+          "schemaVersion": 1,
+          "autopilot": {
+            "hardwareHashUpload": {
+              "pfxSecret": {
+                "kind": "encrypted",
+                "algorithm": "aes-gcm-v1",
+                "keyId": "media",
+                "nonce": "AAAAAAAAAAAAAAAA",
+                "tag": "AAAAAAAAAAAAAAAAAAAAAA",
+                "ciphertext": "AAAAAAAA"
+              }
+            }
           }
         }
         """;

--- a/src/Foundry.Core/Models/Configuration/AutopilotHardwareHashUploadSettings.cs
+++ b/src/Foundry.Core/Models/Configuration/AutopilotHardwareHashUploadSettings.cs
@@ -1,5 +1,7 @@
 namespace Foundry.Core.Models.Configuration;
 
+using System.Text.Json.Serialization;
+
 /// <summary>
 /// Stores persistent metadata for WinPE Autopilot hardware hash upload without private key material.
 /// </summary>
@@ -29,4 +31,36 @@ public sealed record AutopilotHardwareHashUploadSettings
     /// Gets the default Autopilot group tag selected during media generation.
     /// </summary>
     public string? DefaultGroupTag { get; init; }
+
+    /// <summary>
+    /// Gets session-only PFX input used for the current boot media generation.
+    /// </summary>
+    [JsonIgnore]
+    public AutopilotBootMediaCertificateSettings BootMediaCertificate { get; init; } = new();
+}
+
+/// <summary>
+/// Stores session-only Autopilot certificate material selected for boot media generation.
+/// </summary>
+public sealed record AutopilotBootMediaCertificateSettings
+{
+    /// <summary>
+    /// Gets the operator-selected password-protected PFX path.
+    /// </summary>
+    public string? PfxPath { get; init; }
+
+    /// <summary>
+    /// Gets the PFX password for the current app session only.
+    /// </summary>
+    public string? PfxPassword { get; init; }
+
+    /// <summary>
+    /// Gets the validated PFX leaf certificate thumbprint.
+    /// </summary>
+    public string? ValidatedThumbprint { get; init; }
+
+    /// <summary>
+    /// Gets the validated PFX leaf certificate expiration.
+    /// </summary>
+    public DateTimeOffset? ValidatedExpiresOnUtc { get; init; }
 }

--- a/src/Foundry.Core/Services/Autopilot/AutopilotPfxCertificateValidator.cs
+++ b/src/Foundry.Core/Services/Autopilot/AutopilotPfxCertificateValidator.cs
@@ -9,16 +9,33 @@ namespace Foundry.Core.Services.Autopilot;
 public static class AutopilotPfxCertificateValidator
 {
     /// <summary>
-    /// Validates that a password-protected PFX contains private key material for the configured active certificate.
+    /// Validates that a password-protected PFX contains private key material and returns its certificate metadata.
     /// </summary>
     /// <param name="pfxBytes">PFX bytes provided by the operator.</param>
     /// <param name="password">PFX password provided by the operator.</param>
-    /// <param name="expectedThumbprint">Thumbprint of the active certificate configured on the managed app registration.</param>
     /// <returns>Validation result describing whether the PFX can be embedded into generated media.</returns>
-    public static AutopilotPfxValidationResult Validate(
+    public static AutopilotPfxValidationResult Validate(byte[] pfxBytes, string? password)
+    {
+        return Validate(pfxBytes, password, expectedThumbprint: null, requireExpectedThumbprint: false);
+    }
+
+    /// <summary>
+    /// Validates that a password-protected PFX contains private key material for the configured certificate.
+    /// </summary>
+    /// <param name="pfxBytes">PFX bytes provided by the operator.</param>
+    /// <param name="password">PFX password provided by the operator.</param>
+    /// <param name="expectedThumbprint">Thumbprint of the certificate configured on the managed app registration.</param>
+    /// <returns>Validation result describing whether the PFX can be embedded into generated media.</returns>
+    public static AutopilotPfxValidationResult Validate(byte[] pfxBytes, string? password, string? expectedThumbprint)
+    {
+        return Validate(pfxBytes, password, expectedThumbprint, requireExpectedThumbprint: true);
+    }
+
+    private static AutopilotPfxValidationResult Validate(
         byte[] pfxBytes,
         string? password,
-        string? expectedThumbprint)
+        string? expectedThumbprint,
+        bool requireExpectedThumbprint)
     {
         ArgumentNullException.ThrowIfNull(pfxBytes);
 
@@ -33,7 +50,7 @@ public static class AutopilotPfxCertificateValidator
         }
 
         string? normalizedExpectedThumbprint = NormalizeThumbprint(expectedThumbprint);
-        if (string.IsNullOrWhiteSpace(normalizedExpectedThumbprint))
+        if (requireExpectedThumbprint && string.IsNullOrWhiteSpace(normalizedExpectedThumbprint))
         {
             return AutopilotPfxValidationResult.Failure(AutopilotPfxValidationCode.ExpectedThumbprintRequired);
         }
@@ -45,7 +62,8 @@ public static class AutopilotPfxCertificateValidator
                 password,
                 X509KeyStorageFlags.EphemeralKeySet);
             string actualThumbprint = NormalizeThumbprint(certificate.Thumbprint)!;
-            if (!string.Equals(actualThumbprint, normalizedExpectedThumbprint, StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrWhiteSpace(normalizedExpectedThumbprint) &&
+                !string.Equals(actualThumbprint, normalizedExpectedThumbprint, StringComparison.OrdinalIgnoreCase))
             {
                 return AutopilotPfxValidationResult.Failure(AutopilotPfxValidationCode.ThumbprintMismatch, actualThumbprint);
             }

--- a/src/Foundry.Core/Services/Autopilot/AutopilotPfxCertificateValidator.cs
+++ b/src/Foundry.Core/Services/Autopilot/AutopilotPfxCertificateValidator.cs
@@ -1,0 +1,153 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Foundry.Core.Services.Autopilot;
+
+/// <summary>
+/// Validates operator-provided Autopilot PFX material before it is embedded into generated media.
+/// </summary>
+public static class AutopilotPfxCertificateValidator
+{
+    /// <summary>
+    /// Validates that a password-protected PFX contains private key material for the configured active certificate.
+    /// </summary>
+    /// <param name="pfxBytes">PFX bytes provided by the operator.</param>
+    /// <param name="password">PFX password provided by the operator.</param>
+    /// <param name="expectedThumbprint">Thumbprint of the active certificate configured on the managed app registration.</param>
+    /// <returns>Validation result describing whether the PFX can be embedded into generated media.</returns>
+    public static AutopilotPfxValidationResult Validate(
+        byte[] pfxBytes,
+        string? password,
+        string? expectedThumbprint)
+    {
+        ArgumentNullException.ThrowIfNull(pfxBytes);
+
+        if (pfxBytes.Length == 0)
+        {
+            return AutopilotPfxValidationResult.Failure(AutopilotPfxValidationCode.PfxRequired);
+        }
+
+        if (string.IsNullOrWhiteSpace(password))
+        {
+            return AutopilotPfxValidationResult.Failure(AutopilotPfxValidationCode.PasswordRequired);
+        }
+
+        string? normalizedExpectedThumbprint = NormalizeThumbprint(expectedThumbprint);
+        if (string.IsNullOrWhiteSpace(normalizedExpectedThumbprint))
+        {
+            return AutopilotPfxValidationResult.Failure(AutopilotPfxValidationCode.ExpectedThumbprintRequired);
+        }
+
+        try
+        {
+            using var certificate = X509CertificateLoader.LoadPkcs12(
+                pfxBytes,
+                password,
+                X509KeyStorageFlags.EphemeralKeySet);
+            string actualThumbprint = NormalizeThumbprint(certificate.Thumbprint)!;
+            if (!string.Equals(actualThumbprint, normalizedExpectedThumbprint, StringComparison.OrdinalIgnoreCase))
+            {
+                return AutopilotPfxValidationResult.Failure(AutopilotPfxValidationCode.ThumbprintMismatch, actualThumbprint);
+            }
+
+            if (!certificate.HasPrivateKey)
+            {
+                return AutopilotPfxValidationResult.Failure(AutopilotPfxValidationCode.PrivateKeyMissing, actualThumbprint);
+            }
+
+            return AutopilotPfxValidationResult.Success(actualThumbprint, certificate.NotAfter.ToUniversalTime());
+        }
+        catch (Exception ex) when (ex is CryptographicException or ArgumentException)
+        {
+            return AutopilotPfxValidationResult.Failure(AutopilotPfxValidationCode.InvalidPfx);
+        }
+    }
+
+    private static string? NormalizeThumbprint(string? thumbprint)
+    {
+        string? normalized = thumbprint?.Replace(" ", string.Empty, StringComparison.Ordinal).Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized.ToUpperInvariant();
+    }
+}
+
+public sealed record AutopilotPfxValidationResult
+{
+    /// <summary>
+    /// Gets whether the PFX is valid for media embedding.
+    /// </summary>
+    public bool IsValid { get; init; }
+
+    /// <summary>
+    /// Gets the validation outcome code.
+    /// </summary>
+    public AutopilotPfxValidationCode Code { get; init; }
+
+    /// <summary>
+    /// Gets the normalized certificate thumbprint when it could be read.
+    /// </summary>
+    public string? Thumbprint { get; init; }
+
+    /// <summary>
+    /// Gets the certificate expiration time when validation succeeds.
+    /// </summary>
+    public DateTimeOffset? ExpiresOnUtc { get; init; }
+
+    /// <summary>
+    /// Creates a successful PFX validation result.
+    /// </summary>
+    /// <param name="thumbprint">Normalized certificate thumbprint.</param>
+    /// <param name="expiresOnUtc">Certificate expiration time.</param>
+    /// <returns>Successful validation result.</returns>
+    public static AutopilotPfxValidationResult Success(string thumbprint, DateTimeOffset expiresOnUtc)
+    {
+        return new AutopilotPfxValidationResult
+        {
+            IsValid = true,
+            Code = AutopilotPfxValidationCode.Valid,
+            Thumbprint = thumbprint,
+            ExpiresOnUtc = expiresOnUtc
+        };
+    }
+
+    /// <summary>
+    /// Creates a failed PFX validation result.
+    /// </summary>
+    /// <param name="code">Failure code.</param>
+    /// <param name="thumbprint">Normalized certificate thumbprint, when available.</param>
+    /// <returns>Failed validation result.</returns>
+    public static AutopilotPfxValidationResult Failure(
+        AutopilotPfxValidationCode code,
+        string? thumbprint = null)
+    {
+        return new AutopilotPfxValidationResult
+        {
+            IsValid = false,
+            Code = code,
+            Thumbprint = thumbprint
+        };
+    }
+}
+
+public enum AutopilotPfxValidationCode
+{
+    /// <summary>The PFX is valid for media embedding.</summary>
+    Valid,
+
+    /// <summary>No PFX bytes were provided.</summary>
+    PfxRequired,
+
+    /// <summary>No PFX password was provided.</summary>
+    PasswordRequired,
+
+    /// <summary>No expected active certificate thumbprint was configured.</summary>
+    ExpectedThumbprintRequired,
+
+    /// <summary>The PFX could not be loaded.</summary>
+    InvalidPfx,
+
+    /// <summary>The PFX leaf certificate thumbprint does not match the active app certificate.</summary>
+    ThumbprintMismatch,
+
+    /// <summary>The PFX does not contain private key material.</summary>
+    PrivateKeyMissing
+}

--- a/src/Foundry.Core/Services/Autopilot/AutopilotTenantOnboardingEvaluator.cs
+++ b/src/Foundry.Core/Services/Autopilot/AutopilotTenantOnboardingEvaluator.cs
@@ -52,16 +52,21 @@ public static class AutopilotTenantOnboardingEvaluator
                 snapshot.ServicePrincipal);
         }
 
+        AutopilotGraphKeyCredential[] validManagedCredentials = snapshot.KeyCredentials
+            .Where(credential =>
+                string.Equals(credential.DisplayName, snapshot.ManagedAppDisplayName, StringComparison.OrdinalIgnoreCase) &&
+                credential.ExpiresOnUtc > snapshot.CurrentTimeUtc)
+            .OrderBy(credential => credential.ExpiresOnUtc)
+            .ToArray();
         AutopilotCertificateMetadata? activeCertificate = snapshot.ActiveCertificate;
         if (activeCertificate is null)
         {
-            int foundryCredentialCount = snapshot.KeyCredentials.Count(credential =>
-                string.Equals(credential.DisplayName, snapshot.ManagedAppDisplayName, StringComparison.OrdinalIgnoreCase));
-            return foundryCredentialCount > 0
+            return validManagedCredentials.Length > 0
                 ? AutopilotTenantOnboardingEvaluation.FromStatus(
                     AutopilotTenantOnboardingStatus.Ready,
                     application,
-                    snapshot.ServicePrincipal)
+                    snapshot.ServicePrincipal,
+                    validManagedCredentials[0])
                 : AutopilotTenantOnboardingEvaluation.FromStatus(
                     AutopilotTenantOnboardingStatus.ActiveCertificateMissing,
                     application,
@@ -73,18 +78,30 @@ public static class AutopilotTenantOnboardingEvaluator
             string.Equals(NormalizeThumbprint(credential.Thumbprint), NormalizeThumbprint(activeCertificate.Thumbprint), StringComparison.Ordinal));
         if (graphCredential is null)
         {
-            return AutopilotTenantOnboardingEvaluation.FromStatus(
-                AutopilotTenantOnboardingStatus.ActiveCertificateNotFound,
-                application,
-                snapshot.ServicePrincipal);
+            return validManagedCredentials.Length > 0
+                ? AutopilotTenantOnboardingEvaluation.FromStatus(
+                    AutopilotTenantOnboardingStatus.Ready,
+                    application,
+                    snapshot.ServicePrincipal,
+                    validManagedCredentials[0])
+                : AutopilotTenantOnboardingEvaluation.FromStatus(
+                    AutopilotTenantOnboardingStatus.ActiveCertificateNotFound,
+                    application,
+                    snapshot.ServicePrincipal);
         }
 
         if (graphCredential.ExpiresOnUtc <= snapshot.CurrentTimeUtc)
         {
-            return AutopilotTenantOnboardingEvaluation.FromStatus(
-                AutopilotTenantOnboardingStatus.ActiveCertificateExpired,
-                application,
-                snapshot.ServicePrincipal);
+            return validManagedCredentials.Length > 0
+                ? AutopilotTenantOnboardingEvaluation.FromStatus(
+                    AutopilotTenantOnboardingStatus.Ready,
+                    application,
+                    snapshot.ServicePrincipal,
+                    validManagedCredentials[0])
+                : AutopilotTenantOnboardingEvaluation.FromStatus(
+                    AutopilotTenantOnboardingStatus.ActiveCertificateExpired,
+                    application,
+                    snapshot.ServicePrincipal);
         }
 
         return AutopilotTenantOnboardingEvaluation.FromStatus(

--- a/src/Foundry.Core/Services/Autopilot/AutopilotTenantOnboardingEvaluator.cs
+++ b/src/Foundry.Core/Services/Autopilot/AutopilotTenantOnboardingEvaluator.cs
@@ -1,0 +1,336 @@
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Core.Services.Autopilot;
+
+/// <summary>
+/// Evaluates the managed tenant registration state used by Autopilot hardware hash upload.
+/// </summary>
+public static class AutopilotTenantOnboardingEvaluator
+{
+    /// <summary>
+    /// Computes the current onboarding status from Microsoft Graph state and persisted Foundry metadata.
+    /// </summary>
+    /// <param name="snapshot">Current tenant registration snapshot.</param>
+    /// <returns>Evaluated onboarding status and resolved identifiers.</returns>
+    public static AutopilotTenantOnboardingEvaluation Evaluate(AutopilotTenantOnboardingSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        AutopilotGraphApplication? application = FindApplication(snapshot);
+        if (application is null)
+        {
+            return AutopilotTenantOnboardingEvaluation.FromStatus(AutopilotTenantOnboardingStatus.AppRegistrationMissing);
+        }
+
+        if (string.IsNullOrWhiteSpace(snapshot.PersistedApplicationObjectId) &&
+            string.Equals(application.DisplayName, snapshot.ManagedAppDisplayName, StringComparison.OrdinalIgnoreCase))
+        {
+            return AutopilotTenantOnboardingEvaluation.FromStatus(
+                AutopilotTenantOnboardingStatus.AdoptionRequired,
+                application);
+        }
+
+        if (!AutopilotGraphPermissionCatalog.HasRequiredWinPeApplicationPermissions(application.RequiredPermissionValues))
+        {
+            return AutopilotTenantOnboardingEvaluation.FromStatus(
+                AutopilotTenantOnboardingStatus.PermissionMissing,
+                application);
+        }
+
+        if (snapshot.ServicePrincipal is not { IsEnabled: true })
+        {
+            return AutopilotTenantOnboardingEvaluation.FromStatus(
+                AutopilotTenantOnboardingStatus.ServicePrincipalUnavailable,
+                application);
+        }
+
+        if (!AutopilotGraphPermissionCatalog.HasRequiredWinPeApplicationPermissions(snapshot.ServicePrincipal.ConsentedPermissionValues))
+        {
+            return AutopilotTenantOnboardingEvaluation.FromStatus(
+                AutopilotTenantOnboardingStatus.ConsentMissing,
+                application,
+                snapshot.ServicePrincipal);
+        }
+
+        AutopilotCertificateMetadata? activeCertificate = snapshot.ActiveCertificate;
+        if (activeCertificate is null)
+        {
+            int foundryCredentialCount = snapshot.KeyCredentials.Count(credential =>
+                string.Equals(credential.DisplayName, snapshot.ManagedAppDisplayName, StringComparison.OrdinalIgnoreCase));
+            return foundryCredentialCount > 1
+                ? AutopilotTenantOnboardingEvaluation.FromStatus(
+                    AutopilotTenantOnboardingStatus.MultipleFoundryCertificatesNeedSelection,
+                    application,
+                    snapshot.ServicePrincipal)
+                : AutopilotTenantOnboardingEvaluation.FromStatus(
+                    AutopilotTenantOnboardingStatus.ActiveCertificateMissing,
+                    application,
+                    snapshot.ServicePrincipal);
+        }
+
+        AutopilotGraphKeyCredential? graphCredential = snapshot.KeyCredentials.FirstOrDefault(credential =>
+            string.Equals(credential.KeyId, activeCertificate.KeyId, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(NormalizeThumbprint(credential.Thumbprint), NormalizeThumbprint(activeCertificate.Thumbprint), StringComparison.Ordinal));
+        if (graphCredential is null)
+        {
+            return AutopilotTenantOnboardingEvaluation.FromStatus(
+                AutopilotTenantOnboardingStatus.ActiveCertificateNotFound,
+                application,
+                snapshot.ServicePrincipal);
+        }
+
+        if (graphCredential.ExpiresOnUtc <= snapshot.CurrentTimeUtc)
+        {
+            return AutopilotTenantOnboardingEvaluation.FromStatus(
+                AutopilotTenantOnboardingStatus.ActiveCertificateExpired,
+                application,
+                snapshot.ServicePrincipal);
+        }
+
+        return AutopilotTenantOnboardingEvaluation.FromStatus(
+            AutopilotTenantOnboardingStatus.Ready,
+            application,
+            snapshot.ServicePrincipal,
+            graphCredential);
+    }
+
+    private static AutopilotGraphApplication? FindApplication(AutopilotTenantOnboardingSnapshot snapshot)
+    {
+        if (!string.IsNullOrWhiteSpace(snapshot.PersistedApplicationObjectId))
+        {
+            AutopilotGraphApplication? persisted = snapshot.Applications.FirstOrDefault(application =>
+                string.Equals(application.ObjectId, snapshot.PersistedApplicationObjectId, StringComparison.OrdinalIgnoreCase));
+            if (persisted is not null)
+            {
+                return persisted;
+            }
+        }
+
+        return snapshot.Applications.FirstOrDefault(application =>
+            string.Equals(application.DisplayName, snapshot.ManagedAppDisplayName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string? NormalizeThumbprint(string? thumbprint)
+    {
+        string? normalized = thumbprint?.Replace(" ", string.Empty, StringComparison.Ordinal).Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized.ToUpperInvariant();
+    }
+}
+
+/// <summary>
+/// Represents the Microsoft Graph and persisted Foundry state required to evaluate tenant onboarding.
+/// </summary>
+public sealed record AutopilotTenantOnboardingSnapshot
+{
+    /// <summary>Gets the connected tenant ID.</summary>
+    public required string TenantId { get; init; }
+
+    /// <summary>Gets the persisted managed app object ID, when Foundry already owns one.</summary>
+    public string? PersistedApplicationObjectId { get; init; }
+
+    /// <summary>Gets the display name expected for the managed Foundry app registration.</summary>
+    public required string ManagedAppDisplayName { get; init; }
+
+    /// <summary>Gets candidate applications discovered in Microsoft Graph.</summary>
+    public IReadOnlyList<AutopilotGraphApplication> Applications { get; init; } = [];
+
+    /// <summary>Gets the managed app service principal, when it exists.</summary>
+    public AutopilotGraphServicePrincipal? ServicePrincipal { get; init; }
+
+    /// <summary>Gets the active certificate metadata persisted by Foundry.</summary>
+    public AutopilotCertificateMetadata? ActiveCertificate { get; init; }
+
+    /// <summary>Gets certificate credentials currently present on the app registration.</summary>
+    public IReadOnlyList<AutopilotGraphKeyCredential> KeyCredentials { get; init; } = [];
+
+    /// <summary>Gets the evaluation clock used for certificate expiration checks.</summary>
+    public DateTimeOffset CurrentTimeUtc { get; init; } = DateTimeOffset.UtcNow;
+}
+
+/// <summary>
+/// Result of evaluating the managed Autopilot app registration onboarding state.
+/// </summary>
+public sealed record AutopilotTenantOnboardingEvaluation
+{
+    /// <summary>Gets the evaluated onboarding status.</summary>
+    public AutopilotTenantOnboardingStatus Status { get; init; }
+
+    /// <summary>Gets the selected application object ID, when available.</summary>
+    public string? ApplicationObjectId { get; init; }
+
+    /// <summary>Gets the selected application client ID, when available.</summary>
+    public string? ClientId { get; init; }
+
+    /// <summary>Gets the selected service principal object ID, when available.</summary>
+    public string? ServicePrincipalObjectId { get; init; }
+
+    /// <summary>Gets the active app credential found in Microsoft Graph, when available.</summary>
+    public AutopilotGraphKeyCredential? ActiveCertificateCredential { get; init; }
+
+    /// <summary>
+    /// Creates an evaluation result for the supplied status and resolved Graph objects.
+    /// </summary>
+    public static AutopilotTenantOnboardingEvaluation FromStatus(
+        AutopilotTenantOnboardingStatus status,
+        AutopilotGraphApplication? application = null,
+        AutopilotGraphServicePrincipal? servicePrincipal = null,
+        AutopilotGraphKeyCredential? activeCertificateCredential = null)
+    {
+        return new AutopilotTenantOnboardingEvaluation
+        {
+            Status = status,
+            ApplicationObjectId = application?.ObjectId,
+            ClientId = application?.ClientId,
+            ServicePrincipalObjectId = servicePrincipal?.ObjectId,
+            ActiveCertificateCredential = activeCertificateCredential
+        };
+    }
+}
+
+/// <summary>
+/// Autopilot hardware hash tenant onboarding status.
+/// </summary>
+public enum AutopilotTenantOnboardingStatus
+{
+    /// <summary>The managed app registration is ready for hardware hash upload media generation.</summary>
+    Ready,
+
+    /// <summary>The managed app registration does not exist.</summary>
+    AppRegistrationMissing,
+
+    /// <summary>An app with the managed display name exists but is not yet adopted by persisted Foundry metadata.</summary>
+    AdoptionRequired,
+
+    /// <summary>The managed app registration is missing required Graph application permissions.</summary>
+    PermissionMissing,
+
+    /// <summary>The managed service principal is missing admin consent for required Graph permissions.</summary>
+    ConsentMissing,
+
+    /// <summary>The managed service principal is missing or disabled.</summary>
+    ServicePrincipalUnavailable,
+
+    /// <summary>No active certificate is selected in persisted Foundry metadata.</summary>
+    ActiveCertificateMissing,
+
+    /// <summary>The selected active certificate was not found in the app registration credentials.</summary>
+    ActiveCertificateNotFound,
+
+    /// <summary>The selected active certificate is expired.</summary>
+    ActiveCertificateExpired,
+
+    /// <summary>Multiple Foundry-looking certificates exist and no persisted active certificate resolves ownership.</summary>
+    MultipleFoundryCertificatesNeedSelection
+}
+
+/// <summary>
+/// Minimal Microsoft Graph application state required for Autopilot onboarding evaluation.
+/// </summary>
+public sealed record AutopilotGraphApplication(
+    string ObjectId,
+    string ClientId,
+    string DisplayName,
+    IReadOnlySet<string> RequiredPermissionValues);
+
+/// <summary>
+/// Minimal Microsoft Graph service principal state required for Autopilot onboarding evaluation.
+/// </summary>
+public sealed record AutopilotGraphServicePrincipal(
+    string ObjectId,
+    bool IsEnabled,
+    IReadOnlySet<string> ConsentedPermissionValues);
+
+/// <summary>
+/// Minimal Microsoft Graph certificate credential state required for Autopilot onboarding evaluation.
+/// </summary>
+public sealed record AutopilotGraphKeyCredential(
+    string KeyId,
+    string DisplayName,
+    string Thumbprint,
+    DateTimeOffset StartsOnUtc,
+    DateTimeOffset ExpiresOnUtc);
+
+/// <summary>
+/// Central catalog of Graph permissions required by the WinPE app-only upload path.
+/// </summary>
+public static class AutopilotGraphPermissionCatalog
+{
+    /// <summary>
+    /// Graph application permission required to import and poll Windows Autopilot device identities.
+    /// </summary>
+    public const string DeviceManagementServiceConfigReadWriteAll = "DeviceManagementServiceConfig.ReadWrite.All";
+
+    /// <summary>
+    /// Gets the required Graph application permissions for WinPE app-only upload.
+    /// </summary>
+    public static readonly IReadOnlySet<string> RequiredWinPeApplicationPermissionValues =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            DeviceManagementServiceConfigReadWriteAll
+        };
+
+    /// <summary>
+    /// Determines whether the supplied permission values include every permission required by WinPE upload.
+    /// </summary>
+    /// <param name="permissionValues">Permission values to evaluate.</param>
+    /// <returns><see langword="true"/> when all required permissions are present.</returns>
+    public static bool HasRequiredWinPeApplicationPermissions(IReadOnlySet<string> permissionValues)
+    {
+        ArgumentNullException.ThrowIfNull(permissionValues);
+        return RequiredWinPeApplicationPermissionValues.All(permissionValues.Contains);
+    }
+}
+
+/// <summary>
+/// Provides pure helpers for safe app registration certificate credential collection updates.
+/// </summary>
+public static class AutopilotAppRegistrationCertificateCollection
+{
+    /// <summary>
+    /// Adds or replaces one certificate credential without pruning unrelated credentials.
+    /// </summary>
+    public static IReadOnlyList<AutopilotGraphKeyCredential> AddCertificate(
+        IReadOnlyList<AutopilotGraphKeyCredential> currentCredentials,
+        AutopilotGraphKeyCredential credential)
+    {
+        ArgumentNullException.ThrowIfNull(currentCredentials);
+        ArgumentNullException.ThrowIfNull(credential);
+        return currentCredentials
+            .Where(existing => !string.Equals(existing.KeyId, credential.KeyId, StringComparison.OrdinalIgnoreCase))
+            .Concat([credential])
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Replaces the persisted active certificate credential while preserving unrelated credentials.
+    /// </summary>
+    public static IReadOnlyList<AutopilotGraphKeyCredential> ReplaceActiveCertificate(
+        IReadOnlyList<AutopilotGraphKeyCredential> currentCredentials,
+        AutopilotGraphKeyCredential credential,
+        string? activeKeyIdToReplace)
+    {
+        ArgumentNullException.ThrowIfNull(currentCredentials);
+        ArgumentNullException.ThrowIfNull(credential);
+        return currentCredentials
+            .Where(existing =>
+                !string.Equals(existing.KeyId, credential.KeyId, StringComparison.OrdinalIgnoreCase) &&
+                (string.IsNullOrWhiteSpace(activeKeyIdToReplace) ||
+                 !string.Equals(existing.KeyId, activeKeyIdToReplace, StringComparison.OrdinalIgnoreCase)))
+            .Concat([credential])
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Removes only the persisted active certificate credential.
+    /// </summary>
+    public static IReadOnlyList<AutopilotGraphKeyCredential> RetireActiveCertificate(
+        IReadOnlyList<AutopilotGraphKeyCredential> currentCredentials,
+        string activeKeyId)
+    {
+        ArgumentNullException.ThrowIfNull(currentCredentials);
+        ArgumentException.ThrowIfNullOrWhiteSpace(activeKeyId);
+        return currentCredentials
+            .Where(credential => !string.Equals(credential.KeyId, activeKeyId, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+    }
+}

--- a/src/Foundry.Core/Services/Autopilot/AutopilotTenantOnboardingEvaluator.cs
+++ b/src/Foundry.Core/Services/Autopilot/AutopilotTenantOnboardingEvaluator.cs
@@ -302,25 +302,6 @@ public static class AutopilotAppRegistrationCertificateCollection
     }
 
     /// <summary>
-    /// Replaces the persisted active certificate credential while preserving unrelated credentials.
-    /// </summary>
-    public static IReadOnlyList<AutopilotGraphKeyCredential> ReplaceActiveCertificate(
-        IReadOnlyList<AutopilotGraphKeyCredential> currentCredentials,
-        AutopilotGraphKeyCredential credential,
-        string? activeKeyIdToReplace)
-    {
-        ArgumentNullException.ThrowIfNull(currentCredentials);
-        ArgumentNullException.ThrowIfNull(credential);
-        return currentCredentials
-            .Where(existing =>
-                !string.Equals(existing.KeyId, credential.KeyId, StringComparison.OrdinalIgnoreCase) &&
-                (string.IsNullOrWhiteSpace(activeKeyIdToReplace) ||
-                 !string.Equals(existing.KeyId, activeKeyIdToReplace, StringComparison.OrdinalIgnoreCase)))
-            .Concat([credential])
-            .ToArray();
-    }
-
-    /// <summary>
     /// Removes only the persisted active certificate credential.
     /// </summary>
     public static IReadOnlyList<AutopilotGraphKeyCredential> RetireActiveCertificate(

--- a/src/Foundry.Core/Services/Autopilot/AutopilotTenantOnboardingEvaluator.cs
+++ b/src/Foundry.Core/Services/Autopilot/AutopilotTenantOnboardingEvaluator.cs
@@ -57,9 +57,9 @@ public static class AutopilotTenantOnboardingEvaluator
         {
             int foundryCredentialCount = snapshot.KeyCredentials.Count(credential =>
                 string.Equals(credential.DisplayName, snapshot.ManagedAppDisplayName, StringComparison.OrdinalIgnoreCase));
-            return foundryCredentialCount > 1
+            return foundryCredentialCount > 0
                 ? AutopilotTenantOnboardingEvaluation.FromStatus(
-                    AutopilotTenantOnboardingStatus.MultipleFoundryCertificatesNeedSelection,
+                    AutopilotTenantOnboardingStatus.Ready,
                     application,
                     snapshot.ServicePrincipal)
                 : AutopilotTenantOnboardingEvaluation.FromStatus(
@@ -217,10 +217,7 @@ public enum AutopilotTenantOnboardingStatus
     ActiveCertificateNotFound,
 
     /// <summary>The selected active certificate is expired.</summary>
-    ActiveCertificateExpired,
-
-    /// <summary>Multiple Foundry-looking certificates exist and no persisted active certificate resolves ownership.</summary>
-    MultipleFoundryCertificatesNeedSelection
+    ActiveCertificateExpired
 }
 
 /// <summary>

--- a/src/Foundry.Core/Services/Autopilot/MediaSecretEnvelopeProtector.cs
+++ b/src/Foundry.Core/Services/Autopilot/MediaSecretEnvelopeProtector.cs
@@ -1,0 +1,281 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Core.Services.Autopilot;
+
+/// <summary>
+/// Protects media-embedded secrets with the shared Foundry AES-GCM envelope format.
+/// </summary>
+public static class MediaSecretEnvelopeProtector
+{
+    /// <summary>
+    /// Envelope kind used for media-embedded encrypted secrets.
+    /// </summary>
+    public const string Kind = "encrypted";
+
+    /// <summary>
+    /// Encryption algorithm identifier serialized into media secret envelopes.
+    /// </summary>
+    public const string Algorithm = "aes-gcm-v1";
+
+    /// <summary>
+    /// Logical key identifier for the media secret key stored with generated boot media.
+    /// </summary>
+    public const string KeyId = "media";
+
+    /// <summary>
+    /// Required AES-256 media secret key length.
+    /// </summary>
+    public const int KeySizeBytes = 32;
+
+    /// <summary>
+    /// Required AES-GCM nonce length.
+    /// </summary>
+    public const int NonceSizeBytes = 12;
+
+    /// <summary>
+    /// Required AES-GCM authentication tag length.
+    /// </summary>
+    public const int TagSizeBytes = 16;
+
+    /// <summary>
+    /// Creates a new random media secret key for generated boot media.
+    /// </summary>
+    /// <returns>A 32-byte media secret key.</returns>
+    public static byte[] GenerateMediaKey()
+    {
+        byte[] key = new byte[KeySizeBytes];
+        RandomNumberGenerator.Fill(key);
+        return key;
+    }
+
+    /// <summary>
+    /// Encrypts a UTF-8 string into the shared media secret envelope format.
+    /// </summary>
+    /// <param name="plaintext">Plaintext value to encrypt.</param>
+    /// <param name="key">Media secret key.</param>
+    /// <returns>Encrypted secret envelope safe to serialize into generated configuration.</returns>
+    public static SecretEnvelope EncryptString(string plaintext, byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(plaintext);
+        byte[] plaintextBytes = Encoding.UTF8.GetBytes(plaintext);
+        try
+        {
+            return EncryptBytes(plaintextBytes, key);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(plaintextBytes);
+        }
+    }
+
+    /// <summary>
+    /// Decrypts a media secret envelope into a UTF-8 string.
+    /// </summary>
+    /// <param name="envelope">Encrypted secret envelope.</param>
+    /// <param name="key">Media secret key.</param>
+    /// <returns>Decrypted string value.</returns>
+    public static string DecryptString(SecretEnvelope envelope, byte[] key)
+    {
+        byte[] plaintextBytes = DecryptBytes(envelope, key);
+        try
+        {
+            return Encoding.UTF8.GetString(plaintextBytes);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(plaintextBytes);
+        }
+    }
+
+    /// <summary>
+    /// Encrypts binary secret material into the shared media secret envelope format.
+    /// </summary>
+    /// <param name="plaintext">Plaintext bytes to encrypt.</param>
+    /// <param name="key">Media secret key.</param>
+    /// <returns>Encrypted secret envelope safe to serialize into generated configuration.</returns>
+    public static SecretEnvelope EncryptBytes(byte[] plaintext, byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(plaintext);
+        ValidateKey(key);
+
+        byte[] nonce = new byte[NonceSizeBytes];
+        byte[] tag = new byte[TagSizeBytes];
+        byte[] ciphertext = new byte[plaintext.Length];
+
+        RandomNumberGenerator.Fill(nonce);
+        using var aes = new AesGcm(key, TagSizeBytes);
+        aes.Encrypt(nonce, plaintext, ciphertext, tag);
+
+        return new SecretEnvelope
+        {
+            Kind = Kind,
+            Algorithm = Algorithm,
+            KeyId = KeyId,
+            Nonce = Base64UrlEncode(nonce),
+            Tag = Base64UrlEncode(tag),
+            Ciphertext = Base64UrlEncode(ciphertext)
+        };
+    }
+
+    /// <summary>
+    /// Decrypts binary secret material from a media secret envelope.
+    /// </summary>
+    /// <param name="envelope">Encrypted secret envelope.</param>
+    /// <param name="key">Media secret key.</param>
+    /// <returns>Decrypted bytes. The caller is responsible for zeroing the returned buffer.</returns>
+    public static byte[] DecryptBytes(SecretEnvelope envelope, byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+        ValidateEnvelope(envelope);
+        ValidateKey(key);
+
+        byte[] nonce = Base64UrlDecode(envelope.Nonce);
+        byte[] tag = Base64UrlDecode(envelope.Tag);
+        byte[] ciphertext = Base64UrlDecode(envelope.Ciphertext);
+        byte[] plaintext = new byte[ciphertext.Length];
+
+        if (nonce.Length != NonceSizeBytes)
+        {
+            throw new CryptographicException("Encrypted secret nonce has an invalid length.");
+        }
+
+        if (tag.Length != TagSizeBytes)
+        {
+            throw new CryptographicException("Encrypted secret tag has an invalid length.");
+        }
+
+        try
+        {
+            using var aes = new AesGcm(key, TagSizeBytes);
+            aes.Decrypt(nonce, ciphertext, tag, plaintext);
+            return plaintext;
+        }
+        catch (CryptographicException ex)
+        {
+            CryptographicOperations.ZeroMemory(plaintext);
+            throw new CryptographicException("Encrypted secret could not be decrypted.", ex);
+        }
+    }
+
+    /// <summary>
+    /// Detects whether serialized JSON contains at least one shared media secret envelope.
+    /// </summary>
+    /// <param name="json">Serialized configuration JSON.</param>
+    /// <returns><see langword="true"/> when an encrypted media secret envelope is present.</returns>
+    public static bool HasEncryptedSecrets(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return false;
+        }
+
+        using JsonDocument document = JsonDocument.Parse(json);
+        return HasEncryptedSecrets(document.RootElement);
+    }
+
+    /// <summary>
+    /// Determines whether a JSON object matches the shared media secret envelope shape.
+    /// </summary>
+    /// <param name="element">JSON element to inspect.</param>
+    /// <returns><see langword="true"/> when the element is a complete encrypted media secret envelope.</returns>
+    public static bool IsEncryptedSecretEnvelope(JsonElement element)
+    {
+        return element.ValueKind == JsonValueKind.Object &&
+               HasStringProperty(element, "kind", Kind) &&
+               HasStringProperty(element, "algorithm", Algorithm) &&
+               HasStringProperty(element, "keyId", KeyId) &&
+               HasNonEmptyStringProperty(element, "nonce") &&
+               HasNonEmptyStringProperty(element, "tag") &&
+               HasNonEmptyStringProperty(element, "ciphertext");
+    }
+
+    private static bool HasEncryptedSecrets(JsonElement element)
+    {
+        if (IsEncryptedSecretEnvelope(element))
+        {
+            return true;
+        }
+
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (JsonProperty property in element.EnumerateObject())
+            {
+                if (HasEncryptedSecrets(property.Value))
+                {
+                    return true;
+                }
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement item in element.EnumerateArray())
+            {
+                if (HasEncryptedSecrets(item))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static void ValidateEnvelope(SecretEnvelope envelope)
+    {
+        if (!string.Equals(envelope.Kind, Kind, StringComparison.Ordinal) ||
+            !string.Equals(envelope.Algorithm, Algorithm, StringComparison.Ordinal) ||
+            !string.Equals(envelope.KeyId, KeyId, StringComparison.Ordinal))
+        {
+            throw new CryptographicException("Encrypted secret envelope is not supported.");
+        }
+
+        if (string.IsNullOrWhiteSpace(envelope.Nonce) ||
+            string.IsNullOrWhiteSpace(envelope.Tag) ||
+            string.IsNullOrWhiteSpace(envelope.Ciphertext))
+        {
+            throw new CryptographicException("Encrypted secret envelope is incomplete.");
+        }
+    }
+
+    private static void ValidateKey(byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        if (key.Length != KeySizeBytes)
+        {
+            throw new ArgumentException($"Media secret key must be {KeySizeBytes} bytes.", nameof(key));
+        }
+    }
+
+    private static string Base64UrlEncode(byte[] value)
+    {
+        return Convert.ToBase64String(value)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    private static byte[] Base64UrlDecode(string value)
+    {
+        string base64 = value.Replace('-', '+').Replace('_', '/');
+        int padding = (4 - base64.Length % 4) % 4;
+        base64 = base64.PadRight(base64.Length + padding, '=');
+        return Convert.FromBase64String(base64);
+    }
+
+    private static bool HasStringProperty(JsonElement element, string propertyName, string expectedValue)
+    {
+        return element.TryGetProperty(propertyName, out JsonElement property) &&
+               property.ValueKind == JsonValueKind.String &&
+               string.Equals(property.GetString(), expectedValue, StringComparison.Ordinal);
+    }
+
+    private static bool HasNonEmptyStringProperty(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out JsonElement property) &&
+               property.ValueKind == JsonValueKind.String &&
+               !string.IsNullOrWhiteSpace(property.GetString());
+    }
+}

--- a/src/Foundry.Core/Services/Configuration/AutopilotConfigurationValidator.cs
+++ b/src/Foundry.Core/Services/Configuration/AutopilotConfigurationValidator.cs
@@ -79,6 +79,7 @@ public static class AutopilotConfigurationValidator
         return !string.IsNullOrWhiteSpace(settings.Tenant.TenantId) &&
                !string.IsNullOrWhiteSpace(settings.Tenant.ApplicationObjectId) &&
                !string.IsNullOrWhiteSpace(settings.Tenant.ClientId) &&
+               !string.IsNullOrWhiteSpace(settings.Tenant.ServicePrincipalObjectId) &&
                !string.IsNullOrWhiteSpace(settings.ActiveCertificate?.KeyId) &&
                !string.IsNullOrWhiteSpace(settings.ActiveCertificate.Thumbprint) &&
                settings.ActiveCertificate.ExpiresOnUtc is { } expiresOnUtc &&

--- a/src/Foundry.Core/Services/Configuration/AutopilotConfigurationValidator.cs
+++ b/src/Foundry.Core/Services/Configuration/AutopilotConfigurationValidator.cs
@@ -109,6 +109,12 @@ public static class AutopilotConfigurationValidator
             return AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashServicePrincipalMissing);
         }
 
+        AutopilotConfigurationValidationResult bootMediaResult = EvaluateBootMediaCertificate(settings, currentTimeUtc);
+        if (!bootMediaResult.IsReady)
+        {
+            return bootMediaResult;
+        }
+
         if (string.IsNullOrWhiteSpace(settings.ActiveCertificate?.KeyId))
         {
             return AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashActiveCertificateMissing);
@@ -129,7 +135,7 @@ public static class AutopilotConfigurationValidator
             return AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashActiveCertificateExpired);
         }
 
-        return EvaluateBootMediaCertificate(settings, currentTimeUtc);
+        return AutopilotConfigurationValidationResult.Ready(AutopilotConfigurationValidationCode.Ready);
     }
 
     private static AutopilotConfigurationValidationResult EvaluateBootMediaCertificate(

--- a/src/Foundry.Core/Services/Configuration/AutopilotConfigurationValidator.cs
+++ b/src/Foundry.Core/Services/Configuration/AutopilotConfigurationValidator.cs
@@ -15,18 +15,31 @@ public static class AutopilotConfigurationValidator
     /// <returns><see langword="true"/> when the selected Autopilot mode is ready for output.</returns>
     public static bool IsReady(AutopilotSettings settings, DateTimeOffset currentTimeUtc)
     {
+        return Evaluate(settings, currentTimeUtc).IsReady;
+    }
+
+    /// <summary>
+    /// Evaluates Autopilot media readiness and returns the precise blocking reason.
+    /// </summary>
+    /// <param name="settings">Autopilot settings to evaluate.</param>
+    /// <param name="currentTimeUtc">Current UTC time used for certificate expiration checks.</param>
+    /// <returns>The Autopilot validation result.</returns>
+    public static AutopilotConfigurationValidationResult Evaluate(AutopilotSettings settings, DateTimeOffset currentTimeUtc)
+    {
         ArgumentNullException.ThrowIfNull(settings);
 
         if (!settings.IsEnabled)
         {
-            return true;
+            return AutopilotConfigurationValidationResult.Ready(AutopilotConfigurationValidationCode.Disabled);
         }
 
         return settings.ProvisioningMode switch
         {
-            AutopilotProvisioningMode.JsonProfile => GetSelectedJsonProfile(settings) is not null,
-            AutopilotProvisioningMode.HardwareHashUpload => IsHardwareHashUploadReady(settings.HardwareHashUpload, currentTimeUtc),
-            _ => false
+            AutopilotProvisioningMode.JsonProfile => GetSelectedJsonProfile(settings) is not null
+                ? AutopilotConfigurationValidationResult.Ready(AutopilotConfigurationValidationCode.Ready)
+                : AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.JsonProfileMissing),
+            AutopilotProvisioningMode.HardwareHashUpload => EvaluateHardwareHashUpload(settings.HardwareHashUpload, currentTimeUtc),
+            _ => AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.UnsupportedProvisioningMode)
         };
     }
 
@@ -45,9 +58,9 @@ public static class AutopilotConfigurationValidator
         }
 
         if (settings.ProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload &&
-            !IsHardwareHashUploadReady(settings.HardwareHashUpload, currentTimeUtc))
+            !EvaluateHardwareHashUpload(settings.HardwareHashUpload, currentTimeUtc).IsReady)
         {
-            throw new InvalidOperationException("Autopilot hardware hash upload mode requires complete tenant and unexpired certificate metadata.");
+            throw new InvalidOperationException("Autopilot hardware hash upload mode requires complete tenant metadata and a validated unexpired PFX matching the active certificate.");
         }
 
         if (!Enum.IsDefined(settings.ProvisioningMode))
@@ -67,22 +80,207 @@ public static class AutopilotConfigurationValidator
             string.Equals(profile.Id, settings.DefaultProfileId, StringComparison.OrdinalIgnoreCase));
     }
 
-    private static bool IsHardwareHashUploadReady(
+    private static AutopilotConfigurationValidationResult EvaluateHardwareHashUpload(
         AutopilotHardwareHashUploadSettings? settings,
         DateTimeOffset currentTimeUtc)
     {
         if (settings?.Tenant is null)
         {
-            return false;
+            return AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashSettingsMissing);
         }
 
-        return !string.IsNullOrWhiteSpace(settings.Tenant.TenantId) &&
-               !string.IsNullOrWhiteSpace(settings.Tenant.ApplicationObjectId) &&
-               !string.IsNullOrWhiteSpace(settings.Tenant.ClientId) &&
-               !string.IsNullOrWhiteSpace(settings.Tenant.ServicePrincipalObjectId) &&
-               !string.IsNullOrWhiteSpace(settings.ActiveCertificate?.KeyId) &&
-               !string.IsNullOrWhiteSpace(settings.ActiveCertificate.Thumbprint) &&
-               settings.ActiveCertificate.ExpiresOnUtc is { } expiresOnUtc &&
-               expiresOnUtc > currentTimeUtc;
+        if (string.IsNullOrWhiteSpace(settings.Tenant.TenantId))
+        {
+            return AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashTenantMissing);
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.Tenant.ApplicationObjectId))
+        {
+            return AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashAppRegistrationMissing);
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.Tenant.ClientId))
+        {
+            return AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashClientIdMissing);
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.Tenant.ServicePrincipalObjectId))
+        {
+            return AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashServicePrincipalMissing);
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.ActiveCertificate?.KeyId))
+        {
+            return AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashActiveCertificateMissing);
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.ActiveCertificate.Thumbprint))
+        {
+            return AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashActiveCertificateThumbprintMissing);
+        }
+
+        if (settings.ActiveCertificate.ExpiresOnUtc is not { } expiresOnUtc)
+        {
+            return AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashActiveCertificateExpirationMissing);
+        }
+
+        if (expiresOnUtc <= currentTimeUtc)
+        {
+            return AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashActiveCertificateExpired);
+        }
+
+        return EvaluateBootMediaCertificate(settings, currentTimeUtc);
     }
+
+    private static AutopilotConfigurationValidationResult EvaluateBootMediaCertificate(
+        AutopilotHardwareHashUploadSettings settings,
+        DateTimeOffset currentTimeUtc)
+    {
+        AutopilotBootMediaCertificateSettings bootMediaCertificate = settings.BootMediaCertificate;
+
+        if (string.IsNullOrWhiteSpace(bootMediaCertificate.PfxPath))
+        {
+            return AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashBootMediaPfxMissing);
+        }
+
+        if (string.IsNullOrWhiteSpace(bootMediaCertificate.PfxPassword))
+        {
+            return AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashBootMediaPfxPasswordMissing);
+        }
+
+        if (string.IsNullOrWhiteSpace(bootMediaCertificate.ValidatedThumbprint))
+        {
+            return AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashBootMediaCertificateNotValidated);
+        }
+
+        if (!string.Equals(
+                NormalizeThumbprint(settings.ActiveCertificate?.Thumbprint),
+                NormalizeThumbprint(bootMediaCertificate.ValidatedThumbprint),
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashBootMediaCertificateThumbprintMismatch);
+        }
+
+        if (bootMediaCertificate.ValidatedExpiresOnUtc is not { } expiresOnUtc)
+        {
+            return AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashBootMediaCertificateExpirationMissing);
+        }
+
+        return expiresOnUtc > currentTimeUtc
+            ? AutopilotConfigurationValidationResult.Ready(AutopilotConfigurationValidationCode.Ready)
+            : AutopilotConfigurationValidationResult.Blocked(AutopilotConfigurationValidationCode.HardwareHashBootMediaCertificateExpired);
+    }
+
+    private static string? NormalizeThumbprint(string? thumbprint)
+    {
+        string? normalized = thumbprint?.Replace(" ", string.Empty, StringComparison.Ordinal).Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized.ToUpperInvariant();
+    }
+}
+
+/// <summary>
+/// Describes Autopilot media readiness and the most specific blocking reason.
+/// </summary>
+public sealed record AutopilotConfigurationValidationResult
+{
+    /// <summary>
+    /// Gets whether the selected Autopilot mode is ready for media generation.
+    /// </summary>
+    public bool IsReady { get; init; }
+
+    /// <summary>
+    /// Gets the readiness or blocking reason code.
+    /// </summary>
+    public AutopilotConfigurationValidationCode Code { get; init; }
+
+    /// <summary>
+    /// Creates a ready validation result.
+    /// </summary>
+    /// <param name="code">Ready code.</param>
+    /// <returns>A ready validation result.</returns>
+    public static AutopilotConfigurationValidationResult Ready(AutopilotConfigurationValidationCode code)
+    {
+        return new AutopilotConfigurationValidationResult
+        {
+            IsReady = true,
+            Code = code
+        };
+    }
+
+    /// <summary>
+    /// Creates a blocked validation result.
+    /// </summary>
+    /// <param name="code">Blocking reason code.</param>
+    /// <returns>A blocked validation result.</returns>
+    public static AutopilotConfigurationValidationResult Blocked(AutopilotConfigurationValidationCode code)
+    {
+        return new AutopilotConfigurationValidationResult
+        {
+            IsReady = false,
+            Code = code
+        };
+    }
+}
+
+/// <summary>
+/// Identifies the Autopilot readiness status or blocking reason.
+/// </summary>
+public enum AutopilotConfigurationValidationCode
+{
+    /// <summary>Autopilot is ready for media generation.</summary>
+    Ready,
+
+    /// <summary>Autopilot is disabled.</summary>
+    Disabled,
+
+    /// <summary>The selected Autopilot provisioning mode is unsupported.</summary>
+    UnsupportedProvisioningMode,
+
+    /// <summary>JSON profile mode has no valid selected profile.</summary>
+    JsonProfileMissing,
+
+    /// <summary>Hardware hash settings are missing.</summary>
+    HardwareHashSettingsMissing,
+
+    /// <summary>The tenant ID is missing.</summary>
+    HardwareHashTenantMissing,
+
+    /// <summary>The managed app registration object ID is missing.</summary>
+    HardwareHashAppRegistrationMissing,
+
+    /// <summary>The managed app client ID is missing.</summary>
+    HardwareHashClientIdMissing,
+
+    /// <summary>The managed app service principal object ID is missing.</summary>
+    HardwareHashServicePrincipalMissing,
+
+    /// <summary>The active certificate key ID is missing.</summary>
+    HardwareHashActiveCertificateMissing,
+
+    /// <summary>The active certificate thumbprint is missing.</summary>
+    HardwareHashActiveCertificateThumbprintMissing,
+
+    /// <summary>The active certificate expiration is missing.</summary>
+    HardwareHashActiveCertificateExpirationMissing,
+
+    /// <summary>The active certificate is expired.</summary>
+    HardwareHashActiveCertificateExpired,
+
+    /// <summary>The boot media PFX file was not selected.</summary>
+    HardwareHashBootMediaPfxMissing,
+
+    /// <summary>The boot media PFX password is missing.</summary>
+    HardwareHashBootMediaPfxPasswordMissing,
+
+    /// <summary>The boot media PFX has not been validated.</summary>
+    HardwareHashBootMediaCertificateNotValidated,
+
+    /// <summary>The boot media PFX thumbprint does not match the active certificate.</summary>
+    HardwareHashBootMediaCertificateThumbprintMismatch,
+
+    /// <summary>The boot media PFX expiration is missing.</summary>
+    HardwareHashBootMediaCertificateExpirationMissing,
+
+    /// <summary>The boot media PFX certificate is expired.</summary>
+    HardwareHashBootMediaCertificateExpired
 }

--- a/src/Foundry.Core/Services/Configuration/ConnectSecretEnvelopeProtector.cs
+++ b/src/Foundry.Core/Services/Configuration/ConnectSecretEnvelopeProtector.cs
@@ -1,71 +1,24 @@
-using System.Security.Cryptography;
-using System.Text;
 using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Autopilot;
 
 namespace Foundry.Core.Services.Configuration;
 
 internal static class ConnectSecretEnvelopeProtector
 {
-    public const string Kind = "encrypted";
-    public const string Algorithm = "aes-gcm-v1";
-    public const string KeyId = "media";
-    public const int KeySizeBytes = 32;
-    public const int NonceSizeBytes = 12;
-    public const int TagSizeBytes = 16;
+    public const string Kind = MediaSecretEnvelopeProtector.Kind;
+    public const string Algorithm = MediaSecretEnvelopeProtector.Algorithm;
+    public const string KeyId = MediaSecretEnvelopeProtector.KeyId;
+    public const int KeySizeBytes = MediaSecretEnvelopeProtector.KeySizeBytes;
+    public const int NonceSizeBytes = MediaSecretEnvelopeProtector.NonceSizeBytes;
+    public const int TagSizeBytes = MediaSecretEnvelopeProtector.TagSizeBytes;
 
     public static byte[] GenerateMediaKey()
     {
-        byte[] key = new byte[KeySizeBytes];
-        RandomNumberGenerator.Fill(key);
-        return key;
+        return MediaSecretEnvelopeProtector.GenerateMediaKey();
     }
 
     public static SecretEnvelope Encrypt(string plaintext, byte[] key)
     {
-        ArgumentNullException.ThrowIfNull(plaintext);
-        ValidateKey(key);
-
-        byte[] nonce = new byte[NonceSizeBytes];
-        byte[] tag = new byte[TagSizeBytes];
-        byte[] plaintextBytes = Encoding.UTF8.GetBytes(plaintext);
-        byte[] ciphertext = new byte[plaintextBytes.Length];
-
-        try
-        {
-            RandomNumberGenerator.Fill(nonce);
-            using var aes = new AesGcm(key, TagSizeBytes);
-            aes.Encrypt(nonce, plaintextBytes, ciphertext, tag);
-
-            return new SecretEnvelope
-            {
-                Kind = Kind,
-                Algorithm = Algorithm,
-                KeyId = KeyId,
-                Nonce = Base64UrlEncode(nonce),
-                Tag = Base64UrlEncode(tag),
-                Ciphertext = Base64UrlEncode(ciphertext)
-            };
-        }
-        finally
-        {
-            CryptographicOperations.ZeroMemory(plaintextBytes);
-        }
-    }
-
-    private static void ValidateKey(byte[] key)
-    {
-        ArgumentNullException.ThrowIfNull(key);
-        if (key.Length != KeySizeBytes)
-        {
-            throw new ArgumentException($"Media secret key must be {KeySizeBytes} bytes.", nameof(key));
-        }
-    }
-
-    private static string Base64UrlEncode(byte[] value)
-    {
-        return Convert.ToBase64String(value)
-            .TrimEnd('=')
-            .Replace('+', '-')
-            .Replace('/', '_');
+        return MediaSecretEnvelopeProtector.EncryptString(plaintext, key);
     }
 }

--- a/src/Foundry.Core/Services/Media/MediaPreflightOptions.cs
+++ b/src/Foundry.Core/Services/Media/MediaPreflightOptions.cs
@@ -1,4 +1,5 @@
 using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Configuration;
 using Foundry.Core.Services.WinPe;
 
 namespace Foundry.Core.Services.Media;
@@ -42,6 +43,12 @@ public sealed record MediaPreflightOptions
     /// Gets a value indicating whether the selected Autopilot provisioning mode is valid.
     /// </summary>
     public bool IsAutopilotConfigurationReady { get; init; } = true;
+
+    /// <summary>
+    /// Gets the detailed Autopilot validation code for the selected provisioning mode.
+    /// </summary>
+    public AutopilotConfigurationValidationCode AutopilotConfigurationValidationCode { get; init; } =
+        AutopilotConfigurationValidationCode.Ready;
 
     /// <summary>
     /// Gets the selected Autopilot provisioning mode.

--- a/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningService.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using Foundry.Core.Models.Configuration;
 using Foundry.Core.Models.Configuration.Deploy;
+using Foundry.Core.Services.Autopilot;
 using Foundry.Core.Services.Configuration;
 
 namespace Foundry.Core.Services.WinPe;
@@ -106,6 +107,7 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
         await WriteMediaSecretsKeyAsync(
             foundryConfigPath,
             connectConfigurationJson,
+            deployConfigurationJson,
             options.MediaSecretsKey,
             cancellationToken).ConfigureAwait(false);
 
@@ -134,15 +136,17 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
     private static async Task WriteMediaSecretsKeyAsync(
         string foundryConfigPath,
         string connectConfigurationJson,
+        string deployConfigurationJson,
         byte[]? mediaSecretsKey,
         CancellationToken cancellationToken)
     {
-        bool hasEncryptedSecrets = HasEncryptedSecrets(connectConfigurationJson);
+        bool hasEncryptedSecrets = MediaSecretEnvelopeProtector.HasEncryptedSecrets(connectConfigurationJson) ||
+                                   MediaSecretEnvelopeProtector.HasEncryptedSecrets(deployConfigurationJson);
         if (mediaSecretsKey is null || mediaSecretsKey.Length == 0)
         {
             if (hasEncryptedSecrets)
             {
-                throw new ArgumentException("Foundry Connect encrypted secrets require a media secret key.");
+                throw new ArgumentException("Foundry encrypted media secrets require a media secret key.");
             }
 
             return;
@@ -150,7 +154,7 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
 
         if (!hasEncryptedSecrets)
         {
-            throw new ArgumentException("A media secret key must not be provisioned without encrypted Foundry Connect secrets.");
+            throw new ArgumentException("A media secret key must not be provisioned without encrypted Foundry media secrets.");
         }
 
         if (mediaSecretsKey.Length != 32)
@@ -164,67 +168,6 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
             Path.Combine(secretsPath, "media-secrets.key"),
             mediaSecretsKey,
             cancellationToken).ConfigureAwait(false);
-    }
-
-    private static bool HasEncryptedSecrets(string connectConfigurationJson)
-    {
-        using JsonDocument document = JsonDocument.Parse(connectConfigurationJson);
-        return HasEncryptedSecrets(document.RootElement);
-    }
-
-    private static bool HasEncryptedSecrets(JsonElement element)
-    {
-        if (element.ValueKind == JsonValueKind.Object)
-        {
-            if (IsEncryptedSecretEnvelope(element))
-            {
-                return true;
-            }
-
-            foreach (JsonProperty property in element.EnumerateObject())
-            {
-                if (HasEncryptedSecrets(property.Value))
-                {
-                    return true;
-                }
-            }
-        }
-        else if (element.ValueKind == JsonValueKind.Array)
-        {
-            foreach (JsonElement item in element.EnumerateArray())
-            {
-                if (HasEncryptedSecrets(item))
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    private static bool IsEncryptedSecretEnvelope(JsonElement element)
-    {
-        return HasStringProperty(element, "kind", "encrypted") &&
-               HasStringProperty(element, "algorithm", "aes-gcm-v1") &&
-               HasStringProperty(element, "keyId", "media") &&
-               HasNonEmptyStringProperty(element, "nonce") &&
-               HasNonEmptyStringProperty(element, "tag") &&
-               HasNonEmptyStringProperty(element, "ciphertext");
-    }
-
-    private static bool HasStringProperty(JsonElement element, string propertyName, string expectedValue)
-    {
-        return element.TryGetProperty(propertyName, out JsonElement property) &&
-               property.ValueKind == JsonValueKind.String &&
-               string.Equals(property.GetString(), expectedValue, StringComparison.Ordinal);
-    }
-
-    private static bool HasNonEmptyStringProperty(JsonElement element, string propertyName)
-    {
-        return element.TryGetProperty(propertyName, out JsonElement property) &&
-               property.ValueKind == JsonValueKind.String &&
-               !string.IsNullOrWhiteSpace(property.GetString());
     }
 
     private static void CopyConnectAssetFiles(

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -89,6 +89,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IConnectConfigurationGenerator, ConnectConfigurationGenerator>();
         services.AddSingleton<IAutopilotProfileImportService, AutopilotProfileImportService>();
         services.AddSingleton<IAutopilotTenantProfileService, AutopilotTenantProfileService>();
+        services.AddSingleton<IAutopilotHardwareHashGraphSessionService, AutopilotHardwareHashGraphSessionService>();
         services.AddSingleton<IAutopilotTenantOnboardingService, AutopilotTenantOnboardingService>();
         services.AddSingleton<IAutopilotTenantOperationDialogService, AutopilotTenantOperationDialogService>();
         services.AddSingleton<IAutopilotCertificateDialogService, AutopilotCertificateDialogService>();

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -90,7 +90,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IAutopilotProfileImportService, AutopilotProfileImportService>();
         services.AddSingleton<IAutopilotTenantProfileService, AutopilotTenantProfileService>();
         services.AddSingleton<IAutopilotTenantOnboardingService, AutopilotTenantOnboardingService>();
-        services.AddSingleton<IAutopilotTenantDownloadDialogService, AutopilotTenantDownloadDialogService>();
+        services.AddSingleton<IAutopilotTenantOperationDialogService, AutopilotTenantOperationDialogService>();
         services.AddSingleton<IAutopilotCertificateDialogService, AutopilotCertificateDialogService>();
         services.AddSingleton<IAutopilotProfileSelectionDialogService, AutopilotProfileSelectionDialogService>();
         services.AddSingleton<IAutopilotHardwareHashSessionState, AutopilotHardwareHashSessionState>();

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -89,6 +89,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IConnectConfigurationGenerator, ConnectConfigurationGenerator>();
         services.AddSingleton<IAutopilotProfileImportService, AutopilotProfileImportService>();
         services.AddSingleton<IAutopilotTenantProfileService, AutopilotTenantProfileService>();
+        services.AddSingleton<IAutopilotTenantOnboardingService, AutopilotTenantOnboardingService>();
         services.AddSingleton<IAutopilotTenantDownloadDialogService, AutopilotTenantDownloadDialogService>();
         services.AddSingleton<IAutopilotProfileSelectionDialogService, AutopilotProfileSelectionDialogService>();
         services.AddSingleton<ILanguageRegistryService, EmbeddedLanguageRegistryService>();

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -93,6 +93,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IAutopilotTenantDownloadDialogService, AutopilotTenantDownloadDialogService>();
         services.AddSingleton<IAutopilotCertificateDialogService, AutopilotCertificateDialogService>();
         services.AddSingleton<IAutopilotProfileSelectionDialogService, AutopilotProfileSelectionDialogService>();
+        services.AddSingleton<IAutopilotHardwareHashSessionState, AutopilotHardwareHashSessionState>();
         services.AddSingleton<ILanguageRegistryService, EmbeddedLanguageRegistryService>();
         services.AddSingleton<INetworkSecretStateService, NetworkSecretStateService>();
         services.AddSingleton<IFoundryConfigurationStateService, FoundryConfigurationStateService>();

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -91,6 +91,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IAutopilotTenantProfileService, AutopilotTenantProfileService>();
         services.AddSingleton<IAutopilotTenantOnboardingService, AutopilotTenantOnboardingService>();
         services.AddSingleton<IAutopilotTenantDownloadDialogService, AutopilotTenantDownloadDialogService>();
+        services.AddSingleton<IAutopilotCertificateDialogService, AutopilotCertificateDialogService>();
         services.AddSingleton<IAutopilotProfileSelectionDialogService, AutopilotProfileSelectionDialogService>();
         services.AddSingleton<ILanguageRegistryService, EmbeddedLanguageRegistryService>();
         services.AddSingleton<INetworkSecretStateService, NetworkSecretStateService>();

--- a/src/Foundry/Services/Autopilot/AutopilotCertificateCreationResult.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotCertificateCreationResult.cs
@@ -1,0 +1,24 @@
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Services.Autopilot;
+
+/// <summary>
+/// Represents a created app registration certificate and the one-time generated PFX password.
+/// </summary>
+public sealed record AutopilotCertificateCreationResult
+{
+    /// <summary>
+    /// Gets updated hardware hash upload settings with the created certificate selected as active.
+    /// </summary>
+    public AutopilotHardwareHashUploadSettings Settings { get; init; } = new();
+
+    /// <summary>
+    /// Gets the generated password for the exported PFX. This must not be persisted by Foundry.
+    /// </summary>
+    public string GeneratedPassword { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the certificate metadata selected as active after creation.
+    /// </summary>
+    public AutopilotCertificateMetadata Certificate { get; init; } = new();
+}

--- a/src/Foundry/Services/Autopilot/AutopilotCertificateCreationResult.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotCertificateCreationResult.cs
@@ -1,4 +1,5 @@
 using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Autopilot;
 
 namespace Foundry.Services.Autopilot;
 
@@ -21,4 +22,9 @@ public sealed record AutopilotCertificateCreationResult
     /// Gets the certificate metadata selected as active after creation.
     /// </summary>
     public AutopilotCertificateMetadata Certificate { get; init; } = new();
+
+    /// <summary>
+    /// Gets the app registration certificate credentials after creation.
+    /// </summary>
+    public IReadOnlyList<AutopilotGraphKeyCredential> Certificates { get; init; } = [];
 }

--- a/src/Foundry/Services/Autopilot/AutopilotCertificateDialogService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotCertificateDialogService.cs
@@ -1,0 +1,67 @@
+using Foundry.Services.Localization;
+
+namespace Foundry.Services.Autopilot;
+
+public sealed class AutopilotCertificateDialogService(
+    IApplicationLocalizationService localizationService) : IAutopilotCertificateDialogService
+{
+    public async Task ShowCreatedAsync(string pfxOutputPath, string password)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pfxOutputPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(password);
+
+        var dialog = new ContentDialog
+        {
+            XamlRoot = App.MainWindow.Content.XamlRoot,
+            Title = localizationService.GetString("Autopilot.HardwareHashCertificateCreatedTitle"),
+            Content = CreateContent(pfxOutputPath, password),
+            CloseButtonText = localizationService.GetString("Common.Close"),
+            DefaultButton = ContentDialogButton.Close
+        };
+
+        await dialog.ShowAsync();
+    }
+
+    private FrameworkElement CreateContent(string pfxOutputPath, string password)
+    {
+        return new StackPanel
+        {
+            MinWidth = 480,
+            MaxWidth = 560,
+            Spacing = 12,
+            Children =
+            {
+                new TextBlock
+                {
+                    Text = localizationService.GetString("Autopilot.HardwareHashCertificateCreatedInstruction"),
+                    TextWrapping = TextWrapping.Wrap,
+                    IsTextSelectionEnabled = true
+                },
+                new TextBlock
+                {
+                    Text = localizationService.GetString("Autopilot.HardwareHashCertificateCreatedPathLabel"),
+                    Style = (Style)Microsoft.UI.Xaml.Application.Current.Resources["BodyStrongTextBlockStyle"]
+                },
+                new TextBlock
+                {
+                    Text = pfxOutputPath,
+                    TextWrapping = TextWrapping.Wrap,
+                    IsTextSelectionEnabled = true
+                },
+                new TextBlock
+                {
+                    Text = localizationService.GetString("Autopilot.HardwareHashCertificateCreatedPasswordLabel"),
+                    Style = (Style)Microsoft.UI.Xaml.Application.Current.Resources["BodyStrongTextBlockStyle"],
+                    Margin = new Thickness(0, 8, 0, 0)
+                },
+                new Microsoft.UI.Xaml.Controls.TextBox
+                {
+                    Text = password,
+                    IsReadOnly = true,
+                    TextWrapping = TextWrapping.NoWrap,
+                    FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Consolas")
+                }
+            }
+        };
+    }
+}

--- a/src/Foundry/Services/Autopilot/AutopilotCertificateDialogService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotCertificateDialogService.cs
@@ -1,4 +1,5 @@
 using Foundry.Services.Localization;
+using Windows.ApplicationModel.DataTransfer;
 
 namespace Foundry.Services.Autopilot;
 
@@ -54,13 +55,61 @@ public sealed class AutopilotCertificateDialogService(
                     Style = (Style)Microsoft.UI.Xaml.Application.Current.Resources["BodyStrongTextBlockStyle"],
                     Margin = new Thickness(0, 8, 0, 0)
                 },
-                new Microsoft.UI.Xaml.Controls.TextBox
+                CreatePasswordRow(password)
+            }
+        };
+    }
+
+    private FrameworkElement CreatePasswordRow(string password)
+    {
+        var copiedTextBlock = new TextBlock
+        {
+            Text = localizationService.GetString("Autopilot.HardwareHashCertificateCreatedPasswordCopied"),
+            Foreground = (Microsoft.UI.Xaml.Media.Brush)Microsoft.UI.Xaml.Application.Current.Resources["SystemFillColorSuccessBrush"],
+            Visibility = Visibility.Collapsed
+        };
+
+        var copyButton = new Button
+        {
+            Content = localizationService.GetString("Autopilot.HardwareHashCertificateCreatedCopyPasswordButton"),
+            MinWidth = 128
+        };
+        Grid.SetColumn(copyButton, 1);
+
+        copyButton.Click += (_, _) =>
+        {
+            var dataPackage = new DataPackage();
+            dataPackage.SetText(password);
+            Clipboard.SetContent(dataPackage);
+            copiedTextBlock.Visibility = Visibility.Visible;
+        };
+
+        return new StackPanel
+        {
+            Spacing = 8,
+            Children =
+            {
+                new Grid
                 {
-                    Text = password,
-                    IsReadOnly = true,
-                    TextWrapping = TextWrapping.NoWrap,
-                    FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Consolas")
-                }
+                    ColumnSpacing = 8,
+                    ColumnDefinitions =
+                    {
+                        new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                        new ColumnDefinition { Width = GridLength.Auto }
+                    },
+                    Children =
+                    {
+                        new Microsoft.UI.Xaml.Controls.TextBox
+                        {
+                            Text = password,
+                            IsReadOnly = true,
+                            TextWrapping = TextWrapping.NoWrap,
+                            FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Consolas")
+                        },
+                        copyButton
+                    }
+                },
+                copiedTextBlock
             }
         };
     }

--- a/src/Foundry/Services/Autopilot/AutopilotCertificateRemovalResult.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotCertificateRemovalResult.cs
@@ -1,0 +1,20 @@
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Autopilot;
+
+namespace Foundry.Services.Autopilot;
+
+/// <summary>
+/// Represents app registration certificate state after removing a selected credential.
+/// </summary>
+public sealed record AutopilotCertificateRemovalResult
+{
+    /// <summary>
+    /// Gets updated hardware hash upload settings after certificate removal.
+    /// </summary>
+    public AutopilotHardwareHashUploadSettings Settings { get; init; } = new();
+
+    /// <summary>
+    /// Gets the app registration certificate credentials after removal.
+    /// </summary>
+    public IReadOnlyList<AutopilotGraphKeyCredential> Certificates { get; init; } = [];
+}

--- a/src/Foundry/Services/Autopilot/AutopilotGraphAuthenticationDefaults.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotGraphAuthenticationDefaults.cs
@@ -1,0 +1,27 @@
+namespace Foundry.Services.Autopilot;
+
+/// <summary>
+/// Defines the Foundry-owned Microsoft Graph public client used for interactive Autopilot tenant onboarding.
+/// </summary>
+internal static class AutopilotGraphAuthenticationDefaults
+{
+    /// <summary>
+    /// Official multi-tenant public client ID for the Foundry bootstrap app.
+    /// This app is used only for interactive OSD admin sign-in and is not embedded into generated WinPE media.
+    /// </summary>
+    public const string FoundryBootstrapClientId = "83eb3a92-030d-49b7-881b-32a1eb3e110a";
+
+    /// <summary>
+    /// Optional override for private builds or forks that use their own bootstrap public client.
+    /// </summary>
+    public const string ClientIdEnvironmentVariableName = "FOUNDRY_AUTOPILOT_GRAPH_CLIENT_ID";
+
+    /// <summary>
+    /// Optional tenant override for development and controlled validation scenarios.
+    /// </summary>
+    public const string TenantIdEnvironmentVariableName = "FOUNDRY_AUTOPILOT_GRAPH_TENANT_ID";
+
+    public const string DefaultTenantId = "common";
+    public const string RedirectUri = "http://localhost";
+    public const string TokenCacheName = "FoundryAutopilotGraph";
+}

--- a/src/Foundry/Services/Autopilot/AutopilotGraphAuthenticationDefaults.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotGraphAuthenticationDefaults.cs
@@ -23,5 +23,4 @@ internal static class AutopilotGraphAuthenticationDefaults
 
     public const string DefaultTenantId = "common";
     public const string RedirectUri = "http://localhost";
-    public const string TokenCacheName = "FoundryAutopilotGraph";
 }

--- a/src/Foundry/Services/Autopilot/AutopilotHardwareHashGraphSessionService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotHardwareHashGraphSessionService.cs
@@ -74,11 +74,7 @@ public sealed class AutopilotHardwareHashGraphSessionService : IAutopilotHardwar
         {
             ClientId = clientId,
             TenantId = string.IsNullOrWhiteSpace(tenantId) ? AutopilotGraphAuthenticationDefaults.DefaultTenantId : tenantId.Trim(),
-            RedirectUri = new Uri(AutopilotGraphAuthenticationDefaults.RedirectUri, UriKind.Absolute),
-            TokenCachePersistenceOptions = new TokenCachePersistenceOptions
-            {
-                Name = AutopilotGraphAuthenticationDefaults.TokenCacheName
-            }
+            RedirectUri = new Uri(AutopilotGraphAuthenticationDefaults.RedirectUri, UriKind.Absolute)
         });
     }
 }

--- a/src/Foundry/Services/Autopilot/AutopilotHardwareHashGraphSessionService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotHardwareHashGraphSessionService.cs
@@ -8,11 +8,6 @@ namespace Foundry.Services.Autopilot;
 /// </summary>
 public sealed class AutopilotHardwareHashGraphSessionService : IAutopilotHardwareHashGraphSessionService
 {
-    private const string DefaultClientId = "83eb3a92-030d-49b7-881b-32a1eb3e110a";
-    private const string ClientIdEnvironmentVariableName = "FOUNDRY_AUTOPILOT_GRAPH_CLIENT_ID";
-    private const string TenantIdEnvironmentVariableName = "FOUNDRY_AUTOPILOT_GRAPH_TENANT_ID";
-    private const string DefaultTenantId = "common";
-    private const string DefaultRedirectUri = "http://localhost";
     private static readonly TimeSpan TokenRefreshSkew = TimeSpan.FromMinutes(5);
 
     private static readonly string[] GraphScopes =
@@ -70,18 +65,18 @@ public sealed class AutopilotHardwareHashGraphSessionService : IAutopilotHardwar
 
     private static TokenCredential CreateCredential()
     {
-        string clientId = Environment.GetEnvironmentVariable(ClientIdEnvironmentVariableName)?.Trim()
-            ?? DefaultClientId;
-        string? tenantId = Environment.GetEnvironmentVariable(TenantIdEnvironmentVariableName);
+        string clientId = Environment.GetEnvironmentVariable(AutopilotGraphAuthenticationDefaults.ClientIdEnvironmentVariableName)?.Trim()
+            ?? AutopilotGraphAuthenticationDefaults.FoundryBootstrapClientId;
+        string? tenantId = Environment.GetEnvironmentVariable(AutopilotGraphAuthenticationDefaults.TenantIdEnvironmentVariableName);
 
         return new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
         {
             ClientId = clientId,
-            TenantId = string.IsNullOrWhiteSpace(tenantId) ? DefaultTenantId : tenantId.Trim(),
-            RedirectUri = new Uri(DefaultRedirectUri, UriKind.Absolute),
+            TenantId = string.IsNullOrWhiteSpace(tenantId) ? AutopilotGraphAuthenticationDefaults.DefaultTenantId : tenantId.Trim(),
+            RedirectUri = new Uri(AutopilotGraphAuthenticationDefaults.RedirectUri, UriKind.Absolute),
             TokenCachePersistenceOptions = new TokenCachePersistenceOptions
             {
-                Name = "FoundryAutopilotGraph"
+                Name = AutopilotGraphAuthenticationDefaults.TokenCacheName
             }
         });
     }

--- a/src/Foundry/Services/Autopilot/AutopilotHardwareHashGraphSessionService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotHardwareHashGraphSessionService.cs
@@ -14,7 +14,8 @@ public sealed class AutopilotHardwareHashGraphSessionService : IAutopilotHardwar
     [
         "Application.ReadWrite.All",
         "AppRoleAssignment.ReadWrite.All",
-        "DeviceManagementServiceConfig.Read.All"
+        "DeviceManagementServiceConfig.Read.All",
+        "User.Read"
     ];
 
     private TokenCredential? credential;

--- a/src/Foundry/Services/Autopilot/AutopilotHardwareHashGraphSessionService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotHardwareHashGraphSessionService.cs
@@ -1,0 +1,88 @@
+using Azure.Core;
+using Azure.Identity;
+
+namespace Foundry.Services.Autopilot;
+
+/// <summary>
+/// Owns the session-scoped interactive Microsoft Graph credential used for Autopilot hardware hash onboarding.
+/// </summary>
+public sealed class AutopilotHardwareHashGraphSessionService : IAutopilotHardwareHashGraphSessionService
+{
+    private const string DefaultClientId = "83eb3a92-030d-49b7-881b-32a1eb3e110a";
+    private const string ClientIdEnvironmentVariableName = "FOUNDRY_AUTOPILOT_GRAPH_CLIENT_ID";
+    private const string TenantIdEnvironmentVariableName = "FOUNDRY_AUTOPILOT_GRAPH_TENANT_ID";
+    private const string DefaultTenantId = "common";
+    private const string DefaultRedirectUri = "http://localhost";
+    private static readonly TimeSpan TokenRefreshSkew = TimeSpan.FromMinutes(5);
+
+    private static readonly string[] GraphScopes =
+    [
+        "Application.ReadWrite.All",
+        "AppRoleAssignment.ReadWrite.All",
+        "DeviceManagementServiceConfig.Read.All"
+    ];
+
+    private TokenCredential? credential;
+    private AccessToken? currentToken;
+
+    /// <inheritdoc />
+    public async Task<string> ConnectAsync(CancellationToken cancellationToken = default)
+    {
+        credential = CreateCredential();
+        try
+        {
+            currentToken = await credential.GetTokenAsync(new TokenRequestContext(GraphScopes), cancellationToken)
+                .ConfigureAwait(false);
+            return currentToken.Value.Token;
+        }
+        catch
+        {
+            Disconnect();
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken = default)
+    {
+        if (currentToken is { } cachedToken &&
+            cachedToken.ExpiresOn > DateTimeOffset.UtcNow.Add(TokenRefreshSkew))
+        {
+            return cachedToken.Token;
+        }
+
+        if (credential is null)
+        {
+            throw new InvalidOperationException("Connect to the tenant before managing Autopilot certificates.");
+        }
+
+        currentToken = await credential.GetTokenAsync(new TokenRequestContext(GraphScopes), cancellationToken)
+            .ConfigureAwait(false);
+        return currentToken.Value.Token;
+    }
+
+    /// <inheritdoc />
+    public void Disconnect()
+    {
+        credential = null;
+        currentToken = null;
+    }
+
+    private static TokenCredential CreateCredential()
+    {
+        string clientId = Environment.GetEnvironmentVariable(ClientIdEnvironmentVariableName)?.Trim()
+            ?? DefaultClientId;
+        string? tenantId = Environment.GetEnvironmentVariable(TenantIdEnvironmentVariableName);
+
+        return new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
+        {
+            ClientId = clientId,
+            TenantId = string.IsNullOrWhiteSpace(tenantId) ? DefaultTenantId : tenantId.Trim(),
+            RedirectUri = new Uri(DefaultRedirectUri, UriKind.Absolute),
+            TokenCachePersistenceOptions = new TokenCachePersistenceOptions
+            {
+                Name = "FoundryAutopilotGraph"
+            }
+        });
+    }
+}

--- a/src/Foundry/Services/Autopilot/AutopilotHardwareHashSessionState.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotHardwareHashSessionState.cs
@@ -1,0 +1,23 @@
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Autopilot;
+
+namespace Foundry.Services.Autopilot;
+
+internal sealed class AutopilotHardwareHashSessionState : IAutopilotHardwareHashSessionState
+{
+    public bool HasConnectedTenant { get; set; }
+
+    public AutopilotTenantOnboardingStatus? TenantOnboardingStatus { get; set; }
+
+    public AutopilotBootMediaCertificateSettings BootMediaCertificate { get; set; } = new();
+
+    public IReadOnlyList<AutopilotGraphKeyCredential> Certificates { get; set; } = [];
+
+    public void ClearTenantConnection()
+    {
+        HasConnectedTenant = false;
+        TenantOnboardingStatus = null;
+        Certificates = [];
+        BootMediaCertificate = new AutopilotBootMediaCertificateSettings();
+    }
+}

--- a/src/Foundry/Services/Autopilot/AutopilotTenantDownloadDialogService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantDownloadDialogService.cs
@@ -6,13 +6,43 @@ namespace Foundry.Services.Autopilot;
 public sealed class AutopilotTenantDownloadDialogService(
     IApplicationLocalizationService localizationService) : IAutopilotTenantDownloadDialogService
 {
+    public Task<TResult?> RunAsync<TResult>(
+        string title,
+        string message,
+        Func<CancellationToken, Task<TResult>> operationAsync)
+        where TResult : class
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+        ArgumentNullException.ThrowIfNull(operationAsync);
+
+        return RunWithDialogAsync(
+            title,
+            message,
+            localizationService.GetString("Autopilot.TenantDownloadDialogCancel"),
+            operationAsync);
+    }
+
     public async Task<IReadOnlyList<AutopilotProfileSettings>?> DownloadAsync(
         Func<CancellationToken, Task<IReadOnlyList<AutopilotProfileSettings>>> downloadProfilesAsync)
     {
         ArgumentNullException.ThrowIfNull(downloadProfilesAsync);
+        return await RunWithDialogAsync(
+            localizationService.GetString("Autopilot.TenantDownloadDialogTitle"),
+            localizationService.GetString("Autopilot.TenantDownloadDialogMessage"),
+            localizationService.GetString("Autopilot.TenantDownloadDialogCancel"),
+            downloadProfilesAsync).ConfigureAwait(false);
+    }
 
+    private static async Task<TResult?> RunWithDialogAsync<TResult>(
+        string title,
+        string message,
+        string cancelText,
+        Func<CancellationToken, Task<TResult>> operationAsync)
+        where TResult : class
+    {
         using var cancellationTokenSource = new CancellationTokenSource();
-        ContentDialog dialog = CreateDialog(cancellationTokenSource);
+        ContentDialog dialog = CreateDialog(title, message, cancelText, cancellationTokenSource);
         TaskCompletionSource dialogOpenedTask = new(TaskCreationOptions.RunContinuationsAsynchronously);
         dialog.Opened += OnDialogOpened;
         Task<ContentDialogResult> dialogTask = dialog.ShowAsync().AsTask();
@@ -22,24 +52,24 @@ public sealed class AutopilotTenantDownloadDialogService(
         if (completedBeforeOpenTask == dialogTask)
         {
             cancellationTokenSource.Cancel();
-            return null;
+            return default;
         }
 
-        Task<IReadOnlyList<AutopilotProfileSettings>> downloadTask = Task.Run(
-            () => downloadProfilesAsync(cancellationTokenSource.Token),
+        Task<TResult> operationTask = Task.Run(
+            () => operationAsync(cancellationTokenSource.Token),
             cancellationTokenSource.Token);
-        Task completedTask = await Task.WhenAny(downloadTask, dialogTask);
+        Task completedTask = await Task.WhenAny(operationTask, dialogTask);
         if (completedTask == dialogTask)
         {
             cancellationTokenSource.Cancel();
-            _ = ObserveDownloadTaskAsync(downloadTask);
-            return null;
+            _ = ObserveTaskAsync(operationTask);
+            return default;
         }
 
-        IReadOnlyList<AutopilotProfileSettings> profiles;
+        TResult result;
         try
         {
-            profiles = await downloadTask;
+            result = await operationTask;
         }
         catch
         {
@@ -48,7 +78,7 @@ public sealed class AutopilotTenantDownloadDialogService(
         }
 
         await CloseDialogAsync(dialog, dialogTask);
-        return profiles;
+        return result;
 
         void OnDialogOpened(ContentDialog sender, ContentDialogOpenedEventArgs args)
         {
@@ -56,14 +86,14 @@ public sealed class AutopilotTenantDownloadDialogService(
         }
     }
 
-    private ContentDialog CreateDialog(CancellationTokenSource cancellationTokenSource)
+    private static ContentDialog CreateDialog(string title, string message, string cancelText, CancellationTokenSource cancellationTokenSource)
     {
         var dialog = new ContentDialog
         {
             XamlRoot = App.MainWindow.Content.XamlRoot,
-            Title = localizationService.GetString("Autopilot.TenantDownloadDialogTitle"),
-            Content = CreateDialogContent(),
-            CloseButtonText = localizationService.GetString("Autopilot.TenantDownloadDialogCancel"),
+            Title = title,
+            Content = CreateDialogContent(message),
+            CloseButtonText = cancelText,
             DefaultButton = ContentDialogButton.Close
         };
 
@@ -71,7 +101,7 @@ public sealed class AutopilotTenantDownloadDialogService(
         return dialog;
     }
 
-    private FrameworkElement CreateDialogContent()
+    private static FrameworkElement CreateDialogContent(string message)
     {
         return new StackPanel
         {
@@ -88,7 +118,7 @@ public sealed class AutopilotTenantDownloadDialogService(
                 },
                 new TextBlock
                 {
-                    Text = localizationService.GetString("Autopilot.TenantDownloadDialogMessage"),
+                    Text = message,
                     TextWrapping = TextWrapping.Wrap,
                     TextAlignment = TextAlignment.Center
                 }
@@ -96,11 +126,11 @@ public sealed class AutopilotTenantDownloadDialogService(
         };
     }
 
-    private static async Task ObserveDownloadTaskAsync(Task<IReadOnlyList<AutopilotProfileSettings>> downloadTask)
+    private static async Task ObserveTaskAsync<TResult>(Task<TResult> task)
     {
         try
         {
-            await downloadTask.ConfigureAwait(false);
+            await task.ConfigureAwait(false);
         }
         catch
         {

--- a/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingResult.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingResult.cs
@@ -19,6 +19,11 @@ public sealed record AutopilotTenantOnboardingResult
     public AutopilotTenantOnboardingStatus Status { get; init; }
 
     /// <summary>
+    /// Gets the app registration certificate credentials discovered from Microsoft Graph.
+    /// </summary>
+    public IReadOnlyList<AutopilotGraphKeyCredential> Certificates { get; init; } = [];
+
+    /// <summary>
     /// Gets a non-sensitive status message suitable for logs and UI.
     /// </summary>
     public string Message { get; init; } = string.Empty;

--- a/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingResult.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingResult.cs
@@ -22,9 +22,4 @@ public sealed record AutopilotTenantOnboardingResult
     /// Gets the app registration certificate credentials discovered from Microsoft Graph.
     /// </summary>
     public IReadOnlyList<AutopilotGraphKeyCredential> Certificates { get; init; } = [];
-
-    /// <summary>
-    /// Gets a non-sensitive status message suitable for logs and UI.
-    /// </summary>
-    public string Message { get; init; } = string.Empty;
 }

--- a/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingResult.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingResult.cs
@@ -1,0 +1,25 @@
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Autopilot;
+
+namespace Foundry.Services.Autopilot;
+
+/// <summary>
+/// Represents the result of a tenant onboarding pass for the managed Autopilot app registration.
+/// </summary>
+public sealed record AutopilotTenantOnboardingResult
+{
+    /// <summary>
+    /// Gets the updated persistent settings.
+    /// </summary>
+    public AutopilotHardwareHashUploadSettings Settings { get; init; } = new();
+
+    /// <summary>
+    /// Gets the evaluated tenant registration status after Graph discovery and repair.
+    /// </summary>
+    public AutopilotTenantOnboardingStatus Status { get; init; }
+
+    /// <summary>
+    /// Gets a non-sensitive status message suitable for logs and UI.
+    /// </summary>
+    public string Message { get; init; } = string.Empty;
+}

--- a/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
@@ -911,12 +911,13 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
 
     private static string? ResolveDefaultGroupTag(string? currentDefaultGroupTag, string[] groupTags)
     {
-        if (!string.IsNullOrWhiteSpace(currentDefaultGroupTag))
+        if (!string.IsNullOrWhiteSpace(currentDefaultGroupTag) &&
+            groupTags.Contains(currentDefaultGroupTag.Trim(), StringComparer.OrdinalIgnoreCase))
         {
             return currentDefaultGroupTag.Trim();
         }
 
-        return groupTags.FirstOrDefault();
+        return null;
     }
 
     private static string CreateKeyCredentialJson(

--- a/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
@@ -101,6 +101,8 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
             cancellationToken).ConfigureAwait(false);
 
         string[] groupTags = await TryGetGroupTagsAsync(accessToken, cancellationToken).ConfigureAwait(false);
+        IReadOnlyList<AutopilotGraphKeyCredential> keyCredentials =
+            await GetApplicationKeyCredentialsAsync(accessToken, application.ObjectId, cancellationToken).ConfigureAwait(false);
         AutopilotTenantOnboardingSnapshot snapshot = new()
         {
             TenantId = tenantId,
@@ -109,7 +111,7 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
             Applications = [application],
             ServicePrincipal = servicePrincipal,
             ActiveCertificate = currentSettings.ActiveCertificate,
-            KeyCredentials = await GetApplicationKeyCredentialsAsync(accessToken, application.ObjectId, cancellationToken).ConfigureAwait(false),
+            KeyCredentials = keyCredentials,
             CurrentTimeUtc = DateTimeOffset.UtcNow
         };
         AutopilotTenantOnboardingEvaluation evaluation = AutopilotTenantOnboardingEvaluator.Evaluate(snapshot);
@@ -130,6 +132,7 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
         {
             Settings = updatedSettings,
             Status = evaluation.Status,
+            Certificates = keyCredentials,
             Message = evaluation.Status == AutopilotTenantOnboardingStatus.Ready
                 ? "The managed app registration is ready."
                 : $"The managed app registration requires attention: {evaluation.Status}."
@@ -200,24 +203,35 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
             ExpiresOnUtc = expiresOnUtc
         };
 
+        IReadOnlyList<AutopilotGraphKeyCredential> keyCredentials = await GetApplicationKeyCredentialsAsync(
+            accessToken,
+            currentSettings.Tenant.ApplicationObjectId,
+            cancellationToken).ConfigureAwait(false);
+
         return new AutopilotCertificateCreationResult
         {
             Settings = currentSettings with { ActiveCertificate = metadata },
             GeneratedPassword = password,
-            Certificate = metadata
+            Certificate = metadata,
+            Certificates = keyCredentials
         };
     }
 
     /// <inheritdoc />
-    public async Task<AutopilotHardwareHashUploadSettings> RetireActiveCertificateAsync(
+    public async Task<AutopilotCertificateRemovalResult> RemoveCertificateAsync(
         AutopilotHardwareHashUploadSettings currentSettings,
+        string certificateKeyId,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(currentSettings);
-        if (string.IsNullOrWhiteSpace(currentSettings.Tenant.ApplicationObjectId) ||
-            string.IsNullOrWhiteSpace(currentSettings.ActiveCertificate?.KeyId))
+        ArgumentException.ThrowIfNullOrWhiteSpace(certificateKeyId);
+
+        if (string.IsNullOrWhiteSpace(currentSettings.Tenant.ApplicationObjectId))
         {
-            return currentSettings with { ActiveCertificate = null };
+            return new AutopilotCertificateRemovalResult
+            {
+                Settings = currentSettings with { ActiveCertificate = null }
+            };
         }
 
         TokenCredential credential = CreateCredential();
@@ -225,9 +239,24 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
         await RemoveKeyCredentialAsync(
             accessToken,
             currentSettings.Tenant.ApplicationObjectId,
-            currentSettings.ActiveCertificate.KeyId,
+            certificateKeyId,
             cancellationToken).ConfigureAwait(false);
-        return currentSettings with { ActiveCertificate = null };
+        AutopilotHardwareHashUploadSettings updatedSettings = string.Equals(
+            currentSettings.ActiveCertificate?.KeyId,
+            certificateKeyId,
+            StringComparison.OrdinalIgnoreCase)
+            ? currentSettings with { ActiveCertificate = null }
+            : currentSettings;
+        IReadOnlyList<AutopilotGraphKeyCredential> keyCredentials = await GetApplicationKeyCredentialsAsync(
+            accessToken,
+            currentSettings.Tenant.ApplicationObjectId,
+            cancellationToken).ConfigureAwait(false);
+
+        return new AutopilotCertificateRemovalResult
+        {
+            Settings = updatedSettings,
+            Certificates = keyCredentials
+        };
     }
 
     private static TokenCredential CreateCredential()

--- a/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
@@ -105,12 +105,11 @@ public sealed class AutopilotTenantOnboardingService(
                 CurrentTimeUtc = DateTimeOffset.UtcNow
             };
             AutopilotTenantOnboardingEvaluation evaluation = AutopilotTenantOnboardingEvaluator.Evaluate(snapshot);
-            AutopilotCertificateMetadata? activeCertificate = evaluation.Status == AutopilotTenantOnboardingStatus.ActiveCertificateNotFound
-                ? null
-                : currentSettings.ActiveCertificate;
-            AutopilotTenantOnboardingStatus status = evaluation.Status == AutopilotTenantOnboardingStatus.ActiveCertificateNotFound
-                ? AutopilotTenantOnboardingStatus.ActiveCertificateMissing
-                : evaluation.Status;
+            AutopilotCertificateMetadata? activeCertificate = IsPersistedActiveCertificateResolved(
+                currentSettings.ActiveCertificate,
+                evaluation.ActiveCertificateCredential)
+                ? currentSettings.ActiveCertificate
+                : null;
 
             AutopilotHardwareHashUploadSettings updatedSettings = currentSettings with
             {
@@ -129,11 +128,11 @@ public sealed class AutopilotTenantOnboardingService(
             return new AutopilotTenantOnboardingResult
             {
                 Settings = updatedSettings,
-                Status = status,
+                Status = evaluation.Status,
                 Certificates = keyCredentials,
-                Message = status == AutopilotTenantOnboardingStatus.Ready
+                Message = evaluation.Status == AutopilotTenantOnboardingStatus.Ready
                     ? "The managed app registration is ready."
-                    : $"The managed app registration requires attention: {status}."
+                    : $"The managed app registration requires attention: {evaluation.Status}."
             };
         }
         catch
@@ -259,6 +258,25 @@ public sealed class AutopilotTenantOnboardingService(
             Settings = updatedSettings,
             Certificates = keyCredentials
         };
+    }
+
+    private static bool IsPersistedActiveCertificateResolved(
+        AutopilotCertificateMetadata? activeCertificate,
+        AutopilotGraphKeyCredential? resolvedCredential)
+    {
+        return activeCertificate is not null &&
+               resolvedCredential is not null &&
+               string.Equals(activeCertificate.KeyId, resolvedCredential.KeyId, StringComparison.OrdinalIgnoreCase) &&
+               string.Equals(
+                   NormalizeThumbprint(activeCertificate.Thumbprint),
+                   NormalizeThumbprint(resolvedCredential.Thumbprint),
+                   StringComparison.Ordinal);
+    }
+
+    private static string? NormalizeThumbprint(string? thumbprint)
+    {
+        string? normalized = thumbprint?.Replace(" ", string.Empty, StringComparison.Ordinal).Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized.ToUpperInvariant();
     }
 
     private static async Task<string> GetTenantIdAsync(string accessToken, CancellationToken cancellationToken)

--- a/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
@@ -99,7 +99,7 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
             requiredRole,
             cancellationToken).ConfigureAwait(false);
 
-        string[] groupTags = await GetGroupTagsAsync(accessToken, cancellationToken).ConfigureAwait(false);
+        string[] groupTags = await TryGetGroupTagsAsync(accessToken, cancellationToken).ConfigureAwait(false);
         AutopilotTenantOnboardingSnapshot snapshot = new()
         {
             TenantId = tenantId,
@@ -662,6 +662,21 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
             $"v1.0/applications/{applicationObjectId}",
             body,
             cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<string[]> TryGetGroupTagsAsync(string accessToken, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await GetGroupTagsAsync(accessToken, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.Warning(
+                "Autopilot group tag discovery failed and will be skipped. StatusCode={StatusCode}",
+                ex.StatusCode);
+            return [];
+        }
     }
 
     private static async Task<string[]> GetGroupTagsAsync(string accessToken, CancellationToken cancellationToken)

--- a/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
@@ -27,7 +27,7 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
     private const string OrganizationRequestPath = "v1.0/organization?$select=id";
     private const string ApplicationSelect = "$select=id,appId,displayName,requiredResourceAccess,keyCredentials";
     private const string ServicePrincipalSelect = "$select=id,appId,accountEnabled";
-    private const string GroupTagRequestPath = "v1.0/deviceManagement/windowsAutopilotDeviceIdentities?$select=groupTag";
+    private const string GroupTagRequestPath = "v1.0/deviceManagement/windowsAutopilotDeviceIdentities";
     private const int MaximumCertificateValidityMonths = 12;
 
     private static readonly string[] GraphScopes =

--- a/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
@@ -1,0 +1,893 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Text.Json;
+using Azure.Core;
+using Azure.Identity;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Autopilot;
+using Serilog;
+
+namespace Foundry.Services.Autopilot;
+
+/// <summary>
+/// Performs interactive Microsoft Graph tenant onboarding for Autopilot hardware hash upload.
+/// </summary>
+public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilotTenantOnboardingService
+{
+    private const string DefaultClientId = "83eb3a92-030d-49b7-881b-32a1eb3e110a";
+    private const string ClientIdEnvironmentVariableName = "FOUNDRY_AUTOPILOT_GRAPH_CLIENT_ID";
+    private const string TenantIdEnvironmentVariableName = "FOUNDRY_AUTOPILOT_GRAPH_TENANT_ID";
+    private const string DefaultTenantId = "common";
+    private const string DefaultRedirectUri = "http://localhost";
+    private const string GraphAppId = "00000003-0000-0000-c000-000000000000";
+    private const string OrganizationRequestPath = "v1.0/organization?$select=id";
+    private const string ApplicationSelect = "$select=id,appId,displayName,requiredResourceAccess,keyCredentials";
+    private const string ServicePrincipalSelect = "$select=id,appId,accountEnabled";
+    private const string GroupTagRequestPath = "v1.0/deviceManagement/windowsAutopilotDeviceIdentities?$select=groupTag";
+
+    private static readonly string[] GraphScopes =
+    [
+        "Application.ReadWrite.All",
+        "AppRoleAssignment.ReadWrite.All",
+        "DeviceManagementServiceConfig.Read.All"
+    ];
+
+    private static readonly HttpClient GraphHttpClient = new()
+    {
+        BaseAddress = new Uri("https://graph.microsoft.com/", UriKind.Absolute)
+    };
+
+    private readonly ILogger logger = logger.ForContext<AutopilotTenantOnboardingService>();
+
+    /// <inheritdoc />
+    public async Task<AutopilotTenantOnboardingResult> ConnectAsync(
+        AutopilotHardwareHashUploadSettings currentSettings,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(currentSettings);
+
+        TokenCredential credential = CreateCredential();
+        string accessToken = await AcquireAccessTokenAsync(credential, cancellationToken).ConfigureAwait(false);
+        string tenantId = await GetTenantIdAsync(accessToken, cancellationToken).ConfigureAwait(false);
+        GraphAppRole requiredRole = await GetGraphAppRoleAsync(
+            accessToken,
+            AutopilotGraphPermissionCatalog.DeviceManagementServiceConfigReadWriteAll,
+            cancellationToken).ConfigureAwait(false);
+
+        AutopilotGraphApplication? application = await FindApplicationAsync(
+            accessToken,
+            currentSettings.Tenant.ApplicationObjectId,
+            requiredRole,
+            cancellationToken).ConfigureAwait(false);
+        application ??= await FindApplicationByDisplayNameAsync(accessToken, requiredRole, cancellationToken).ConfigureAwait(false);
+
+        if (application is null)
+        {
+            application = await CreateApplicationAsync(accessToken, requiredRole, cancellationToken).ConfigureAwait(false);
+            logger.Information("Created managed Autopilot app registration. ApplicationObjectId={ApplicationObjectId}", application.ObjectId);
+        }
+        else if (string.IsNullOrWhiteSpace(currentSettings.Tenant.ApplicationObjectId) &&
+                 string.Equals(application.DisplayName, AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName, StringComparison.OrdinalIgnoreCase))
+        {
+            logger.Information("Adopted existing managed Autopilot app registration. ApplicationObjectId={ApplicationObjectId}", application.ObjectId);
+        }
+
+        application = await EnsureRequiredApplicationPermissionAsync(
+            accessToken,
+            application,
+            requiredRole,
+            cancellationToken).ConfigureAwait(false);
+
+        AutopilotGraphServicePrincipal? servicePrincipal = await FindServicePrincipalAsync(
+            accessToken,
+            application.ClientId,
+            requiredRole,
+            cancellationToken).ConfigureAwait(false);
+        servicePrincipal ??= await CreateServicePrincipalAsync(
+            accessToken,
+            application.ClientId,
+            requiredRole,
+            cancellationToken).ConfigureAwait(false);
+
+        servicePrincipal = await EnsureAdminConsentAsync(
+            accessToken,
+            servicePrincipal,
+            requiredRole,
+            cancellationToken).ConfigureAwait(false);
+
+        string[] groupTags = await GetGroupTagsAsync(accessToken, cancellationToken).ConfigureAwait(false);
+        AutopilotTenantOnboardingSnapshot snapshot = new()
+        {
+            TenantId = tenantId,
+            PersistedApplicationObjectId = application.ObjectId,
+            ManagedAppDisplayName = AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName,
+            Applications = [application],
+            ServicePrincipal = servicePrincipal,
+            ActiveCertificate = currentSettings.ActiveCertificate,
+            KeyCredentials = await GetApplicationKeyCredentialsAsync(accessToken, application.ObjectId, cancellationToken).ConfigureAwait(false),
+            CurrentTimeUtc = DateTimeOffset.UtcNow
+        };
+        AutopilotTenantOnboardingEvaluation evaluation = AutopilotTenantOnboardingEvaluator.Evaluate(snapshot);
+        AutopilotHardwareHashUploadSettings updatedSettings = currentSettings with
+        {
+            Tenant = new AutopilotTenantRegistrationSettings
+            {
+                TenantId = tenantId,
+                ApplicationObjectId = application.ObjectId,
+                ClientId = application.ClientId,
+                ServicePrincipalObjectId = servicePrincipal.ObjectId
+            },
+            KnownGroupTags = groupTags,
+            DefaultGroupTag = ResolveDefaultGroupTag(currentSettings.DefaultGroupTag, groupTags)
+        };
+
+        return new AutopilotTenantOnboardingResult
+        {
+            Settings = updatedSettings,
+            Status = evaluation.Status,
+            Message = evaluation.Status == AutopilotTenantOnboardingStatus.Ready
+                ? "The managed app registration is ready."
+                : $"The managed app registration requires attention: {evaluation.Status}."
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<AutopilotCertificateCreationResult> CreateCertificateAsync(
+        AutopilotHardwareHashUploadSettings currentSettings,
+        string pfxOutputPath,
+        int validityMonths,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(currentSettings);
+        ArgumentException.ThrowIfNullOrWhiteSpace(pfxOutputPath);
+
+        if (string.IsNullOrWhiteSpace(currentSettings.Tenant.ApplicationObjectId))
+        {
+            throw new InvalidOperationException("The managed app registration must be connected before creating a certificate.");
+        }
+
+        TokenCredential credential = CreateCredential();
+        string accessToken = await AcquireAccessTokenAsync(credential, cancellationToken).ConfigureAwait(false);
+        DateTimeOffset startsOnUtc = DateTimeOffset.UtcNow.AddMinutes(-5);
+        DateTimeOffset expiresOnUtc = DateTimeOffset.UtcNow.AddMonths(validityMonths);
+        string keyId = Guid.NewGuid().ToString("D");
+        string password = GeneratePfxPassword();
+
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            $"CN={AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName}",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        using X509Certificate2 certificate = request.CreateSelfSigned(startsOnUtc, expiresOnUtc);
+        byte[] pfxBytes = certificate.Export(X509ContentType.Pfx, password);
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(pfxOutputPath))!);
+            await File.WriteAllBytesAsync(pfxOutputPath, pfxBytes, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(pfxBytes);
+        }
+
+        string newCredentialJson = CreateKeyCredentialJson(keyId, certificate, startsOnUtc, expiresOnUtc);
+        await ReplaceActiveKeyCredentialAsync(
+            accessToken,
+            currentSettings.Tenant.ApplicationObjectId,
+            newCredentialJson,
+            currentSettings.ActiveCertificate?.KeyId,
+            cancellationToken).ConfigureAwait(false);
+
+        var metadata = new AutopilotCertificateMetadata
+        {
+            KeyId = keyId,
+            Thumbprint = certificate.Thumbprint?.ToUpperInvariant(),
+            DisplayName = AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName,
+            ExpiresOnUtc = expiresOnUtc
+        };
+
+        return new AutopilotCertificateCreationResult
+        {
+            Settings = currentSettings with { ActiveCertificate = metadata },
+            GeneratedPassword = password,
+            Certificate = metadata
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<AutopilotHardwareHashUploadSettings> RetireActiveCertificateAsync(
+        AutopilotHardwareHashUploadSettings currentSettings,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(currentSettings);
+        if (string.IsNullOrWhiteSpace(currentSettings.Tenant.ApplicationObjectId) ||
+            string.IsNullOrWhiteSpace(currentSettings.ActiveCertificate?.KeyId))
+        {
+            return currentSettings with { ActiveCertificate = null };
+        }
+
+        TokenCredential credential = CreateCredential();
+        string accessToken = await AcquireAccessTokenAsync(credential, cancellationToken).ConfigureAwait(false);
+        await RemoveKeyCredentialAsync(
+            accessToken,
+            currentSettings.Tenant.ApplicationObjectId,
+            currentSettings.ActiveCertificate.KeyId,
+            cancellationToken).ConfigureAwait(false);
+        return currentSettings with { ActiveCertificate = null };
+    }
+
+    private static TokenCredential CreateCredential()
+    {
+        string clientId = Environment.GetEnvironmentVariable(ClientIdEnvironmentVariableName)?.Trim()
+            ?? DefaultClientId;
+        string? tenantId = Environment.GetEnvironmentVariable(TenantIdEnvironmentVariableName);
+
+        return new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
+        {
+            ClientId = clientId,
+            TenantId = string.IsNullOrWhiteSpace(tenantId) ? DefaultTenantId : tenantId.Trim(),
+            RedirectUri = new Uri(DefaultRedirectUri, UriKind.Absolute),
+            TokenCachePersistenceOptions = new TokenCachePersistenceOptions
+            {
+                Name = "FoundryAutopilotGraph"
+            }
+        });
+    }
+
+    private static async Task<string> AcquireAccessTokenAsync(TokenCredential credential, CancellationToken cancellationToken)
+    {
+        AccessToken accessToken = await credential.GetTokenAsync(new TokenRequestContext(GraphScopes), cancellationToken)
+            .ConfigureAwait(false);
+        return accessToken.Token;
+    }
+
+    private static async Task<string> GetTenantIdAsync(string accessToken, CancellationToken cancellationToken)
+    {
+        using JsonDocument document = await SendGraphRequestAsync(
+            accessToken,
+            HttpMethod.Get,
+            OrganizationRequestPath,
+            null,
+            cancellationToken).ConfigureAwait(false);
+        JsonElement organization = document.RootElement.GetProperty("value").EnumerateArray().FirstOrDefault();
+        return organization.GetProperty("id").GetString()
+               ?? throw new InvalidOperationException("Microsoft Graph did not return a tenant ID.");
+    }
+
+    private static async Task<GraphAppRole> GetGraphAppRoleAsync(
+        string accessToken,
+        string roleValue,
+        CancellationToken cancellationToken)
+    {
+        string requestPath = $"v1.0/servicePrincipals?$filter=appId eq '{GraphAppId}'&$select=id,appRoles";
+        using JsonDocument document = await SendGraphRequestAsync(
+            accessToken,
+            HttpMethod.Get,
+            requestPath,
+            null,
+            cancellationToken).ConfigureAwait(false);
+        JsonElement graphServicePrincipal = document.RootElement.GetProperty("value").EnumerateArray().FirstOrDefault();
+        string graphServicePrincipalId = graphServicePrincipal.GetProperty("id").GetString()
+            ?? throw new InvalidOperationException("Microsoft Graph service principal ID was not returned.");
+
+        foreach (JsonElement appRole in graphServicePrincipal.GetProperty("appRoles").EnumerateArray())
+        {
+            if (appRole.TryGetProperty("value", out JsonElement value) &&
+                string.Equals(value.GetString(), roleValue, StringComparison.OrdinalIgnoreCase) &&
+                appRole.TryGetProperty("id", out JsonElement id))
+            {
+                return new GraphAppRole(graphServicePrincipalId, id.GetString()!, roleValue);
+            }
+        }
+
+        throw new InvalidOperationException($"Microsoft Graph app role '{roleValue}' was not found.");
+    }
+
+    private static async Task<AutopilotGraphApplication?> FindApplicationAsync(
+        string accessToken,
+        string? applicationObjectId,
+        GraphAppRole requiredRole,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(applicationObjectId))
+        {
+            return null;
+        }
+
+        try
+        {
+            using JsonDocument document = await SendGraphRequestAsync(
+                accessToken,
+                HttpMethod.Get,
+                $"v1.0/applications/{applicationObjectId}?{ApplicationSelect}",
+                null,
+                cancellationToken).ConfigureAwait(false);
+            return ParseApplication(document.RootElement, requiredRole);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    private static async Task<AutopilotGraphApplication?> FindApplicationByDisplayNameAsync(
+        string accessToken,
+        GraphAppRole requiredRole,
+        CancellationToken cancellationToken)
+    {
+        string displayName = AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName.Replace("'", "''", StringComparison.Ordinal);
+        using JsonDocument document = await SendGraphRequestAsync(
+            accessToken,
+            HttpMethod.Get,
+            $"v1.0/applications?$filter=displayName eq '{displayName}'&{ApplicationSelect}",
+            null,
+            cancellationToken).ConfigureAwait(false);
+        JsonElement application = document.RootElement.GetProperty("value").EnumerateArray().FirstOrDefault();
+        return application.ValueKind == JsonValueKind.Undefined ? null : ParseApplication(application, requiredRole);
+    }
+
+    private static async Task<AutopilotGraphApplication> CreateApplicationAsync(
+        string accessToken,
+        GraphAppRole requiredRole,
+        CancellationToken cancellationToken)
+    {
+        string body = $$"""
+            {
+              "displayName": "{{AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName}}",
+              "signInAudience": "AzureADMyOrg",
+              "requiredResourceAccess": [
+                {
+                  "resourceAppId": "{{GraphAppId}}",
+                  "resourceAccess": [
+                    {
+                      "id": "{{requiredRole.AppRoleId}}",
+                      "type": "Role"
+                    }
+                  ]
+                }
+              ]
+            }
+            """;
+
+        using JsonDocument document = await SendGraphRequestAsync(
+            accessToken,
+            HttpMethod.Post,
+            "v1.0/applications",
+            body,
+            cancellationToken).ConfigureAwait(false);
+        return ParseApplication(document.RootElement, requiredRole);
+    }
+
+    private static async Task<AutopilotGraphApplication> EnsureRequiredApplicationPermissionAsync(
+        string accessToken,
+        AutopilotGraphApplication application,
+        GraphAppRole requiredRole,
+        CancellationToken cancellationToken)
+    {
+        if (application.RequiredPermissionValues.Contains(requiredRole.Value))
+        {
+            return application;
+        }
+
+        string body = await CreateRequiredResourceAccessPatchBodyAsync(
+            accessToken,
+            application.ObjectId,
+            requiredRole,
+            cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await SendGraphNoContentAsync(
+                accessToken,
+                HttpMethod.Patch,
+                $"v1.0/applications/{application.ObjectId}",
+                body,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized)
+        {
+            return application;
+        }
+
+        return application with
+        {
+            RequiredPermissionValues = AutopilotGraphPermissionCatalog.RequiredWinPeApplicationPermissionValues
+        };
+    }
+
+    private static async Task<string> CreateRequiredResourceAccessPatchBodyAsync(
+        string accessToken,
+        string applicationObjectId,
+        GraphAppRole requiredRole,
+        CancellationToken cancellationToken)
+    {
+        using JsonDocument document = await SendGraphRequestAsync(
+            accessToken,
+            HttpMethod.Get,
+            $"v1.0/applications/{applicationObjectId}?$select=requiredResourceAccess",
+            null,
+            cancellationToken).ConfigureAwait(false);
+
+        List<string> resources = [];
+        bool graphResourceFound = false;
+        if (document.RootElement.TryGetProperty("requiredResourceAccess", out JsonElement requiredResourceAccess))
+        {
+            foreach (JsonElement resource in requiredResourceAccess.EnumerateArray())
+            {
+                string? resourceAppId = resource.TryGetProperty("resourceAppId", out JsonElement resourceAppIdElement)
+                    ? resourceAppIdElement.GetString()
+                    : null;
+                if (!string.Equals(resourceAppId, GraphAppId, StringComparison.OrdinalIgnoreCase))
+                {
+                    resources.Add(resource.GetRawText());
+                    continue;
+                }
+
+                graphResourceFound = true;
+                string resourceAccessJson = CreateResourceAccessJson(resource, requiredRole);
+                resources.Add($$"""
+                    {
+                      "resourceAppId": "{{GraphAppId}}",
+                      "resourceAccess": [
+                        {{resourceAccessJson}}
+                      ]
+                    }
+                    """);
+            }
+        }
+
+        if (!graphResourceFound)
+        {
+            resources.Add(CreateRequiredGraphResourceAccessJson(requiredRole));
+        }
+
+        return $$"""
+            {
+              "requiredResourceAccess": [
+                {{string.Join(",", resources)}}
+              ]
+            }
+            """;
+    }
+
+    private static string CreateResourceAccessJson(JsonElement graphResource, GraphAppRole requiredRole)
+    {
+        List<string> resourceAccess = graphResource.TryGetProperty("resourceAccess", out JsonElement resourceAccessElement)
+            ? resourceAccessElement.EnumerateArray().Select(access => access.GetRawText()).ToList()
+            : [];
+        bool roleExists = resourceAccessElement.ValueKind == JsonValueKind.Array &&
+                          resourceAccessElement.EnumerateArray().Any(access =>
+                              access.TryGetProperty("id", out JsonElement id) &&
+                              string.Equals(id.GetString(), requiredRole.AppRoleId, StringComparison.OrdinalIgnoreCase));
+        if (!roleExists)
+        {
+            resourceAccess.Add(CreateRequiredResourceAccessEntryJson(requiredRole));
+        }
+
+        return string.Join(",", resourceAccess);
+    }
+
+    private static string CreateRequiredGraphResourceAccessJson(GraphAppRole requiredRole)
+    {
+        string resourceAccessJson = CreateRequiredResourceAccessEntryJson(requiredRole);
+        return $$"""
+            {
+              "resourceAppId": "{{GraphAppId}}",
+              "resourceAccess": [
+                {{resourceAccessJson}}
+              ]
+            }
+            """;
+    }
+
+    private static string CreateRequiredResourceAccessEntryJson(GraphAppRole requiredRole)
+    {
+        return $$"""
+            {
+              "id": "{{requiredRole.AppRoleId}}",
+              "type": "Role"
+            }
+            """;
+    }
+
+    private static async Task<AutopilotGraphServicePrincipal?> FindServicePrincipalAsync(
+        string accessToken,
+        string clientId,
+        GraphAppRole requiredRole,
+        CancellationToken cancellationToken)
+    {
+        using JsonDocument document = await SendGraphRequestAsync(
+            accessToken,
+            HttpMethod.Get,
+            $"v1.0/servicePrincipals?$filter=appId eq '{clientId}'&{ServicePrincipalSelect}",
+            null,
+            cancellationToken).ConfigureAwait(false);
+        JsonElement servicePrincipal = document.RootElement.GetProperty("value").EnumerateArray().FirstOrDefault();
+        if (servicePrincipal.ValueKind == JsonValueKind.Undefined)
+        {
+            return null;
+        }
+
+        return await ParseServicePrincipalAsync(accessToken, servicePrincipal, requiredRole, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<AutopilotGraphServicePrincipal> CreateServicePrincipalAsync(
+        string accessToken,
+        string clientId,
+        GraphAppRole requiredRole,
+        CancellationToken cancellationToken)
+    {
+        string body = $$"""
+            {
+              "appId": "{{clientId}}"
+            }
+            """;
+        using JsonDocument document = await SendGraphRequestAsync(
+            accessToken,
+            HttpMethod.Post,
+            "v1.0/servicePrincipals",
+            body,
+            cancellationToken).ConfigureAwait(false);
+        return await ParseServicePrincipalAsync(accessToken, document.RootElement, requiredRole, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<AutopilotGraphServicePrincipal> EnsureAdminConsentAsync(
+        string accessToken,
+        AutopilotGraphServicePrincipal servicePrincipal,
+        GraphAppRole requiredRole,
+        CancellationToken cancellationToken)
+    {
+        if (servicePrincipal.ConsentedPermissionValues.Contains(requiredRole.Value))
+        {
+            return servicePrincipal;
+        }
+
+        string body = $$"""
+            {
+              "principalId": "{{servicePrincipal.ObjectId}}",
+              "resourceId": "{{requiredRole.ResourceServicePrincipalId}}",
+              "appRoleId": "{{requiredRole.AppRoleId}}"
+            }
+            """;
+        try
+        {
+            await SendGraphNoContentAsync(
+                accessToken,
+                HttpMethod.Post,
+                $"v1.0/servicePrincipals/{servicePrincipal.ObjectId}/appRoleAssignments",
+                body,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized)
+        {
+            return servicePrincipal;
+        }
+
+        return servicePrincipal with
+        {
+            ConsentedPermissionValues = AutopilotGraphPermissionCatalog.RequiredWinPeApplicationPermissionValues
+        };
+    }
+
+    private static async Task<IReadOnlyList<AutopilotGraphKeyCredential>> GetApplicationKeyCredentialsAsync(
+        string accessToken,
+        string applicationObjectId,
+        CancellationToken cancellationToken)
+    {
+        using JsonDocument document = await SendGraphRequestAsync(
+            accessToken,
+            HttpMethod.Get,
+            $"v1.0/applications/{applicationObjectId}?$select=keyCredentials",
+            null,
+            cancellationToken).ConfigureAwait(false);
+        return ParseKeyCredentials(document.RootElement);
+    }
+
+    private static async Task ReplaceActiveKeyCredentialAsync(
+        string accessToken,
+        string applicationObjectId,
+        string newCredentialJson,
+        string? activeKeyIdToReplace,
+        CancellationToken cancellationToken)
+    {
+        using JsonDocument document = await SendGraphRequestAsync(
+            accessToken,
+            HttpMethod.Get,
+            $"v1.0/applications/{applicationObjectId}?$select=keyCredentials",
+            null,
+            cancellationToken).ConfigureAwait(false);
+
+        string existingCredentialsJson = document.RootElement.TryGetProperty("keyCredentials", out JsonElement keyCredentials)
+            ? string.Join(
+                ",",
+                keyCredentials.EnumerateArray().Where(credential =>
+                    string.IsNullOrWhiteSpace(activeKeyIdToReplace) ||
+                    !credential.TryGetProperty("keyId", out JsonElement existingKeyId) ||
+                    !string.Equals(existingKeyId.GetString(), activeKeyIdToReplace, StringComparison.OrdinalIgnoreCase))
+                    .Select(credential => credential.GetRawText()))
+            : string.Empty;
+        string separator = string.IsNullOrWhiteSpace(existingCredentialsJson) ? string.Empty : ",";
+        string body = $$"""
+            {
+              "keyCredentials": [
+                {{existingCredentialsJson}}{{separator}}{{newCredentialJson}}
+              ]
+            }
+            """;
+
+        await SendGraphNoContentAsync(
+            accessToken,
+            HttpMethod.Patch,
+            $"v1.0/applications/{applicationObjectId}",
+            body,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task RemoveKeyCredentialAsync(
+        string accessToken,
+        string applicationObjectId,
+        string keyId,
+        CancellationToken cancellationToken)
+    {
+        using JsonDocument document = await SendGraphRequestAsync(
+            accessToken,
+            HttpMethod.Get,
+            $"v1.0/applications/{applicationObjectId}?$select=keyCredentials",
+            null,
+            cancellationToken).ConfigureAwait(false);
+
+        string retainedCredentialsJson = document.RootElement.TryGetProperty("keyCredentials", out JsonElement keyCredentials)
+            ? string.Join(
+                ",",
+                keyCredentials.EnumerateArray().Where(credential =>
+                    !credential.TryGetProperty("keyId", out JsonElement existingKeyId) ||
+                    !string.Equals(existingKeyId.GetString(), keyId, StringComparison.OrdinalIgnoreCase))
+                    .Select(credential => credential.GetRawText()))
+            : string.Empty;
+        string body = $$"""
+            {
+              "keyCredentials": [
+                {{retainedCredentialsJson}}
+              ]
+            }
+            """;
+
+        await SendGraphNoContentAsync(
+            accessToken,
+            HttpMethod.Patch,
+            $"v1.0/applications/{applicationObjectId}",
+            body,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<string[]> GetGroupTagsAsync(string accessToken, CancellationToken cancellationToken)
+    {
+        List<string> groupTags = [];
+        string? requestPath = GroupTagRequestPath;
+        while (!string.IsNullOrWhiteSpace(requestPath))
+        {
+            using JsonDocument document = await SendGraphRequestAsync(
+                accessToken,
+                HttpMethod.Get,
+                requestPath,
+                null,
+                cancellationToken).ConfigureAwait(false);
+
+            foreach (JsonElement item in document.RootElement.GetProperty("value").EnumerateArray())
+            {
+                if (item.TryGetProperty("groupTag", out JsonElement groupTag) &&
+                    groupTag.GetString()?.Trim() is { Length: > 0 } value)
+                {
+                    groupTags.Add(value);
+                }
+            }
+
+            requestPath = document.RootElement.TryGetProperty("@odata.nextLink", out JsonElement nextLink)
+                ? nextLink.GetString()
+                : null;
+        }
+
+        return groupTags
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(groupTag => groupTag, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static async Task<JsonDocument> SendGraphRequestAsync(
+        string accessToken,
+        HttpMethod method,
+        string requestPath,
+        string? jsonBody,
+        CancellationToken cancellationToken)
+    {
+        using HttpResponseMessage response = await SendGraphRawAsync(
+            accessToken,
+            method,
+            requestPath,
+            jsonBody,
+            cancellationToken).ConfigureAwait(false);
+        string responseBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        return JsonDocument.Parse(responseBody);
+    }
+
+    private static async Task SendGraphNoContentAsync(
+        string accessToken,
+        HttpMethod method,
+        string requestPath,
+        string? jsonBody,
+        CancellationToken cancellationToken)
+    {
+        using HttpResponseMessage response = await SendGraphRawAsync(
+            accessToken,
+            method,
+            requestPath,
+            jsonBody,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<HttpResponseMessage> SendGraphRawAsync(
+        string accessToken,
+        HttpMethod method,
+        string requestPath,
+        string? jsonBody,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(method, requestPath);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        if (jsonBody is not null)
+        {
+            request.Content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+        }
+
+        HttpResponseMessage response = await GraphHttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            string message = $"Microsoft Graph request failed for '{method} {requestPath}' with status code {(int)response.StatusCode}.";
+            throw new HttpRequestException(message, null, response.StatusCode);
+        }
+
+        return response;
+    }
+
+    private static AutopilotGraphApplication ParseApplication(JsonElement application, GraphAppRole requiredRole)
+    {
+        string objectId = application.GetProperty("id").GetString()
+            ?? throw new InvalidOperationException("Application object ID was not returned.");
+        string clientId = application.GetProperty("appId").GetString()
+            ?? throw new InvalidOperationException("Application client ID was not returned.");
+        string displayName = application.GetProperty("displayName").GetString() ?? string.Empty;
+        HashSet<string> requiredPermissionValues = new(StringComparer.OrdinalIgnoreCase);
+
+        if (application.TryGetProperty("requiredResourceAccess", out JsonElement requiredResourceAccess))
+        {
+            foreach (JsonElement resourceAccess in requiredResourceAccess.EnumerateArray())
+            {
+                if (resourceAccess.TryGetProperty("resourceAccess", out JsonElement permissions))
+                {
+                    foreach (JsonElement permission in permissions.EnumerateArray())
+                    {
+                        if (permission.TryGetProperty("id", out JsonElement id) &&
+                            string.Equals(id.GetString(), requiredRole.AppRoleId, StringComparison.OrdinalIgnoreCase))
+                        {
+                            requiredPermissionValues.Add(requiredRole.Value);
+                        }
+                    }
+                }
+            }
+        }
+
+        return new AutopilotGraphApplication(objectId, clientId, displayName, requiredPermissionValues);
+    }
+
+    private static async Task<AutopilotGraphServicePrincipal> ParseServicePrincipalAsync(
+        string accessToken,
+        JsonElement servicePrincipal,
+        GraphAppRole requiredRole,
+        CancellationToken cancellationToken)
+    {
+        string objectId = servicePrincipal.GetProperty("id").GetString()
+            ?? throw new InvalidOperationException("Service principal object ID was not returned.");
+        bool isEnabled = !servicePrincipal.TryGetProperty("accountEnabled", out JsonElement accountEnabled) ||
+                         accountEnabled.GetBoolean();
+        HashSet<string> consentedPermissionValues = new(StringComparer.OrdinalIgnoreCase);
+        using JsonDocument assignments = await SendGraphRequestAsync(
+            accessToken,
+            HttpMethod.Get,
+            $"v1.0/servicePrincipals/{objectId}/appRoleAssignments?$select=appRoleId",
+            null,
+            cancellationToken).ConfigureAwait(false);
+        foreach (JsonElement assignment in assignments.RootElement.GetProperty("value").EnumerateArray())
+        {
+            if (assignment.TryGetProperty("appRoleId", out JsonElement appRoleId) &&
+                string.Equals(appRoleId.GetString(), requiredRole.AppRoleId, StringComparison.OrdinalIgnoreCase))
+            {
+                consentedPermissionValues.Add(requiredRole.Value);
+            }
+        }
+
+        return new AutopilotGraphServicePrincipal(objectId, isEnabled, consentedPermissionValues);
+    }
+
+    private static IReadOnlyList<AutopilotGraphKeyCredential> ParseKeyCredentials(JsonElement application)
+    {
+        if (!application.TryGetProperty("keyCredentials", out JsonElement keyCredentials))
+        {
+            return [];
+        }
+
+        List<AutopilotGraphKeyCredential> credentials = [];
+        foreach (JsonElement credential in keyCredentials.EnumerateArray())
+        {
+            string keyId = credential.GetProperty("keyId").GetString() ?? string.Empty;
+            string displayName = credential.TryGetProperty("displayName", out JsonElement displayNameElement)
+                ? displayNameElement.GetString() ?? string.Empty
+                : string.Empty;
+            string thumbprint = credential.TryGetProperty("customKeyIdentifier", out JsonElement customKeyIdentifier) &&
+                                customKeyIdentifier.GetString() is { Length: > 0 } base64Thumbprint
+                ? Convert.ToHexString(Convert.FromBase64String(base64Thumbprint))
+                : string.Empty;
+            DateTimeOffset startsOnUtc = credential.TryGetProperty("startDateTime", out JsonElement startDateTime) &&
+                                         startDateTime.GetDateTimeOffset() is { } start
+                ? start
+                : DateTimeOffset.MinValue;
+            DateTimeOffset expiresOnUtc = credential.TryGetProperty("endDateTime", out JsonElement endDateTime) &&
+                                          endDateTime.GetDateTimeOffset() is { } end
+                ? end
+                : DateTimeOffset.MinValue;
+            credentials.Add(new AutopilotGraphKeyCredential(keyId, displayName, thumbprint, startsOnUtc, expiresOnUtc));
+        }
+
+        return credentials;
+    }
+
+    private static string? ResolveDefaultGroupTag(string? currentDefaultGroupTag, string[] groupTags)
+    {
+        if (!string.IsNullOrWhiteSpace(currentDefaultGroupTag))
+        {
+            return currentDefaultGroupTag.Trim();
+        }
+
+        return groupTags.FirstOrDefault();
+    }
+
+    private static string CreateKeyCredentialJson(
+        string keyId,
+        X509Certificate2 certificate,
+        DateTimeOffset startsOnUtc,
+        DateTimeOffset expiresOnUtc)
+    {
+        string certificateRawData = Convert.ToBase64String(certificate.RawData);
+        string customKeyIdentifier = Convert.ToBase64String(certificate.GetCertHash());
+        return $$"""
+            {
+              "customKeyIdentifier": "{{customKeyIdentifier}}",
+              "displayName": "{{AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName}}",
+              "endDateTime": "{{expiresOnUtc.UtcDateTime.ToString("O", CultureInfo.InvariantCulture)}}",
+              "key": "{{certificateRawData}}",
+              "keyId": "{{keyId}}",
+              "startDateTime": "{{startsOnUtc.UtcDateTime.ToString("O", CultureInfo.InvariantCulture)}}",
+              "type": "AsymmetricX509Cert",
+              "usage": "Verify"
+            }
+            """;
+    }
+
+    private static string GeneratePfxPassword()
+    {
+        byte[] bytes = RandomNumberGenerator.GetBytes(32);
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    private sealed record GraphAppRole(
+        string ResourceServicePrincipalId,
+        string AppRoleId,
+        string Value);
+}

--- a/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
@@ -90,7 +90,8 @@ public sealed class AutopilotTenantOnboardingService(
                 requiredRole,
                 cancellationToken).ConfigureAwait(false);
 
-            string[] groupTags = await TryGetGroupTagsAsync(accessToken, cancellationToken).ConfigureAwait(false);
+            string[]? discoveredGroupTags = await TryGetGroupTagsAsync(accessToken, cancellationToken).ConfigureAwait(false);
+            string[] groupTags = discoveredGroupTags ?? NormalizeGroupTags(currentSettings.KnownGroupTags);
             IReadOnlyList<AutopilotGraphKeyCredential> keyCredentials =
                 await GetApplicationKeyCredentialsAsync(accessToken, application.ObjectId, cancellationToken).ConfigureAwait(false);
             AutopilotTenantOnboardingSnapshot snapshot = new()
@@ -122,17 +123,16 @@ public sealed class AutopilotTenantOnboardingService(
                 },
                 ActiveCertificate = activeCertificate,
                 KnownGroupTags = groupTags,
-                DefaultGroupTag = ResolveDefaultGroupTag(currentSettings.DefaultGroupTag, groupTags)
+                DefaultGroupTag = discoveredGroupTags is null
+                    ? currentSettings.DefaultGroupTag
+                    : ResolveDefaultGroupTag(currentSettings.DefaultGroupTag, groupTags)
             };
 
             return new AutopilotTenantOnboardingResult
             {
                 Settings = updatedSettings,
                 Status = evaluation.Status,
-                Certificates = keyCredentials,
-                Message = evaluation.Status == AutopilotTenantOnboardingStatus.Ready
-                    ? "The managed app registration is ready."
-                    : $"The managed app registration requires attention: {evaluation.Status}."
+                Certificates = keyCredentials
             };
         }
         catch
@@ -190,12 +190,20 @@ public sealed class AutopilotTenantOnboardingService(
         }
 
         string newCredentialJson = CreateKeyCredentialJson(keyId, certificate, startsOnUtc, expiresOnUtc);
-        await AddKeyCredentialAsync(
-            accessToken,
-            currentSettings.Tenant.ApplicationObjectId,
-            keyId,
-            newCredentialJson,
-            cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await AddKeyCredentialAsync(
+                accessToken,
+                currentSettings.Tenant.ApplicationObjectId,
+                keyId,
+                newCredentialJson,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            DeletePfxOutputAfterFailedGraphUpload(pfxOutputPath);
+            throw;
+        }
 
         var metadata = new AutopilotCertificateMetadata
         {
@@ -696,7 +704,7 @@ public sealed class AutopilotTenantOnboardingService(
             cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<string[]> TryGetGroupTagsAsync(string accessToken, CancellationToken cancellationToken)
+    private async Task<string[]?> TryGetGroupTagsAsync(string accessToken, CancellationToken cancellationToken)
     {
         try
         {
@@ -707,7 +715,7 @@ public sealed class AutopilotTenantOnboardingService(
             logger.Warning(
                 "Autopilot group tag discovery failed and will be skipped. StatusCode={StatusCode}",
                 ex.StatusCode);
-            return [];
+            return null;
         }
     }
 
@@ -904,6 +912,31 @@ public sealed class AutopilotTenantOnboardingService(
         }
 
         return null;
+    }
+
+    private static string[] NormalizeGroupTags(IReadOnlyList<string> groupTags)
+    {
+        return groupTags
+            .Where(groupTag => !string.IsNullOrWhiteSpace(groupTag))
+            .Select(groupTag => groupTag.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(groupTag => groupTag, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private void DeletePfxOutputAfterFailedGraphUpload(string pfxOutputPath)
+    {
+        try
+        {
+            if (File.Exists(pfxOutputPath))
+            {
+                File.Delete(pfxOutputPath);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            logger.Warning(ex, "Failed to remove generated PFX after Graph certificate upload failed.");
+        }
     }
 
     private static string CreateKeyCredentialJson(

--- a/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
@@ -5,8 +5,6 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json;
-using Azure.Core;
-using Azure.Identity;
 using Foundry.Core.Models.Configuration;
 using Foundry.Core.Services.Autopilot;
 using Serilog;
@@ -16,13 +14,10 @@ namespace Foundry.Services.Autopilot;
 /// <summary>
 /// Performs interactive Microsoft Graph tenant onboarding for Autopilot hardware hash upload.
 /// </summary>
-public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilotTenantOnboardingService
+public sealed class AutopilotTenantOnboardingService(
+    IAutopilotHardwareHashGraphSessionService graphSessionService,
+    ILogger logger) : IAutopilotTenantOnboardingService
 {
-    private const string DefaultClientId = "83eb3a92-030d-49b7-881b-32a1eb3e110a";
-    private const string ClientIdEnvironmentVariableName = "FOUNDRY_AUTOPILOT_GRAPH_CLIENT_ID";
-    private const string TenantIdEnvironmentVariableName = "FOUNDRY_AUTOPILOT_GRAPH_TENANT_ID";
-    private const string DefaultTenantId = "common";
-    private const string DefaultRedirectUri = "http://localhost";
     private const string GraphAppId = "00000003-0000-0000-c000-000000000000";
     private const string OrganizationRequestPath = "v1.0/organization?$select=id";
     private const string ApplicationSelect = "$select=id,appId,displayName,requiredResourceAccess,keyCredentials";
@@ -30,18 +25,12 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
     private const string GroupTagRequestPath = "v1.0/deviceManagement/windowsAutopilotDeviceIdentities";
     private const int MaximumCertificateValidityMonths = 12;
 
-    private static readonly string[] GraphScopes =
-    [
-        "Application.ReadWrite.All",
-        "AppRoleAssignment.ReadWrite.All",
-        "DeviceManagementServiceConfig.Read.All"
-    ];
-
     private static readonly HttpClient GraphHttpClient = new()
     {
         BaseAddress = new Uri("https://graph.microsoft.com/", UriKind.Absolute)
     };
 
+    private readonly IAutopilotHardwareHashGraphSessionService graphSessionService = graphSessionService;
     private readonly ILogger logger = logger.ForContext<AutopilotTenantOnboardingService>();
 
     /// <inheritdoc />
@@ -51,100 +40,107 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
     {
         ArgumentNullException.ThrowIfNull(currentSettings);
 
-        TokenCredential credential = CreateCredential();
-        string accessToken = await AcquireAccessTokenAsync(credential, cancellationToken).ConfigureAwait(false);
-        string tenantId = await GetTenantIdAsync(accessToken, cancellationToken).ConfigureAwait(false);
-        GraphAppRole requiredRole = await GetGraphAppRoleAsync(
-            accessToken,
-            AutopilotGraphPermissionCatalog.DeviceManagementServiceConfigReadWriteAll,
-            cancellationToken).ConfigureAwait(false);
-
-        AutopilotGraphApplication? application = await FindApplicationAsync(
-            accessToken,
-            currentSettings.Tenant.ApplicationObjectId,
-            requiredRole,
-            cancellationToken).ConfigureAwait(false);
-        application ??= await FindApplicationByDisplayNameAsync(accessToken, requiredRole, cancellationToken).ConfigureAwait(false);
-
-        if (application is null)
+        string accessToken = await graphSessionService.ConnectAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            application = await CreateApplicationAsync(accessToken, requiredRole, cancellationToken).ConfigureAwait(false);
-            logger.Information("Created managed Autopilot app registration. ApplicationObjectId={ApplicationObjectId}", application.ObjectId);
-        }
-        else if (string.IsNullOrWhiteSpace(currentSettings.Tenant.ApplicationObjectId) &&
-                 string.Equals(application.DisplayName, AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName, StringComparison.OrdinalIgnoreCase))
-        {
-            logger.Information("Adopted existing managed Autopilot app registration. ApplicationObjectId={ApplicationObjectId}", application.ObjectId);
-        }
+            string tenantId = await GetTenantIdAsync(accessToken, cancellationToken).ConfigureAwait(false);
+            GraphAppRole requiredRole = await GetGraphAppRoleAsync(
+                accessToken,
+                AutopilotGraphPermissionCatalog.DeviceManagementServiceConfigReadWriteAll,
+                cancellationToken).ConfigureAwait(false);
 
-        application = await EnsureRequiredApplicationPermissionAsync(
-            accessToken,
-            application,
-            requiredRole,
-            cancellationToken).ConfigureAwait(false);
+            AutopilotGraphApplication? application = await FindApplicationAsync(
+                accessToken,
+                currentSettings.Tenant.ApplicationObjectId,
+                requiredRole,
+                cancellationToken).ConfigureAwait(false);
+            application ??= await FindApplicationByDisplayNameAsync(accessToken, requiredRole, cancellationToken).ConfigureAwait(false);
 
-        AutopilotGraphServicePrincipal? servicePrincipal = await FindServicePrincipalAsync(
-            accessToken,
-            application.ClientId,
-            requiredRole,
-            cancellationToken).ConfigureAwait(false);
-        servicePrincipal ??= await CreateServicePrincipalAsync(
-            accessToken,
-            application.ClientId,
-            requiredRole,
-            cancellationToken).ConfigureAwait(false);
+            if (application is null)
+            {
+                application = await CreateApplicationAsync(accessToken, requiredRole, cancellationToken).ConfigureAwait(false);
+                logger.Information("Created managed Autopilot app registration. ApplicationObjectId={ApplicationObjectId}", application.ObjectId);
+            }
+            else if (string.IsNullOrWhiteSpace(currentSettings.Tenant.ApplicationObjectId) &&
+                     string.Equals(application.DisplayName, AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName, StringComparison.OrdinalIgnoreCase))
+            {
+                logger.Information("Adopted existing managed Autopilot app registration. ApplicationObjectId={ApplicationObjectId}", application.ObjectId);
+            }
 
-        servicePrincipal = await EnsureAdminConsentAsync(
-            accessToken,
-            servicePrincipal,
-            requiredRole,
-            cancellationToken).ConfigureAwait(false);
+            application = await EnsureRequiredApplicationPermissionAsync(
+                accessToken,
+                application,
+                requiredRole,
+                cancellationToken).ConfigureAwait(false);
 
-        string[] groupTags = await TryGetGroupTagsAsync(accessToken, cancellationToken).ConfigureAwait(false);
-        IReadOnlyList<AutopilotGraphKeyCredential> keyCredentials =
-            await GetApplicationKeyCredentialsAsync(accessToken, application.ObjectId, cancellationToken).ConfigureAwait(false);
-        AutopilotTenantOnboardingSnapshot snapshot = new()
-        {
-            TenantId = tenantId,
-            PersistedApplicationObjectId = application.ObjectId,
-            ManagedAppDisplayName = AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName,
-            Applications = [application],
-            ServicePrincipal = servicePrincipal,
-            ActiveCertificate = currentSettings.ActiveCertificate,
-            KeyCredentials = keyCredentials,
-            CurrentTimeUtc = DateTimeOffset.UtcNow
-        };
-        AutopilotTenantOnboardingEvaluation evaluation = AutopilotTenantOnboardingEvaluator.Evaluate(snapshot);
-        AutopilotCertificateMetadata? activeCertificate = evaluation.Status == AutopilotTenantOnboardingStatus.ActiveCertificateNotFound
-            ? null
-            : currentSettings.ActiveCertificate;
-        AutopilotTenantOnboardingStatus status = evaluation.Status == AutopilotTenantOnboardingStatus.ActiveCertificateNotFound
-            ? AutopilotTenantOnboardingStatus.ActiveCertificateMissing
-            : evaluation.Status;
+            AutopilotGraphServicePrincipal? servicePrincipal = await FindServicePrincipalAsync(
+                accessToken,
+                application.ClientId,
+                requiredRole,
+                cancellationToken).ConfigureAwait(false);
+            servicePrincipal ??= await CreateServicePrincipalAsync(
+                accessToken,
+                application.ClientId,
+                requiredRole,
+                cancellationToken).ConfigureAwait(false);
 
-        AutopilotHardwareHashUploadSettings updatedSettings = currentSettings with
-        {
-            Tenant = new AutopilotTenantRegistrationSettings
+            servicePrincipal = await EnsureAdminConsentAsync(
+                accessToken,
+                servicePrincipal,
+                requiredRole,
+                cancellationToken).ConfigureAwait(false);
+
+            string[] groupTags = await TryGetGroupTagsAsync(accessToken, cancellationToken).ConfigureAwait(false);
+            IReadOnlyList<AutopilotGraphKeyCredential> keyCredentials =
+                await GetApplicationKeyCredentialsAsync(accessToken, application.ObjectId, cancellationToken).ConfigureAwait(false);
+            AutopilotTenantOnboardingSnapshot snapshot = new()
             {
                 TenantId = tenantId,
-                ApplicationObjectId = application.ObjectId,
-                ClientId = application.ClientId,
-                ServicePrincipalObjectId = servicePrincipal.ObjectId
-            },
-            ActiveCertificate = activeCertificate,
-            KnownGroupTags = groupTags,
-            DefaultGroupTag = ResolveDefaultGroupTag(currentSettings.DefaultGroupTag, groupTags)
-        };
+                PersistedApplicationObjectId = application.ObjectId,
+                ManagedAppDisplayName = AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName,
+                Applications = [application],
+                ServicePrincipal = servicePrincipal,
+                ActiveCertificate = currentSettings.ActiveCertificate,
+                KeyCredentials = keyCredentials,
+                CurrentTimeUtc = DateTimeOffset.UtcNow
+            };
+            AutopilotTenantOnboardingEvaluation evaluation = AutopilotTenantOnboardingEvaluator.Evaluate(snapshot);
+            AutopilotCertificateMetadata? activeCertificate = evaluation.Status == AutopilotTenantOnboardingStatus.ActiveCertificateNotFound
+                ? null
+                : currentSettings.ActiveCertificate;
+            AutopilotTenantOnboardingStatus status = evaluation.Status == AutopilotTenantOnboardingStatus.ActiveCertificateNotFound
+                ? AutopilotTenantOnboardingStatus.ActiveCertificateMissing
+                : evaluation.Status;
 
-        return new AutopilotTenantOnboardingResult
+            AutopilotHardwareHashUploadSettings updatedSettings = currentSettings with
+            {
+                Tenant = new AutopilotTenantRegistrationSettings
+                {
+                    TenantId = tenantId,
+                    ApplicationObjectId = application.ObjectId,
+                    ClientId = application.ClientId,
+                    ServicePrincipalObjectId = servicePrincipal.ObjectId
+                },
+                ActiveCertificate = activeCertificate,
+                KnownGroupTags = groupTags,
+                DefaultGroupTag = ResolveDefaultGroupTag(currentSettings.DefaultGroupTag, groupTags)
+            };
+
+            return new AutopilotTenantOnboardingResult
+            {
+                Settings = updatedSettings,
+                Status = status,
+                Certificates = keyCredentials,
+                Message = status == AutopilotTenantOnboardingStatus.Ready
+                    ? "The managed app registration is ready."
+                    : $"The managed app registration requires attention: {status}."
+            };
+        }
+        catch
         {
-            Settings = updatedSettings,
-            Status = status,
-            Certificates = keyCredentials,
-            Message = status == AutopilotTenantOnboardingStatus.Ready
-                ? "The managed app registration is ready."
-                : $"The managed app registration requires attention: {status}."
-        };
+            graphSessionService.Disconnect();
+            throw;
+        }
     }
 
     /// <inheritdoc />
@@ -170,8 +166,7 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
                 $"Microsoft Graph application certificate credentials cannot exceed {MaximumCertificateValidityMonths} months.");
         }
 
-        TokenCredential credential = CreateCredential();
-        string accessToken = await AcquireAccessTokenAsync(credential, cancellationToken).ConfigureAwait(false);
+        string accessToken = await graphSessionService.GetAccessTokenAsync(cancellationToken).ConfigureAwait(false);
         DateTimeOffset startsOnUtc = DateTimeOffset.UtcNow.AddMinutes(-5);
         DateTimeOffset expiresOnUtc = startsOnUtc.AddMonths(validityMonths);
         string keyId = Guid.NewGuid().ToString("D");
@@ -242,8 +237,7 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
             };
         }
 
-        TokenCredential credential = CreateCredential();
-        string accessToken = await AcquireAccessTokenAsync(credential, cancellationToken).ConfigureAwait(false);
+        string accessToken = await graphSessionService.GetAccessTokenAsync(cancellationToken).ConfigureAwait(false);
         await RemoveKeyCredentialAsync(
             accessToken,
             currentSettings.Tenant.ApplicationObjectId,
@@ -265,31 +259,6 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
             Settings = updatedSettings,
             Certificates = keyCredentials
         };
-    }
-
-    private static TokenCredential CreateCredential()
-    {
-        string clientId = Environment.GetEnvironmentVariable(ClientIdEnvironmentVariableName)?.Trim()
-            ?? DefaultClientId;
-        string? tenantId = Environment.GetEnvironmentVariable(TenantIdEnvironmentVariableName);
-
-        return new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
-        {
-            ClientId = clientId,
-            TenantId = string.IsNullOrWhiteSpace(tenantId) ? DefaultTenantId : tenantId.Trim(),
-            RedirectUri = new Uri(DefaultRedirectUri, UriKind.Absolute),
-            TokenCachePersistenceOptions = new TokenCachePersistenceOptions
-            {
-                Name = "FoundryAutopilotGraph"
-            }
-        });
-    }
-
-    private static async Task<string> AcquireAccessTokenAsync(TokenCredential credential, CancellationToken cancellationToken)
-    {
-        AccessToken accessToken = await credential.GetTokenAsync(new TokenRequestContext(GraphScopes), cancellationToken)
-            .ConfigureAwait(false);
-        return accessToken.Token;
     }
 
     private static async Task<string> GetTenantIdAsync(string accessToken, CancellationToken cancellationToken)

--- a/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
@@ -191,11 +191,11 @@ public sealed class AutopilotTenantOnboardingService(
         }
 
         string newCredentialJson = CreateKeyCredentialJson(keyId, certificate, startsOnUtc, expiresOnUtc);
-        await ReplaceActiveKeyCredentialAsync(
+        await AddKeyCredentialAsync(
             accessToken,
             currentSettings.Tenant.ApplicationObjectId,
+            keyId,
             newCredentialJson,
-            currentSettings.ActiveCertificate?.KeyId,
             cancellationToken).ConfigureAwait(false);
 
         var metadata = new AutopilotCertificateMetadata
@@ -602,11 +602,11 @@ public sealed class AutopilotTenantOnboardingService(
         return ParseKeyCredentials(document.RootElement);
     }
 
-    private static async Task ReplaceActiveKeyCredentialAsync(
+    private static async Task AddKeyCredentialAsync(
         string accessToken,
         string applicationObjectId,
+        string newKeyId,
         string newCredentialJson,
-        string? activeKeyIdToReplace,
         CancellationToken cancellationToken)
     {
         using JsonDocument document = await SendGraphRequestAsync(
@@ -620,9 +620,8 @@ public sealed class AutopilotTenantOnboardingService(
             ? string.Join(
                 ",",
                 keyCredentials.EnumerateArray().Where(credential =>
-                    string.IsNullOrWhiteSpace(activeKeyIdToReplace) ||
                     !credential.TryGetProperty("keyId", out JsonElement existingKeyId) ||
-                    !string.Equals(existingKeyId.GetString(), activeKeyIdToReplace, StringComparison.OrdinalIgnoreCase))
+                    !string.Equals(existingKeyId.GetString(), newKeyId, StringComparison.OrdinalIgnoreCase))
                     .Select(credential => credential.GetRawText()))
             : string.Empty;
         string separator = string.IsNullOrWhiteSpace(existingCredentialsJson) ? string.Empty : ",";

--- a/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
@@ -28,6 +28,7 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
     private const string ApplicationSelect = "$select=id,appId,displayName,requiredResourceAccess,keyCredentials";
     private const string ServicePrincipalSelect = "$select=id,appId,accountEnabled";
     private const string GroupTagRequestPath = "v1.0/deviceManagement/windowsAutopilotDeviceIdentities?$select=groupTag";
+    private const int MaximumCertificateValidityMonths = 12;
 
     private static readonly string[] GraphScopes =
     [
@@ -150,10 +151,18 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
             throw new InvalidOperationException("The managed app registration must be connected before creating a certificate.");
         }
 
+        if (validityMonths is <= 0 or > MaximumCertificateValidityMonths)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(validityMonths),
+                validityMonths,
+                $"Microsoft Graph application certificate credentials cannot exceed {MaximumCertificateValidityMonths} months.");
+        }
+
         TokenCredential credential = CreateCredential();
         string accessToken = await AcquireAccessTokenAsync(credential, cancellationToken).ConfigureAwait(false);
         DateTimeOffset startsOnUtc = DateTimeOffset.UtcNow.AddMinutes(-5);
-        DateTimeOffset expiresOnUtc = DateTimeOffset.UtcNow.AddMonths(validityMonths);
+        DateTimeOffset expiresOnUtc = startsOnUtc.AddMonths(validityMonths);
         string keyId = Guid.NewGuid().ToString("D");
         string password = GeneratePfxPassword();
 
@@ -762,7 +771,10 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
         HttpResponseMessage response = await GraphHttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
-            string message = $"Microsoft Graph request failed for '{method} {requestPath}' with status code {(int)response.StatusCode}.";
+            string? graphError = await TryReadGraphErrorAsync(response, cancellationToken).ConfigureAwait(false);
+            string message = string.IsNullOrWhiteSpace(graphError)
+                ? $"Microsoft Graph request failed for '{method} {requestPath}' with status code {(int)response.StatusCode}."
+                : $"Microsoft Graph request failed for '{method} {requestPath}' with status code {(int)response.StatusCode}: {graphError}.";
             throw new HttpRequestException(message, null, response.StatusCode);
         }
 
@@ -878,18 +890,64 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
     {
         string certificateRawData = Convert.ToBase64String(certificate.RawData);
         string customKeyIdentifier = Convert.ToBase64String(certificate.GetCertHash());
-        return $$"""
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("customKeyIdentifier", customKeyIdentifier);
+            writer.WriteString("displayName", AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName);
+            writer.WriteString("endDateTime", FormatGraphUtcDateTime(expiresOnUtc));
+            writer.WriteString("key", certificateRawData);
+            writer.WriteString("keyId", keyId);
+            writer.WriteString("startDateTime", FormatGraphUtcDateTime(startsOnUtc));
+            writer.WriteString("type", "AsymmetricX509Cert");
+            writer.WriteString("usage", "Verify");
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static string FormatGraphUtcDateTime(DateTimeOffset value)
+    {
+        return value.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
+    }
+
+    private static async Task<string?> TryReadGraphErrorAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        string responseBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(responseBody))
+        {
+            return null;
+        }
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(responseBody);
+            if (document.RootElement.TryGetProperty("error", out JsonElement error))
             {
-              "customKeyIdentifier": "{{customKeyIdentifier}}",
-              "displayName": "{{AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName}}",
-              "endDateTime": "{{expiresOnUtc.UtcDateTime.ToString("O", CultureInfo.InvariantCulture)}}",
-              "key": "{{certificateRawData}}",
-              "keyId": "{{keyId}}",
-              "startDateTime": "{{startsOnUtc.UtcDateTime.ToString("O", CultureInfo.InvariantCulture)}}",
-              "type": "AsymmetricX509Cert",
-              "usage": "Verify"
+                string? code = error.TryGetProperty("code", out JsonElement codeElement)
+                    ? codeElement.GetString()
+                    : null;
+                string? message = error.TryGetProperty("message", out JsonElement messageElement)
+                    ? messageElement.GetString()
+                    : null;
+
+                return string.Join(
+                    ": ",
+                    new[] { code, message }
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim()));
             }
-            """;
+        }
+        catch (JsonException)
+        {
+            return responseBody.Length <= 500
+                ? responseBody
+                : responseBody[..500];
+        }
+
+        return null;
     }
 
     private static string GeneratePfxPassword()

--- a/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
@@ -115,6 +115,13 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
             CurrentTimeUtc = DateTimeOffset.UtcNow
         };
         AutopilotTenantOnboardingEvaluation evaluation = AutopilotTenantOnboardingEvaluator.Evaluate(snapshot);
+        AutopilotCertificateMetadata? activeCertificate = evaluation.Status == AutopilotTenantOnboardingStatus.ActiveCertificateNotFound
+            ? null
+            : currentSettings.ActiveCertificate;
+        AutopilotTenantOnboardingStatus status = evaluation.Status == AutopilotTenantOnboardingStatus.ActiveCertificateNotFound
+            ? AutopilotTenantOnboardingStatus.ActiveCertificateMissing
+            : evaluation.Status;
+
         AutopilotHardwareHashUploadSettings updatedSettings = currentSettings with
         {
             Tenant = new AutopilotTenantRegistrationSettings
@@ -124,6 +131,7 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
                 ClientId = application.ClientId,
                 ServicePrincipalObjectId = servicePrincipal.ObjectId
             },
+            ActiveCertificate = activeCertificate,
             KnownGroupTags = groupTags,
             DefaultGroupTag = ResolveDefaultGroupTag(currentSettings.DefaultGroupTag, groupTags)
         };
@@ -131,11 +139,11 @@ public sealed class AutopilotTenantOnboardingService(ILogger logger) : IAutopilo
         return new AutopilotTenantOnboardingResult
         {
             Settings = updatedSettings,
-            Status = evaluation.Status,
+            Status = status,
             Certificates = keyCredentials,
-            Message = evaluation.Status == AutopilotTenantOnboardingStatus.Ready
+            Message = status == AutopilotTenantOnboardingStatus.Ready
                 ? "The managed app registration is ready."
-                : $"The managed app registration requires attention: {evaluation.Status}."
+                : $"The managed app registration requires attention: {status}."
         };
     }
 

--- a/src/Foundry/Services/Autopilot/AutopilotTenantOperationDialogService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantOperationDialogService.cs
@@ -1,11 +1,14 @@
-using Foundry.Core.Models.Configuration;
 using Foundry.Services.Localization;
 
 namespace Foundry.Services.Autopilot;
 
-public sealed class AutopilotTenantDownloadDialogService(
-    IApplicationLocalizationService localizationService) : IAutopilotTenantDownloadDialogService
+/// <summary>
+/// Coordinates shared Microsoft Graph tenant operation progress and cancellation dialogs.
+/// </summary>
+public sealed class AutopilotTenantOperationDialogService(
+    IApplicationLocalizationService localizationService) : IAutopilotTenantOperationDialogService
 {
+    /// <inheritdoc />
     public Task<TResult?> RunAsync<TResult>(
         string title,
         string message,
@@ -19,19 +22,8 @@ public sealed class AutopilotTenantDownloadDialogService(
         return RunWithDialogAsync(
             title,
             message,
-            localizationService.GetString("Autopilot.TenantDownloadDialogCancel"),
+            localizationService.GetString("Common.Cancel"),
             operationAsync);
-    }
-
-    public async Task<IReadOnlyList<AutopilotProfileSettings>?> DownloadAsync(
-        Func<CancellationToken, Task<IReadOnlyList<AutopilotProfileSettings>>> downloadProfilesAsync)
-    {
-        ArgumentNullException.ThrowIfNull(downloadProfilesAsync);
-        return await RunWithDialogAsync(
-            localizationService.GetString("Autopilot.TenantDownloadDialogTitle"),
-            localizationService.GetString("Autopilot.TenantDownloadDialogMessage"),
-            localizationService.GetString("Autopilot.TenantDownloadDialogCancel"),
-            downloadProfilesAsync).ConfigureAwait(false);
     }
 
     private static async Task<TResult?> RunWithDialogAsync<TResult>(
@@ -44,45 +36,65 @@ public sealed class AutopilotTenantDownloadDialogService(
         using var cancellationTokenSource = new CancellationTokenSource();
         ContentDialog dialog = CreateDialog(title, message, cancelText, cancellationTokenSource);
         TaskCompletionSource dialogOpenedTask = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource dialogCanceledTask = new(TaskCreationOptions.RunContinuationsAsynchronously);
         dialog.Opened += OnDialogOpened;
-        Task<ContentDialogResult> dialogTask = dialog.ShowAsync().AsTask();
+        dialog.Closing += OnDialogClosing;
 
-        Task completedBeforeOpenTask = await Task.WhenAny(dialogOpenedTask.Task, dialogTask);
-        dialog.Opened -= OnDialogOpened;
-        if (completedBeforeOpenTask == dialogTask)
-        {
-            cancellationTokenSource.Cancel();
-            return default;
-        }
-
-        Task<TResult> operationTask = Task.Run(
-            () => operationAsync(cancellationTokenSource.Token),
-            cancellationTokenSource.Token);
-        Task completedTask = await Task.WhenAny(operationTask, dialogTask);
-        if (completedTask == dialogTask)
-        {
-            cancellationTokenSource.Cancel();
-            _ = ObserveTaskAsync(operationTask);
-            return default;
-        }
-
-        TResult result;
         try
         {
-            result = await operationTask;
-        }
-        catch
-        {
-            await CloseDialogAsync(dialog, dialogTask);
-            throw;
-        }
+            Task<ContentDialogResult> dialogTask = dialog.ShowAsync().AsTask();
+            Task completedBeforeOpenTask = await Task.WhenAny(dialogOpenedTask.Task, dialogCanceledTask.Task, dialogTask);
+            if (completedBeforeOpenTask != dialogOpenedTask.Task)
+            {
+                cancellationTokenSource.Cancel();
+                await ObserveDialogTaskAsync(dialogTask);
+                return default;
+            }
 
-        await CloseDialogAsync(dialog, dialogTask);
-        return result;
+            Task<TResult> operationTask = Task.Run(
+                () => operationAsync(cancellationTokenSource.Token),
+                cancellationTokenSource.Token);
+            Task completedTask = await Task.WhenAny(operationTask, dialogCanceledTask.Task, dialogTask);
+            if (completedTask != operationTask)
+            {
+                cancellationTokenSource.Cancel();
+                _ = ObserveTaskAsync(operationTask);
+                await CloseDialogWithoutBlockingAsync(dialog, dialogTask);
+                return default;
+            }
+
+            try
+            {
+                TResult result = await operationTask;
+                await CloseDialogWithoutBlockingAsync(dialog, dialogTask);
+                return result;
+            }
+            catch (OperationCanceledException) when (cancellationTokenSource.IsCancellationRequested)
+            {
+                await CloseDialogWithoutBlockingAsync(dialog, dialogTask);
+                return default;
+            }
+            catch
+            {
+                await CloseDialogWithoutBlockingAsync(dialog, dialogTask);
+                throw;
+            }
+        }
+        finally
+        {
+            dialog.Opened -= OnDialogOpened;
+            dialog.Closing -= OnDialogClosing;
+        }
 
         void OnDialogOpened(ContentDialog sender, ContentDialogOpenedEventArgs args)
         {
             dialogOpenedTask.TrySetResult();
+        }
+
+        void OnDialogClosing(ContentDialog sender, ContentDialogClosingEventArgs args)
+        {
+            cancellationTokenSource.Cancel();
+            dialogCanceledTask.TrySetResult();
         }
     }
 
@@ -138,13 +150,25 @@ public sealed class AutopilotTenantDownloadDialogService(
         }
     }
 
-    private static async Task CloseDialogAsync(ContentDialog dialog, Task<ContentDialogResult> dialogTask)
+    private static async Task ObserveDialogTaskAsync(Task<ContentDialogResult> dialogTask)
+    {
+        try
+        {
+            await dialogTask;
+        }
+        catch
+        {
+            // Dialog teardown after cancellation should not keep the tenant operation alive.
+        }
+    }
+
+    private static async Task CloseDialogWithoutBlockingAsync(ContentDialog dialog, Task<ContentDialogResult> dialogTask)
     {
         if (!dialogTask.IsCompleted)
         {
             dialog.Hide();
         }
 
-        await dialogTask;
+        await Task.WhenAny(dialogTask, Task.Delay(TimeSpan.FromSeconds(2)));
     }
 }

--- a/src/Foundry/Services/Autopilot/AutopilotTenantProfileService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantProfileService.cs
@@ -136,12 +136,7 @@ public sealed class AutopilotTenantProfileService(ILogger logger) : IAutopilotTe
         {
             ClientId = clientId,
             TenantId = string.IsNullOrWhiteSpace(tenantId) ? AutopilotGraphAuthenticationDefaults.DefaultTenantId : tenantId.Trim(),
-            RedirectUri = new Uri(AutopilotGraphAuthenticationDefaults.RedirectUri, UriKind.Absolute),
-            TokenCachePersistenceOptions = new TokenCachePersistenceOptions
-            {
-                // Keep Graph auth reusable for Foundry without sharing a token cache name with unrelated tools.
-                Name = AutopilotGraphAuthenticationDefaults.TokenCacheName
-            }
+            RedirectUri = new Uri(AutopilotGraphAuthenticationDefaults.RedirectUri, UriKind.Absolute)
         });
     }
 

--- a/src/Foundry/Services/Autopilot/AutopilotTenantProfileService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantProfileService.cs
@@ -15,11 +15,6 @@ namespace Foundry.Services.Autopilot;
 /// </summary>
 public sealed class AutopilotTenantProfileService(ILogger logger) : IAutopilotTenantProfileService
 {
-    private const string DefaultClientId = "83eb3a92-030d-49b7-881b-32a1eb3e110a";
-    private const string ClientIdEnvironmentVariableName = "FOUNDRY_AUTOPILOT_GRAPH_CLIENT_ID";
-    private const string TenantIdEnvironmentVariableName = "FOUNDRY_AUTOPILOT_GRAPH_TENANT_ID";
-    private const string DefaultTenantId = "common";
-    private const string DefaultRedirectUri = "http://localhost";
     private const string OrganizationRequestPath = "v1.0/organization?$select=id,verifiedDomains";
     private const string AutopilotProfilesRequestPath = "beta/deviceManagement/windowsAutopilotDeploymentProfiles";
     private const string TenantDownloadSource = "Tenant download";
@@ -133,19 +128,19 @@ public sealed class AutopilotTenantProfileService(ILogger logger) : IAutopilotTe
 
     private static TokenCredential CreateCredential()
     {
-        string clientId = Environment.GetEnvironmentVariable(ClientIdEnvironmentVariableName)?.Trim()
-            ?? DefaultClientId;
-        string? tenantId = Environment.GetEnvironmentVariable(TenantIdEnvironmentVariableName);
+        string clientId = Environment.GetEnvironmentVariable(AutopilotGraphAuthenticationDefaults.ClientIdEnvironmentVariableName)?.Trim()
+            ?? AutopilotGraphAuthenticationDefaults.FoundryBootstrapClientId;
+        string? tenantId = Environment.GetEnvironmentVariable(AutopilotGraphAuthenticationDefaults.TenantIdEnvironmentVariableName);
 
         return new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
         {
             ClientId = clientId,
-            TenantId = string.IsNullOrWhiteSpace(tenantId) ? DefaultTenantId : tenantId.Trim(),
-            RedirectUri = new Uri(DefaultRedirectUri, UriKind.Absolute),
+            TenantId = string.IsNullOrWhiteSpace(tenantId) ? AutopilotGraphAuthenticationDefaults.DefaultTenantId : tenantId.Trim(),
+            RedirectUri = new Uri(AutopilotGraphAuthenticationDefaults.RedirectUri, UriKind.Absolute),
             TokenCachePersistenceOptions = new TokenCachePersistenceOptions
             {
                 // Keep Graph auth reusable for Foundry without sharing a token cache name with unrelated tools.
-                Name = "FoundryAutopilotGraph"
+                Name = AutopilotGraphAuthenticationDefaults.TokenCacheName
             }
         });
     }

--- a/src/Foundry/Services/Autopilot/IAutopilotCertificateDialogService.cs
+++ b/src/Foundry/Services/Autopilot/IAutopilotCertificateDialogService.cs
@@ -1,0 +1,14 @@
+namespace Foundry.Services.Autopilot;
+
+/// <summary>
+/// Shows Autopilot certificate dialogs that require richer selectable content.
+/// </summary>
+public interface IAutopilotCertificateDialogService
+{
+    /// <summary>
+    /// Shows the one-time generated PFX password after certificate creation.
+    /// </summary>
+    /// <param name="pfxOutputPath">Operator-selected PFX output path.</param>
+    /// <param name="password">Generated PFX password.</param>
+    Task ShowCreatedAsync(string pfxOutputPath, string password);
+}

--- a/src/Foundry/Services/Autopilot/IAutopilotHardwareHashGraphSessionService.cs
+++ b/src/Foundry/Services/Autopilot/IAutopilotHardwareHashGraphSessionService.cs
@@ -1,0 +1,26 @@
+namespace Foundry.Services.Autopilot;
+
+/// <summary>
+/// Stores the current app-session Microsoft Graph credential used by Autopilot hardware hash onboarding actions.
+/// </summary>
+public interface IAutopilotHardwareHashGraphSessionService
+{
+    /// <summary>
+    /// Starts or refreshes the interactive Microsoft Graph session.
+    /// </summary>
+    /// <param name="cancellationToken">Token that cancels authentication.</param>
+    /// <returns>A Microsoft Graph access token for the configured hardware hash onboarding scopes.</returns>
+    Task<string> ConnectAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets an access token from the current app session without creating a new tenant connection.
+    /// </summary>
+    /// <param name="cancellationToken">Token that cancels token refresh.</param>
+    /// <returns>A Microsoft Graph access token for the configured hardware hash onboarding scopes.</returns>
+    Task<string> GetAccessTokenAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Clears the current app-session credential and cached token.
+    /// </summary>
+    void Disconnect();
+}

--- a/src/Foundry/Services/Autopilot/IAutopilotHardwareHashSessionState.cs
+++ b/src/Foundry/Services/Autopilot/IAutopilotHardwareHashSessionState.cs
@@ -1,0 +1,35 @@
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Autopilot;
+
+namespace Foundry.Services.Autopilot;
+
+/// <summary>
+/// Stores Autopilot hardware hash state that is valid only for the current app session.
+/// </summary>
+public interface IAutopilotHardwareHashSessionState
+{
+    /// <summary>
+    /// Gets or sets whether the tenant was connected during the current app session.
+    /// </summary>
+    bool HasConnectedTenant { get; set; }
+
+    /// <summary>
+    /// Gets or sets the last tenant onboarding status from the current app session.
+    /// </summary>
+    AutopilotTenantOnboardingStatus? TenantOnboardingStatus { get; set; }
+
+    /// <summary>
+    /// Gets or sets the session-only PFX selected for boot media generation.
+    /// </summary>
+    AutopilotBootMediaCertificateSettings BootMediaCertificate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the certificate credentials discovered from Graph in the current app session.
+    /// </summary>
+    IReadOnlyList<AutopilotGraphKeyCredential> Certificates { get; set; }
+
+    /// <summary>
+    /// Clears tenant, certificate table, and boot media PFX state without touching persisted settings.
+    /// </summary>
+    void ClearTenantConnection();
+}

--- a/src/Foundry/Services/Autopilot/IAutopilotTenantDownloadDialogService.cs
+++ b/src/Foundry/Services/Autopilot/IAutopilotTenantDownloadDialogService.cs
@@ -8,6 +8,20 @@ namespace Foundry.Services.Autopilot;
 public interface IAutopilotTenantDownloadDialogService
 {
     /// <summary>
+    /// Runs a tenant Graph operation through the shared tenant sign-in dialog.
+    /// </summary>
+    /// <typeparam name="TResult">Operation result type.</typeparam>
+    /// <param name="title">Dialog title.</param>
+    /// <param name="message">Dialog message.</param>
+    /// <param name="operationAsync">Delegate that runs using the dialog-owned cancellation token.</param>
+    /// <returns>The operation result, or <see langword="null"/> when the dialog is canceled.</returns>
+    Task<TResult?> RunAsync<TResult>(
+        string title,
+        string message,
+        Func<CancellationToken, Task<TResult>> operationAsync)
+        where TResult : class;
+
+    /// <summary>
     /// Runs a profile download through a modal dialog.
     /// </summary>
     /// <param name="downloadProfilesAsync">Delegate that downloads profiles using the dialog-owned cancellation token.</param>

--- a/src/Foundry/Services/Autopilot/IAutopilotTenantOnboardingService.cs
+++ b/src/Foundry/Services/Autopilot/IAutopilotTenantOnboardingService.cs
@@ -33,12 +33,14 @@ public interface IAutopilotTenantOnboardingService
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Removes only the configured active certificate credential from the managed app registration.
+    /// Removes the selected certificate credential from the managed app registration.
     /// </summary>
     /// <param name="currentSettings">Current persisted hardware hash upload settings.</param>
+    /// <param name="certificateKeyId">Microsoft Graph key credential identifier to remove.</param>
     /// <param name="cancellationToken">Token that cancels authentication and Graph requests.</param>
-    /// <returns>Updated settings with the active certificate cleared.</returns>
-    Task<AutopilotHardwareHashUploadSettings> RetireActiveCertificateAsync(
+    /// <returns>Updated settings and app registration certificate credentials.</returns>
+    Task<AutopilotCertificateRemovalResult> RemoveCertificateAsync(
         AutopilotHardwareHashUploadSettings currentSettings,
+        string certificateKeyId,
         CancellationToken cancellationToken = default);
 }

--- a/src/Foundry/Services/Autopilot/IAutopilotTenantOnboardingService.cs
+++ b/src/Foundry/Services/Autopilot/IAutopilotTenantOnboardingService.cs
@@ -1,0 +1,44 @@
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Autopilot;
+
+namespace Foundry.Services.Autopilot;
+
+/// <summary>
+/// Coordinates interactive tenant onboarding for Autopilot hardware hash upload.
+/// </summary>
+public interface IAutopilotTenantOnboardingService
+{
+    /// <summary>
+    /// Connects to Microsoft Graph, creates or reuses the managed app registration, and returns the updated settings.
+    /// </summary>
+    /// <param name="currentSettings">Current persisted hardware hash upload settings.</param>
+    /// <param name="cancellationToken">Token that cancels authentication and Graph requests.</param>
+    /// <returns>The tenant onboarding result and sanitized settings to persist.</returns>
+    Task<AutopilotTenantOnboardingResult> ConnectAsync(
+        AutopilotHardwareHashUploadSettings currentSettings,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a password-protected PFX certificate, adds its public credential to the managed app, and selects it as active.
+    /// </summary>
+    /// <param name="currentSettings">Current persisted hardware hash upload settings.</param>
+    /// <param name="pfxOutputPath">Operator-selected PFX output path.</param>
+    /// <param name="validityMonths">Certificate validity duration in months.</param>
+    /// <param name="cancellationToken">Token that cancels authentication and Graph requests.</param>
+    /// <returns>The certificate creation result and updated persistent settings.</returns>
+    Task<AutopilotCertificateCreationResult> CreateCertificateAsync(
+        AutopilotHardwareHashUploadSettings currentSettings,
+        string pfxOutputPath,
+        int validityMonths,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes only the configured active certificate credential from the managed app registration.
+    /// </summary>
+    /// <param name="currentSettings">Current persisted hardware hash upload settings.</param>
+    /// <param name="cancellationToken">Token that cancels authentication and Graph requests.</param>
+    /// <returns>Updated settings with the active certificate cleared.</returns>
+    Task<AutopilotHardwareHashUploadSettings> RetireActiveCertificateAsync(
+        AutopilotHardwareHashUploadSettings currentSettings,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Foundry/Services/Autopilot/IAutopilotTenantOnboardingService.cs
+++ b/src/Foundry/Services/Autopilot/IAutopilotTenantOnboardingService.cs
@@ -12,7 +12,7 @@ public interface IAutopilotTenantOnboardingService
     /// Connects to Microsoft Graph, creates or reuses the managed app registration, and returns the updated settings.
     /// </summary>
     /// <param name="currentSettings">Current persisted hardware hash upload settings.</param>
-    /// <param name="cancellationToken">Token that cancels authentication and Graph requests.</param>
+    /// <param name="cancellationToken">Token that cancels Graph requests.</param>
     /// <returns>The tenant onboarding result and sanitized settings to persist.</returns>
     Task<AutopilotTenantOnboardingResult> ConnectAsync(
         AutopilotHardwareHashUploadSettings currentSettings,
@@ -24,7 +24,7 @@ public interface IAutopilotTenantOnboardingService
     /// <param name="currentSettings">Current persisted hardware hash upload settings.</param>
     /// <param name="pfxOutputPath">Operator-selected PFX output path.</param>
     /// <param name="validityMonths">Certificate validity duration in months.</param>
-    /// <param name="cancellationToken">Token that cancels authentication and Graph requests.</param>
+    /// <param name="cancellationToken">Token that cancels Graph requests.</param>
     /// <returns>The certificate creation result and updated persistent settings.</returns>
     Task<AutopilotCertificateCreationResult> CreateCertificateAsync(
         AutopilotHardwareHashUploadSettings currentSettings,

--- a/src/Foundry/Services/Autopilot/IAutopilotTenantOperationDialogService.cs
+++ b/src/Foundry/Services/Autopilot/IAutopilotTenantOperationDialogService.cs
@@ -1,11 +1,9 @@
-using Foundry.Core.Models.Configuration;
-
 namespace Foundry.Services.Autopilot;
 
 /// <summary>
-/// Shows the tenant profile download dialog and coordinates cancellation with the download operation.
+/// Shows the shared tenant Microsoft Graph operation dialog and coordinates cancellation with the operation.
 /// </summary>
-public interface IAutopilotTenantDownloadDialogService
+public interface IAutopilotTenantOperationDialogService
 {
     /// <summary>
     /// Runs a tenant Graph operation through the shared tenant sign-in dialog.
@@ -20,12 +18,4 @@ public interface IAutopilotTenantDownloadDialogService
         string message,
         Func<CancellationToken, Task<TResult>> operationAsync)
         where TResult : class;
-
-    /// <summary>
-    /// Runs a profile download through a modal dialog.
-    /// </summary>
-    /// <param name="downloadProfilesAsync">Delegate that downloads profiles using the dialog-owned cancellation token.</param>
-    /// <returns>Downloaded profiles, or <see langword="null"/> when the dialog is canceled.</returns>
-    Task<IReadOnlyList<AutopilotProfileSettings>?> DownloadAsync(
-        Func<CancellationToken, Task<IReadOnlyList<AutopilotProfileSettings>>> downloadProfilesAsync);
 }

--- a/src/Foundry/Services/Configuration/FoundryConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/FoundryConfigurationStateService.cs
@@ -1,6 +1,7 @@
 using Foundry.Core.Models.Configuration;
 using Foundry.Core.Services.Configuration;
 using Foundry.Core.Services.WinPe;
+using Foundry.Services.Autopilot;
 using Foundry.Telemetry;
 using Serilog;
 using AppSettingsService = Foundry.Services.Settings.IAppSettingsService;
@@ -20,6 +21,7 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
     private readonly IDeployConfigurationGenerator deployConfigurationGenerator;
     private readonly IConnectConfigurationGenerator connectConfigurationGenerator;
     private readonly INetworkSecretStateService networkSecretStateService;
+    private readonly IAutopilotHardwareHashSessionState autopilotHardwareHashSessionState;
     private readonly AppSettingsService appSettingsService;
     private readonly ILogger logger;
 
@@ -28,6 +30,7 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
         IDeployConfigurationGenerator deployConfigurationGenerator,
         IConnectConfigurationGenerator connectConfigurationGenerator,
         INetworkSecretStateService networkSecretStateService,
+        IAutopilotHardwareHashSessionState autopilotHardwareHashSessionState,
         AppSettingsService appSettingsService,
         ILogger logger)
     {
@@ -35,6 +38,7 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
         this.deployConfigurationGenerator = deployConfigurationGenerator;
         this.connectConfigurationGenerator = connectConfigurationGenerator;
         this.networkSecretStateService = networkSecretStateService;
+        this.autopilotHardwareHashSessionState = autopilotHardwareHashSessionState;
         this.appSettingsService = appSettingsService;
         this.logger = logger.ForContext<FoundryConfigurationStateService>();
         Current = SanitizeForPersistence(Load());
@@ -78,7 +82,11 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
     public bool IsAutopilotEnabled => Current.Autopilot.IsEnabled;
 
     /// <inheritdoc />
-    public bool IsAutopilotConfigurationReady => AutopilotConfigurationValidator.IsReady(Current.Autopilot, DateTimeOffset.UtcNow);
+    public bool IsAutopilotConfigurationReady => AutopilotConfigurationValidation.IsReady;
+
+    /// <inheritdoc />
+    public AutopilotConfigurationValidationResult AutopilotConfigurationValidation =>
+        AutopilotConfigurationValidator.Evaluate(CreateAutopilotSettingsForValidation(Current.Autopilot), DateTimeOffset.UtcNow);
 
     /// <inheritdoc />
     public AutopilotProvisioningMode AutopilotProvisioningMode => Current.Autopilot.ProvisioningMode;
@@ -153,9 +161,7 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
     /// <inheritdoc />
     public string GenerateDeployConfigurationJson(TelemetrySettings? telemetryOverride = null)
     {
-        FoundryConfigurationDocument document = telemetryOverride is null
-            ? Current
-            : Current with { Telemetry = telemetryOverride };
+        FoundryConfigurationDocument document = CreateDocumentForDeployGeneration(telemetryOverride);
 
         return deployConfigurationGenerator.Serialize(deployConfigurationGenerator.Generate(document));
     }
@@ -192,6 +198,26 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
             TryMoveInvalidState(backupPath, ex);
             return CreateDefaultDocument();
         }
+    }
+
+    private FoundryConfigurationDocument CreateDocumentForDeployGeneration(TelemetrySettings? telemetryOverride)
+    {
+        return Current with
+        {
+            Autopilot = CreateAutopilotSettingsForValidation(Current.Autopilot),
+            Telemetry = telemetryOverride ?? Current.Telemetry
+        };
+    }
+
+    private AutopilotSettings CreateAutopilotSettingsForValidation(AutopilotSettings settings)
+    {
+        return settings with
+        {
+            HardwareHashUpload = settings.HardwareHashUpload with
+            {
+                BootMediaCertificate = autopilotHardwareHashSessionState.BootMediaCertificate
+            }
+        };
     }
 
     private static FoundryConfigurationDocument CreateDefaultDocument()

--- a/src/Foundry/Services/Configuration/IFoundryConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/IFoundryConfigurationStateService.cs
@@ -1,4 +1,5 @@
 using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Configuration;
 using Foundry.Telemetry;
 
 namespace Foundry.Services.Configuration;
@@ -51,6 +52,11 @@ public interface IFoundryConfigurationStateService
     /// Gets a value indicating whether the selected Autopilot profiles are valid for output.
     /// </summary>
     bool IsAutopilotConfigurationReady { get; }
+
+    /// <summary>
+    /// Gets the detailed Autopilot readiness status for the selected provisioning mode.
+    /// </summary>
+    AutopilotConfigurationValidationResult AutopilotConfigurationValidation { get; }
 
     /// <summary>
     /// Gets the selected Autopilot provisioning mode.

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -306,6 +306,12 @@
   <data name="Autopilot.HardwareHashConnectingTenantStatus" xml:space="preserve">
     <value>Connecting tenant...</value>
   </data>
+  <data name="Autopilot.HardwareHashTenantConnectionDialogTitle" xml:space="preserve">
+    <value>Sign in to Microsoft Graph</value>
+  </data>
+  <data name="Autopilot.HardwareHashTenantConnectionDialogMessage" xml:space="preserve">
+    <value>Complete sign-in in the browser to configure Autopilot hardware hash upload.</value>
+  </data>
   <data name="Autopilot.HardwareHashTenantStatusLabel" xml:space="preserve">
     <value>Tenant connection</value>
   </data>
@@ -384,6 +390,15 @@
   <data name="Autopilot.HardwareHashCertificateCreatedMessageFormat" xml:space="preserve">
     <value>The PFX was saved to {1}. Store this password now; Foundry will not show it again: {0}</value>
   </data>
+  <data name="Autopilot.HardwareHashCertificateCreatedInstruction" xml:space="preserve">
+    <value>Store this password now. Foundry will not show it again.</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreatedPathLabel" xml:space="preserve">
+    <value>PFX file</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreatedPasswordLabel" xml:space="preserve">
+    <value>PFX password</value>
+  </data>
   <data name="Autopilot.HardwareHashCertificateCreateFailedTitle" xml:space="preserve">
     <value>Certificate creation failed</value>
   </data>
@@ -391,10 +406,10 @@
     <value>Foundry could not create the app registration certificate. {0}</value>
   </data>
   <data name="Autopilot.HardwareHashRetireCertificateConfirmationTitle" xml:space="preserve">
-    <value>Remove active certificate?</value>
+    <value>Remove selected certificate?</value>
   </data>
   <data name="Autopilot.HardwareHashRetireCertificateConfirmationMessage" xml:space="preserve">
-    <value>Foundry will remove only the selected active certificate from the managed app registration. Other app credentials will be preserved.</value>
+    <value>Foundry will remove only the selected certificate from the managed app registration. Other app credentials will be preserved.</value>
   </data>
   <data name="Autopilot.HardwareHashRetireCertificateConfirmationPrimary" xml:space="preserve">
     <value>Remove certificate</value>
@@ -403,13 +418,13 @@
     <value>Certificate removed</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateRetiredMessage" xml:space="preserve">
-    <value>The active certificate was removed from the managed app registration.</value>
+    <value>The selected certificate was removed from the managed app registration.</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateRetireFailedTitle" xml:space="preserve">
     <value>Certificate removal failed</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateRetireFailedMessageFormat" xml:space="preserve">
-    <value>Foundry could not remove the active app registration certificate. {0}</value>
+    <value>Foundry could not remove the selected app registration certificate. {0}</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateMissing" xml:space="preserve">
     <value>No active certificate is configured.</value>
@@ -425,6 +440,21 @@
   </data>
   <data name="Autopilot.HardwareHashCertificateExpiredWarning" xml:space="preserve">
     <value>Regenerate the certificate and boot media before using hardware hash upload.</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificatesEmpty" xml:space="preserve">
+    <value>No app registration certificate was discovered. Connect to the tenant or create a certificate.</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateThumbprintColumn" xml:space="preserve">
+    <value>Thumbprint</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreatedColumn" xml:space="preserve">
+    <value>Created</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateExpiresColumn" xml:space="preserve">
+    <value>Expiration</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateIdColumn" xml:space="preserve">
+    <value>Certificate ID</value>
   </data>
   <data name="Autopilot.HardwareHashDefaultGroupTagLabel" xml:space="preserve">
     <value>Default group tag</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -477,6 +477,9 @@
   <data name="Autopilot.HardwareHashBootMediaCertificateDescription" xml:space="preserve">
     <value>Password-protected PFX copied into boot media for hardware hash upload.</value>
   </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateTenantCertificateLabel" xml:space="preserve">
+    <value>Certificate</value>
+  </data>
   <data name="Autopilot.HardwareHashBootMediaCertificatePfxPathLabel" xml:space="preserve">
     <value>PFX file</value>
   </data>
@@ -490,10 +493,10 @@
     <value>Select Autopilot certificate PFX</value>
   </data>
   <data name="Autopilot.HardwareHashBootMediaCertificateActiveMissing" xml:space="preserve">
-    <value>Create or select an active app registration certificate first.</value>
+    <value>Select an app registration certificate first.</value>
   </data>
   <data name="Autopilot.HardwareHashBootMediaCertificateActiveExpired" xml:space="preserve">
-    <value>The active certificate is expired. Regenerate the certificate before creating boot media.</value>
+    <value>The selected certificate is expired. Create or select a valid certificate before creating boot media.</value>
   </data>
   <data name="Autopilot.HardwareHashBootMediaCertificatePfxMissing" xml:space="preserve">
     <value>Select the matching password-protected PFX before creating boot media.</value>
@@ -505,7 +508,7 @@
     <value>Enter the PFX password.</value>
   </data>
   <data name="Autopilot.HardwareHashBootMediaCertificateThumbprintMismatch" xml:space="preserve">
-    <value>The PFX certificate thumbprint does not match the active app registration certificate.</value>
+    <value>The PFX certificate thumbprint does not match the selected app registration certificate.</value>
   </data>
   <data name="Autopilot.HardwareHashBootMediaCertificatePrivateKeyMissing" xml:space="preserve">
     <value>The selected PFX does not contain private key material.</value>
@@ -1435,16 +1438,16 @@
     <value>Hardware hash upload is enabled but the app service principal is missing or not ready.</value>
   </data>
   <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateMissing" xml:space="preserve">
-    <value>Hardware hash upload is enabled but no active app registration certificate is configured.</value>
+    <value>Hardware hash upload is enabled but no app registration certificate is selected for boot media.</value>
   </data>
   <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateThumbprintMissing" xml:space="preserve">
-    <value>Hardware hash upload is enabled but the active certificate thumbprint is missing.</value>
+    <value>Hardware hash upload is enabled but the selected certificate thumbprint is missing.</value>
   </data>
   <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateExpirationMissing" xml:space="preserve">
-    <value>Hardware hash upload is enabled but the active certificate expiration is missing.</value>
+    <value>Hardware hash upload is enabled but the selected certificate expiration is missing.</value>
   </data>
   <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateExpired" xml:space="preserve">
-    <value>Hardware hash upload is enabled but the active certificate is expired. Regenerate the certificate and recreate boot media.</value>
+    <value>Hardware hash upload is enabled but the selected certificate is expired. Select a valid certificate before creating boot media.</value>
   </data>
   <data name="StartMedia.Autopilot.Validation.HardwareHashBootMediaPfxMissing" xml:space="preserve">
     <value>Hardware hash upload is enabled but no boot media PFX is selected.</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -303,6 +303,9 @@
   <data name="Autopilot.HardwareHashConnectTenantButton" xml:space="preserve">
     <value>Connect tenant</value>
   </data>
+  <data name="Autopilot.HardwareHashDisconnectTenantButton" xml:space="preserve">
+    <value>Disconnect tenant</value>
+  </data>
   <data name="Autopilot.HardwareHashConnectingTenantStatus" xml:space="preserve">
     <value>Connecting tenant...</value>
   </data>
@@ -449,9 +452,6 @@
   </data>
   <data name="Autopilot.HardwareHashCertificateExpiredWarning" xml:space="preserve">
     <value>Regenerate the certificate and boot media before using hardware hash upload.</value>
-  </data>
-  <data name="Autopilot.HardwareHashCertificatesEmpty" xml:space="preserve">
-    <value>No app registration certificate was discovered. Connect to the tenant or create a certificate.</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateThumbprintColumn" xml:space="preserve">
     <value>Thumbprint</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -423,6 +423,9 @@
   <data name="Autopilot.HardwareHashRetireCertificateConfirmationMessage" xml:space="preserve">
     <value>Foundry will remove only the selected certificate from the managed app registration. Other app credentials will be preserved.</value>
   </data>
+  <data name="Autopilot.HardwareHashRetireCertificatesConfirmationMessageFormat" xml:space="preserve">
+    <value>Foundry will remove only the {0} selected certificates from the managed app registration. Other app credentials will be preserved.</value>
+  </data>
   <data name="Autopilot.HardwareHashRetireCertificateConfirmationPrimary" xml:space="preserve">
     <value>Remove certificate</value>
   </data>
@@ -430,7 +433,7 @@
     <value>Certificate removed</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateRetiredMessage" xml:space="preserve">
-    <value>The selected certificate was removed from the managed app registration.</value>
+    <value>The selected certificate credentials were removed from the managed app registration.</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateRetireFailedTitle" xml:space="preserve">
     <value>Certificate removal failed</value>
@@ -465,6 +468,48 @@
   <data name="Autopilot.HardwareHashCertificateIdColumn" xml:space="preserve">
     <value>Certificate ID</value>
   </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateLabel" xml:space="preserve">
+    <value>Boot media certificate</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificatePfxPathLabel" xml:space="preserve">
+    <value>PFX file</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificatePasswordLabel" xml:space="preserve">
+    <value>PFX password</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateSelectButton" xml:space="preserve">
+    <value>Select PFX</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificatePfxPickerTitle" xml:space="preserve">
+    <value>Select Autopilot certificate PFX</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateActiveMissing" xml:space="preserve">
+    <value>Create or select an active app registration certificate first.</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateActiveExpired" xml:space="preserve">
+    <value>The active certificate is expired. Regenerate the certificate before creating boot media.</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificatePfxMissing" xml:space="preserve">
+    <value>Select the matching password-protected PFX before creating boot media.</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateFileMissing" xml:space="preserve">
+    <value>The selected PFX file no longer exists.</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificatePasswordMissing" xml:space="preserve">
+    <value>Enter the PFX password.</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateThumbprintMismatch" xml:space="preserve">
+    <value>The PFX certificate thumbprint does not match the active app registration certificate.</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificatePrivateKeyMissing" xml:space="preserve">
+    <value>The selected PFX does not contain private key material.</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateInvalidPfx" xml:space="preserve">
+    <value>The selected PFX could not be opened with the provided password.</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateReady" xml:space="preserve">
+    <value>Certificate ready for boot media generation.</value>
+  </data>
   <data name="Autopilot.HardwareHashDefaultGroupTagLabel" xml:space="preserve">
     <value>Default group tag</value>
   </data>
@@ -472,7 +517,7 @@
     <value>No default group tag selected.</value>
   </data>
   <data name="Autopilot.HardwareHashKnownGroupTagsLabel" xml:space="preserve">
-    <value>Known group tags</value>
+    <value>Available group tags</value>
   </data>
   <data name="Autopilot.HardwareHashKnownGroupTagsNone" xml:space="preserve">
     <value>No group tags discovered.</value>
@@ -1349,6 +1394,57 @@
   </data>
   <data name="StartMedia.Autopilot.NotReady" xml:space="preserve">
     <value>Enabled; default profile missing</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.UnsupportedProvisioningMode" xml:space="preserve">
+    <value>Autopilot uses an unsupported provisioning mode.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.JsonProfileMissing" xml:space="preserve">
+    <value>Autopilot JSON profile mode is enabled but no valid default profile is selected.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashSettingsMissing" xml:space="preserve">
+    <value>Hardware hash upload is enabled but settings are missing.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashTenantMissing" xml:space="preserve">
+    <value>Hardware hash upload is enabled but the tenant connection is missing. Connect to the tenant from Autopilot.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashAppRegistrationMissing" xml:space="preserve">
+    <value>Hardware hash upload is enabled but the app registration is not configured. Connect to the tenant from Autopilot.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashClientIdMissing" xml:space="preserve">
+    <value>Hardware hash upload is enabled but the app client ID is missing. Reconnect to the tenant from Autopilot.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashServicePrincipalMissing" xml:space="preserve">
+    <value>Hardware hash upload is enabled but the app service principal is missing or not ready.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateMissing" xml:space="preserve">
+    <value>Hardware hash upload is enabled but no active app registration certificate is configured.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateThumbprintMissing" xml:space="preserve">
+    <value>Hardware hash upload is enabled but the active certificate thumbprint is missing.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateExpirationMissing" xml:space="preserve">
+    <value>Hardware hash upload is enabled but the active certificate expiration is missing.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateExpired" xml:space="preserve">
+    <value>Hardware hash upload is enabled but the active certificate is expired. Regenerate the certificate and recreate boot media.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashBootMediaPfxMissing" xml:space="preserve">
+    <value>Hardware hash upload is enabled but no boot media PFX is selected.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashBootMediaPfxPasswordMissing" xml:space="preserve">
+    <value>Hardware hash upload is enabled but the boot media PFX password is missing.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashBootMediaCertificateNotValidated" xml:space="preserve">
+    <value>Hardware hash upload is enabled but the boot media PFX has not been validated.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashBootMediaCertificateThumbprintMismatch" xml:space="preserve">
+    <value>Hardware hash upload is enabled but the selected PFX does not match the active certificate.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashBootMediaCertificateExpirationMissing" xml:space="preserve">
+    <value>Hardware hash upload is enabled but the boot media PFX expiration could not be validated.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashBootMediaCertificateExpired" xml:space="preserve">
+    <value>Hardware hash upload is enabled but the selected boot media PFX is expired.</value>
   </data>
   <data name="StartMedia.BlockingReason.AdkNotReady" xml:space="preserve">
     <value>ADK or WinPE Add-on is not ready.</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -255,9 +255,6 @@
   <data name="Autopilot.TenantDownloadDialogMessage" xml:space="preserve">
     <value>Complete sign-in in the browser to download Autopilot profiles.</value>
   </data>
-  <data name="Autopilot.TenantDownloadDialogCancel" xml:space="preserve">
-    <value>Cancel</value>
-  </data>
   <data name="Autopilot.DownloadNoProfilesTitle" xml:space="preserve">
     <value>No Autopilot profiles found</value>
   </data>
@@ -356,9 +353,6 @@
   </data>
   <data name="Autopilot.HardwareHashTenantDetailsClientId" xml:space="preserve">
     <value>Client ID</value>
-  </data>
-  <data name="Autopilot.HardwareHashTenantDetailsFormat" xml:space="preserve">
-    <value>Tenant ID: {0}</value>
   </data>
   <data name="Autopilot.HardwareHashAppRegistrationLabel" xml:space="preserve">
     <value>App registration</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -477,9 +477,6 @@
   <data name="Autopilot.HardwareHashBootMediaCertificateDescription" xml:space="preserve">
     <value>Password-protected PFX copied into boot media for hardware hash upload.</value>
   </data>
-  <data name="Autopilot.HardwareHashBootMediaCertificateTenantCertificateLabel" xml:space="preserve">
-    <value>Certificate</value>
-  </data>
   <data name="Autopilot.HardwareHashBootMediaCertificatePfxPathLabel" xml:space="preserve">
     <value>PFX file</value>
   </data>
@@ -493,7 +490,7 @@
     <value>Select Autopilot certificate PFX</value>
   </data>
   <data name="Autopilot.HardwareHashBootMediaCertificateActiveMissing" xml:space="preserve">
-    <value>Select an app registration certificate first.</value>
+    <value>Select a PFX that matches an app registration certificate.</value>
   </data>
   <data name="Autopilot.HardwareHashBootMediaCertificateActiveExpired" xml:space="preserve">
     <value>The selected certificate is expired. Create or select a valid certificate before creating boot media.</value>
@@ -1438,7 +1435,7 @@
     <value>Hardware hash upload is enabled but the app service principal is missing or not ready.</value>
   </data>
   <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateMissing" xml:space="preserve">
-    <value>Hardware hash upload is enabled but no app registration certificate is selected for boot media.</value>
+    <value>Hardware hash upload is enabled but the selected PFX does not match an app registration certificate.</value>
   </data>
   <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateThumbprintMissing" xml:space="preserve">
     <value>Hardware hash upload is enabled but the selected certificate thumbprint is missing.</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -318,8 +318,17 @@
   <data name="Autopilot.HardwareHashTenantNotConnected" xml:space="preserve">
     <value>Not connected</value>
   </data>
+  <data name="Autopilot.HardwareHashTenantConnected" xml:space="preserve">
+    <value>Connected</value>
+  </data>
   <data name="Autopilot.HardwareHashTenantConnectedFormat" xml:space="preserve">
     <value>Connected to tenant {0}</value>
+  </data>
+  <data name="Autopilot.HardwareHashTenantDetailsLabel" xml:space="preserve">
+    <value>Tenant details</value>
+  </data>
+  <data name="Autopilot.HardwareHashTenantDetailsFormat" xml:space="preserve">
+    <value>Tenant ID: {0}</value>
   </data>
   <data name="Autopilot.HardwareHashAppRegistrationLabel" xml:space="preserve">
     <value>App registration</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -333,9 +333,6 @@
   <data name="Autopilot.HardwareHashTenantConnected" xml:space="preserve">
     <value>Connected</value>
   </data>
-  <data name="Autopilot.HardwareHashTenantConnectedFormat" xml:space="preserve">
-    <value>Connected to tenant {0}</value>
-  </data>
   <data name="Autopilot.HardwareHashTenantReadinessLabel" xml:space="preserve">
     <value>Tenant readiness</value>
   </data>
@@ -435,12 +432,6 @@
   <data name="Autopilot.HardwareHashRetireCertificateConfirmationPrimary" xml:space="preserve">
     <value>Remove certificate</value>
   </data>
-  <data name="Autopilot.HardwareHashCertificateRetiredTitle" xml:space="preserve">
-    <value>Certificate removed</value>
-  </data>
-  <data name="Autopilot.HardwareHashCertificateRetiredMessage" xml:space="preserve">
-    <value>The selected certificate credentials were removed from the managed app registration.</value>
-  </data>
   <data name="Autopilot.HardwareHashCertificateRetireFailedTitle" xml:space="preserve">
     <value>Certificate removal failed</value>
   </data>
@@ -524,6 +515,30 @@
   </data>
   <data name="Autopilot.HardwareHashOnboardingFailedMessageFormat" xml:space="preserve">
     <value>Foundry could not configure the Autopilot app registration. {0}</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingMessageAppRegistrationMissing" xml:space="preserve">
+    <value>The managed app registration could not be found. Reconnect to let Foundry create or adopt it.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingMessageAdoptionRequired" xml:space="preserve">
+    <value>An existing app registration with the Foundry name was found. Reconnect to adopt it into the Foundry configuration.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingMessagePermissionMissing" xml:space="preserve">
+    <value>The managed app registration is missing the required Microsoft Graph application permission. Reconnect with an account that can update app registrations.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingMessageConsentMissing" xml:space="preserve">
+    <value>The managed service principal is missing admin consent for the required Microsoft Graph permission. Grant admin consent and reconnect.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingMessageServicePrincipalUnavailable" xml:space="preserve">
+    <value>The managed service principal is missing or disabled. Reconnect with an account that can create or manage enterprise applications.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingMessageActiveCertificateNotFound" xml:space="preserve">
+    <value>The previously selected certificate no longer exists in the managed app registration. Select a valid PFX that matches a provisioned certificate.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingMessageActiveCertificateExpired" xml:space="preserve">
+    <value>The selected certificate is expired. Create a new certificate, save its PFX and password, then select it for boot media.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingMessageGeneric" xml:space="preserve">
+    <value>The managed app registration is not ready. Review tenant readiness and reconnect.</value>
   </data>
   <data name="CustomizationPage_Title.Text" xml:space="preserve">
     <value>Customization</value>
@@ -1382,9 +1397,6 @@
   </data>
   <data name="StartMedia.Autopilot.HardwareHashUpload" xml:space="preserve">
     <value>Enabled: hardware hash upload</value>
-  </data>
-  <data name="StartMedia.Autopilot.NotReady" xml:space="preserve">
-    <value>Enabled; default profile missing</value>
   </data>
   <data name="StartMedia.Autopilot.Validation.UnsupportedProvisioningMode" xml:space="preserve">
     <value>Autopilot uses an unsupported provisioning mode.</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -519,6 +519,9 @@
   <data name="Autopilot.HardwareHashKnownGroupTagsLabel" xml:space="preserve">
     <value>Available group tags</value>
   </data>
+  <data name="Autopilot.HardwareHashAvailableGroupTagColumn" xml:space="preserve">
+    <value>Group tag</value>
+  </data>
   <data name="Autopilot.HardwareHashKnownGroupTagsNone" xml:space="preserve">
     <value>No group tags discovered.</value>
   </data>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -507,6 +507,9 @@
   <data name="Autopilot.HardwareHashDefaultGroupTagNoneOption" xml:space="preserve">
     <value>None</value>
   </data>
+  <data name="Autopilot.HardwareHashDefaultGroupTagNoSelection" xml:space="preserve">
+    <value>None</value>
+  </data>
   <data name="Autopilot.HardwareHashOnboardingRequiresAttentionTitle" xml:space="preserve">
     <value>Tenant onboarding requires attention</value>
   </data>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -516,6 +516,9 @@
   <data name="Autopilot.HardwareHashDefaultGroupTagNone" xml:space="preserve">
     <value>No default group tag selected.</value>
   </data>
+  <data name="Autopilot.HardwareHashDefaultGroupTagNoneOption" xml:space="preserve">
+    <value>None</value>
+  </data>
   <data name="Autopilot.HardwareHashKnownGroupTagsLabel" xml:space="preserve">
     <value>Available group tags</value>
   </data>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -508,28 +508,16 @@
     <value>Certificate ready for boot media generation.</value>
   </data>
   <data name="Autopilot.HardwareHashGroupTagLabel" xml:space="preserve">
-    <value>Group tag</value>
+    <value>Default group tag</value>
   </data>
   <data name="Autopilot.HardwareHashGroupTagDescription" xml:space="preserve">
-    <value>Optional Autopilot group tag discovery and default selection.</value>
-  </data>
-  <data name="Autopilot.HardwareHashDefaultGroupTagLabel" xml:space="preserve">
-    <value>Default group tag</value>
+    <value>Optional group tag preselected in Foundry Deploy during hardware hash upload.</value>
   </data>
   <data name="Autopilot.HardwareHashDefaultGroupTagNone" xml:space="preserve">
     <value>No default group tag selected.</value>
   </data>
   <data name="Autopilot.HardwareHashDefaultGroupTagNoneOption" xml:space="preserve">
     <value>None</value>
-  </data>
-  <data name="Autopilot.HardwareHashKnownGroupTagsLabel" xml:space="preserve">
-    <value>Available group tags</value>
-  </data>
-  <data name="Autopilot.HardwareHashAvailableGroupTagColumn" xml:space="preserve">
-    <value>Group tag</value>
-  </data>
-  <data name="Autopilot.HardwareHashKnownGroupTagsNone" xml:space="preserve">
-    <value>No group tags discovered. Group tag assignment is optional.</value>
   </data>
   <data name="Autopilot.HardwareHashOnboardingCompletedTitle" xml:space="preserve">
     <value>Tenant onboarding complete</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -186,6 +186,9 @@
   <data name="Autopilot.ActionsHeader" xml:space="preserve">
     <value>Profile actions</value>
   </data>
+  <data name="Autopilot.ActionsDescription" xml:space="preserve">
+    <value>Import local JSON profiles or download them from Intune.</value>
+  </data>
   <data name="Autopilot.ImportingStatus" xml:space="preserve">
     <value>Importing Autopilot profile...</value>
   </data>
@@ -213,8 +216,14 @@
   <data name="Autopilot.DefaultProfileLabel" xml:space="preserve">
     <value>Default profile</value>
   </data>
+  <data name="Autopilot.DefaultProfileDescription" xml:space="preserve">
+    <value>Profile staged by default in the applied Windows image.</value>
+  </data>
   <data name="Autopilot.ProfilesLabel" xml:space="preserve">
     <value>Imported profiles</value>
+  </data>
+  <data name="Autopilot.ProfilesDescription" xml:space="preserve">
+    <value>Offline Autopilot profiles available for JSON profile provisioning.</value>
   </data>
   <data name="Autopilot.ProfilesEmptyLabel" xml:space="preserve">
     <value>No Autopilot profiles imported.</value>
@@ -318,6 +327,9 @@
   <data name="Autopilot.HardwareHashTenantStatusLabel" xml:space="preserve">
     <value>Tenant connection</value>
   </data>
+  <data name="Autopilot.HardwareHashTenantStatusDescription" xml:space="preserve">
+    <value>Connect to Microsoft Graph for this app session to manage hash upload settings.</value>
+  </data>
   <data name="Autopilot.HardwareHashTenantNotConnected" xml:space="preserve">
     <value>Not connected</value>
   </data>
@@ -330,11 +342,29 @@
   <data name="Autopilot.HardwareHashTenantDetailsLabel" xml:space="preserve">
     <value>Tenant details</value>
   </data>
+  <data name="Autopilot.HardwareHashTenantDetailsDescription" xml:space="preserve">
+    <value>Tenant and application identifiers used by generated boot media.</value>
+  </data>
+  <data name="Autopilot.HardwareHashTenantDetailsNameColumn" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="Autopilot.HardwareHashTenantDetailsValueColumn" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="Autopilot.HardwareHashTenantDetailsTenantId" xml:space="preserve">
+    <value>Tenant ID</value>
+  </data>
+  <data name="Autopilot.HardwareHashTenantDetailsClientId" xml:space="preserve">
+    <value>Client ID</value>
+  </data>
   <data name="Autopilot.HardwareHashTenantDetailsFormat" xml:space="preserve">
     <value>Tenant ID: {0}</value>
   </data>
   <data name="Autopilot.HardwareHashAppRegistrationLabel" xml:space="preserve">
     <value>App registration</value>
+  </data>
+  <data name="Autopilot.HardwareHashAppRegistrationDescription" xml:space="preserve">
+    <value>Managed Entra app registration used by Foundry Deploy in WinPE.</value>
   </data>
   <data name="Autopilot.HardwareHashAppRegistrationMissing" xml:space="preserve">
     <value>Foundry OSD Autopilot Registration is not configured.</value>
@@ -344,6 +374,9 @@
   </data>
   <data name="Autopilot.HardwareHashOnboardingStatusLabel" xml:space="preserve">
     <value>Onboarding status</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusDescription" xml:space="preserve">
+    <value>Readiness state for permissions, consent, service principal, and certificate configuration.</value>
   </data>
   <data name="Autopilot.HardwareHashOnboardingStatusNotChecked" xml:space="preserve">
     <value>Connect to the tenant to check permissions, consent, service principal, and certificate state.</value>
@@ -380,6 +413,9 @@
   </data>
   <data name="Autopilot.HardwareHashCertificateStatusLabel" xml:space="preserve">
     <value>Certificate</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateStatusDescription" xml:space="preserve">
+    <value>App registration certificates trusted for WinPE Graph authentication.</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateValidityLabel" xml:space="preserve">
     <value>Validity</value>
@@ -471,6 +507,9 @@
   <data name="Autopilot.HardwareHashBootMediaCertificateLabel" xml:space="preserve">
     <value>Boot media certificate</value>
   </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateDescription" xml:space="preserve">
+    <value>Password-protected PFX copied into boot media for hardware hash upload.</value>
+  </data>
   <data name="Autopilot.HardwareHashBootMediaCertificatePfxPathLabel" xml:space="preserve">
     <value>PFX file</value>
   </data>
@@ -513,6 +552,9 @@
   <data name="Autopilot.HardwareHashDefaultGroupTagLabel" xml:space="preserve">
     <value>Default group tag</value>
   </data>
+  <data name="Autopilot.HardwareHashDefaultGroupTagDescription" xml:space="preserve">
+    <value>Optional group tag preselected in Foundry Deploy during hardware hash upload.</value>
+  </data>
   <data name="Autopilot.HardwareHashDefaultGroupTagNone" xml:space="preserve">
     <value>No default group tag selected.</value>
   </data>
@@ -521,6 +563,9 @@
   </data>
   <data name="Autopilot.HardwareHashKnownGroupTagsLabel" xml:space="preserve">
     <value>Available group tags</value>
+  </data>
+  <data name="Autopilot.HardwareHashKnownGroupTagsDescription" xml:space="preserve">
+    <value>Group tags discovered from existing Windows Autopilot device identities.</value>
   </data>
   <data name="Autopilot.HardwareHashAvailableGroupTagColumn" xml:space="preserve">
     <value>Group tag</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -513,9 +513,6 @@
   <data name="Autopilot.HardwareHashDefaultGroupTagNoneOption" xml:space="preserve">
     <value>None</value>
   </data>
-  <data name="Autopilot.HardwareHashOnboardingCompletedTitle" xml:space="preserve">
-    <value>Tenant onboarding complete</value>
-  </data>
   <data name="Autopilot.HardwareHashOnboardingRequiresAttentionTitle" xml:space="preserve">
     <value>Tenant onboarding requires attention</value>
   </data>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -372,38 +372,11 @@
   <data name="Autopilot.HardwareHashOnboardingStatusDescription" xml:space="preserve">
     <value>Readiness state for permissions, consent, service principal, and certificate configuration.</value>
   </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusNotChecked" xml:space="preserve">
-    <value>Connect to the tenant to check permissions, consent, service principal, and certificate state.</value>
-  </data>
   <data name="Autopilot.HardwareHashOnboardingStatusReady" xml:space="preserve">
-    <value>Ready. Permissions, admin consent, service principal, and active certificate are valid.</value>
+    <value>Ready</value>
   </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusAppMissing" xml:space="preserve">
-    <value>The managed app registration was not found.</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusAdoptionRequired" xml:space="preserve">
-    <value>An existing managed app registration was found and must be adopted before media generation.</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusPermissionMissing" xml:space="preserve">
-    <value>The managed app registration is missing required Microsoft Graph application permissions.</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusConsentMissing" xml:space="preserve">
-    <value>Admin consent is missing for the required Microsoft Graph application permissions.</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusServicePrincipalUnavailable" xml:space="preserve">
-    <value>The managed app service principal is missing or disabled.</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusCertificateMissing" xml:space="preserve">
-    <value>No active certificate is selected. Create a certificate before generating boot media.</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusCertificateNotFound" xml:space="preserve">
-    <value>The selected active certificate no longer exists on the managed app registration.</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusCertificateExpired" xml:space="preserve">
-    <value>The active certificate is expired. Regenerate the certificate and boot media.</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusMultipleCertificates" xml:space="preserve">
-    <value>Multiple Foundry certificates exist and no active certificate can be selected from persisted metadata.</value>
+  <data name="Autopilot.HardwareHashOnboardingStatusNotReady" xml:space="preserve">
+    <value>Not ready</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateStatusLabel" xml:space="preserve">
     <value>Certificate</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -169,7 +169,7 @@
     <value>Autopilot</value>
   </data>
   <data name="Autopilot.Description" xml:space="preserve">
-    <value>Import and select offline Autopilot profiles for deployment media.</value>
+    <value>Choose the Autopilot provisioning method for deployment media: JSON profile staging or WinPE hardware hash upload.</value>
   </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Enable Autopilot</value>
@@ -400,19 +400,22 @@
     <value>PFX certificate</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateCreatedTitle" xml:space="preserve">
-    <value>Certificate created</value>
-  </data>
-  <data name="Autopilot.HardwareHashCertificateCreatedMessageFormat" xml:space="preserve">
-    <value>The PFX was saved to {1}. Store this password now; Foundry will not show it again: {0}</value>
+    <value>Certificate ready</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateCreatedInstruction" xml:space="preserve">
-    <value>Store this password now. Foundry will not show it again.</value>
+    <value>Save this PFX file and password now in a secure location. Foundry does not store the password and cannot show it again after this dialog closes. You will need both values to generate boot media for hardware hash upload.</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateCreatedPathLabel" xml:space="preserve">
     <value>PFX file</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateCreatedPasswordLabel" xml:space="preserve">
     <value>PFX password</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreatedCopyPasswordButton" xml:space="preserve">
+    <value>Copy password</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreatedPasswordCopied" xml:space="preserve">
+    <value>Password copied.</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateCreateFailedTitle" xml:space="preserve">
     <value>Certificate creation failed</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -342,6 +342,12 @@
   <data name="Autopilot.HardwareHashTenantReadinessDescription" xml:space="preserve">
     <value>Tenant, app registration, and readiness information for hardware hash upload.</value>
   </data>
+  <data name="Autopilot.HardwareHashTenantReadinessNameColumn" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="Autopilot.HardwareHashTenantReadinessValueColumn" xml:space="preserve">
+    <value>Value</value>
+  </data>
   <data name="Autopilot.HardwareHashTenantDetailsTenantId" xml:space="preserve">
     <value>Tenant ID</value>
   </data>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -378,14 +378,20 @@
   <data name="Autopilot.HardwareHashOnboardingStatusNotReady" xml:space="preserve">
     <value>Not ready</value>
   </data>
-  <data name="Autopilot.HardwareHashCertificateStatusLabel" xml:space="preserve">
-    <value>Certificate</value>
+  <data name="Autopilot.HardwareHashCertificateActionsLabel" xml:space="preserve">
+    <value>Certificate actions</value>
   </data>
-  <data name="Autopilot.HardwareHashCertificateStatusDescription" xml:space="preserve">
+  <data name="Autopilot.HardwareHashCertificateActionsDescription" xml:space="preserve">
+    <value>Create or remove app registration certificate credentials.</value>
+  </data>
+  <data name="Autopilot.HardwareHashProvisionedCertificatesLabel" xml:space="preserve">
+    <value>Provisioned certificates</value>
+  </data>
+  <data name="Autopilot.HardwareHashProvisionedCertificatesDescription" xml:space="preserve">
     <value>App registration certificates trusted for WinPE Graph authentication.</value>
   </data>
-  <data name="Autopilot.HardwareHashCertificateValidityLabel" xml:space="preserve">
-    <value>Validity</value>
+  <data name="Autopilot.HardwareHashCertificatesNone" xml:space="preserve">
+    <value>No certificates are provisioned.</value>
   </data>
   <data name="Autopilot.HardwareHashCreateCertificateButton" xml:space="preserve">
     <value>Create certificate</value>
@@ -444,21 +450,6 @@
   <data name="Autopilot.HardwareHashCertificateRetireFailedMessageFormat" xml:space="preserve">
     <value>Foundry could not remove the selected app registration certificate. {0}</value>
   </data>
-  <data name="Autopilot.HardwareHashCertificateMissing" xml:space="preserve">
-    <value>No active certificate is configured.</value>
-  </data>
-  <data name="Autopilot.HardwareHashCertificateExpirationMissing" xml:space="preserve">
-    <value>The active certificate expiration is missing.</value>
-  </data>
-  <data name="Autopilot.HardwareHashCertificateValidFormat" xml:space="preserve">
-    <value>Valid until {0}</value>
-  </data>
-  <data name="Autopilot.HardwareHashCertificateExpiredFormat" xml:space="preserve">
-    <value>Expired on {0}</value>
-  </data>
-  <data name="Autopilot.HardwareHashCertificateExpiredWarning" xml:space="preserve">
-    <value>Regenerate the certificate and boot media before using hardware hash upload.</value>
-  </data>
   <data name="Autopilot.HardwareHashCertificateThumbprintColumn" xml:space="preserve">
     <value>Thumbprint</value>
   </data>
@@ -516,11 +507,14 @@
   <data name="Autopilot.HardwareHashBootMediaCertificateReady" xml:space="preserve">
     <value>Certificate ready for boot media generation.</value>
   </data>
+  <data name="Autopilot.HardwareHashGroupTagLabel" xml:space="preserve">
+    <value>Group tag</value>
+  </data>
+  <data name="Autopilot.HardwareHashGroupTagDescription" xml:space="preserve">
+    <value>Optional Autopilot group tag discovery and default selection.</value>
+  </data>
   <data name="Autopilot.HardwareHashDefaultGroupTagLabel" xml:space="preserve">
     <value>Default group tag</value>
-  </data>
-  <data name="Autopilot.HardwareHashDefaultGroupTagDescription" xml:space="preserve">
-    <value>Optional group tag preselected in Foundry Deploy during hardware hash upload.</value>
   </data>
   <data name="Autopilot.HardwareHashDefaultGroupTagNone" xml:space="preserve">
     <value>No default group tag selected.</value>
@@ -531,14 +525,11 @@
   <data name="Autopilot.HardwareHashKnownGroupTagsLabel" xml:space="preserve">
     <value>Available group tags</value>
   </data>
-  <data name="Autopilot.HardwareHashKnownGroupTagsDescription" xml:space="preserve">
-    <value>Group tags discovered from existing Windows Autopilot device identities.</value>
-  </data>
   <data name="Autopilot.HardwareHashAvailableGroupTagColumn" xml:space="preserve">
     <value>Group tag</value>
   </data>
   <data name="Autopilot.HardwareHashKnownGroupTagsNone" xml:space="preserve">
-    <value>No group tags discovered.</value>
+    <value>No group tags discovered. Group tag assignment is optional.</value>
   </data>
   <data name="Autopilot.HardwareHashOnboardingCompletedTitle" xml:space="preserve">
     <value>Tenant onboarding complete</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -303,6 +303,9 @@
   <data name="Autopilot.HardwareHashConnectTenantButton" xml:space="preserve">
     <value>Connect tenant</value>
   </data>
+  <data name="Autopilot.HardwareHashConnectingTenantStatus" xml:space="preserve">
+    <value>Connecting tenant...</value>
+  </data>
   <data name="Autopilot.HardwareHashTenantStatusLabel" xml:space="preserve">
     <value>Tenant connection</value>
   </data>
@@ -321,8 +324,92 @@
   <data name="Autopilot.HardwareHashAppRegistrationFoundFormat" xml:space="preserve">
     <value>{0} is configured.</value>
   </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusLabel" xml:space="preserve">
+    <value>Onboarding status</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusNotChecked" xml:space="preserve">
+    <value>Connect to the tenant to check permissions, consent, service principal, and certificate state.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusReady" xml:space="preserve">
+    <value>Ready. Permissions, admin consent, service principal, and active certificate are valid.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusAppMissing" xml:space="preserve">
+    <value>The managed app registration was not found.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusAdoptionRequired" xml:space="preserve">
+    <value>An existing managed app registration was found and must be adopted before media generation.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusPermissionMissing" xml:space="preserve">
+    <value>The managed app registration is missing required Microsoft Graph application permissions.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusConsentMissing" xml:space="preserve">
+    <value>Admin consent is missing for the required Microsoft Graph application permissions.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusServicePrincipalUnavailable" xml:space="preserve">
+    <value>The managed app service principal is missing or disabled.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusCertificateMissing" xml:space="preserve">
+    <value>No active certificate is selected. Create a certificate before generating boot media.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusCertificateNotFound" xml:space="preserve">
+    <value>The selected active certificate no longer exists on the managed app registration.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusCertificateExpired" xml:space="preserve">
+    <value>The active certificate is expired. Regenerate the certificate and boot media.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusMultipleCertificates" xml:space="preserve">
+    <value>Multiple Foundry certificates exist and no active certificate can be selected from persisted metadata.</value>
+  </data>
   <data name="Autopilot.HardwareHashCertificateStatusLabel" xml:space="preserve">
     <value>Certificate</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateValidityLabel" xml:space="preserve">
+    <value>Validity</value>
+  </data>
+  <data name="Autopilot.HardwareHashCreateCertificateButton" xml:space="preserve">
+    <value>Create certificate</value>
+  </data>
+  <data name="Autopilot.HardwareHashRetireCertificateButton" xml:space="preserve">
+    <value>Remove certificate</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateSavePickerTitle" xml:space="preserve">
+    <value>Save Autopilot certificate PFX</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificatePfxFileType" xml:space="preserve">
+    <value>PFX certificate</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreatedTitle" xml:space="preserve">
+    <value>Certificate created</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreatedMessageFormat" xml:space="preserve">
+    <value>The PFX was saved to {1}. Store this password now; Foundry will not show it again: {0}</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreateFailedTitle" xml:space="preserve">
+    <value>Certificate creation failed</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreateFailedMessageFormat" xml:space="preserve">
+    <value>Foundry could not create the app registration certificate. {0}</value>
+  </data>
+  <data name="Autopilot.HardwareHashRetireCertificateConfirmationTitle" xml:space="preserve">
+    <value>Remove active certificate?</value>
+  </data>
+  <data name="Autopilot.HardwareHashRetireCertificateConfirmationMessage" xml:space="preserve">
+    <value>Foundry will remove only the selected active certificate from the managed app registration. Other app credentials will be preserved.</value>
+  </data>
+  <data name="Autopilot.HardwareHashRetireCertificateConfirmationPrimary" xml:space="preserve">
+    <value>Remove certificate</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateRetiredTitle" xml:space="preserve">
+    <value>Certificate removed</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateRetiredMessage" xml:space="preserve">
+    <value>The active certificate was removed from the managed app registration.</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateRetireFailedTitle" xml:space="preserve">
+    <value>Certificate removal failed</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateRetireFailedMessageFormat" xml:space="preserve">
+    <value>Foundry could not remove the active app registration certificate. {0}</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateMissing" xml:space="preserve">
     <value>No active certificate is configured.</value>
@@ -351,11 +438,17 @@
   <data name="Autopilot.HardwareHashKnownGroupTagsNone" xml:space="preserve">
     <value>No group tags discovered.</value>
   </data>
-  <data name="Autopilot.HardwareHashOnboardingUnavailableTitle" xml:space="preserve">
-    <value>Tenant onboarding</value>
+  <data name="Autopilot.HardwareHashOnboardingCompletedTitle" xml:space="preserve">
+    <value>Tenant onboarding complete</value>
   </data>
-  <data name="Autopilot.HardwareHashOnboardingUnavailableMessage" xml:space="preserve">
-    <value>Tenant onboarding and certificate creation are implemented in the next security phase.</value>
+  <data name="Autopilot.HardwareHashOnboardingRequiresAttentionTitle" xml:space="preserve">
+    <value>Tenant onboarding requires attention</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingFailedTitle" xml:space="preserve">
+    <value>Tenant onboarding failed</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingFailedMessageFormat" xml:space="preserve">
+    <value>Foundry could not configure the Autopilot app registration. {0}</value>
   </data>
   <data name="CustomizationPage_Title.Text" xml:space="preserve">
     <value>Customization</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -336,17 +336,11 @@
   <data name="Autopilot.HardwareHashTenantConnectedFormat" xml:space="preserve">
     <value>Connected to tenant {0}</value>
   </data>
-  <data name="Autopilot.HardwareHashTenantDetailsLabel" xml:space="preserve">
-    <value>Tenant details</value>
+  <data name="Autopilot.HardwareHashTenantReadinessLabel" xml:space="preserve">
+    <value>Tenant readiness</value>
   </data>
-  <data name="Autopilot.HardwareHashTenantDetailsDescription" xml:space="preserve">
-    <value>Tenant and application identifiers used by generated boot media.</value>
-  </data>
-  <data name="Autopilot.HardwareHashTenantDetailsNameColumn" xml:space="preserve">
-    <value>Name</value>
-  </data>
-  <data name="Autopilot.HardwareHashTenantDetailsValueColumn" xml:space="preserve">
-    <value>Value</value>
+  <data name="Autopilot.HardwareHashTenantReadinessDescription" xml:space="preserve">
+    <value>Tenant, app registration, and readiness information for hardware hash upload.</value>
   </data>
   <data name="Autopilot.HardwareHashTenantDetailsTenantId" xml:space="preserve">
     <value>Tenant ID</value>
@@ -355,10 +349,7 @@
     <value>Client ID</value>
   </data>
   <data name="Autopilot.HardwareHashAppRegistrationLabel" xml:space="preserve">
-    <value>App registration</value>
-  </data>
-  <data name="Autopilot.HardwareHashAppRegistrationDescription" xml:space="preserve">
-    <value>Managed Entra app registration used by Foundry Deploy in WinPE.</value>
+    <value>Managed app registration</value>
   </data>
   <data name="Autopilot.HardwareHashAppRegistrationMissing" xml:space="preserve">
     <value>Foundry OSD Autopilot Registration is not configured.</value>
@@ -367,10 +358,7 @@
     <value>{0} is configured.</value>
   </data>
   <data name="Autopilot.HardwareHashOnboardingStatusLabel" xml:space="preserve">
-    <value>Onboarding status</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusDescription" xml:space="preserve">
-    <value>Readiness state for permissions, consent, service principal, and certificate configuration.</value>
+    <value>Status</value>
   </data>
   <data name="Autopilot.HardwareHashOnboardingStatusReady" xml:space="preserve">
     <value>Ready</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -306,6 +306,12 @@
   <data name="Autopilot.HardwareHashConnectingTenantStatus" xml:space="preserve">
     <value>Connexion au tenant...</value>
   </data>
+  <data name="Autopilot.HardwareHashTenantConnectionDialogTitle" xml:space="preserve">
+    <value>Connexion à Microsoft Graph</value>
+  </data>
+  <data name="Autopilot.HardwareHashTenantConnectionDialogMessage" xml:space="preserve">
+    <value>Terminez la connexion dans le navigateur pour configurer l'upload du hardware hash Autopilot.</value>
+  </data>
   <data name="Autopilot.HardwareHashTenantStatusLabel" xml:space="preserve">
     <value>Connexion tenant</value>
   </data>
@@ -384,6 +390,15 @@
   <data name="Autopilot.HardwareHashCertificateCreatedMessageFormat" xml:space="preserve">
     <value>Le PFX a été enregistré ici : {1}. Stockez ce mot de passe maintenant ; Foundry ne l'affichera plus : {0}</value>
   </data>
+  <data name="Autopilot.HardwareHashCertificateCreatedInstruction" xml:space="preserve">
+    <value>Stockez ce mot de passe maintenant. Foundry ne l'affichera plus.</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreatedPathLabel" xml:space="preserve">
+    <value>Fichier PFX</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreatedPasswordLabel" xml:space="preserve">
+    <value>Mot de passe PFX</value>
+  </data>
   <data name="Autopilot.HardwareHashCertificateCreateFailedTitle" xml:space="preserve">
     <value>Échec de création du certificat</value>
   </data>
@@ -391,10 +406,10 @@
     <value>Foundry n'a pas pu créer le certificat de l'app registration. {0}</value>
   </data>
   <data name="Autopilot.HardwareHashRetireCertificateConfirmationTitle" xml:space="preserve">
-    <value>Supprimer le certificat actif ?</value>
+    <value>Supprimer le certificat sélectionné ?</value>
   </data>
   <data name="Autopilot.HardwareHashRetireCertificateConfirmationMessage" xml:space="preserve">
-    <value>Foundry supprimera uniquement le certificat actif sélectionné dans l'app registration managée. Les autres identifiants de l'app seront conservés.</value>
+    <value>Foundry supprimera uniquement le certificat sélectionné dans l'app registration managée. Les autres identifiants de l'app seront conservés.</value>
   </data>
   <data name="Autopilot.HardwareHashRetireCertificateConfirmationPrimary" xml:space="preserve">
     <value>Supprimer le certificat</value>
@@ -403,13 +418,13 @@
     <value>Certificat supprimé</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateRetiredMessage" xml:space="preserve">
-    <value>Le certificat actif a été supprimé de l'app registration managée.</value>
+    <value>Le certificat sélectionné a été supprimé de l'app registration managée.</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateRetireFailedTitle" xml:space="preserve">
     <value>Échec de suppression du certificat</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateRetireFailedMessageFormat" xml:space="preserve">
-    <value>Foundry n'a pas pu supprimer le certificat actif de l'app registration. {0}</value>
+    <value>Foundry n'a pas pu supprimer le certificat sélectionné de l'app registration. {0}</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateMissing" xml:space="preserve">
     <value>Aucun certificat actif n'est configuré.</value>
@@ -425,6 +440,21 @@
   </data>
   <data name="Autopilot.HardwareHashCertificateExpiredWarning" xml:space="preserve">
     <value>Regénérez le certificat et le média de démarrage avant d'utiliser l'upload du hardware hash.</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificatesEmpty" xml:space="preserve">
+    <value>Aucun certificat d'app registration n'a été découvert. Connectez le tenant ou créez un certificat.</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateThumbprintColumn" xml:space="preserve">
+    <value>Empreinte</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreatedColumn" xml:space="preserve">
+    <value>Création</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateExpiresColumn" xml:space="preserve">
+    <value>Expiration</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateIdColumn" xml:space="preserve">
+    <value>ID du certificat</value>
   </data>
   <data name="Autopilot.HardwareHashDefaultGroupTagLabel" xml:space="preserve">
     <value>Group tag par défaut</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -477,9 +477,6 @@
   <data name="Autopilot.HardwareHashBootMediaCertificateDescription" xml:space="preserve">
     <value>PFX protégé par mot de passe copié dans le média de démarrage pour l'upload du hardware hash.</value>
   </data>
-  <data name="Autopilot.HardwareHashBootMediaCertificateTenantCertificateLabel" xml:space="preserve">
-    <value>Certificat</value>
-  </data>
   <data name="Autopilot.HardwareHashBootMediaCertificatePfxPathLabel" xml:space="preserve">
     <value>Fichier PFX</value>
   </data>
@@ -493,7 +490,7 @@
     <value>Sélectionner le PFX du certificat Autopilot</value>
   </data>
   <data name="Autopilot.HardwareHashBootMediaCertificateActiveMissing" xml:space="preserve">
-    <value>Sélectionnez d'abord un certificat dans l'app registration.</value>
+    <value>Sélectionnez un PFX qui correspond à un certificat de l'app registration.</value>
   </data>
   <data name="Autopilot.HardwareHashBootMediaCertificateActiveExpired" xml:space="preserve">
     <value>Le certificat sélectionné est expiré. Créez ou sélectionnez un certificat valide avant de créer le média de démarrage.</value>
@@ -1438,7 +1435,7 @@
     <value>L'upload du hardware hash est activé mais le service principal de l'app est manquant ou pas prêt.</value>
   </data>
   <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateMissing" xml:space="preserve">
-    <value>L'upload du hardware hash est activé mais aucun certificat d'app registration n'est sélectionné pour le média de démarrage.</value>
+    <value>L'upload du hardware hash est activé mais le PFX sélectionné ne correspond à aucun certificat de l'app registration.</value>
   </data>
   <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateThumbprintMissing" xml:space="preserve">
     <value>L'upload du hardware hash est activé mais l'empreinte du certificat sélectionné est manquante.</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -318,8 +318,17 @@
   <data name="Autopilot.HardwareHashTenantNotConnected" xml:space="preserve">
     <value>Non connecté</value>
   </data>
+  <data name="Autopilot.HardwareHashTenantConnected" xml:space="preserve">
+    <value>Connecté</value>
+  </data>
   <data name="Autopilot.HardwareHashTenantConnectedFormat" xml:space="preserve">
     <value>Connecté au tenant {0}</value>
+  </data>
+  <data name="Autopilot.HardwareHashTenantDetailsLabel" xml:space="preserve">
+    <value>Détails du tenant</value>
+  </data>
+  <data name="Autopilot.HardwareHashTenantDetailsFormat" xml:space="preserve">
+    <value>ID du tenant : {0}</value>
   </data>
   <data name="Autopilot.HardwareHashAppRegistrationLabel" xml:space="preserve">
     <value>App registration</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -303,6 +303,9 @@
   <data name="Autopilot.HardwareHashConnectTenantButton" xml:space="preserve">
     <value>Se connecter au tenant</value>
   </data>
+  <data name="Autopilot.HardwareHashDisconnectTenantButton" xml:space="preserve">
+    <value>Se déconnecter du tenant</value>
+  </data>
   <data name="Autopilot.HardwareHashConnectingTenantStatus" xml:space="preserve">
     <value>Connexion au tenant...</value>
   </data>
@@ -449,9 +452,6 @@
   </data>
   <data name="Autopilot.HardwareHashCertificateExpiredWarning" xml:space="preserve">
     <value>Regénérez le certificat et le média de démarrage avant d'utiliser l'upload du hardware hash.</value>
-  </data>
-  <data name="Autopilot.HardwareHashCertificatesEmpty" xml:space="preserve">
-    <value>Aucun certificat d'app registration n'a été découvert. Connectez le tenant ou créez un certificat.</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateThumbprintColumn" xml:space="preserve">
     <value>Empreinte</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -513,9 +513,6 @@
   <data name="Autopilot.HardwareHashDefaultGroupTagNoneOption" xml:space="preserve">
     <value>None</value>
   </data>
-  <data name="Autopilot.HardwareHashOnboardingCompletedTitle" xml:space="preserve">
-    <value>Onboarding tenant terminé</value>
-  </data>
   <data name="Autopilot.HardwareHashOnboardingRequiresAttentionTitle" xml:space="preserve">
     <value>L'onboarding tenant demande une action</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -333,9 +333,6 @@
   <data name="Autopilot.HardwareHashTenantConnected" xml:space="preserve">
     <value>Connecté</value>
   </data>
-  <data name="Autopilot.HardwareHashTenantConnectedFormat" xml:space="preserve">
-    <value>Connecté au tenant {0}</value>
-  </data>
   <data name="Autopilot.HardwareHashTenantReadinessLabel" xml:space="preserve">
     <value>État du tenant</value>
   </data>
@@ -435,12 +432,6 @@
   <data name="Autopilot.HardwareHashRetireCertificateConfirmationPrimary" xml:space="preserve">
     <value>Supprimer le certificat</value>
   </data>
-  <data name="Autopilot.HardwareHashCertificateRetiredTitle" xml:space="preserve">
-    <value>Certificat supprimé</value>
-  </data>
-  <data name="Autopilot.HardwareHashCertificateRetiredMessage" xml:space="preserve">
-    <value>Les identifiants de certificat sélectionnés ont été supprimés de l'app registration managée.</value>
-  </data>
   <data name="Autopilot.HardwareHashCertificateRetireFailedTitle" xml:space="preserve">
     <value>Échec de suppression du certificat</value>
   </data>
@@ -524,6 +515,30 @@
   </data>
   <data name="Autopilot.HardwareHashOnboardingFailedMessageFormat" xml:space="preserve">
     <value>Foundry n'a pas pu configurer l'app registration Autopilot. {0}</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingMessageAppRegistrationMissing" xml:space="preserve">
+    <value>L'app registration managée est introuvable. Reconnectez-vous pour laisser Foundry la créer ou l'adopter.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingMessageAdoptionRequired" xml:space="preserve">
+    <value>Une app registration existante avec le nom Foundry a été trouvée. Reconnectez-vous pour l'adopter dans la configuration Foundry.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingMessagePermissionMissing" xml:space="preserve">
+    <value>Il manque l'autorisation d'application Microsoft Graph requise sur l'app registration managée. Reconnectez-vous avec un compte autorisé à modifier les app registrations.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingMessageConsentMissing" xml:space="preserve">
+    <value>Le service principal managé n'a pas le consentement administrateur pour l'autorisation Microsoft Graph requise. Accordez le consentement administrateur puis reconnectez-vous.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingMessageServicePrincipalUnavailable" xml:space="preserve">
+    <value>Le service principal managé est absent ou désactivé. Reconnectez-vous avec un compte autorisé à créer ou gérer les applications d'entreprise.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingMessageActiveCertificateNotFound" xml:space="preserve">
+    <value>Le certificat précédemment sélectionné n'existe plus dans l'app registration managée. Sélectionnez un PFX valide correspondant à un certificat provisionné.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingMessageActiveCertificateExpired" xml:space="preserve">
+    <value>Le certificat sélectionné est expiré. Créez un nouveau certificat, conservez son PFX et son mot de passe, puis sélectionnez-le pour le média de démarrage.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingMessageGeneric" xml:space="preserve">
+    <value>L'app registration managée n'est pas prête. Vérifiez l'état du tenant puis reconnectez-vous.</value>
   </data>
   <data name="CustomizationPage_Title.Text" xml:space="preserve">
     <value>Personnalisation</value>
@@ -1382,9 +1397,6 @@
   </data>
   <data name="StartMedia.Autopilot.HardwareHashUpload" xml:space="preserve">
     <value>Activé : upload du hardware hash</value>
-  </data>
-  <data name="StartMedia.Autopilot.NotReady" xml:space="preserve">
-    <value>Activé ; profil par défaut manquant</value>
   </data>
   <data name="StartMedia.Autopilot.Validation.UnsupportedProvisioningMode" xml:space="preserve">
     <value>Autopilot utilise un mode de provisionnement non supporté.</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -186,6 +186,9 @@
   <data name="Autopilot.ActionsHeader" xml:space="preserve">
     <value>Actions de profil</value>
   </data>
+  <data name="Autopilot.ActionsDescription" xml:space="preserve">
+    <value>Importe des profils JSON locaux ou les télécharge depuis Intune.</value>
+  </data>
   <data name="Autopilot.ImportingStatus" xml:space="preserve">
     <value>Import du profil Autopilot...</value>
   </data>
@@ -213,8 +216,14 @@
   <data name="Autopilot.DefaultProfileLabel" xml:space="preserve">
     <value>Profil par défaut</value>
   </data>
+  <data name="Autopilot.DefaultProfileDescription" xml:space="preserve">
+    <value>Profil ajouté par défaut dans l'image Windows appliquée.</value>
+  </data>
   <data name="Autopilot.ProfilesLabel" xml:space="preserve">
     <value>Profils importés</value>
+  </data>
+  <data name="Autopilot.ProfilesDescription" xml:space="preserve">
+    <value>Profils Autopilot hors ligne disponibles pour le provisionnement par profil JSON.</value>
   </data>
   <data name="Autopilot.ProfilesEmptyLabel" xml:space="preserve">
     <value>Aucun profil Autopilot importé.</value>
@@ -318,6 +327,9 @@
   <data name="Autopilot.HardwareHashTenantStatusLabel" xml:space="preserve">
     <value>Connexion tenant</value>
   </data>
+  <data name="Autopilot.HardwareHashTenantStatusDescription" xml:space="preserve">
+    <value>Connecte Microsoft Graph pour cette session afin de gérer l'upload du hardware hash.</value>
+  </data>
   <data name="Autopilot.HardwareHashTenantNotConnected" xml:space="preserve">
     <value>Non connecté</value>
   </data>
@@ -330,11 +342,29 @@
   <data name="Autopilot.HardwareHashTenantDetailsLabel" xml:space="preserve">
     <value>Détails du tenant</value>
   </data>
+  <data name="Autopilot.HardwareHashTenantDetailsDescription" xml:space="preserve">
+    <value>Identifiants du tenant et de l'application utilisés par le média de démarrage généré.</value>
+  </data>
+  <data name="Autopilot.HardwareHashTenantDetailsNameColumn" xml:space="preserve">
+    <value>Nom</value>
+  </data>
+  <data name="Autopilot.HardwareHashTenantDetailsValueColumn" xml:space="preserve">
+    <value>Valeur</value>
+  </data>
+  <data name="Autopilot.HardwareHashTenantDetailsTenantId" xml:space="preserve">
+    <value>ID du tenant</value>
+  </data>
+  <data name="Autopilot.HardwareHashTenantDetailsClientId" xml:space="preserve">
+    <value>ID client</value>
+  </data>
   <data name="Autopilot.HardwareHashTenantDetailsFormat" xml:space="preserve">
     <value>ID du tenant : {0}</value>
   </data>
   <data name="Autopilot.HardwareHashAppRegistrationLabel" xml:space="preserve">
     <value>App registration</value>
+  </data>
+  <data name="Autopilot.HardwareHashAppRegistrationDescription" xml:space="preserve">
+    <value>App registration Entra managée utilisée par Foundry Deploy dans WinPE.</value>
   </data>
   <data name="Autopilot.HardwareHashAppRegistrationMissing" xml:space="preserve">
     <value>Foundry OSD Autopilot Registration n'est pas configurée.</value>
@@ -344,6 +374,9 @@
   </data>
   <data name="Autopilot.HardwareHashOnboardingStatusLabel" xml:space="preserve">
     <value>État de l'onboarding</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusDescription" xml:space="preserve">
+    <value>État de préparation des permissions, du consentement, du service principal et du certificat.</value>
   </data>
   <data name="Autopilot.HardwareHashOnboardingStatusNotChecked" xml:space="preserve">
     <value>Connectez le tenant pour vérifier les permissions, le consentement, le service principal et le certificat.</value>
@@ -380,6 +413,9 @@
   </data>
   <data name="Autopilot.HardwareHashCertificateStatusLabel" xml:space="preserve">
     <value>Certificat</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateStatusDescription" xml:space="preserve">
+    <value>Certificats de l'app registration autorisés pour l'authentification Graph dans WinPE.</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateValidityLabel" xml:space="preserve">
     <value>Validité</value>
@@ -471,6 +507,9 @@
   <data name="Autopilot.HardwareHashBootMediaCertificateLabel" xml:space="preserve">
     <value>Certificat du média de démarrage</value>
   </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateDescription" xml:space="preserve">
+    <value>PFX protégé par mot de passe copié dans le média de démarrage pour l'upload du hardware hash.</value>
+  </data>
   <data name="Autopilot.HardwareHashBootMediaCertificatePfxPathLabel" xml:space="preserve">
     <value>Fichier PFX</value>
   </data>
@@ -513,6 +552,9 @@
   <data name="Autopilot.HardwareHashDefaultGroupTagLabel" xml:space="preserve">
     <value>Group tag par défaut</value>
   </data>
+  <data name="Autopilot.HardwareHashDefaultGroupTagDescription" xml:space="preserve">
+    <value>Group tag optionnel présélectionné dans Foundry Deploy pendant l'upload du hardware hash.</value>
+  </data>
   <data name="Autopilot.HardwareHashDefaultGroupTagNone" xml:space="preserve">
     <value>Aucun group tag par défaut sélectionné.</value>
   </data>
@@ -521,6 +563,9 @@
   </data>
   <data name="Autopilot.HardwareHashKnownGroupTagsLabel" xml:space="preserve">
     <value>Group tags disponibles</value>
+  </data>
+  <data name="Autopilot.HardwareHashKnownGroupTagsDescription" xml:space="preserve">
+    <value>Group tags découverts depuis les appareils Windows Autopilot existants.</value>
   </data>
   <data name="Autopilot.HardwareHashAvailableGroupTagColumn" xml:space="preserve">
     <value>Group tag</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -519,6 +519,9 @@
   <data name="Autopilot.HardwareHashKnownGroupTagsLabel" xml:space="preserve">
     <value>Group tags disponibles</value>
   </data>
+  <data name="Autopilot.HardwareHashAvailableGroupTagColumn" xml:space="preserve">
+    <value>Group tag</value>
+  </data>
   <data name="Autopilot.HardwareHashKnownGroupTagsNone" xml:space="preserve">
     <value>Aucun group tag découvert.</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -516,6 +516,9 @@
   <data name="Autopilot.HardwareHashDefaultGroupTagNone" xml:space="preserve">
     <value>Aucun group tag par défaut sélectionné.</value>
   </data>
+  <data name="Autopilot.HardwareHashDefaultGroupTagNoneOption" xml:space="preserve">
+    <value>None</value>
+  </data>
   <data name="Autopilot.HardwareHashKnownGroupTagsLabel" xml:space="preserve">
     <value>Group tags disponibles</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -303,6 +303,9 @@
   <data name="Autopilot.HardwareHashConnectTenantButton" xml:space="preserve">
     <value>Se connecter au tenant</value>
   </data>
+  <data name="Autopilot.HardwareHashConnectingTenantStatus" xml:space="preserve">
+    <value>Connexion au tenant...</value>
+  </data>
   <data name="Autopilot.HardwareHashTenantStatusLabel" xml:space="preserve">
     <value>Connexion tenant</value>
   </data>
@@ -321,8 +324,92 @@
   <data name="Autopilot.HardwareHashAppRegistrationFoundFormat" xml:space="preserve">
     <value>{0} est configurée.</value>
   </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusLabel" xml:space="preserve">
+    <value>État de l'onboarding</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusNotChecked" xml:space="preserve">
+    <value>Connectez le tenant pour vérifier les permissions, le consentement, le service principal et le certificat.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusReady" xml:space="preserve">
+    <value>Prêt. Les permissions, le consentement admin, le service principal et le certificat actif sont valides.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusAppMissing" xml:space="preserve">
+    <value>L'app registration managée est introuvable.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusAdoptionRequired" xml:space="preserve">
+    <value>Une app registration managée existante a été trouvée et doit être adoptée avant la génération du média.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusPermissionMissing" xml:space="preserve">
+    <value>L'app registration managée n'a pas les permissions Microsoft Graph applicatives requises.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusConsentMissing" xml:space="preserve">
+    <value>Le consentement admin est manquant pour les permissions Microsoft Graph applicatives requises.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusServicePrincipalUnavailable" xml:space="preserve">
+    <value>Le service principal de l'app managée est manquant ou désactivé.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusCertificateMissing" xml:space="preserve">
+    <value>Aucun certificat actif n'est sélectionné. Créez un certificat avant de générer le média de démarrage.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusCertificateNotFound" xml:space="preserve">
+    <value>Le certificat actif sélectionné n'existe plus dans l'app registration managée.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusCertificateExpired" xml:space="preserve">
+    <value>Le certificat actif est expiré. Regénérez le certificat et le média de démarrage.</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingStatusMultipleCertificates" xml:space="preserve">
+    <value>Plusieurs certificats Foundry existent et aucun certificat actif ne peut être sélectionné depuis les métadonnées persistées.</value>
+  </data>
   <data name="Autopilot.HardwareHashCertificateStatusLabel" xml:space="preserve">
     <value>Certificat</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateValidityLabel" xml:space="preserve">
+    <value>Validité</value>
+  </data>
+  <data name="Autopilot.HardwareHashCreateCertificateButton" xml:space="preserve">
+    <value>Créer le certificat</value>
+  </data>
+  <data name="Autopilot.HardwareHashRetireCertificateButton" xml:space="preserve">
+    <value>Supprimer le certificat</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateSavePickerTitle" xml:space="preserve">
+    <value>Enregistrer le PFX Autopilot</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificatePfxFileType" xml:space="preserve">
+    <value>Certificat PFX</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreatedTitle" xml:space="preserve">
+    <value>Certificat créé</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreatedMessageFormat" xml:space="preserve">
+    <value>Le PFX a été enregistré ici : {1}. Stockez ce mot de passe maintenant ; Foundry ne l'affichera plus : {0}</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreateFailedTitle" xml:space="preserve">
+    <value>Échec de création du certificat</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreateFailedMessageFormat" xml:space="preserve">
+    <value>Foundry n'a pas pu créer le certificat de l'app registration. {0}</value>
+  </data>
+  <data name="Autopilot.HardwareHashRetireCertificateConfirmationTitle" xml:space="preserve">
+    <value>Supprimer le certificat actif ?</value>
+  </data>
+  <data name="Autopilot.HardwareHashRetireCertificateConfirmationMessage" xml:space="preserve">
+    <value>Foundry supprimera uniquement le certificat actif sélectionné dans l'app registration managée. Les autres identifiants de l'app seront conservés.</value>
+  </data>
+  <data name="Autopilot.HardwareHashRetireCertificateConfirmationPrimary" xml:space="preserve">
+    <value>Supprimer le certificat</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateRetiredTitle" xml:space="preserve">
+    <value>Certificat supprimé</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateRetiredMessage" xml:space="preserve">
+    <value>Le certificat actif a été supprimé de l'app registration managée.</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateRetireFailedTitle" xml:space="preserve">
+    <value>Échec de suppression du certificat</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateRetireFailedMessageFormat" xml:space="preserve">
+    <value>Foundry n'a pas pu supprimer le certificat actif de l'app registration. {0}</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateMissing" xml:space="preserve">
     <value>Aucun certificat actif n'est configuré.</value>
@@ -351,11 +438,17 @@
   <data name="Autopilot.HardwareHashKnownGroupTagsNone" xml:space="preserve">
     <value>Aucun group tag découvert.</value>
   </data>
-  <data name="Autopilot.HardwareHashOnboardingUnavailableTitle" xml:space="preserve">
-    <value>Onboarding tenant</value>
+  <data name="Autopilot.HardwareHashOnboardingCompletedTitle" xml:space="preserve">
+    <value>Onboarding tenant terminé</value>
   </data>
-  <data name="Autopilot.HardwareHashOnboardingUnavailableMessage" xml:space="preserve">
-    <value>L'onboarding tenant et la création de certificat seront implémentés dans la prochaine phase de sécurité.</value>
+  <data name="Autopilot.HardwareHashOnboardingRequiresAttentionTitle" xml:space="preserve">
+    <value>L'onboarding tenant demande une action</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingFailedTitle" xml:space="preserve">
+    <value>Échec de l'onboarding tenant</value>
+  </data>
+  <data name="Autopilot.HardwareHashOnboardingFailedMessageFormat" xml:space="preserve">
+    <value>Foundry n'a pas pu configurer l'app registration Autopilot. {0}</value>
   </data>
   <data name="CustomizationPage_Title.Text" xml:space="preserve">
     <value>Personnalisation</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -477,6 +477,9 @@
   <data name="Autopilot.HardwareHashBootMediaCertificateDescription" xml:space="preserve">
     <value>PFX protégé par mot de passe copié dans le média de démarrage pour l'upload du hardware hash.</value>
   </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateTenantCertificateLabel" xml:space="preserve">
+    <value>Certificat</value>
+  </data>
   <data name="Autopilot.HardwareHashBootMediaCertificatePfxPathLabel" xml:space="preserve">
     <value>Fichier PFX</value>
   </data>
@@ -490,10 +493,10 @@
     <value>Sélectionner le PFX du certificat Autopilot</value>
   </data>
   <data name="Autopilot.HardwareHashBootMediaCertificateActiveMissing" xml:space="preserve">
-    <value>Créez ou sélectionnez d'abord un certificat actif dans l'app registration.</value>
+    <value>Sélectionnez d'abord un certificat dans l'app registration.</value>
   </data>
   <data name="Autopilot.HardwareHashBootMediaCertificateActiveExpired" xml:space="preserve">
-    <value>Le certificat actif est expiré. Regénérez le certificat avant de créer le média de démarrage.</value>
+    <value>Le certificat sélectionné est expiré. Créez ou sélectionnez un certificat valide avant de créer le média de démarrage.</value>
   </data>
   <data name="Autopilot.HardwareHashBootMediaCertificatePfxMissing" xml:space="preserve">
     <value>Sélectionnez le PFX protégé par mot de passe correspondant avant de créer le média de démarrage.</value>
@@ -505,7 +508,7 @@
     <value>Renseignez le mot de passe du PFX.</value>
   </data>
   <data name="Autopilot.HardwareHashBootMediaCertificateThumbprintMismatch" xml:space="preserve">
-    <value>L'empreinte du certificat PFX ne correspond pas au certificat actif de l'app registration.</value>
+    <value>L'empreinte du certificat PFX ne correspond pas au certificat sélectionné dans l'app registration.</value>
   </data>
   <data name="Autopilot.HardwareHashBootMediaCertificatePrivateKeyMissing" xml:space="preserve">
     <value>Le PFX sélectionné ne contient pas la clé privée.</value>
@@ -1435,16 +1438,16 @@
     <value>L'upload du hardware hash est activé mais le service principal de l'app est manquant ou pas prêt.</value>
   </data>
   <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateMissing" xml:space="preserve">
-    <value>L'upload du hardware hash est activé mais aucun certificat actif n'est configuré dans l'app registration.</value>
+    <value>L'upload du hardware hash est activé mais aucun certificat d'app registration n'est sélectionné pour le média de démarrage.</value>
   </data>
   <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateThumbprintMissing" xml:space="preserve">
-    <value>L'upload du hardware hash est activé mais l'empreinte du certificat actif est manquante.</value>
+    <value>L'upload du hardware hash est activé mais l'empreinte du certificat sélectionné est manquante.</value>
   </data>
   <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateExpirationMissing" xml:space="preserve">
-    <value>L'upload du hardware hash est activé mais l'expiration du certificat actif est manquante.</value>
+    <value>L'upload du hardware hash est activé mais l'expiration du certificat sélectionné est manquante.</value>
   </data>
   <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateExpired" xml:space="preserve">
-    <value>L'upload du hardware hash est activé mais le certificat actif est expiré. Regénérez le certificat et recréez le média de démarrage.</value>
+    <value>L'upload du hardware hash est activé mais le certificat sélectionné est expiré. Sélectionnez un certificat valide avant de créer le média de démarrage.</value>
   </data>
   <data name="StartMedia.Autopilot.Validation.HardwareHashBootMediaPfxMissing" xml:space="preserve">
     <value>L'upload du hardware hash est activé mais aucun PFX de média de démarrage n'est sélectionné.</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -508,28 +508,16 @@
     <value>Le certificat est prêt pour la génération du média de démarrage.</value>
   </data>
   <data name="Autopilot.HardwareHashGroupTagLabel" xml:space="preserve">
-    <value>Group tag</value>
+    <value>Group tag par défaut</value>
   </data>
   <data name="Autopilot.HardwareHashGroupTagDescription" xml:space="preserve">
-    <value>Découverte optionnelle des group tags Autopilot et sélection par défaut.</value>
-  </data>
-  <data name="Autopilot.HardwareHashDefaultGroupTagLabel" xml:space="preserve">
-    <value>Group tag par défaut</value>
+    <value>Group tag optionnel présélectionné dans Foundry Deploy pendant l'upload du hardware hash.</value>
   </data>
   <data name="Autopilot.HardwareHashDefaultGroupTagNone" xml:space="preserve">
     <value>Aucun group tag par défaut sélectionné.</value>
   </data>
   <data name="Autopilot.HardwareHashDefaultGroupTagNoneOption" xml:space="preserve">
     <value>None</value>
-  </data>
-  <data name="Autopilot.HardwareHashKnownGroupTagsLabel" xml:space="preserve">
-    <value>Group tags disponibles</value>
-  </data>
-  <data name="Autopilot.HardwareHashAvailableGroupTagColumn" xml:space="preserve">
-    <value>Group tag</value>
-  </data>
-  <data name="Autopilot.HardwareHashKnownGroupTagsNone" xml:space="preserve">
-    <value>Aucun group tag découvert. L'affectation d'un group tag est optionnelle.</value>
   </data>
   <data name="Autopilot.HardwareHashOnboardingCompletedTitle" xml:space="preserve">
     <value>Onboarding tenant terminé</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -507,6 +507,9 @@
   <data name="Autopilot.HardwareHashDefaultGroupTagNoneOption" xml:space="preserve">
     <value>None</value>
   </data>
+  <data name="Autopilot.HardwareHashDefaultGroupTagNoSelection" xml:space="preserve">
+    <value>Aucun</value>
+  </data>
   <data name="Autopilot.HardwareHashOnboardingRequiresAttentionTitle" xml:space="preserve">
     <value>L'onboarding tenant demande une action</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -169,7 +169,7 @@
     <value>Autopilot</value>
   </data>
   <data name="Autopilot.Description" xml:space="preserve">
-    <value>Importer et sélectionner des profils Autopilot hors ligne pour le média de déploiement.</value>
+    <value>Choisir la méthode de provisionnement Autopilot pour le média de déploiement : profil JSON ou upload du hardware hash depuis WinPE.</value>
   </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Activer Autopilot</value>
@@ -400,19 +400,22 @@
     <value>Certificat PFX</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateCreatedTitle" xml:space="preserve">
-    <value>Certificat créé</value>
-  </data>
-  <data name="Autopilot.HardwareHashCertificateCreatedMessageFormat" xml:space="preserve">
-    <value>Le PFX a été enregistré ici : {1}. Stockez ce mot de passe maintenant ; Foundry ne l'affichera plus : {0}</value>
+    <value>Certificat prêt</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateCreatedInstruction" xml:space="preserve">
-    <value>Stockez ce mot de passe maintenant. Foundry ne l'affichera plus.</value>
+    <value>Enregistrez maintenant ce fichier PFX et ce mot de passe dans un emplacement sécurisé. Foundry ne stocke pas le mot de passe et ne pourra plus l'afficher après la fermeture de cette fenêtre. Ces deux éléments seront nécessaires pour générer le média de boot avec upload du hardware hash.</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateCreatedPathLabel" xml:space="preserve">
     <value>Fichier PFX</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateCreatedPasswordLabel" xml:space="preserve">
     <value>Mot de passe PFX</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreatedCopyPasswordButton" xml:space="preserve">
+    <value>Copier le mot de passe</value>
+  </data>
+  <data name="Autopilot.HardwareHashCertificateCreatedPasswordCopied" xml:space="preserve">
+    <value>Mot de passe copié.</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateCreateFailedTitle" xml:space="preserve">
     <value>Échec de création du certificat</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -336,17 +336,11 @@
   <data name="Autopilot.HardwareHashTenantConnectedFormat" xml:space="preserve">
     <value>Connecté au tenant {0}</value>
   </data>
-  <data name="Autopilot.HardwareHashTenantDetailsLabel" xml:space="preserve">
-    <value>Détails du tenant</value>
+  <data name="Autopilot.HardwareHashTenantReadinessLabel" xml:space="preserve">
+    <value>État du tenant</value>
   </data>
-  <data name="Autopilot.HardwareHashTenantDetailsDescription" xml:space="preserve">
-    <value>Identifiants du tenant et de l'application utilisés par le média de démarrage généré.</value>
-  </data>
-  <data name="Autopilot.HardwareHashTenantDetailsNameColumn" xml:space="preserve">
-    <value>Nom</value>
-  </data>
-  <data name="Autopilot.HardwareHashTenantDetailsValueColumn" xml:space="preserve">
-    <value>Valeur</value>
+  <data name="Autopilot.HardwareHashTenantReadinessDescription" xml:space="preserve">
+    <value>Informations du tenant, de l'app registration et de l'état de préparation pour l'upload du hardware hash.</value>
   </data>
   <data name="Autopilot.HardwareHashTenantDetailsTenantId" xml:space="preserve">
     <value>ID du tenant</value>
@@ -355,10 +349,7 @@
     <value>ID client</value>
   </data>
   <data name="Autopilot.HardwareHashAppRegistrationLabel" xml:space="preserve">
-    <value>App registration</value>
-  </data>
-  <data name="Autopilot.HardwareHashAppRegistrationDescription" xml:space="preserve">
-    <value>App registration Entra managée utilisée par Foundry Deploy dans WinPE.</value>
+    <value>App registration managée</value>
   </data>
   <data name="Autopilot.HardwareHashAppRegistrationMissing" xml:space="preserve">
     <value>Foundry OSD Autopilot Registration n'est pas configurée.</value>
@@ -367,10 +358,7 @@
     <value>{0} est configurée.</value>
   </data>
   <data name="Autopilot.HardwareHashOnboardingStatusLabel" xml:space="preserve">
-    <value>État de l'onboarding</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusDescription" xml:space="preserve">
-    <value>État de préparation des permissions, du consentement, du service principal et du certificat.</value>
+    <value>État</value>
   </data>
   <data name="Autopilot.HardwareHashOnboardingStatusReady" xml:space="preserve">
     <value>Prêt</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -378,14 +378,20 @@
   <data name="Autopilot.HardwareHashOnboardingStatusNotReady" xml:space="preserve">
     <value>Non prêt</value>
   </data>
-  <data name="Autopilot.HardwareHashCertificateStatusLabel" xml:space="preserve">
-    <value>Certificat</value>
+  <data name="Autopilot.HardwareHashCertificateActionsLabel" xml:space="preserve">
+    <value>Actions certificat</value>
   </data>
-  <data name="Autopilot.HardwareHashCertificateStatusDescription" xml:space="preserve">
+  <data name="Autopilot.HardwareHashCertificateActionsDescription" xml:space="preserve">
+    <value>Créer ou supprimer les identifiants de certificat de l'app registration.</value>
+  </data>
+  <data name="Autopilot.HardwareHashProvisionedCertificatesLabel" xml:space="preserve">
+    <value>Certificats provisionnés</value>
+  </data>
+  <data name="Autopilot.HardwareHashProvisionedCertificatesDescription" xml:space="preserve">
     <value>Certificats de l'app registration autorisés pour l'authentification Graph dans WinPE.</value>
   </data>
-  <data name="Autopilot.HardwareHashCertificateValidityLabel" xml:space="preserve">
-    <value>Validité</value>
+  <data name="Autopilot.HardwareHashCertificatesNone" xml:space="preserve">
+    <value>Aucun certificat n'est provisionné.</value>
   </data>
   <data name="Autopilot.HardwareHashCreateCertificateButton" xml:space="preserve">
     <value>Créer le certificat</value>
@@ -444,21 +450,6 @@
   <data name="Autopilot.HardwareHashCertificateRetireFailedMessageFormat" xml:space="preserve">
     <value>Foundry n'a pas pu supprimer le certificat sélectionné de l'app registration. {0}</value>
   </data>
-  <data name="Autopilot.HardwareHashCertificateMissing" xml:space="preserve">
-    <value>Aucun certificat actif n'est configuré.</value>
-  </data>
-  <data name="Autopilot.HardwareHashCertificateExpirationMissing" xml:space="preserve">
-    <value>L'expiration du certificat actif est manquante.</value>
-  </data>
-  <data name="Autopilot.HardwareHashCertificateValidFormat" xml:space="preserve">
-    <value>Valide jusqu'au {0}</value>
-  </data>
-  <data name="Autopilot.HardwareHashCertificateExpiredFormat" xml:space="preserve">
-    <value>Expiré le {0}</value>
-  </data>
-  <data name="Autopilot.HardwareHashCertificateExpiredWarning" xml:space="preserve">
-    <value>Regénérez le certificat et le média de démarrage avant d'utiliser l'upload du hardware hash.</value>
-  </data>
   <data name="Autopilot.HardwareHashCertificateThumbprintColumn" xml:space="preserve">
     <value>Empreinte</value>
   </data>
@@ -516,11 +507,14 @@
   <data name="Autopilot.HardwareHashBootMediaCertificateReady" xml:space="preserve">
     <value>Le certificat est prêt pour la génération du média de démarrage.</value>
   </data>
+  <data name="Autopilot.HardwareHashGroupTagLabel" xml:space="preserve">
+    <value>Group tag</value>
+  </data>
+  <data name="Autopilot.HardwareHashGroupTagDescription" xml:space="preserve">
+    <value>Découverte optionnelle des group tags Autopilot et sélection par défaut.</value>
+  </data>
   <data name="Autopilot.HardwareHashDefaultGroupTagLabel" xml:space="preserve">
     <value>Group tag par défaut</value>
-  </data>
-  <data name="Autopilot.HardwareHashDefaultGroupTagDescription" xml:space="preserve">
-    <value>Group tag optionnel présélectionné dans Foundry Deploy pendant l'upload du hardware hash.</value>
   </data>
   <data name="Autopilot.HardwareHashDefaultGroupTagNone" xml:space="preserve">
     <value>Aucun group tag par défaut sélectionné.</value>
@@ -531,14 +525,11 @@
   <data name="Autopilot.HardwareHashKnownGroupTagsLabel" xml:space="preserve">
     <value>Group tags disponibles</value>
   </data>
-  <data name="Autopilot.HardwareHashKnownGroupTagsDescription" xml:space="preserve">
-    <value>Group tags découverts depuis les appareils Windows Autopilot existants.</value>
-  </data>
   <data name="Autopilot.HardwareHashAvailableGroupTagColumn" xml:space="preserve">
     <value>Group tag</value>
   </data>
   <data name="Autopilot.HardwareHashKnownGroupTagsNone" xml:space="preserve">
-    <value>Aucun group tag découvert.</value>
+    <value>Aucun group tag découvert. L'affectation d'un group tag est optionnelle.</value>
   </data>
   <data name="Autopilot.HardwareHashOnboardingCompletedTitle" xml:space="preserve">
     <value>Onboarding tenant terminé</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -372,38 +372,11 @@
   <data name="Autopilot.HardwareHashOnboardingStatusDescription" xml:space="preserve">
     <value>État de préparation des permissions, du consentement, du service principal et du certificat.</value>
   </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusNotChecked" xml:space="preserve">
-    <value>Connectez le tenant pour vérifier les permissions, le consentement, le service principal et le certificat.</value>
-  </data>
   <data name="Autopilot.HardwareHashOnboardingStatusReady" xml:space="preserve">
-    <value>Prêt. Les permissions, le consentement admin, le service principal et le certificat actif sont valides.</value>
+    <value>Prêt</value>
   </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusAppMissing" xml:space="preserve">
-    <value>L'app registration managée est introuvable.</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusAdoptionRequired" xml:space="preserve">
-    <value>Une app registration managée existante a été trouvée et doit être adoptée avant la génération du média.</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusPermissionMissing" xml:space="preserve">
-    <value>L'app registration managée n'a pas les permissions Microsoft Graph applicatives requises.</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusConsentMissing" xml:space="preserve">
-    <value>Le consentement admin est manquant pour les permissions Microsoft Graph applicatives requises.</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusServicePrincipalUnavailable" xml:space="preserve">
-    <value>Le service principal de l'app managée est manquant ou désactivé.</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusCertificateMissing" xml:space="preserve">
-    <value>Aucun certificat actif n'est sélectionné. Créez un certificat avant de générer le média de démarrage.</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusCertificateNotFound" xml:space="preserve">
-    <value>Le certificat actif sélectionné n'existe plus dans l'app registration managée.</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusCertificateExpired" xml:space="preserve">
-    <value>Le certificat actif est expiré. Regénérez le certificat et le média de démarrage.</value>
-  </data>
-  <data name="Autopilot.HardwareHashOnboardingStatusMultipleCertificates" xml:space="preserve">
-    <value>Plusieurs certificats Foundry existent et aucun certificat actif ne peut être sélectionné depuis les métadonnées persistées.</value>
+  <data name="Autopilot.HardwareHashOnboardingStatusNotReady" xml:space="preserve">
+    <value>Non prêt</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateStatusLabel" xml:space="preserve">
     <value>Certificat</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -342,6 +342,12 @@
   <data name="Autopilot.HardwareHashTenantReadinessDescription" xml:space="preserve">
     <value>Informations du tenant, de l'app registration et de l'état de préparation pour l'upload du hardware hash.</value>
   </data>
+  <data name="Autopilot.HardwareHashTenantReadinessNameColumn" xml:space="preserve">
+    <value>Nom</value>
+  </data>
+  <data name="Autopilot.HardwareHashTenantReadinessValueColumn" xml:space="preserve">
+    <value>Valeur</value>
+  </data>
   <data name="Autopilot.HardwareHashTenantDetailsTenantId" xml:space="preserve">
     <value>ID du tenant</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -255,9 +255,6 @@
   <data name="Autopilot.TenantDownloadDialogMessage" xml:space="preserve">
     <value>Terminez l'authentification dans le navigateur pour télécharger les profils Autopilot.</value>
   </data>
-  <data name="Autopilot.TenantDownloadDialogCancel" xml:space="preserve">
-    <value>Annuler</value>
-  </data>
   <data name="Autopilot.DownloadNoProfilesTitle" xml:space="preserve">
     <value>Aucun profil Autopilot trouvé</value>
   </data>
@@ -356,9 +353,6 @@
   </data>
   <data name="Autopilot.HardwareHashTenantDetailsClientId" xml:space="preserve">
     <value>ID client</value>
-  </data>
-  <data name="Autopilot.HardwareHashTenantDetailsFormat" xml:space="preserve">
-    <value>ID du tenant : {0}</value>
   </data>
   <data name="Autopilot.HardwareHashAppRegistrationLabel" xml:space="preserve">
     <value>App registration</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -423,6 +423,9 @@
   <data name="Autopilot.HardwareHashRetireCertificateConfirmationMessage" xml:space="preserve">
     <value>Foundry supprimera uniquement le certificat sélectionné dans l'app registration managée. Les autres identifiants de l'app seront conservés.</value>
   </data>
+  <data name="Autopilot.HardwareHashRetireCertificatesConfirmationMessageFormat" xml:space="preserve">
+    <value>Foundry supprimera uniquement les {0} certificats sélectionnés dans l'app registration managée. Les autres identifiants de l'app seront conservés.</value>
+  </data>
   <data name="Autopilot.HardwareHashRetireCertificateConfirmationPrimary" xml:space="preserve">
     <value>Supprimer le certificat</value>
   </data>
@@ -430,7 +433,7 @@
     <value>Certificat supprimé</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateRetiredMessage" xml:space="preserve">
-    <value>Le certificat sélectionné a été supprimé de l'app registration managée.</value>
+    <value>Les identifiants de certificat sélectionnés ont été supprimés de l'app registration managée.</value>
   </data>
   <data name="Autopilot.HardwareHashCertificateRetireFailedTitle" xml:space="preserve">
     <value>Échec de suppression du certificat</value>
@@ -465,6 +468,48 @@
   <data name="Autopilot.HardwareHashCertificateIdColumn" xml:space="preserve">
     <value>ID du certificat</value>
   </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateLabel" xml:space="preserve">
+    <value>Certificat du média de démarrage</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificatePfxPathLabel" xml:space="preserve">
+    <value>Fichier PFX</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificatePasswordLabel" xml:space="preserve">
+    <value>Mot de passe PFX</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateSelectButton" xml:space="preserve">
+    <value>Sélectionner le PFX</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificatePfxPickerTitle" xml:space="preserve">
+    <value>Sélectionner le PFX du certificat Autopilot</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateActiveMissing" xml:space="preserve">
+    <value>Créez ou sélectionnez d'abord un certificat actif dans l'app registration.</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateActiveExpired" xml:space="preserve">
+    <value>Le certificat actif est expiré. Regénérez le certificat avant de créer le média de démarrage.</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificatePfxMissing" xml:space="preserve">
+    <value>Sélectionnez le PFX protégé par mot de passe correspondant avant de créer le média de démarrage.</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateFileMissing" xml:space="preserve">
+    <value>Le fichier PFX sélectionné n'existe plus.</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificatePasswordMissing" xml:space="preserve">
+    <value>Renseignez le mot de passe du PFX.</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateThumbprintMismatch" xml:space="preserve">
+    <value>L'empreinte du certificat PFX ne correspond pas au certificat actif de l'app registration.</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificatePrivateKeyMissing" xml:space="preserve">
+    <value>Le PFX sélectionné ne contient pas la clé privée.</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateInvalidPfx" xml:space="preserve">
+    <value>Le PFX sélectionné ne peut pas être ouvert avec le mot de passe fourni.</value>
+  </data>
+  <data name="Autopilot.HardwareHashBootMediaCertificateReady" xml:space="preserve">
+    <value>Le certificat est prêt pour la génération du média de démarrage.</value>
+  </data>
   <data name="Autopilot.HardwareHashDefaultGroupTagLabel" xml:space="preserve">
     <value>Group tag par défaut</value>
   </data>
@@ -472,7 +517,7 @@
     <value>Aucun group tag par défaut sélectionné.</value>
   </data>
   <data name="Autopilot.HardwareHashKnownGroupTagsLabel" xml:space="preserve">
-    <value>Group tags connus</value>
+    <value>Group tags disponibles</value>
   </data>
   <data name="Autopilot.HardwareHashKnownGroupTagsNone" xml:space="preserve">
     <value>Aucun group tag découvert.</value>
@@ -1349,6 +1394,57 @@
   </data>
   <data name="StartMedia.Autopilot.NotReady" xml:space="preserve">
     <value>Activé ; profil par défaut manquant</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.UnsupportedProvisioningMode" xml:space="preserve">
+    <value>Autopilot utilise un mode de provisionnement non supporté.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.JsonProfileMissing" xml:space="preserve">
+    <value>Le mode profil JSON Autopilot est activé mais aucun profil par défaut valide n'est sélectionné.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashSettingsMissing" xml:space="preserve">
+    <value>L'upload du hardware hash est activé mais les paramètres sont manquants.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashTenantMissing" xml:space="preserve">
+    <value>L'upload du hardware hash est activé mais la connexion au tenant est manquante. Connectez-vous au tenant depuis Autopilot.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashAppRegistrationMissing" xml:space="preserve">
+    <value>L'upload du hardware hash est activé mais l'app registration n'est pas configurée. Connectez-vous au tenant depuis Autopilot.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashClientIdMissing" xml:space="preserve">
+    <value>L'upload du hardware hash est activé mais l'ID client de l'app est manquant. Reconnectez-vous au tenant depuis Autopilot.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashServicePrincipalMissing" xml:space="preserve">
+    <value>L'upload du hardware hash est activé mais le service principal de l'app est manquant ou pas prêt.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateMissing" xml:space="preserve">
+    <value>L'upload du hardware hash est activé mais aucun certificat actif n'est configuré dans l'app registration.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateThumbprintMissing" xml:space="preserve">
+    <value>L'upload du hardware hash est activé mais l'empreinte du certificat actif est manquante.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateExpirationMissing" xml:space="preserve">
+    <value>L'upload du hardware hash est activé mais l'expiration du certificat actif est manquante.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashActiveCertificateExpired" xml:space="preserve">
+    <value>L'upload du hardware hash est activé mais le certificat actif est expiré. Regénérez le certificat et recréez le média de démarrage.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashBootMediaPfxMissing" xml:space="preserve">
+    <value>L'upload du hardware hash est activé mais aucun PFX de média de démarrage n'est sélectionné.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashBootMediaPfxPasswordMissing" xml:space="preserve">
+    <value>L'upload du hardware hash est activé mais le mot de passe du PFX de média de démarrage est manquant.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashBootMediaCertificateNotValidated" xml:space="preserve">
+    <value>L'upload du hardware hash est activé mais le PFX de média de démarrage n'a pas été validé.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashBootMediaCertificateThumbprintMismatch" xml:space="preserve">
+    <value>L'upload du hardware hash est activé mais le PFX sélectionné ne correspond pas au certificat actif.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashBootMediaCertificateExpirationMissing" xml:space="preserve">
+    <value>L'upload du hardware hash est activé mais l'expiration du PFX de média de démarrage n'a pas pu être validée.</value>
+  </data>
+  <data name="StartMedia.Autopilot.Validation.HardwareHashBootMediaCertificateExpired" xml:space="preserve">
+    <value>L'upload du hardware hash est activé mais le PFX de média de démarrage sélectionné est expiré.</value>
   </data>
   <data name="StartMedia.BlockingReason.AdkNotReady" xml:space="preserve">
     <value>L'ADK ou le module complémentaire WinPE n'est pas prêt.</value>

--- a/src/Foundry/ViewModels/AutopilotCertificateEntryViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotCertificateEntryViewModel.cs
@@ -1,0 +1,47 @@
+using System.Globalization;
+using Foundry.Core.Services.Autopilot;
+using Microsoft.UI.Xaml.Media;
+
+namespace Foundry.ViewModels;
+
+/// <summary>
+/// Represents an app registration certificate credential displayed in the Autopilot page.
+/// </summary>
+public sealed record AutopilotCertificateEntryViewModel(
+    string KeyId,
+    string Thumbprint,
+    DateTimeOffset StartsOnUtc,
+    DateTimeOffset ExpiresOnUtc)
+{
+    private static readonly TimeSpan ExpirationWarningThreshold = TimeSpan.FromDays(30);
+
+    public string StartsOnDisplay => StartsOnUtc.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
+
+    public string ExpiresOnDisplay => ExpiresOnUtc.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
+
+    public Brush ValidityForeground => (Brush)Application.Current.Resources[ResolveValidityBrushKey()];
+
+    public static AutopilotCertificateEntryViewModel FromGraphCredential(AutopilotGraphKeyCredential credential)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+
+        return new AutopilotCertificateEntryViewModel(
+            credential.KeyId,
+            credential.Thumbprint,
+            credential.StartsOnUtc,
+            credential.ExpiresOnUtc);
+    }
+
+    private string ResolveValidityBrushKey()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        if (ExpiresOnUtc <= now)
+        {
+            return "SystemFillColorCriticalBrush";
+        }
+
+        return ExpiresOnUtc - now <= ExpirationWarningThreshold
+            ? "SystemFillColorCautionBrush"
+            : "SystemFillColorSuccessBrush";
+    }
+}

--- a/src/Foundry/ViewModels/AutopilotCertificateEntryViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotCertificateEntryViewModel.cs
@@ -19,6 +19,8 @@ public sealed record AutopilotCertificateEntryViewModel(
 
     public string ExpiresOnDisplay => ExpiresOnUtc.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
 
+    public string SelectionDisplayName => $"{Thumbprint} - {ExpiresOnDisplay}";
+
     public Brush ValidityForeground => (Brush)Application.Current.Resources[ResolveValidityBrushKey()];
 
     public static AutopilotCertificateEntryViewModel FromGraphCredential(AutopilotGraphKeyCredential credential)

--- a/src/Foundry/ViewModels/AutopilotCertificateEntryViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotCertificateEntryViewModel.cs
@@ -19,8 +19,6 @@ public sealed record AutopilotCertificateEntryViewModel(
 
     public string ExpiresOnDisplay => ExpiresOnUtc.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
 
-    public string SelectionDisplayName => $"{Thumbprint} - {ExpiresOnDisplay}";
-
     public Brush ValidityForeground => (Brush)Application.Current.Resources[ResolveValidityBrushKey()];
 
     public static AutopilotCertificateEntryViewModel FromGraphCredential(AutopilotGraphKeyCredential credential)

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -352,9 +352,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string BootMediaCertificateDescription { get; set; }
 
     [ObservableProperty]
-    public partial string BootMediaCertificateTenantCertificateLabel { get; set; }
-
-    [ObservableProperty]
     public partial string BootMediaCertificatePfxPathLabel { get; set; }
 
     [ObservableProperty]
@@ -494,10 +491,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RetireActiveCertificateCommand))]
     public partial AutopilotCertificateEntryViewModel? SelectedCertificate { get; set; }
-
-    [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(SelectBootMediaCertificatePfxCommand))]
-    public partial AutopilotCertificateEntryViewModel? SelectedBootMediaCertificate { get; set; }
 
     [ObservableProperty]
     public partial AutopilotGroupTagEntryViewModel? SelectedDefaultGroupTag { get; set; }
@@ -1002,7 +995,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         CertificateIdColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateIdColumn");
         BootMediaCertificateLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateLabel");
         BootMediaCertificateDescription = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateDescription");
-        BootMediaCertificateTenantCertificateLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateTenantCertificateLabel");
         BootMediaCertificatePfxPathLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePfxPathLabel");
         BootMediaCertificatePasswordLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePasswordLabel");
         SelectBootMediaCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateSelectButton");
@@ -1170,12 +1162,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         }
 
         SelectedCertificate = null;
-        SelectedBootMediaCertificate = Certificates.FirstOrDefault(certificate =>
-            string.Equals(certificate.KeyId, hardwareHashUploadSettings.ActiveCertificate?.KeyId, StringComparison.OrdinalIgnoreCase) &&
-            string.Equals(
-                NormalizeThumbprint(certificate.Thumbprint),
-                NormalizeThumbprint(hardwareHashUploadSettings.ActiveCertificate?.Thumbprint),
-                StringComparison.OrdinalIgnoreCase));
         hardwareHashSessionState.Certificates = credentials;
         OnPropertyChanged(nameof(HasCertificates));
         OnPropertyChanged(nameof(CertificatesVisibility));
@@ -1187,7 +1173,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         AutopilotCertificateMetadata? certificate = hardwareHashUploadSettings.ActiveCertificate;
         if (certificate is null)
         {
-            return localizationService.GetString("Autopilot.HardwareHashCertificateMissing");
+            return HasCertificates
+                ? string.Empty
+                : localizationService.GetString("Autopilot.HardwareHashCertificateMissing");
         }
 
         if (certificate.ExpiresOnUtc is null)
@@ -1295,26 +1283,46 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
                 {
                     AutopilotPfxValidationResult validation = AutopilotPfxCertificateValidator.Validate(
                         File.ReadAllBytes(normalizedPath),
-                        password,
-                        hardwareHashUploadSettings.ActiveCertificate?.Thumbprint);
+                        password);
                     bootMediaCertificateValidationCode = validation.Code;
                     if (validation.IsValid)
                     {
-                        bootMediaCertificate = bootMediaCertificate with
+                        AutopilotCertificateEntryViewModel? matchingCertificate = FindTenantCertificateByThumbprint(validation.Thumbprint);
+                        if (matchingCertificate is null)
                         {
-                            ValidatedThumbprint = validation.Thumbprint,
-                            ValidatedExpiresOnUtc = validation.ExpiresOnUtc
-                        };
+                            bootMediaCertificateValidationCode = AutopilotPfxValidationCode.ThumbprintMismatch;
+                            hardwareHashUploadSettings = hardwareHashUploadSettings with { ActiveCertificate = null };
+                        }
+                        else
+                        {
+                            hardwareHashUploadSettings = hardwareHashUploadSettings with
+                            {
+                                ActiveCertificate = CreateCertificateMetadata(matchingCertificate)
+                            };
+                            tenantOnboardingStatus = ResolveCertificateSelectionStatus(matchingCertificate);
+                            hardwareHashSessionState.TenantOnboardingStatus = tenantOnboardingStatus;
+                            bootMediaCertificate = bootMediaCertificate with
+                            {
+                                ValidatedThumbprint = validation.Thumbprint,
+                                ValidatedExpiresOnUtc = validation.ExpiresOnUtc
+                            };
+                        }
+                    }
+                    else
+                    {
+                        hardwareHashUploadSettings = hardwareHashUploadSettings with { ActiveCertificate = null };
                     }
                 }
                 catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
                 {
                     bootMediaCertificateValidationCode = AutopilotPfxValidationCode.InvalidPfx;
+                    hardwareHashUploadSettings = hardwareHashUploadSettings with { ActiveCertificate = null };
                 }
             }
             else
             {
                 isBootMediaCertificateFileMissing = true;
+                hardwareHashUploadSettings = hardwareHashUploadSettings with { ActiveCertificate = null };
             }
         }
 
@@ -1372,8 +1380,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     private static bool ShouldShowTenantOnboardingResultDialog(AutopilotTenantOnboardingStatus status)
     {
-        return status is not AutopilotTenantOnboardingStatus.ActiveCertificateMissing
-            and not AutopilotTenantOnboardingStatus.MultipleFoundryCertificatesNeedSelection;
+        return status is not AutopilotTenantOnboardingStatus.ActiveCertificateMissing;
     }
 
     private void RefreshProfileState()
@@ -1411,24 +1418,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             DefaultGroupTag = value?.GroupTag
         };
         OnPropertyChanged(nameof(DefaultGroupTagText));
-        SaveState();
-    }
-
-    partial void OnSelectedBootMediaCertificateChanged(AutopilotCertificateEntryViewModel? value)
-    {
-        if (isApplyingState)
-        {
-            return;
-        }
-
-        hardwareHashUploadSettings = hardwareHashUploadSettings with
-        {
-            ActiveCertificate = value is null ? null : CreateCertificateMetadata(value)
-        };
-        tenantOnboardingStatus = ResolveCertificateSelectionStatus(value);
-        hardwareHashSessionState.TenantOnboardingStatus = tenantOnboardingStatus;
-        ClearBootMediaCertificateIfActiveCertificateChanged();
-        RefreshHardwareHashUploadState();
         SaveState();
     }
 
@@ -1492,6 +1481,21 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         };
     }
 
+    private AutopilotCertificateEntryViewModel? FindTenantCertificateByThumbprint(string? thumbprint)
+    {
+        string? normalizedThumbprint = NormalizeThumbprint(thumbprint);
+        if (string.IsNullOrWhiteSpace(normalizedThumbprint))
+        {
+            return null;
+        }
+
+        return Certificates.FirstOrDefault(certificate =>
+            string.Equals(
+                NormalizeThumbprint(certificate.Thumbprint),
+                normalizedThumbprint,
+                StringComparison.OrdinalIgnoreCase));
+    }
+
     private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
     {
         RefreshLocalizedText();
@@ -1553,8 +1557,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
                IsHardwareHashUploadMode &&
                !IsBusy &&
                HasConnectedTenantInCurrentSession &&
-               hardwareHashUploadSettings.ActiveCertificate is not null &&
-               !IsHardwareHashCertificateExpired;
+               HasCertificates;
     }
 
     private static string? NormalizeThumbprint(string? thumbprint)

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -114,6 +114,11 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     /// </summary>
     public ObservableCollection<AutopilotGroupTagEntryViewModel> AvailableGroupTags { get; } = [];
 
+    /// <summary>
+    /// Gets default group tag choices, including the optional None choice.
+    /// </summary>
+    public ObservableCollection<AutopilotGroupTagEntryViewModel> DefaultGroupTagOptions { get; } = [];
+
     public bool IsAutopilotSectionEnabled => IsAutopilotEnabled;
     public bool HasProfiles => Profiles.Count > 0;
     public Visibility EmptyProfilesVisibility => HasProfiles ? Visibility.Collapsed : Visibility.Visible;
@@ -312,6 +317,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     [ObservableProperty]
     public partial string DefaultGroupTagLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string DefaultGroupTagNoneOptionText { get; set; }
 
     [ObservableProperty]
     public partial string KnownGroupTagsLabel { get; set; }
@@ -925,6 +933,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         BootMediaCertificatePasswordLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePasswordLabel");
         SelectBootMediaCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateSelectButton");
         DefaultGroupTagLabel = localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagLabel");
+        DefaultGroupTagNoneOptionText = localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagNoneOption");
         KnownGroupTagsLabel = localizationService.GetString("Autopilot.HardwareHashKnownGroupTagsLabel");
         AvailableGroupTagColumnHeader = localizationService.GetString("Autopilot.HardwareHashAvailableGroupTagColumn");
         ImportButtonText = localizationService.GetString("Autopilot.ImportButton");
@@ -990,6 +999,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         OnPropertyChanged(nameof(IsHardwareHashCertificateExpired));
         OnPropertyChanged(nameof(HardwareHashCertificateWarningVisibility));
         OnPropertyChanged(nameof(DefaultGroupTagText));
+        OnPropertyChanged(nameof(DefaultGroupTagOptions));
         OnPropertyChanged(nameof(KnownGroupTagsText));
         OnPropertyChanged(nameof(HasAvailableGroupTags));
         OnPropertyChanged(nameof(AvailableGroupTagsVisibility));
@@ -1025,14 +1035,18 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             .ToArray();
 
         AvailableGroupTags.Clear();
+        DefaultGroupTagOptions.Clear();
+        DefaultGroupTagOptions.Add(new AutopilotGroupTagEntryViewModel(DefaultGroupTagNoneOptionText, null));
         foreach (string groupTag in orderedGroupTags)
         {
-            AvailableGroupTags.Add(new AutopilotGroupTagEntryViewModel(groupTag));
+            AutopilotGroupTagEntryViewModel groupTagEntry = new(groupTag, groupTag);
+            AvailableGroupTags.Add(groupTagEntry);
+            DefaultGroupTagOptions.Add(groupTagEntry);
         }
 
-        AutopilotGroupTagEntryViewModel? selectedGroupTag = AvailableGroupTags.FirstOrDefault(groupTag =>
+        AutopilotGroupTagEntryViewModel? selectedGroupTag = DefaultGroupTagOptions.FirstOrDefault(groupTag =>
                                                        string.Equals(groupTag.GroupTag, preferredDefaultGroupTag, StringComparison.OrdinalIgnoreCase))
-                                                   ?? AvailableGroupTags.FirstOrDefault();
+                                                   ?? DefaultGroupTagOptions.First();
         SelectedDefaultGroupTag = selectedGroupTag;
         hardwareHashUploadSettings = hardwareHashUploadSettings with
         {

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -119,6 +119,11 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     /// </summary>
     public ObservableCollection<AutopilotGroupTagEntryViewModel> DefaultGroupTagOptions { get; } = [];
 
+    /// <summary>
+    /// Gets tenant metadata displayed after a successful tenant connection.
+    /// </summary>
+    public ObservableCollection<AutopilotTenantDetailEntryViewModel> TenantDetails { get; } = [];
+
     public bool IsAutopilotSectionEnabled => IsAutopilotEnabled;
     public bool HasProfiles => Profiles.Count > 0;
     public Visibility EmptyProfilesVisibility => HasProfiles ? Visibility.Collapsed : Visibility.Visible;
@@ -247,6 +252,15 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string JsonProfileEnableText { get; set; }
 
     [ObservableProperty]
+    public partial string ActionsDescription { get; set; }
+
+    [ObservableProperty]
+    public partial string DefaultProfileDescription { get; set; }
+
+    [ObservableProperty]
+    public partial string ProfilesDescription { get; set; }
+
+    [ObservableProperty]
     public partial string HardwareHashHeader { get; set; }
 
     [ObservableProperty]
@@ -277,16 +291,43 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string TenantStatusLabel { get; set; }
 
     [ObservableProperty]
+    public partial string TenantStatusDescription { get; set; }
+
+    [ObservableProperty]
     public partial string TenantDetailsLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string TenantDetailsDescription { get; set; }
+
+    [ObservableProperty]
+    public partial string TenantDetailsNameColumnHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string TenantDetailsValueColumnHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string TenantDetailsTenantIdLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string TenantDetailsClientIdLabel { get; set; }
 
     [ObservableProperty]
     public partial string AppRegistrationLabel { get; set; }
 
     [ObservableProperty]
+    public partial string AppRegistrationDescription { get; set; }
+
+    [ObservableProperty]
     public partial string TenantOnboardingStatusLabel { get; set; }
 
     [ObservableProperty]
+    public partial string TenantOnboardingStatusDescription { get; set; }
+
+    [ObservableProperty]
     public partial string CertificateStatusLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string CertificateStatusDescription { get; set; }
 
     [ObservableProperty]
     public partial string CertificateExpiredWarningText { get; set; }
@@ -307,6 +348,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string BootMediaCertificateLabel { get; set; }
 
     [ObservableProperty]
+    public partial string BootMediaCertificateDescription { get; set; }
+
+    [ObservableProperty]
     public partial string BootMediaCertificatePfxPathLabel { get; set; }
 
     [ObservableProperty]
@@ -319,10 +363,16 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string DefaultGroupTagLabel { get; set; }
 
     [ObservableProperty]
+    public partial string DefaultGroupTagDescription { get; set; }
+
+    [ObservableProperty]
     public partial string DefaultGroupTagNoneOptionText { get; set; }
 
     [ObservableProperty]
     public partial string KnownGroupTagsLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string KnownGroupTagsDescription { get; set; }
 
     [ObservableProperty]
     public partial string AvailableGroupTagColumnHeader { get; set; }
@@ -909,6 +959,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         JsonProfileHeader = localizationService.GetString("Autopilot.JsonProfileHeader");
         JsonProfileDescription = localizationService.GetString("Autopilot.JsonProfileDescription");
         JsonProfileEnableText = localizationService.GetString("Autopilot.JsonProfileEnableLabel");
+        ActionsDescription = localizationService.GetString("Autopilot.ActionsDescription");
+        DefaultProfileDescription = localizationService.GetString("Autopilot.DefaultProfileDescription");
+        ProfilesDescription = localizationService.GetString("Autopilot.ProfilesDescription");
         HardwareHashHeader = localizationService.GetString("Autopilot.HardwareHashHeader");
         HardwareHashDescription = localizationService.GetString("Autopilot.HardwareHashDescription");
         HardwareHashEnableText = localizationService.GetString("Autopilot.HardwareHashEnableLabel");
@@ -919,22 +972,34 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         CreateCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashCreateCertificateButton");
         RetireCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashRetireCertificateButton");
         TenantStatusLabel = localizationService.GetString("Autopilot.HardwareHashTenantStatusLabel");
+        TenantStatusDescription = localizationService.GetString("Autopilot.HardwareHashTenantStatusDescription");
         TenantDetailsLabel = localizationService.GetString("Autopilot.HardwareHashTenantDetailsLabel");
+        TenantDetailsDescription = localizationService.GetString("Autopilot.HardwareHashTenantDetailsDescription");
+        TenantDetailsNameColumnHeader = localizationService.GetString("Autopilot.HardwareHashTenantDetailsNameColumn");
+        TenantDetailsValueColumnHeader = localizationService.GetString("Autopilot.HardwareHashTenantDetailsValueColumn");
+        TenantDetailsTenantIdLabel = localizationService.GetString("Autopilot.HardwareHashTenantDetailsTenantId");
+        TenantDetailsClientIdLabel = localizationService.GetString("Autopilot.HardwareHashTenantDetailsClientId");
         AppRegistrationLabel = localizationService.GetString("Autopilot.HardwareHashAppRegistrationLabel");
+        AppRegistrationDescription = localizationService.GetString("Autopilot.HardwareHashAppRegistrationDescription");
         TenantOnboardingStatusLabel = localizationService.GetString("Autopilot.HardwareHashOnboardingStatusLabel");
+        TenantOnboardingStatusDescription = localizationService.GetString("Autopilot.HardwareHashOnboardingStatusDescription");
         CertificateStatusLabel = localizationService.GetString("Autopilot.HardwareHashCertificateStatusLabel");
+        CertificateStatusDescription = localizationService.GetString("Autopilot.HardwareHashCertificateStatusDescription");
         CertificateExpiredWarningText = localizationService.GetString("Autopilot.HardwareHashCertificateExpiredWarning");
         CertificateThumbprintColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateThumbprintColumn");
         CertificateCreatedColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateCreatedColumn");
         CertificateExpiresColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateExpiresColumn");
         CertificateIdColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateIdColumn");
         BootMediaCertificateLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateLabel");
+        BootMediaCertificateDescription = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateDescription");
         BootMediaCertificatePfxPathLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePfxPathLabel");
         BootMediaCertificatePasswordLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePasswordLabel");
         SelectBootMediaCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateSelectButton");
         DefaultGroupTagLabel = localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagLabel");
+        DefaultGroupTagDescription = localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagDescription");
         DefaultGroupTagNoneOptionText = localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagNoneOption");
         KnownGroupTagsLabel = localizationService.GetString("Autopilot.HardwareHashKnownGroupTagsLabel");
+        KnownGroupTagsDescription = localizationService.GetString("Autopilot.HardwareHashKnownGroupTagsDescription");
         AvailableGroupTagColumnHeader = localizationService.GetString("Autopilot.HardwareHashAvailableGroupTagColumn");
         ImportButtonText = localizationService.GetString("Autopilot.ImportButton");
         DownloadButtonText = localizationService.GetString("Autopilot.DownloadButton");
@@ -988,6 +1053,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     private void RefreshHardwareHashUploadState()
     {
+        RefreshTenantDetails();
         OnPropertyChanged(nameof(TenantStatusText));
         OnPropertyChanged(nameof(TenantConnectionButtonText));
         OnPropertyChanged(nameof(TenantDetailsText));
@@ -1012,6 +1078,22 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         OnPropertyChanged(nameof(IsBootMediaCertificateReady));
         RetireActiveCertificateCommand.NotifyCanExecuteChanged();
         SelectBootMediaCertificatePfxCommand.NotifyCanExecuteChanged();
+    }
+
+    private void RefreshTenantDetails()
+    {
+        TenantDetails.Clear();
+        if (!HasTenantRegistration)
+        {
+            return;
+        }
+
+        TenantDetails.Add(new AutopilotTenantDetailEntryViewModel(
+            TenantDetailsTenantIdLabel,
+            hardwareHashUploadSettings.Tenant.TenantId!));
+        TenantDetails.Add(new AutopilotTenantDetailEntryViewModel(
+            TenantDetailsClientIdLabel,
+            hardwareHashUploadSettings.Tenant.ClientId!));
     }
 
     private void DisconnectTenantSession()

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -103,7 +103,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public Visibility EmptyProfilesVisibility => HasProfiles ? Visibility.Collapsed : Visibility.Visible;
     public Visibility ProfilesVisibility => HasProfiles ? Visibility.Visible : Visibility.Collapsed;
     public bool HasCertificates => Certificates.Count > 0;
-    public Visibility EmptyCertificatesVisibility => HasCertificates ? Visibility.Collapsed : Visibility.Visible;
     public Visibility CertificatesVisibility => HasCertificates ? Visibility.Visible : Visibility.Collapsed;
     public Visibility ConnectedTenantDetailsVisibility => HasConnectedTenantInCurrentSession ? Visibility.Visible : Visibility.Collapsed;
     public bool IsBusy => IsImporting || IsDownloading || IsConnectingTenant;
@@ -158,6 +157,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public string TenantStatusText => HasConnectedTenantInCurrentSession && HasTenantRegistration
         ? localizationService.GetString("Autopilot.HardwareHashTenantConnected")
         : localizationService.GetString("Autopilot.HardwareHashTenantNotConnected");
+    public string TenantConnectionButtonText => HasConnectedTenantInCurrentSession
+        ? DisconnectTenantButtonText
+        : ConnectTenantButtonText;
     public string TenantDetailsText => HasTenantRegistration
         ? localizationService.FormatString("Autopilot.HardwareHashTenantDetailsFormat", hardwareHashUploadSettings.Tenant.TenantId!)
         : string.Empty;
@@ -213,6 +215,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string ConnectTenantButtonText { get; set; }
 
     [ObservableProperty]
+    public partial string DisconnectTenantButtonText { get; set; }
+
+    [ObservableProperty]
     public partial string ConnectingTenantStatusText { get; set; }
 
     [ObservableProperty]
@@ -241,9 +246,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     [ObservableProperty]
     public partial string CertificateExpiredWarningText { get; set; }
-
-    [ObservableProperty]
-    public partial string CertificatesEmptyText { get; set; }
 
     [ObservableProperty]
     public partial string CertificateThumbprintColumnHeader { get; set; }
@@ -515,6 +517,12 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     [RelayCommand(CanExecute = nameof(CanConnectTenant))]
     private async Task ConnectTenantAsync()
     {
+        if (HasConnectedTenantInCurrentSession)
+        {
+            DisconnectTenantSession();
+            return;
+        }
+
         IsConnectingTenant = true;
         try
         {
@@ -540,9 +548,12 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
                 result.Status,
                 result.Settings.Tenant.TenantId,
                 result.Settings.Tenant.ApplicationObjectId);
-            await dialogService.ShowMessageAsync(new DialogRequest(
-                GetTenantOnboardingDialogTitle(result.Status),
-                result.Message));
+            if (ShouldShowTenantOnboardingResultDialog(result.Status))
+            {
+                await dialogService.ShowMessageAsync(new DialogRequest(
+                    GetTenantOnboardingDialogTitle(result.Status),
+                    result.Message));
+            }
         }
         catch (Exception ex) when (ex is AuthenticationFailedException or HttpRequestException or InvalidOperationException or JsonException)
         {
@@ -766,6 +777,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         HardwareHashDescription = localizationService.GetString("Autopilot.HardwareHashDescription");
         HardwareHashEnableText = localizationService.GetString("Autopilot.HardwareHashEnableLabel");
         ConnectTenantButtonText = localizationService.GetString("Autopilot.HardwareHashConnectTenantButton");
+        DisconnectTenantButtonText = localizationService.GetString("Autopilot.HardwareHashDisconnectTenantButton");
         ConnectingTenantStatusText = localizationService.GetString("Autopilot.HardwareHashConnectingTenantStatus");
         CertificateValidityLabel = localizationService.GetString("Autopilot.HardwareHashCertificateValidityLabel");
         CreateCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashCreateCertificateButton");
@@ -776,7 +788,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         TenantOnboardingStatusLabel = localizationService.GetString("Autopilot.HardwareHashOnboardingStatusLabel");
         CertificateStatusLabel = localizationService.GetString("Autopilot.HardwareHashCertificateStatusLabel");
         CertificateExpiredWarningText = localizationService.GetString("Autopilot.HardwareHashCertificateExpiredWarning");
-        CertificatesEmptyText = localizationService.GetString("Autopilot.HardwareHashCertificatesEmpty");
         CertificateThumbprintColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateThumbprintColumn");
         CertificateCreatedColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateCreatedColumn");
         CertificateExpiresColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateExpiresColumn");
@@ -801,6 +812,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         ProfileImportedColumnHeader = localizationService.GetString("Autopilot.ColumnImported");
         ProfileFolderColumnHeader = localizationService.GetString("Autopilot.ColumnFolder");
         OnPropertyChanged(nameof(BusyStatusText));
+        OnPropertyChanged(nameof(TenantConnectionButtonText));
         RefreshHardwareHashUploadState();
     }
 
@@ -835,6 +847,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private void RefreshHardwareHashUploadState()
     {
         OnPropertyChanged(nameof(TenantStatusText));
+        OnPropertyChanged(nameof(TenantConnectionButtonText));
         OnPropertyChanged(nameof(TenantDetailsText));
         OnPropertyChanged(nameof(AppRegistrationStatusText));
         OnPropertyChanged(nameof(TenantOnboardingStatusText));
@@ -846,6 +859,14 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         OnPropertyChanged(nameof(KnownGroupTagsText));
         OnPropertyChanged(nameof(ConnectedTenantDetailsVisibility));
         RetireActiveCertificateCommand.NotifyCanExecuteChanged();
+    }
+
+    private void DisconnectTenantSession()
+    {
+        HasConnectedTenantInCurrentSession = false;
+        tenantOnboardingStatus = null;
+        ReplaceCertificates([]);
+        RefreshHardwareHashUploadState();
     }
 
     private void ReplaceCertificates(IReadOnlyList<AutopilotGraphKeyCredential> credentials)
@@ -863,7 +884,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
                                   string.Equals(certificate.KeyId, selectedKeyId, StringComparison.OrdinalIgnoreCase))
                               ?? Certificates.FirstOrDefault();
         OnPropertyChanged(nameof(HasCertificates));
-        OnPropertyChanged(nameof(EmptyCertificatesVisibility));
         OnPropertyChanged(nameof(CertificatesVisibility));
     }
 
@@ -926,6 +946,11 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         return status == AutopilotTenantOnboardingStatus.Ready
             ? localizationService.GetString("Autopilot.HardwareHashOnboardingCompletedTitle")
             : localizationService.GetString("Autopilot.HardwareHashOnboardingRequiresAttentionTitle");
+    }
+
+    private static bool ShouldShowTenantOnboardingResultDialog(AutopilotTenantOnboardingStatus status)
+    {
+        return status != AutopilotTenantOnboardingStatus.ActiveCertificateMissing;
     }
 
     private void RefreshProfileState()

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -9,6 +9,7 @@ using Foundry.Services.Autopilot;
 using Foundry.Services.Configuration;
 using Foundry.Services.Localization;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
 using Serilog;
 
 namespace Foundry.ViewModels;
@@ -23,6 +24,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private readonly IAutopilotTenantProfileService autopilotTenantProfileService;
     private readonly IAutopilotTenantOnboardingService autopilotTenantOnboardingService;
     private readonly IAutopilotTenantDownloadDialogService tenantDownloadDialogService;
+    private readonly IAutopilotCertificateDialogService certificateDialogService;
     private readonly IAutopilotProfileSelectionDialogService profileSelectionDialogService;
     private readonly IFilePickerService filePickerService;
     private readonly IDialogService dialogService;
@@ -40,6 +42,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         IAutopilotTenantProfileService autopilotTenantProfileService,
         IAutopilotTenantOnboardingService autopilotTenantOnboardingService,
         IAutopilotTenantDownloadDialogService tenantDownloadDialogService,
+        IAutopilotCertificateDialogService certificateDialogService,
         IAutopilotProfileSelectionDialogService profileSelectionDialogService,
         IFilePickerService filePickerService,
         IDialogService dialogService,
@@ -51,6 +54,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         this.autopilotTenantProfileService = autopilotTenantProfileService;
         this.autopilotTenantOnboardingService = autopilotTenantOnboardingService;
         this.tenantDownloadDialogService = tenantDownloadDialogService;
+        this.certificateDialogService = certificateDialogService;
         this.profileSelectionDialogService = profileSelectionDialogService;
         this.filePickerService = filePickerService;
         this.dialogService = dialogService;
@@ -79,6 +83,11 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public ObservableCollection<AutopilotProfileEntryViewModel> SelectedProfiles { get; } = [];
 
     /// <summary>
+    /// Gets app registration certificate credentials discovered from Microsoft Graph.
+    /// </summary>
+    public ObservableCollection<AutopilotCertificateEntryViewModel> Certificates { get; } = [];
+
+    /// <summary>
     /// Gets the fixed certificate validity options available for managed Autopilot app certificates.
     /// </summary>
     public ObservableCollection<CertificateValidityOptionViewModel> CertificateValidityOptions { get; } =
@@ -93,6 +102,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public bool HasProfiles => Profiles.Count > 0;
     public Visibility EmptyProfilesVisibility => HasProfiles ? Visibility.Collapsed : Visibility.Visible;
     public Visibility ProfilesVisibility => HasProfiles ? Visibility.Visible : Visibility.Collapsed;
+    public bool HasCertificates => Certificates.Count > 0;
+    public Visibility EmptyCertificatesVisibility => HasCertificates ? Visibility.Collapsed : Visibility.Visible;
+    public Visibility CertificatesVisibility => HasCertificates ? Visibility.Visible : Visibility.Collapsed;
     public bool IsBusy => IsImporting || IsDownloading || IsConnectingTenant;
     public Visibility BusyStatusVisibility => IsBusy ? Visibility.Visible : Visibility.Collapsed;
     public string BusyStatusText => IsImporting
@@ -150,6 +162,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         : localizationService.FormatString("Autopilot.HardwareHashAppRegistrationFoundFormat", ManagedAppRegistrationName);
     public string TenantOnboardingStatusText => CreateTenantOnboardingStatusText();
     public string CertificateStatusText => CreateCertificateStatusText();
+    public Brush CertificateStatusForeground => ResolveCertificateStatusBrush();
     public string DefaultGroupTagText => string.IsNullOrWhiteSpace(hardwareHashUploadSettings.DefaultGroupTag)
         ? localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagNone")
         : hardwareHashUploadSettings.DefaultGroupTag!;
@@ -219,6 +232,21 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     [ObservableProperty]
     public partial string CertificateExpiredWarningText { get; set; }
+
+    [ObservableProperty]
+    public partial string CertificatesEmptyText { get; set; }
+
+    [ObservableProperty]
+    public partial string CertificateThumbprintColumnHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string CertificateCreatedColumnHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string CertificateExpiresColumnHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string CertificateIdColumnHeader { get; set; }
 
     [ObservableProperty]
     public partial string DefaultGroupTagLabel { get; set; }
@@ -331,6 +359,10 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(CreateCertificateCommand))]
     public partial CertificateValidityOptionViewModel? SelectedCertificateValidityOption { get; set; }
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(RetireActiveCertificateCommand))]
+    public partial AutopilotCertificateEntryViewModel? SelectedCertificate { get; set; }
 
     /// <summary>
     /// Releases subscriptions to localization, configuration state, and profile collections.
@@ -478,9 +510,19 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         try
         {
             logger.Information("Starting Autopilot hardware hash tenant onboarding.");
-            AutopilotTenantOnboardingResult result = await autopilotTenantOnboardingService.ConnectAsync(hardwareHashUploadSettings);
+            AutopilotTenantOnboardingResult? result = await tenantDownloadDialogService.RunAsync(
+                localizationService.GetString("Autopilot.HardwareHashTenantConnectionDialogTitle"),
+                localizationService.GetString("Autopilot.HardwareHashTenantConnectionDialogMessage"),
+                cancellationToken => autopilotTenantOnboardingService.ConnectAsync(hardwareHashUploadSettings, cancellationToken));
+            if (result is null)
+            {
+                logger.Information("Autopilot hardware hash tenant onboarding was canceled.");
+                return;
+            }
+
             hardwareHashUploadSettings = result.Settings;
             tenantOnboardingStatus = result.Status;
+            ReplaceCertificates(result.Certificates);
             RefreshHardwareHashUploadState();
             SaveState();
             logger.Information(
@@ -526,15 +568,12 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
                 outputPath,
                 SelectedCertificateValidityOption.Months);
             hardwareHashUploadSettings = result.Settings;
+            tenantOnboardingStatus = AutopilotTenantOnboardingStatus.Ready;
+            ReplaceCertificates(result.Certificates);
             RefreshHardwareHashUploadState();
             SaveState();
 
-            await dialogService.ShowMessageAsync(new DialogRequest(
-                localizationService.GetString("Autopilot.HardwareHashCertificateCreatedTitle"),
-                localizationService.FormatString(
-                    "Autopilot.HardwareHashCertificateCreatedMessageFormat",
-                    result.GeneratedPassword,
-                    outputPath)));
+            await certificateDialogService.ShowCreatedAsync(outputPath, result.GeneratedPassword);
         }
         catch (Exception ex) when (ex is AuthenticationFailedException or HttpRequestException or InvalidOperationException or IOException or UnauthorizedAccessException)
         {
@@ -565,8 +604,21 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         IsConnectingTenant = true;
         try
         {
-            hardwareHashUploadSettings = await autopilotTenantOnboardingService.RetireActiveCertificateAsync(hardwareHashUploadSettings);
-            tenantOnboardingStatus = AutopilotTenantOnboardingStatus.ActiveCertificateMissing;
+            if (SelectedCertificate is null)
+            {
+                return;
+            }
+
+            AutopilotCertificateRemovalResult result = await autopilotTenantOnboardingService.RemoveCertificateAsync(
+                hardwareHashUploadSettings,
+                SelectedCertificate.KeyId);
+            hardwareHashUploadSettings = result.Settings;
+            if (hardwareHashUploadSettings.ActiveCertificate is null)
+            {
+                tenantOnboardingStatus = AutopilotTenantOnboardingStatus.ActiveCertificateMissing;
+            }
+
+            ReplaceCertificates(result.Certificates);
             RefreshHardwareHashUploadState();
             SaveState();
 
@@ -613,6 +665,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
                 ? settings.ProvisioningMode
                 : AutopilotProvisioningMode.JsonProfile;
             hardwareHashUploadSettings = settings.HardwareHashUpload ?? new AutopilotHardwareHashUploadSettings();
+            ReplaceCertificates([]);
             ReplaceProfiles(
                 settings.Profiles.Select(AutopilotProfileEntryViewModel.FromSettings),
                 settings.DefaultProfileId);
@@ -712,6 +765,11 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         TenantOnboardingStatusLabel = localizationService.GetString("Autopilot.HardwareHashOnboardingStatusLabel");
         CertificateStatusLabel = localizationService.GetString("Autopilot.HardwareHashCertificateStatusLabel");
         CertificateExpiredWarningText = localizationService.GetString("Autopilot.HardwareHashCertificateExpiredWarning");
+        CertificatesEmptyText = localizationService.GetString("Autopilot.HardwareHashCertificatesEmpty");
+        CertificateThumbprintColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateThumbprintColumn");
+        CertificateCreatedColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateCreatedColumn");
+        CertificateExpiresColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateExpiresColumn");
+        CertificateIdColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateIdColumn");
         DefaultGroupTagLabel = localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagLabel");
         KnownGroupTagsLabel = localizationService.GetString("Autopilot.HardwareHashKnownGroupTagsLabel");
         ImportButtonText = localizationService.GetString("Autopilot.ImportButton");
@@ -769,11 +827,31 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         OnPropertyChanged(nameof(AppRegistrationStatusText));
         OnPropertyChanged(nameof(TenantOnboardingStatusText));
         OnPropertyChanged(nameof(CertificateStatusText));
+        OnPropertyChanged(nameof(CertificateStatusForeground));
         OnPropertyChanged(nameof(IsHardwareHashCertificateExpired));
         OnPropertyChanged(nameof(HardwareHashCertificateWarningVisibility));
         OnPropertyChanged(nameof(DefaultGroupTagText));
         OnPropertyChanged(nameof(KnownGroupTagsText));
         RetireActiveCertificateCommand.NotifyCanExecuteChanged();
+    }
+
+    private void ReplaceCertificates(IReadOnlyList<AutopilotGraphKeyCredential> credentials)
+    {
+        string? selectedKeyId = SelectedCertificate?.KeyId ?? hardwareHashUploadSettings.ActiveCertificate?.KeyId;
+        Certificates.Clear();
+        foreach (AutopilotCertificateEntryViewModel certificate in credentials
+                     .OrderBy(certificate => certificate.ExpiresOnUtc)
+                     .Select(AutopilotCertificateEntryViewModel.FromGraphCredential))
+        {
+            Certificates.Add(certificate);
+        }
+
+        SelectedCertificate = Certificates.FirstOrDefault(certificate =>
+                                  string.Equals(certificate.KeyId, selectedKeyId, StringComparison.OrdinalIgnoreCase))
+                              ?? Certificates.FirstOrDefault();
+        OnPropertyChanged(nameof(HasCertificates));
+        OnPropertyChanged(nameof(EmptyCertificatesVisibility));
+        OnPropertyChanged(nameof(CertificatesVisibility));
     }
 
     private string CreateCertificateStatusText()
@@ -792,6 +870,24 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         return certificate.ExpiresOnUtc <= DateTimeOffset.UtcNow
             ? localizationService.FormatString("Autopilot.HardwareHashCertificateExpiredFormat", certificate.ExpiresOnUtc.Value.LocalDateTime)
             : localizationService.FormatString("Autopilot.HardwareHashCertificateValidFormat", certificate.ExpiresOnUtc.Value.LocalDateTime);
+    }
+
+    private Brush ResolveCertificateStatusBrush()
+    {
+        AutopilotCertificateMetadata? certificate = hardwareHashUploadSettings.ActiveCertificate;
+        if (certificate?.ExpiresOnUtc is not DateTimeOffset expiresOnUtc)
+        {
+            return (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"];
+        }
+
+        if (expiresOnUtc <= DateTimeOffset.UtcNow)
+        {
+            return (Brush)Application.Current.Resources["SystemFillColorCriticalBrush"];
+        }
+
+        return expiresOnUtc - DateTimeOffset.UtcNow <= TimeSpan.FromDays(30)
+            ? (Brush)Application.Current.Resources["SystemFillColorCautionBrush"]
+            : (Brush)Application.Current.Resources["SystemFillColorSuccessBrush"];
     }
 
     private string CreateTenantOnboardingStatusText()
@@ -850,6 +946,15 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         }
     }
 
+    /// <summary>
+    /// Replaces the selected certificate row after a XAML selection change.
+    /// </summary>
+    /// <param name="certificates">The selected certificate view models.</param>
+    public void ReplaceSelectedCertificate(IEnumerable<AutopilotCertificateEntryViewModel> certificates)
+    {
+        SelectedCertificate = certificates.FirstOrDefault();
+    }
+
     private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
     {
         RefreshLocalizedText();
@@ -900,7 +1005,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
                IsHardwareHashUploadMode &&
                !IsBusy &&
                !string.IsNullOrWhiteSpace(hardwareHashUploadSettings.Tenant.ApplicationObjectId) &&
-               !string.IsNullOrWhiteSpace(hardwareHashUploadSettings.ActiveCertificate?.KeyId);
+               SelectedCertificate is not null;
     }
 
     public sealed record CertificateValidityOptionViewModel(int Months, string DisplayName);

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -133,6 +133,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public Visibility ProfilesVisibility => HasProfiles ? Visibility.Visible : Visibility.Collapsed;
     public bool HasCertificates => Certificates.Count > 0;
     public Visibility CertificatesVisibility => HasCertificates ? Visibility.Visible : Visibility.Collapsed;
+    public Visibility EmptyCertificatesVisibility => HasCertificates ? Visibility.Collapsed : Visibility.Visible;
     public bool HasAvailableGroupTags => AvailableGroupTags.Count > 0;
     public Visibility AvailableGroupTagsVisibility => HasAvailableGroupTags ? Visibility.Visible : Visibility.Collapsed;
     public Visibility EmptyAvailableGroupTagsVisibility => HasAvailableGroupTags ? Visibility.Collapsed : Visibility.Visible;
@@ -184,7 +185,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
                                                     expiresOnUtc <= DateTimeOffset.UtcNow;
     public Visibility JsonProfileSettingsVisibility => IsJsonProfileMode ? Visibility.Visible : Visibility.Collapsed;
     public Visibility HardwareHashSettingsVisibility => IsHardwareHashUploadMode ? Visibility.Visible : Visibility.Collapsed;
-    public Visibility HardwareHashCertificateWarningVisibility => IsHardwareHashCertificateExpired ? Visibility.Visible : Visibility.Collapsed;
     public Visibility BootMediaCertificateVisibility => HasConnectedTenantInCurrentSession &&
                                                         HasCertificates
         ? Visibility.Visible
@@ -212,9 +212,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         : localizationService.FormatString("Autopilot.HardwareHashAppRegistrationFoundFormat", ManagedAppRegistrationName);
     public string TenantOnboardingStatusText => CreateTenantOnboardingStatusText();
     public Brush TenantOnboardingStatusForeground => ResolveTenantOnboardingStatusBrush();
-    public string CertificateStatusText => CreateCertificateStatusText();
-    public Visibility CertificateStatusVisibility => string.IsNullOrWhiteSpace(CertificateStatusText) ? Visibility.Collapsed : Visibility.Visible;
-    public Brush CertificateStatusForeground => ResolveCertificateStatusBrush();
     public string DefaultGroupTagText => string.IsNullOrWhiteSpace(hardwareHashUploadSettings.DefaultGroupTag)
         ? localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagNone")
         : hardwareHashUploadSettings.DefaultGroupTag!;
@@ -280,9 +277,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string ConnectingTenantStatusText { get; set; }
 
     [ObservableProperty]
-    public partial string CertificateValidityLabel { get; set; }
-
-    [ObservableProperty]
     public partial string CreateCertificateButtonText { get; set; }
 
     [ObservableProperty]
@@ -325,13 +319,19 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string TenantOnboardingStatusDescription { get; set; }
 
     [ObservableProperty]
-    public partial string CertificateStatusLabel { get; set; }
+    public partial string CertificateActionsLabel { get; set; }
 
     [ObservableProperty]
-    public partial string CertificateStatusDescription { get; set; }
+    public partial string CertificateActionsDescription { get; set; }
 
     [ObservableProperty]
-    public partial string CertificateExpiredWarningText { get; set; }
+    public partial string ProvisionedCertificatesLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string ProvisionedCertificatesDescription { get; set; }
+
+    [ObservableProperty]
+    public partial string EmptyCertificatesText { get; set; }
 
     [ObservableProperty]
     public partial string CertificateThumbprintColumnHeader { get; set; }
@@ -361,19 +361,19 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string SelectBootMediaCertificateButtonText { get; set; }
 
     [ObservableProperty]
-    public partial string DefaultGroupTagLabel { get; set; }
+    public partial string GroupTagLabel { get; set; }
 
     [ObservableProperty]
-    public partial string DefaultGroupTagDescription { get; set; }
+    public partial string GroupTagDescription { get; set; }
+
+    [ObservableProperty]
+    public partial string DefaultGroupTagLabel { get; set; }
 
     [ObservableProperty]
     public partial string DefaultGroupTagNoneOptionText { get; set; }
 
     [ObservableProperty]
     public partial string KnownGroupTagsLabel { get; set; }
-
-    [ObservableProperty]
-    public partial string KnownGroupTagsDescription { get; set; }
 
     [ObservableProperty]
     public partial string AvailableGroupTagColumnHeader { get; set; }
@@ -971,7 +971,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         ConnectTenantButtonText = localizationService.GetString("Autopilot.HardwareHashConnectTenantButton");
         DisconnectTenantButtonText = localizationService.GetString("Autopilot.HardwareHashDisconnectTenantButton");
         ConnectingTenantStatusText = localizationService.GetString("Autopilot.HardwareHashConnectingTenantStatus");
-        CertificateValidityLabel = localizationService.GetString("Autopilot.HardwareHashCertificateValidityLabel");
         CreateCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashCreateCertificateButton");
         RetireCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashRetireCertificateButton");
         TenantStatusLabel = localizationService.GetString("Autopilot.HardwareHashTenantStatusLabel");
@@ -986,9 +985,11 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         AppRegistrationDescription = localizationService.GetString("Autopilot.HardwareHashAppRegistrationDescription");
         TenantOnboardingStatusLabel = localizationService.GetString("Autopilot.HardwareHashOnboardingStatusLabel");
         TenantOnboardingStatusDescription = localizationService.GetString("Autopilot.HardwareHashOnboardingStatusDescription");
-        CertificateStatusLabel = localizationService.GetString("Autopilot.HardwareHashCertificateStatusLabel");
-        CertificateStatusDescription = localizationService.GetString("Autopilot.HardwareHashCertificateStatusDescription");
-        CertificateExpiredWarningText = localizationService.GetString("Autopilot.HardwareHashCertificateExpiredWarning");
+        CertificateActionsLabel = localizationService.GetString("Autopilot.HardwareHashCertificateActionsLabel");
+        CertificateActionsDescription = localizationService.GetString("Autopilot.HardwareHashCertificateActionsDescription");
+        ProvisionedCertificatesLabel = localizationService.GetString("Autopilot.HardwareHashProvisionedCertificatesLabel");
+        ProvisionedCertificatesDescription = localizationService.GetString("Autopilot.HardwareHashProvisionedCertificatesDescription");
+        EmptyCertificatesText = localizationService.GetString("Autopilot.HardwareHashCertificatesNone");
         CertificateThumbprintColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateThumbprintColumn");
         CertificateCreatedColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateCreatedColumn");
         CertificateExpiresColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateExpiresColumn");
@@ -998,11 +999,11 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         BootMediaCertificatePfxPathLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePfxPathLabel");
         BootMediaCertificatePasswordLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePasswordLabel");
         SelectBootMediaCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateSelectButton");
+        GroupTagLabel = localizationService.GetString("Autopilot.HardwareHashGroupTagLabel");
+        GroupTagDescription = localizationService.GetString("Autopilot.HardwareHashGroupTagDescription");
         DefaultGroupTagLabel = localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagLabel");
-        DefaultGroupTagDescription = localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagDescription");
         DefaultGroupTagNoneOptionText = localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagNoneOption");
         KnownGroupTagsLabel = localizationService.GetString("Autopilot.HardwareHashKnownGroupTagsLabel");
-        KnownGroupTagsDescription = localizationService.GetString("Autopilot.HardwareHashKnownGroupTagsDescription");
         AvailableGroupTagColumnHeader = localizationService.GetString("Autopilot.HardwareHashAvailableGroupTagColumn");
         ImportButtonText = localizationService.GetString("Autopilot.ImportButton");
         DownloadButtonText = localizationService.GetString("Autopilot.DownloadButton");
@@ -1062,11 +1063,8 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         OnPropertyChanged(nameof(AppRegistrationStatusText));
         OnPropertyChanged(nameof(TenantOnboardingStatusText));
         OnPropertyChanged(nameof(TenantOnboardingStatusForeground));
-        OnPropertyChanged(nameof(CertificateStatusText));
-        OnPropertyChanged(nameof(CertificateStatusVisibility));
-        OnPropertyChanged(nameof(CertificateStatusForeground));
         OnPropertyChanged(nameof(IsHardwareHashCertificateExpired));
-        OnPropertyChanged(nameof(HardwareHashCertificateWarningVisibility));
+        OnPropertyChanged(nameof(EmptyCertificatesVisibility));
         OnPropertyChanged(nameof(DefaultGroupTagText));
         OnPropertyChanged(nameof(DefaultGroupTagOptions));
         OnPropertyChanged(nameof(KnownGroupTagsText));
@@ -1165,45 +1163,8 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         hardwareHashSessionState.Certificates = credentials;
         OnPropertyChanged(nameof(HasCertificates));
         OnPropertyChanged(nameof(CertificatesVisibility));
+        OnPropertyChanged(nameof(EmptyCertificatesVisibility));
         OnPropertyChanged(nameof(BootMediaCertificateVisibility));
-    }
-
-    private string CreateCertificateStatusText()
-    {
-        AutopilotCertificateMetadata? certificate = hardwareHashUploadSettings.ActiveCertificate;
-        if (certificate is null)
-        {
-            return HasCertificates
-                ? string.Empty
-                : localizationService.GetString("Autopilot.HardwareHashCertificateMissing");
-        }
-
-        if (certificate.ExpiresOnUtc is null)
-        {
-            return localizationService.GetString("Autopilot.HardwareHashCertificateExpirationMissing");
-        }
-
-        return certificate.ExpiresOnUtc <= DateTimeOffset.UtcNow
-            ? localizationService.FormatString("Autopilot.HardwareHashCertificateExpiredFormat", certificate.ExpiresOnUtc.Value.LocalDateTime)
-            : string.Empty;
-    }
-
-    private Brush ResolveCertificateStatusBrush()
-    {
-        AutopilotCertificateMetadata? certificate = hardwareHashUploadSettings.ActiveCertificate;
-        if (certificate?.ExpiresOnUtc is not DateTimeOffset expiresOnUtc)
-        {
-            return (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"];
-        }
-
-        if (expiresOnUtc <= DateTimeOffset.UtcNow)
-        {
-            return (Brush)Application.Current.Resources["SystemFillColorCriticalBrush"];
-        }
-
-        return expiresOnUtc - DateTimeOffset.UtcNow <= TimeSpan.FromDays(30)
-            ? (Brush)Application.Current.Resources["SystemFillColorCautionBrush"]
-            : (Brush)Application.Current.Resources["SystemFillColorSuccessBrush"];
     }
 
     private string CreateBootMediaCertificateStatusText()

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -656,7 +656,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             {
                 await dialogService.ShowMessageAsync(new DialogRequest(
                     GetTenantOnboardingDialogTitle(),
-                    result.Message));
+                    CreateTenantOnboardingResultMessage(result.Status)));
             }
         }
         catch (Exception ex) when (ex is AuthenticationFailedException or HttpRequestException or InvalidOperationException or JsonException)
@@ -760,10 +760,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             ClearBootMediaCertificateIfActiveCertificateChanged();
             RefreshHardwareHashUploadState();
             SaveState();
-
-            await dialogService.ShowMessageAsync(new DialogRequest(
-                localizationService.GetString("Autopilot.HardwareHashCertificateRetiredTitle"),
-                localizationService.GetString("Autopilot.HardwareHashCertificateRetiredMessage")));
         }
         catch (Exception ex) when (ex is AuthenticationFailedException or HttpRequestException or InvalidOperationException or JsonException)
         {
@@ -1128,9 +1124,13 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     private void ReplaceCertificates(IReadOnlyList<AutopilotGraphKeyCredential> credentials)
     {
+        AutopilotGraphKeyCredential[] managedCredentials = credentials
+            .Where(IsManagedCertificateCredential)
+            .ToArray();
+
         Certificates.Clear();
         SelectedCertificates.Clear();
-        foreach (AutopilotCertificateEntryViewModel certificate in credentials
+        foreach (AutopilotCertificateEntryViewModel certificate in managedCredentials
                      .OrderBy(certificate => certificate.ExpiresOnUtc)
                      .Select(AutopilotCertificateEntryViewModel.FromGraphCredential))
         {
@@ -1138,7 +1138,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         }
 
         SelectedCertificate = null;
-        hardwareHashSessionState.Certificates = credentials;
+        hardwareHashSessionState.Certificates = managedCredentials;
         OnPropertyChanged(nameof(HasCertificates));
         OnPropertyChanged(nameof(CertificatesVisibility));
         OnPropertyChanged(nameof(EmptyCertificatesVisibility));
@@ -1162,11 +1162,24 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePasswordMissing");
         }
 
+        if (bootMediaCertificateValidationCode == AutopilotPfxValidationCode.InvalidPfx)
+        {
+            return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateInvalidPfx");
+        }
+
+        if (bootMediaCertificateValidationCode == AutopilotPfxValidationCode.PrivateKeyMissing)
+        {
+            return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePrivateKeyMissing");
+        }
+
+        if (bootMediaCertificateValidationCode == AutopilotPfxValidationCode.ThumbprintMismatch)
+        {
+            return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateThumbprintMismatch");
+        }
+
         if (hardwareHashUploadSettings.ActiveCertificate is null)
         {
-            return bootMediaCertificateValidationCode == AutopilotPfxValidationCode.ThumbprintMismatch
-                ? localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateThumbprintMismatch")
-                : localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateActiveMissing");
+            return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateActiveMissing");
         }
 
         if (IsHardwareHashCertificateExpired)
@@ -1174,19 +1187,10 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateActiveExpired");
         }
 
-        if (IsBootMediaCertificateReady)
-        {
-            return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateReady");
-        }
-
         return bootMediaCertificateValidationCode switch
         {
             AutopilotPfxValidationCode.Valid => localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateReady"),
-            AutopilotPfxValidationCode.PasswordRequired => localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePasswordMissing"),
-            AutopilotPfxValidationCode.ThumbprintMismatch => localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateThumbprintMismatch"),
-            AutopilotPfxValidationCode.PrivateKeyMissing => localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePrivateKeyMissing"),
             AutopilotPfxValidationCode.ExpectedThumbprintRequired => localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateActiveMissing"),
-            AutopilotPfxValidationCode.InvalidPfx => localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateInvalidPfx"),
             _ => localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePfxMissing")
         };
     }
@@ -1241,6 +1245,11 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
                         {
                             bootMediaCertificateValidationCode = AutopilotPfxValidationCode.ThumbprintMismatch;
                             hardwareHashUploadSettings = hardwareHashUploadSettings with { ActiveCertificate = null };
+                            bootMediaCertificate = bootMediaCertificate with
+                            {
+                                ValidatedThumbprint = validation.Thumbprint,
+                                ValidatedExpiresOnUtc = validation.ExpiresOnUtc
+                            };
                         }
                         else
                         {
@@ -1257,21 +1266,15 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
                             };
                         }
                     }
-                    else
-                    {
-                        hardwareHashUploadSettings = hardwareHashUploadSettings with { ActiveCertificate = null };
-                    }
                 }
                 catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
                 {
                     bootMediaCertificateValidationCode = AutopilotPfxValidationCode.InvalidPfx;
-                    hardwareHashUploadSettings = hardwareHashUploadSettings with { ActiveCertificate = null };
                 }
             }
             else
             {
                 isBootMediaCertificateFileMissing = true;
-                hardwareHashUploadSettings = hardwareHashUploadSettings with { ActiveCertificate = null };
             }
         }
 
@@ -1325,9 +1328,34 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         return localizationService.GetString("Autopilot.HardwareHashOnboardingRequiresAttentionTitle");
     }
 
+    private string CreateTenantOnboardingResultMessage(AutopilotTenantOnboardingStatus status)
+    {
+        string key = status switch
+        {
+            AutopilotTenantOnboardingStatus.AppRegistrationMissing => "Autopilot.HardwareHashOnboardingMessageAppRegistrationMissing",
+            AutopilotTenantOnboardingStatus.AdoptionRequired => "Autopilot.HardwareHashOnboardingMessageAdoptionRequired",
+            AutopilotTenantOnboardingStatus.PermissionMissing => "Autopilot.HardwareHashOnboardingMessagePermissionMissing",
+            AutopilotTenantOnboardingStatus.ConsentMissing => "Autopilot.HardwareHashOnboardingMessageConsentMissing",
+            AutopilotTenantOnboardingStatus.ServicePrincipalUnavailable => "Autopilot.HardwareHashOnboardingMessageServicePrincipalUnavailable",
+            AutopilotTenantOnboardingStatus.ActiveCertificateNotFound => "Autopilot.HardwareHashOnboardingMessageActiveCertificateNotFound",
+            AutopilotTenantOnboardingStatus.ActiveCertificateExpired => "Autopilot.HardwareHashOnboardingMessageActiveCertificateExpired",
+            _ => "Autopilot.HardwareHashOnboardingMessageGeneric"
+        };
+
+        return localizationService.GetString(key);
+    }
+
     private static bool ShouldShowTenantOnboardingResultDialog(AutopilotTenantOnboardingStatus status)
     {
         return status is not (AutopilotTenantOnboardingStatus.Ready or AutopilotTenantOnboardingStatus.ActiveCertificateMissing);
+    }
+
+    private static bool IsManagedCertificateCredential(AutopilotGraphKeyCredential credential)
+    {
+        return string.Equals(
+            credential.DisplayName,
+            AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName,
+            StringComparison.OrdinalIgnoreCase);
     }
 
     private void RefreshProfileState()

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -23,6 +23,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private readonly IAutopilotProfileImportService autopilotProfileImportService;
     private readonly IAutopilotTenantProfileService autopilotTenantProfileService;
     private readonly IAutopilotTenantOnboardingService autopilotTenantOnboardingService;
+    private readonly IAutopilotHardwareHashGraphSessionService hardwareHashGraphSessionService;
     private readonly IAutopilotTenantOperationDialogService tenantOperationDialogService;
     private readonly IAutopilotCertificateDialogService certificateDialogService;
     private readonly IAutopilotProfileSelectionDialogService profileSelectionDialogService;
@@ -44,6 +45,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         IAutopilotProfileImportService autopilotProfileImportService,
         IAutopilotTenantProfileService autopilotTenantProfileService,
         IAutopilotTenantOnboardingService autopilotTenantOnboardingService,
+        IAutopilotHardwareHashGraphSessionService hardwareHashGraphSessionService,
         IAutopilotTenantOperationDialogService tenantOperationDialogService,
         IAutopilotCertificateDialogService certificateDialogService,
         IAutopilotProfileSelectionDialogService profileSelectionDialogService,
@@ -57,6 +59,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         this.autopilotProfileImportService = autopilotProfileImportService;
         this.autopilotTenantProfileService = autopilotTenantProfileService;
         this.autopilotTenantOnboardingService = autopilotTenantOnboardingService;
+        this.hardwareHashGraphSessionService = hardwareHashGraphSessionService;
         this.tenantOperationDialogService = tenantOperationDialogService;
         this.certificateDialogService = certificateDialogService;
         this.profileSelectionDialogService = profileSelectionDialogService;
@@ -208,6 +211,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         ? localizationService.GetString("Autopilot.HardwareHashAppRegistrationMissing")
         : localizationService.FormatString("Autopilot.HardwareHashAppRegistrationFoundFormat", ManagedAppRegistrationName);
     public string TenantOnboardingStatusText => CreateTenantOnboardingStatusText();
+    public Brush TenantOnboardingStatusForeground => ResolveTenantOnboardingStatusBrush();
     public string CertificateStatusText => CreateCertificateStatusText();
     public Visibility CertificateStatusVisibility => string.IsNullOrWhiteSpace(CertificateStatusText) ? Visibility.Collapsed : Visibility.Visible;
     public Brush CertificateStatusForeground => ResolveCertificateStatusBrush();
@@ -642,7 +646,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             return;
         }
 
-            IsConnectingTenant = true;
+        IsConnectingTenant = true;
         try
         {
             logger.Information("Starting Autopilot hardware hash tenant onboarding.");
@@ -1057,6 +1061,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         OnPropertyChanged(nameof(TenantConnectionButtonText));
         OnPropertyChanged(nameof(AppRegistrationStatusText));
         OnPropertyChanged(nameof(TenantOnboardingStatusText));
+        OnPropertyChanged(nameof(TenantOnboardingStatusForeground));
         OnPropertyChanged(nameof(CertificateStatusText));
         OnPropertyChanged(nameof(CertificateStatusVisibility));
         OnPropertyChanged(nameof(CertificateStatusForeground));
@@ -1096,6 +1101,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     private void DisconnectTenantSession()
     {
+        hardwareHashGraphSessionService.Disconnect();
         HasConnectedTenantInCurrentSession = false;
         tenantOnboardingStatus = null;
         ReplaceCertificates([]);
@@ -1321,20 +1327,16 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     private string CreateTenantOnboardingStatusText()
     {
-        return tenantOnboardingStatus switch
-        {
-            AutopilotTenantOnboardingStatus.Ready => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusReady"),
-            AutopilotTenantOnboardingStatus.AppRegistrationMissing => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusAppMissing"),
-            AutopilotTenantOnboardingStatus.AdoptionRequired => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusAdoptionRequired"),
-            AutopilotTenantOnboardingStatus.PermissionMissing => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusPermissionMissing"),
-            AutopilotTenantOnboardingStatus.ConsentMissing => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusConsentMissing"),
-            AutopilotTenantOnboardingStatus.ServicePrincipalUnavailable => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusServicePrincipalUnavailable"),
-            AutopilotTenantOnboardingStatus.ActiveCertificateMissing => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusCertificateMissing"),
-            AutopilotTenantOnboardingStatus.ActiveCertificateNotFound => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusCertificateNotFound"),
-            AutopilotTenantOnboardingStatus.ActiveCertificateExpired => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusCertificateExpired"),
-            AutopilotTenantOnboardingStatus.MultipleFoundryCertificatesNeedSelection => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusMultipleCertificates"),
-            _ => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusNotChecked")
-        };
+        return tenantOnboardingStatus == AutopilotTenantOnboardingStatus.Ready
+            ? localizationService.GetString("Autopilot.HardwareHashOnboardingStatusReady")
+            : localizationService.GetString("Autopilot.HardwareHashOnboardingStatusNotReady");
+    }
+
+    private Brush ResolveTenantOnboardingStatusBrush()
+    {
+        return tenantOnboardingStatus == AutopilotTenantOnboardingStatus.Ready
+            ? (Brush)Application.Current.Resources["SystemFillColorSuccessBrush"]
+            : (Brush)Application.Current.Resources["SystemFillColorCriticalBrush"];
     }
 
     private string GetTenantOnboardingDialogTitle(AutopilotTenantOnboardingStatus status)

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -65,7 +65,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         Profiles.CollectionChanged += OnProfilesCollectionChanged;
         SelectedProfiles.CollectionChanged += OnSelectedProfilesCollectionChanged;
         isApplyingState = false;
-        SelectedCertificateValidityOption = CertificateValidityOptions.First(option => option.Months == 12);
+        SelectedCertificateValidityOption = CertificateValidityOptions.First(option => option.Months == 6);
     }
 
     /// <summary>
@@ -83,6 +83,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     /// </summary>
     public ObservableCollection<CertificateValidityOptionViewModel> CertificateValidityOptions { get; } =
     [
+        new(1, "1 month"),
         new(3, "3 months"),
         new(6, "6 months"),
         new(12, "12 months")

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.Text.Json;
 using Azure.Identity;
 using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Autopilot;
 using Foundry.Core.Services.Application;
 using Foundry.Core.Services.Configuration;
 using Foundry.Services.Autopilot;
@@ -20,6 +21,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private readonly IFoundryConfigurationStateService configurationStateService;
     private readonly IAutopilotProfileImportService autopilotProfileImportService;
     private readonly IAutopilotTenantProfileService autopilotTenantProfileService;
+    private readonly IAutopilotTenantOnboardingService autopilotTenantOnboardingService;
     private readonly IAutopilotTenantDownloadDialogService tenantDownloadDialogService;
     private readonly IAutopilotProfileSelectionDialogService profileSelectionDialogService;
     private readonly IFilePickerService filePickerService;
@@ -30,11 +32,13 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private bool isSavingState;
     private AutopilotProvisioningMode provisioningMode = AutopilotProvisioningMode.JsonProfile;
     private AutopilotHardwareHashUploadSettings hardwareHashUploadSettings = new();
+    private AutopilotTenantOnboardingStatus? tenantOnboardingStatus;
 
     public AutopilotConfigurationViewModel(
         IFoundryConfigurationStateService configurationStateService,
         IAutopilotProfileImportService autopilotProfileImportService,
         IAutopilotTenantProfileService autopilotTenantProfileService,
+        IAutopilotTenantOnboardingService autopilotTenantOnboardingService,
         IAutopilotTenantDownloadDialogService tenantDownloadDialogService,
         IAutopilotProfileSelectionDialogService profileSelectionDialogService,
         IFilePickerService filePickerService,
@@ -45,6 +49,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         this.configurationStateService = configurationStateService;
         this.autopilotProfileImportService = autopilotProfileImportService;
         this.autopilotTenantProfileService = autopilotTenantProfileService;
+        this.autopilotTenantOnboardingService = autopilotTenantOnboardingService;
         this.tenantDownloadDialogService = tenantDownloadDialogService;
         this.profileSelectionDialogService = profileSelectionDialogService;
         this.filePickerService = filePickerService;
@@ -60,6 +65,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         Profiles.CollectionChanged += OnProfilesCollectionChanged;
         SelectedProfiles.CollectionChanged += OnSelectedProfilesCollectionChanged;
         isApplyingState = false;
+        SelectedCertificateValidityOption = CertificateValidityOptions.First(option => option.Months == 12);
     }
 
     /// <summary>
@@ -72,17 +78,30 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     /// </summary>
     public ObservableCollection<AutopilotProfileEntryViewModel> SelectedProfiles { get; } = [];
 
+    /// <summary>
+    /// Gets the fixed certificate validity options available for managed Autopilot app certificates.
+    /// </summary>
+    public ObservableCollection<CertificateValidityOptionViewModel> CertificateValidityOptions { get; } =
+    [
+        new(3, "3 months"),
+        new(6, "6 months"),
+        new(12, "12 months"),
+        new(24, "24 months")
+    ];
+
     public bool IsAutopilotSectionEnabled => IsAutopilotEnabled;
     public bool HasProfiles => Profiles.Count > 0;
     public Visibility EmptyProfilesVisibility => HasProfiles ? Visibility.Collapsed : Visibility.Visible;
     public Visibility ProfilesVisibility => HasProfiles ? Visibility.Visible : Visibility.Collapsed;
-    public bool IsBusy => IsImporting || IsDownloading;
+    public bool IsBusy => IsImporting || IsDownloading || IsConnectingTenant;
     public Visibility BusyStatusVisibility => IsBusy ? Visibility.Visible : Visibility.Collapsed;
     public string BusyStatusText => IsImporting
         ? ImportingStatusText
         : IsDownloading
             ? DownloadingStatusText
-            : string.Empty;
+            : IsConnectingTenant
+                ? ConnectingTenantStatusText
+                : string.Empty;
     public bool UseJsonProfileProvisioning
     {
         get => provisioningMode == AutopilotProvisioningMode.JsonProfile;
@@ -129,6 +148,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public string AppRegistrationStatusText => string.IsNullOrWhiteSpace(hardwareHashUploadSettings.Tenant.ApplicationObjectId)
         ? localizationService.GetString("Autopilot.HardwareHashAppRegistrationMissing")
         : localizationService.FormatString("Autopilot.HardwareHashAppRegistrationFoundFormat", ManagedAppRegistrationName);
+    public string TenantOnboardingStatusText => CreateTenantOnboardingStatusText();
     public string CertificateStatusText => CreateCertificateStatusText();
     public string DefaultGroupTagText => string.IsNullOrWhiteSpace(hardwareHashUploadSettings.DefaultGroupTag)
         ? localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagNone")
@@ -174,10 +194,25 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string ConnectTenantButtonText { get; set; }
 
     [ObservableProperty]
+    public partial string ConnectingTenantStatusText { get; set; }
+
+    [ObservableProperty]
+    public partial string CertificateValidityLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string CreateCertificateButtonText { get; set; }
+
+    [ObservableProperty]
+    public partial string RetireCertificateButtonText { get; set; }
+
+    [ObservableProperty]
     public partial string TenantStatusLabel { get; set; }
 
     [ObservableProperty]
     public partial string AppRegistrationLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string TenantOnboardingStatusLabel { get; set; }
 
     [ObservableProperty]
     public partial string CertificateStatusLabel { get; set; }
@@ -190,12 +225,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     [ObservableProperty]
     public partial string KnownGroupTagsLabel { get; set; }
-
-    [ObservableProperty]
-    public partial string HardwareHashOnboardingUnavailableTitle { get; set; }
-
-    [ObservableProperty]
-    public partial string HardwareHashOnboardingUnavailableMessage { get; set; }
 
     [ObservableProperty]
     public partial string ImportButtonText { get; set; }
@@ -256,6 +285,8 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     [NotifyCanExecuteChangedFor(nameof(DownloadProfilesCommand))]
     [NotifyCanExecuteChangedFor(nameof(RemoveSelectedProfilesCommand))]
     [NotifyCanExecuteChangedFor(nameof(ConnectTenantCommand))]
+    [NotifyCanExecuteChangedFor(nameof(CreateCertificateCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RetireActiveCertificateCommand))]
     public partial bool IsAutopilotEnabled { get; set; }
 
     [ObservableProperty]
@@ -269,6 +300,8 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     [NotifyPropertyChangedFor(nameof(BusyStatusText))]
     [NotifyPropertyChangedFor(nameof(BusyStatusVisibility))]
     [NotifyCanExecuteChangedFor(nameof(ConnectTenantCommand))]
+    [NotifyCanExecuteChangedFor(nameof(CreateCertificateCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RetireActiveCertificateCommand))]
     public partial bool IsImporting { get; set; }
 
     [ObservableProperty]
@@ -279,7 +312,25 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     [NotifyPropertyChangedFor(nameof(BusyStatusText))]
     [NotifyPropertyChangedFor(nameof(BusyStatusVisibility))]
     [NotifyCanExecuteChangedFor(nameof(ConnectTenantCommand))]
+    [NotifyCanExecuteChangedFor(nameof(CreateCertificateCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RetireActiveCertificateCommand))]
     public partial bool IsDownloading { get; set; }
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ImportProfileCommand))]
+    [NotifyCanExecuteChangedFor(nameof(DownloadProfilesCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RemoveSelectedProfilesCommand))]
+    [NotifyPropertyChangedFor(nameof(IsBusy))]
+    [NotifyPropertyChangedFor(nameof(BusyStatusText))]
+    [NotifyPropertyChangedFor(nameof(BusyStatusVisibility))]
+    [NotifyCanExecuteChangedFor(nameof(ConnectTenantCommand))]
+    [NotifyCanExecuteChangedFor(nameof(CreateCertificateCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RetireActiveCertificateCommand))]
+    public partial bool IsConnectingTenant { get; set; }
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(CreateCertificateCommand))]
+    public partial CertificateValidityOptionViewModel? SelectedCertificateValidityOption { get; set; }
 
     /// <summary>
     /// Releases subscriptions to localization, configuration state, and profile collections.
@@ -423,9 +474,117 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     [RelayCommand(CanExecute = nameof(CanConnectTenant))]
     private async Task ConnectTenantAsync()
     {
-        await dialogService.ShowMessageAsync(new DialogRequest(
-            HardwareHashOnboardingUnavailableTitle,
-            HardwareHashOnboardingUnavailableMessage));
+        IsConnectingTenant = true;
+        try
+        {
+            logger.Information("Starting Autopilot hardware hash tenant onboarding.");
+            AutopilotTenantOnboardingResult result = await autopilotTenantOnboardingService.ConnectAsync(hardwareHashUploadSettings);
+            hardwareHashUploadSettings = result.Settings;
+            tenantOnboardingStatus = result.Status;
+            RefreshHardwareHashUploadState();
+            SaveState();
+            logger.Information(
+                "Autopilot hardware hash tenant onboarding updated. Status={Status}, TenantId={TenantId}, ApplicationObjectId={ApplicationObjectId}",
+                result.Status,
+                result.Settings.Tenant.TenantId,
+                result.Settings.Tenant.ApplicationObjectId);
+            await dialogService.ShowMessageAsync(new DialogRequest(
+                GetTenantOnboardingDialogTitle(result.Status),
+                result.Message));
+        }
+        catch (Exception ex) when (ex is AuthenticationFailedException or HttpRequestException or InvalidOperationException or JsonException)
+        {
+            logger.Error(ex, "Autopilot hardware hash tenant onboarding failed.");
+            await dialogService.ShowMessageAsync(new DialogRequest(
+                localizationService.GetString("Autopilot.HardwareHashOnboardingFailedTitle"),
+                localizationService.FormatString("Autopilot.HardwareHashOnboardingFailedMessageFormat", ex.Message)));
+        }
+        finally
+        {
+            IsConnectingTenant = false;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanCreateCertificate))]
+    private async Task CreateCertificateAsync()
+    {
+        string? outputPath = await filePickerService.PickSaveFileAsync(new FileSavePickerRequest(
+            localizationService.GetString("Autopilot.HardwareHashCertificateSavePickerTitle"),
+            "foundry-osd-autopilot-registration.pfx",
+            [new FilePickerTypeChoice(localizationService.GetString("Autopilot.HardwareHashCertificatePfxFileType"), [".pfx"])],
+            ".pfx"));
+        if (string.IsNullOrWhiteSpace(outputPath) || SelectedCertificateValidityOption is null)
+        {
+            return;
+        }
+
+        IsConnectingTenant = true;
+        try
+        {
+            AutopilotCertificateCreationResult result = await autopilotTenantOnboardingService.CreateCertificateAsync(
+                hardwareHashUploadSettings,
+                outputPath,
+                SelectedCertificateValidityOption.Months);
+            hardwareHashUploadSettings = result.Settings;
+            RefreshHardwareHashUploadState();
+            SaveState();
+
+            await dialogService.ShowMessageAsync(new DialogRequest(
+                localizationService.GetString("Autopilot.HardwareHashCertificateCreatedTitle"),
+                localizationService.FormatString(
+                    "Autopilot.HardwareHashCertificateCreatedMessageFormat",
+                    result.GeneratedPassword,
+                    outputPath)));
+        }
+        catch (Exception ex) when (ex is AuthenticationFailedException or HttpRequestException or InvalidOperationException or IOException or UnauthorizedAccessException)
+        {
+            logger.Error("Autopilot hardware hash certificate creation failed. ErrorType={ErrorType}", ex.GetType().Name);
+            await dialogService.ShowMessageAsync(new DialogRequest(
+                localizationService.GetString("Autopilot.HardwareHashCertificateCreateFailedTitle"),
+                localizationService.FormatString("Autopilot.HardwareHashCertificateCreateFailedMessageFormat", ex.Message)));
+        }
+        finally
+        {
+            IsConnectingTenant = false;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRetireActiveCertificate))]
+    private async Task RetireActiveCertificateAsync()
+    {
+        bool confirmed = await dialogService.ConfirmAsync(new ConfirmationDialogRequest(
+            localizationService.GetString("Autopilot.HardwareHashRetireCertificateConfirmationTitle"),
+            localizationService.GetString("Autopilot.HardwareHashRetireCertificateConfirmationMessage"),
+            localizationService.GetString("Autopilot.HardwareHashRetireCertificateConfirmationPrimary"),
+            localizationService.GetString("Common.Cancel")));
+        if (!confirmed)
+        {
+            return;
+        }
+
+        IsConnectingTenant = true;
+        try
+        {
+            hardwareHashUploadSettings = await autopilotTenantOnboardingService.RetireActiveCertificateAsync(hardwareHashUploadSettings);
+            tenantOnboardingStatus = AutopilotTenantOnboardingStatus.ActiveCertificateMissing;
+            RefreshHardwareHashUploadState();
+            SaveState();
+
+            await dialogService.ShowMessageAsync(new DialogRequest(
+                localizationService.GetString("Autopilot.HardwareHashCertificateRetiredTitle"),
+                localizationService.GetString("Autopilot.HardwareHashCertificateRetiredMessage")));
+        }
+        catch (Exception ex) when (ex is AuthenticationFailedException or HttpRequestException or InvalidOperationException or JsonException)
+        {
+            logger.Error(ex, "Autopilot hardware hash certificate retirement failed.");
+            await dialogService.ShowMessageAsync(new DialogRequest(
+                localizationService.GetString("Autopilot.HardwareHashCertificateRetireFailedTitle"),
+                localizationService.FormatString("Autopilot.HardwareHashCertificateRetireFailedMessageFormat", ex.Message)));
+        }
+        finally
+        {
+            IsConnectingTenant = false;
+        }
     }
 
     partial void OnIsAutopilotEnabledChanged(bool value)
@@ -434,6 +593,8 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         DownloadProfilesCommand.NotifyCanExecuteChanged();
         RemoveSelectedProfilesCommand.NotifyCanExecuteChanged();
         ConnectTenantCommand.NotifyCanExecuteChanged();
+        CreateCertificateCommand.NotifyCanExecuteChanged();
+        RetireActiveCertificateCommand.NotifyCanExecuteChanged();
         SaveState();
     }
 
@@ -542,14 +703,17 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         HardwareHashDescription = localizationService.GetString("Autopilot.HardwareHashDescription");
         HardwareHashEnableText = localizationService.GetString("Autopilot.HardwareHashEnableLabel");
         ConnectTenantButtonText = localizationService.GetString("Autopilot.HardwareHashConnectTenantButton");
+        ConnectingTenantStatusText = localizationService.GetString("Autopilot.HardwareHashConnectingTenantStatus");
+        CertificateValidityLabel = localizationService.GetString("Autopilot.HardwareHashCertificateValidityLabel");
+        CreateCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashCreateCertificateButton");
+        RetireCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashRetireCertificateButton");
         TenantStatusLabel = localizationService.GetString("Autopilot.HardwareHashTenantStatusLabel");
         AppRegistrationLabel = localizationService.GetString("Autopilot.HardwareHashAppRegistrationLabel");
+        TenantOnboardingStatusLabel = localizationService.GetString("Autopilot.HardwareHashOnboardingStatusLabel");
         CertificateStatusLabel = localizationService.GetString("Autopilot.HardwareHashCertificateStatusLabel");
         CertificateExpiredWarningText = localizationService.GetString("Autopilot.HardwareHashCertificateExpiredWarning");
         DefaultGroupTagLabel = localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagLabel");
         KnownGroupTagsLabel = localizationService.GetString("Autopilot.HardwareHashKnownGroupTagsLabel");
-        HardwareHashOnboardingUnavailableTitle = localizationService.GetString("Autopilot.HardwareHashOnboardingUnavailableTitle");
-        HardwareHashOnboardingUnavailableMessage = localizationService.GetString("Autopilot.HardwareHashOnboardingUnavailableMessage");
         ImportButtonText = localizationService.GetString("Autopilot.ImportButton");
         DownloadButtonText = localizationService.GetString("Autopilot.DownloadButton");
         RemoveButtonText = localizationService.GetString("Autopilot.RemoveButton");
@@ -595,17 +759,21 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         DownloadProfilesCommand.NotifyCanExecuteChanged();
         RemoveSelectedProfilesCommand.NotifyCanExecuteChanged();
         ConnectTenantCommand.NotifyCanExecuteChanged();
+        CreateCertificateCommand.NotifyCanExecuteChanged();
+        RetireActiveCertificateCommand.NotifyCanExecuteChanged();
     }
 
     private void RefreshHardwareHashUploadState()
     {
         OnPropertyChanged(nameof(TenantStatusText));
         OnPropertyChanged(nameof(AppRegistrationStatusText));
+        OnPropertyChanged(nameof(TenantOnboardingStatusText));
         OnPropertyChanged(nameof(CertificateStatusText));
         OnPropertyChanged(nameof(IsHardwareHashCertificateExpired));
         OnPropertyChanged(nameof(HardwareHashCertificateWarningVisibility));
         OnPropertyChanged(nameof(DefaultGroupTagText));
         OnPropertyChanged(nameof(KnownGroupTagsText));
+        RetireActiveCertificateCommand.NotifyCanExecuteChanged();
     }
 
     private string CreateCertificateStatusText()
@@ -624,6 +792,31 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         return certificate.ExpiresOnUtc <= DateTimeOffset.UtcNow
             ? localizationService.FormatString("Autopilot.HardwareHashCertificateExpiredFormat", certificate.ExpiresOnUtc.Value.LocalDateTime)
             : localizationService.FormatString("Autopilot.HardwareHashCertificateValidFormat", certificate.ExpiresOnUtc.Value.LocalDateTime);
+    }
+
+    private string CreateTenantOnboardingStatusText()
+    {
+        return tenantOnboardingStatus switch
+        {
+            AutopilotTenantOnboardingStatus.Ready => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusReady"),
+            AutopilotTenantOnboardingStatus.AppRegistrationMissing => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusAppMissing"),
+            AutopilotTenantOnboardingStatus.AdoptionRequired => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusAdoptionRequired"),
+            AutopilotTenantOnboardingStatus.PermissionMissing => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusPermissionMissing"),
+            AutopilotTenantOnboardingStatus.ConsentMissing => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusConsentMissing"),
+            AutopilotTenantOnboardingStatus.ServicePrincipalUnavailable => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusServicePrincipalUnavailable"),
+            AutopilotTenantOnboardingStatus.ActiveCertificateMissing => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusCertificateMissing"),
+            AutopilotTenantOnboardingStatus.ActiveCertificateNotFound => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusCertificateNotFound"),
+            AutopilotTenantOnboardingStatus.ActiveCertificateExpired => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusCertificateExpired"),
+            AutopilotTenantOnboardingStatus.MultipleFoundryCertificatesNeedSelection => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusMultipleCertificates"),
+            _ => localizationService.GetString("Autopilot.HardwareHashOnboardingStatusNotChecked")
+        };
+    }
+
+    private string GetTenantOnboardingDialogTitle(AutopilotTenantOnboardingStatus status)
+    {
+        return status == AutopilotTenantOnboardingStatus.Ready
+            ? localizationService.GetString("Autopilot.HardwareHashOnboardingCompletedTitle")
+            : localizationService.GetString("Autopilot.HardwareHashOnboardingRequiresAttentionTitle");
     }
 
     private void RefreshProfileState()
@@ -691,4 +884,24 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     {
         return IsAutopilotEnabled && IsHardwareHashUploadMode && !IsBusy;
     }
+
+    private bool CanCreateCertificate()
+    {
+        return IsAutopilotEnabled &&
+               IsHardwareHashUploadMode &&
+               !IsBusy &&
+               SelectedCertificateValidityOption is not null &&
+               !string.IsNullOrWhiteSpace(hardwareHashUploadSettings.Tenant.ApplicationObjectId);
+    }
+
+    private bool CanRetireActiveCertificate()
+    {
+        return IsAutopilotEnabled &&
+               IsHardwareHashUploadMode &&
+               !IsBusy &&
+               !string.IsNullOrWhiteSpace(hardwareHashUploadSettings.Tenant.ApplicationObjectId) &&
+               !string.IsNullOrWhiteSpace(hardwareHashUploadSettings.ActiveCertificate?.KeyId);
+    }
+
+    public sealed record CertificateValidityOptionViewModel(int Months, string DisplayName);
 }

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -105,6 +105,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public bool HasCertificates => Certificates.Count > 0;
     public Visibility EmptyCertificatesVisibility => HasCertificates ? Visibility.Collapsed : Visibility.Visible;
     public Visibility CertificatesVisibility => HasCertificates ? Visibility.Visible : Visibility.Collapsed;
+    public Visibility ConnectedTenantDetailsVisibility => HasConnectedTenantInCurrentSession ? Visibility.Visible : Visibility.Collapsed;
     public bool IsBusy => IsImporting || IsDownloading || IsConnectingTenant;
     public Visibility BusyStatusVisibility => IsBusy ? Visibility.Visible : Visibility.Collapsed;
     public string BusyStatusText => IsImporting
@@ -172,6 +173,8 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     private bool HasTenantRegistration => !string.IsNullOrWhiteSpace(hardwareHashUploadSettings.Tenant.TenantId) &&
                                           !string.IsNullOrWhiteSpace(hardwareHashUploadSettings.Tenant.ClientId);
+
+    private bool HasConnectedTenantInCurrentSession { get; set; }
 
     [ObservableProperty]
     public partial string PageTitle { get; set; }
@@ -522,6 +525,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
             hardwareHashUploadSettings = result.Settings;
             tenantOnboardingStatus = result.Status;
+            HasConnectedTenantInCurrentSession = true;
             ReplaceCertificates(result.Certificates);
             RefreshHardwareHashUploadState();
             SaveState();
@@ -832,6 +836,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         OnPropertyChanged(nameof(HardwareHashCertificateWarningVisibility));
         OnPropertyChanged(nameof(DefaultGroupTagText));
         OnPropertyChanged(nameof(KnownGroupTagsText));
+        OnPropertyChanged(nameof(ConnectedTenantDetailsVisibility));
         RetireActiveCertificateCommand.NotifyCanExecuteChanged();
     }
 
@@ -996,6 +1001,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
                IsHardwareHashUploadMode &&
                !IsBusy &&
                SelectedCertificateValidityOption is not null &&
+               HasConnectedTenantInCurrentSession &&
                !string.IsNullOrWhiteSpace(hardwareHashUploadSettings.Tenant.ApplicationObjectId);
     }
 
@@ -1004,6 +1010,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         return IsAutopilotEnabled &&
                IsHardwareHashUploadMode &&
                !IsBusy &&
+               HasConnectedTenantInCurrentSession &&
                !string.IsNullOrWhiteSpace(hardwareHashUploadSettings.Tenant.ApplicationObjectId) &&
                SelectedCertificate is not null;
     }

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -842,7 +842,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         }
 
         SetBootMediaCertificateInput(hardwareHashUploadSettings.BootMediaCertificate.PfxPath, password);
-        RefreshHardwareHashUploadState();
+        RefreshBootMediaCertificateState();
         SaveState();
     }
 
@@ -1081,6 +1081,14 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         OnPropertyChanged(nameof(IsBootMediaCertificateReady));
         RetireActiveCertificateCommand.NotifyCanExecuteChanged();
         SelectBootMediaCertificatePfxCommand.NotifyCanExecuteChanged();
+    }
+
+    private void RefreshBootMediaCertificateState()
+    {
+        OnPropertyChanged(nameof(BootMediaCertificatePfxPath));
+        OnPropertyChanged(nameof(BootMediaCertificateStatusText));
+        OnPropertyChanged(nameof(BootMediaCertificateStatusForeground));
+        OnPropertyChanged(nameof(IsBootMediaCertificateReady));
     }
 
     private void RefreshTenantDetails()

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -23,7 +23,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private readonly IAutopilotProfileImportService autopilotProfileImportService;
     private readonly IAutopilotTenantProfileService autopilotTenantProfileService;
     private readonly IAutopilotTenantOnboardingService autopilotTenantOnboardingService;
-    private readonly IAutopilotTenantDownloadDialogService tenantDownloadDialogService;
+    private readonly IAutopilotTenantOperationDialogService tenantOperationDialogService;
     private readonly IAutopilotCertificateDialogService certificateDialogService;
     private readonly IAutopilotProfileSelectionDialogService profileSelectionDialogService;
     private readonly IAutopilotHardwareHashSessionState hardwareHashSessionState;
@@ -44,7 +44,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         IAutopilotProfileImportService autopilotProfileImportService,
         IAutopilotTenantProfileService autopilotTenantProfileService,
         IAutopilotTenantOnboardingService autopilotTenantOnboardingService,
-        IAutopilotTenantDownloadDialogService tenantDownloadDialogService,
+        IAutopilotTenantOperationDialogService tenantOperationDialogService,
         IAutopilotCertificateDialogService certificateDialogService,
         IAutopilotProfileSelectionDialogService profileSelectionDialogService,
         IAutopilotHardwareHashSessionState hardwareHashSessionState,
@@ -57,7 +57,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         this.autopilotProfileImportService = autopilotProfileImportService;
         this.autopilotTenantProfileService = autopilotTenantProfileService;
         this.autopilotTenantOnboardingService = autopilotTenantOnboardingService;
-        this.tenantDownloadDialogService = tenantDownloadDialogService;
+        this.tenantOperationDialogService = tenantOperationDialogService;
         this.certificateDialogService = certificateDialogService;
         this.profileSelectionDialogService = profileSelectionDialogService;
         this.hardwareHashSessionState = hardwareHashSessionState;
@@ -204,9 +204,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public string TenantConnectionButtonText => HasConnectedTenantInCurrentSession
         ? DisconnectTenantButtonText
         : ConnectTenantButtonText;
-    public string TenantDetailsText => HasTenantRegistration
-        ? localizationService.FormatString("Autopilot.HardwareHashTenantDetailsFormat", hardwareHashUploadSettings.Tenant.TenantId!)
-        : string.Empty;
     public string AppRegistrationStatusText => string.IsNullOrWhiteSpace(hardwareHashUploadSettings.Tenant.ApplicationObjectId)
         ? localizationService.GetString("Autopilot.HardwareHashAppRegistrationMissing")
         : localizationService.FormatString("Autopilot.HardwareHashAppRegistrationFoundFormat", ManagedAppRegistrationName);
@@ -541,8 +538,10 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         try
         {
             logger.Information("Starting Autopilot profile download from tenant.");
-            IReadOnlyList<AutopilotProfileSettings>? availableProfiles =
-                await tenantDownloadDialogService.DownloadAsync(autopilotTenantProfileService.DownloadFromTenantAsync);
+            IReadOnlyList<AutopilotProfileSettings>? availableProfiles = await tenantOperationDialogService.RunAsync(
+                localizationService.GetString("Autopilot.TenantDownloadDialogTitle"),
+                localizationService.GetString("Autopilot.TenantDownloadDialogMessage"),
+                autopilotTenantProfileService.DownloadFromTenantAsync);
             if (availableProfiles is null)
             {
                 logger.Information("Autopilot tenant download was canceled.");
@@ -643,11 +642,11 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             return;
         }
 
-        IsConnectingTenant = true;
+            IsConnectingTenant = true;
         try
         {
             logger.Information("Starting Autopilot hardware hash tenant onboarding.");
-            AutopilotTenantOnboardingResult? result = await tenantDownloadDialogService.RunAsync(
+            AutopilotTenantOnboardingResult? result = await tenantOperationDialogService.RunAsync(
                 localizationService.GetString("Autopilot.HardwareHashTenantConnectionDialogTitle"),
                 localizationService.GetString("Autopilot.HardwareHashTenantConnectionDialogMessage"),
                 cancellationToken => autopilotTenantOnboardingService.ConnectAsync(hardwareHashUploadSettings, cancellationToken));
@@ -1056,7 +1055,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         RefreshTenantDetails();
         OnPropertyChanged(nameof(TenantStatusText));
         OnPropertyChanged(nameof(TenantConnectionButtonText));
-        OnPropertyChanged(nameof(TenantDetailsText));
         OnPropertyChanged(nameof(AppRegistrationStatusText));
         OnPropertyChanged(nameof(TenantOnboardingStatusText));
         OnPropertyChanged(nameof(CertificateStatusText));

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -186,7 +186,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public Visibility HardwareHashSettingsVisibility => IsHardwareHashUploadMode ? Visibility.Visible : Visibility.Collapsed;
     public Visibility HardwareHashCertificateWarningVisibility => IsHardwareHashCertificateExpired ? Visibility.Visible : Visibility.Collapsed;
     public Visibility BootMediaCertificateVisibility => HasConnectedTenantInCurrentSession &&
-                                                        hardwareHashUploadSettings.ActiveCertificate is not null
+                                                        HasCertificates
         ? Visibility.Visible
         : Visibility.Collapsed;
     public string BootMediaCertificatePfxPath => hardwareHashUploadSettings.BootMediaCertificate.PfxPath ?? string.Empty;
@@ -352,6 +352,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string BootMediaCertificateDescription { get; set; }
 
     [ObservableProperty]
+    public partial string BootMediaCertificateTenantCertificateLabel { get; set; }
+
+    [ObservableProperty]
     public partial string BootMediaCertificatePfxPathLabel { get; set; }
 
     [ObservableProperty]
@@ -491,6 +494,10 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RetireActiveCertificateCommand))]
     public partial AutopilotCertificateEntryViewModel? SelectedCertificate { get; set; }
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SelectBootMediaCertificatePfxCommand))]
+    public partial AutopilotCertificateEntryViewModel? SelectedBootMediaCertificate { get; set; }
 
     [ObservableProperty]
     public partial AutopilotGroupTagEntryViewModel? SelectedDefaultGroupTag { get; set; }
@@ -995,6 +1002,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         CertificateIdColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateIdColumn");
         BootMediaCertificateLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateLabel");
         BootMediaCertificateDescription = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateDescription");
+        BootMediaCertificateTenantCertificateLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateTenantCertificateLabel");
         BootMediaCertificatePfxPathLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePfxPathLabel");
         BootMediaCertificatePasswordLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePasswordLabel");
         SelectBootMediaCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateSelectButton");
@@ -1089,6 +1097,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         OnPropertyChanged(nameof(BootMediaCertificateStatusText));
         OnPropertyChanged(nameof(BootMediaCertificateStatusForeground));
         OnPropertyChanged(nameof(IsBootMediaCertificateReady));
+        SelectBootMediaCertificatePfxCommand.NotifyCanExecuteChanged();
     }
 
     private void RefreshTenantDetails()
@@ -1161,9 +1170,16 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         }
 
         SelectedCertificate = null;
+        SelectedBootMediaCertificate = Certificates.FirstOrDefault(certificate =>
+            string.Equals(certificate.KeyId, hardwareHashUploadSettings.ActiveCertificate?.KeyId, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(
+                NormalizeThumbprint(certificate.Thumbprint),
+                NormalizeThumbprint(hardwareHashUploadSettings.ActiveCertificate?.Thumbprint),
+                StringComparison.OrdinalIgnoreCase));
         hardwareHashSessionState.Certificates = credentials;
         OnPropertyChanged(nameof(HasCertificates));
         OnPropertyChanged(nameof(CertificatesVisibility));
+        OnPropertyChanged(nameof(BootMediaCertificateVisibility));
     }
 
     private string CreateCertificateStatusText()
@@ -1356,7 +1372,8 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     private static bool ShouldShowTenantOnboardingResultDialog(AutopilotTenantOnboardingStatus status)
     {
-        return status != AutopilotTenantOnboardingStatus.ActiveCertificateMissing;
+        return status is not AutopilotTenantOnboardingStatus.ActiveCertificateMissing
+            and not AutopilotTenantOnboardingStatus.MultipleFoundryCertificatesNeedSelection;
     }
 
     private void RefreshProfileState()
@@ -1397,6 +1414,24 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         SaveState();
     }
 
+    partial void OnSelectedBootMediaCertificateChanged(AutopilotCertificateEntryViewModel? value)
+    {
+        if (isApplyingState)
+        {
+            return;
+        }
+
+        hardwareHashUploadSettings = hardwareHashUploadSettings with
+        {
+            ActiveCertificate = value is null ? null : CreateCertificateMetadata(value)
+        };
+        tenantOnboardingStatus = ResolveCertificateSelectionStatus(value);
+        hardwareHashSessionState.TenantOnboardingStatus = tenantOnboardingStatus;
+        ClearBootMediaCertificateIfActiveCertificateChanged();
+        RefreshHardwareHashUploadState();
+        SaveState();
+    }
+
     /// <summary>
     /// Replaces the selected profile rows after a XAML selection change.
     /// </summary>
@@ -1423,6 +1458,38 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         }
 
         SelectedCertificate = SelectedCertificates.FirstOrDefault();
+    }
+
+    private AutopilotTenantOnboardingStatus? ResolveCertificateSelectionStatus(AutopilotCertificateEntryViewModel? certificate)
+    {
+        if (tenantOnboardingStatus is AutopilotTenantOnboardingStatus.PermissionMissing
+            or AutopilotTenantOnboardingStatus.ConsentMissing
+            or AutopilotTenantOnboardingStatus.ServicePrincipalUnavailable
+            or AutopilotTenantOnboardingStatus.AppRegistrationMissing
+            or AutopilotTenantOnboardingStatus.AdoptionRequired)
+        {
+            return tenantOnboardingStatus;
+        }
+
+        if (certificate is null)
+        {
+            return AutopilotTenantOnboardingStatus.ActiveCertificateMissing;
+        }
+
+        return certificate.ExpiresOnUtc <= DateTimeOffset.UtcNow
+            ? AutopilotTenantOnboardingStatus.ActiveCertificateExpired
+            : AutopilotTenantOnboardingStatus.Ready;
+    }
+
+    private static AutopilotCertificateMetadata CreateCertificateMetadata(AutopilotCertificateEntryViewModel certificate)
+    {
+        return new AutopilotCertificateMetadata
+        {
+            KeyId = certificate.KeyId,
+            Thumbprint = certificate.Thumbprint,
+            DisplayName = AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName,
+            ExpiresOnUtc = certificate.ExpiresOnUtc
+        };
     }
 
     private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -113,12 +113,14 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     ];
 
     /// <summary>
-    /// Gets tenant-discovered Autopilot group tags available for the default deployment selection.
-    /// </summary>
-    /// <summary>
     /// Gets default group tag choices, including the optional None choice.
     /// </summary>
     public ObservableCollection<AutopilotGroupTagEntryViewModel> DefaultGroupTagOptions { get; } = [];
+
+    /// <summary>
+    /// Gets tenant readiness information displayed after a successful tenant connection.
+    /// </summary>
+    public ObservableCollection<AutopilotTenantReadinessEntryViewModel> TenantReadinessEntries { get; } = [];
 
     public bool IsAutopilotSectionEnabled => IsAutopilotEnabled;
     public bool HasProfiles => Profiles.Count > 0;
@@ -194,6 +196,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public string TenantStatusText => HasConnectedTenantInCurrentSession && HasTenantRegistration
         ? localizationService.GetString("Autopilot.HardwareHashTenantConnected")
         : localizationService.GetString("Autopilot.HardwareHashTenantNotConnected");
+    public Brush TenantStatusForeground => HasConnectedTenantInCurrentSession && HasTenantRegistration
+        ? (Brush)Application.Current.Resources["SystemFillColorSuccessBrush"]
+        : (Brush)Application.Current.Resources["SystemFillColorCriticalBrush"];
     public string TenantConnectionButtonText => HasConnectedTenantInCurrentSession
         ? DisconnectTenantButtonText
         : ConnectTenantButtonText;
@@ -281,6 +286,12 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     [ObservableProperty]
     public partial string TenantReadinessDescription { get; set; }
+
+    [ObservableProperty]
+    public partial string TenantReadinessNameColumnHeader { get; set; }
+
+    [ObservableProperty]
+    public partial string TenantReadinessValueColumnHeader { get; set; }
 
     [ObservableProperty]
     public partial string TenantDetailsTenantIdLabel { get; set; }
@@ -944,6 +955,8 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         TenantStatusDescription = localizationService.GetString("Autopilot.HardwareHashTenantStatusDescription");
         TenantReadinessLabel = localizationService.GetString("Autopilot.HardwareHashTenantReadinessLabel");
         TenantReadinessDescription = localizationService.GetString("Autopilot.HardwareHashTenantReadinessDescription");
+        TenantReadinessNameColumnHeader = localizationService.GetString("Autopilot.HardwareHashTenantReadinessNameColumn");
+        TenantReadinessValueColumnHeader = localizationService.GetString("Autopilot.HardwareHashTenantReadinessValueColumn");
         TenantDetailsTenantIdLabel = localizationService.GetString("Autopilot.HardwareHashTenantDetailsTenantId");
         TenantDetailsClientIdLabel = localizationService.GetString("Autopilot.HardwareHashTenantDetailsClientId");
         AppRegistrationLabel = localizationService.GetString("Autopilot.HardwareHashAppRegistrationLabel");
@@ -984,6 +997,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         ProfileFolderColumnHeader = localizationService.GetString("Autopilot.ColumnFolder");
         OnPropertyChanged(nameof(BusyStatusText));
         OnPropertyChanged(nameof(TenantConnectionButtonText));
+        OnPropertyChanged(nameof(TenantStatusForeground));
         RefreshHardwareHashUploadState();
     }
 
@@ -1018,12 +1032,14 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private void RefreshHardwareHashUploadState()
     {
         OnPropertyChanged(nameof(TenantStatusText));
+        OnPropertyChanged(nameof(TenantStatusForeground));
         OnPropertyChanged(nameof(TenantConnectionButtonText));
         OnPropertyChanged(nameof(AppRegistrationStatusText));
         OnPropertyChanged(nameof(TenantIdText));
         OnPropertyChanged(nameof(ClientIdText));
         OnPropertyChanged(nameof(TenantOnboardingStatusText));
         OnPropertyChanged(nameof(TenantOnboardingStatusForeground));
+        RefreshTenantReadinessEntries();
         OnPropertyChanged(nameof(IsHardwareHashCertificateExpired));
         OnPropertyChanged(nameof(EmptyCertificatesVisibility));
         OnPropertyChanged(nameof(DefaultGroupTagText));
@@ -1045,6 +1061,32 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         OnPropertyChanged(nameof(BootMediaCertificateStatusForeground));
         OnPropertyChanged(nameof(IsBootMediaCertificateReady));
         SelectBootMediaCertificatePfxCommand.NotifyCanExecuteChanged();
+    }
+
+    private void RefreshTenantReadinessEntries()
+    {
+        TenantReadinessEntries.Clear();
+        if (!HasTenantRegistration)
+        {
+            return;
+        }
+
+        TenantReadinessEntries.Add(new AutopilotTenantReadinessEntryViewModel(
+            AppRegistrationLabel,
+            AppRegistrationStatusText,
+            null));
+        TenantReadinessEntries.Add(new AutopilotTenantReadinessEntryViewModel(
+            TenantDetailsTenantIdLabel,
+            TenantIdText,
+            null));
+        TenantReadinessEntries.Add(new AutopilotTenantReadinessEntryViewModel(
+            TenantDetailsClientIdLabel,
+            ClientIdText,
+            null));
+        TenantReadinessEntries.Add(new AutopilotTenantReadinessEntryViewModel(
+            TenantOnboardingStatusLabel,
+            TenantOnboardingStatusText,
+            TenantOnboardingStatusForeground));
     }
 
     private void DisconnectTenantSession()

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -156,8 +156,11 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public Visibility HardwareHashCertificateWarningVisibility => IsHardwareHashCertificateExpired ? Visibility.Visible : Visibility.Collapsed;
     public string ManagedAppRegistrationName => AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName;
     public string TenantStatusText => HasTenantRegistration
-        ? localizationService.FormatString("Autopilot.HardwareHashTenantConnectedFormat", hardwareHashUploadSettings.Tenant.TenantId!)
+        ? localizationService.GetString("Autopilot.HardwareHashTenantConnected")
         : localizationService.GetString("Autopilot.HardwareHashTenantNotConnected");
+    public string TenantDetailsText => HasTenantRegistration
+        ? localizationService.FormatString("Autopilot.HardwareHashTenantDetailsFormat", hardwareHashUploadSettings.Tenant.TenantId!)
+        : string.Empty;
     public string AppRegistrationStatusText => string.IsNullOrWhiteSpace(hardwareHashUploadSettings.Tenant.ApplicationObjectId)
         ? localizationService.GetString("Autopilot.HardwareHashAppRegistrationMissing")
         : localizationService.FormatString("Autopilot.HardwareHashAppRegistrationFoundFormat", ManagedAppRegistrationName);
@@ -223,6 +226,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     [ObservableProperty]
     public partial string TenantStatusLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string TenantDetailsLabel { get; set; }
 
     [ObservableProperty]
     public partial string AppRegistrationLabel { get; set; }
@@ -765,6 +771,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         CreateCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashCreateCertificateButton");
         RetireCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashRetireCertificateButton");
         TenantStatusLabel = localizationService.GetString("Autopilot.HardwareHashTenantStatusLabel");
+        TenantDetailsLabel = localizationService.GetString("Autopilot.HardwareHashTenantDetailsLabel");
         AppRegistrationLabel = localizationService.GetString("Autopilot.HardwareHashAppRegistrationLabel");
         TenantOnboardingStatusLabel = localizationService.GetString("Autopilot.HardwareHashOnboardingStatusLabel");
         CertificateStatusLabel = localizationService.GetString("Autopilot.HardwareHashCertificateStatusLabel");
@@ -828,6 +835,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private void RefreshHardwareHashUploadState()
     {
         OnPropertyChanged(nameof(TenantStatusText));
+        OnPropertyChanged(nameof(TenantDetailsText));
         OnPropertyChanged(nameof(AppRegistrationStatusText));
         OnPropertyChanged(nameof(TenantOnboardingStatusText));
         OnPropertyChanged(nameof(CertificateStatusText));

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -120,11 +120,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     /// </summary>
     public ObservableCollection<AutopilotGroupTagEntryViewModel> DefaultGroupTagOptions { get; } = [];
 
-    /// <summary>
-    /// Gets tenant metadata displayed after a successful tenant connection.
-    /// </summary>
-    public ObservableCollection<AutopilotTenantDetailEntryViewModel> TenantDetails { get; } = [];
-
     public bool IsAutopilotSectionEnabled => IsAutopilotEnabled;
     public bool HasProfiles => Profiles.Count > 0;
     public Visibility EmptyProfilesVisibility => HasProfiles ? Visibility.Collapsed : Visibility.Visible;
@@ -205,6 +200,8 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public string AppRegistrationStatusText => string.IsNullOrWhiteSpace(hardwareHashUploadSettings.Tenant.ApplicationObjectId)
         ? localizationService.GetString("Autopilot.HardwareHashAppRegistrationMissing")
         : localizationService.FormatString("Autopilot.HardwareHashAppRegistrationFoundFormat", ManagedAppRegistrationName);
+    public string TenantIdText => hardwareHashUploadSettings.Tenant.TenantId ?? string.Empty;
+    public string ClientIdText => hardwareHashUploadSettings.Tenant.ClientId ?? string.Empty;
     public string TenantOnboardingStatusText => CreateTenantOnboardingStatusText();
     public Brush TenantOnboardingStatusForeground => ResolveTenantOnboardingStatusBrush();
     public string DefaultGroupTagText => string.IsNullOrWhiteSpace(hardwareHashUploadSettings.DefaultGroupTag)
@@ -280,16 +277,10 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string TenantStatusDescription { get; set; }
 
     [ObservableProperty]
-    public partial string TenantDetailsLabel { get; set; }
+    public partial string TenantReadinessLabel { get; set; }
 
     [ObservableProperty]
-    public partial string TenantDetailsDescription { get; set; }
-
-    [ObservableProperty]
-    public partial string TenantDetailsNameColumnHeader { get; set; }
-
-    [ObservableProperty]
-    public partial string TenantDetailsValueColumnHeader { get; set; }
+    public partial string TenantReadinessDescription { get; set; }
 
     [ObservableProperty]
     public partial string TenantDetailsTenantIdLabel { get; set; }
@@ -301,13 +292,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string AppRegistrationLabel { get; set; }
 
     [ObservableProperty]
-    public partial string AppRegistrationDescription { get; set; }
-
-    [ObservableProperty]
     public partial string TenantOnboardingStatusLabel { get; set; }
-
-    [ObservableProperty]
-    public partial string TenantOnboardingStatusDescription { get; set; }
 
     [ObservableProperty]
     public partial string CertificateActionsLabel { get; set; }
@@ -957,16 +942,12 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         RetireCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashRetireCertificateButton");
         TenantStatusLabel = localizationService.GetString("Autopilot.HardwareHashTenantStatusLabel");
         TenantStatusDescription = localizationService.GetString("Autopilot.HardwareHashTenantStatusDescription");
-        TenantDetailsLabel = localizationService.GetString("Autopilot.HardwareHashTenantDetailsLabel");
-        TenantDetailsDescription = localizationService.GetString("Autopilot.HardwareHashTenantDetailsDescription");
-        TenantDetailsNameColumnHeader = localizationService.GetString("Autopilot.HardwareHashTenantDetailsNameColumn");
-        TenantDetailsValueColumnHeader = localizationService.GetString("Autopilot.HardwareHashTenantDetailsValueColumn");
+        TenantReadinessLabel = localizationService.GetString("Autopilot.HardwareHashTenantReadinessLabel");
+        TenantReadinessDescription = localizationService.GetString("Autopilot.HardwareHashTenantReadinessDescription");
         TenantDetailsTenantIdLabel = localizationService.GetString("Autopilot.HardwareHashTenantDetailsTenantId");
         TenantDetailsClientIdLabel = localizationService.GetString("Autopilot.HardwareHashTenantDetailsClientId");
         AppRegistrationLabel = localizationService.GetString("Autopilot.HardwareHashAppRegistrationLabel");
-        AppRegistrationDescription = localizationService.GetString("Autopilot.HardwareHashAppRegistrationDescription");
         TenantOnboardingStatusLabel = localizationService.GetString("Autopilot.HardwareHashOnboardingStatusLabel");
-        TenantOnboardingStatusDescription = localizationService.GetString("Autopilot.HardwareHashOnboardingStatusDescription");
         CertificateActionsLabel = localizationService.GetString("Autopilot.HardwareHashCertificateActionsLabel");
         CertificateActionsDescription = localizationService.GetString("Autopilot.HardwareHashCertificateActionsDescription");
         ProvisionedCertificatesLabel = localizationService.GetString("Autopilot.HardwareHashProvisionedCertificatesLabel");
@@ -1036,10 +1017,11 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     private void RefreshHardwareHashUploadState()
     {
-        RefreshTenantDetails();
         OnPropertyChanged(nameof(TenantStatusText));
         OnPropertyChanged(nameof(TenantConnectionButtonText));
         OnPropertyChanged(nameof(AppRegistrationStatusText));
+        OnPropertyChanged(nameof(TenantIdText));
+        OnPropertyChanged(nameof(ClientIdText));
         OnPropertyChanged(nameof(TenantOnboardingStatusText));
         OnPropertyChanged(nameof(TenantOnboardingStatusForeground));
         OnPropertyChanged(nameof(IsHardwareHashCertificateExpired));
@@ -1063,22 +1045,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         OnPropertyChanged(nameof(BootMediaCertificateStatusForeground));
         OnPropertyChanged(nameof(IsBootMediaCertificateReady));
         SelectBootMediaCertificatePfxCommand.NotifyCanExecuteChanged();
-    }
-
-    private void RefreshTenantDetails()
-    {
-        TenantDetails.Clear();
-        if (!HasTenantRegistration)
-        {
-            return;
-        }
-
-        TenantDetails.Add(new AutopilotTenantDetailEntryViewModel(
-            TenantDetailsTenantIdLabel,
-            hardwareHashUploadSettings.Tenant.TenantId!));
-        TenantDetails.Add(new AutopilotTenantDetailEntryViewModel(
-            TenantDetailsClientIdLabel,
-            hardwareHashUploadSettings.Tenant.ClientId!));
     }
 
     private void DisconnectTenantSession()

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -655,7 +655,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             if (ShouldShowTenantOnboardingResultDialog(result.Status))
             {
                 await dialogService.ShowMessageAsync(new DialogRequest(
-                    GetTenantOnboardingDialogTitle(result.Status),
+                    GetTenantOnboardingDialogTitle(),
                     result.Message));
             }
         }
@@ -753,11 +753,8 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
                 return;
             }
 
-            if (hardwareHashUploadSettings.ActiveCertificate is null)
-            {
-                tenantOnboardingStatus = AutopilotTenantOnboardingStatus.ActiveCertificateMissing;
-                hardwareHashSessionState.TenantOnboardingStatus = tenantOnboardingStatus;
-            }
+            tenantOnboardingStatus = ResolveTenantReadinessAfterCertificateChange(result.Certificates);
+            hardwareHashSessionState.TenantOnboardingStatus = tenantOnboardingStatus;
 
             ReplaceCertificates(result.Certificates);
             ClearBootMediaCertificateIfActiveCertificateChanged();
@@ -1323,16 +1320,14 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             : (Brush)Application.Current.Resources["SystemFillColorCriticalBrush"];
     }
 
-    private string GetTenantOnboardingDialogTitle(AutopilotTenantOnboardingStatus status)
+    private string GetTenantOnboardingDialogTitle()
     {
-        return status == AutopilotTenantOnboardingStatus.Ready
-            ? localizationService.GetString("Autopilot.HardwareHashOnboardingCompletedTitle")
-            : localizationService.GetString("Autopilot.HardwareHashOnboardingRequiresAttentionTitle");
+        return localizationService.GetString("Autopilot.HardwareHashOnboardingRequiresAttentionTitle");
     }
 
     private static bool ShouldShowTenantOnboardingResultDialog(AutopilotTenantOnboardingStatus status)
     {
-        return status is not AutopilotTenantOnboardingStatus.ActiveCertificateMissing;
+        return status is not (AutopilotTenantOnboardingStatus.Ready or AutopilotTenantOnboardingStatus.ActiveCertificateMissing);
     }
 
     private void RefreshProfileState()
@@ -1420,6 +1415,28 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         return certificate.ExpiresOnUtc <= DateTimeOffset.UtcNow
             ? AutopilotTenantOnboardingStatus.ActiveCertificateExpired
             : AutopilotTenantOnboardingStatus.Ready;
+    }
+
+    private AutopilotTenantOnboardingStatus ResolveTenantReadinessAfterCertificateChange(
+        IReadOnlyList<AutopilotGraphKeyCredential> credentials)
+    {
+        if (tenantOnboardingStatus is AutopilotTenantOnboardingStatus.PermissionMissing
+            or AutopilotTenantOnboardingStatus.ConsentMissing
+            or AutopilotTenantOnboardingStatus.ServicePrincipalUnavailable
+            or AutopilotTenantOnboardingStatus.AppRegistrationMissing
+            or AutopilotTenantOnboardingStatus.AdoptionRequired)
+        {
+            return tenantOnboardingStatus.Value;
+        }
+
+        return credentials.Any(credential =>
+            string.Equals(
+                credential.DisplayName,
+                AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName,
+                StringComparison.OrdinalIgnoreCase) &&
+            credential.ExpiresOnUtc > DateTimeOffset.UtcNow)
+            ? AutopilotTenantOnboardingStatus.Ready
+            : AutopilotTenantOnboardingStatus.ActiveCertificateMissing;
     }
 
     private static AutopilotCertificateMetadata CreateCertificateMetadata(AutopilotCertificateEntryViewModel certificate)

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -109,12 +109,20 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         new(12, "12 months")
     ];
 
+    /// <summary>
+    /// Gets tenant-discovered Autopilot group tags available for the default deployment selection.
+    /// </summary>
+    public ObservableCollection<AutopilotGroupTagEntryViewModel> AvailableGroupTags { get; } = [];
+
     public bool IsAutopilotSectionEnabled => IsAutopilotEnabled;
     public bool HasProfiles => Profiles.Count > 0;
     public Visibility EmptyProfilesVisibility => HasProfiles ? Visibility.Collapsed : Visibility.Visible;
     public Visibility ProfilesVisibility => HasProfiles ? Visibility.Visible : Visibility.Collapsed;
     public bool HasCertificates => Certificates.Count > 0;
     public Visibility CertificatesVisibility => HasCertificates ? Visibility.Visible : Visibility.Collapsed;
+    public bool HasAvailableGroupTags => AvailableGroupTags.Count > 0;
+    public Visibility AvailableGroupTagsVisibility => HasAvailableGroupTags ? Visibility.Visible : Visibility.Collapsed;
+    public Visibility EmptyAvailableGroupTagsVisibility => HasAvailableGroupTags ? Visibility.Collapsed : Visibility.Visible;
     public Visibility ConnectedTenantDetailsVisibility => HasConnectedTenantInCurrentSession ? Visibility.Visible : Visibility.Collapsed;
     public bool IsBusy => IsImporting || IsDownloading || IsConnectingTenant;
     public Visibility BusyStatusVisibility => IsBusy ? Visibility.Visible : Visibility.Collapsed;
@@ -309,6 +317,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string KnownGroupTagsLabel { get; set; }
 
     [ObservableProperty]
+    public partial string AvailableGroupTagColumnHeader { get; set; }
+
+    [ObservableProperty]
     public partial string ImportButtonText { get; set; }
 
     [ObservableProperty]
@@ -421,6 +432,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RetireActiveCertificateCommand))]
     public partial AutopilotCertificateEntryViewModel? SelectedCertificate { get; set; }
+
+    [ObservableProperty]
+    public partial AutopilotGroupTagEntryViewModel? SelectedDefaultGroupTag { get; set; }
 
     /// <summary>
     /// Releases subscriptions to localization, configuration state, and profile collections.
@@ -590,6 +604,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             hardwareHashSessionState.TenantOnboardingStatus = result.Status;
             HasConnectedTenantInCurrentSession = true;
             ReplaceCertificates(result.Certificates);
+            ReplaceAvailableGroupTags(result.Settings.KnownGroupTags, result.Settings.DefaultGroupTag);
             ClearBootMediaCertificateIfActiveCertificateChanged();
             RefreshHardwareHashUploadState();
             SaveState();
@@ -799,6 +814,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             };
             tenantOnboardingStatus = hardwareHashSessionState.TenantOnboardingStatus;
             ReplaceCertificates(HasConnectedTenantInCurrentSession ? hardwareHashSessionState.Certificates : []);
+            ReplaceAvailableGroupTags(hardwareHashUploadSettings.KnownGroupTags, hardwareHashUploadSettings.DefaultGroupTag);
             ReplaceProfiles(
                 settings.Profiles.Select(AutopilotProfileEntryViewModel.FromSettings),
                 settings.DefaultProfileId);
@@ -910,6 +926,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         SelectBootMediaCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateSelectButton");
         DefaultGroupTagLabel = localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagLabel");
         KnownGroupTagsLabel = localizationService.GetString("Autopilot.HardwareHashKnownGroupTagsLabel");
+        AvailableGroupTagColumnHeader = localizationService.GetString("Autopilot.HardwareHashAvailableGroupTagColumn");
         ImportButtonText = localizationService.GetString("Autopilot.ImportButton");
         DownloadButtonText = localizationService.GetString("Autopilot.DownloadButton");
         RemoveButtonText = localizationService.GetString("Autopilot.RemoveButton");
@@ -974,6 +991,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         OnPropertyChanged(nameof(HardwareHashCertificateWarningVisibility));
         OnPropertyChanged(nameof(DefaultGroupTagText));
         OnPropertyChanged(nameof(KnownGroupTagsText));
+        OnPropertyChanged(nameof(HasAvailableGroupTags));
+        OnPropertyChanged(nameof(AvailableGroupTagsVisibility));
+        OnPropertyChanged(nameof(EmptyAvailableGroupTagsVisibility));
         OnPropertyChanged(nameof(ConnectedTenantDetailsVisibility));
         OnPropertyChanged(nameof(BootMediaCertificateVisibility));
         OnPropertyChanged(nameof(BootMediaCertificatePfxPath));
@@ -993,6 +1013,32 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         hardwareHashSessionState.ClearTenantConnection();
         RefreshHardwareHashUploadState();
         SaveState();
+    }
+
+    private void ReplaceAvailableGroupTags(IReadOnlyList<string> groupTags, string? preferredDefaultGroupTag)
+    {
+        string[] orderedGroupTags = groupTags
+            .Where(groupTag => !string.IsNullOrWhiteSpace(groupTag))
+            .Select(groupTag => groupTag.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(groupTag => groupTag, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        AvailableGroupTags.Clear();
+        foreach (string groupTag in orderedGroupTags)
+        {
+            AvailableGroupTags.Add(new AutopilotGroupTagEntryViewModel(groupTag));
+        }
+
+        AutopilotGroupTagEntryViewModel? selectedGroupTag = AvailableGroupTags.FirstOrDefault(groupTag =>
+                                                       string.Equals(groupTag.GroupTag, preferredDefaultGroupTag, StringComparison.OrdinalIgnoreCase))
+                                                   ?? AvailableGroupTags.FirstOrDefault();
+        SelectedDefaultGroupTag = selectedGroupTag;
+        hardwareHashUploadSettings = hardwareHashUploadSettings with
+        {
+            KnownGroupTags = orderedGroupTags,
+            DefaultGroupTag = selectedGroupTag?.GroupTag
+        };
     }
 
     private void ReplaceCertificates(IReadOnlyList<AutopilotGraphKeyCredential> credentials)
@@ -1068,6 +1114,11 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         if (isBootMediaCertificateFileMissing)
         {
             return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateFileMissing");
+        }
+
+        if (IsBootMediaCertificateReady)
+        {
+            return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateReady");
         }
 
         return bootMediaCertificateValidationCode switch
@@ -1225,6 +1276,21 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private void OnSelectedCertificatesCollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
     {
         RetireActiveCertificateCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnSelectedDefaultGroupTagChanged(AutopilotGroupTagEntryViewModel? value)
+    {
+        if (isApplyingState)
+        {
+            return;
+        }
+
+        hardwareHashUploadSettings = hardwareHashUploadSettings with
+        {
+            DefaultGroupTag = value?.GroupTag
+        };
+        OnPropertyChanged(nameof(DefaultGroupTagText));
+        SaveState();
     }
 
     /// <summary>

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -1208,16 +1208,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     private string CreateBootMediaCertificateStatusText()
     {
-        if (hardwareHashUploadSettings.ActiveCertificate is null)
-        {
-            return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateActiveMissing");
-        }
-
-        if (IsHardwareHashCertificateExpired)
-        {
-            return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateActiveExpired");
-        }
-
         if (string.IsNullOrWhiteSpace(hardwareHashUploadSettings.BootMediaCertificate.PfxPath))
         {
             return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePfxMissing");
@@ -1226,6 +1216,23 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         if (isBootMediaCertificateFileMissing)
         {
             return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateFileMissing");
+        }
+
+        if (bootMediaCertificateValidationCode == AutopilotPfxValidationCode.PasswordRequired)
+        {
+            return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePasswordMissing");
+        }
+
+        if (hardwareHashUploadSettings.ActiveCertificate is null)
+        {
+            return bootMediaCertificateValidationCode == AutopilotPfxValidationCode.ThumbprintMismatch
+                ? localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateThumbprintMismatch")
+                : localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateActiveMissing");
+        }
+
+        if (IsHardwareHashCertificateExpired)
+        {
+            return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateActiveExpired");
         }
 
         if (IsBootMediaCertificateReady)
@@ -1254,6 +1261,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
         if (IsHardwareHashCertificateExpired ||
             isBootMediaCertificateFileMissing ||
+            (hardwareHashUploadSettings.ActiveCertificate is null &&
+             !string.IsNullOrWhiteSpace(hardwareHashUploadSettings.BootMediaCertificate.PfxPath) &&
+             bootMediaCertificateValidationCode != AutopilotPfxValidationCode.PasswordRequired) ||
             bootMediaCertificateValidationCode is AutopilotPfxValidationCode.InvalidPfx
                 or AutopilotPfxValidationCode.PrivateKeyMissing
                 or AutopilotPfxValidationCode.ThumbprintMismatch)

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -155,7 +155,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public Visibility HardwareHashSettingsVisibility => IsHardwareHashUploadMode ? Visibility.Visible : Visibility.Collapsed;
     public Visibility HardwareHashCertificateWarningVisibility => IsHardwareHashCertificateExpired ? Visibility.Visible : Visibility.Collapsed;
     public string ManagedAppRegistrationName => AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName;
-    public string TenantStatusText => HasTenantRegistration
+    public string TenantStatusText => HasConnectedTenantInCurrentSession && HasTenantRegistration
         ? localizationService.GetString("Autopilot.HardwareHashTenantConnected")
         : localizationService.GetString("Autopilot.HardwareHashTenantNotConnected");
     public string TenantDetailsText => HasTenantRegistration

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -85,8 +85,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     [
         new(3, "3 months"),
         new(6, "6 months"),
-        new(12, "12 months"),
-        new(24, "24 months")
+        new(12, "12 months")
     ];
 
     public bool IsAutopilotSectionEnabled => IsAutopilotEnabled;

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -970,7 +970,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         SelectBootMediaCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateSelectButton");
         GroupTagLabel = localizationService.GetString("Autopilot.HardwareHashGroupTagLabel");
         GroupTagDescription = localizationService.GetString("Autopilot.HardwareHashGroupTagDescription");
-        DefaultGroupTagNoneOptionText = localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagNoneOption");
+        DefaultGroupTagNoneOptionText = localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagNoSelection");
         ImportButtonText = localizationService.GetString("Autopilot.ImportButton");
         DownloadButtonText = localizationService.GetString("Autopilot.DownloadButton");
         RemoveButtonText = localizationService.GetString("Autopilot.RemoveButton");

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -115,8 +115,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     /// <summary>
     /// Gets tenant-discovered Autopilot group tags available for the default deployment selection.
     /// </summary>
-    public ObservableCollection<AutopilotGroupTagEntryViewModel> AvailableGroupTags { get; } = [];
-
     /// <summary>
     /// Gets default group tag choices, including the optional None choice.
     /// </summary>
@@ -134,9 +132,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public bool HasCertificates => Certificates.Count > 0;
     public Visibility CertificatesVisibility => HasCertificates ? Visibility.Visible : Visibility.Collapsed;
     public Visibility EmptyCertificatesVisibility => HasCertificates ? Visibility.Collapsed : Visibility.Visible;
-    public bool HasAvailableGroupTags => AvailableGroupTags.Count > 0;
-    public Visibility AvailableGroupTagsVisibility => HasAvailableGroupTags ? Visibility.Visible : Visibility.Collapsed;
-    public Visibility EmptyAvailableGroupTagsVisibility => HasAvailableGroupTags ? Visibility.Collapsed : Visibility.Visible;
     public Visibility ConnectedTenantDetailsVisibility => HasConnectedTenantInCurrentSession ? Visibility.Visible : Visibility.Collapsed;
     public bool IsBusy => IsImporting || IsDownloading || IsConnectingTenant;
     public Visibility BusyStatusVisibility => IsBusy ? Visibility.Visible : Visibility.Collapsed;
@@ -215,10 +210,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public string DefaultGroupTagText => string.IsNullOrWhiteSpace(hardwareHashUploadSettings.DefaultGroupTag)
         ? localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagNone")
         : hardwareHashUploadSettings.DefaultGroupTag!;
-    public string KnownGroupTagsText => hardwareHashUploadSettings.KnownGroupTags.Count == 0
-        ? localizationService.GetString("Autopilot.HardwareHashKnownGroupTagsNone")
-        : string.Join(", ", hardwareHashUploadSettings.KnownGroupTags);
-
     private bool HasTenantRegistration => !string.IsNullOrWhiteSpace(hardwareHashUploadSettings.Tenant.TenantId) &&
                                           !string.IsNullOrWhiteSpace(hardwareHashUploadSettings.Tenant.ClientId);
 
@@ -367,16 +358,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string GroupTagDescription { get; set; }
 
     [ObservableProperty]
-    public partial string DefaultGroupTagLabel { get; set; }
-
-    [ObservableProperty]
     public partial string DefaultGroupTagNoneOptionText { get; set; }
-
-    [ObservableProperty]
-    public partial string KnownGroupTagsLabel { get; set; }
-
-    [ObservableProperty]
-    public partial string AvailableGroupTagColumnHeader { get; set; }
 
     [ObservableProperty]
     public partial string ImportButtonText { get; set; }
@@ -665,7 +647,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             hardwareHashSessionState.TenantOnboardingStatus = result.Status;
             HasConnectedTenantInCurrentSession = true;
             ReplaceCertificates(result.Certificates);
-            ReplaceAvailableGroupTags(result.Settings.KnownGroupTags, result.Settings.DefaultGroupTag);
+            ReplaceDefaultGroupTagOptions(result.Settings.KnownGroupTags, result.Settings.DefaultGroupTag);
             ClearBootMediaCertificateIfActiveCertificateChanged();
             RefreshHardwareHashUploadState();
             SaveState();
@@ -875,7 +857,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             };
             tenantOnboardingStatus = hardwareHashSessionState.TenantOnboardingStatus;
             ReplaceCertificates(HasConnectedTenantInCurrentSession ? hardwareHashSessionState.Certificates : []);
-            ReplaceAvailableGroupTags(hardwareHashUploadSettings.KnownGroupTags, hardwareHashUploadSettings.DefaultGroupTag);
+            ReplaceDefaultGroupTagOptions(hardwareHashUploadSettings.KnownGroupTags, hardwareHashUploadSettings.DefaultGroupTag);
             ReplaceProfiles(
                 settings.Profiles.Select(AutopilotProfileEntryViewModel.FromSettings),
                 settings.DefaultProfileId);
@@ -1001,10 +983,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         SelectBootMediaCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateSelectButton");
         GroupTagLabel = localizationService.GetString("Autopilot.HardwareHashGroupTagLabel");
         GroupTagDescription = localizationService.GetString("Autopilot.HardwareHashGroupTagDescription");
-        DefaultGroupTagLabel = localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagLabel");
         DefaultGroupTagNoneOptionText = localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagNoneOption");
-        KnownGroupTagsLabel = localizationService.GetString("Autopilot.HardwareHashKnownGroupTagsLabel");
-        AvailableGroupTagColumnHeader = localizationService.GetString("Autopilot.HardwareHashAvailableGroupTagColumn");
         ImportButtonText = localizationService.GetString("Autopilot.ImportButton");
         DownloadButtonText = localizationService.GetString("Autopilot.DownloadButton");
         RemoveButtonText = localizationService.GetString("Autopilot.RemoveButton");
@@ -1067,10 +1046,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         OnPropertyChanged(nameof(EmptyCertificatesVisibility));
         OnPropertyChanged(nameof(DefaultGroupTagText));
         OnPropertyChanged(nameof(DefaultGroupTagOptions));
-        OnPropertyChanged(nameof(KnownGroupTagsText));
-        OnPropertyChanged(nameof(HasAvailableGroupTags));
-        OnPropertyChanged(nameof(AvailableGroupTagsVisibility));
-        OnPropertyChanged(nameof(EmptyAvailableGroupTagsVisibility));
         OnPropertyChanged(nameof(ConnectedTenantDetailsVisibility));
         OnPropertyChanged(nameof(BootMediaCertificateVisibility));
         OnPropertyChanged(nameof(BootMediaCertificatePfxPath));
@@ -1118,7 +1093,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         SaveState();
     }
 
-    private void ReplaceAvailableGroupTags(IReadOnlyList<string> groupTags, string? preferredDefaultGroupTag)
+    private void ReplaceDefaultGroupTagOptions(IReadOnlyList<string> groupTags, string? preferredDefaultGroupTag)
     {
         string[] orderedGroupTags = groupTags
             .Where(groupTag => !string.IsNullOrWhiteSpace(groupTag))
@@ -1127,13 +1102,11 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             .OrderBy(groupTag => groupTag, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
-        AvailableGroupTags.Clear();
         DefaultGroupTagOptions.Clear();
         DefaultGroupTagOptions.Add(new AutopilotGroupTagEntryViewModel(DefaultGroupTagNoneOptionText, null));
         foreach (string groupTag in orderedGroupTags)
         {
             AutopilotGroupTagEntryViewModel groupTagEntry = new(groupTag, groupTag);
-            AvailableGroupTags.Add(groupTagEntry);
             DefaultGroupTagOptions.Add(groupTagEntry);
         }
 

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -26,6 +26,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private readonly IAutopilotTenantDownloadDialogService tenantDownloadDialogService;
     private readonly IAutopilotCertificateDialogService certificateDialogService;
     private readonly IAutopilotProfileSelectionDialogService profileSelectionDialogService;
+    private readonly IAutopilotHardwareHashSessionState hardwareHashSessionState;
     private readonly IFilePickerService filePickerService;
     private readonly IDialogService dialogService;
     private readonly IApplicationLocalizationService localizationService;
@@ -35,6 +36,8 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private AutopilotProvisioningMode provisioningMode = AutopilotProvisioningMode.JsonProfile;
     private AutopilotHardwareHashUploadSettings hardwareHashUploadSettings = new();
     private AutopilotTenantOnboardingStatus? tenantOnboardingStatus;
+    private AutopilotPfxValidationCode bootMediaCertificateValidationCode = AutopilotPfxValidationCode.PfxRequired;
+    private bool isBootMediaCertificateFileMissing;
 
     public AutopilotConfigurationViewModel(
         IFoundryConfigurationStateService configurationStateService,
@@ -44,6 +47,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         IAutopilotTenantDownloadDialogService tenantDownloadDialogService,
         IAutopilotCertificateDialogService certificateDialogService,
         IAutopilotProfileSelectionDialogService profileSelectionDialogService,
+        IAutopilotHardwareHashSessionState hardwareHashSessionState,
         IFilePickerService filePickerService,
         IDialogService dialogService,
         IApplicationLocalizationService localizationService,
@@ -56,6 +60,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         this.tenantDownloadDialogService = tenantDownloadDialogService;
         this.certificateDialogService = certificateDialogService;
         this.profileSelectionDialogService = profileSelectionDialogService;
+        this.hardwareHashSessionState = hardwareHashSessionState;
         this.filePickerService = filePickerService;
         this.dialogService = dialogService;
         this.localizationService = localizationService;
@@ -68,6 +73,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         configurationStateService.StateChanged += OnConfigurationStateChanged;
         Profiles.CollectionChanged += OnProfilesCollectionChanged;
         SelectedProfiles.CollectionChanged += OnSelectedProfilesCollectionChanged;
+        SelectedCertificates.CollectionChanged += OnSelectedCertificatesCollectionChanged;
         isApplyingState = false;
         SelectedCertificateValidityOption = CertificateValidityOptions.First(option => option.Months == 6);
     }
@@ -86,6 +92,11 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     /// Gets app registration certificate credentials discovered from Microsoft Graph.
     /// </summary>
     public ObservableCollection<AutopilotCertificateEntryViewModel> Certificates { get; } = [];
+
+    /// <summary>
+    /// Gets the currently selected certificate rows for bulk UI actions.
+    /// </summary>
+    public ObservableCollection<AutopilotCertificateEntryViewModel> SelectedCertificates { get; } = [];
 
     /// <summary>
     /// Gets the fixed certificate validity options available for managed Autopilot app certificates.
@@ -153,6 +164,21 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public Visibility JsonProfileSettingsVisibility => IsJsonProfileMode ? Visibility.Visible : Visibility.Collapsed;
     public Visibility HardwareHashSettingsVisibility => IsHardwareHashUploadMode ? Visibility.Visible : Visibility.Collapsed;
     public Visibility HardwareHashCertificateWarningVisibility => IsHardwareHashCertificateExpired ? Visibility.Visible : Visibility.Collapsed;
+    public Visibility BootMediaCertificateVisibility => HasConnectedTenantInCurrentSession &&
+                                                        hardwareHashUploadSettings.ActiveCertificate is not null
+        ? Visibility.Visible
+        : Visibility.Collapsed;
+    public string BootMediaCertificatePfxPath => hardwareHashUploadSettings.BootMediaCertificate.PfxPath ?? string.Empty;
+    public string BootMediaCertificateStatusText => CreateBootMediaCertificateStatusText();
+    public Brush BootMediaCertificateStatusForeground => ResolveBootMediaCertificateStatusBrush();
+    public bool IsBootMediaCertificateReady => hardwareHashUploadSettings.BootMediaCertificate.ValidatedExpiresOnUtc is DateTimeOffset expiresOnUtc &&
+                                               expiresOnUtc > DateTimeOffset.UtcNow &&
+                                               !string.IsNullOrWhiteSpace(hardwareHashUploadSettings.BootMediaCertificate.PfxPath) &&
+                                               !string.IsNullOrWhiteSpace(hardwareHashUploadSettings.BootMediaCertificate.PfxPassword) &&
+                                               string.Equals(
+                                                   NormalizeThumbprint(hardwareHashUploadSettings.ActiveCertificate?.Thumbprint),
+                                                   NormalizeThumbprint(hardwareHashUploadSettings.BootMediaCertificate.ValidatedThumbprint),
+                                                   StringComparison.OrdinalIgnoreCase);
     public string ManagedAppRegistrationName => AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName;
     public string TenantStatusText => HasConnectedTenantInCurrentSession && HasTenantRegistration
         ? localizationService.GetString("Autopilot.HardwareHashTenantConnected")
@@ -168,6 +194,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         : localizationService.FormatString("Autopilot.HardwareHashAppRegistrationFoundFormat", ManagedAppRegistrationName);
     public string TenantOnboardingStatusText => CreateTenantOnboardingStatusText();
     public string CertificateStatusText => CreateCertificateStatusText();
+    public Visibility CertificateStatusVisibility => string.IsNullOrWhiteSpace(CertificateStatusText) ? Visibility.Collapsed : Visibility.Visible;
     public Brush CertificateStatusForeground => ResolveCertificateStatusBrush();
     public string DefaultGroupTagText => string.IsNullOrWhiteSpace(hardwareHashUploadSettings.DefaultGroupTag)
         ? localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagNone")
@@ -179,7 +206,11 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private bool HasTenantRegistration => !string.IsNullOrWhiteSpace(hardwareHashUploadSettings.Tenant.TenantId) &&
                                           !string.IsNullOrWhiteSpace(hardwareHashUploadSettings.Tenant.ClientId);
 
-    private bool HasConnectedTenantInCurrentSession { get; set; }
+    private bool HasConnectedTenantInCurrentSession
+    {
+        get => hardwareHashSessionState.HasConnectedTenant;
+        set => hardwareHashSessionState.HasConnectedTenant = value;
+    }
 
     [ObservableProperty]
     public partial string PageTitle { get; set; }
@@ -260,6 +291,18 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string CertificateIdColumnHeader { get; set; }
 
     [ObservableProperty]
+    public partial string BootMediaCertificateLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string BootMediaCertificatePfxPathLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string BootMediaCertificatePasswordLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string SelectBootMediaCertificateButtonText { get; set; }
+
+    [ObservableProperty]
     public partial string DefaultGroupTagLabel { get; set; }
 
     [ObservableProperty]
@@ -326,6 +369,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     [NotifyCanExecuteChangedFor(nameof(ConnectTenantCommand))]
     [NotifyCanExecuteChangedFor(nameof(CreateCertificateCommand))]
     [NotifyCanExecuteChangedFor(nameof(RetireActiveCertificateCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SelectBootMediaCertificatePfxCommand))]
     public partial bool IsAutopilotEnabled { get; set; }
 
     [ObservableProperty]
@@ -341,6 +385,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     [NotifyCanExecuteChangedFor(nameof(ConnectTenantCommand))]
     [NotifyCanExecuteChangedFor(nameof(CreateCertificateCommand))]
     [NotifyCanExecuteChangedFor(nameof(RetireActiveCertificateCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SelectBootMediaCertificatePfxCommand))]
     public partial bool IsImporting { get; set; }
 
     [ObservableProperty]
@@ -353,6 +398,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     [NotifyCanExecuteChangedFor(nameof(ConnectTenantCommand))]
     [NotifyCanExecuteChangedFor(nameof(CreateCertificateCommand))]
     [NotifyCanExecuteChangedFor(nameof(RetireActiveCertificateCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SelectBootMediaCertificatePfxCommand))]
     public partial bool IsDownloading { get; set; }
 
     [ObservableProperty]
@@ -365,6 +411,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     [NotifyCanExecuteChangedFor(nameof(ConnectTenantCommand))]
     [NotifyCanExecuteChangedFor(nameof(CreateCertificateCommand))]
     [NotifyCanExecuteChangedFor(nameof(RetireActiveCertificateCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SelectBootMediaCertificatePfxCommand))]
     public partial bool IsConnectingTenant { get; set; }
 
     [ObservableProperty]
@@ -384,6 +431,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         configurationStateService.StateChanged -= OnConfigurationStateChanged;
         Profiles.CollectionChanged -= OnProfilesCollectionChanged;
         SelectedProfiles.CollectionChanged -= OnSelectedProfilesCollectionChanged;
+        SelectedCertificates.CollectionChanged -= OnSelectedCertificatesCollectionChanged;
     }
 
     [RelayCommand(CanExecute = nameof(CanImportProfile))]
@@ -539,8 +587,10 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
             hardwareHashUploadSettings = result.Settings;
             tenantOnboardingStatus = result.Status;
+            hardwareHashSessionState.TenantOnboardingStatus = result.Status;
             HasConnectedTenantInCurrentSession = true;
             ReplaceCertificates(result.Certificates);
+            ClearBootMediaCertificateIfActiveCertificateChanged();
             RefreshHardwareHashUploadState();
             SaveState();
             logger.Information(
@@ -590,7 +640,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
                 SelectedCertificateValidityOption.Months);
             hardwareHashUploadSettings = result.Settings;
             tenantOnboardingStatus = AutopilotTenantOnboardingStatus.Ready;
+            hardwareHashSessionState.TenantOnboardingStatus = tenantOnboardingStatus;
             ReplaceCertificates(result.Certificates);
+            SetBootMediaCertificateInput(outputPath, result.GeneratedPassword);
             RefreshHardwareHashUploadState();
             SaveState();
 
@@ -612,9 +664,17 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     [RelayCommand(CanExecute = nameof(CanRetireActiveCertificate))]
     private async Task RetireActiveCertificateAsync()
     {
+        AutopilotCertificateEntryViewModel[] certificatesToRemove = SelectedCertificates.ToArray();
+        if (certificatesToRemove.Length == 0)
+        {
+            return;
+        }
+
         bool confirmed = await dialogService.ConfirmAsync(new ConfirmationDialogRequest(
             localizationService.GetString("Autopilot.HardwareHashRetireCertificateConfirmationTitle"),
-            localizationService.GetString("Autopilot.HardwareHashRetireCertificateConfirmationMessage"),
+            certificatesToRemove.Length == 1
+                ? localizationService.GetString("Autopilot.HardwareHashRetireCertificateConfirmationMessage")
+                : localizationService.FormatString("Autopilot.HardwareHashRetireCertificatesConfirmationMessageFormat", certificatesToRemove.Length),
             localizationService.GetString("Autopilot.HardwareHashRetireCertificateConfirmationPrimary"),
             localizationService.GetString("Common.Cancel")));
         if (!confirmed)
@@ -625,21 +685,28 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         IsConnectingTenant = true;
         try
         {
-            if (SelectedCertificate is null)
+            AutopilotCertificateRemovalResult? result = null;
+            foreach (AutopilotCertificateEntryViewModel certificate in certificatesToRemove)
+            {
+                result = await autopilotTenantOnboardingService.RemoveCertificateAsync(
+                    hardwareHashUploadSettings,
+                    certificate.KeyId);
+                hardwareHashUploadSettings = result.Settings;
+            }
+
+            if (result is null)
             {
                 return;
             }
 
-            AutopilotCertificateRemovalResult result = await autopilotTenantOnboardingService.RemoveCertificateAsync(
-                hardwareHashUploadSettings,
-                SelectedCertificate.KeyId);
-            hardwareHashUploadSettings = result.Settings;
             if (hardwareHashUploadSettings.ActiveCertificate is null)
             {
                 tenantOnboardingStatus = AutopilotTenantOnboardingStatus.ActiveCertificateMissing;
+                hardwareHashSessionState.TenantOnboardingStatus = tenantOnboardingStatus;
             }
 
             ReplaceCertificates(result.Certificates);
+            ClearBootMediaCertificateIfActiveCertificateChanged();
             RefreshHardwareHashUploadState();
             SaveState();
 
@@ -668,7 +735,48 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         ConnectTenantCommand.NotifyCanExecuteChanged();
         CreateCertificateCommand.NotifyCanExecuteChanged();
         RetireActiveCertificateCommand.NotifyCanExecuteChanged();
+        SelectBootMediaCertificatePfxCommand.NotifyCanExecuteChanged();
         SaveState();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanSelectBootMediaCertificatePfx))]
+    private async Task SelectBootMediaCertificatePfxAsync()
+    {
+        string? filePath = await filePickerService.PickOpenFileAsync(
+            new FileOpenPickerRequest(localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePfxPickerTitle"), [".pfx"]));
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            return;
+        }
+
+        SetBootMediaCertificateInput(filePath, hardwareHashUploadSettings.BootMediaCertificate.PfxPassword);
+        RefreshHardwareHashUploadState();
+        SaveState();
+    }
+
+    /// <summary>
+    /// Updates the session-only boot media PFX password after the password box changes.
+    /// </summary>
+    /// <param name="password">PFX password entered by the operator.</param>
+    public void SetBootMediaCertificatePassword(string password)
+    {
+        if (string.Equals(hardwareHashUploadSettings.BootMediaCertificate.PfxPassword, password, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        SetBootMediaCertificateInput(hardwareHashUploadSettings.BootMediaCertificate.PfxPath, password);
+        RefreshHardwareHashUploadState();
+        SaveState();
+    }
+
+    /// <summary>
+    /// Gets the session-only boot media PFX password for synchronizing the password box.
+    /// </summary>
+    /// <returns>The current session PFX password, or an empty string.</returns>
+    public string GetBootMediaCertificatePassword()
+    {
+        return hardwareHashUploadSettings.BootMediaCertificate.PfxPassword ?? string.Empty;
     }
 
     partial void OnSelectedDefaultProfileChanged(AutopilotProfileEntryViewModel? value)
@@ -685,8 +793,12 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             provisioningMode = Enum.IsDefined(settings.ProvisioningMode)
                 ? settings.ProvisioningMode
                 : AutopilotProvisioningMode.JsonProfile;
-            hardwareHashUploadSettings = settings.HardwareHashUpload ?? new AutopilotHardwareHashUploadSettings();
-            ReplaceCertificates([]);
+            hardwareHashUploadSettings = (settings.HardwareHashUpload ?? new AutopilotHardwareHashUploadSettings()) with
+            {
+                BootMediaCertificate = hardwareHashSessionState.BootMediaCertificate
+            };
+            tenantOnboardingStatus = hardwareHashSessionState.TenantOnboardingStatus;
+            ReplaceCertificates(HasConnectedTenantInCurrentSession ? hardwareHashSessionState.Certificates : []);
             ReplaceProfiles(
                 settings.Profiles.Select(AutopilotProfileEntryViewModel.FromSettings),
                 settings.DefaultProfileId);
@@ -792,6 +904,10 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         CertificateCreatedColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateCreatedColumn");
         CertificateExpiresColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateExpiresColumn");
         CertificateIdColumnHeader = localizationService.GetString("Autopilot.HardwareHashCertificateIdColumn");
+        BootMediaCertificateLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateLabel");
+        BootMediaCertificatePfxPathLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePfxPathLabel");
+        BootMediaCertificatePasswordLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePasswordLabel");
+        SelectBootMediaCertificateButtonText = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateSelectButton");
         DefaultGroupTagLabel = localizationService.GetString("Autopilot.HardwareHashDefaultGroupTagLabel");
         KnownGroupTagsLabel = localizationService.GetString("Autopilot.HardwareHashKnownGroupTagsLabel");
         ImportButtonText = localizationService.GetString("Autopilot.ImportButton");
@@ -852,13 +968,20 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         OnPropertyChanged(nameof(AppRegistrationStatusText));
         OnPropertyChanged(nameof(TenantOnboardingStatusText));
         OnPropertyChanged(nameof(CertificateStatusText));
+        OnPropertyChanged(nameof(CertificateStatusVisibility));
         OnPropertyChanged(nameof(CertificateStatusForeground));
         OnPropertyChanged(nameof(IsHardwareHashCertificateExpired));
         OnPropertyChanged(nameof(HardwareHashCertificateWarningVisibility));
         OnPropertyChanged(nameof(DefaultGroupTagText));
         OnPropertyChanged(nameof(KnownGroupTagsText));
         OnPropertyChanged(nameof(ConnectedTenantDetailsVisibility));
+        OnPropertyChanged(nameof(BootMediaCertificateVisibility));
+        OnPropertyChanged(nameof(BootMediaCertificatePfxPath));
+        OnPropertyChanged(nameof(BootMediaCertificateStatusText));
+        OnPropertyChanged(nameof(BootMediaCertificateStatusForeground));
+        OnPropertyChanged(nameof(IsBootMediaCertificateReady));
         RetireActiveCertificateCommand.NotifyCanExecuteChanged();
+        SelectBootMediaCertificatePfxCommand.NotifyCanExecuteChanged();
     }
 
     private void DisconnectTenantSession()
@@ -866,13 +989,16 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         HasConnectedTenantInCurrentSession = false;
         tenantOnboardingStatus = null;
         ReplaceCertificates([]);
+        ClearBootMediaCertificateInput();
+        hardwareHashSessionState.ClearTenantConnection();
         RefreshHardwareHashUploadState();
+        SaveState();
     }
 
     private void ReplaceCertificates(IReadOnlyList<AutopilotGraphKeyCredential> credentials)
     {
-        string? selectedKeyId = SelectedCertificate?.KeyId ?? hardwareHashUploadSettings.ActiveCertificate?.KeyId;
         Certificates.Clear();
+        SelectedCertificates.Clear();
         foreach (AutopilotCertificateEntryViewModel certificate in credentials
                      .OrderBy(certificate => certificate.ExpiresOnUtc)
                      .Select(AutopilotCertificateEntryViewModel.FromGraphCredential))
@@ -880,9 +1006,8 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
             Certificates.Add(certificate);
         }
 
-        SelectedCertificate = Certificates.FirstOrDefault(certificate =>
-                                  string.Equals(certificate.KeyId, selectedKeyId, StringComparison.OrdinalIgnoreCase))
-                              ?? Certificates.FirstOrDefault();
+        SelectedCertificate = null;
+        hardwareHashSessionState.Certificates = credentials;
         OnPropertyChanged(nameof(HasCertificates));
         OnPropertyChanged(nameof(CertificatesVisibility));
     }
@@ -902,7 +1027,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
         return certificate.ExpiresOnUtc <= DateTimeOffset.UtcNow
             ? localizationService.FormatString("Autopilot.HardwareHashCertificateExpiredFormat", certificate.ExpiresOnUtc.Value.LocalDateTime)
-            : localizationService.FormatString("Autopilot.HardwareHashCertificateValidFormat", certificate.ExpiresOnUtc.Value.LocalDateTime);
+            : string.Empty;
     }
 
     private Brush ResolveCertificateStatusBrush()
@@ -921,6 +1046,132 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         return expiresOnUtc - DateTimeOffset.UtcNow <= TimeSpan.FromDays(30)
             ? (Brush)Application.Current.Resources["SystemFillColorCautionBrush"]
             : (Brush)Application.Current.Resources["SystemFillColorSuccessBrush"];
+    }
+
+    private string CreateBootMediaCertificateStatusText()
+    {
+        if (hardwareHashUploadSettings.ActiveCertificate is null)
+        {
+            return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateActiveMissing");
+        }
+
+        if (IsHardwareHashCertificateExpired)
+        {
+            return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateActiveExpired");
+        }
+
+        if (string.IsNullOrWhiteSpace(hardwareHashUploadSettings.BootMediaCertificate.PfxPath))
+        {
+            return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePfxMissing");
+        }
+
+        if (isBootMediaCertificateFileMissing)
+        {
+            return localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateFileMissing");
+        }
+
+        return bootMediaCertificateValidationCode switch
+        {
+            AutopilotPfxValidationCode.Valid => localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateReady"),
+            AutopilotPfxValidationCode.PasswordRequired => localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePasswordMissing"),
+            AutopilotPfxValidationCode.ThumbprintMismatch => localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateThumbprintMismatch"),
+            AutopilotPfxValidationCode.PrivateKeyMissing => localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePrivateKeyMissing"),
+            AutopilotPfxValidationCode.ExpectedThumbprintRequired => localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateActiveMissing"),
+            AutopilotPfxValidationCode.InvalidPfx => localizationService.GetString("Autopilot.HardwareHashBootMediaCertificateInvalidPfx"),
+            _ => localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePfxMissing")
+        };
+    }
+
+    private Brush ResolveBootMediaCertificateStatusBrush()
+    {
+        if (IsBootMediaCertificateReady)
+        {
+            return (Brush)Application.Current.Resources["SystemFillColorSuccessBrush"];
+        }
+
+        if (IsHardwareHashCertificateExpired ||
+            isBootMediaCertificateFileMissing ||
+            bootMediaCertificateValidationCode is AutopilotPfxValidationCode.InvalidPfx
+                or AutopilotPfxValidationCode.PrivateKeyMissing
+                or AutopilotPfxValidationCode.ThumbprintMismatch)
+        {
+            return (Brush)Application.Current.Resources["SystemFillColorCriticalBrush"];
+        }
+
+        return (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"];
+    }
+
+    private void SetBootMediaCertificateInput(string? pfxPath, string? password)
+    {
+        string? normalizedPath = string.IsNullOrWhiteSpace(pfxPath) ? null : pfxPath.Trim();
+        AutopilotBootMediaCertificateSettings bootMediaCertificate = new()
+        {
+            PfxPath = normalizedPath,
+            PfxPassword = password
+        };
+
+        isBootMediaCertificateFileMissing = false;
+        bootMediaCertificateValidationCode = AutopilotPfxValidationCode.PfxRequired;
+        if (!string.IsNullOrWhiteSpace(normalizedPath))
+        {
+            if (File.Exists(normalizedPath))
+            {
+                try
+                {
+                    AutopilotPfxValidationResult validation = AutopilotPfxCertificateValidator.Validate(
+                        File.ReadAllBytes(normalizedPath),
+                        password,
+                        hardwareHashUploadSettings.ActiveCertificate?.Thumbprint);
+                    bootMediaCertificateValidationCode = validation.Code;
+                    if (validation.IsValid)
+                    {
+                        bootMediaCertificate = bootMediaCertificate with
+                        {
+                            ValidatedThumbprint = validation.Thumbprint,
+                            ValidatedExpiresOnUtc = validation.ExpiresOnUtc
+                        };
+                    }
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    bootMediaCertificateValidationCode = AutopilotPfxValidationCode.InvalidPfx;
+                }
+            }
+            else
+            {
+                isBootMediaCertificateFileMissing = true;
+            }
+        }
+
+        hardwareHashUploadSettings = hardwareHashUploadSettings with
+        {
+            BootMediaCertificate = bootMediaCertificate
+        };
+        hardwareHashSessionState.BootMediaCertificate = bootMediaCertificate;
+    }
+
+    private void ClearBootMediaCertificateIfActiveCertificateChanged()
+    {
+        string? activeThumbprint = NormalizeThumbprint(hardwareHashUploadSettings.ActiveCertificate?.Thumbprint);
+        string? validatedThumbprint = NormalizeThumbprint(hardwareHashUploadSettings.BootMediaCertificate.ValidatedThumbprint);
+        if (string.Equals(activeThumbprint, validatedThumbprint, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        ClearBootMediaCertificateInput();
+    }
+
+    private void ClearBootMediaCertificateInput()
+    {
+        bootMediaCertificateValidationCode = AutopilotPfxValidationCode.PfxRequired;
+        isBootMediaCertificateFileMissing = false;
+        hardwareHashUploadSettings = hardwareHashUploadSettings with
+        {
+            BootMediaCertificate = new AutopilotBootMediaCertificateSettings()
+        };
+        hardwareHashSessionState.BootMediaCertificate = hardwareHashUploadSettings.BootMediaCertificate;
+        OnPropertyChanged(nameof(BootMediaCertificatePfxPath));
     }
 
     private string CreateTenantOnboardingStatusText()
@@ -971,6 +1222,11 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         RemoveSelectedProfilesCommand.NotifyCanExecuteChanged();
     }
 
+    private void OnSelectedCertificatesCollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        RetireActiveCertificateCommand.NotifyCanExecuteChanged();
+    }
+
     /// <summary>
     /// Replaces the selected profile rows after a XAML selection change.
     /// </summary>
@@ -985,12 +1241,18 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     }
 
     /// <summary>
-    /// Replaces the selected certificate row after a XAML selection change.
+    /// Replaces the selected certificate rows after a XAML selection change.
     /// </summary>
     /// <param name="certificates">The selected certificate view models.</param>
     public void ReplaceSelectedCertificate(IEnumerable<AutopilotCertificateEntryViewModel> certificates)
     {
-        SelectedCertificate = certificates.FirstOrDefault();
+        SelectedCertificates.Clear();
+        foreach (AutopilotCertificateEntryViewModel certificate in certificates)
+        {
+            SelectedCertificates.Add(certificate);
+        }
+
+        SelectedCertificate = SelectedCertificates.FirstOrDefault();
     }
 
     private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
@@ -1045,7 +1307,23 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
                !IsBusy &&
                HasConnectedTenantInCurrentSession &&
                !string.IsNullOrWhiteSpace(hardwareHashUploadSettings.Tenant.ApplicationObjectId) &&
-               SelectedCertificate is not null;
+               SelectedCertificates.Count > 0;
+    }
+
+    private bool CanSelectBootMediaCertificatePfx()
+    {
+        return IsAutopilotEnabled &&
+               IsHardwareHashUploadMode &&
+               !IsBusy &&
+               HasConnectedTenantInCurrentSession &&
+               hardwareHashUploadSettings.ActiveCertificate is not null &&
+               !IsHardwareHashCertificateExpired;
+    }
+
+    private static string? NormalizeThumbprint(string? thumbprint)
+    {
+        string? normalized = thumbprint?.Replace(" ", string.Empty, StringComparison.Ordinal).Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized.ToUpperInvariant();
     }
 
     public sealed record CertificateValidityOptionViewModel(int Months, string DisplayName);

--- a/src/Foundry/ViewModels/AutopilotGroupTagEntryViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotGroupTagEntryViewModel.cs
@@ -1,0 +1,6 @@
+namespace Foundry.ViewModels;
+
+/// <summary>
+/// Represents one tenant-discovered Autopilot group tag for selection and display.
+/// </summary>
+public sealed record AutopilotGroupTagEntryViewModel(string GroupTag);

--- a/src/Foundry/ViewModels/AutopilotGroupTagEntryViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotGroupTagEntryViewModel.cs
@@ -3,4 +3,4 @@ namespace Foundry.ViewModels;
 /// <summary>
 /// Represents one tenant-discovered Autopilot group tag for selection and display.
 /// </summary>
-public sealed record AutopilotGroupTagEntryViewModel(string GroupTag);
+public sealed record AutopilotGroupTagEntryViewModel(string DisplayName, string? GroupTag);

--- a/src/Foundry/ViewModels/AutopilotTenantDetailEntryViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotTenantDetailEntryViewModel.cs
@@ -1,0 +1,6 @@
+namespace Foundry.ViewModels;
+
+/// <summary>
+/// Represents one tenant metadata row displayed after a successful tenant connection.
+/// </summary>
+public sealed record AutopilotTenantDetailEntryViewModel(string Name, string Value);

--- a/src/Foundry/ViewModels/AutopilotTenantDetailEntryViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotTenantDetailEntryViewModel.cs
@@ -1,6 +1,0 @@
-namespace Foundry.ViewModels;
-
-/// <summary>
-/// Represents one tenant metadata row displayed after a successful tenant connection.
-/// </summary>
-public sealed record AutopilotTenantDetailEntryViewModel(string Name, string Value);

--- a/src/Foundry/ViewModels/AutopilotTenantReadinessEntryViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotTenantReadinessEntryViewModel.cs
@@ -1,0 +1,8 @@
+using Microsoft.UI.Xaml.Media;
+
+namespace Foundry.ViewModels;
+
+/// <summary>
+/// Represents one tenant readiness value displayed in the Autopilot hardware hash upload configuration.
+/// </summary>
+public sealed record AutopilotTenantReadinessEntryViewModel(string Name, string Value, Brush? ValueForeground);

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Text;
 using Foundry.Core.Models.Configuration;
 using Foundry.Core.Services.Application;
+using Foundry.Core.Services.Configuration;
 using Foundry.Core.Services.Media;
 using Foundry.Core.Services.Telemetry;
 using Foundry.Core.Services.WinPe;
@@ -1204,6 +1205,8 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             vendors.Add(WinPeVendorSelection.Hp);
         }
 
+        AutopilotConfigurationValidationResult autopilotValidation = foundryConfigurationStateService.AutopilotConfigurationValidation;
+
         return new MediaPreflightOptions
         {
             IsAdkReady = adkService.CurrentStatus.CanCreateMedia,
@@ -1212,7 +1215,8 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             IsConnectProvisioningReady = foundryConfigurationStateService.IsConnectProvisioningReady,
             AreRequiredSecretsReady = foundryConfigurationStateService.AreRequiredSecretsReady,
             IsAutopilotEnabled = foundryConfigurationStateService.IsAutopilotEnabled,
-            IsAutopilotConfigurationReady = foundryConfigurationStateService.IsAutopilotConfigurationReady,
+            IsAutopilotConfigurationReady = autopilotValidation.IsReady,
+            AutopilotConfigurationValidationCode = autopilotValidation.Code,
             AutopilotProvisioningMode = foundryConfigurationStateService.AutopilotProvisioningMode,
             AutopilotProfileDisplayName = foundryConfigurationStateService.SelectedAutopilotProfileDisplayName,
             AutopilotProfileFolderName = foundryConfigurationStateService.SelectedAutopilotProfileFolderName,
@@ -1526,7 +1530,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             options.IsAutopilotConfigurationReady ? StartReadinessState.Ready : StartReadinessState.Blocked,
             options.IsAutopilotConfigurationReady
                 ? FormatAutopilot(options)
-                : GetBlockingReasonText(MediaPreflightBlockingReason.AutopilotConfigurationNotReady),
+                : GetAutopilotValidationText(options.AutopilotConfigurationValidationCode),
             options.IsAutopilotConfigurationReady ? StartReadinessNavigationTarget.None : StartReadinessNavigationTarget.Autopilot);
     }
 
@@ -1783,7 +1787,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
         if (!options.IsAutopilotConfigurationReady)
         {
-            return localizationService.GetString("StartMedia.Autopilot.NotReady");
+            return GetAutopilotValidationText(options.AutopilotConfigurationValidationCode);
         }
 
         if (options.AutopilotProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload)
@@ -1795,6 +1799,15 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             localizationService.GetString("StartMedia.Autopilot.ProfileFormat"),
             FormatValue(options.AutopilotProfileDisplayName),
             FormatValue(options.AutopilotProfileFolderName));
+    }
+
+    private string GetAutopilotValidationText(AutopilotConfigurationValidationCode code)
+    {
+        string key = $"StartMedia.Autopilot.Validation.{code}";
+        string value = localizationService.GetString(key);
+        return string.Equals(value, key, StringComparison.Ordinal)
+            ? GetBlockingReasonText(MediaPreflightBlockingReason.AutopilotConfigurationNotReady)
+            : value;
     }
 
     private static string FormatValue(string? value)

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -221,6 +221,7 @@
                                         <tv:TableViewTemplateColumn.CellTemplate>
                                             <DataTemplate>
                                                 <TextBlock Foreground="{Binding ValidityForeground}"
+                                                           Margin="12,0,12,0"
                                                            Text="{Binding ExpiresOnDisplay}"
                                                            TextTrimming="CharacterEllipsis" />
                                             </DataTemplate>
@@ -267,17 +268,43 @@
                     <wct:SettingsCard Header="{x:Bind ViewModel.DefaultGroupTagLabel, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
-                        <TextBlock HorizontalAlignment="Right"
-                                   Text="{x:Bind ViewModel.DefaultGroupTagText, Mode=OneWay}"
-                                   TextWrapping="WrapWholeWords" />
+                        <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                  HorizontalAlignment="Right"
+                                  DisplayMemberPath="GroupTag"
+                                  ItemsSource="{x:Bind ViewModel.AvailableGroupTags, Mode=OneWay}"
+                                  PlaceholderText="{x:Bind ViewModel.DefaultGroupTagText, Mode=OneWay}"
+                                  SelectedItem="{x:Bind ViewModel.SelectedDefaultGroupTag, Mode=TwoWay}" />
                     </wct:SettingsCard>
 
                     <wct:SettingsCard Header="{x:Bind ViewModel.KnownGroupTagsLabel, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
-                        <TextBlock HorizontalAlignment="Right"
-                                   Text="{x:Bind ViewModel.KnownGroupTagsText, Mode=OneWay}"
-                                   TextWrapping="WrapWholeWords" />
+                        <StackPanel HorizontalAlignment="Right">
+                            <tv:TableView AutoGenerateColumns="False"
+                                          CanFilterColumns="False"
+                                          CanReorderColumns="False"
+                                          CanResizeColumns="False"
+                                          CanSortColumns="False"
+                                          CornerButtonMode="None"
+                                          HeadersVisibility="Columns"
+                                          IsReadOnly="True"
+                                          ItemsSource="{x:Bind ViewModel.AvailableGroupTags, Mode=OneWay}"
+                                          MaxHeight="{ThemeResource FoundryTableMaxHeight}"
+                                          MinWidth="{ThemeResource FoundryWideInputMinWidth}"
+                                          SelectionMode="None"
+                                          SelectionUnit="Row"
+                                          ShowExportOptions="False"
+                                          Visibility="{x:Bind ViewModel.AvailableGroupTagsVisibility, Mode=OneWay}">
+                                <tv:TableView.Columns>
+                                    <tv:TableViewTextColumn Binding="{Binding GroupTag}"
+                                                            Header="{x:Bind ViewModel.AvailableGroupTagColumnHeader, Mode=OneWay}" />
+                                </tv:TableView.Columns>
+                            </tv:TableView>
+                            <TextBlock HorizontalAlignment="Right"
+                                       Text="{x:Bind ViewModel.KnownGroupTagsText, Mode=OneWay}"
+                                       TextWrapping="WrapWholeWords"
+                                       Visibility="{x:Bind ViewModel.EmptyAvailableGroupTagsVisibility, Mode=OneWay}" />
+                        </StackPanel>
                     </wct:SettingsCard>
                 </wct:SettingsExpander.Items>
             </wct:SettingsExpander>

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -172,12 +172,30 @@
                             <TextBlock HorizontalAlignment="Right"
                                        Foreground="{x:Bind ViewModel.CertificateStatusForeground, Mode=OneWay}"
                                        Text="{x:Bind ViewModel.CertificateStatusText, Mode=OneWay}"
-                                       TextWrapping="WrapWholeWords" />
+                                       TextWrapping="WrapWholeWords"
+                                       Visibility="{x:Bind ViewModel.CertificateStatusVisibility, Mode=OneWay}" />
                             <TextBlock Foreground="{ThemeResource SystemFillColorCriticalBrush}"
                                        HorizontalAlignment="Right"
                                        Text="{x:Bind ViewModel.CertificateExpiredWarningText, Mode=OneWay}"
                                        TextWrapping="WrapWholeWords"
                                        Visibility="{x:Bind ViewModel.HardwareHashCertificateWarningVisibility, Mode=OneWay}" />
+                            <StackPanel HorizontalAlignment="Right"
+                                        Orientation="Horizontal"
+                                        Spacing="{ThemeResource FoundryInlineControlSpacing}">
+                                <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                          DisplayMemberPath="DisplayName"
+                                          Header="{x:Bind ViewModel.CertificateValidityLabel, Mode=OneWay}"
+                                          ItemsSource="{x:Bind ViewModel.CertificateValidityOptions, Mode=OneWay}"
+                                          SelectedItem="{x:Bind ViewModel.SelectedCertificateValidityOption, Mode=TwoWay}" />
+                                <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                        VerticalAlignment="Bottom"
+                                        Command="{x:Bind ViewModel.CreateCertificateCommand}"
+                                        Content="{x:Bind ViewModel.CreateCertificateButtonText, Mode=OneWay}" />
+                                <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                        VerticalAlignment="Bottom"
+                                        Command="{x:Bind ViewModel.RetireActiveCertificateCommand}"
+                                        Content="{x:Bind ViewModel.RetireCertificateButtonText, Mode=OneWay}" />
+                            </StackPanel>
                             <tv:TableView x:Name="CertificatesTable"
                                           AutoGenerateColumns="False"
                                           CanFilterColumns="False"
@@ -190,7 +208,7 @@
                                           ItemsSource="{x:Bind ViewModel.Certificates, Mode=OneWay}"
                                           MaxHeight="{ThemeResource FoundryTableMaxHeight}"
                                           SelectionChanged="CertificatesTable_SelectionChanged"
-                                          SelectionMode="Single"
+                                          SelectionMode="Multiple"
                                           SelectionUnit="Row"
                                           ShowExportOptions="False"
                                           Visibility="{x:Bind ViewModel.CertificatesVisibility, Mode=OneWay}">
@@ -212,23 +230,37 @@
                                                             Header="{x:Bind ViewModel.CertificateIdColumnHeader, Mode=OneWay}" />
                                 </tv:TableView.Columns>
                             </tv:TableView>
-                            <StackPanel HorizontalAlignment="Right"
-                                        Orientation="Horizontal"
-                                        Spacing="{ThemeResource FoundryInlineControlSpacing}">
-                                <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                          DisplayMemberPath="DisplayName"
-                                          Header="{x:Bind ViewModel.CertificateValidityLabel, Mode=OneWay}"
-                                          ItemsSource="{x:Bind ViewModel.CertificateValidityOptions, Mode=OneWay}"
-                                          SelectedItem="{x:Bind ViewModel.SelectedCertificateValidityOption, Mode=TwoWay}" />
-                                <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                        </StackPanel>
+                    </wct:SettingsCard>
+
+                    <wct:SettingsCard Header="{x:Bind ViewModel.BootMediaCertificateLabel, Mode=OneWay}"
+                                      HorizontalContentAlignment="Stretch"
+                                      Visibility="{x:Bind ViewModel.BootMediaCertificateVisibility, Mode=OneWay}">
+                        <StackPanel HorizontalAlignment="Right"
+                                    Spacing="{ThemeResource FoundrySpace8}">
+                            <Grid ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <TextBox MinWidth="{ThemeResource FoundryWideInputMinWidth}"
+                                         Header="{x:Bind ViewModel.BootMediaCertificatePfxPathLabel, Mode=OneWay}"
+                                         IsReadOnly="True"
+                                         Text="{x:Bind ViewModel.BootMediaCertificatePfxPath, Mode=OneWay}" />
+                                <Button Grid.Column="1"
+                                        MinWidth="{StaticResource SettingActionControlMinWidth}"
                                         VerticalAlignment="Bottom"
-                                        Command="{x:Bind ViewModel.CreateCertificateCommand}"
-                                        Content="{x:Bind ViewModel.CreateCertificateButtonText, Mode=OneWay}" />
-                                <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                        VerticalAlignment="Bottom"
-                                        Command="{x:Bind ViewModel.RetireActiveCertificateCommand}"
-                                        Content="{x:Bind ViewModel.RetireCertificateButtonText, Mode=OneWay}" />
-                            </StackPanel>
+                                        Command="{x:Bind ViewModel.SelectBootMediaCertificatePfxCommand}"
+                                        Content="{x:Bind ViewModel.SelectBootMediaCertificateButtonText, Mode=OneWay}" />
+                            </Grid>
+                            <PasswordBox x:Name="BootMediaCertificatePasswordBox"
+                                         MinWidth="{ThemeResource FoundryWideInputMinWidth}"
+                                         Header="{x:Bind ViewModel.BootMediaCertificatePasswordLabel, Mode=OneWay}"
+                                         Loaded="BootMediaCertificatePasswordBox_OnLoaded"
+                                         PasswordChanged="BootMediaCertificatePasswordBox_OnPasswordChanged" />
+                            <TextBlock Foreground="{x:Bind ViewModel.BootMediaCertificateStatusForeground, Mode=OneWay}"
+                                       Text="{x:Bind ViewModel.BootMediaCertificateStatusText, Mode=OneWay}"
+                                       TextWrapping="WrapWholeWords" />
                         </StackPanel>
                     </wct:SettingsCard>
 

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -265,11 +265,6 @@
                                       Visibility="{x:Bind ViewModel.BootMediaCertificateVisibility, Mode=OneWay}">
                         <StackPanel HorizontalAlignment="Right"
                                     Spacing="{ThemeResource FoundrySpace8}">
-                            <ComboBox MinWidth="{ThemeResource FoundryWideInputMinWidth}"
-                                      DisplayMemberPath="SelectionDisplayName"
-                                      Header="{x:Bind ViewModel.BootMediaCertificateTenantCertificateLabel, Mode=OneWay}"
-                                      ItemsSource="{x:Bind ViewModel.Certificates, Mode=OneWay}"
-                                      SelectedItem="{x:Bind ViewModel.SelectedBootMediaCertificate, Mode=TwoWay}" />
                             <Grid ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -138,6 +138,7 @@
                                     Orientation="Horizontal"
                                     Spacing="{ThemeResource FoundryInlineControlSpacing}">
                             <TextBlock VerticalAlignment="Center"
+                                       Foreground="{x:Bind ViewModel.TenantStatusForeground, Mode=OneWay}"
                                        Text="{x:Bind ViewModel.TenantStatusText, Mode=OneWay}" />
                             <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     Command="{x:Bind ViewModel.ConnectTenantCommand}"
@@ -149,52 +150,36 @@
                                       Description="{x:Bind ViewModel.TenantReadinessDescription, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
-                        <Grid MinWidth="{ThemeResource FoundryWideInputMinWidth}"
-                              HorizontalAlignment="Right"
-                              ColumnSpacing="{ThemeResource FoundrySpace12}"
-                              RowSpacing="{ThemeResource FoundrySpace8}">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
-                            </Grid.RowDefinitions>
-
-                            <TextBlock Text="{x:Bind ViewModel.AppRegistrationLabel, Mode=OneWay}" />
-                            <TextBlock Grid.Column="1"
-                                       HorizontalAlignment="Right"
-                                       Text="{x:Bind ViewModel.AppRegistrationStatusText, Mode=OneWay}"
-                                       TextWrapping="WrapWholeWords" />
-
-                            <TextBlock Grid.Row="1"
-                                       Text="{x:Bind ViewModel.TenantDetailsTenantIdLabel, Mode=OneWay}" />
-                            <TextBlock Grid.Row="1"
-                                       Grid.Column="1"
-                                       HorizontalAlignment="Right"
-                                       Text="{x:Bind ViewModel.TenantIdText, Mode=OneWay}"
-                                       TextWrapping="WrapWholeWords" />
-
-                            <TextBlock Grid.Row="2"
-                                       Text="{x:Bind ViewModel.TenantDetailsClientIdLabel, Mode=OneWay}" />
-                            <TextBlock Grid.Row="2"
-                                       Grid.Column="1"
-                                       HorizontalAlignment="Right"
-                                       Text="{x:Bind ViewModel.ClientIdText, Mode=OneWay}"
-                                       TextWrapping="WrapWholeWords" />
-
-                            <TextBlock Grid.Row="3"
-                                       Text="{x:Bind ViewModel.TenantOnboardingStatusLabel, Mode=OneWay}" />
-                            <TextBlock Grid.Row="3"
-                                       Grid.Column="1"
-                                       HorizontalAlignment="Right"
-                                       Foreground="{x:Bind ViewModel.TenantOnboardingStatusForeground, Mode=OneWay}"
-                                       Text="{x:Bind ViewModel.TenantOnboardingStatusText, Mode=OneWay}"
-                                       TextWrapping="WrapWholeWords" />
-                        </Grid>
+                        <tv:TableView AutoGenerateColumns="False"
+                                      CanFilterColumns="False"
+                                      CanReorderColumns="False"
+                                      CanResizeColumns="False"
+                                      CanSortColumns="False"
+                                      CornerButtonMode="None"
+                                      HeadersVisibility="Columns"
+                                      HorizontalAlignment="Right"
+                                      IsReadOnly="True"
+                                      ItemsSource="{x:Bind ViewModel.TenantReadinessEntries, Mode=OneWay}"
+                                      MaxHeight="{ThemeResource FoundryTableMaxHeight}"
+                                      MinWidth="{ThemeResource FoundryWideInputMinWidth}"
+                                      SelectionMode="None"
+                                      SelectionUnit="Row"
+                                      ShowExportOptions="False">
+                            <tv:TableView.Columns>
+                                <tv:TableViewTextColumn Binding="{Binding Name}"
+                                                        Header="{x:Bind ViewModel.TenantReadinessNameColumnHeader, Mode=OneWay}" />
+                                <tv:TableViewTemplateColumn Header="{x:Bind ViewModel.TenantReadinessValueColumnHeader, Mode=OneWay}">
+                                    <tv:TableViewTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Foreground="{Binding ValueForeground}"
+                                                       Margin="12,0,12,0"
+                                                       Text="{Binding Value}"
+                                                       TextTrimming="CharacterEllipsis" />
+                                        </DataTemplate>
+                                    </tv:TableViewTemplateColumn.CellTemplate>
+                                </tv:TableViewTemplateColumn>
+                            </tv:TableView.Columns>
+                        </tv:TableView>
                     </wct:SettingsCard>
 
                     <wct:SettingsCard Header="{x:Bind ViewModel.CertificateActionsLabel, Mode=OneWay}"

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -160,14 +160,53 @@
                     <wct:SettingsCard Header="{x:Bind ViewModel.CertificateStatusLabel, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.HardwareHashSettingsVisibility, Mode=OneWay}">
-                        <StackPanel HorizontalAlignment="Right"
-                                    Spacing="{ThemeResource FoundrySpace8}">
-                            <TextBlock Text="{x:Bind ViewModel.CertificateStatusText, Mode=OneWay}"
+                        <StackPanel Spacing="{ThemeResource FoundrySpace8}">
+                            <TextBlock HorizontalAlignment="Right"
+                                       Foreground="{x:Bind ViewModel.CertificateStatusForeground, Mode=OneWay}"
+                                       Text="{x:Bind ViewModel.CertificateStatusText, Mode=OneWay}"
                                        TextWrapping="WrapWholeWords" />
                             <TextBlock Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                       HorizontalAlignment="Right"
                                        Text="{x:Bind ViewModel.CertificateExpiredWarningText, Mode=OneWay}"
                                        TextWrapping="WrapWholeWords"
                                        Visibility="{x:Bind ViewModel.HardwareHashCertificateWarningVisibility, Mode=OneWay}" />
+                            <TextBlock Text="{x:Bind ViewModel.CertificatesEmptyText, Mode=OneWay}"
+                                       TextWrapping="Wrap"
+                                       Visibility="{x:Bind ViewModel.EmptyCertificatesVisibility, Mode=OneWay}" />
+                            <tv:TableView x:Name="CertificatesTable"
+                                          AutoGenerateColumns="False"
+                                          CanFilterColumns="False"
+                                          CanReorderColumns="False"
+                                          CanResizeColumns="False"
+                                          CanSortColumns="False"
+                                          CornerButtonMode="None"
+                                          HeadersVisibility="Columns"
+                                          IsReadOnly="True"
+                                          ItemsSource="{x:Bind ViewModel.Certificates, Mode=OneWay}"
+                                          MaxHeight="{ThemeResource FoundryTableMaxHeight}"
+                                          SelectionChanged="CertificatesTable_SelectionChanged"
+                                          SelectionMode="Single"
+                                          SelectionUnit="Row"
+                                          ShowExportOptions="False"
+                                          Visibility="{x:Bind ViewModel.CertificatesVisibility, Mode=OneWay}">
+                                <tv:TableView.Columns>
+                                    <tv:TableViewTextColumn Binding="{Binding Thumbprint}"
+                                                            Header="{x:Bind ViewModel.CertificateThumbprintColumnHeader, Mode=OneWay}" />
+                                    <tv:TableViewTextColumn Binding="{Binding StartsOnDisplay}"
+                                                            Header="{x:Bind ViewModel.CertificateCreatedColumnHeader, Mode=OneWay}" />
+                                    <tv:TableViewTemplateColumn Header="{x:Bind ViewModel.CertificateExpiresColumnHeader, Mode=OneWay}">
+                                        <tv:TableViewTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Foreground="{Binding ValidityForeground}"
+                                                           Text="{Binding ExpiresOnDisplay}"
+                                                           TextTrimming="CharacterEllipsis" />
+                                            </DataTemplate>
+                                        </tv:TableViewTemplateColumn.CellTemplate>
+                                    </tv:TableViewTemplateColumn>
+                                    <tv:TableViewTextColumn Binding="{Binding KeyId}"
+                                                            Header="{x:Bind ViewModel.CertificateIdColumnHeader, Mode=OneWay}" />
+                                </tv:TableView.Columns>
+                            </tv:TableView>
                             <StackPanel HorizontalAlignment="Right"
                                         Orientation="Horizontal"
                                         Spacing="{ThemeResource FoundryInlineControlSpacing}">

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -145,49 +145,56 @@
                         </StackPanel>
                     </wct:SettingsCard>
 
-                    <wct:SettingsCard Header="{x:Bind ViewModel.AppRegistrationLabel, Mode=OneWay}"
-                                      Description="{x:Bind ViewModel.AppRegistrationDescription, Mode=OneWay}"
+                    <wct:SettingsCard Header="{x:Bind ViewModel.TenantReadinessLabel, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.TenantReadinessDescription, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
-                        <TextBlock HorizontalAlignment="Right"
-                                   Text="{x:Bind ViewModel.AppRegistrationStatusText, Mode=OneWay}"
-                                   TextWrapping="WrapWholeWords" />
-                    </wct:SettingsCard>
+                        <Grid MinWidth="{ThemeResource FoundryWideInputMinWidth}"
+                              HorizontalAlignment="Right"
+                              ColumnSpacing="{ThemeResource FoundrySpace12}"
+                              RowSpacing="{ThemeResource FoundrySpace8}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
 
-                    <wct:SettingsCard Header="{x:Bind ViewModel.TenantDetailsLabel, Mode=OneWay}"
-                                      Description="{x:Bind ViewModel.TenantDetailsDescription, Mode=OneWay}"
-                                      HorizontalContentAlignment="Stretch"
-                                      Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
-                        <tv:TableView AutoGenerateColumns="False"
-                                      CanFilterColumns="False"
-                                      CanReorderColumns="False"
-                                      CanResizeColumns="False"
-                                      CanSortColumns="False"
-                                      CornerButtonMode="None"
-                                      HeadersVisibility="Columns"
-                                      HorizontalAlignment="Right"
-                                      IsReadOnly="True"
-                                      ItemsSource="{x:Bind ViewModel.TenantDetails, Mode=OneWay}"
-                                      SelectionMode="None"
-                                      SelectionUnit="Row"
-                                      ShowExportOptions="False">
-                            <tv:TableView.Columns>
-                                <tv:TableViewTextColumn Binding="{Binding Name}"
-                                                        Header="{x:Bind ViewModel.TenantDetailsNameColumnHeader, Mode=OneWay}" />
-                                <tv:TableViewTextColumn Binding="{Binding Value}"
-                                                        Header="{x:Bind ViewModel.TenantDetailsValueColumnHeader, Mode=OneWay}" />
-                            </tv:TableView.Columns>
-                        </tv:TableView>
-                    </wct:SettingsCard>
+                            <TextBlock Text="{x:Bind ViewModel.AppRegistrationLabel, Mode=OneWay}" />
+                            <TextBlock Grid.Column="1"
+                                       HorizontalAlignment="Right"
+                                       Text="{x:Bind ViewModel.AppRegistrationStatusText, Mode=OneWay}"
+                                       TextWrapping="WrapWholeWords" />
 
-                    <wct:SettingsCard Header="{x:Bind ViewModel.TenantOnboardingStatusLabel, Mode=OneWay}"
-                                      Description="{x:Bind ViewModel.TenantOnboardingStatusDescription, Mode=OneWay}"
-                                      HorizontalContentAlignment="Stretch"
-                                      Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
-                        <TextBlock HorizontalAlignment="Right"
-                                   Foreground="{x:Bind ViewModel.TenantOnboardingStatusForeground, Mode=OneWay}"
-                                   Text="{x:Bind ViewModel.TenantOnboardingStatusText, Mode=OneWay}"
-                                   TextWrapping="WrapWholeWords" />
+                            <TextBlock Grid.Row="1"
+                                       Text="{x:Bind ViewModel.TenantDetailsTenantIdLabel, Mode=OneWay}" />
+                            <TextBlock Grid.Row="1"
+                                       Grid.Column="1"
+                                       HorizontalAlignment="Right"
+                                       Text="{x:Bind ViewModel.TenantIdText, Mode=OneWay}"
+                                       TextWrapping="WrapWholeWords" />
+
+                            <TextBlock Grid.Row="2"
+                                       Text="{x:Bind ViewModel.TenantDetailsClientIdLabel, Mode=OneWay}" />
+                            <TextBlock Grid.Row="2"
+                                       Grid.Column="1"
+                                       HorizontalAlignment="Right"
+                                       Text="{x:Bind ViewModel.ClientIdText, Mode=OneWay}"
+                                       TextWrapping="WrapWholeWords" />
+
+                            <TextBlock Grid.Row="3"
+                                       Text="{x:Bind ViewModel.TenantOnboardingStatusLabel, Mode=OneWay}" />
+                            <TextBlock Grid.Row="3"
+                                       Grid.Column="1"
+                                       HorizontalAlignment="Right"
+                                       Foreground="{x:Bind ViewModel.TenantOnboardingStatusForeground, Mode=OneWay}"
+                                       Text="{x:Bind ViewModel.TenantOnboardingStatusText, Mode=OneWay}"
+                                       TextWrapping="WrapWholeWords" />
+                        </Grid>
                     </wct:SettingsCard>
 
                     <wct:SettingsCard Header="{x:Bind ViewModel.CertificateActionsLabel, Mode=OneWay}"

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -270,8 +270,8 @@
                                       Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
                         <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
                                   HorizontalAlignment="Right"
-                                  DisplayMemberPath="GroupTag"
-                                  ItemsSource="{x:Bind ViewModel.AvailableGroupTags, Mode=OneWay}"
+                                  DisplayMemberPath="DisplayName"
+                                  ItemsSource="{x:Bind ViewModel.DefaultGroupTagOptions, Mode=OneWay}"
                                   PlaceholderText="{x:Bind ViewModel.DefaultGroupTagText, Mode=OneWay}"
                                   SelectedItem="{x:Bind ViewModel.SelectedDefaultGroupTag, Mode=TwoWay}" />
                     </wct:SettingsCard>
@@ -290,13 +290,13 @@
                                           IsReadOnly="True"
                                           ItemsSource="{x:Bind ViewModel.AvailableGroupTags, Mode=OneWay}"
                                           MaxHeight="{ThemeResource FoundryTableMaxHeight}"
-                                          MinWidth="{ThemeResource FoundryWideInputMinWidth}"
+                                          HorizontalAlignment="Right"
                                           SelectionMode="None"
                                           SelectionUnit="Row"
                                           ShowExportOptions="False"
                                           Visibility="{x:Bind ViewModel.AvailableGroupTagsVisibility, Mode=OneWay}">
                                 <tv:TableView.Columns>
-                                    <tv:TableViewTextColumn Binding="{Binding GroupTag}"
+                                    <tv:TableViewTextColumn Binding="{Binding DisplayName}"
                                                             Header="{x:Bind ViewModel.AvailableGroupTagColumnHeader, Mode=OneWay}" />
                                 </tv:TableView.Columns>
                             </tv:TableView>

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -296,57 +296,12 @@
                                       Description="{x:Bind ViewModel.GroupTagDescription, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
-                        <Grid HorizontalAlignment="Right"
-                              ColumnSpacing="{ThemeResource FoundrySpace12}">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <Grid ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}"
-                                  VerticalAlignment="Top">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <TextBlock VerticalAlignment="Center"
-                                           Text="{x:Bind ViewModel.DefaultGroupTagLabel, Mode=OneWay}" />
-                                <ComboBox Grid.Column="1"
-                                          MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                           DisplayMemberPath="DisplayName"
-                                           ItemsSource="{x:Bind ViewModel.DefaultGroupTagOptions, Mode=OneWay}"
-                                           PlaceholderText="{x:Bind ViewModel.DefaultGroupTagText, Mode=OneWay}"
-                                           SelectedItem="{x:Bind ViewModel.SelectedDefaultGroupTag, Mode=TwoWay}" />
-                            </Grid>
-                            <StackPanel Grid.Column="1"
-                                        Width="{ThemeResource FoundryMediumInputMinWidth}"
-                                        VerticalAlignment="Top"
-                                        Spacing="{ThemeResource FoundrySpace8}">
-                                <TextBlock Text="{x:Bind ViewModel.KnownGroupTagsLabel, Mode=OneWay}" />
-                                <tv:TableView AutoGenerateColumns="False"
-                                              CanFilterColumns="False"
-                                              CanReorderColumns="False"
-                                              CanResizeColumns="False"
-                                              CanSortColumns="False"
-                                              CornerButtonMode="None"
-                                              HeadersVisibility="Columns"
-                                              IsReadOnly="True"
-                                              ItemsSource="{x:Bind ViewModel.AvailableGroupTags, Mode=OneWay}"
-                                              MaxHeight="120"
-                                              SelectionMode="None"
-                                              SelectionUnit="Row"
-                                              ShowExportOptions="False"
-                                              Visibility="{x:Bind ViewModel.AvailableGroupTagsVisibility, Mode=OneWay}">
-                                    <tv:TableView.Columns>
-                                        <tv:TableViewTextColumn Binding="{Binding DisplayName}"
-                                                                Header="{x:Bind ViewModel.AvailableGroupTagColumnHeader, Mode=OneWay}" />
-                                    </tv:TableView.Columns>
-                                </tv:TableView>
-                                <TextBlock HorizontalAlignment="Right"
-                                           Text="{x:Bind ViewModel.KnownGroupTagsText, Mode=OneWay}"
-                                           TextWrapping="WrapWholeWords"
-                                           Visibility="{x:Bind ViewModel.EmptyAvailableGroupTagsVisibility, Mode=OneWay}" />
-                            </StackPanel>
-                        </Grid>
+                        <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                  HorizontalAlignment="Right"
+                                  DisplayMemberPath="DisplayName"
+                                  ItemsSource="{x:Bind ViewModel.DefaultGroupTagOptions, Mode=OneWay}"
+                                  PlaceholderText="{x:Bind ViewModel.DefaultGroupTagText, Mode=OneWay}"
+                                  SelectedItem="{x:Bind ViewModel.SelectedDefaultGroupTag, Mode=TwoWay}" />
                     </wct:SettingsCard>
                 </wct:SettingsExpander.Items>
             </wct:SettingsExpander>

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -143,7 +143,7 @@
 
                     <wct:SettingsCard Header="{x:Bind ViewModel.AppRegistrationLabel, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
-                                      Visibility="{x:Bind ViewModel.HardwareHashSettingsVisibility, Mode=OneWay}">
+                                      Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
                         <TextBlock HorizontalAlignment="Right"
                                    Text="{x:Bind ViewModel.AppRegistrationStatusText, Mode=OneWay}"
                                    TextWrapping="WrapWholeWords" />
@@ -151,7 +151,7 @@
 
                     <wct:SettingsCard Header="{x:Bind ViewModel.TenantOnboardingStatusLabel, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
-                                      Visibility="{x:Bind ViewModel.HardwareHashSettingsVisibility, Mode=OneWay}">
+                                      Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
                         <TextBlock HorizontalAlignment="Right"
                                    Text="{x:Bind ViewModel.TenantOnboardingStatusText, Mode=OneWay}"
                                    TextWrapping="WrapWholeWords" />
@@ -159,7 +159,7 @@
 
                     <wct:SettingsCard Header="{x:Bind ViewModel.CertificateStatusLabel, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
-                                      Visibility="{x:Bind ViewModel.HardwareHashSettingsVisibility, Mode=OneWay}">
+                                      Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
                         <StackPanel Spacing="{ThemeResource FoundrySpace8}">
                             <TextBlock HorizontalAlignment="Right"
                                        Foreground="{x:Bind ViewModel.CertificateStatusForeground, Mode=OneWay}"
@@ -229,7 +229,7 @@
 
                     <wct:SettingsCard Header="{x:Bind ViewModel.DefaultGroupTagLabel, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
-                                      Visibility="{x:Bind ViewModel.HardwareHashSettingsVisibility, Mode=OneWay}">
+                                      Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
                         <TextBlock HorizontalAlignment="Right"
                                    Text="{x:Bind ViewModel.DefaultGroupTagText, Mode=OneWay}"
                                    TextWrapping="WrapWholeWords" />
@@ -237,7 +237,7 @@
 
                     <wct:SettingsCard Header="{x:Bind ViewModel.KnownGroupTagsLabel, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
-                                      Visibility="{x:Bind ViewModel.HardwareHashSettingsVisibility, Mode=OneWay}">
+                                      Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
                         <TextBlock HorizontalAlignment="Right"
                                    Text="{x:Bind ViewModel.KnownGroupTagsText, Mode=OneWay}"
                                    TextWrapping="WrapWholeWords" />

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -190,37 +190,38 @@
                                    TextWrapping="WrapWholeWords" />
                     </wct:SettingsCard>
 
-                    <wct:SettingsCard Header="{x:Bind ViewModel.CertificateStatusLabel, Mode=OneWay}"
-                                      Description="{x:Bind ViewModel.CertificateStatusDescription, Mode=OneWay}"
+                    <wct:SettingsCard Header="{x:Bind ViewModel.CertificateActionsLabel, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.CertificateActionsDescription, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
-                        <StackPanel Spacing="{ThemeResource FoundrySpace8}">
+                        <StackPanel HorizontalAlignment="Right"
+                                    Orientation="Horizontal"
+                                    Spacing="{ThemeResource FoundryInlineControlSpacing}">
+                            <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                      DisplayMemberPath="DisplayName"
+                                      ItemsSource="{x:Bind ViewModel.CertificateValidityOptions, Mode=OneWay}"
+                                      SelectedItem="{x:Bind ViewModel.SelectedCertificateValidityOption, Mode=TwoWay}" />
+                            <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    VerticalAlignment="Bottom"
+                                    Command="{x:Bind ViewModel.CreateCertificateCommand}"
+                                    Content="{x:Bind ViewModel.CreateCertificateButtonText, Mode=OneWay}" />
+                            <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    VerticalAlignment="Bottom"
+                                    Command="{x:Bind ViewModel.RetireActiveCertificateCommand}"
+                                    Content="{x:Bind ViewModel.RetireCertificateButtonText, Mode=OneWay}" />
+                        </StackPanel>
+                    </wct:SettingsCard>
+
+                    <wct:SettingsCard Header="{x:Bind ViewModel.ProvisionedCertificatesLabel, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.ProvisionedCertificatesDescription, Mode=OneWay}"
+                                      HorizontalContentAlignment="Stretch"
+                                      Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
+                        <StackPanel HorizontalAlignment="Right"
+                                    Spacing="{ThemeResource FoundrySpace8}">
                             <TextBlock HorizontalAlignment="Right"
-                                       Foreground="{x:Bind ViewModel.CertificateStatusForeground, Mode=OneWay}"
-                                       Text="{x:Bind ViewModel.CertificateStatusText, Mode=OneWay}"
+                                       Text="{x:Bind ViewModel.EmptyCertificatesText, Mode=OneWay}"
                                        TextWrapping="WrapWholeWords"
-                                       Visibility="{x:Bind ViewModel.CertificateStatusVisibility, Mode=OneWay}" />
-                            <TextBlock Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                                       HorizontalAlignment="Right"
-                                       Text="{x:Bind ViewModel.CertificateExpiredWarningText, Mode=OneWay}"
-                                       TextWrapping="WrapWholeWords"
-                                       Visibility="{x:Bind ViewModel.HardwareHashCertificateWarningVisibility, Mode=OneWay}" />
-                            <StackPanel HorizontalAlignment="Right"
-                                        Orientation="Horizontal"
-                                        Spacing="{ThemeResource FoundryInlineControlSpacing}">
-                                <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                          DisplayMemberPath="DisplayName"
-                                          ItemsSource="{x:Bind ViewModel.CertificateValidityOptions, Mode=OneWay}"
-                                          SelectedItem="{x:Bind ViewModel.SelectedCertificateValidityOption, Mode=TwoWay}" />
-                                <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                        VerticalAlignment="Bottom"
-                                        Command="{x:Bind ViewModel.CreateCertificateCommand}"
-                                        Content="{x:Bind ViewModel.CreateCertificateButtonText, Mode=OneWay}" />
-                                <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                        VerticalAlignment="Bottom"
-                                        Command="{x:Bind ViewModel.RetireActiveCertificateCommand}"
-                                        Content="{x:Bind ViewModel.RetireCertificateButtonText, Mode=OneWay}" />
-                            </StackPanel>
+                                       Visibility="{x:Bind ViewModel.EmptyCertificatesVisibility, Mode=OneWay}" />
                             <tv:TableView x:Name="CertificatesTable"
                                           AutoGenerateColumns="False"
                                           CanFilterColumns="False"
@@ -291,47 +292,53 @@
                         </StackPanel>
                     </wct:SettingsCard>
 
-                    <wct:SettingsCard Header="{x:Bind ViewModel.DefaultGroupTagLabel, Mode=OneWay}"
-                                      Description="{x:Bind ViewModel.DefaultGroupTagDescription, Mode=OneWay}"
+                    <wct:SettingsCard Header="{x:Bind ViewModel.GroupTagLabel, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.GroupTagDescription, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
-                        <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                  HorizontalAlignment="Right"
-                                  DisplayMemberPath="DisplayName"
-                                  ItemsSource="{x:Bind ViewModel.DefaultGroupTagOptions, Mode=OneWay}"
-                                  PlaceholderText="{x:Bind ViewModel.DefaultGroupTagText, Mode=OneWay}"
-                                  SelectedItem="{x:Bind ViewModel.SelectedDefaultGroupTag, Mode=TwoWay}" />
-                    </wct:SettingsCard>
-
-                    <wct:SettingsCard Header="{x:Bind ViewModel.KnownGroupTagsLabel, Mode=OneWay}"
-                                      Description="{x:Bind ViewModel.KnownGroupTagsDescription, Mode=OneWay}"
-                                      HorizontalContentAlignment="Stretch"
-                                      Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
-                        <StackPanel HorizontalAlignment="Right">
-                            <tv:TableView AutoGenerateColumns="False"
-                                          CanFilterColumns="False"
-                                          CanReorderColumns="False"
-                                          CanResizeColumns="False"
-                                          CanSortColumns="False"
-                                          CornerButtonMode="None"
-                                          HeadersVisibility="Columns"
-                                          IsReadOnly="True"
-                                          ItemsSource="{x:Bind ViewModel.AvailableGroupTags, Mode=OneWay}"
-                                          MaxHeight="{ThemeResource FoundryTableMaxHeight}"
-                                          HorizontalAlignment="Right"
-                                          SelectionMode="None"
-                                          SelectionUnit="Row"
-                                          ShowExportOptions="False"
-                                          Visibility="{x:Bind ViewModel.AvailableGroupTagsVisibility, Mode=OneWay}">
-                                <tv:TableView.Columns>
-                                    <tv:TableViewTextColumn Binding="{Binding DisplayName}"
-                                                            Header="{x:Bind ViewModel.AvailableGroupTagColumnHeader, Mode=OneWay}" />
-                                </tv:TableView.Columns>
-                            </tv:TableView>
-                            <TextBlock HorizontalAlignment="Right"
-                                       Text="{x:Bind ViewModel.KnownGroupTagsText, Mode=OneWay}"
-                                       TextWrapping="WrapWholeWords"
-                                       Visibility="{x:Bind ViewModel.EmptyAvailableGroupTagsVisibility, Mode=OneWay}" />
+                        <StackPanel HorizontalAlignment="Right"
+                                    Spacing="{ThemeResource FoundrySpace12}">
+                            <Grid ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock VerticalAlignment="Center"
+                                           Text="{x:Bind ViewModel.DefaultGroupTagLabel, Mode=OneWay}" />
+                                <ComboBox Grid.Column="1"
+                                          MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                          DisplayMemberPath="DisplayName"
+                                          ItemsSource="{x:Bind ViewModel.DefaultGroupTagOptions, Mode=OneWay}"
+                                          PlaceholderText="{x:Bind ViewModel.DefaultGroupTagText, Mode=OneWay}"
+                                          SelectedItem="{x:Bind ViewModel.SelectedDefaultGroupTag, Mode=TwoWay}" />
+                            </Grid>
+                            <StackPanel HorizontalAlignment="Right"
+                                        Spacing="{ThemeResource FoundrySpace8}">
+                                <TextBlock Text="{x:Bind ViewModel.KnownGroupTagsLabel, Mode=OneWay}" />
+                                <tv:TableView AutoGenerateColumns="False"
+                                              CanFilterColumns="False"
+                                              CanReorderColumns="False"
+                                              CanResizeColumns="False"
+                                              CanSortColumns="False"
+                                              CornerButtonMode="None"
+                                              HeadersVisibility="Columns"
+                                              IsReadOnly="True"
+                                              ItemsSource="{x:Bind ViewModel.AvailableGroupTags, Mode=OneWay}"
+                                              MaxHeight="{ThemeResource FoundryTableMaxHeight}"
+                                              SelectionMode="None"
+                                              SelectionUnit="Row"
+                                              ShowExportOptions="False"
+                                              Visibility="{x:Bind ViewModel.AvailableGroupTagsVisibility, Mode=OneWay}">
+                                    <tv:TableView.Columns>
+                                        <tv:TableViewTextColumn Binding="{Binding DisplayName}"
+                                                                Header="{x:Bind ViewModel.AvailableGroupTagColumnHeader, Mode=OneWay}" />
+                                    </tv:TableView.Columns>
+                                </tv:TableView>
+                                <TextBlock HorizontalAlignment="Right"
+                                           Text="{x:Bind ViewModel.KnownGroupTagsText, Mode=OneWay}"
+                                           TextWrapping="WrapWholeWords"
+                                           Visibility="{x:Bind ViewModel.EmptyAvailableGroupTagsVisibility, Mode=OneWay}" />
+                            </StackPanel>
                         </StackPanel>
                     </wct:SettingsCard>
                 </wct:SettingsExpander.Items>

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -296,9 +296,14 @@
                                       Description="{x:Bind ViewModel.GroupTagDescription, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
-                        <StackPanel HorizontalAlignment="Right"
-                                    Spacing="{ThemeResource FoundrySpace12}">
-                            <Grid ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}">
+                        <Grid HorizontalAlignment="Right"
+                              ColumnSpacing="{ThemeResource FoundrySpace12}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Grid ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}"
+                                  VerticalAlignment="Top">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="Auto" />
@@ -307,12 +312,14 @@
                                            Text="{x:Bind ViewModel.DefaultGroupTagLabel, Mode=OneWay}" />
                                 <ComboBox Grid.Column="1"
                                           MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                          DisplayMemberPath="DisplayName"
-                                          ItemsSource="{x:Bind ViewModel.DefaultGroupTagOptions, Mode=OneWay}"
-                                          PlaceholderText="{x:Bind ViewModel.DefaultGroupTagText, Mode=OneWay}"
-                                          SelectedItem="{x:Bind ViewModel.SelectedDefaultGroupTag, Mode=TwoWay}" />
+                                           DisplayMemberPath="DisplayName"
+                                           ItemsSource="{x:Bind ViewModel.DefaultGroupTagOptions, Mode=OneWay}"
+                                           PlaceholderText="{x:Bind ViewModel.DefaultGroupTagText, Mode=OneWay}"
+                                           SelectedItem="{x:Bind ViewModel.SelectedDefaultGroupTag, Mode=TwoWay}" />
                             </Grid>
-                            <StackPanel HorizontalAlignment="Right"
+                            <StackPanel Grid.Column="1"
+                                        Width="{ThemeResource FoundryMediumInputMinWidth}"
+                                        VerticalAlignment="Top"
                                         Spacing="{ThemeResource FoundrySpace8}">
                                 <TextBlock Text="{x:Bind ViewModel.KnownGroupTagsLabel, Mode=OneWay}" />
                                 <tv:TableView AutoGenerateColumns="False"
@@ -324,7 +331,7 @@
                                               HeadersVisibility="Columns"
                                               IsReadOnly="True"
                                               ItemsSource="{x:Bind ViewModel.AvailableGroupTags, Mode=OneWay}"
-                                              MaxHeight="{ThemeResource FoundryTableMaxHeight}"
+                                              MaxHeight="120"
                                               SelectionMode="None"
                                               SelectionUnit="Row"
                                               ShowExportOptions="False"
@@ -339,7 +346,7 @@
                                            TextWrapping="WrapWholeWords"
                                            Visibility="{x:Bind ViewModel.EmptyAvailableGroupTagsVisibility, Mode=OneWay}" />
                             </StackPanel>
-                        </StackPanel>
+                        </Grid>
                     </wct:SettingsCard>
                 </wct:SettingsExpander.Items>
             </wct:SettingsExpander>

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -149,17 +149,42 @@
                                    TextWrapping="WrapWholeWords" />
                     </wct:SettingsCard>
 
+                    <wct:SettingsCard Header="{x:Bind ViewModel.TenantOnboardingStatusLabel, Mode=OneWay}"
+                                      HorizontalContentAlignment="Stretch"
+                                      Visibility="{x:Bind ViewModel.HardwareHashSettingsVisibility, Mode=OneWay}">
+                        <TextBlock HorizontalAlignment="Right"
+                                   Text="{x:Bind ViewModel.TenantOnboardingStatusText, Mode=OneWay}"
+                                   TextWrapping="WrapWholeWords" />
+                    </wct:SettingsCard>
+
                     <wct:SettingsCard Header="{x:Bind ViewModel.CertificateStatusLabel, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.HardwareHashSettingsVisibility, Mode=OneWay}">
                         <StackPanel HorizontalAlignment="Right"
-                                    Spacing="{ThemeResource FoundrySpace4}">
+                                    Spacing="{ThemeResource FoundrySpace8}">
                             <TextBlock Text="{x:Bind ViewModel.CertificateStatusText, Mode=OneWay}"
                                        TextWrapping="WrapWholeWords" />
                             <TextBlock Foreground="{ThemeResource SystemFillColorCriticalBrush}"
                                        Text="{x:Bind ViewModel.CertificateExpiredWarningText, Mode=OneWay}"
                                        TextWrapping="WrapWholeWords"
                                        Visibility="{x:Bind ViewModel.HardwareHashCertificateWarningVisibility, Mode=OneWay}" />
+                            <StackPanel HorizontalAlignment="Right"
+                                        Orientation="Horizontal"
+                                        Spacing="{ThemeResource FoundryInlineControlSpacing}">
+                                <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                          DisplayMemberPath="DisplayName"
+                                          Header="{x:Bind ViewModel.CertificateValidityLabel, Mode=OneWay}"
+                                          ItemsSource="{x:Bind ViewModel.CertificateValidityOptions, Mode=OneWay}"
+                                          SelectedItem="{x:Bind ViewModel.SelectedCertificateValidityOption, Mode=TwoWay}" />
+                                <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                        VerticalAlignment="Bottom"
+                                        Command="{x:Bind ViewModel.CreateCertificateCommand}"
+                                        Content="{x:Bind ViewModel.CreateCertificateButtonText, Mode=OneWay}" />
+                                <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                        VerticalAlignment="Bottom"
+                                        Command="{x:Bind ViewModel.RetireActiveCertificateCommand}"
+                                        Content="{x:Bind ViewModel.RetireCertificateButtonText, Mode=OneWay}" />
+                            </StackPanel>
                         </StackPanel>
                     </wct:SettingsCard>
 

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -35,6 +35,7 @@
                               IsOn="{x:Bind ViewModel.UseJsonProfileProvisioning, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 <wct:SettingsExpander.Items>
                     <wct:SettingsCard Header="{x:Bind ViewModel.ActionsHeader, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.ActionsDescription, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.JsonProfileSettingsVisibility, Mode=OneWay}">
                         <Grid ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}">
@@ -71,6 +72,7 @@
                     </wct:SettingsCard>
 
                     <wct:SettingsCard Header="{x:Bind ViewModel.DefaultProfileLabel, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.DefaultProfileDescription, Mode=OneWay}"
                                       Visibility="{x:Bind ViewModel.JsonProfileSettingsVisibility, Mode=OneWay}">
                         <ComboBox Width="{ThemeResource FoundryWideInputMinWidth}"
                                   DisplayMemberPath="DisplayName"
@@ -79,6 +81,7 @@
                     </wct:SettingsCard>
 
                     <wct:SettingsCard Header="{x:Bind ViewModel.ProfilesLabel, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.ProfilesDescription, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.JsonProfileSettingsVisibility, Mode=OneWay}">
                         <StackPanel Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
@@ -128,6 +131,7 @@
                               IsOn="{x:Bind ViewModel.UseHardwareHashUploadProvisioning, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 <wct:SettingsExpander.Items>
                     <wct:SettingsCard Header="{x:Bind ViewModel.TenantStatusLabel, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.TenantStatusDescription, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.HardwareHashSettingsVisibility, Mode=OneWay}">
                         <StackPanel HorizontalAlignment="Right"
@@ -142,6 +146,7 @@
                     </wct:SettingsCard>
 
                     <wct:SettingsCard Header="{x:Bind ViewModel.AppRegistrationLabel, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.AppRegistrationDescription, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
                         <TextBlock HorizontalAlignment="Right"
@@ -150,14 +155,33 @@
                     </wct:SettingsCard>
 
                     <wct:SettingsCard Header="{x:Bind ViewModel.TenantDetailsLabel, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.TenantDetailsDescription, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
-                        <TextBlock HorizontalAlignment="Right"
-                                   Text="{x:Bind ViewModel.TenantDetailsText, Mode=OneWay}"
-                                   TextWrapping="WrapWholeWords" />
+                        <tv:TableView AutoGenerateColumns="False"
+                                      CanFilterColumns="False"
+                                      CanReorderColumns="False"
+                                      CanResizeColumns="False"
+                                      CanSortColumns="False"
+                                      CornerButtonMode="None"
+                                      HeadersVisibility="Columns"
+                                      HorizontalAlignment="Right"
+                                      IsReadOnly="True"
+                                      ItemsSource="{x:Bind ViewModel.TenantDetails, Mode=OneWay}"
+                                      SelectionMode="None"
+                                      SelectionUnit="Row"
+                                      ShowExportOptions="False">
+                            <tv:TableView.Columns>
+                                <tv:TableViewTextColumn Binding="{Binding Name}"
+                                                        Header="{x:Bind ViewModel.TenantDetailsNameColumnHeader, Mode=OneWay}" />
+                                <tv:TableViewTextColumn Binding="{Binding Value}"
+                                                        Header="{x:Bind ViewModel.TenantDetailsValueColumnHeader, Mode=OneWay}" />
+                            </tv:TableView.Columns>
+                        </tv:TableView>
                     </wct:SettingsCard>
 
                     <wct:SettingsCard Header="{x:Bind ViewModel.TenantOnboardingStatusLabel, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.TenantOnboardingStatusDescription, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
                         <TextBlock HorizontalAlignment="Right"
@@ -166,6 +190,7 @@
                     </wct:SettingsCard>
 
                     <wct:SettingsCard Header="{x:Bind ViewModel.CertificateStatusLabel, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.CertificateStatusDescription, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
                         <StackPanel Spacing="{ThemeResource FoundrySpace8}">
@@ -184,7 +209,6 @@
                                         Spacing="{ThemeResource FoundryInlineControlSpacing}">
                                 <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
                                           DisplayMemberPath="DisplayName"
-                                          Header="{x:Bind ViewModel.CertificateValidityLabel, Mode=OneWay}"
                                           ItemsSource="{x:Bind ViewModel.CertificateValidityOptions, Mode=OneWay}"
                                           SelectedItem="{x:Bind ViewModel.SelectedCertificateValidityOption, Mode=TwoWay}" />
                                 <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
@@ -235,6 +259,7 @@
                     </wct:SettingsCard>
 
                     <wct:SettingsCard Header="{x:Bind ViewModel.BootMediaCertificateLabel, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.BootMediaCertificateDescription, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.BootMediaCertificateVisibility, Mode=OneWay}">
                         <StackPanel HorizontalAlignment="Right"
@@ -266,6 +291,7 @@
                     </wct:SettingsCard>
 
                     <wct:SettingsCard Header="{x:Bind ViewModel.DefaultGroupTagLabel, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.DefaultGroupTagDescription, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
                         <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
@@ -277,6 +303,7 @@
                     </wct:SettingsCard>
 
                     <wct:SettingsCard Header="{x:Bind ViewModel.KnownGroupTagsLabel, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.KnownGroupTagsDescription, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
                         <StackPanel HorizontalAlignment="Right">

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -137,7 +137,7 @@
                                        Text="{x:Bind ViewModel.TenantStatusText, Mode=OneWay}" />
                             <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     Command="{x:Bind ViewModel.ConnectTenantCommand}"
-                                    Content="{x:Bind ViewModel.ConnectTenantButtonText, Mode=OneWay}" />
+                                    Content="{x:Bind ViewModel.TenantConnectionButtonText, Mode=OneWay}" />
                         </StackPanel>
                     </wct:SettingsCard>
 
@@ -178,9 +178,6 @@
                                        Text="{x:Bind ViewModel.CertificateExpiredWarningText, Mode=OneWay}"
                                        TextWrapping="WrapWholeWords"
                                        Visibility="{x:Bind ViewModel.HardwareHashCertificateWarningVisibility, Mode=OneWay}" />
-                            <TextBlock Text="{x:Bind ViewModel.CertificatesEmptyText, Mode=OneWay}"
-                                       TextWrapping="Wrap"
-                                       Visibility="{x:Bind ViewModel.EmptyCertificatesVisibility, Mode=OneWay}" />
                             <tv:TableView x:Name="CertificatesTable"
                                           AutoGenerateColumns="False"
                                           CanFilterColumns="False"

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -149,6 +149,14 @@
                                    TextWrapping="WrapWholeWords" />
                     </wct:SettingsCard>
 
+                    <wct:SettingsCard Header="{x:Bind ViewModel.TenantDetailsLabel, Mode=OneWay}"
+                                      HorizontalContentAlignment="Stretch"
+                                      Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
+                        <TextBlock HorizontalAlignment="Right"
+                                   Text="{x:Bind ViewModel.TenantDetailsText, Mode=OneWay}"
+                                   TextWrapping="WrapWholeWords" />
+                    </wct:SettingsCard>
+
                     <wct:SettingsCard Header="{x:Bind ViewModel.TenantOnboardingStatusLabel, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -265,6 +265,11 @@
                                       Visibility="{x:Bind ViewModel.BootMediaCertificateVisibility, Mode=OneWay}">
                         <StackPanel HorizontalAlignment="Right"
                                     Spacing="{ThemeResource FoundrySpace8}">
+                            <ComboBox MinWidth="{ThemeResource FoundryWideInputMinWidth}"
+                                      DisplayMemberPath="SelectionDisplayName"
+                                      Header="{x:Bind ViewModel.BootMediaCertificateTenantCertificateLabel, Mode=OneWay}"
+                                      ItemsSource="{x:Bind ViewModel.Certificates, Mode=OneWay}"
+                                      SelectedItem="{x:Bind ViewModel.SelectedBootMediaCertificate, Mode=TwoWay}" />
                             <Grid ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -185,6 +185,7 @@
                                       HorizontalContentAlignment="Stretch"
                                       Visibility="{x:Bind ViewModel.ConnectedTenantDetailsVisibility, Mode=OneWay}">
                         <TextBlock HorizontalAlignment="Right"
+                                   Foreground="{x:Bind ViewModel.TenantOnboardingStatusForeground, Mode=OneWay}"
                                    Text="{x:Bind ViewModel.TenantOnboardingStatusText, Mode=OneWay}"
                                    TextWrapping="WrapWholeWords" />
                     </wct:SettingsCard>

--- a/src/Foundry/Views/AutopilotPage.xaml.cs
+++ b/src/Foundry/Views/AutopilotPage.xaml.cs
@@ -24,4 +24,12 @@ public sealed partial class AutopilotPage : Page
             ViewModel.ReplaceSelectedProfiles(tableView.SelectedItems.OfType<AutopilotProfileEntryViewModel>());
         }
     }
+
+    private void CertificatesTable_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (sender is WinUI.TableView.TableView tableView)
+        {
+            ViewModel.ReplaceSelectedCertificate(tableView.SelectedItems.OfType<AutopilotCertificateEntryViewModel>());
+        }
+    }
 }

--- a/src/Foundry/Views/AutopilotPage.xaml.cs
+++ b/src/Foundry/Views/AutopilotPage.xaml.cs
@@ -8,12 +8,14 @@ public sealed partial class AutopilotPage : Page
     {
         ViewModel = App.GetService<AutopilotConfigurationViewModel>();
         InitializeComponent();
+        ViewModel.PropertyChanged += OnViewModelPropertyChanged;
         Unloaded += OnUnloaded;
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
         Unloaded -= OnUnloaded;
+        ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
         ViewModel.Dispose();
     }
 
@@ -30,6 +32,38 @@ public sealed partial class AutopilotPage : Page
         if (sender is WinUI.TableView.TableView tableView)
         {
             ViewModel.ReplaceSelectedCertificate(tableView.SelectedItems.OfType<AutopilotCertificateEntryViewModel>());
+        }
+    }
+
+    private void BootMediaCertificatePasswordBox_OnLoaded(object sender, RoutedEventArgs e)
+    {
+        SyncBootMediaCertificatePasswordBox();
+    }
+
+    private void BootMediaCertificatePasswordBox_OnPasswordChanged(object sender, RoutedEventArgs e)
+    {
+        if (sender is not PasswordBox passwordBox ||
+            string.Equals(ViewModel.GetBootMediaCertificatePassword(), passwordBox.Password, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        ViewModel.SetBootMediaCertificatePassword(passwordBox.Password);
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (string.Equals(e.PropertyName, nameof(AutopilotConfigurationViewModel.BootMediaCertificatePfxPath), StringComparison.Ordinal))
+        {
+            SyncBootMediaCertificatePasswordBox();
+        }
+    }
+
+    private void SyncBootMediaCertificatePasswordBox()
+    {
+        if (!string.Equals(BootMediaCertificatePasswordBox.Password, ViewModel.GetBootMediaCertificatePassword(), StringComparison.Ordinal))
+        {
+            BootMediaCertificatePasswordBox.Password = ViewModel.GetBootMediaCertificatePassword();
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds Phase 2 of the Autopilot hardware hash upload implementation plan: secure tenant onboarding, managed app registration handling, certificate lifecycle groundwork, and shared media secret protection.

## Reason
Foundry needs an OSS-friendly WinPE Autopilot hardware hash upload path that uses certificate-based Microsoft Graph authentication without storing PFX material in ProgramData or relying on PowerShell for the final implementation.

## Main changes
- Adds Microsoft Graph tenant onboarding for the managed `Foundry OSD Autopilot Registration` app registration.
- Creates or adopts the managed app, repairs required Graph application permissions, checks admin consent, and validates service principal state.
- Adds active certificate creation/removal controls in Foundry OSD with one-time PFX password display and selected output path.
- Replaces only the previous active Foundry certificate during certificate rotation and preserves unrelated credentials.
- Adds explicit onboarding status UI for permission, consent, service principal, certificate, adoption, and expiration states.
- Adds Core security helpers for PFX thumbprint validation, app onboarding evaluation, and shared AES-GCM media secret envelopes.
- Generalizes the WinPE media secret key guard so encrypted envelopes can exist in Connect or Deploy configuration.
- Updates the Phase 2 implementation checklist.

## Testing
- `dotnet test .\src\Foundry.slnx --configuration Debug /p:Platform=x64`
- `dotnet build .\src\Foundry.slnx --configuration Debug /p:Platform=ARM64`
- `git diff --check`

## Notes
Manual tenant validation remains required before merging the final foundation branch: clean-tenant app creation, consent visibility, certificate rotation/removal, and real Graph behavior.