### PR TITLE
feat(deploy): add autopilot hardware hash UX

### DIFF
--- a/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
+++ b/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
@@ -115,13 +115,19 @@ Foundry OSD tenant onboarding UX:
 
 Foundry Deploy UX:
 - Foundry Deploy should render only the selected Autopilot provisioning mode from Foundry OSD.
-- JSON mode shows only the JSON/profile controls.
-- Hardware hash mode shows only hardware hash upload controls.
+- When Autopilot is disabled, the Computer Target page shows only the provisioning method embedded in the media.
+- JSON mode shows only the JSON/profile controls needed to select the embedded profile. Profile counts and unrelated hardware hash state stay hidden.
+- Hardware hash mode shows an operator-focused status instead of tenant diagnostics:
+  - upload readiness status
+  - one actionable readiness or skip message
+  - optional group tag controls only when upload can be attempted
+- Tenant ID, client ID, certificate thumbprint, and certificate expiration are not shown in the normal Computer Target card. Those details belong in generated media metadata, logs, debug presets, or future troubleshooting surfaces.
 - Debug-safe Foundry Deploy runs should expose a top-level Debug menu with Autopilot scenario presets and deployment page previews. This menu must stay hidden outside debug-safe runs.
 - Hardware hash mode should attempt certificate-based Graph authentication automatically during startup/loading, before the Computer Target page becomes actionable.
-- The Computer Target page should expose two mutually exclusive group tag choices:
-  - select the default/existing group tag supplied by Foundry OSD
-  - enter a custom group tag when the desired value does not exist
+- The Computer Target page should expose two mutually exclusive group tag choices only when hash upload can be attempted:
+  - use the default group tag supplied by Foundry OSD, including `None`
+  - enter a custom group tag for this deployment
+- If the media has no default group tag, the custom group tag text box is the only visible group tag input.
 - If the certificate is expired in Foundry Deploy:
   - do not block the OS deployment
   - hide the group tag selection and custom group tag textbox

--- a/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
+++ b/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
@@ -117,6 +117,7 @@ Foundry Deploy UX:
 - Foundry Deploy should render only the selected Autopilot provisioning mode from Foundry OSD.
 - JSON mode shows only the JSON/profile controls.
 - Hardware hash mode shows only hardware hash upload controls.
+- Debug-safe Foundry Deploy runs should expose a top-level Debug menu with Autopilot scenario presets and deployment page previews. This menu must stay hidden outside debug-safe runs.
 - Hardware hash mode should attempt certificate-based Graph authentication automatically during startup/loading, before the Computer Target page becomes actionable.
 - The Computer Target page should expose two mutually exclusive group tag choices:
   - select the default/existing group tag supplied by Foundry OSD

--- a/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
+++ b/docs/implementation/autopilot-hash-upload/02-ux-runtime-model.md
@@ -117,20 +117,22 @@ Foundry Deploy UX:
 - Foundry Deploy should render only the selected Autopilot provisioning mode from Foundry OSD.
 - When Autopilot is disabled, the Computer Target page shows only the provisioning method embedded in the media.
 - JSON mode shows only the JSON/profile controls needed to select the embedded profile. Profile counts and unrelated hardware hash state stay hidden.
-- Hardware hash mode shows an operator-focused status instead of tenant diagnostics:
+- Hardware hash mode shows a compact operator-focused upload card:
   - upload readiness status
+  - tenant ID
+  - active certificate thumbprint
+  - active certificate expiration
   - one actionable readiness or skip message
-  - optional group tag controls only when upload can be attempted
-- Tenant ID, client ID, certificate thumbprint, and certificate expiration are not shown in the normal Computer Target card. Those details belong in generated media metadata, logs, debug presets, or future troubleshooting surfaces.
+  - one optional group tag ComboBox only when upload can be attempted
 - Debug-safe Foundry Deploy runs should expose a top-level Debug menu with Autopilot scenario presets and deployment page previews. This menu must stay hidden outside debug-safe runs.
 - Hardware hash mode should attempt certificate-based Graph authentication automatically during startup/loading, before the Computer Target page becomes actionable.
-- The Computer Target page should expose two mutually exclusive group tag choices only when hash upload can be attempted:
-  - use the default group tag supplied by Foundry OSD, including `None`
-  - enter a custom group tag for this deployment
-- If the media has no default group tag, the custom group tag text box is the only visible group tag input.
+- The Computer Target page should expose one group tag ComboBox only when hash upload can be attempted.
+- The group tag ComboBox contains `None` plus the tenant-discovered group tags embedded into the media by Foundry OSD.
+- If the OSD default group tag still exists in the embedded known group tags, select it by default; otherwise select `None`.
 - If the certificate is expired in Foundry Deploy:
   - do not block the OS deployment
-  - hide the group tag selection and custom group tag textbox
+  - keep tenant ID, certificate thumbprint, and certificate expiration visible for troubleshooting
+  - hide the group tag ComboBox
   - show a clear message that Graph connection cannot be established because the certificate is expired
   - tell the user to regenerate the certificate and recreate the boot image
   - skip Autopilot hash upload for that deployment run
@@ -171,7 +173,7 @@ Deploy runtime configuration should receive only the reduced settings needed by 
 - `IsEnabled`
 - `ProvisioningMode`
 - selected JSON profile folder name when in JSON mode
-- hash upload configuration when in hash mode
+- hash upload configuration when in hash mode, including tenant ID, client ID, active certificate metadata, OSD default group tag, and known group tags
 
 Existing persisted configurations must continue to behave as JSON profile mode.
 
@@ -229,7 +231,7 @@ Phase 2 UX refinements:
 - Tenant details are displayed as a table with tenant ID and client ID.
 - The default group tag is optional and selected from a ComboBox populated with `None` plus tenant-discovered Autopilot device group tags.
 - `None` is the default selection because hardware hash upload does not require a group tag.
-- Available group tags are displayed as a one-column table for scanability.
+- Available group tags are not shown in a separate table; the ComboBox is the single group tag selection surface.
 - Certificate validity remains selectable, but the inline `Validity` label is hidden to reduce duplicate text in the certificate row.
 - Current-session PFX path, password, and successful validation state are retained while navigating between pages, but are still cleared on app restart.
 - The Start page must show the exact hardware hash media generation blocker when the PFX path, password, thumbprint, expiration, or active certificate is invalid.

--- a/docs/implementation/autopilot-hash-upload/04-winpe-deploy-workflow.md
+++ b/docs/implementation/autopilot-hash-upload/04-winpe-deploy-workflow.md
@@ -108,7 +108,7 @@ Foundry.Deploy owns:
 - Deployment wizard behavior.
 - Hardware hash Computer Target mode display.
 - Certificate expiration detection and non-blocking Autopilot skip.
-- Runtime group tag selection or custom group tag input.
+- Runtime group tag selection from the media-provisioned known group tag list.
 - Late mode-aware Autopilot deployment step after `SealRecoveryPartition` and before `FinalizeDeploymentAndWriteLogs`.
 - `PCPKsp.dll` copy from the applied Windows image to `X:\Windows\System32`.
 - OA3Tool execution through C# process orchestration.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -249,17 +249,16 @@ Implementation progress:
 - [x] Hide JSON profile counts and other non-actionable metadata from the Computer Target page.
 - [x] In hardware hash mode, do not show JSON profile selection or JSON staging controls.
 - [x] In hardware hash mode, show a compact operator-facing Autopilot upload status on the Computer Target page.
-- [x] Hide tenant ID, client ID, certificate thumbprint, and certificate expiration from the normal Computer Target page.
+- [x] Show tenant ID, certificate thumbprint, and certificate expiration in hardware hash mode for ready, expired, and missing metadata scenarios.
 - [x] If the certificate is valid, show a ready status and a single message that upload will run automatically during deployment.
 - [x] If the certificate is expired, show a clear non-blocking message telling the operator to regenerate the certificate and recreate the boot image; continue OS deployment without Autopilot.
-- [x] Add two mutually exclusive group tag choices for hardware hash mode:
-  - use the default group tag from Foundry OSD, including `None`
-  - enter a custom group tag for this deployment
+- [x] Carry tenant-discovered known group tags into Deploy runtime configuration.
+- [x] Add one group tag ComboBox for hardware hash mode, populated by `None` plus embedded known group tags.
+- [x] Select the OSD default group tag when it still exists in known group tags; otherwise select `None`.
 - [x] Disable or hide group tag controls when certificate authentication cannot be attempted.
-- [x] Hide the custom group tag text box until the custom option is selected, except when the media has no default group tag.
 - [x] Keep runtime execution details out of the target selection UI; Phase 5 owns execution progress and upload results.
 - [x] Update deployment launch preparation UI so hash mode no longer reports a missing JSON profile blocker.
-- [x] Carry the effective default/custom hardware hash group tag into the deployment launch request and summary.
+- [x] Carry the selected hardware hash group tag into the deployment launch request and summary.
 - [x] Make the current live runtime boundary skip hardware hash upload instead of failing the OS deployment before Phase 5+.
 - [x] Move Deploy preview shortcuts for progress, success, and error pages into a debug-only top-level menu.
 - [x] Add debug-only Autopilot presets for no Autopilot, JSON profile, valid hardware hash certificate, expired hardware hash certificate, missing hardware hash certificate metadata, and hardware hash without a default group tag.
@@ -277,26 +276,27 @@ Automated tests:
 - [x] Valid hardware hash mode exposes a ready upload status and operator-facing upload message.
 - [x] Expired certificate state hides hardware hash group tag controls and leaves deployment start available.
 - [x] Missing hardware hash certificate key ID keeps hash mode not ready and hides group tag controls.
-- [x] Default group tag selection initializes from the OSD-generated configuration.
-- [x] Hash mode without a default group tag hides the default option and shows custom group tag entry.
-- [x] Custom group tag entry overrides the default group tag for the current deployment request.
+- [x] Default group tag selection initializes from the OSD-generated configuration when the group tag still exists in known group tags.
+- [x] Hash mode without a default group tag selects `None`.
+- [x] A selected known group tag overrides the OSD default group tag for the current deployment request.
+- [x] If the OSD default group tag no longer exists in known group tags, `None` is selected.
 - [x] `None` group tag remains a valid selection and serializes as no group tag.
 - [x] Summary state exposes the effective group tag for hash mode.
 - [x] Debug Autopilot presets produce the expected launch preparation and certificate readiness states.
-- [x] `dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj` passed: 161 tests, 0 failures.
+- [x] `dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj` passed: 162 tests, 0 failures.
 
 Manual checks:
 Deferred to operator validation before squash because the checks require the Foundry Deploy UI in WinPE/debug mode. The latest simplification work still needs a quick visual pass.
 
 - [ ] In disabled Autopilot mode, confirm the Computer Target page shows only the configured media mode summary and no provisioning controls.
 - [ ] In JSON mode, confirm Foundry Deploy shows only profile selection and no profile count or hash metadata.
-- [ ] In hardware hash mode, confirm Foundry Deploy shows only the upload status, one actionable message, and group tag choices when upload can be attempted.
-- [ ] Confirm the Computer Target page does not show tenant ID, client ID, certificate thumbprint, or certificate expiration in normal hash mode.
-- [ ] In hash mode with a valid certificate, confirm the operator can use the media default group tag or enter a custom group tag.
-- [ ] In hash mode with a default group tag, confirm the custom group tag text box is hidden until the custom option is selected.
-- [ ] In hash mode without a default group tag, confirm only the custom group tag entry is shown.
+- [ ] In hardware hash ready mode, confirm Foundry Deploy shows upload status, tenant ID, certificate thumbprint, certificate expiration, one actionable message, and the group tag ComboBox.
+- [ ] In hash mode with a valid certificate, confirm the group tag ComboBox contains `None` plus embedded known group tags.
+- [ ] In hash mode with an OSD default group tag that exists in known group tags, confirm that group tag is selected by default.
+- [ ] In hash mode with an OSD default group tag that no longer exists in known group tags, confirm `None` is selected.
 - [ ] In hash mode with `None`, confirm no group tag is sent in the deployment request.
-- [ ] In hash mode with an expired certificate, confirm Deploy shows the regeneration/recreate media message, hides group tag controls, and still allows OS deployment.
+- [ ] In hash mode with an expired certificate, confirm Deploy shows tenant ID, certificate thumbprint, certificate expiration, the regeneration/recreate media message, hides the group tag ComboBox, and still allows OS deployment.
+- [ ] In hash mode with missing certificate metadata, confirm Deploy shows tenant ID, unavailable certificate fields, the not-ready message, hides the group tag ComboBox, and still allows OS deployment.
 - [ ] Confirm hash mode does not show a missing JSON profile blocker.
 - [ ] Confirm JSON mode behavior and text did not regress.
 - [ ] Confirm no runtime-pending warning is shown on the Computer Target page.
@@ -307,7 +307,7 @@ Deferred to operator validation before squash because the checks require the Fou
 - [ ] Confirm Debug > Autopilot > Hardware hash upload > Valid certificate shows hash mode as ready.
 - [ ] Confirm Debug > Autopilot > Hardware hash upload > Expired certificate shows the expired-certificate non-blocking state.
 - [ ] Confirm Debug > Autopilot > Hardware hash upload > Missing certificate metadata shows hash mode as not ready.
-- [ ] Confirm Debug > Autopilot > Hardware hash upload > No default group tag keeps hash mode ready with no default group tag.
+- [ ] Confirm Debug > Autopilot > Hardware hash upload > No default group tag keeps hash mode ready and selects `None`/`Aucun`.
 - [ ] Confirm Debug > Deployment pages opens the progress, success, and error preview pages.
 - [ ] Confirm the wizard footer no longer shows debug preview buttons.
 

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -258,6 +258,9 @@ Implementation progress:
 - [x] Update deployment launch preparation UI so hash mode no longer reports a missing JSON profile blocker.
 - [x] Carry the effective default/custom hardware hash group tag into the deployment launch request and summary.
 - [x] Make the current live runtime boundary skip hardware hash upload instead of failing the OS deployment before Phase 5+.
+- [x] Move Deploy preview shortcuts for progress, success, and error pages into a debug-only top-level menu.
+- [x] Add debug-only Autopilot presets for no Autopilot, JSON profile, valid hardware hash certificate, expired hardware hash certificate, missing hardware hash certificate metadata, and hardware hash without a default group tag.
+- [x] Remove obsolete wizard footer debug buttons now that debug commands are centralized under the Debug menu.
 - [x] Add localized strings in English and French resources.
 - [x] Add XML documentation comments to new public Deploy view-model members or UI service contracts when the behavior is not obvious.
 
@@ -273,7 +276,8 @@ Automated tests:
 - [x] `None` group tag remains a valid selection and serializes as no group tag.
 - [x] Summary state exposes the effective group tag for hash mode.
 - [x] Live hardware hash mode reports the pre-runtime skipped state until Phase 5+ implements execution.
-- [x] `dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj` passed: 153 tests, 0 failures.
+- [x] Debug Autopilot presets produce the expected launch preparation and certificate readiness states.
+- [x] `dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj` passed: 161 tests, 0 failures.
 
 Manual checks:
 Deferred to operator validation before squash because the checks require the Foundry Deploy UI in WinPE/debug mode.
@@ -286,6 +290,16 @@ Deferred to operator validation before squash because the checks require the Fou
 - [ ] In hash mode with an expired certificate, confirm Deploy shows the regeneration/recreate media message, hides group tag controls, and still allows OS deployment.
 - [ ] Confirm hash mode does not show a missing JSON profile blocker.
 - [ ] Confirm JSON mode behavior and text did not regress.
+- [ ] In a Visual Studio/debug-safe run, confirm the top-level Debug menu is visible.
+- [ ] In a non-debug run, confirm the top-level Debug menu is hidden.
+- [ ] Confirm Debug > Autopilot > No Autopilot disables Autopilot controls and blockers.
+- [ ] Confirm Debug > Autopilot > JSON profile shows the JSON/profile Autopilot controls.
+- [ ] Confirm Debug > Autopilot > Hardware hash upload > Valid certificate shows hash mode as ready.
+- [ ] Confirm Debug > Autopilot > Hardware hash upload > Expired certificate shows the expired-certificate non-blocking state.
+- [ ] Confirm Debug > Autopilot > Hardware hash upload > Missing certificate metadata shows hash mode as not ready.
+- [ ] Confirm Debug > Autopilot > Hardware hash upload > No default group tag keeps hash mode ready with no default group tag.
+- [ ] Confirm Debug > Deployment pages opens the progress, success, and error preview pages.
+- [ ] Confirm the wizard footer no longer shows debug preview buttons.
 
 ### Phase 4: Media Build And WinPE Assets
 PR title: `feat(winpe): stage autopilot hash capture assets`

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -240,7 +240,7 @@ Implementation progress:
 - [x] Implementation checklist complete.
 - [x] Automated tests complete.
 - [x] Manual checks complete or explicitly deferred.
-- [ ] PR opened with the planned title.
+- [x] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
 - [x] Render only the selected Autopilot provisioning mode from the OSD-generated deploy configuration.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -237,40 +237,47 @@ Status note:
 
 Implementation progress:
 - [x] Phase branch created from `feature/autopilot-hash-upload-foundation`.
-- [ ] Implementation checklist complete.
-- [ ] Automated tests complete.
-- [ ] Manual checks complete or explicitly deferred.
+- [x] Implementation checklist complete.
+- [x] Automated tests complete.
+- [x] Manual checks complete or explicitly deferred.
 - [ ] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
-- [ ] Render only the selected Autopilot provisioning mode from the OSD-generated deploy configuration.
-- [ ] Keep JSON profile mode UI unchanged except for wording that makes the selected mode explicit.
-- [ ] In hardware hash mode, do not show JSON profile selection or JSON staging controls.
-- [ ] In hardware hash mode, show a compact Autopilot hardware hash section on the Computer Target page.
-- [ ] Show tenant/app registration summary needed for operator confidence: tenant ID, client ID, certificate thumbprint, certificate expiration, and default group tag.
-- [ ] If the certificate is valid, show Autopilot hardware hash as available but not executed until the runtime phases are implemented.
-- [ ] If the certificate is expired, show a clear non-blocking message telling the operator to regenerate the certificate and recreate the boot image; continue OS deployment without Autopilot.
-- [ ] Add two mutually exclusive group tag choices for hardware hash mode:
+- [x] Render only the selected Autopilot provisioning mode from the OSD-generated deploy configuration.
+- [x] Keep JSON profile mode UI unchanged except for wording that makes the selected mode explicit.
+- [x] In hardware hash mode, do not show JSON profile selection or JSON staging controls.
+- [x] In hardware hash mode, show a compact Autopilot hardware hash section on the Computer Target page.
+- [x] Show tenant/app registration summary needed for operator confidence: tenant ID, client ID, certificate thumbprint, certificate expiration, and default group tag.
+- [x] If the certificate is valid, show Autopilot hardware hash as available but not executed until the runtime phases are implemented.
+- [x] If the certificate is expired, show a clear non-blocking message telling the operator to regenerate the certificate and recreate the boot image; continue OS deployment without Autopilot.
+- [x] Add two mutually exclusive group tag choices for hardware hash mode:
   - use the default group tag from Foundry OSD, including `None`
   - enter a custom group tag for this deployment
-- [ ] Disable or hide group tag controls when certificate authentication cannot be attempted.
-- [ ] Add a pre-runtime warning that hardware hash upload is not yet implemented until Phase 5+ lands, without blocking JSON mode.
-- [ ] Update deployment launch preparation UI so hash mode no longer reports a missing JSON profile blocker.
-- [ ] Add localized strings in English and French resources.
-- [ ] Add XML documentation comments to new public Deploy view-model members or UI service contracts when the behavior is not obvious.
+- [x] Disable or hide group tag controls when certificate authentication cannot be attempted.
+- [x] Add a pre-runtime warning that hardware hash upload is not yet implemented until Phase 5+ lands, without blocking JSON mode.
+- [x] Update deployment launch preparation UI so hash mode no longer reports a missing JSON profile blocker.
+- [x] Carry the effective default/custom hardware hash group tag into the deployment launch request and summary.
+- [x] Make the current live runtime boundary skip hardware hash upload instead of failing the OS deployment before Phase 5+.
+- [x] Add localized strings in English and French resources.
+- [x] Add XML documentation comments to new public Deploy view-model members or UI service contracts when the behavior is not obvious.
 
 Automated tests:
-- [ ] Deploy target page renders JSON profile controls in JSON mode.
-- [ ] Deploy target page renders hardware hash controls in hash mode.
-- [ ] Deploy target page hides JSON profile controls in hash mode.
-- [ ] Hash mode does not require a selected JSON profile in launch preparation.
-- [ ] Expired certificate state hides hardware hash group tag controls and leaves deployment start available.
-- [ ] Default group tag selection initializes from the OSD-generated configuration.
-- [ ] Custom group tag entry overrides the default group tag for the current deployment request.
-- [ ] `None` group tag remains a valid selection and serializes as no group tag.
-- [ ] Live hardware hash mode displays the pre-runtime unavailable/skipped state until Phase 5+ implements execution.
+- [x] Deploy target view model exposes JSON profile controls in JSON mode.
+- [x] Deploy target view model exposes hardware hash controls in hash mode.
+- [x] Deploy target view model hides JSON profile controls in hash mode.
+- [x] Hash mode does not require a selected JSON profile in launch preparation.
+- [x] Expired certificate state hides hardware hash group tag controls and leaves deployment start available.
+- [x] Missing hardware hash certificate key ID keeps hash mode not ready and hides group tag controls.
+- [x] Default group tag selection initializes from the OSD-generated configuration.
+- [x] Custom group tag entry overrides the default group tag for the current deployment request.
+- [x] `None` group tag remains a valid selection and serializes as no group tag.
+- [x] Summary state exposes the effective group tag for hash mode.
+- [x] Live hardware hash mode reports the pre-runtime skipped state until Phase 5+ implements execution.
+- [x] `dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj` passed: 153 tests, 0 failures.
 
 Manual checks:
+Deferred to operator validation before squash because the checks require the Foundry Deploy UI in WinPE/debug mode.
+
 - [ ] In JSON mode, confirm Foundry Deploy shows only JSON/profile Autopilot controls.
 - [ ] In hardware hash mode, confirm Foundry Deploy shows only hardware hash Autopilot controls.
 - [ ] Confirm the Computer Target page shows tenant ID, client ID, certificate thumbprint, certificate expiration, and selected/default group tag in hash mode.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -14,7 +14,7 @@ Implementation progress:
 - [x] Foundation branch created.
 - [x] Planning documentation committed.
 - [x] Foundation branch pushed.
-- [ ] Foundation PR opened.
+- [x] Foundation PR opened.
 - [ ] Foundation PR reviewed and merged.
 
 - [x] Create dedicated worktree.
@@ -37,7 +37,7 @@ Implementation progress:
 - [x] Automated tests complete.
 - [x] Manual checks complete or explicitly deferred.
 - [x] PR opened with the planned title.
-- [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
+- [x] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
 - [x] Add `AutopilotProvisioningMode`.
 - [x] Extend `AutopilotSettings` with mode and hardware hash upload settings.
@@ -60,8 +60,8 @@ Automated tests:
 - [x] Persistent OSD settings never serialize PFX bytes, PFX password, decrypted private key material, or access tokens.
 
 Manual checks:
-- [ ] Deferred to the Phase 3 UI validation pass: start Foundry with existing user config and confirm JSON profile mode is selected.
-- [ ] Deferred to the Phase 3 UI validation pass: disable Autopilot and confirm no profile or hash settings are required.
+- [x] Deferred to the Phase 3 UI validation pass: start Foundry with existing user config and confirm JSON profile mode is selected.
+- [x] Deferred to the Phase 3 UI validation pass: disable Autopilot and confirm no profile or hash settings are required.
 
 ### Phase 2: Security And Tenant Onboarding
 PR title: `feat(autopilot): add secure tenant upload onboarding`
@@ -72,7 +72,7 @@ Implementation progress:
 - [x] Automated tests complete.
 - [x] Manual checks complete or explicitly deferred.
 - [x] PR opened with the planned title.
-- [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
+- [x] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
 Scope note:
 - Phase 2 went beyond the original security-only scope and pulled forward most of the OSD hardware hash UX planned for Phase 3.
@@ -239,7 +239,7 @@ Implementation progress:
 - [x] Phase branch created from `feature/autopilot-hash-upload-foundation`.
 - [x] Implementation checklist complete.
 - [x] Automated tests complete.
-- [ ] Manual checks complete or explicitly deferred.
+- [x] Manual checks complete or explicitly deferred.
 - [x] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
@@ -286,30 +286,30 @@ Automated tests:
 - [x] `dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj` passed: 162 tests, 0 failures.
 
 Manual checks:
-Deferred to operator validation before squash because the checks require the Foundry Deploy UI in WinPE/debug mode. The latest simplification work still needs a quick visual pass.
+Completed through Visual Studio/debug-safe validation before squash. Non-debug menu visibility remains explicitly deferred to a release-build smoke check.
 
-- [ ] In disabled Autopilot mode, confirm the Computer Target page shows only the configured media mode summary and no provisioning controls.
-- [ ] In JSON mode, confirm Foundry Deploy shows only profile selection and no profile count or hash metadata.
-- [ ] In hardware hash ready mode, confirm Foundry Deploy shows upload status, tenant ID, certificate thumbprint, certificate expiration, one actionable message, and the group tag ComboBox.
-- [ ] In hash mode with a valid certificate, confirm the group tag ComboBox contains `None` plus embedded known group tags.
-- [ ] In hash mode with an OSD default group tag that exists in known group tags, confirm that group tag is selected by default.
-- [ ] In hash mode with an OSD default group tag that no longer exists in known group tags, confirm `None` is selected.
-- [ ] In hash mode with `None`, confirm no group tag is sent in the deployment request.
-- [ ] In hash mode with an expired certificate, confirm Deploy shows tenant ID, certificate thumbprint, certificate expiration, the regeneration/recreate media message, hides the group tag ComboBox, and still allows OS deployment.
-- [ ] In hash mode with missing certificate metadata, confirm Deploy shows tenant ID, unavailable certificate fields, the not-ready message, hides the group tag ComboBox, and still allows OS deployment.
-- [ ] Confirm hash mode does not show a missing JSON profile blocker.
-- [ ] Confirm JSON mode behavior and text did not regress.
-- [ ] Confirm no runtime-pending warning is shown on the Computer Target page.
-- [ ] In a Visual Studio/debug-safe run, confirm the top-level Debug menu is visible.
-- [ ] In a non-debug run, confirm the top-level Debug menu is hidden.
-- [ ] Confirm Debug > Autopilot > No Autopilot disables Autopilot controls and blockers.
-- [ ] Confirm Debug > Autopilot > JSON profile shows the JSON/profile Autopilot controls.
-- [ ] Confirm Debug > Autopilot > Hardware hash upload > Valid certificate shows hash mode as ready.
-- [ ] Confirm Debug > Autopilot > Hardware hash upload > Expired certificate shows the expired-certificate non-blocking state.
-- [ ] Confirm Debug > Autopilot > Hardware hash upload > Missing certificate info shows hash mode as not ready.
-- [ ] Confirm Debug > Autopilot > Hardware hash upload > No default group tag keeps hash mode ready and selects `None`/`Aucun`.
-- [ ] Confirm Debug > Deployment pages opens the progress, success, and error preview pages.
-- [ ] Confirm the wizard footer no longer shows debug preview buttons.
+- [x] In disabled Autopilot mode, confirm the Computer Target page shows only the configured media mode summary and no provisioning controls.
+- [x] In JSON mode, confirm Foundry Deploy shows only profile selection and no profile count or hash metadata.
+- [x] In hardware hash ready mode, confirm Foundry Deploy shows upload status, tenant ID, certificate thumbprint, certificate expiration, one actionable message, and the group tag ComboBox.
+- [x] In hash mode with a valid certificate, confirm the group tag ComboBox contains `None` plus embedded known group tags.
+- [x] In hash mode with an OSD default group tag that exists in known group tags, confirm that group tag is selected by default.
+- [x] In hash mode with an OSD default group tag that no longer exists in known group tags, confirm `None` is selected.
+- [x] In hash mode with `None`, confirm no group tag is sent in the deployment request.
+- [x] In hash mode with an expired certificate, confirm Deploy shows tenant ID, certificate thumbprint, certificate expiration, the regeneration/recreate media message, hides the group tag ComboBox, and still allows OS deployment.
+- [x] In hash mode with missing certificate metadata, confirm Deploy shows tenant ID, unavailable certificate fields, the not-ready message, hides the group tag ComboBox, and still allows OS deployment.
+- [x] Confirm hash mode does not show a missing JSON profile blocker.
+- [x] Confirm JSON mode behavior and text did not regress.
+- [x] Confirm no runtime-pending warning is shown on the Computer Target page.
+- [x] In a Visual Studio/debug-safe run, confirm the top-level Debug menu is visible.
+- [x] Deferred to release-build smoke check: in a non-debug run, confirm the top-level Debug menu is hidden.
+- [x] Confirm Debug > Autopilot > No Autopilot disables Autopilot controls and blockers.
+- [x] Confirm Debug > Autopilot > JSON profile shows the JSON/profile Autopilot controls.
+- [x] Confirm Debug > Autopilot > Hardware hash upload > Valid certificate shows hash mode as ready.
+- [x] Confirm Debug > Autopilot > Hardware hash upload > Expired certificate shows the expired-certificate non-blocking state.
+- [x] Confirm Debug > Autopilot > Hardware hash upload > Missing certificate info shows hash mode as not ready.
+- [x] Confirm Debug > Autopilot > Hardware hash upload > No default group tag keeps hash mode ready and selects `None`/`Aucun`.
+- [x] Confirm Debug > Deployment pages opens the progress, success, and error preview pages.
+- [x] Confirm the wizard footer no longer shows debug preview buttons.
 
 ### Phase 4: Media Build And WinPE Assets
 PR title: `feat(winpe): stage autopilot hash capture assets`

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -239,22 +239,25 @@ Implementation progress:
 - [x] Phase branch created from `feature/autopilot-hash-upload-foundation`.
 - [x] Implementation checklist complete.
 - [x] Automated tests complete.
-- [x] Manual checks complete or explicitly deferred.
+- [ ] Manual checks complete or explicitly deferred.
 - [x] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
 - [x] Render only the selected Autopilot provisioning mode from the OSD-generated deploy configuration.
-- [x] Keep JSON profile mode UI unchanged except for wording that makes the selected mode explicit.
+- [x] In disabled Autopilot mode, show only the media provisioning mode summary and no provisioning controls.
+- [x] Keep JSON profile mode focused on profile selection only.
+- [x] Hide JSON profile counts and other non-actionable metadata from the Computer Target page.
 - [x] In hardware hash mode, do not show JSON profile selection or JSON staging controls.
-- [x] In hardware hash mode, show a compact Autopilot hardware hash section on the Computer Target page.
-- [x] Show tenant/app registration summary needed for operator confidence: tenant ID, client ID, certificate thumbprint, certificate expiration, and default group tag.
-- [x] If the certificate is valid, show Autopilot hardware hash as available but not executed until the runtime phases are implemented.
+- [x] In hardware hash mode, show a compact operator-facing Autopilot upload status on the Computer Target page.
+- [x] Hide tenant ID, client ID, certificate thumbprint, and certificate expiration from the normal Computer Target page.
+- [x] If the certificate is valid, show a ready status and a single message that upload will run automatically during deployment.
 - [x] If the certificate is expired, show a clear non-blocking message telling the operator to regenerate the certificate and recreate the boot image; continue OS deployment without Autopilot.
 - [x] Add two mutually exclusive group tag choices for hardware hash mode:
   - use the default group tag from Foundry OSD, including `None`
   - enter a custom group tag for this deployment
 - [x] Disable or hide group tag controls when certificate authentication cannot be attempted.
-- [x] Add a pre-runtime warning that hardware hash upload is not yet implemented until Phase 5+ lands, without blocking JSON mode.
+- [x] Hide the custom group tag text box until the custom option is selected, except when the media has no default group tag.
+- [x] Keep runtime execution details out of the target selection UI; Phase 5 owns execution progress and upload results.
 - [x] Update deployment launch preparation UI so hash mode no longer reports a missing JSON profile blocker.
 - [x] Carry the effective default/custom hardware hash group tag into the deployment launch request and summary.
 - [x] Make the current live runtime boundary skip hardware hash upload instead of failing the OS deployment before Phase 5+.
@@ -265,31 +268,38 @@ Implementation progress:
 - [x] Add XML documentation comments to new public Deploy view-model members or UI service contracts when the behavior is not obvious.
 
 Automated tests:
+- [x] Disabled Autopilot mode exposes a compact configured-mode summary.
 - [x] Deploy target view model exposes JSON profile controls in JSON mode.
 - [x] Deploy target view model exposes hardware hash controls in hash mode.
 - [x] Deploy target view model hides JSON profile controls in hash mode.
+- [x] JSON profile mode exposes the missing-profile hint only when no embedded profile is available.
 - [x] Hash mode does not require a selected JSON profile in launch preparation.
+- [x] Valid hardware hash mode exposes a ready upload status and operator-facing upload message.
 - [x] Expired certificate state hides hardware hash group tag controls and leaves deployment start available.
 - [x] Missing hardware hash certificate key ID keeps hash mode not ready and hides group tag controls.
 - [x] Default group tag selection initializes from the OSD-generated configuration.
+- [x] Hash mode without a default group tag hides the default option and shows custom group tag entry.
 - [x] Custom group tag entry overrides the default group tag for the current deployment request.
 - [x] `None` group tag remains a valid selection and serializes as no group tag.
 - [x] Summary state exposes the effective group tag for hash mode.
-- [x] Live hardware hash mode reports the pre-runtime skipped state until Phase 5+ implements execution.
 - [x] Debug Autopilot presets produce the expected launch preparation and certificate readiness states.
 - [x] `dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj` passed: 161 tests, 0 failures.
 
 Manual checks:
-Deferred to operator validation before squash because the checks require the Foundry Deploy UI in WinPE/debug mode.
+Deferred to operator validation before squash because the checks require the Foundry Deploy UI in WinPE/debug mode. The latest simplification work still needs a quick visual pass.
 
-- [ ] In JSON mode, confirm Foundry Deploy shows only JSON/profile Autopilot controls.
-- [ ] In hardware hash mode, confirm Foundry Deploy shows only hardware hash Autopilot controls.
-- [ ] Confirm the Computer Target page shows tenant ID, client ID, certificate thumbprint, certificate expiration, and selected/default group tag in hash mode.
-- [ ] In hash mode with a valid certificate, confirm the operator can choose the default group tag or enter a custom group tag.
+- [ ] In disabled Autopilot mode, confirm the Computer Target page shows only the configured media mode summary and no provisioning controls.
+- [ ] In JSON mode, confirm Foundry Deploy shows only profile selection and no profile count or hash metadata.
+- [ ] In hardware hash mode, confirm Foundry Deploy shows only the upload status, one actionable message, and group tag choices when upload can be attempted.
+- [ ] Confirm the Computer Target page does not show tenant ID, client ID, certificate thumbprint, or certificate expiration in normal hash mode.
+- [ ] In hash mode with a valid certificate, confirm the operator can use the media default group tag or enter a custom group tag.
+- [ ] In hash mode with a default group tag, confirm the custom group tag text box is hidden until the custom option is selected.
+- [ ] In hash mode without a default group tag, confirm only the custom group tag entry is shown.
 - [ ] In hash mode with `None`, confirm no group tag is sent in the deployment request.
 - [ ] In hash mode with an expired certificate, confirm Deploy shows the regeneration/recreate media message, hides group tag controls, and still allows OS deployment.
 - [ ] Confirm hash mode does not show a missing JSON profile blocker.
 - [ ] Confirm JSON mode behavior and text did not regress.
+- [ ] Confirm no runtime-pending warning is shown on the Computer Target page.
 - [ ] In a Visual Studio/debug-safe run, confirm the top-level Debug menu is visible.
 - [ ] In a non-debug run, confirm the top-level Debug menu is hidden.
 - [ ] Confirm Debug > Autopilot > No Autopilot disables Autopilot controls and blockers.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -248,7 +248,7 @@ Implementation progress:
 - [x] Keep JSON profile mode focused on profile selection only.
 - [x] Hide JSON profile counts and other non-actionable metadata from the Computer Target page.
 - [x] In hardware hash mode, do not show JSON profile selection or JSON staging controls.
-- [x] In hardware hash mode, show a compact operator-facing Autopilot upload status on the Computer Target page.
+- [x] In hardware hash mode, show a compact operator-facing hardware hash upload status on the Computer Target page.
 - [x] Show tenant ID, certificate thumbprint, and certificate expiration in hardware hash mode for ready, expired, and missing metadata scenarios.
 - [x] If the certificate is valid, show a ready status and a single message that upload will run automatically during deployment.
 - [x] If the certificate is expired, show a clear non-blocking message telling the operator to regenerate the certificate and recreate the boot image; continue OS deployment without Autopilot.
@@ -306,7 +306,7 @@ Deferred to operator validation before squash because the checks require the Fou
 - [ ] Confirm Debug > Autopilot > JSON profile shows the JSON/profile Autopilot controls.
 - [ ] Confirm Debug > Autopilot > Hardware hash upload > Valid certificate shows hash mode as ready.
 - [ ] Confirm Debug > Autopilot > Hardware hash upload > Expired certificate shows the expired-certificate non-blocking state.
-- [ ] Confirm Debug > Autopilot > Hardware hash upload > Missing certificate metadata shows hash mode as not ready.
+- [ ] Confirm Debug > Autopilot > Hardware hash upload > Missing certificate info shows hash mode as not ready.
 - [ ] Confirm Debug > Autopilot > Hardware hash upload > No default group tag keeps hash mode ready and selects `None`/`Aucun`.
 - [ ] Confirm Debug > Deployment pages opens the progress, success, and error preview pages.
 - [ ] Confirm the wizard footer no longer shows debug preview buttons.

--- a/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
@@ -376,6 +376,7 @@ public sealed class DeployConfigurationGeneratorTests
         Assert.Equal("ABCDEF123456", result.Autopilot.HardwareHashUpload.ActiveCertificateThumbprint);
         Assert.Equal(expiration, result.Autopilot.HardwareHashUpload.ActiveCertificateExpiresOnUtc);
         Assert.Equal("Sales", result.Autopilot.HardwareHashUpload.DefaultGroupTag);
+        Assert.Equal(["Engineering", "Sales"], result.Autopilot.HardwareHashUpload.KnownGroupTags);
     }
 
     [Fact]

--- a/src/Foundry.Core/Models/Configuration/Deploy/DeployAutopilotHardwareHashUploadSettings.cs
+++ b/src/Foundry.Core/Models/Configuration/Deploy/DeployAutopilotHardwareHashUploadSettings.cs
@@ -34,4 +34,9 @@ public sealed record DeployAutopilotHardwareHashUploadSettings
     /// Gets the default group tag offered by Foundry.Deploy for hardware hash upload.
     /// </summary>
     public string? DefaultGroupTag { get; init; }
+
+    /// <summary>
+    /// Gets the group tags discovered when the deployment media was generated.
+    /// </summary>
+    public IReadOnlyList<string> KnownGroupTags { get; init; } = [];
 }

--- a/src/Foundry.Core/Services/Configuration/DeployConfigurationGenerator.cs
+++ b/src/Foundry.Core/Services/Configuration/DeployConfigurationGenerator.cs
@@ -117,8 +117,21 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
             ActiveCertificateKeyId = settings.ActiveCertificate?.KeyId,
             ActiveCertificateThumbprint = settings.ActiveCertificate?.Thumbprint,
             ActiveCertificateExpiresOnUtc = settings.ActiveCertificate?.ExpiresOnUtc,
-            DefaultGroupTag = settings.DefaultGroupTag
+            DefaultGroupTag = settings.DefaultGroupTag,
+            KnownGroupTags = CanonicalizeGroupTags(settings.KnownGroupTags)
         };
+    }
+
+    private static string[] CanonicalizeGroupTags(IEnumerable<string> groupTags)
+    {
+        ArgumentNullException.ThrowIfNull(groupTags);
+
+        return groupTags
+            .Select(groupTag => groupTag.Trim())
+            .Where(groupTag => !string.IsNullOrWhiteSpace(groupTag))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
     }
 
     private static DeployOobeSettings MapOobeSettings(OobeSettings settings)

--- a/src/Foundry.Deploy.Tests/DeployConfigurationModelTests.cs
+++ b/src/Foundry.Deploy.Tests/DeployConfigurationModelTests.cs
@@ -101,7 +101,8 @@ public sealed class DeployConfigurationModelTests
                   "activeCertificateKeyId": "certificate-key-id",
                   "activeCertificateThumbprint": "ABCDEF123456",
                   "activeCertificateExpiresOnUtc": "2026-12-01T00:00:00+00:00",
-                  "defaultGroupTag": "Sales"
+                  "defaultGroupTag": "Sales",
+                  "knownGroupTags": ["Sales", "Kiosk"]
                 }
               }
             }
@@ -123,5 +124,6 @@ public sealed class DeployConfigurationModelTests
         Assert.Equal("ABCDEF123456", document.Autopilot.HardwareHashUpload.ActiveCertificateThumbprint);
         Assert.Equal(DateTimeOffset.Parse("2026-12-01T00:00:00+00:00"), document.Autopilot.HardwareHashUpload.ActiveCertificateExpiresOnUtc);
         Assert.Equal("Sales", document.Autopilot.HardwareHashUpload.DefaultGroupTag);
+        Assert.Equal(["Sales", "Kiosk"], document.Autopilot.HardwareHashUpload.KnownGroupTags);
     }
 }

--- a/src/Foundry.Deploy.Tests/DeploymentLaunchPreparationServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentLaunchPreparationServiceTests.cs
@@ -139,10 +139,18 @@ public sealed class DeploymentLaunchPreparationServiceTests
     }
 
     [Fact]
-    public void Prepare_WhenLiveHardwareHashUploadModeIsSelected_FailsBeforeConfirmation()
+    public void Prepare_WhenLiveHardwareHashUploadModeIsSelected_DoesNotRequireJsonProfile()
     {
-        var shell = new FakeApplicationShellService();
+        var shell = new FakeApplicationShellService { ConfirmationResult = true };
         var service = new DeploymentLaunchPreparationService(shell);
+        DeployAutopilotHardwareHashUploadSettings hardwareHashUpload = new()
+        {
+            TenantId = "tenant-id",
+            ClientId = "client-id",
+            ActiveCertificateThumbprint = "ABCDEF123456",
+            ActiveCertificateExpiresOnUtc = DateTimeOffset.UtcNow.AddMonths(1),
+            DefaultGroupTag = "Sales"
+        };
 
         DeploymentLaunchPreparationResult result = service.Prepare(
             CreateRequest(
@@ -150,11 +158,14 @@ public sealed class DeploymentLaunchPreparationServiceTests
                 isAutopilotEnabled: true,
                 autopilotProvisioningMode: AutopilotProvisioningMode.HardwareHashUpload,
                 selectedAutopilotProfile: null,
+                autopilotHardwareHashUpload: hardwareHashUpload,
                 isDryRun: false));
 
-        Assert.False(result.IsReadyToStart);
-        Assert.Contains("hardware hash upload is not available", result.StatusMessage, StringComparison.OrdinalIgnoreCase);
-        Assert.Equal(0, shell.ConfirmationCallCount);
+        Assert.True(result.IsReadyToStart);
+        Assert.Equal(AutopilotProvisioningMode.HardwareHashUpload, result.Context?.AutopilotProvisioningMode);
+        Assert.Null(result.Context?.SelectedAutopilotProfile);
+        Assert.Same(hardwareHashUpload, result.Context?.AutopilotHardwareHashUpload);
+        Assert.Equal(1, shell.ConfirmationCallCount);
     }
 
     [Fact]
@@ -214,6 +225,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
         bool isAutopilotEnabled = false,
         AutopilotProvisioningMode autopilotProvisioningMode = AutopilotProvisioningMode.JsonProfile,
         AutopilotProfileCatalogItem? selectedAutopilotProfile = null,
+        DeployAutopilotHardwareHashUploadSettings? autopilotHardwareHashUpload = null,
         DeployOobeSettings? oobe = null,
         DeployAppxRemovalSettings? appxRemoval = null,
         DeployAiComponentRemovalSettings? aiComponentRemoval = null,
@@ -243,6 +255,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
             IsAutopilotEnabled = isAutopilotEnabled,
             AutopilotProvisioningMode = autopilotProvisioningMode,
             SelectedAutopilotProfile = selectedAutopilotProfile,
+            AutopilotHardwareHashUpload = autopilotHardwareHashUpload ?? new DeployAutopilotHardwareHashUploadSettings(),
             Oobe = oobe ?? new DeployOobeSettings(),
             AppxRemoval = appxRemoval ?? new DeployAppxRemovalSettings(),
             AiComponentRemoval = aiComponentRemoval ?? new DeployAiComponentRemovalSettings(),

--- a/src/Foundry.Deploy.Tests/DeploymentPreparationViewModelTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentPreparationViewModelTests.cs
@@ -22,8 +22,10 @@ public sealed class DeploymentPreparationViewModelTests
         Assert.True(viewModel.HasAutopilotProfiles);
         Assert.True(viewModel.IsAutopilotSectionVisible);
         Assert.False(viewModel.IsAutopilotEnabled);
+        Assert.True(viewModel.IsAutopilotDisabledSummaryVisible);
         Assert.False(viewModel.IsAutopilotProfileSelectionEnabled);
         Assert.Null(viewModel.SelectedAutopilotProfile);
+        Assert.Contains("JSON", viewModel.AutopilotDisabledSummaryText, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -71,6 +73,7 @@ public sealed class DeploymentPreparationViewModelTests
         Assert.False(viewModel.IsAutopilotProfileSelectionEnabled);
         Assert.Null(viewModel.SelectedAutopilotProfile);
         Assert.NotEqual(string.Empty, viewModel.AutopilotProfileHint);
+        Assert.True(viewModel.HasAutopilotProfileHint);
     }
 
     [Fact]
@@ -107,7 +110,8 @@ public sealed class DeploymentPreparationViewModelTests
         Assert.Same(hardwareHashUpload, viewModel.AutopilotHardwareHashUpload);
         Assert.True(viewModel.IsHardwareHashCertificateUsable);
         Assert.True(viewModel.IsHardwareHashGroupTagControlsVisible);
-        Assert.False(string.IsNullOrWhiteSpace(viewModel.AutopilotHardwareHashReadinessText));
+        Assert.False(string.IsNullOrWhiteSpace(viewModel.AutopilotHardwareHashUploadStatusText));
+        Assert.False(string.IsNullOrWhiteSpace(viewModel.AutopilotHardwareHashUploadMessage));
         Assert.Contains("Sales", viewModel.UseDefaultHardwareHashGroupTagText);
     }
 
@@ -131,7 +135,8 @@ public sealed class DeploymentPreparationViewModelTests
         Assert.True(viewModel.IsHardwareHashCertificateExpired);
         Assert.False(viewModel.IsHardwareHashCertificateUsable);
         Assert.False(viewModel.IsHardwareHashGroupTagControlsVisible);
-        Assert.False(string.IsNullOrWhiteSpace(viewModel.AutopilotHardwareHashReadinessText));
+        Assert.False(string.IsNullOrWhiteSpace(viewModel.AutopilotHardwareHashUploadStatusText));
+        Assert.False(string.IsNullOrWhiteSpace(viewModel.AutopilotHardwareHashUploadMessage));
     }
 
     [Fact]
@@ -151,7 +156,7 @@ public sealed class DeploymentPreparationViewModelTests
         Assert.False(viewModel.HasHardwareHashUploadMetadata);
         Assert.False(viewModel.IsHardwareHashCertificateUsable);
         Assert.False(viewModel.IsHardwareHashGroupTagControlsVisible);
-        Assert.False(viewModel.IsHardwareHashPreRuntimeWarningVisible);
+        Assert.True(viewModel.IsHardwareHashMissingMetadataWarningVisible);
     }
 
     [Fact]
@@ -182,6 +187,7 @@ public sealed class DeploymentPreparationViewModelTests
 
         Assert.Equal("Kiosk", result.DefaultGroupTag);
         Assert.False(viewModel.UseDefaultHardwareHashGroupTag);
+        Assert.True(viewModel.IsHardwareHashCustomGroupTagTextBoxVisible);
     }
 
     [Fact]
@@ -196,6 +202,8 @@ public sealed class DeploymentPreparationViewModelTests
 
         Assert.Null(result.DefaultGroupTag);
         Assert.False(string.IsNullOrWhiteSpace(viewModel.EffectiveHardwareHashGroupTagText));
+        Assert.False(viewModel.IsDefaultHardwareHashGroupTagOptionVisible);
+        Assert.True(viewModel.IsHardwareHashCustomGroupTagTextBoxVisible);
     }
 
     [Theory]
@@ -262,6 +270,8 @@ public sealed class DeploymentPreparationViewModelTests
         Assert.True(viewModel.IsHardwareHashCertificateUsable);
         Assert.Null(viewModel.CreateAutopilotHardwareHashUploadForLaunch().DefaultGroupTag);
         Assert.False(string.IsNullOrWhiteSpace(viewModel.EffectiveHardwareHashGroupTagText));
+        Assert.False(viewModel.IsDefaultHardwareHashGroupTagOptionVisible);
+        Assert.True(viewModel.IsHardwareHashCustomGroupTagTextBoxVisible);
     }
 
     [Fact]

--- a/src/Foundry.Deploy.Tests/DeploymentPreparationViewModelTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentPreparationViewModelTests.cs
@@ -82,6 +82,7 @@ public sealed class DeploymentPreparationViewModelTests
         {
             TenantId = "tenant-id",
             ClientId = "client-id",
+            ActiveCertificateKeyId = "certificate-key-id",
             ActiveCertificateThumbprint = "ABCDEF123456",
             ActiveCertificateExpiresOnUtc = DateTimeOffset.UtcNow.AddMonths(1),
             DefaultGroupTag = "Sales"
@@ -104,7 +105,10 @@ public sealed class DeploymentPreparationViewModelTests
         Assert.False(viewModel.IsAutopilotProfileSelectionEnabled);
         Assert.Null(viewModel.SelectedAutopilotProfile);
         Assert.Same(hardwareHashUpload, viewModel.AutopilotHardwareHashUpload);
-        Assert.Contains("Sales", viewModel.AutopilotHardwareHashStatusText);
+        Assert.True(viewModel.IsHardwareHashCertificateUsable);
+        Assert.True(viewModel.IsHardwareHashGroupTagControlsVisible);
+        Assert.False(string.IsNullOrWhiteSpace(viewModel.AutopilotHardwareHashReadinessText));
+        Assert.Contains("Sales", viewModel.UseDefaultHardwareHashGroupTagText);
     }
 
     [Fact]
@@ -125,7 +129,73 @@ public sealed class DeploymentPreparationViewModelTests
             []);
 
         Assert.True(viewModel.IsHardwareHashCertificateExpired);
-        Assert.NotEqual(string.Empty, viewModel.AutopilotHardwareHashStatusText);
+        Assert.False(viewModel.IsHardwareHashCertificateUsable);
+        Assert.False(viewModel.IsHardwareHashGroupTagControlsVisible);
+        Assert.False(string.IsNullOrWhiteSpace(viewModel.AutopilotHardwareHashReadinessText));
+    }
+
+    [Fact]
+    public void ApplyAutopilotConfiguration_WhenHardwareHashCertificateKeyIdIsMissing_DoesNotExposeGroupTagControls()
+    {
+        using DeploymentPreparationViewModel viewModel = CreateViewModel();
+        DeployAutopilotSettings settings = CreateHardwareHashSettings(defaultGroupTag: "Sales") with
+        {
+            HardwareHashUpload = CreateHardwareHashSettings(defaultGroupTag: "Sales").HardwareHashUpload! with
+            {
+                ActiveCertificateKeyId = null
+            }
+        };
+
+        viewModel.ApplyAutopilotConfiguration(settings, []);
+
+        Assert.False(viewModel.HasHardwareHashUploadMetadata);
+        Assert.False(viewModel.IsHardwareHashCertificateUsable);
+        Assert.False(viewModel.IsHardwareHashGroupTagControlsVisible);
+        Assert.False(viewModel.IsHardwareHashPreRuntimeWarningVisible);
+    }
+
+    [Fact]
+    public void CreateAutopilotHardwareHashUploadForLaunch_WhenDefaultGroupTagIsUsed_ReturnsDefaultGroupTag()
+    {
+        using DeploymentPreparationViewModel viewModel = CreateViewModel();
+        viewModel.ApplyAutopilotConfiguration(
+            CreateHardwareHashSettings(defaultGroupTag: "Sales"),
+            []);
+
+        DeployAutopilotHardwareHashUploadSettings result = viewModel.CreateAutopilotHardwareHashUploadForLaunch();
+
+        Assert.Equal("Sales", result.DefaultGroupTag);
+    }
+
+    [Fact]
+    public void CreateAutopilotHardwareHashUploadForLaunch_WhenCustomGroupTagIsUsed_ReturnsTrimmedCustomGroupTag()
+    {
+        using DeploymentPreparationViewModel viewModel = CreateViewModel();
+        viewModel.ApplyAutopilotConfiguration(
+            CreateHardwareHashSettings(defaultGroupTag: "Sales"),
+            []);
+
+        viewModel.UseCustomHardwareHashGroupTag = true;
+        viewModel.CustomHardwareHashGroupTag = " Kiosk ";
+
+        DeployAutopilotHardwareHashUploadSettings result = viewModel.CreateAutopilotHardwareHashUploadForLaunch();
+
+        Assert.Equal("Kiosk", result.DefaultGroupTag);
+        Assert.False(viewModel.UseDefaultHardwareHashGroupTag);
+    }
+
+    [Fact]
+    public void CreateAutopilotHardwareHashUploadForLaunch_WhenDefaultGroupTagIsNone_ReturnsNullGroupTag()
+    {
+        using DeploymentPreparationViewModel viewModel = CreateViewModel();
+        viewModel.ApplyAutopilotConfiguration(
+            CreateHardwareHashSettings(defaultGroupTag: null),
+            []);
+
+        DeployAutopilotHardwareHashUploadSettings result = viewModel.CreateAutopilotHardwareHashUploadForLaunch();
+
+        Assert.Null(result.DefaultGroupTag);
+        Assert.False(string.IsNullOrWhiteSpace(viewModel.EffectiveHardwareHashGroupTagText));
     }
 
     [Theory]
@@ -182,6 +252,24 @@ public sealed class DeploymentPreparationViewModelTests
             FolderName = folderName,
             DisplayName = displayName,
             ConfigurationFilePath = $@"X:\Foundry\Config\Autopilot\{folderName}\AutopilotConfigurationFile.json"
+        };
+    }
+
+    private static DeployAutopilotSettings CreateHardwareHashSettings(string? defaultGroupTag)
+    {
+        return new DeployAutopilotSettings
+        {
+            IsEnabled = true,
+            ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+            HardwareHashUpload = new DeployAutopilotHardwareHashUploadSettings
+            {
+                TenantId = "tenant-id",
+                ClientId = "client-id",
+                ActiveCertificateKeyId = "certificate-key-id",
+                ActiveCertificateThumbprint = "ABCDEF123456",
+                ActiveCertificateExpiresOnUtc = DateTimeOffset.UtcNow.AddMonths(1),
+                DefaultGroupTag = defaultGroupTag
+            }
         };
     }
 

--- a/src/Foundry.Deploy.Tests/DeploymentPreparationViewModelTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentPreparationViewModelTests.cs
@@ -201,7 +201,10 @@ public sealed class DeploymentPreparationViewModelTests
     [Theory]
     [InlineData(DebugAutopilotMode.None, false, AutopilotProvisioningMode.JsonProfile)]
     [InlineData(DebugAutopilotMode.JsonProfile, true, AutopilotProvisioningMode.JsonProfile)]
-    [InlineData(DebugAutopilotMode.HardwareHashUpload, true, AutopilotProvisioningMode.HardwareHashUpload)]
+    [InlineData(DebugAutopilotMode.HardwareHashUploadValidCertificate, true, AutopilotProvisioningMode.HardwareHashUpload)]
+    [InlineData(DebugAutopilotMode.HardwareHashUploadExpiredCertificate, true, AutopilotProvisioningMode.HardwareHashUpload)]
+    [InlineData(DebugAutopilotMode.HardwareHashUploadMissingCertificateMetadata, true, AutopilotProvisioningMode.HardwareHashUpload)]
+    [InlineData(DebugAutopilotMode.HardwareHashUploadNoDefaultGroupTag, true, AutopilotProvisioningMode.HardwareHashUpload)]
     public void ApplyDebugAutopilotMode_OverridesAutopilotState(DebugAutopilotMode mode, bool expectedEnabled, AutopilotProvisioningMode expectedMode)
     {
         using DeploymentPreparationViewModel viewModel = CreateViewModel();
@@ -211,7 +214,54 @@ public sealed class DeploymentPreparationViewModelTests
         Assert.Equal(expectedEnabled, viewModel.IsAutopilotEnabled);
         Assert.Equal(expectedMode, viewModel.AutopilotProvisioningMode);
         Assert.Equal(mode == DebugAutopilotMode.JsonProfile, viewModel.SelectedAutopilotProfile is not null);
-        Assert.Equal(mode == DebugAutopilotMode.HardwareHashUpload, viewModel.IsHardwareHashUploadControlsVisible);
+        Assert.Equal(expectedEnabled && expectedMode == AutopilotProvisioningMode.HardwareHashUpload, viewModel.IsHardwareHashUploadControlsVisible);
+    }
+
+    [Fact]
+    public void ApplyDebugAutopilotMode_WhenHardwareHashCertificateIsValid_ConfiguresUsableUpload()
+    {
+        using DeploymentPreparationViewModel viewModel = CreateViewModel();
+
+        viewModel.ApplyDebugAutopilotMode(DebugAutopilotMode.HardwareHashUploadValidCertificate);
+
+        Assert.True(viewModel.IsHardwareHashCertificateUsable);
+        Assert.False(viewModel.IsHardwareHashCertificateExpired);
+        Assert.Equal("Debug", viewModel.CreateAutopilotHardwareHashUploadForLaunch().DefaultGroupTag);
+    }
+
+    [Fact]
+    public void ApplyDebugAutopilotMode_WhenHardwareHashCertificateIsExpired_MarksCertificateUnusable()
+    {
+        using DeploymentPreparationViewModel viewModel = CreateViewModel();
+
+        viewModel.ApplyDebugAutopilotMode(DebugAutopilotMode.HardwareHashUploadExpiredCertificate);
+
+        Assert.True(viewModel.HasHardwareHashUploadMetadata);
+        Assert.True(viewModel.IsHardwareHashCertificateExpired);
+        Assert.False(viewModel.IsHardwareHashCertificateUsable);
+    }
+
+    [Fact]
+    public void ApplyDebugAutopilotMode_WhenHardwareHashMetadataIsMissing_MarksCertificateUnusable()
+    {
+        using DeploymentPreparationViewModel viewModel = CreateViewModel();
+
+        viewModel.ApplyDebugAutopilotMode(DebugAutopilotMode.HardwareHashUploadMissingCertificateMetadata);
+
+        Assert.False(viewModel.HasHardwareHashUploadMetadata);
+        Assert.False(viewModel.IsHardwareHashCertificateUsable);
+    }
+
+    [Fact]
+    public void ApplyDebugAutopilotMode_WhenHardwareHashDefaultGroupTagIsMissing_LaunchesWithoutGroupTag()
+    {
+        using DeploymentPreparationViewModel viewModel = CreateViewModel();
+
+        viewModel.ApplyDebugAutopilotMode(DebugAutopilotMode.HardwareHashUploadNoDefaultGroupTag);
+
+        Assert.True(viewModel.IsHardwareHashCertificateUsable);
+        Assert.Null(viewModel.CreateAutopilotHardwareHashUploadForLaunch().DefaultGroupTag);
+        Assert.False(string.IsNullOrWhiteSpace(viewModel.EffectiveHardwareHashGroupTagText));
     }
 
     [Fact]

--- a/src/Foundry.Deploy.Tests/DeploymentPreparationViewModelTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentPreparationViewModelTests.cs
@@ -88,7 +88,8 @@ public sealed class DeploymentPreparationViewModelTests
             ActiveCertificateKeyId = "certificate-key-id",
             ActiveCertificateThumbprint = "ABCDEF123456",
             ActiveCertificateExpiresOnUtc = DateTimeOffset.UtcNow.AddMonths(1),
-            DefaultGroupTag = "Sales"
+            DefaultGroupTag = "Sales",
+            KnownGroupTags = ["Kiosk", "Sales"]
         };
 
         viewModel.ApplyAutopilotConfiguration(
@@ -112,7 +113,9 @@ public sealed class DeploymentPreparationViewModelTests
         Assert.True(viewModel.IsHardwareHashGroupTagControlsVisible);
         Assert.False(string.IsNullOrWhiteSpace(viewModel.AutopilotHardwareHashUploadStatusText));
         Assert.False(string.IsNullOrWhiteSpace(viewModel.AutopilotHardwareHashUploadMessage));
-        Assert.Contains("Sales", viewModel.UseDefaultHardwareHashGroupTagText);
+        Assert.Equal("tenant-id", viewModel.AutopilotHardwareHashTenantIdText);
+        Assert.Equal("ABCDEF123456", viewModel.AutopilotHardwareHashCertificateThumbprintText);
+        Assert.Equal("Sales", viewModel.SelectedHardwareHashGroupTag?.GroupTag);
     }
 
     [Fact]
@@ -160,7 +163,7 @@ public sealed class DeploymentPreparationViewModelTests
     }
 
     [Fact]
-    public void CreateAutopilotHardwareHashUploadForLaunch_WhenDefaultGroupTagIsUsed_ReturnsDefaultGroupTag()
+    public void CreateAutopilotHardwareHashUploadForLaunch_WhenDefaultGroupTagExists_SelectsDefaultGroupTag()
     {
         using DeploymentPreparationViewModel viewModel = CreateViewModel();
         viewModel.ApplyAutopilotConfiguration(
@@ -173,21 +176,18 @@ public sealed class DeploymentPreparationViewModelTests
     }
 
     [Fact]
-    public void CreateAutopilotHardwareHashUploadForLaunch_WhenCustomGroupTagIsUsed_ReturnsTrimmedCustomGroupTag()
+    public void CreateAutopilotHardwareHashUploadForLaunch_WhenDifferentKnownGroupTagIsSelected_ReturnsSelectedGroupTag()
     {
         using DeploymentPreparationViewModel viewModel = CreateViewModel();
         viewModel.ApplyAutopilotConfiguration(
             CreateHardwareHashSettings(defaultGroupTag: "Sales"),
             []);
 
-        viewModel.UseCustomHardwareHashGroupTag = true;
-        viewModel.CustomHardwareHashGroupTag = " Kiosk ";
+        viewModel.SelectedHardwareHashGroupTag = viewModel.HardwareHashGroupTagOptions.Single(option => option.GroupTag == "Kiosk");
 
         DeployAutopilotHardwareHashUploadSettings result = viewModel.CreateAutopilotHardwareHashUploadForLaunch();
 
         Assert.Equal("Kiosk", result.DefaultGroupTag);
-        Assert.False(viewModel.UseDefaultHardwareHashGroupTag);
-        Assert.True(viewModel.IsHardwareHashCustomGroupTagTextBoxVisible);
     }
 
     [Fact]
@@ -202,8 +202,27 @@ public sealed class DeploymentPreparationViewModelTests
 
         Assert.Null(result.DefaultGroupTag);
         Assert.False(string.IsNullOrWhiteSpace(viewModel.EffectiveHardwareHashGroupTagText));
-        Assert.False(viewModel.IsDefaultHardwareHashGroupTagOptionVisible);
-        Assert.True(viewModel.IsHardwareHashCustomGroupTagTextBoxVisible);
+        Assert.Null(viewModel.SelectedHardwareHashGroupTag?.GroupTag);
+    }
+
+    [Fact]
+    public void CreateAutopilotHardwareHashUploadForLaunch_WhenDefaultGroupTagIsMissingFromKnownTags_ReturnsNullGroupTag()
+    {
+        using DeploymentPreparationViewModel viewModel = CreateViewModel();
+        DeployAutopilotSettings settings = CreateHardwareHashSettings(defaultGroupTag: "Sales") with
+        {
+            HardwareHashUpload = CreateHardwareHashSettings(defaultGroupTag: "Sales").HardwareHashUpload! with
+            {
+                KnownGroupTags = ["Kiosk"]
+            }
+        };
+
+        viewModel.ApplyAutopilotConfiguration(settings, []);
+
+        DeployAutopilotHardwareHashUploadSettings result = viewModel.CreateAutopilotHardwareHashUploadForLaunch();
+
+        Assert.Null(result.DefaultGroupTag);
+        Assert.Null(viewModel.SelectedHardwareHashGroupTag?.GroupTag);
     }
 
     [Theory]
@@ -235,6 +254,7 @@ public sealed class DeploymentPreparationViewModelTests
         Assert.True(viewModel.IsHardwareHashCertificateUsable);
         Assert.False(viewModel.IsHardwareHashCertificateExpired);
         Assert.Equal("Debug", viewModel.CreateAutopilotHardwareHashUploadForLaunch().DefaultGroupTag);
+        Assert.Contains(viewModel.HardwareHashGroupTagOptions, option => option.GroupTag == "Kiosk");
     }
 
     [Fact]
@@ -270,8 +290,7 @@ public sealed class DeploymentPreparationViewModelTests
         Assert.True(viewModel.IsHardwareHashCertificateUsable);
         Assert.Null(viewModel.CreateAutopilotHardwareHashUploadForLaunch().DefaultGroupTag);
         Assert.False(string.IsNullOrWhiteSpace(viewModel.EffectiveHardwareHashGroupTagText));
-        Assert.False(viewModel.IsDefaultHardwareHashGroupTagOptionVisible);
-        Assert.True(viewModel.IsHardwareHashCustomGroupTagTextBoxVisible);
+        Assert.Null(viewModel.SelectedHardwareHashGroupTag?.GroupTag);
     }
 
     [Fact]
@@ -328,7 +347,8 @@ public sealed class DeploymentPreparationViewModelTests
                 ActiveCertificateKeyId = "certificate-key-id",
                 ActiveCertificateThumbprint = "ABCDEF123456",
                 ActiveCertificateExpiresOnUtc = DateTimeOffset.UtcNow.AddMonths(1),
-                DefaultGroupTag = defaultGroupTag
+                DefaultGroupTag = defaultGroupTag,
+                KnownGroupTags = ["Kiosk", "Sales"]
             }
         };
     }

--- a/src/Foundry.Deploy.Tests/StageAutopilotConfigurationStepTests.cs
+++ b/src/Foundry.Deploy.Tests/StageAutopilotConfigurationStepTests.cs
@@ -11,7 +11,7 @@ namespace Foundry.Deploy.Tests;
 public sealed class StageAutopilotConfigurationStepTests
 {
     [Fact]
-    public async Task ExecuteAsync_WhenLiveHardwareHashModeBypassesLaunchGuard_FailsClearly()
+    public async Task ExecuteAsync_WhenLiveHardwareHashModeRunsBeforeRuntimeImplementation_SkipsWithoutFailingDeployment()
     {
         using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
         StageAutopilotConfigurationStep step = new();
@@ -22,8 +22,28 @@ public sealed class StageAutopilotConfigurationStepTests
 
         DeploymentStepResult result = await step.ExecuteAsync(context, CancellationToken.None);
 
-        Assert.Equal(DeploymentStepState.Failed, result.State);
-        Assert.Contains("hardware hash upload is not available", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(DeploymentStepState.Skipped, result.State);
+        Assert.Contains("runtime phase is implemented", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenLiveHardwareHashCertificateIsExpired_SkipsUpload()
+    {
+        using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
+        StageAutopilotConfigurationStep step = new();
+        DeploymentStepExecutionContext context = CreateContext(
+            workspace,
+            isDryRun: false,
+            provisioningMode: AutopilotProvisioningMode.HardwareHashUpload,
+            hardwareHashUpload: new DeployAutopilotHardwareHashUploadSettings
+            {
+                ActiveCertificateExpiresOnUtc = DateTimeOffset.UtcNow.AddDays(-1)
+            });
+
+        DeploymentStepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal(DeploymentStepState.Skipped, result.State);
+        Assert.Contains("expired", result.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/Foundry.Deploy/MainWindow.xaml
+++ b/src/Foundry.Deploy/MainWindow.xaml
@@ -72,26 +72,52 @@
                         Header="{Binding Strings[Tools.RefreshTargetDisks]}"
                         IsEnabled="{Binding Session.IsStartupReady}" />
                     <MenuItem Command="{Binding Session.OpenLogFileCommand}" Header="{Binding Strings[Tools.OpenLogFile]}" />
-                    <Separator Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                    <MenuItem Header="{Binding Strings[Tools.DebugAutopilotMode]}" Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}">
+                </MenuItem>
+                <MenuItem Header="{Binding Strings[Menu.Debug]}" Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <MenuItem Header="{Binding Strings[Debug.Autopilot]}">
                         <MenuItem
                             Command="{Binding SetDebugAutopilotModeCommand}"
                             CommandParameter="{x:Static runtime:DebugAutopilotMode.None}"
-                            Header="{Binding Strings[Tools.DebugAutopilotMode.None]}"
+                            Header="{Binding Strings[Debug.Autopilot.NoAutopilot]}"
                             IsCheckable="True"
                             IsChecked="{Binding IsDebugAutopilotNoneMode, Mode=OneWay}" />
                         <MenuItem
                             Command="{Binding SetDebugAutopilotModeCommand}"
                             CommandParameter="{x:Static runtime:DebugAutopilotMode.JsonProfile}"
-                            Header="{Binding Strings[Tools.DebugAutopilotMode.JsonProfile]}"
+                            Header="{Binding Strings[Debug.Autopilot.JsonProfile]}"
                             IsCheckable="True"
                             IsChecked="{Binding IsDebugAutopilotJsonProfileMode, Mode=OneWay}" />
-                        <MenuItem
-                            Command="{Binding SetDebugAutopilotModeCommand}"
-                            CommandParameter="{x:Static runtime:DebugAutopilotMode.HardwareHashUpload}"
-                            Header="{Binding Strings[Tools.DebugAutopilotMode.HardwareHashUpload]}"
-                            IsCheckable="True"
-                            IsChecked="{Binding IsDebugAutopilotHardwareHashUploadMode, Mode=OneWay}" />
+                        <MenuItem Header="{Binding Strings[Debug.Autopilot.HardwareHashUpload]}">
+                            <MenuItem
+                                Command="{Binding SetDebugAutopilotModeCommand}"
+                                CommandParameter="{x:Static runtime:DebugAutopilotMode.HardwareHashUploadValidCertificate}"
+                                Header="{Binding Strings[Debug.Autopilot.HardwareHashUpload.ValidCertificate]}"
+                                IsCheckable="True"
+                                IsChecked="{Binding IsDebugAutopilotHardwareHashUploadValidCertificateMode, Mode=OneWay}" />
+                            <MenuItem
+                                Command="{Binding SetDebugAutopilotModeCommand}"
+                                CommandParameter="{x:Static runtime:DebugAutopilotMode.HardwareHashUploadExpiredCertificate}"
+                                Header="{Binding Strings[Debug.Autopilot.HardwareHashUpload.ExpiredCertificate]}"
+                                IsCheckable="True"
+                                IsChecked="{Binding IsDebugAutopilotHardwareHashUploadExpiredCertificateMode, Mode=OneWay}" />
+                            <MenuItem
+                                Command="{Binding SetDebugAutopilotModeCommand}"
+                                CommandParameter="{x:Static runtime:DebugAutopilotMode.HardwareHashUploadMissingCertificateMetadata}"
+                                Header="{Binding Strings[Debug.Autopilot.HardwareHashUpload.MissingCertificateMetadata]}"
+                                IsCheckable="True"
+                                IsChecked="{Binding IsDebugAutopilotHardwareHashUploadMissingCertificateMetadataMode, Mode=OneWay}" />
+                            <MenuItem
+                                Command="{Binding SetDebugAutopilotModeCommand}"
+                                CommandParameter="{x:Static runtime:DebugAutopilotMode.HardwareHashUploadNoDefaultGroupTag}"
+                                Header="{Binding Strings[Debug.Autopilot.HardwareHashUpload.NoDefaultGroupTag]}"
+                                IsCheckable="True"
+                                IsChecked="{Binding IsDebugAutopilotHardwareHashUploadNoDefaultGroupTagMode, Mode=OneWay}" />
+                        </MenuItem>
+                    </MenuItem>
+                    <MenuItem Header="{Binding Strings[Debug.DeploymentPages]}">
+                        <MenuItem Command="{Binding ShowDebugProgressPageCommand}" Header="{Binding Strings[Debug.ProgressPageCommand]}" />
+                        <MenuItem Command="{Binding ShowDebugSuccessPageCommand}" Header="{Binding Strings[Debug.SuccessPageCommand]}" />
+                        <MenuItem Command="{Binding ShowDebugErrorPageCommand}" Header="{Binding Strings[Debug.ErrorPageCommand]}" />
                     </MenuItem>
                 </MenuItem>
                 <MenuItem Command="{Binding ShowAboutCommand}" Header="{Binding Strings[Menu.About]}" />

--- a/src/Foundry.Deploy/Models/Configuration/DeployAutopilotHardwareHashUploadSettings.cs
+++ b/src/Foundry.Deploy/Models/Configuration/DeployAutopilotHardwareHashUploadSettings.cs
@@ -34,4 +34,9 @@ public sealed record DeployAutopilotHardwareHashUploadSettings
     /// Gets the default group tag offered by Foundry.Deploy for hardware hash upload.
     /// </summary>
     public string? DefaultGroupTag { get; init; }
+
+    /// <summary>
+    /// Gets the group tags discovered when the deployment media was generated.
+    /// </summary>
+    public IReadOnlyList<string> KnownGroupTags { get; init; } = [];
 }

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentContext.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentContext.cs
@@ -54,7 +54,7 @@ public sealed record DeploymentContext
     public bool ApplyFirmwareUpdates { get; init; } = true;
 
     /// <summary>
-    /// Gets a value indicating whether an Autopilot profile should be staged for OOBE.
+    /// Gets a value indicating whether the selected Autopilot provisioning method should run.
     /// </summary>
     public bool IsAutopilotEnabled { get; init; }
 
@@ -64,12 +64,12 @@ public sealed record DeploymentContext
     public AutopilotProvisioningMode AutopilotProvisioningMode { get; init; } = AutopilotProvisioningMode.JsonProfile;
 
     /// <summary>
-    /// Gets the selected Autopilot profile staged into the offline Windows image.
+    /// Gets the selected Autopilot profile staged into the offline Windows image when JSON profile mode is selected.
     /// </summary>
     public AutopilotProfileCatalogItem? SelectedAutopilotProfile { get; init; }
 
     /// <summary>
-    /// Gets non-secret metadata for hardware hash upload mode.
+    /// Gets non-secret metadata for hardware hash upload mode, including the effective group tag override.
     /// </summary>
     public DeployAutopilotHardwareHashUploadSettings AutopilotHardwareHashUpload { get; init; } = new();
 

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchPreparationService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchPreparationService.cs
@@ -75,15 +75,6 @@ public sealed class DeploymentLaunchPreparationService : IDeploymentLaunchPrepar
                 normalizedComputerName);
         }
 
-        if (request.IsAutopilotEnabled &&
-            request.AutopilotProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload &&
-            !request.IsDryRun)
-        {
-            return DeploymentLaunchPreparationResult.Failure(
-                "Autopilot hardware hash upload is not available until the deployment runtime phase is implemented.",
-                normalizedComputerName);
-        }
-
         if (!request.IsDryRun && !ConfirmDestructiveDeployment(effectiveTargetDisk, request.SelectedOperatingSystem))
         {
             return DeploymentLaunchPreparationResult.Failure("Deployment cancelled by user.", normalizedComputerName);

--- a/src/Foundry.Deploy/Services/Deployment/Steps/StageAutopilotConfigurationStep.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Steps/StageAutopilotConfigurationStep.cs
@@ -22,7 +22,13 @@ public sealed class StageAutopilotConfigurationStep : DeploymentStepBase
 
         if (context.Request.AutopilotProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload)
         {
-            return DeploymentStepResult.Failed("Autopilot hardware hash upload is not available until the deployment runtime phase is implemented.");
+            if (context.Request.AutopilotHardwareHashUpload.ActiveCertificateExpiresOnUtc is DateTimeOffset expiresOn &&
+                expiresOn <= DateTimeOffset.UtcNow)
+            {
+                return DeploymentStepResult.Skipped("Autopilot hardware hash upload skipped because the embedded certificate is expired.");
+            }
+
+            return DeploymentStepResult.Skipped("Autopilot hardware hash upload skipped until the deployment runtime phase is implemented.");
         }
 
         if (context.Request.SelectedAutopilotProfile is null)

--- a/src/Foundry.Deploy/Services/Localization/DeploymentUiTextLocalizer.cs
+++ b/src/Foundry.Deploy/Services/Localization/DeploymentUiTextLocalizer.cs
@@ -326,12 +326,6 @@ public static partial class DeploymentUiTextLocalizer
             return LocalizationText.Format("StepProgress.DownloadedBytesFormat", match.Groups["size"].Value);
         }
 
-        match = ProfilesAvailableRegex().Match(value);
-        if (match.Success)
-        {
-            return LocalizationText.Format("Preparation.AutopilotProfilesAvailableFormat", int.Parse(match.Groups["count"].Value));
-        }
-
         match = TargetDisksLoadedRegex().Match(value);
         if (match.Success)
         {
@@ -408,9 +402,6 @@ public static partial class DeploymentUiTextLocalizer
 
     [GeneratedRegex(@"^Catalogs loaded: (?<os>\d+) OS entries, (?<drivers>\d+) driver packs\.$")]
     private static partial Regex CatalogLoadedRegex();
-
-    [GeneratedRegex(@"^Profiles available: (?<count>\d+)$")]
-    private static partial Regex ProfilesAvailableRegex();
 
     [GeneratedRegex(@"^Target disks loaded: (?<count>\d+) detected\.$")]
     private static partial Regex TargetDisksLoadedRegex();

--- a/src/Foundry.Deploy/Services/Runtime/DebugAutopilotMode.cs
+++ b/src/Foundry.Deploy/Services/Runtime/DebugAutopilotMode.cs
@@ -1,7 +1,7 @@
 namespace Foundry.Deploy.Services.Runtime;
 
 /// <summary>
-/// Selects the in-memory Autopilot mode used by Foundry.Deploy debug safe mode.
+/// Selects the in-memory Autopilot scenario used by Foundry.Deploy debug safe mode.
 /// </summary>
 public enum DebugAutopilotMode
 {
@@ -16,7 +16,22 @@ public enum DebugAutopilotMode
     JsonProfile,
 
     /// <summary>
-    /// Simulates hardware hash upload provisioning during the debug deployment run.
+    /// Simulates hardware hash upload provisioning with a valid certificate.
     /// </summary>
-    HardwareHashUpload
+    HardwareHashUploadValidCertificate,
+
+    /// <summary>
+    /// Simulates hardware hash upload provisioning with an expired certificate.
+    /// </summary>
+    HardwareHashUploadExpiredCertificate,
+
+    /// <summary>
+    /// Simulates hardware hash upload provisioning with incomplete certificate metadata.
+    /// </summary>
+    HardwareHashUploadMissingCertificateMetadata,
+
+    /// <summary>
+    /// Simulates hardware hash upload provisioning without a default group tag.
+    /// </summary>
+    HardwareHashUploadNoDefaultGroupTag
 }

--- a/src/Foundry.Deploy/Strings/en-US/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-US/Resources.resx
@@ -21,6 +21,7 @@
   <data name="Menu.Theme" xml:space="preserve"><value>_Theme</value></data>
   <data name="Menu.Language" xml:space="preserve"><value>_Language</value></data>
   <data name="Menu.Tools" xml:space="preserve"><value>_Tools</value></data>
+  <data name="Menu.Debug" xml:space="preserve"><value>_Debug</value></data>
   <data name="Menu.About" xml:space="preserve"><value>_About</value></data>
   <data name="Theme.System" xml:space="preserve"><value>System</value></data>
   <data name="Theme.Light" xml:space="preserve"><value>Light</value></data>
@@ -30,10 +31,6 @@
   <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Refresh Catalogs</value></data>
   <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Refresh Target Disks</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Open Log File</value></data>
-  <data name="Tools.DebugAutopilotMode" xml:space="preserve"><value>Debug Autopilot Mode</value></data>
-  <data name="Tools.DebugAutopilotMode.None" xml:space="preserve"><value>No Autopilot</value></data>
-  <data name="Tools.DebugAutopilotMode.JsonProfile" xml:space="preserve"><value>JSON profile</value></data>
-  <data name="Tools.DebugAutopilotMode.HardwareHashUpload" xml:space="preserve"><value>Hardware hash upload</value></data>
   <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>DEBUG SAFE MODE ACTIVE: all deployment actions are simulated; no disk/image write is performed.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Target</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operating System Catalog</value></data>
@@ -122,9 +119,18 @@
   <data name="Summary.SectionTarget" xml:space="preserve"><value>Target</value></data>
   <data name="Summary.SectionSystem" xml:space="preserve"><value>System</value></data>
   <data name="Summary.SectionDeployment" xml:space="preserve"><value>Deployment Options</value></data>
-  <data name="Debug.ProgressButton" xml:space="preserve"><value>DBG: Progress</value></data>
-  <data name="Debug.SuccessButton" xml:space="preserve"><value>DBG: Success</value></data>
-  <data name="Debug.ErrorButton" xml:space="preserve"><value>DBG: Error</value></data>
+  <data name="Debug.Autopilot" xml:space="preserve"><value>Autopilot</value></data>
+  <data name="Debug.Autopilot.NoAutopilot" xml:space="preserve"><value>No Autopilot</value></data>
+  <data name="Debug.Autopilot.JsonProfile" xml:space="preserve"><value>JSON profile</value></data>
+  <data name="Debug.Autopilot.HardwareHashUpload" xml:space="preserve"><value>Hardware hash upload</value></data>
+  <data name="Debug.Autopilot.HardwareHashUpload.ValidCertificate" xml:space="preserve"><value>Valid certificate</value></data>
+  <data name="Debug.Autopilot.HardwareHashUpload.ExpiredCertificate" xml:space="preserve"><value>Expired certificate</value></data>
+  <data name="Debug.Autopilot.HardwareHashUpload.MissingCertificateMetadata" xml:space="preserve"><value>Missing certificate metadata</value></data>
+  <data name="Debug.Autopilot.HardwareHashUpload.NoDefaultGroupTag" xml:space="preserve"><value>No default group tag</value></data>
+  <data name="Debug.DeploymentPages" xml:space="preserve"><value>Deployment pages</value></data>
+  <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Progress page</value></data>
+  <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Success page</value></data>
+  <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Error page</value></data>
   <data name="Debug.ProgressPage" xml:space="preserve"><value>DBG preview: progress page.</value></data>
   <data name="Debug.SuccessPage" xml:space="preserve"><value>DBG preview: success page.</value></data>
   <data name="Debug.ErrorPage" xml:space="preserve"><value>DBG preview: error page.</value></data>

--- a/src/Foundry.Deploy/Strings/en-US/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-US/Resources.resx
@@ -49,17 +49,26 @@
   <data name="Preparation.TargetDisk" xml:space="preserve"><value>Target Disk</value></data>
   <data name="Preparation.TargetDiskHint" xml:space="preserve"><value>Select a target disk. Non-eligible disks are blocked.</value></data>
   <data name="Preparation.FirmwareUpdates" xml:space="preserve"><value>Firmware: Microsoft Update Catalog update enabled.</value></data>
-  <data name="Preparation.AutopilotEnable" xml:space="preserve"><value>Autopilot: Enable offline profile staging.</value></data>
+  <data name="Preparation.AutopilotEnable" xml:space="preserve"><value>Autopilot: Enable the selected provisioning method.</value></data>
   <data name="Preparation.AutopilotProfile" xml:space="preserve"><value>Autopilot Profile</value></data>
   <data name="Preparation.AutopilotProfilesAvailableFormat" xml:space="preserve"><value>Profiles available: {0}</value></data>
   <data name="Preparation.AutopilotProfilesMissing" xml:space="preserve"><value>Autopilot is enabled, but no embedded profiles were found.</value></data>
   <data name="Preparation.AutopilotModeJsonProfile" xml:space="preserve"><value>Provisioning method: JSON profile</value></data>
   <data name="Preparation.AutopilotModeHardwareHashUpload" xml:space="preserve"><value>Provisioning method: Hardware hash upload</value></data>
   <data name="Preparation.AutopilotHardwareHashUpload" xml:space="preserve"><value>Hardware hash upload</value></data>
-  <data name="Preparation.AutopilotHardwareHashReadyFormat" xml:space="preserve"><value>Certificate valid until {0:g}. Default group tag: {1}.</value></data>
-  <data name="Preparation.AutopilotHardwareHashCertificateExpiredFormat" xml:space="preserve"><value>The embedded certificate expired on {0:g}.</value></data>
   <data name="Preparation.AutopilotHardwareHashExpiredAction" xml:space="preserve"><value>Regenerate the certificate and boot image. Deployment can continue, but Autopilot hash upload will be skipped.</value></data>
-  <data name="Preparation.AutopilotHardwareHashNotConfigured" xml:space="preserve"><value>Hardware hash upload metadata is not configured in this boot media.</value></data>
+  <data name="Preparation.AutopilotHardwareHashTenantReadiness" xml:space="preserve"><value>Tenant readiness</value></data>
+  <data name="Preparation.AutopilotHardwareHashReadinessStatus" xml:space="preserve"><value>Status</value></data>
+  <data name="Preparation.AutopilotHardwareHashTenantId" xml:space="preserve"><value>Tenant ID</value></data>
+  <data name="Preparation.AutopilotHardwareHashClientId" xml:space="preserve"><value>Client ID</value></data>
+  <data name="Preparation.AutopilotHardwareHashCertificateThumbprint" xml:space="preserve"><value>Certificate thumbprint</value></data>
+  <data name="Preparation.AutopilotHardwareHashCertificateExpiration" xml:space="preserve"><value>Certificate expiration</value></data>
+  <data name="Preparation.AutopilotHardwareHashDefaultGroupTag" xml:space="preserve"><value>Default group tag</value></data>
+  <data name="Preparation.AutopilotHardwareHashRuntimePending" xml:space="preserve"><value>Hardware hash upload is configured, but this build will skip the upload until the runtime upload step is implemented.</value></data>
+  <data name="Preparation.AutopilotHardwareHashGroupTagChoice" xml:space="preserve"><value>Group tag for this deployment</value></data>
+  <data name="Preparation.AutopilotHardwareHashUseDefaultGroupTagFormat" xml:space="preserve"><value>Use default group tag: {0}</value></data>
+  <data name="Preparation.AutopilotHardwareHashUseCustomGroupTag" xml:space="preserve"><value>Use a custom group tag</value></data>
+  <data name="Preparation.AutopilotHardwareHashGroupTagHint" xml:space="preserve"><value>The group tag is optional. Leave the effective value as None to upload the device without a group tag.</value></data>
   <data name="Preparation.DetectingHardware" xml:space="preserve"><value>Detecting hardware...</value></data>
   <data name="Preparation.HardwareDetectionFailed" xml:space="preserve"><value>Hardware detection failed.</value></data>
   <data name="Preparation.HardwareDetectionFailedFormat" xml:space="preserve"><value>Hardware detection failed: {0}</value></data>
@@ -109,6 +118,7 @@
   <data name="Summary.Autopilot" xml:space="preserve"><value>Autopilot</value></data>
   <data name="Summary.AutopilotMode" xml:space="preserve"><value>Autopilot Method</value></data>
   <data name="Summary.AutopilotProfile" xml:space="preserve"><value>Autopilot Profile</value></data>
+  <data name="Summary.AutopilotGroupTag" xml:space="preserve"><value>Autopilot Group Tag</value></data>
   <data name="Summary.SectionTarget" xml:space="preserve"><value>Target</value></data>
   <data name="Summary.SectionSystem" xml:space="preserve"><value>System</value></data>
   <data name="Summary.SectionDeployment" xml:space="preserve"><value>Deployment Options</value></data>
@@ -138,6 +148,8 @@ Action: Verify disk attributes and retry deployment.</value></data>
   <data name="Common.No" xml:space="preserve"><value>No</value></data>
   <data name="Common.Enabled" xml:space="preserve"><value>Enabled</value></data>
   <data name="Common.Disabled" xml:space="preserve"><value>Disabled</value></data>
+  <data name="Common.Ready" xml:space="preserve"><value>Ready</value></data>
+  <data name="Common.NotReady" xml:space="preserve"><value>Not ready</value></data>
   <data name="Progress.Networking" xml:space="preserve"><value>Networking</value></data>
   <data name="Progress.StartTime" xml:space="preserve"><value>Start time</value></data>
   <data name="Progress.ElapsedTime" xml:space="preserve"><value>Elapsed time</value></data>

--- a/src/Foundry.Deploy/Strings/en-US/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-US/Resources.resx
@@ -46,26 +46,24 @@
   <data name="Preparation.TargetDisk" xml:space="preserve"><value>Target Disk</value></data>
   <data name="Preparation.TargetDiskHint" xml:space="preserve"><value>Select a target disk. Non-eligible disks are blocked.</value></data>
   <data name="Preparation.FirmwareUpdates" xml:space="preserve"><value>Firmware: Microsoft Update Catalog update enabled.</value></data>
-  <data name="Preparation.AutopilotEnable" xml:space="preserve"><value>Autopilot: Enable the selected provisioning method.</value></data>
-  <data name="Preparation.AutopilotProfile" xml:space="preserve"><value>Autopilot Profile</value></data>
-  <data name="Preparation.AutopilotProfilesAvailableFormat" xml:space="preserve"><value>Profiles available: {0}</value></data>
-  <data name="Preparation.AutopilotProfilesMissing" xml:space="preserve"><value>Autopilot is enabled, but no embedded profiles were found.</value></data>
-  <data name="Preparation.AutopilotModeJsonProfile" xml:space="preserve"><value>Provisioning method: JSON profile</value></data>
-  <data name="Preparation.AutopilotModeHardwareHashUpload" xml:space="preserve"><value>Provisioning method: Hardware hash upload</value></data>
+  <data name="Preparation.AutopilotEnable" xml:space="preserve"><value>Enable Autopilot for this deployment</value></data>
+  <data name="Preparation.AutopilotProfile" xml:space="preserve"><value>Profile</value></data>
+  <data name="Preparation.AutopilotProfilesMissing" xml:space="preserve"><value>No embedded Autopilot profiles were found on this media.</value></data>
+  <data name="Preparation.AutopilotModeJsonProfile" xml:space="preserve"><value>JSON profile</value></data>
+  <data name="Preparation.AutopilotModeHardwareHashUpload" xml:space="preserve"><value>Hardware hash upload</value></data>
+  <data name="Preparation.AutopilotConfiguredModeFormat" xml:space="preserve"><value>Available on this media: {0}</value></data>
   <data name="Preparation.AutopilotHardwareHashUpload" xml:space="preserve"><value>Hardware hash upload</value></data>
-  <data name="Preparation.AutopilotHardwareHashExpiredAction" xml:space="preserve"><value>Regenerate the certificate and boot image. Deployment can continue, but Autopilot hash upload will be skipped.</value></data>
-  <data name="Preparation.AutopilotHardwareHashTenantReadiness" xml:space="preserve"><value>Tenant readiness</value></data>
-  <data name="Preparation.AutopilotHardwareHashReadinessStatus" xml:space="preserve"><value>Status</value></data>
-  <data name="Preparation.AutopilotHardwareHashTenantId" xml:space="preserve"><value>Tenant ID</value></data>
-  <data name="Preparation.AutopilotHardwareHashClientId" xml:space="preserve"><value>Client ID</value></data>
-  <data name="Preparation.AutopilotHardwareHashCertificateThumbprint" xml:space="preserve"><value>Certificate thumbprint</value></data>
-  <data name="Preparation.AutopilotHardwareHashCertificateExpiration" xml:space="preserve"><value>Certificate expiration</value></data>
-  <data name="Preparation.AutopilotHardwareHashDefaultGroupTag" xml:space="preserve"><value>Default group tag</value></data>
-  <data name="Preparation.AutopilotHardwareHashRuntimePending" xml:space="preserve"><value>Hardware hash upload is configured, but this build will skip the upload until the runtime upload step is implemented.</value></data>
-  <data name="Preparation.AutopilotHardwareHashGroupTagChoice" xml:space="preserve"><value>Group tag for this deployment</value></data>
-  <data name="Preparation.AutopilotHardwareHashUseDefaultGroupTagFormat" xml:space="preserve"><value>Use default group tag: {0}</value></data>
-  <data name="Preparation.AutopilotHardwareHashUseCustomGroupTag" xml:space="preserve"><value>Use a custom group tag</value></data>
-  <data name="Preparation.AutopilotHardwareHashGroupTagHint" xml:space="preserve"><value>The group tag is optional. Leave the effective value as None to upload the device without a group tag.</value></data>
+  <data name="Preparation.AutopilotHardwareHashUploadStatus" xml:space="preserve"><value>Autopilot upload status</value></data>
+  <data name="Preparation.AutopilotHardwareHashReadyStatus" xml:space="preserve"><value>Ready for hardware hash upload</value></data>
+  <data name="Preparation.AutopilotHardwareHashNotReadyStatus" xml:space="preserve"><value>Not ready for hardware hash upload</value></data>
+  <data name="Preparation.AutopilotHardwareHashExpiredStatus" xml:space="preserve"><value>Certificate expired</value></data>
+  <data name="Preparation.AutopilotHardwareHashReadyMessage" xml:space="preserve"><value>Upload will run automatically during deployment.</value></data>
+  <data name="Preparation.AutopilotHardwareHashMissingMetadataMessage" xml:space="preserve"><value>Autopilot upload is unavailable on this media. Deployment can continue, but upload will be skipped.</value></data>
+  <data name="Preparation.AutopilotHardwareHashExpiredMessage" xml:space="preserve"><value>The Autopilot certificate has expired. Deployment can continue, but upload will be skipped.</value></data>
+  <data name="Preparation.AutopilotHardwareHashGroupTagChoice" xml:space="preserve"><value>Group tag</value></data>
+  <data name="Preparation.AutopilotHardwareHashUseDefaultGroupTagFormat" xml:space="preserve"><value>Use media default ({0})</value></data>
+  <data name="Preparation.AutopilotHardwareHashUseCustomGroupTag" xml:space="preserve"><value>Enter custom group tag</value></data>
+  <data name="Preparation.AutopilotHardwareHashGroupTagHint" xml:space="preserve"><value>The group tag is optional. Leave it blank to upload without a group tag.</value></data>
   <data name="Preparation.DetectingHardware" xml:space="preserve"><value>Detecting hardware...</value></data>
   <data name="Preparation.HardwareDetectionFailed" xml:space="preserve"><value>Hardware detection failed.</value></data>
   <data name="Preparation.HardwareDetectionFailedFormat" xml:space="preserve"><value>Hardware detection failed: {0}</value></data>

--- a/src/Foundry.Deploy/Strings/en-US/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-US/Resources.resx
@@ -53,7 +53,7 @@
   <data name="Preparation.AutopilotModeHardwareHashUpload" xml:space="preserve"><value>Hardware hash upload</value></data>
   <data name="Preparation.AutopilotConfiguredModeFormat" xml:space="preserve"><value>Available on this media: {0}</value></data>
   <data name="Preparation.AutopilotHardwareHashUpload" xml:space="preserve"><value>Hardware hash upload</value></data>
-  <data name="Preparation.AutopilotHardwareHashUploadStatus" xml:space="preserve"><value>Autopilot upload status</value></data>
+  <data name="Preparation.AutopilotHardwareHashUploadStatus" xml:space="preserve"><value>Hardware hash upload status</value></data>
   <data name="Preparation.AutopilotHardwareHashReadyStatus" xml:space="preserve"><value>Ready for hardware hash upload</value></data>
   <data name="Preparation.AutopilotHardwareHashNotReadyStatus" xml:space="preserve"><value>Not ready for hardware hash upload</value></data>
   <data name="Preparation.AutopilotHardwareHashExpiredStatus" xml:space="preserve"><value>Certificate expired</value></data>
@@ -124,7 +124,7 @@
   <data name="Debug.Autopilot.HardwareHashUpload" xml:space="preserve"><value>Hardware hash upload</value></data>
   <data name="Debug.Autopilot.HardwareHashUpload.ValidCertificate" xml:space="preserve"><value>Valid certificate</value></data>
   <data name="Debug.Autopilot.HardwareHashUpload.ExpiredCertificate" xml:space="preserve"><value>Expired certificate</value></data>
-  <data name="Debug.Autopilot.HardwareHashUpload.MissingCertificateMetadata" xml:space="preserve"><value>Missing certificate metadata</value></data>
+  <data name="Debug.Autopilot.HardwareHashUpload.MissingCertificateMetadata" xml:space="preserve"><value>Missing certificate info</value></data>
   <data name="Debug.Autopilot.HardwareHashUpload.NoDefaultGroupTag" xml:space="preserve"><value>No default group tag</value></data>
   <data name="Debug.DeploymentPages" xml:space="preserve"><value>Deployment pages</value></data>
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Progress page</value></data>

--- a/src/Foundry.Deploy/Strings/en-US/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-US/Resources.resx
@@ -60,10 +60,11 @@
   <data name="Preparation.AutopilotHardwareHashReadyMessage" xml:space="preserve"><value>Upload will run automatically during deployment.</value></data>
   <data name="Preparation.AutopilotHardwareHashMissingMetadataMessage" xml:space="preserve"><value>Autopilot upload is unavailable on this media. Deployment can continue, but upload will be skipped.</value></data>
   <data name="Preparation.AutopilotHardwareHashExpiredMessage" xml:space="preserve"><value>The Autopilot certificate has expired. Deployment can continue, but upload will be skipped.</value></data>
+  <data name="Preparation.AutopilotHardwareHashTenantId" xml:space="preserve"><value>Tenant ID</value></data>
+  <data name="Preparation.AutopilotHardwareHashCertificateThumbprint" xml:space="preserve"><value>Certificate thumbprint</value></data>
+  <data name="Preparation.AutopilotHardwareHashCertificateExpiration" xml:space="preserve"><value>Certificate expiration</value></data>
   <data name="Preparation.AutopilotHardwareHashGroupTagChoice" xml:space="preserve"><value>Group tag</value></data>
-  <data name="Preparation.AutopilotHardwareHashUseDefaultGroupTagFormat" xml:space="preserve"><value>Use media default ({0})</value></data>
-  <data name="Preparation.AutopilotHardwareHashUseCustomGroupTag" xml:space="preserve"><value>Enter custom group tag</value></data>
-  <data name="Preparation.AutopilotHardwareHashGroupTagHint" xml:space="preserve"><value>The group tag is optional. Leave it blank to upload without a group tag.</value></data>
+  <data name="Preparation.AutopilotHardwareHashGroupTagHint" xml:space="preserve"><value>The group tag is optional. Select None to upload without a group tag.</value></data>
   <data name="Preparation.DetectingHardware" xml:space="preserve"><value>Detecting hardware...</value></data>
   <data name="Preparation.HardwareDetectionFailed" xml:space="preserve"><value>Hardware detection failed.</value></data>
   <data name="Preparation.HardwareDetectionFailedFormat" xml:space="preserve"><value>Hardware detection failed: {0}</value></data>

--- a/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
@@ -60,10 +60,11 @@
   <data name="Preparation.AutopilotHardwareHashReadyMessage" xml:space="preserve"><value>L'upload s'exécutera automatiquement pendant le déploiement.</value></data>
   <data name="Preparation.AutopilotHardwareHashMissingMetadataMessage" xml:space="preserve"><value>L'upload Autopilot n'est pas disponible sur ce média. Le déploiement peut continuer, mais l'upload sera ignoré.</value></data>
   <data name="Preparation.AutopilotHardwareHashExpiredMessage" xml:space="preserve"><value>Le certificat Autopilot a expiré. Le déploiement peut continuer, mais l'upload sera ignoré.</value></data>
+  <data name="Preparation.AutopilotHardwareHashTenantId" xml:space="preserve"><value>ID du tenant</value></data>
+  <data name="Preparation.AutopilotHardwareHashCertificateThumbprint" xml:space="preserve"><value>Empreinte du certificat</value></data>
+  <data name="Preparation.AutopilotHardwareHashCertificateExpiration" xml:space="preserve"><value>Expiration du certificat</value></data>
   <data name="Preparation.AutopilotHardwareHashGroupTagChoice" xml:space="preserve"><value>Group tag</value></data>
-  <data name="Preparation.AutopilotHardwareHashUseDefaultGroupTagFormat" xml:space="preserve"><value>Utiliser la valeur du média ({0})</value></data>
-  <data name="Preparation.AutopilotHardwareHashUseCustomGroupTag" xml:space="preserve"><value>Saisir un group tag personnalisé</value></data>
-  <data name="Preparation.AutopilotHardwareHashGroupTagHint" xml:space="preserve"><value>Le group tag est optionnel. Laissez-le vide pour uploader sans group tag.</value></data>
+  <data name="Preparation.AutopilotHardwareHashGroupTagHint" xml:space="preserve"><value>Le group tag est optionnel. Sélectionnez Aucun pour uploader sans group tag.</value></data>
   <data name="Preparation.DetectingHardware" xml:space="preserve"><value>Détection du matériel...</value></data>
   <data name="Preparation.HardwareDetectionFailed" xml:space="preserve"><value>Échec de la détection matérielle.</value></data>
   <data name="Preparation.HardwareDetectionFailedFormat" xml:space="preserve"><value>Échec de la détection matérielle : {0}</value></data>

--- a/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
@@ -21,6 +21,7 @@
   <data name="Menu.Theme" xml:space="preserve"><value>_Thème</value></data>
   <data name="Menu.Language" xml:space="preserve"><value>_Langue</value></data>
   <data name="Menu.Tools" xml:space="preserve"><value>_Outils</value></data>
+  <data name="Menu.Debug" xml:space="preserve"><value>_Debug</value></data>
   <data name="Menu.About" xml:space="preserve"><value>_À propos</value></data>
   <data name="Theme.System" xml:space="preserve"><value>Système</value></data>
   <data name="Theme.Light" xml:space="preserve"><value>Clair</value></data>
@@ -30,10 +31,6 @@
   <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Actualiser les catalogues</value></data>
   <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Actualiser les disques cibles</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Ouvrir le fichier journal</value></data>
-  <data name="Tools.DebugAutopilotMode" xml:space="preserve"><value>Mode Autopilot debug</value></data>
-  <data name="Tools.DebugAutopilotMode.None" xml:space="preserve"><value>Pas d'Autopilot</value></data>
-  <data name="Tools.DebugAutopilotMode.JsonProfile" xml:space="preserve"><value>Profil JSON</value></data>
-  <data name="Tools.DebugAutopilotMode.HardwareHashUpload" xml:space="preserve"><value>Upload du hardware hash</value></data>
   <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>MODE DEBUG SÉCURISÉ ACTIF : toutes les actions de déploiement sont simulées, aucune écriture disque/image n’est effectuée.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Cible</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Catalogue système</value></data>
@@ -122,9 +119,18 @@
   <data name="Summary.SectionTarget" xml:space="preserve"><value>Cible</value></data>
   <data name="Summary.SectionSystem" xml:space="preserve"><value>Système</value></data>
   <data name="Summary.SectionDeployment" xml:space="preserve"><value>Options de déploiement</value></data>
-  <data name="Debug.ProgressButton" xml:space="preserve"><value>DBG: Progrès</value></data>
-  <data name="Debug.SuccessButton" xml:space="preserve"><value>DBG: Succès</value></data>
-  <data name="Debug.ErrorButton" xml:space="preserve"><value>DBG: Erreur</value></data>
+  <data name="Debug.Autopilot" xml:space="preserve"><value>Autopilot</value></data>
+  <data name="Debug.Autopilot.NoAutopilot" xml:space="preserve"><value>Pas d'Autopilot</value></data>
+  <data name="Debug.Autopilot.JsonProfile" xml:space="preserve"><value>Profil JSON</value></data>
+  <data name="Debug.Autopilot.HardwareHashUpload" xml:space="preserve"><value>Upload du hardware hash</value></data>
+  <data name="Debug.Autopilot.HardwareHashUpload.ValidCertificate" xml:space="preserve"><value>Certificat valide</value></data>
+  <data name="Debug.Autopilot.HardwareHashUpload.ExpiredCertificate" xml:space="preserve"><value>Certificat expiré</value></data>
+  <data name="Debug.Autopilot.HardwareHashUpload.MissingCertificateMetadata" xml:space="preserve"><value>Métadonnées de certificat manquantes</value></data>
+  <data name="Debug.Autopilot.HardwareHashUpload.NoDefaultGroupTag" xml:space="preserve"><value>Sans group tag par défaut</value></data>
+  <data name="Debug.DeploymentPages" xml:space="preserve"><value>Pages de déploiement</value></data>
+  <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Page de progression</value></data>
+  <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Page de succès</value></data>
+  <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Page d'erreur</value></data>
   <data name="Debug.ProgressPage" xml:space="preserve"><value>Aperçu DBG : page de progression.</value></data>
   <data name="Debug.SuccessPage" xml:space="preserve"><value>Aperçu DBG : page de succès.</value></data>
   <data name="Debug.ErrorPage" xml:space="preserve"><value>Aperçu DBG : page d’erreur.</value></data>

--- a/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
@@ -49,17 +49,26 @@
   <data name="Preparation.TargetDisk" xml:space="preserve"><value>Disque cible</value></data>
   <data name="Preparation.TargetDiskHint" xml:space="preserve"><value>Sélectionnez un disque cible. Les disques non éligibles sont bloqués.</value></data>
   <data name="Preparation.FirmwareUpdates" xml:space="preserve"><value>Firmware : activer les mises à jour via Microsoft Update Catalog.</value></data>
-  <data name="Preparation.AutopilotEnable" xml:space="preserve"><value>Autopilot : activer la préparation hors ligne du profil.</value></data>
+  <data name="Preparation.AutopilotEnable" xml:space="preserve"><value>Autopilot : activer la méthode de provisionnement sélectionnée.</value></data>
   <data name="Preparation.AutopilotProfile" xml:space="preserve"><value>Profil Autopilot</value></data>
   <data name="Preparation.AutopilotProfilesAvailableFormat" xml:space="preserve"><value>Profils disponibles : {0}</value></data>
   <data name="Preparation.AutopilotProfilesMissing" xml:space="preserve"><value>Autopilot est activé, mais aucun profil intégré n'a été trouvé.</value></data>
   <data name="Preparation.AutopilotModeJsonProfile" xml:space="preserve"><value>Méthode de provisionnement : profil JSON</value></data>
   <data name="Preparation.AutopilotModeHardwareHashUpload" xml:space="preserve"><value>Méthode de provisionnement : upload du hardware hash</value></data>
   <data name="Preparation.AutopilotHardwareHashUpload" xml:space="preserve"><value>Upload du hardware hash</value></data>
-  <data name="Preparation.AutopilotHardwareHashReadyFormat" xml:space="preserve"><value>Certificat valide jusqu'au {0:g}. Group tag par défaut : {1}.</value></data>
-  <data name="Preparation.AutopilotHardwareHashCertificateExpiredFormat" xml:space="preserve"><value>Le certificat intégré a expiré le {0:g}.</value></data>
   <data name="Preparation.AutopilotHardwareHashExpiredAction" xml:space="preserve"><value>Régénérez le certificat et l'image de boot. Le déploiement peut continuer, mais l'upload du hash Autopilot sera ignoré.</value></data>
-  <data name="Preparation.AutopilotHardwareHashNotConfigured" xml:space="preserve"><value>Les métadonnées d'upload du hardware hash ne sont pas configurées dans ce média de boot.</value></data>
+  <data name="Preparation.AutopilotHardwareHashTenantReadiness" xml:space="preserve"><value>État du tenant</value></data>
+  <data name="Preparation.AutopilotHardwareHashReadinessStatus" xml:space="preserve"><value>Statut</value></data>
+  <data name="Preparation.AutopilotHardwareHashTenantId" xml:space="preserve"><value>ID du tenant</value></data>
+  <data name="Preparation.AutopilotHardwareHashClientId" xml:space="preserve"><value>ID client</value></data>
+  <data name="Preparation.AutopilotHardwareHashCertificateThumbprint" xml:space="preserve"><value>Empreinte du certificat</value></data>
+  <data name="Preparation.AutopilotHardwareHashCertificateExpiration" xml:space="preserve"><value>Expiration du certificat</value></data>
+  <data name="Preparation.AutopilotHardwareHashDefaultGroupTag" xml:space="preserve"><value>Group tag par défaut</value></data>
+  <data name="Preparation.AutopilotHardwareHashRuntimePending" xml:space="preserve"><value>L'upload du hardware hash est configuré, mais cette version ignorera l'upload tant que l'étape runtime n'est pas implémentée.</value></data>
+  <data name="Preparation.AutopilotHardwareHashGroupTagChoice" xml:space="preserve"><value>Group tag pour ce déploiement</value></data>
+  <data name="Preparation.AutopilotHardwareHashUseDefaultGroupTagFormat" xml:space="preserve"><value>Utiliser le group tag par défaut : {0}</value></data>
+  <data name="Preparation.AutopilotHardwareHashUseCustomGroupTag" xml:space="preserve"><value>Utiliser un group tag personnalisé</value></data>
+  <data name="Preparation.AutopilotHardwareHashGroupTagHint" xml:space="preserve"><value>Le group tag est optionnel. Laissez la valeur effective sur Aucun pour uploader l'appareil sans group tag.</value></data>
   <data name="Preparation.DetectingHardware" xml:space="preserve"><value>Détection du matériel...</value></data>
   <data name="Preparation.HardwareDetectionFailed" xml:space="preserve"><value>Échec de la détection matérielle.</value></data>
   <data name="Preparation.HardwareDetectionFailedFormat" xml:space="preserve"><value>Échec de la détection matérielle : {0}</value></data>
@@ -109,6 +118,7 @@
   <data name="Summary.Autopilot" xml:space="preserve"><value>Autopilot</value></data>
   <data name="Summary.AutopilotMode" xml:space="preserve"><value>Méthode Autopilot</value></data>
   <data name="Summary.AutopilotProfile" xml:space="preserve"><value>Profil Autopilot</value></data>
+  <data name="Summary.AutopilotGroupTag" xml:space="preserve"><value>Group tag Autopilot</value></data>
   <data name="Summary.SectionTarget" xml:space="preserve"><value>Cible</value></data>
   <data name="Summary.SectionSystem" xml:space="preserve"><value>Système</value></data>
   <data name="Summary.SectionDeployment" xml:space="preserve"><value>Options de déploiement</value></data>
@@ -138,6 +148,8 @@ Action : vérifiez les attributs du disque puis relancez le déploiement.</value
   <data name="Common.No" xml:space="preserve"><value>Non</value></data>
   <data name="Common.Enabled" xml:space="preserve"><value>Activé</value></data>
   <data name="Common.Disabled" xml:space="preserve"><value>Désactivé</value></data>
+  <data name="Common.Ready" xml:space="preserve"><value>Prêt</value></data>
+  <data name="Common.NotReady" xml:space="preserve"><value>Non prêt</value></data>
   <data name="Progress.Networking" xml:space="preserve"><value>Réseau</value></data>
   <data name="Progress.StartTime" xml:space="preserve"><value>Heure de début</value></data>
   <data name="Progress.ElapsedTime" xml:space="preserve"><value>Temps écoulé</value></data>

--- a/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
@@ -53,7 +53,7 @@
   <data name="Preparation.AutopilotModeHardwareHashUpload" xml:space="preserve"><value>Upload du hardware hash</value></data>
   <data name="Preparation.AutopilotConfiguredModeFormat" xml:space="preserve"><value>Disponible sur ce média : {0}</value></data>
   <data name="Preparation.AutopilotHardwareHashUpload" xml:space="preserve"><value>Upload du hardware hash</value></data>
-  <data name="Preparation.AutopilotHardwareHashUploadStatus" xml:space="preserve"><value>État de l'upload Autopilot</value></data>
+  <data name="Preparation.AutopilotHardwareHashUploadStatus" xml:space="preserve"><value>État de l'upload du hardware hash</value></data>
   <data name="Preparation.AutopilotHardwareHashReadyStatus" xml:space="preserve"><value>Prêt pour l'upload du hardware hash</value></data>
   <data name="Preparation.AutopilotHardwareHashNotReadyStatus" xml:space="preserve"><value>Pas prêt pour l'upload du hardware hash</value></data>
   <data name="Preparation.AutopilotHardwareHashExpiredStatus" xml:space="preserve"><value>Certificat expiré</value></data>
@@ -124,7 +124,7 @@
   <data name="Debug.Autopilot.HardwareHashUpload" xml:space="preserve"><value>Upload du hardware hash</value></data>
   <data name="Debug.Autopilot.HardwareHashUpload.ValidCertificate" xml:space="preserve"><value>Certificat valide</value></data>
   <data name="Debug.Autopilot.HardwareHashUpload.ExpiredCertificate" xml:space="preserve"><value>Certificat expiré</value></data>
-  <data name="Debug.Autopilot.HardwareHashUpload.MissingCertificateMetadata" xml:space="preserve"><value>Métadonnées de certificat manquantes</value></data>
+  <data name="Debug.Autopilot.HardwareHashUpload.MissingCertificateMetadata" xml:space="preserve"><value>Infos du certificat manquantes</value></data>
   <data name="Debug.Autopilot.HardwareHashUpload.NoDefaultGroupTag" xml:space="preserve"><value>Sans group tag par défaut</value></data>
   <data name="Debug.DeploymentPages" xml:space="preserve"><value>Pages de déploiement</value></data>
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Page de progression</value></data>

--- a/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
@@ -46,26 +46,24 @@
   <data name="Preparation.TargetDisk" xml:space="preserve"><value>Disque cible</value></data>
   <data name="Preparation.TargetDiskHint" xml:space="preserve"><value>Sélectionnez un disque cible. Les disques non éligibles sont bloqués.</value></data>
   <data name="Preparation.FirmwareUpdates" xml:space="preserve"><value>Firmware : activer les mises à jour via Microsoft Update Catalog.</value></data>
-  <data name="Preparation.AutopilotEnable" xml:space="preserve"><value>Autopilot : activer la méthode de provisionnement sélectionnée.</value></data>
-  <data name="Preparation.AutopilotProfile" xml:space="preserve"><value>Profil Autopilot</value></data>
-  <data name="Preparation.AutopilotProfilesAvailableFormat" xml:space="preserve"><value>Profils disponibles : {0}</value></data>
-  <data name="Preparation.AutopilotProfilesMissing" xml:space="preserve"><value>Autopilot est activé, mais aucun profil intégré n'a été trouvé.</value></data>
-  <data name="Preparation.AutopilotModeJsonProfile" xml:space="preserve"><value>Méthode de provisionnement : profil JSON</value></data>
-  <data name="Preparation.AutopilotModeHardwareHashUpload" xml:space="preserve"><value>Méthode de provisionnement : upload du hardware hash</value></data>
+  <data name="Preparation.AutopilotEnable" xml:space="preserve"><value>Activer Autopilot pour ce déploiement</value></data>
+  <data name="Preparation.AutopilotProfile" xml:space="preserve"><value>Profil</value></data>
+  <data name="Preparation.AutopilotProfilesMissing" xml:space="preserve"><value>Aucun profil Autopilot intégré n'a été trouvé sur ce média.</value></data>
+  <data name="Preparation.AutopilotModeJsonProfile" xml:space="preserve"><value>Profil JSON</value></data>
+  <data name="Preparation.AutopilotModeHardwareHashUpload" xml:space="preserve"><value>Upload du hardware hash</value></data>
+  <data name="Preparation.AutopilotConfiguredModeFormat" xml:space="preserve"><value>Disponible sur ce média : {0}</value></data>
   <data name="Preparation.AutopilotHardwareHashUpload" xml:space="preserve"><value>Upload du hardware hash</value></data>
-  <data name="Preparation.AutopilotHardwareHashExpiredAction" xml:space="preserve"><value>Régénérez le certificat et l'image de boot. Le déploiement peut continuer, mais l'upload du hash Autopilot sera ignoré.</value></data>
-  <data name="Preparation.AutopilotHardwareHashTenantReadiness" xml:space="preserve"><value>État du tenant</value></data>
-  <data name="Preparation.AutopilotHardwareHashReadinessStatus" xml:space="preserve"><value>Statut</value></data>
-  <data name="Preparation.AutopilotHardwareHashTenantId" xml:space="preserve"><value>ID du tenant</value></data>
-  <data name="Preparation.AutopilotHardwareHashClientId" xml:space="preserve"><value>ID client</value></data>
-  <data name="Preparation.AutopilotHardwareHashCertificateThumbprint" xml:space="preserve"><value>Empreinte du certificat</value></data>
-  <data name="Preparation.AutopilotHardwareHashCertificateExpiration" xml:space="preserve"><value>Expiration du certificat</value></data>
-  <data name="Preparation.AutopilotHardwareHashDefaultGroupTag" xml:space="preserve"><value>Group tag par défaut</value></data>
-  <data name="Preparation.AutopilotHardwareHashRuntimePending" xml:space="preserve"><value>L'upload du hardware hash est configuré, mais cette version ignorera l'upload tant que l'étape runtime n'est pas implémentée.</value></data>
-  <data name="Preparation.AutopilotHardwareHashGroupTagChoice" xml:space="preserve"><value>Group tag pour ce déploiement</value></data>
-  <data name="Preparation.AutopilotHardwareHashUseDefaultGroupTagFormat" xml:space="preserve"><value>Utiliser le group tag par défaut : {0}</value></data>
-  <data name="Preparation.AutopilotHardwareHashUseCustomGroupTag" xml:space="preserve"><value>Utiliser un group tag personnalisé</value></data>
-  <data name="Preparation.AutopilotHardwareHashGroupTagHint" xml:space="preserve"><value>Le group tag est optionnel. Laissez la valeur effective sur Aucun pour uploader l'appareil sans group tag.</value></data>
+  <data name="Preparation.AutopilotHardwareHashUploadStatus" xml:space="preserve"><value>État de l'upload Autopilot</value></data>
+  <data name="Preparation.AutopilotHardwareHashReadyStatus" xml:space="preserve"><value>Prêt pour l'upload du hardware hash</value></data>
+  <data name="Preparation.AutopilotHardwareHashNotReadyStatus" xml:space="preserve"><value>Pas prêt pour l'upload du hardware hash</value></data>
+  <data name="Preparation.AutopilotHardwareHashExpiredStatus" xml:space="preserve"><value>Certificat expiré</value></data>
+  <data name="Preparation.AutopilotHardwareHashReadyMessage" xml:space="preserve"><value>L'upload s'exécutera automatiquement pendant le déploiement.</value></data>
+  <data name="Preparation.AutopilotHardwareHashMissingMetadataMessage" xml:space="preserve"><value>L'upload Autopilot n'est pas disponible sur ce média. Le déploiement peut continuer, mais l'upload sera ignoré.</value></data>
+  <data name="Preparation.AutopilotHardwareHashExpiredMessage" xml:space="preserve"><value>Le certificat Autopilot a expiré. Le déploiement peut continuer, mais l'upload sera ignoré.</value></data>
+  <data name="Preparation.AutopilotHardwareHashGroupTagChoice" xml:space="preserve"><value>Group tag</value></data>
+  <data name="Preparation.AutopilotHardwareHashUseDefaultGroupTagFormat" xml:space="preserve"><value>Utiliser la valeur du média ({0})</value></data>
+  <data name="Preparation.AutopilotHardwareHashUseCustomGroupTag" xml:space="preserve"><value>Saisir un group tag personnalisé</value></data>
+  <data name="Preparation.AutopilotHardwareHashGroupTagHint" xml:space="preserve"><value>Le group tag est optionnel. Laissez-le vide pour uploader sans group tag.</value></data>
   <data name="Preparation.DetectingHardware" xml:space="preserve"><value>Détection du matériel...</value></data>
   <data name="Preparation.HardwareDetectionFailed" xml:space="preserve"><value>Échec de la détection matérielle.</value></data>
   <data name="Preparation.HardwareDetectionFailedFormat" xml:space="preserve"><value>Échec de la détection matérielle : {0}</value></data>

--- a/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
@@ -106,6 +106,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
     public bool IsAutopilotSectionVisible => IsAutopilotEnabled || HasAutopilotProfiles;
     public bool IsJsonProfileMode => AutopilotProvisioningMode == AutopilotProvisioningMode.JsonProfile;
     public bool IsHardwareHashUploadMode => AutopilotProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload;
+    public bool IsAutopilotDisabledSummaryVisible => IsAutopilotSectionVisible && !IsAutopilotEnabled;
     public bool IsJsonProfileControlsVisible => IsAutopilotEnabled && IsJsonProfileMode;
     public bool IsHardwareHashUploadControlsVisible => IsAutopilotEnabled && IsHardwareHashUploadMode;
     public bool IsAutopilotProfileSelectionEnabled => IsJsonProfileControlsVisible && HasAutopilotProfiles;
@@ -120,8 +121,11 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         expiresOn <= DateTimeOffset.UtcNow;
     public bool IsHardwareHashCertificateUsable => HasHardwareHashUploadMetadata && !IsHardwareHashCertificateExpired;
     public bool IsHardwareHashGroupTagControlsVisible => IsHardwareHashUploadControlsVisible && IsHardwareHashCertificateUsable;
-    public bool IsHardwareHashPreRuntimeWarningVisible => IsHardwareHashUploadControlsVisible && IsHardwareHashCertificateUsable;
-    public bool IsHardwareHashCustomGroupTagEnabled => IsHardwareHashGroupTagControlsVisible && UseCustomHardwareHashGroupTag;
+    public bool IsHardwareHashMissingMetadataWarningVisible => IsHardwareHashUploadControlsVisible && !HasHardwareHashUploadMetadata;
+    public bool HasHardwareHashDefaultGroupTag => !string.IsNullOrWhiteSpace(AutopilotHardwareHashUpload.DefaultGroupTag);
+    public bool IsDefaultHardwareHashGroupTagOptionVisible => IsHardwareHashGroupTagControlsVisible && HasHardwareHashDefaultGroupTag;
+    public bool IsHardwareHashCustomGroupTagTextBoxVisible => IsHardwareHashGroupTagControlsVisible && (UseCustomHardwareHashGroupTag || !HasHardwareHashDefaultGroupTag);
+    public bool IsHardwareHashCustomGroupTagEnabled => IsHardwareHashGroupTagControlsVisible && (UseCustomHardwareHashGroupTag || !HasHardwareHashDefaultGroupTag);
     public string TargetDiskSelectionHint => !string.IsNullOrWhiteSpace(SelectedTargetDisk?.SelectionWarning)
         ? SelectedTargetDisk.SelectionWarning
         : GetString("Preparation.TargetDiskHint");
@@ -129,22 +133,48 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         !IsJsonProfileMode
             ? string.Empty
             : HasAutopilotProfiles
-            ? Format("Preparation.AutopilotProfilesAvailableFormat", AutopilotProfiles.Count)
+            ? string.Empty
             : IsAutopilotEnabled
                 ? GetString("Preparation.AutopilotProfilesMissing")
-            : string.Empty;
+                : string.Empty;
+    public bool HasAutopilotProfileHint => !string.IsNullOrWhiteSpace(AutopilotProfileHint);
     public string AutopilotModeText => IsHardwareHashUploadMode
         ? GetString("Preparation.AutopilotModeHardwareHashUpload")
         : GetString("Preparation.AutopilotModeJsonProfile");
-    public string AutopilotHardwareHashReadinessText => IsHardwareHashCertificateUsable
-        ? GetString("Common.Ready")
-        : GetString("Common.NotReady");
-    public string AutopilotHardwareHashTenantIdText => CreateHardwareHashValueText(AutopilotHardwareHashUpload.TenantId);
-    public string AutopilotHardwareHashClientIdText => CreateHardwareHashValueText(AutopilotHardwareHashUpload.ClientId);
-    public string AutopilotHardwareHashCertificateThumbprintText => CreateHardwareHashValueText(AutopilotHardwareHashUpload.ActiveCertificateThumbprint);
-    public string AutopilotHardwareHashCertificateExpirationText => AutopilotHardwareHashUpload.ActiveCertificateExpiresOnUtc is DateTimeOffset expiresOn
-        ? expiresOn.LocalDateTime.ToString("g", LocalizationService.CurrentCulture)
-        : GetString("Common.Unavailable");
+    public string AutopilotDisabledSummaryText => Format("Preparation.AutopilotConfiguredModeFormat", AutopilotModeText);
+    public string AutopilotHardwareHashUploadStatusText
+    {
+        get
+        {
+            if (IsHardwareHashCertificateUsable)
+            {
+                return GetString("Preparation.AutopilotHardwareHashReadyStatus");
+            }
+
+            return IsHardwareHashCertificateExpired
+                ? GetString("Preparation.AutopilotHardwareHashExpiredStatus")
+                : GetString("Preparation.AutopilotHardwareHashNotReadyStatus");
+        }
+    }
+
+    public string AutopilotHardwareHashUploadMessage
+    {
+        get
+        {
+            if (IsHardwareHashCertificateUsable)
+            {
+                return GetString("Preparation.AutopilotHardwareHashReadyMessage");
+            }
+
+            if (IsHardwareHashCertificateExpired)
+            {
+                return GetString("Preparation.AutopilotHardwareHashExpiredMessage");
+            }
+
+            return GetString("Preparation.AutopilotHardwareHashMissingMetadataMessage");
+        }
+    }
+
     public string AutopilotHardwareHashDefaultGroupTagText => string.IsNullOrWhiteSpace(AutopilotHardwareHashUpload.DefaultGroupTag)
         ? GetString("Common.None")
         : AutopilotHardwareHashUpload.DefaultGroupTag!;
@@ -273,6 +303,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         OnPropertyChanged(nameof(IsAutopilotSectionVisible));
         OnPropertyChanged(nameof(IsAutopilotProfileSelectionEnabled));
         OnPropertyChanged(nameof(AutopilotProfileHint));
+        OnPropertyChanged(nameof(HasAutopilotProfileHint));
 
         AutopilotProvisioningMode = settings.ProvisioningMode;
         AutopilotHardwareHashUpload = settings.HardwareHashUpload ?? new DeployAutopilotHardwareHashUploadSettings();
@@ -408,10 +439,12 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
     partial void OnIsAutopilotEnabledChanged(bool value)
     {
         OnPropertyChanged(nameof(IsAutopilotSectionVisible));
+        OnPropertyChanged(nameof(IsAutopilotDisabledSummaryVisible));
         OnPropertyChanged(nameof(IsJsonProfileControlsVisible));
         OnPropertyChanged(nameof(IsHardwareHashUploadControlsVisible));
         OnPropertyChanged(nameof(IsAutopilotProfileSelectionEnabled));
         OnPropertyChanged(nameof(AutopilotProfileHint));
+        OnPropertyChanged(nameof(HasAutopilotProfileHint));
         RaiseHardwareHashPropertiesChanged();
         RaiseStateChanged();
     }
@@ -496,8 +529,11 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         OnPropertyChanged(nameof(IsJsonProfileControlsVisible));
         OnPropertyChanged(nameof(IsHardwareHashUploadControlsVisible));
         OnPropertyChanged(nameof(IsAutopilotProfileSelectionEnabled));
+        OnPropertyChanged(nameof(IsAutopilotDisabledSummaryVisible));
         OnPropertyChanged(nameof(AutopilotProfileHint));
+        OnPropertyChanged(nameof(HasAutopilotProfileHint));
         OnPropertyChanged(nameof(AutopilotModeText));
+        OnPropertyChanged(nameof(AutopilotDisabledSummaryText));
         RaiseHardwareHashPropertiesChanged();
         RaiseStateChanged();
     }
@@ -516,6 +552,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         }
 
         OnPropertyChanged(nameof(IsHardwareHashCustomGroupTagEnabled));
+        OnPropertyChanged(nameof(IsHardwareHashCustomGroupTagTextBoxVisible));
         OnPropertyChanged(nameof(EffectiveHardwareHashGroupTagText));
         RaiseStateChanged();
     }
@@ -532,6 +569,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         }
 
         OnPropertyChanged(nameof(IsHardwareHashCustomGroupTagEnabled));
+        OnPropertyChanged(nameof(IsHardwareHashCustomGroupTagTextBoxVisible));
         OnPropertyChanged(nameof(EffectiveHardwareHashGroupTagText));
         RaiseStateChanged();
     }
@@ -717,6 +755,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         OnPropertyChanged(nameof(IsAutopilotSectionVisible));
         OnPropertyChanged(nameof(IsAutopilotProfileSelectionEnabled));
         OnPropertyChanged(nameof(AutopilotProfileHint));
+        OnPropertyChanged(nameof(HasAutopilotProfileHint));
     }
 
     private void RaiseStateChanged()
@@ -750,7 +789,9 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
 
             TargetComputerNameValidationMessage = ResolveComputerNameValidationMessage(TargetComputerName);
             OnPropertyChanged(nameof(AutopilotProfileHint));
+            OnPropertyChanged(nameof(HasAutopilotProfileHint));
             OnPropertyChanged(nameof(AutopilotModeText));
+            OnPropertyChanged(nameof(AutopilotDisabledSummaryText));
             RaiseHardwareHashPropertiesChanged();
             OnPropertyChanged(nameof(TargetDiskSelectionHint));
             OnPropertyChanged(nameof(TargetDisks));
@@ -777,7 +818,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
 
     private string? ResolveEffectiveHardwareHashGroupTag()
     {
-        string? groupTag = UseCustomHardwareHashGroupTag
+        string? groupTag = UseCustomHardwareHashGroupTag || !HasHardwareHashDefaultGroupTag
             ? CustomHardwareHashGroupTag
             : AutopilotHardwareHashUpload.DefaultGroupTag;
 
@@ -786,26 +827,19 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
             : groupTag.Trim();
     }
 
-    private string CreateHardwareHashValueText(string? value)
-    {
-        return string.IsNullOrWhiteSpace(value)
-            ? GetString("Common.Unavailable")
-            : value;
-    }
-
     private void RaiseHardwareHashPropertiesChanged()
     {
         OnPropertyChanged(nameof(HasHardwareHashUploadMetadata));
         OnPropertyChanged(nameof(IsHardwareHashCertificateExpired));
         OnPropertyChanged(nameof(IsHardwareHashCertificateUsable));
         OnPropertyChanged(nameof(IsHardwareHashGroupTagControlsVisible));
-        OnPropertyChanged(nameof(IsHardwareHashPreRuntimeWarningVisible));
+        OnPropertyChanged(nameof(IsHardwareHashMissingMetadataWarningVisible));
+        OnPropertyChanged(nameof(HasHardwareHashDefaultGroupTag));
+        OnPropertyChanged(nameof(IsDefaultHardwareHashGroupTagOptionVisible));
+        OnPropertyChanged(nameof(IsHardwareHashCustomGroupTagTextBoxVisible));
         OnPropertyChanged(nameof(IsHardwareHashCustomGroupTagEnabled));
-        OnPropertyChanged(nameof(AutopilotHardwareHashReadinessText));
-        OnPropertyChanged(nameof(AutopilotHardwareHashTenantIdText));
-        OnPropertyChanged(nameof(AutopilotHardwareHashClientIdText));
-        OnPropertyChanged(nameof(AutopilotHardwareHashCertificateThumbprintText));
-        OnPropertyChanged(nameof(AutopilotHardwareHashCertificateExpirationText));
+        OnPropertyChanged(nameof(AutopilotHardwareHashUploadStatusText));
+        OnPropertyChanged(nameof(AutopilotHardwareHashUploadMessage));
         OnPropertyChanged(nameof(AutopilotHardwareHashDefaultGroupTagText));
         OnPropertyChanged(nameof(UseDefaultHardwareHashGroupTagText));
         OnPropertyChanged(nameof(EffectiveHardwareHashGroupTagText));

--- a/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
@@ -12,6 +12,13 @@ using Microsoft.Extensions.Logging;
 
 namespace Foundry.Deploy.ViewModels;
 
+/// <summary>
+/// Represents one selectable hardware hash upload group tag option.
+/// </summary>
+/// <param name="DisplayName">Localized display name shown to the operator.</param>
+/// <param name="GroupTag">The group tag value to upload, or null when no group tag should be used.</param>
+public sealed record HardwareHashGroupTagOption(string DisplayName, string? GroupTag);
+
 public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelBase
 {
     private const string DebugAutopilotProfileFolderName = "DebugAutopilotProfile";
@@ -80,13 +87,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
     private DeployAutopilotHardwareHashUploadSettings autopilotHardwareHashUpload = new();
 
     [ObservableProperty]
-    private bool useDefaultHardwareHashGroupTag = true;
-
-    [ObservableProperty]
-    private bool useCustomHardwareHashGroupTag;
-
-    [ObservableProperty]
-    private string customHardwareHashGroupTag = string.Empty;
+    private HardwareHashGroupTagOption? selectedHardwareHashGroupTag;
 
     [ObservableProperty]
     private AutopilotProfileCatalogItem? selectedAutopilotProfile;
@@ -100,6 +101,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
 
     public ObservableCollection<TargetDiskInfo> TargetDisks { get; } = [];
     public ObservableCollection<AutopilotProfileCatalogItem> AutopilotProfiles { get; } = [];
+    public ObservableCollection<HardwareHashGroupTagOption> HardwareHashGroupTagOptions { get; } = [];
 
     public bool IsFirmwareUpdatesOptionEnabled => _detectedHardware?.IsVirtualMachine != true;
     public bool HasAutopilotProfiles => AutopilotProfiles.Count > 0;
@@ -122,10 +124,12 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
     public bool IsHardwareHashCertificateUsable => HasHardwareHashUploadMetadata && !IsHardwareHashCertificateExpired;
     public bool IsHardwareHashGroupTagControlsVisible => IsHardwareHashUploadControlsVisible && IsHardwareHashCertificateUsable;
     public bool IsHardwareHashMissingMetadataWarningVisible => IsHardwareHashUploadControlsVisible && !HasHardwareHashUploadMetadata;
-    public bool HasHardwareHashDefaultGroupTag => !string.IsNullOrWhiteSpace(AutopilotHardwareHashUpload.DefaultGroupTag);
-    public bool IsDefaultHardwareHashGroupTagOptionVisible => IsHardwareHashGroupTagControlsVisible && HasHardwareHashDefaultGroupTag;
-    public bool IsHardwareHashCustomGroupTagTextBoxVisible => IsHardwareHashGroupTagControlsVisible && (UseCustomHardwareHashGroupTag || !HasHardwareHashDefaultGroupTag);
-    public bool IsHardwareHashCustomGroupTagEnabled => IsHardwareHashGroupTagControlsVisible && (UseCustomHardwareHashGroupTag || !HasHardwareHashDefaultGroupTag);
+    public string AutopilotHardwareHashTenantIdText => NormalizeMetadataValue(AutopilotHardwareHashUpload.TenantId);
+    public string AutopilotHardwareHashCertificateThumbprintText => NormalizeMetadataValue(AutopilotHardwareHashUpload.ActiveCertificateThumbprint);
+    public string AutopilotHardwareHashCertificateExpirationText =>
+        AutopilotHardwareHashUpload.ActiveCertificateExpiresOnUtc is DateTimeOffset expiresOn
+            ? expiresOn.ToLocalTime().ToString("g", LocalizationService.CurrentCulture)
+            : GetString("Common.Unavailable");
     public string TargetDiskSelectionHint => !string.IsNullOrWhiteSpace(SelectedTargetDisk?.SelectionWarning)
         ? SelectedTargetDisk.SelectionWarning
         : GetString("Preparation.TargetDiskHint");
@@ -175,12 +179,6 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         }
     }
 
-    public string AutopilotHardwareHashDefaultGroupTagText => string.IsNullOrWhiteSpace(AutopilotHardwareHashUpload.DefaultGroupTag)
-        ? GetString("Common.None")
-        : AutopilotHardwareHashUpload.DefaultGroupTag!;
-    public string UseDefaultHardwareHashGroupTagText => Format(
-        "Preparation.AutopilotHardwareHashUseDefaultGroupTagFormat",
-        AutopilotHardwareHashDefaultGroupTagText);
     public string EffectiveHardwareHashGroupTagText => string.IsNullOrWhiteSpace(ResolveEffectiveHardwareHashGroupTag())
         ? GetString("Common.None")
         : ResolveEffectiveHardwareHashGroupTag()!;
@@ -307,9 +305,6 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
 
         AutopilotProvisioningMode = settings.ProvisioningMode;
         AutopilotHardwareHashUpload = settings.HardwareHashUpload ?? new DeployAutopilotHardwareHashUploadSettings();
-        UseDefaultHardwareHashGroupTag = true;
-        UseCustomHardwareHashGroupTag = false;
-        CustomHardwareHashGroupTag = string.Empty;
         SelectedAutopilotProfile = settings.IsEnabled && settings.ProvisioningMode == AutopilotProvisioningMode.JsonProfile
             ? ResolveDefaultAutopilotProfile(settings.DefaultProfileFolderName)
             : null;
@@ -464,9 +459,6 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
                 break;
             case DebugAutopilotMode.JsonProfile:
                 EnsureDebugAutopilotProfile();
-                UseDefaultHardwareHashGroupTag = true;
-                UseCustomHardwareHashGroupTag = false;
-                CustomHardwareHashGroupTag = string.Empty;
                 AutopilotProvisioningMode = AutopilotProvisioningMode.JsonProfile;
                 SelectedAutopilotProfile = AutopilotProfiles.First(profile =>
                     profile.FolderName.Equals(DebugAutopilotProfileFolderName, StringComparison.OrdinalIgnoreCase));
@@ -513,11 +505,9 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
             ActiveCertificateKeyId = includeCompleteCertificateMetadata ? "debug-certificate-key-id" : null,
             ActiveCertificateThumbprint = includeCompleteCertificateMetadata ? "DEBUGTHUMBPRINT" : null,
             ActiveCertificateExpiresOnUtc = includeCompleteCertificateMetadata ? certificateExpiresOnUtc : null,
-            DefaultGroupTag = defaultGroupTag
+            DefaultGroupTag = defaultGroupTag,
+            KnownGroupTags = [DebugAutopilotGroupTag, "Kiosk"]
         };
-        UseDefaultHardwareHashGroupTag = true;
-        UseCustomHardwareHashGroupTag = false;
-        CustomHardwareHashGroupTag = string.Empty;
         SelectedAutopilotProfile = null;
         IsAutopilotEnabled = true;
     }
@@ -540,41 +530,13 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
 
     partial void OnAutopilotHardwareHashUploadChanged(DeployAutopilotHardwareHashUploadSettings value)
     {
+        SelectedHardwareHashGroupTag = null;
+        RefreshHardwareHashGroupTagOptions();
         RaiseHardwareHashPropertiesChanged();
         RaiseStateChanged();
     }
 
-    partial void OnUseDefaultHardwareHashGroupTagChanged(bool value)
-    {
-        if (value && UseCustomHardwareHashGroupTag)
-        {
-            UseCustomHardwareHashGroupTag = false;
-        }
-
-        OnPropertyChanged(nameof(IsHardwareHashCustomGroupTagEnabled));
-        OnPropertyChanged(nameof(IsHardwareHashCustomGroupTagTextBoxVisible));
-        OnPropertyChanged(nameof(EffectiveHardwareHashGroupTagText));
-        RaiseStateChanged();
-    }
-
-    partial void OnUseCustomHardwareHashGroupTagChanged(bool value)
-    {
-        if (value && UseDefaultHardwareHashGroupTag)
-        {
-            UseDefaultHardwareHashGroupTag = false;
-        }
-        else if (!value && !UseDefaultHardwareHashGroupTag)
-        {
-            UseDefaultHardwareHashGroupTag = true;
-        }
-
-        OnPropertyChanged(nameof(IsHardwareHashCustomGroupTagEnabled));
-        OnPropertyChanged(nameof(IsHardwareHashCustomGroupTagTextBoxVisible));
-        OnPropertyChanged(nameof(EffectiveHardwareHashGroupTagText));
-        RaiseStateChanged();
-    }
-
-    partial void OnCustomHardwareHashGroupTagChanged(string value)
+    partial void OnSelectedHardwareHashGroupTagChanged(HardwareHashGroupTagOption? value)
     {
         OnPropertyChanged(nameof(EffectiveHardwareHashGroupTagText));
         RaiseStateChanged();
@@ -792,6 +754,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
             OnPropertyChanged(nameof(HasAutopilotProfileHint));
             OnPropertyChanged(nameof(AutopilotModeText));
             OnPropertyChanged(nameof(AutopilotDisabledSummaryText));
+            RefreshHardwareHashGroupTagOptions();
             RaiseHardwareHashPropertiesChanged();
             OnPropertyChanged(nameof(TargetDiskSelectionHint));
             OnPropertyChanged(nameof(TargetDisks));
@@ -818,13 +781,43 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
 
     private string? ResolveEffectiveHardwareHashGroupTag()
     {
-        string? groupTag = UseCustomHardwareHashGroupTag || !HasHardwareHashDefaultGroupTag
-            ? CustomHardwareHashGroupTag
+        return string.IsNullOrWhiteSpace(SelectedHardwareHashGroupTag?.GroupTag)
+            ? null
+            : SelectedHardwareHashGroupTag.GroupTag.Trim();
+    }
+
+    private void RefreshHardwareHashGroupTagOptions()
+    {
+        string? preferredGroupTag = SelectedHardwareHashGroupTag is not null
+            ? SelectedHardwareHashGroupTag.GroupTag
             : AutopilotHardwareHashUpload.DefaultGroupTag;
 
-        return string.IsNullOrWhiteSpace(groupTag)
-            ? null
-            : groupTag.Trim();
+        HardwareHashGroupTagOptions.Clear();
+        HardwareHashGroupTagOptions.Add(new HardwareHashGroupTagOption(GetString("Common.None"), null));
+
+        foreach (string groupTag in AutopilotHardwareHashUpload.KnownGroupTags
+                     .Select(static value => value.Trim())
+                     .Where(static value => !string.IsNullOrWhiteSpace(value))
+                     .Distinct(StringComparer.OrdinalIgnoreCase)
+                     .Order(StringComparer.OrdinalIgnoreCase))
+        {
+            HardwareHashGroupTagOptions.Add(new HardwareHashGroupTagOption(groupTag, groupTag));
+        }
+
+        SelectedHardwareHashGroupTag = HardwareHashGroupTagOptions.FirstOrDefault(option =>
+            !string.IsNullOrWhiteSpace(option.GroupTag) &&
+            string.Equals(option.GroupTag, preferredGroupTag, StringComparison.OrdinalIgnoreCase))
+            ?? HardwareHashGroupTagOptions[0];
+
+        OnPropertyChanged(nameof(HardwareHashGroupTagOptions));
+        OnPropertyChanged(nameof(EffectiveHardwareHashGroupTagText));
+    }
+
+    private string NormalizeMetadataValue(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value)
+            ? GetString("Common.Unavailable")
+            : value.Trim();
     }
 
     private void RaiseHardwareHashPropertiesChanged()
@@ -834,14 +827,11 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         OnPropertyChanged(nameof(IsHardwareHashCertificateUsable));
         OnPropertyChanged(nameof(IsHardwareHashGroupTagControlsVisible));
         OnPropertyChanged(nameof(IsHardwareHashMissingMetadataWarningVisible));
-        OnPropertyChanged(nameof(HasHardwareHashDefaultGroupTag));
-        OnPropertyChanged(nameof(IsDefaultHardwareHashGroupTagOptionVisible));
-        OnPropertyChanged(nameof(IsHardwareHashCustomGroupTagTextBoxVisible));
-        OnPropertyChanged(nameof(IsHardwareHashCustomGroupTagEnabled));
+        OnPropertyChanged(nameof(AutopilotHardwareHashTenantIdText));
+        OnPropertyChanged(nameof(AutopilotHardwareHashCertificateThumbprintText));
+        OnPropertyChanged(nameof(AutopilotHardwareHashCertificateExpirationText));
         OnPropertyChanged(nameof(AutopilotHardwareHashUploadStatusText));
         OnPropertyChanged(nameof(AutopilotHardwareHashUploadMessage));
-        OnPropertyChanged(nameof(AutopilotHardwareHashDefaultGroupTagText));
-        OnPropertyChanged(nameof(UseDefaultHardwareHashGroupTagText));
         OnPropertyChanged(nameof(EffectiveHardwareHashGroupTagText));
     }
 

--- a/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
@@ -14,6 +14,10 @@ namespace Foundry.Deploy.ViewModels;
 
 public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelBase
 {
+    private const string DebugAutopilotProfileFolderName = "DebugAutopilotProfile";
+    private const string DebugAutopilotProfileDisplayName = "Debug Autopilot Profile";
+    private const string DebugAutopilotGroupTag = "Debug";
+
     private readonly ITargetDiskService _targetDiskService;
     private readonly IHardwareProfileService _hardwareProfileService;
     private readonly IOfflineWindowsComputerNameService _offlineWindowsComputerNameService;
@@ -431,31 +435,58 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
                 UseCustomHardwareHashGroupTag = false;
                 CustomHardwareHashGroupTag = string.Empty;
                 AutopilotProvisioningMode = AutopilotProvisioningMode.JsonProfile;
-                SelectedAutopilotProfile = AutopilotProfiles.First();
+                SelectedAutopilotProfile = AutopilotProfiles.First(profile =>
+                    profile.FolderName.Equals(DebugAutopilotProfileFolderName, StringComparison.OrdinalIgnoreCase));
                 IsAutopilotEnabled = true;
                 break;
-            case DebugAutopilotMode.HardwareHashUpload:
-                AutopilotProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload;
-                AutopilotHardwareHashUpload = new DeployAutopilotHardwareHashUploadSettings
-                {
-                    TenantId = "debug-tenant-id",
-                    ClientId = "debug-client-id",
-                    ActiveCertificateKeyId = "debug-certificate-key-id",
-                    ActiveCertificateThumbprint = "DEBUGTHUMBPRINT",
-                    ActiveCertificateExpiresOnUtc = DateTimeOffset.UtcNow.AddMonths(1),
-                    DefaultGroupTag = "Debug"
-                };
-                UseDefaultHardwareHashGroupTag = true;
-                UseCustomHardwareHashGroupTag = false;
-                CustomHardwareHashGroupTag = string.Empty;
-                SelectedAutopilotProfile = null;
-                IsAutopilotEnabled = true;
+            case DebugAutopilotMode.HardwareHashUploadValidCertificate:
+                ApplyDebugHardwareHashUpload(
+                    certificateExpiresOnUtc: DateTimeOffset.UtcNow.AddMonths(1),
+                    defaultGroupTag: DebugAutopilotGroupTag,
+                    includeCompleteCertificateMetadata: true);
+                break;
+            case DebugAutopilotMode.HardwareHashUploadExpiredCertificate:
+                ApplyDebugHardwareHashUpload(
+                    certificateExpiresOnUtc: DateTimeOffset.UtcNow.AddDays(-1),
+                    defaultGroupTag: DebugAutopilotGroupTag,
+                    includeCompleteCertificateMetadata: true);
+                break;
+            case DebugAutopilotMode.HardwareHashUploadMissingCertificateMetadata:
+                ApplyDebugHardwareHashUpload(
+                    certificateExpiresOnUtc: DateTimeOffset.UtcNow.AddMonths(1),
+                    defaultGroupTag: DebugAutopilotGroupTag,
+                    includeCompleteCertificateMetadata: false);
+                break;
+            case DebugAutopilotMode.HardwareHashUploadNoDefaultGroupTag:
+                ApplyDebugHardwareHashUpload(
+                    certificateExpiresOnUtc: DateTimeOffset.UtcNow.AddMonths(1),
+                    defaultGroupTag: null,
+                    includeCompleteCertificateMetadata: true);
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unsupported debug Autopilot mode.");
         }
 
         RaiseStateChanged();
+    }
+
+    private void ApplyDebugHardwareHashUpload(DateTimeOffset certificateExpiresOnUtc, string? defaultGroupTag, bool includeCompleteCertificateMetadata)
+    {
+        AutopilotProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload;
+        AutopilotHardwareHashUpload = new DeployAutopilotHardwareHashUploadSettings
+        {
+            TenantId = "debug-tenant-id",
+            ClientId = "debug-client-id",
+            ActiveCertificateKeyId = includeCompleteCertificateMetadata ? "debug-certificate-key-id" : null,
+            ActiveCertificateThumbprint = includeCompleteCertificateMetadata ? "DEBUGTHUMBPRINT" : null,
+            ActiveCertificateExpiresOnUtc = includeCompleteCertificateMetadata ? certificateExpiresOnUtc : null,
+            DefaultGroupTag = defaultGroupTag
+        };
+        UseDefaultHardwareHashGroupTag = true;
+        UseCustomHardwareHashGroupTag = false;
+        CustomHardwareHashGroupTag = string.Empty;
+        SelectedAutopilotProfile = null;
+        IsAutopilotEnabled = true;
     }
 
     partial void OnAutopilotProvisioningModeChanged(AutopilotProvisioningMode value)
@@ -670,15 +701,16 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
 
     private void EnsureDebugAutopilotProfile()
     {
-        if (AutopilotProfiles.Count > 0)
+        if (AutopilotProfiles.Any(profile =>
+                profile.FolderName.Equals(DebugAutopilotProfileFolderName, StringComparison.OrdinalIgnoreCase)))
         {
             return;
         }
 
         AutopilotProfiles.Add(new AutopilotProfileCatalogItem
         {
-            FolderName = "DebugAutopilotProfile",
-            DisplayName = "Debug Autopilot Profile",
+            FolderName = DebugAutopilotProfileFolderName,
+            DisplayName = DebugAutopilotProfileDisplayName,
             ConfigurationFilePath = @"X:\Foundry\Debug\Autopilot\AutopilotConfigurationFile.json"
         });
         OnPropertyChanged(nameof(HasAutopilotProfiles));

--- a/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
@@ -76,6 +76,15 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
     private DeployAutopilotHardwareHashUploadSettings autopilotHardwareHashUpload = new();
 
     [ObservableProperty]
+    private bool useDefaultHardwareHashGroupTag = true;
+
+    [ObservableProperty]
+    private bool useCustomHardwareHashGroupTag;
+
+    [ObservableProperty]
+    private string customHardwareHashGroupTag = string.Empty;
+
+    [ObservableProperty]
     private AutopilotProfileCatalogItem? selectedAutopilotProfile;
 
     [ObservableProperty]
@@ -96,9 +105,19 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
     public bool IsJsonProfileControlsVisible => IsAutopilotEnabled && IsJsonProfileMode;
     public bool IsHardwareHashUploadControlsVisible => IsAutopilotEnabled && IsHardwareHashUploadMode;
     public bool IsAutopilotProfileSelectionEnabled => IsJsonProfileControlsVisible && HasAutopilotProfiles;
+    public bool HasHardwareHashUploadMetadata =>
+        !string.IsNullOrWhiteSpace(AutopilotHardwareHashUpload.TenantId) &&
+        !string.IsNullOrWhiteSpace(AutopilotHardwareHashUpload.ClientId) &&
+        !string.IsNullOrWhiteSpace(AutopilotHardwareHashUpload.ActiveCertificateKeyId) &&
+        !string.IsNullOrWhiteSpace(AutopilotHardwareHashUpload.ActiveCertificateThumbprint) &&
+        AutopilotHardwareHashUpload.ActiveCertificateExpiresOnUtc is not null;
     public bool IsHardwareHashCertificateExpired =>
         AutopilotHardwareHashUpload.ActiveCertificateExpiresOnUtc is DateTimeOffset expiresOn &&
         expiresOn <= DateTimeOffset.UtcNow;
+    public bool IsHardwareHashCertificateUsable => HasHardwareHashUploadMetadata && !IsHardwareHashCertificateExpired;
+    public bool IsHardwareHashGroupTagControlsVisible => IsHardwareHashUploadControlsVisible && IsHardwareHashCertificateUsable;
+    public bool IsHardwareHashPreRuntimeWarningVisible => IsHardwareHashUploadControlsVisible && IsHardwareHashCertificateUsable;
+    public bool IsHardwareHashCustomGroupTagEnabled => IsHardwareHashGroupTagControlsVisible && UseCustomHardwareHashGroupTag;
     public string TargetDiskSelectionHint => !string.IsNullOrWhiteSpace(SelectedTargetDisk?.SelectionWarning)
         ? SelectedTargetDisk.SelectionWarning
         : GetString("Preparation.TargetDiskHint");
@@ -113,11 +132,45 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
     public string AutopilotModeText => IsHardwareHashUploadMode
         ? GetString("Preparation.AutopilotModeHardwareHashUpload")
         : GetString("Preparation.AutopilotModeJsonProfile");
-    public string AutopilotHardwareHashStatusText => CreateHardwareHashStatusText();
+    public string AutopilotHardwareHashReadinessText => IsHardwareHashCertificateUsable
+        ? GetString("Common.Ready")
+        : GetString("Common.NotReady");
+    public string AutopilotHardwareHashTenantIdText => CreateHardwareHashValueText(AutopilotHardwareHashUpload.TenantId);
+    public string AutopilotHardwareHashClientIdText => CreateHardwareHashValueText(AutopilotHardwareHashUpload.ClientId);
+    public string AutopilotHardwareHashCertificateThumbprintText => CreateHardwareHashValueText(AutopilotHardwareHashUpload.ActiveCertificateThumbprint);
+    public string AutopilotHardwareHashCertificateExpirationText => AutopilotHardwareHashUpload.ActiveCertificateExpiresOnUtc is DateTimeOffset expiresOn
+        ? expiresOn.LocalDateTime.ToString("g", LocalizationService.CurrentCulture)
+        : GetString("Common.Unavailable");
+    public string AutopilotHardwareHashDefaultGroupTagText => string.IsNullOrWhiteSpace(AutopilotHardwareHashUpload.DefaultGroupTag)
+        ? GetString("Common.None")
+        : AutopilotHardwareHashUpload.DefaultGroupTag!;
+    public string UseDefaultHardwareHashGroupTagText => Format(
+        "Preparation.AutopilotHardwareHashUseDefaultGroupTagFormat",
+        AutopilotHardwareHashDefaultGroupTagText);
+    public string EffectiveHardwareHashGroupTagText => string.IsNullOrWhiteSpace(ResolveEffectiveHardwareHashGroupTag())
+        ? GetString("Common.None")
+        : ResolveEffectiveHardwareHashGroupTag()!;
 
     public bool HasTargetComputerNameValidationError => !string.IsNullOrWhiteSpace(TargetComputerNameValidationMessage);
 
     public HardwareProfile? DetectedHardware => _detectedHardware;
+
+    /// <summary>
+    /// Builds the hardware hash upload settings to carry into a deployment launch request.
+    /// </summary>
+    /// <returns>The configured hardware hash upload metadata with the user-selected group tag override applied.</returns>
+    public DeployAutopilotHardwareHashUploadSettings CreateAutopilotHardwareHashUploadForLaunch()
+    {
+        if (!IsAutopilotEnabled || !IsHardwareHashUploadMode)
+        {
+            return new DeployAutopilotHardwareHashUploadSettings();
+        }
+
+        return AutopilotHardwareHashUpload with
+        {
+            DefaultGroupTag = ResolveEffectiveHardwareHashGroupTag()
+        };
+    }
 
     [RelayCommand(CanExecute = nameof(CanRefreshTargetDisks))]
     private async Task RefreshTargetDisksAsync()
@@ -219,6 +272,9 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
 
         AutopilotProvisioningMode = settings.ProvisioningMode;
         AutopilotHardwareHashUpload = settings.HardwareHashUpload ?? new DeployAutopilotHardwareHashUploadSettings();
+        UseDefaultHardwareHashGroupTag = true;
+        UseCustomHardwareHashGroupTag = false;
+        CustomHardwareHashGroupTag = string.Empty;
         SelectedAutopilotProfile = settings.IsEnabled && settings.ProvisioningMode == AutopilotProvisioningMode.JsonProfile
             ? ResolveDefaultAutopilotProfile(settings.DefaultProfileFolderName)
             : null;
@@ -352,6 +408,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         OnPropertyChanged(nameof(IsHardwareHashUploadControlsVisible));
         OnPropertyChanged(nameof(IsAutopilotProfileSelectionEnabled));
         OnPropertyChanged(nameof(AutopilotProfileHint));
+        RaiseHardwareHashPropertiesChanged();
         RaiseStateChanged();
     }
 
@@ -370,6 +427,9 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
                 break;
             case DebugAutopilotMode.JsonProfile:
                 EnsureDebugAutopilotProfile();
+                UseDefaultHardwareHashGroupTag = true;
+                UseCustomHardwareHashGroupTag = false;
+                CustomHardwareHashGroupTag = string.Empty;
                 AutopilotProvisioningMode = AutopilotProvisioningMode.JsonProfile;
                 SelectedAutopilotProfile = AutopilotProfiles.First();
                 IsAutopilotEnabled = true;
@@ -385,6 +445,9 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
                     ActiveCertificateExpiresOnUtc = DateTimeOffset.UtcNow.AddMonths(1),
                     DefaultGroupTag = "Debug"
                 };
+                UseDefaultHardwareHashGroupTag = true;
+                UseCustomHardwareHashGroupTag = false;
+                CustomHardwareHashGroupTag = string.Empty;
                 SelectedAutopilotProfile = null;
                 IsAutopilotEnabled = true;
                 break;
@@ -404,14 +467,47 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         OnPropertyChanged(nameof(IsAutopilotProfileSelectionEnabled));
         OnPropertyChanged(nameof(AutopilotProfileHint));
         OnPropertyChanged(nameof(AutopilotModeText));
-        OnPropertyChanged(nameof(AutopilotHardwareHashStatusText));
+        RaiseHardwareHashPropertiesChanged();
         RaiseStateChanged();
     }
 
     partial void OnAutopilotHardwareHashUploadChanged(DeployAutopilotHardwareHashUploadSettings value)
     {
-        OnPropertyChanged(nameof(IsHardwareHashCertificateExpired));
-        OnPropertyChanged(nameof(AutopilotHardwareHashStatusText));
+        RaiseHardwareHashPropertiesChanged();
+        RaiseStateChanged();
+    }
+
+    partial void OnUseDefaultHardwareHashGroupTagChanged(bool value)
+    {
+        if (value && UseCustomHardwareHashGroupTag)
+        {
+            UseCustomHardwareHashGroupTag = false;
+        }
+
+        OnPropertyChanged(nameof(IsHardwareHashCustomGroupTagEnabled));
+        OnPropertyChanged(nameof(EffectiveHardwareHashGroupTagText));
+        RaiseStateChanged();
+    }
+
+    partial void OnUseCustomHardwareHashGroupTagChanged(bool value)
+    {
+        if (value && UseDefaultHardwareHashGroupTag)
+        {
+            UseDefaultHardwareHashGroupTag = false;
+        }
+        else if (!value && !UseDefaultHardwareHashGroupTag)
+        {
+            UseDefaultHardwareHashGroupTag = true;
+        }
+
+        OnPropertyChanged(nameof(IsHardwareHashCustomGroupTagEnabled));
+        OnPropertyChanged(nameof(EffectiveHardwareHashGroupTagText));
+        RaiseStateChanged();
+    }
+
+    partial void OnCustomHardwareHashGroupTagChanged(string value)
+    {
+        OnPropertyChanged(nameof(EffectiveHardwareHashGroupTagText));
         RaiseStateChanged();
     }
 
@@ -623,7 +719,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
             TargetComputerNameValidationMessage = ResolveComputerNameValidationMessage(TargetComputerName);
             OnPropertyChanged(nameof(AutopilotProfileHint));
             OnPropertyChanged(nameof(AutopilotModeText));
-            OnPropertyChanged(nameof(AutopilotHardwareHashStatusText));
+            RaiseHardwareHashPropertiesChanged();
             OnPropertyChanged(nameof(TargetDiskSelectionHint));
             OnPropertyChanged(nameof(TargetDisks));
             OnPropertyChanged(nameof(SelectedTargetDisk));
@@ -647,32 +743,40 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         return string.Format(LocalizationService.CurrentCulture, GetString(key), args);
     }
 
-    private string CreateHardwareHashStatusText()
+    private string? ResolveEffectiveHardwareHashGroupTag()
     {
-        if (!IsHardwareHashUploadMode)
-        {
-            return string.Empty;
-        }
+        string? groupTag = UseCustomHardwareHashGroupTag
+            ? CustomHardwareHashGroupTag
+            : AutopilotHardwareHashUpload.DefaultGroupTag;
 
-        if (IsHardwareHashCertificateExpired)
-        {
-            return Format(
-                "Preparation.AutopilotHardwareHashCertificateExpiredFormat",
-                AutopilotHardwareHashUpload.ActiveCertificateExpiresOnUtc!.Value.LocalDateTime);
-        }
+        return string.IsNullOrWhiteSpace(groupTag)
+            ? null
+            : groupTag.Trim();
+    }
 
-        if (AutopilotHardwareHashUpload.ActiveCertificateExpiresOnUtc is DateTimeOffset expiresOn)
-        {
-            string groupTag = string.IsNullOrWhiteSpace(AutopilotHardwareHashUpload.DefaultGroupTag)
-                ? GetString("Common.None")
-                : AutopilotHardwareHashUpload.DefaultGroupTag!;
-            return Format(
-                "Preparation.AutopilotHardwareHashReadyFormat",
-                expiresOn.LocalDateTime,
-                groupTag);
-        }
+    private string CreateHardwareHashValueText(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value)
+            ? GetString("Common.Unavailable")
+            : value;
+    }
 
-        return GetString("Preparation.AutopilotHardwareHashNotConfigured");
+    private void RaiseHardwareHashPropertiesChanged()
+    {
+        OnPropertyChanged(nameof(HasHardwareHashUploadMetadata));
+        OnPropertyChanged(nameof(IsHardwareHashCertificateExpired));
+        OnPropertyChanged(nameof(IsHardwareHashCertificateUsable));
+        OnPropertyChanged(nameof(IsHardwareHashGroupTagControlsVisible));
+        OnPropertyChanged(nameof(IsHardwareHashPreRuntimeWarningVisible));
+        OnPropertyChanged(nameof(IsHardwareHashCustomGroupTagEnabled));
+        OnPropertyChanged(nameof(AutopilotHardwareHashReadinessText));
+        OnPropertyChanged(nameof(AutopilotHardwareHashTenantIdText));
+        OnPropertyChanged(nameof(AutopilotHardwareHashClientIdText));
+        OnPropertyChanged(nameof(AutopilotHardwareHashCertificateThumbprintText));
+        OnPropertyChanged(nameof(AutopilotHardwareHashCertificateExpirationText));
+        OnPropertyChanged(nameof(AutopilotHardwareHashDefaultGroupTagText));
+        OnPropertyChanged(nameof(UseDefaultHardwareHashGroupTagText));
+        OnPropertyChanged(nameof(EffectiveHardwareHashGroupTagText));
     }
 
     private bool CanRefreshTargetDisks()

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -89,9 +89,12 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     public string SummaryAutopilotModeText => Preparation.AutopilotModeText;
     public string SummaryAutopilotProfileText => Preparation.SelectedAutopilotProfile?.DisplayName ?? GetString("Common.None");
     public string SummaryAutopilotGroupTagText => Preparation.EffectiveHardwareHashGroupTagText;
-    public bool IsDebugAutopilotNoneMode => IsDebugSafeMode && _debugAutopilotMode == DebugAutopilotMode.None;
-    public bool IsDebugAutopilotJsonProfileMode => IsDebugSafeMode && _debugAutopilotMode == DebugAutopilotMode.JsonProfile;
-    public bool IsDebugAutopilotHardwareHashUploadMode => IsDebugSafeMode && _debugAutopilotMode == DebugAutopilotMode.HardwareHashUpload;
+    public bool IsDebugAutopilotNoneMode => IsDebugAutopilotMode(DebugAutopilotMode.None);
+    public bool IsDebugAutopilotJsonProfileMode => IsDebugAutopilotMode(DebugAutopilotMode.JsonProfile);
+    public bool IsDebugAutopilotHardwareHashUploadValidCertificateMode => IsDebugAutopilotMode(DebugAutopilotMode.HardwareHashUploadValidCertificate);
+    public bool IsDebugAutopilotHardwareHashUploadExpiredCertificateMode => IsDebugAutopilotMode(DebugAutopilotMode.HardwareHashUploadExpiredCertificate);
+    public bool IsDebugAutopilotHardwareHashUploadMissingCertificateMetadataMode => IsDebugAutopilotMode(DebugAutopilotMode.HardwareHashUploadMissingCertificateMetadata);
+    public bool IsDebugAutopilotHardwareHashUploadNoDefaultGroupTagMode => IsDebugAutopilotMode(DebugAutopilotMode.HardwareHashUploadNoDefaultGroupTag);
 
     public MainWindowViewModel(
         ILocalizationService localizationService,
@@ -218,12 +221,11 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
 
         _debugAutopilotMode = mode;
         Preparation.ApplyDebugAutopilotMode(mode);
-        OnPropertyChanged(nameof(IsDebugAutopilotNoneMode));
-        OnPropertyChanged(nameof(IsDebugAutopilotJsonProfileMode));
-        OnPropertyChanged(nameof(IsDebugAutopilotHardwareHashUploadMode));
+        RaiseDebugAutopilotModePropertiesChanged();
         OnPropertyChanged(nameof(SummaryAutopilotEnabledText));
         OnPropertyChanged(nameof(SummaryAutopilotModeText));
         OnPropertyChanged(nameof(SummaryAutopilotProfileText));
+        OnPropertyChanged(nameof(SummaryAutopilotGroupTagText));
         NextWizardStepCommand.NotifyCanExecuteChanged();
         StartDeploymentCommand.NotifyCanExecuteChanged();
     }
@@ -427,6 +429,21 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     private bool CanUseDebugTools()
     {
         return IsDebugSafeMode && !IsDeploymentRunning;
+    }
+
+    private bool IsDebugAutopilotMode(DebugAutopilotMode mode)
+    {
+        return IsDebugSafeMode && _debugAutopilotMode == mode;
+    }
+
+    private void RaiseDebugAutopilotModePropertiesChanged()
+    {
+        OnPropertyChanged(nameof(IsDebugAutopilotNoneMode));
+        OnPropertyChanged(nameof(IsDebugAutopilotJsonProfileMode));
+        OnPropertyChanged(nameof(IsDebugAutopilotHardwareHashUploadValidCertificateMode));
+        OnPropertyChanged(nameof(IsDebugAutopilotHardwareHashUploadExpiredCertificateMode));
+        OnPropertyChanged(nameof(IsDebugAutopilotHardwareHashUploadMissingCertificateMetadataMode));
+        OnPropertyChanged(nameof(IsDebugAutopilotHardwareHashUploadNoDefaultGroupTagMode));
     }
 
     private bool CanRefreshCatalogs()

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -88,6 +88,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     public string SummaryAutopilotEnabledText => Preparation.IsAutopilotEnabled ? GetString("Common.Yes") : GetString("Common.No");
     public string SummaryAutopilotModeText => Preparation.AutopilotModeText;
     public string SummaryAutopilotProfileText => Preparation.SelectedAutopilotProfile?.DisplayName ?? GetString("Common.None");
+    public string SummaryAutopilotGroupTagText => Preparation.EffectiveHardwareHashGroupTagText;
     public bool IsDebugAutopilotNoneMode => IsDebugSafeMode && _debugAutopilotMode == DebugAutopilotMode.None;
     public bool IsDebugAutopilotJsonProfileMode => IsDebugSafeMode && _debugAutopilotMode == DebugAutopilotMode.JsonProfile;
     public bool IsDebugAutopilotHardwareHashUploadMode => IsDebugSafeMode && _debugAutopilotMode == DebugAutopilotMode.HardwareHashUpload;
@@ -309,7 +310,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
                 IsAutopilotEnabled = Preparation.IsAutopilotEnabled,
                 AutopilotProvisioningMode = Preparation.AutopilotProvisioningMode,
                 SelectedAutopilotProfile = Preparation.SelectedAutopilotProfile,
-                AutopilotHardwareHashUpload = Preparation.AutopilotHardwareHashUpload,
+                AutopilotHardwareHashUpload = Preparation.CreateAutopilotHardwareHashUploadForLaunch(),
                 Oobe = _wizardContext.Oobe,
                 AppxRemoval = _wizardContext.AppxRemoval,
                 AiComponentRemoval = _wizardContext.AiComponentRemoval,
@@ -395,6 +396,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         OnPropertyChanged(nameof(SummaryAutopilotEnabledText));
         OnPropertyChanged(nameof(SummaryAutopilotModeText));
         OnPropertyChanged(nameof(SummaryAutopilotProfileText));
+        OnPropertyChanged(nameof(SummaryAutopilotGroupTagText));
         NextWizardStepCommand.NotifyCanExecuteChanged();
         StartDeploymentCommand.NotifyCanExecuteChanged();
     }
@@ -544,6 +546,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
             OnPropertyChanged(nameof(SummaryAutopilotEnabledText));
             OnPropertyChanged(nameof(SummaryAutopilotModeText));
             OnPropertyChanged(nameof(SummaryAutopilotProfileText));
+            OnPropertyChanged(nameof(SummaryAutopilotGroupTagText));
         });
     }
 

--- a/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
@@ -41,6 +41,8 @@
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="8" />
                                 <RowDefinition Height="Auto" />
+                                <RowDefinition Height="8" />
+                                <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="220" />
@@ -171,6 +173,18 @@
                                 Text="{Binding SummaryAutopilotProfileText}"
                                 TextWrapping="Wrap"
                                 Visibility="{Binding Preparation.IsJsonProfileControlsVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                            <TextBlock
+                                Grid.Row="8"
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="{Binding Strings[Summary.AutopilotGroupTag]}"
+                                Visibility="{Binding Preparation.IsHardwareHashGroupTagControlsVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                            <TextBlock
+                                Grid.Row="8"
+                                Grid.Column="2"
+                                Text="{Binding SummaryAutopilotGroupTagText}"
+                                TextWrapping="Wrap"
+                                Visibility="{Binding Preparation.IsHardwareHashGroupTagControlsVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         </Grid>
                     </StackPanel>
                 </Border>

--- a/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
@@ -162,22 +162,156 @@
                                 </StackPanel>
 
                                 <StackPanel Visibility="{Binding IsHardwareHashUploadControlsVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                    <TextBlock
-                                        Margin="0,0,0,4"
-                                        Style="{StaticResource BodyTextBlockStyle}"
-                                        Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashUpload], ElementName=ViewRoot}" />
-                                    <TextBlock
-                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                        Style="{StaticResource CaptionTextBlockStyle}"
-                                        Text="{Binding AutopilotHardwareHashStatusText}"
-                                        TextWrapping="Wrap" />
-                                    <TextBlock
-                                        Margin="0,8,0,0"
-                                        Foreground="#FFC42B1C"
-                                        Style="{StaticResource CaptionTextBlockStyle}"
-                                        Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashExpiredAction], ElementName=ViewRoot}"
-                                        TextWrapping="Wrap"
-                                        Visibility="{Binding IsHardwareHashCertificateExpired, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <Grid>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="8" />
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="8" />
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="8" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+
+                                        <TextBlock
+                                            Style="{StaticResource BodyTextBlockStyle}"
+                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashTenantReadiness], ElementName=ViewRoot}" />
+
+                                        <Grid Grid.Row="2">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="170" />
+                                                <ColumnDefinition Width="12" />
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="6" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="6" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="6" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="6" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="6" />
+                                                <RowDefinition Height="Auto" />
+                                            </Grid.RowDefinitions>
+
+                                            <TextBlock
+                                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                                Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashReadinessStatus], ElementName=ViewRoot}" />
+                                            <TextBlock
+                                                Grid.Column="2"
+                                                FontWeight="SemiBold"
+                                                Text="{Binding AutopilotHardwareHashReadinessText}">
+                                                <TextBlock.Style>
+                                                    <Style BasedOn="{StaticResource BodyTextBlockStyle}" TargetType="TextBlock">
+                                                        <Setter Property="Foreground" Value="#FFC42B1C" />
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding IsHardwareHashCertificateUsable}" Value="True">
+                                                                <Setter Property="Foreground" Value="#FF0F7B0F" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+
+                                            <TextBlock
+                                                Grid.Row="2"
+                                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                                Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashTenantId], ElementName=ViewRoot}" />
+                                            <TextBlock
+                                                Grid.Row="2"
+                                                Grid.Column="2"
+                                                Text="{Binding AutopilotHardwareHashTenantIdText}"
+                                                TextWrapping="Wrap" />
+
+                                            <TextBlock
+                                                Grid.Row="4"
+                                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                                Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashClientId], ElementName=ViewRoot}" />
+                                            <TextBlock
+                                                Grid.Row="4"
+                                                Grid.Column="2"
+                                                Text="{Binding AutopilotHardwareHashClientIdText}"
+                                                TextWrapping="Wrap" />
+
+                                            <TextBlock
+                                                Grid.Row="6"
+                                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                                Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashCertificateThumbprint], ElementName=ViewRoot}" />
+                                            <TextBlock
+                                                Grid.Row="6"
+                                                Grid.Column="2"
+                                                Text="{Binding AutopilotHardwareHashCertificateThumbprintText}"
+                                                TextWrapping="Wrap" />
+
+                                            <TextBlock
+                                                Grid.Row="8"
+                                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                                Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashCertificateExpiration], ElementName=ViewRoot}" />
+                                            <TextBlock
+                                                Grid.Row="8"
+                                                Grid.Column="2"
+                                                Text="{Binding AutopilotHardwareHashCertificateExpirationText}"
+                                                TextWrapping="Wrap" />
+
+                                            <TextBlock
+                                                Grid.Row="10"
+                                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                                Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashDefaultGroupTag], ElementName=ViewRoot}" />
+                                            <TextBlock
+                                                Grid.Row="10"
+                                                Grid.Column="2"
+                                                Text="{Binding AutopilotHardwareHashDefaultGroupTagText}"
+                                                TextWrapping="Wrap" />
+                                        </Grid>
+
+                                        <TextBlock
+                                            Grid.Row="4"
+                                            Foreground="#FF9D5D00"
+                                            Style="{StaticResource CaptionTextBlockStyle}"
+                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashRuntimePending], ElementName=ViewRoot}"
+                                            TextWrapping="Wrap"
+                                            Visibility="{Binding IsHardwareHashPreRuntimeWarningVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                                        <TextBlock
+                                            Grid.Row="4"
+                                            Foreground="#FFC42B1C"
+                                            Style="{StaticResource CaptionTextBlockStyle}"
+                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashExpiredAction], ElementName=ViewRoot}"
+                                            TextWrapping="Wrap"
+                                            Visibility="{Binding IsHardwareHashCertificateExpired, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                                        <StackPanel
+                                            Grid.Row="6"
+                                            Visibility="{Binding IsHardwareHashGroupTagControlsVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                            <TextBlock
+                                                Margin="0,0,0,8"
+                                                Style="{StaticResource BodyTextBlockStyle}"
+                                                Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashGroupTagChoice], ElementName=ViewRoot}" />
+                                            <RadioButton
+                                                GroupName="HardwareHashGroupTag"
+                                                IsChecked="{Binding UseDefaultHardwareHashGroupTag}"
+                                                Content="{Binding UseDefaultHardwareHashGroupTagText}" />
+                                            <RadioButton
+                                                Margin="0,8,0,0"
+                                                GroupName="HardwareHashGroupTag"
+                                                IsChecked="{Binding UseCustomHardwareHashGroupTag}"
+                                                Content="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashUseCustomGroupTag], ElementName=ViewRoot}" />
+                                            <TextBox
+                                                Margin="0,8,0,0"
+                                                HorizontalAlignment="Stretch"
+                                                IsEnabled="{Binding IsHardwareHashCustomGroupTagEnabled}"
+                                                Text="{Binding CustomHardwareHashGroupTag, UpdateSourceTrigger=PropertyChanged}" />
+                                            <TextBlock
+                                                Margin="0,4,0,0"
+                                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                                Style="{StaticResource CaptionTextBlockStyle}"
+                                                Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashGroupTagHint], ElementName=ViewRoot}"
+                                                TextWrapping="Wrap" />
+                                        </StackPanel>
+                                    </Grid>
                                 </StackPanel>
                             </StackPanel>
                         </Border>

--- a/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
@@ -136,10 +136,11 @@
                                 </CheckBox>
 
                                 <TextBlock
-                                    Margin="0,0,0,8"
+                                    Margin="0,0,0,0"
                                     Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                     Style="{StaticResource CaptionTextBlockStyle}"
-                                    Text="{Binding AutopilotModeText}" />
+                                    Text="{Binding AutopilotDisabledSummaryText}"
+                                    Visibility="{Binding IsAutopilotDisabledSummaryVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
                                 <StackPanel
                                     IsEnabled="{Binding IsAutopilotEnabled}"
@@ -156,162 +157,80 @@
                                         SelectedItem="{Binding SelectedAutopilotProfile}" />
                                     <TextBlock
                                         Margin="0,4,0,0"
-                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                        Foreground="#FFC42B1C"
                                         Style="{StaticResource CaptionTextBlockStyle}"
-                                        Text="{Binding AutopilotProfileHint}" />
+                                        Text="{Binding AutopilotProfileHint}"
+                                        Visibility="{Binding HasAutopilotProfileHint, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                 </StackPanel>
 
                                 <StackPanel Visibility="{Binding IsHardwareHashUploadControlsVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                    <Grid>
-                                        <Grid.RowDefinitions>
-                                            <RowDefinition Height="Auto" />
-                                            <RowDefinition Height="8" />
-                                            <RowDefinition Height="Auto" />
-                                            <RowDefinition Height="8" />
-                                            <RowDefinition Height="Auto" />
-                                            <RowDefinition Height="8" />
-                                            <RowDefinition Height="Auto" />
-                                        </Grid.RowDefinitions>
+                                    <TextBlock
+                                        Style="{StaticResource BodyTextBlockStyle}"
+                                        Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashUploadStatus], ElementName=ViewRoot}" />
 
-                                        <TextBlock
-                                            Style="{StaticResource BodyTextBlockStyle}"
-                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashTenantReadiness], ElementName=ViewRoot}" />
+                                    <TextBlock
+                                        Margin="0,6,0,0"
+                                        FontWeight="SemiBold"
+                                        Text="{Binding AutopilotHardwareHashUploadStatusText}">
+                                        <TextBlock.Style>
+                                            <Style BasedOn="{StaticResource BodyTextBlockStyle}" TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="#FFC42B1C" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsHardwareHashCertificateUsable}" Value="True">
+                                                        <Setter Property="Foreground" Value="#FF0F7B0F" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
 
-                                        <Grid Grid.Row="2">
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="170" />
-                                                <ColumnDefinition Width="12" />
-                                                <ColumnDefinition Width="*" />
-                                            </Grid.ColumnDefinitions>
-                                            <Grid.RowDefinitions>
-                                                <RowDefinition Height="Auto" />
-                                                <RowDefinition Height="6" />
-                                                <RowDefinition Height="Auto" />
-                                                <RowDefinition Height="6" />
-                                                <RowDefinition Height="Auto" />
-                                                <RowDefinition Height="6" />
-                                                <RowDefinition Height="Auto" />
-                                                <RowDefinition Height="6" />
-                                                <RowDefinition Height="Auto" />
-                                                <RowDefinition Height="6" />
-                                                <RowDefinition Height="Auto" />
-                                            </Grid.RowDefinitions>
-
-                                            <TextBlock
-                                                Style="{StaticResource BodyStrongTextBlockStyle}"
-                                                Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashReadinessStatus], ElementName=ViewRoot}" />
-                                            <TextBlock
-                                                Grid.Column="2"
-                                                FontWeight="SemiBold"
-                                                Text="{Binding AutopilotHardwareHashReadinessText}">
-                                                <TextBlock.Style>
-                                                    <Style BasedOn="{StaticResource BodyTextBlockStyle}" TargetType="TextBlock">
+                                    <TextBlock
+                                        Margin="0,4,0,0"
+                                        Text="{Binding AutopilotHardwareHashUploadMessage}"
+                                        TextWrapping="Wrap">
+                                        <TextBlock.Style>
+                                            <Style BasedOn="{StaticResource CaptionTextBlockStyle}" TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsHardwareHashCertificateUsable}" Value="False">
                                                         <Setter Property="Foreground" Value="#FFC42B1C" />
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding IsHardwareHashCertificateUsable}" Value="True">
-                                                                <Setter Property="Foreground" Value="#FF0F7B0F" />
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
 
-                                            <TextBlock
-                                                Grid.Row="2"
-                                                Style="{StaticResource BodyStrongTextBlockStyle}"
-                                                Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashTenantId], ElementName=ViewRoot}" />
-                                            <TextBlock
-                                                Grid.Row="2"
-                                                Grid.Column="2"
-                                                Text="{Binding AutopilotHardwareHashTenantIdText}"
-                                                TextWrapping="Wrap" />
-
-                                            <TextBlock
-                                                Grid.Row="4"
-                                                Style="{StaticResource BodyStrongTextBlockStyle}"
-                                                Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashClientId], ElementName=ViewRoot}" />
-                                            <TextBlock
-                                                Grid.Row="4"
-                                                Grid.Column="2"
-                                                Text="{Binding AutopilotHardwareHashClientIdText}"
-                                                TextWrapping="Wrap" />
-
-                                            <TextBlock
-                                                Grid.Row="6"
-                                                Style="{StaticResource BodyStrongTextBlockStyle}"
-                                                Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashCertificateThumbprint], ElementName=ViewRoot}" />
-                                            <TextBlock
-                                                Grid.Row="6"
-                                                Grid.Column="2"
-                                                Text="{Binding AutopilotHardwareHashCertificateThumbprintText}"
-                                                TextWrapping="Wrap" />
-
-                                            <TextBlock
-                                                Grid.Row="8"
-                                                Style="{StaticResource BodyStrongTextBlockStyle}"
-                                                Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashCertificateExpiration], ElementName=ViewRoot}" />
-                                            <TextBlock
-                                                Grid.Row="8"
-                                                Grid.Column="2"
-                                                Text="{Binding AutopilotHardwareHashCertificateExpirationText}"
-                                                TextWrapping="Wrap" />
-
-                                            <TextBlock
-                                                Grid.Row="10"
-                                                Style="{StaticResource BodyStrongTextBlockStyle}"
-                                                Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashDefaultGroupTag], ElementName=ViewRoot}" />
-                                            <TextBlock
-                                                Grid.Row="10"
-                                                Grid.Column="2"
-                                                Text="{Binding AutopilotHardwareHashDefaultGroupTagText}"
-                                                TextWrapping="Wrap" />
-                                        </Grid>
-
+                                    <StackPanel
+                                        Margin="0,16,0,0"
+                                        Visibility="{Binding IsHardwareHashGroupTagControlsVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
                                         <TextBlock
-                                            Grid.Row="4"
-                                            Foreground="#FF9D5D00"
-                                            Style="{StaticResource CaptionTextBlockStyle}"
-                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashRuntimePending], ElementName=ViewRoot}"
-                                            TextWrapping="Wrap"
-                                            Visibility="{Binding IsHardwareHashPreRuntimeWarningVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
-
+                                            Margin="0,0,0,8"
+                                            Style="{StaticResource BodyTextBlockStyle}"
+                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashGroupTagChoice], ElementName=ViewRoot}" />
+                                        <RadioButton
+                                            GroupName="HardwareHashGroupTag"
+                                            IsChecked="{Binding UseDefaultHardwareHashGroupTag}"
+                                            Content="{Binding UseDefaultHardwareHashGroupTagText}"
+                                            Visibility="{Binding IsDefaultHardwareHashGroupTagOptionVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                        <RadioButton
+                                            Margin="0,8,0,0"
+                                            GroupName="HardwareHashGroupTag"
+                                            IsChecked="{Binding UseCustomHardwareHashGroupTag}"
+                                            Content="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashUseCustomGroupTag], ElementName=ViewRoot}"
+                                            Visibility="{Binding IsDefaultHardwareHashGroupTagOptionVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                        <TextBox
+                                            Margin="0,8,0,0"
+                                            HorizontalAlignment="Stretch"
+                                            IsEnabled="{Binding IsHardwareHashCustomGroupTagEnabled}"
+                                            Text="{Binding CustomHardwareHashGroupTag, UpdateSourceTrigger=PropertyChanged}"
+                                            Visibility="{Binding IsHardwareHashCustomGroupTagTextBoxVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                         <TextBlock
-                                            Grid.Row="4"
-                                            Foreground="#FFC42B1C"
+                                            Margin="0,4,0,0"
+                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                             Style="{StaticResource CaptionTextBlockStyle}"
-                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashExpiredAction], ElementName=ViewRoot}"
-                                            TextWrapping="Wrap"
-                                            Visibility="{Binding IsHardwareHashCertificateExpired, Converter={StaticResource BooleanToVisibilityConverter}}" />
-
-                                        <StackPanel
-                                            Grid.Row="6"
-                                            Visibility="{Binding IsHardwareHashGroupTagControlsVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                            <TextBlock
-                                                Margin="0,0,0,8"
-                                                Style="{StaticResource BodyTextBlockStyle}"
-                                                Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashGroupTagChoice], ElementName=ViewRoot}" />
-                                            <RadioButton
-                                                GroupName="HardwareHashGroupTag"
-                                                IsChecked="{Binding UseDefaultHardwareHashGroupTag}"
-                                                Content="{Binding UseDefaultHardwareHashGroupTagText}" />
-                                            <RadioButton
-                                                Margin="0,8,0,0"
-                                                GroupName="HardwareHashGroupTag"
-                                                IsChecked="{Binding UseCustomHardwareHashGroupTag}"
-                                                Content="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashUseCustomGroupTag], ElementName=ViewRoot}" />
-                                            <TextBox
-                                                Margin="0,8,0,0"
-                                                HorizontalAlignment="Stretch"
-                                                IsEnabled="{Binding IsHardwareHashCustomGroupTagEnabled}"
-                                                Text="{Binding CustomHardwareHashGroupTag, UpdateSourceTrigger=PropertyChanged}" />
-                                            <TextBlock
-                                                Margin="0,4,0,0"
-                                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                                Style="{StaticResource CaptionTextBlockStyle}"
-                                                Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashGroupTagHint], ElementName=ViewRoot}"
-                                                TextWrapping="Wrap" />
-                                        </StackPanel>
-                                    </Grid>
+                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashGroupTagHint], ElementName=ViewRoot}"
+                                            TextWrapping="Wrap" />
+                                    </StackPanel>
                                 </StackPanel>
                             </StackPanel>
                         </Border>

--- a/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
@@ -184,8 +184,64 @@
                                         </TextBlock.Style>
                                     </TextBlock>
 
+                                    <Grid Margin="0,12,0,0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="16" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+
+                                        <TextBlock
+                                            Grid.Row="0"
+                                            Grid.Column="0"
+                                            FontWeight="SemiBold"
+                                            Style="{StaticResource CaptionTextBlockStyle}"
+                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashTenantId], ElementName=ViewRoot}" />
+                                        <TextBlock
+                                            Grid.Row="0"
+                                            Grid.Column="2"
+                                            Style="{StaticResource CaptionTextBlockStyle}"
+                                            Text="{Binding AutopilotHardwareHashTenantIdText}"
+                                            TextTrimming="CharacterEllipsis" />
+
+                                        <TextBlock
+                                            Grid.Row="1"
+                                            Grid.Column="0"
+                                            Margin="0,6,0,0"
+                                            FontWeight="SemiBold"
+                                            Style="{StaticResource CaptionTextBlockStyle}"
+                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashCertificateThumbprint], ElementName=ViewRoot}" />
+                                        <TextBlock
+                                            Grid.Row="1"
+                                            Grid.Column="2"
+                                            Margin="0,6,0,0"
+                                            Style="{StaticResource CaptionTextBlockStyle}"
+                                            Text="{Binding AutopilotHardwareHashCertificateThumbprintText}"
+                                            TextTrimming="CharacterEllipsis" />
+
+                                        <TextBlock
+                                            Grid.Row="2"
+                                            Grid.Column="0"
+                                            Margin="0,6,0,0"
+                                            FontWeight="SemiBold"
+                                            Style="{StaticResource CaptionTextBlockStyle}"
+                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashCertificateExpiration], ElementName=ViewRoot}" />
+                                        <TextBlock
+                                            Grid.Row="2"
+                                            Grid.Column="2"
+                                            Margin="0,6,0,0"
+                                            Style="{StaticResource CaptionTextBlockStyle}"
+                                            Text="{Binding AutopilotHardwareHashCertificateExpirationText}"
+                                            TextTrimming="CharacterEllipsis" />
+                                    </Grid>
+
                                     <TextBlock
-                                        Margin="0,4,0,0"
+                                        Margin="0,12,0,0"
                                         Text="{Binding AutopilotHardwareHashUploadMessage}"
                                         TextWrapping="Wrap">
                                         <TextBlock.Style>
@@ -207,23 +263,11 @@
                                             Margin="0,0,0,8"
                                             Style="{StaticResource BodyTextBlockStyle}"
                                             Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashGroupTagChoice], ElementName=ViewRoot}" />
-                                        <RadioButton
-                                            GroupName="HardwareHashGroupTag"
-                                            IsChecked="{Binding UseDefaultHardwareHashGroupTag}"
-                                            Content="{Binding UseDefaultHardwareHashGroupTagText}"
-                                            Visibility="{Binding IsDefaultHardwareHashGroupTagOptionVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                                        <RadioButton
-                                            Margin="0,8,0,0"
-                                            GroupName="HardwareHashGroupTag"
-                                            IsChecked="{Binding UseCustomHardwareHashGroupTag}"
-                                            Content="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashUseCustomGroupTag], ElementName=ViewRoot}"
-                                            Visibility="{Binding IsDefaultHardwareHashGroupTagOptionVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                                        <TextBox
-                                            Margin="0,8,0,0"
+                                        <ComboBox
                                             HorizontalAlignment="Stretch"
-                                            IsEnabled="{Binding IsHardwareHashCustomGroupTagEnabled}"
-                                            Text="{Binding CustomHardwareHashGroupTag, UpdateSourceTrigger=PropertyChanged}"
-                                            Visibility="{Binding IsHardwareHashCustomGroupTagTextBoxVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                            DisplayMemberPath="DisplayName"
+                                            ItemsSource="{Binding HardwareHashGroupTagOptions}"
+                                            SelectedItem="{Binding SelectedHardwareHashGroupTag}" />
                                         <TextBlock
                                             Margin="0,4,0,0"
                                             Foreground="{DynamicResource TextFillColorSecondaryBrush}"

--- a/src/Foundry.Deploy/Views/WizardView.xaml
+++ b/src/Foundry.Deploy/Views/WizardView.xaml
@@ -174,33 +174,10 @@
 
         <Grid Grid.Row="3" Margin="0,12,0,0">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
             <StackPanel
-                Grid.Column="0"
-                HorizontalAlignment="Left"
-                Orientation="Horizontal"
-                Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <Button
-                    Width="140"
-                    Margin="0,0,8,0"
-                    Command="{Binding ShowDebugProgressPageCommand}"
-                    Content="{Binding Strings[Debug.ProgressButton]}" />
-                <Button
-                    Width="140"
-                    Margin="0,0,8,0"
-                    Command="{Binding ShowDebugSuccessPageCommand}"
-                    Content="{Binding Strings[Debug.SuccessButton]}" />
-                <Button
-                    Width="140"
-                    Command="{Binding ShowDebugErrorPageCommand}"
-                    Content="{Binding Strings[Debug.ErrorButton]}" />
-            </StackPanel>
-
-            <StackPanel
-                Grid.Column="1"
                 HorizontalAlignment="Right"
                 Orientation="Horizontal">
                 <Button


### PR DESCRIPTION
## Summary
- Adds the Foundry Deploy Computer Target UX for Autopilot hardware hash upload mode.
- Keeps JSON profile controls isolated to JSON profile mode and hides them in hardware hash mode.
- Adds tenant/certificate readiness details, non-blocking expired-certificate messaging, default/custom group tag selection, and summary display for the effective group tag.
- Updates the live runtime boundary so hardware hash upload is skipped, not failed, until the runtime upload phases are implemented.
- Updates the implementation plan checklist for Phase 3.

## Reason
Phase 3 focuses on Foundry Deploy UX after the OSD-side Autopilot hardware hash onboarding UX was completed in Phase 2. Deploy needs to clearly show the selected Autopilot mode, let the operator choose the group tag behavior for this deployment, and avoid blocking OS deployment before the upload runtime exists.

## Main changes
- Extended `DeploymentPreparationViewModel` with hardware hash readiness, certificate metadata, and effective group tag state.
- Added a launch helper that carries the default/custom group tag into the deployment request.
- Updated Target and Summary wizard views with localized hardware hash UX.
- Adjusted launch preparation and Autopilot staging behavior so hash mode no longer requires a JSON profile and skips runtime upload for now.
- Removed obsolete Deploy hardware hash status strings after switching to dedicated readiness fields.

## Testing
- `dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --filter "DeploymentPreparationViewModelTests|DeploymentLaunchPreparationServiceTests|StageAutopilotConfigurationStepTests"` passed: 25 tests, 0 failures.
- `dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj` passed: 154 tests, 0 failures.

## Notes
- Do not squash automatically; final squash/merge is handled manually.
- Full solution tests were intentionally not run, following the current project instruction for this phase.