### PR TITLE
feat(winpe): stage autopilot hash capture assets

### DIFF
--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -345,14 +345,14 @@ Automated tests:
 - [x] `dotnet build .\src\Foundry\Foundry.csproj --configuration Debug /p:Platform=x64 --no-restore --verbosity minimal` passed: 0 warnings, 0 errors.
 
 Manual checks:
-Deferred to an operator media validation pass with ADK, test tenant credentials, and generated boot media.
+Validated from x64 boot.wim extracts under `E:\Test\JSON` and `E:\Test\HASH`. ARM64 media generation remains deferred until ARM64 ADK/media validation is available.
 
-- [ ] Build x64 ISO in JSON profile mode and confirm existing profile files are present.
-- [ ] Build x64 ISO in hash upload mode and confirm OA3/hash assets are present.
+- [x] Build x64 ISO in JSON profile mode and confirm existing profile files are present.
+- [x] Build x64 ISO in hash upload mode and confirm OA3/hash assets are present.
 - [ ] Build ARM64 ISO in JSON profile mode and confirm existing profile files are present.
 - [ ] Build ARM64 ISO in hash upload mode and confirm OA3/hash assets are present.
-- [ ] Confirm `WinPE-SecureStartup` is present in the mounted image package list.
-- [ ] Confirm no plaintext PFX, PFX password, private key, token, or client secret is written to media.
+- [x] Confirm `WinPE-SecureStartup` is present in the mounted image package list.
+- [x] Confirm no plaintext PFX, PFX password, private key, token, or client secret is written to Foundry-authored media payloads.
 
 ### Phase 5: Foundry Deploy Runtime Branching
 PR title: `feat(deploy): branch autopilot runtime by provisioning mode`

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -325,7 +325,7 @@ Implementation progress:
 - [x] Add `WinPE-SecureStartup` to the default required optional components for all generated WinPE media.
 - [x] Locate and stage architecture-specific `oa3tool.exe` from the ADK for x64 and ARM64.
 - [x] Add hash capture templates under a Foundry-owned WinPE path.
-- [x] Add hash upload runtime configuration under `X:\Foundry\Config`.
+- [x] Add the hash upload OA3 runtime workspace under `X:\Foundry\Runtime\AutopilotHash`.
 - [x] Write encrypted Autopilot PFX and PFX password envelopes plus the media secret key through the shared media secret provisioning path.
 - [x] Keep current profile JSON staging unchanged in JSON profile mode.
 - [x] Do not stage JSON profile folders in hash upload mode unless the user also keeps profiles for another purpose.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -315,33 +315,38 @@ Completed through Visual Studio/debug-safe validation before squash. Non-debug m
 PR title: `feat(winpe): stage autopilot hash capture assets`
 
 Implementation progress:
-- [ ] Phase branch created from `feature/autopilot-hash-upload-foundation`.
-- [ ] Implementation checklist complete.
-- [ ] Automated tests complete.
-- [ ] Manual checks complete or explicitly deferred.
+- [x] Phase branch created from `feature/autopilot-hash-upload-foundation`.
+- [x] Implementation checklist complete.
+- [x] Automated tests complete.
+- [x] Manual checks complete or explicitly deferred.
 - [ ] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
-- [ ] Add `WinPE-SecureStartup` to the default required optional components for all generated WinPE media.
-- [ ] Locate and stage architecture-specific `oa3tool.exe` from the ADK for x64 and ARM64.
-- [ ] Add hash capture templates under a Foundry-owned WinPE path.
-- [ ] Add hash upload runtime configuration under `X:\Foundry\Config`.
-- [ ] Write encrypted Autopilot PFX and PFX password envelopes plus the media secret key through the shared media secret provisioning path.
-- [ ] Keep current profile JSON staging unchanged in JSON profile mode.
-- [ ] Do not stage JSON profile folders in hash upload mode unless the user also keeps profiles for another purpose.
-- [ ] Do not stage `PCPKsp.dll` during media build.
-- [ ] Add XML documentation comments to new public media asset provisioning APIs and secret envelope APIs.
+- [x] Add `WinPE-SecureStartup` to the default required optional components for all generated WinPE media.
+- [x] Locate and stage architecture-specific `oa3tool.exe` from the ADK for x64 and ARM64.
+- [x] Add hash capture templates under a Foundry-owned WinPE path.
+- [x] Add hash upload runtime configuration under `X:\Foundry\Config`.
+- [x] Write encrypted Autopilot PFX and PFX password envelopes plus the media secret key through the shared media secret provisioning path.
+- [x] Keep current profile JSON staging unchanged in JSON profile mode.
+- [x] Do not stage JSON profile folders in hash upload mode unless the user also keeps profiles for another purpose.
+- [x] Do not stage `PCPKsp.dll` during media build.
+- [x] Add XML documentation comments to new public media asset provisioning APIs and secret envelope APIs.
 
 Automated tests:
-- [ ] Media asset provisioning writes JSON profile assets only in JSON mode.
-- [ ] Media asset provisioning writes hash upload assets only in hash mode.
-- [ ] Missing `oa3tool.exe` produces a clear validation error.
-- [ ] ADK asset resolution chooses the expected path for x64 and ARM64 media.
-- [ ] Encrypted Autopilot secrets require a media secret key.
-- [ ] A media secret key is rejected when no encrypted media secrets exist.
-- [ ] `WinPE-SecureStartup` missing or not applicable is surfaced clearly during media preparation.
+- [x] Media asset provisioning writes JSON profile assets only in JSON mode.
+- [x] Media asset provisioning writes hash upload assets only in hash mode.
+- [x] Missing `oa3tool.exe` produces a clear validation error.
+- [x] ADK asset resolution chooses the expected path for x64 and ARM64 media.
+- [x] Encrypted Autopilot secrets require a media secret key.
+- [x] A media secret key is rejected when no encrypted media secrets exist.
+- [x] `WinPE-SecureStartup` is included in the default optional component list and existing DISM optional component failure handling surfaces package failures.
+- [x] `dotnet test .\src\Foundry.Core.Tests\Foundry.Core.Tests.csproj --configuration Debug /p:Platform=x64 --no-restore --verbosity minimal` passed: 246 tests, 0 failures.
+- [x] `dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --configuration Debug /p:Platform=x64 --verbosity minimal` passed: 162 tests, 0 failures.
+- [x] `dotnet build .\src\Foundry\Foundry.csproj --configuration Debug /p:Platform=x64 --no-restore --verbosity minimal` passed: 0 warnings, 0 errors.
 
 Manual checks:
+Deferred to an operator media validation pass with ADK, test tenant credentials, and generated boot media.
+
 - [ ] Build x64 ISO in JSON profile mode and confirm existing profile files are present.
 - [ ] Build x64 ISO in hash upload mode and confirm OA3/hash assets are present.
 - [ ] Build ARM64 ISO in JSON profile mode and confirm existing profile files are present.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -319,7 +319,7 @@ Implementation progress:
 - [x] Implementation checklist complete.
 - [x] Automated tests complete.
 - [x] Manual checks complete or explicitly deferred.
-- [ ] PR opened with the planned title.
+- [x] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
 - [x] Add `WinPE-SecureStartup` to the default required optional components for all generated WinPE media.

--- a/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
@@ -1,5 +1,6 @@
 using Foundry.Core.Models.Configuration;
 using Foundry.Core.Models.Configuration.Deploy;
+using Foundry.Core.Services.Autopilot;
 using Foundry.Core.Services.Configuration;
 using Foundry.Telemetry;
 
@@ -377,6 +378,94 @@ public sealed class DeployConfigurationGeneratorTests
         Assert.Equal(expiration, result.Autopilot.HardwareHashUpload.ActiveCertificateExpiresOnUtc);
         Assert.Equal("Sales", result.Autopilot.HardwareHashUpload.DefaultGroupTag);
         Assert.Equal(["Engineering", "Sales"], result.Autopilot.HardwareHashUpload.KnownGroupTags);
+    }
+
+    [Fact]
+    public void Generate_WhenHardwareHashModeHasMediaKey_EmbedsEncryptedPfxSecrets()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"foundry-deploy-config-{Guid.NewGuid():N}");
+        string pfxPath = Path.Combine(root, "certificate.pfx");
+        byte[] pfxBytes = [1, 2, 3, 4, 5];
+        byte[] mediaKey = Enumerable.Range(0, 32).Select(static value => (byte)value).ToArray();
+        Directory.CreateDirectory(root);
+        File.WriteAllBytes(pfxPath, pfxBytes);
+
+        try
+        {
+            var generator = new DeployConfigurationGenerator();
+            var document = new FoundryConfigurationDocument
+            {
+                Autopilot = new AutopilotSettings
+                {
+                    IsEnabled = true,
+                    ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+                    HardwareHashUpload = CreateCompleteHardwareHashSettings(DateTimeOffset.UtcNow.AddMonths(6)) with
+                    {
+                        BootMediaCertificate = new AutopilotBootMediaCertificateSettings
+                        {
+                            PfxPath = pfxPath,
+                            PfxPassword = "PfxPassword-DoNotLeak",
+                            ValidatedThumbprint = "ABCDEF123456",
+                            ValidatedExpiresOnUtc = DateTimeOffset.UtcNow.AddMonths(6)
+                        }
+                    }
+                }
+            };
+
+            FoundryDeployConfigurationDocument result = generator.Generate(document, mediaKey);
+
+            Assert.NotNull(result.Autopilot.HardwareHashUpload.CertificatePfxSecret);
+            Assert.NotNull(result.Autopilot.HardwareHashUpload.CertificatePfxPasswordSecret);
+            Assert.Equal(pfxBytes, MediaSecretEnvelopeProtector.DecryptBytes(result.Autopilot.HardwareHashUpload.CertificatePfxSecret!, mediaKey));
+            Assert.Equal("PfxPassword-DoNotLeak", MediaSecretEnvelopeProtector.DecryptString(result.Autopilot.HardwareHashUpload.CertificatePfxPasswordSecret!, mediaKey));
+
+            string json = generator.Serialize(result);
+            Assert.DoesNotContain(Convert.ToBase64String(pfxBytes), json, StringComparison.Ordinal);
+            Assert.DoesNotContain("PfxPassword-DoNotLeak", json, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Generate_WhenHardwareHashModeNeedsSecretsWithInvalidMediaKey_ThrowsInvalidOperationException()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"foundry-deploy-config-{Guid.NewGuid():N}");
+        string pfxPath = Path.Combine(root, "certificate.pfx");
+        Directory.CreateDirectory(root);
+        File.WriteAllBytes(pfxPath, [1, 2, 3]);
+
+        try
+        {
+            var generator = new DeployConfigurationGenerator();
+            var document = new FoundryConfigurationDocument
+            {
+                Autopilot = new AutopilotSettings
+                {
+                    IsEnabled = true,
+                    ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+                    HardwareHashUpload = CreateCompleteHardwareHashSettings(DateTimeOffset.UtcNow.AddMonths(6)) with
+                    {
+                        BootMediaCertificate = new AutopilotBootMediaCertificateSettings
+                        {
+                            PfxPath = pfxPath,
+                            PfxPassword = "password",
+                            ValidatedThumbprint = "ABCDEF123456",
+                            ValidatedExpiresOnUtc = DateTimeOffset.UtcNow.AddMonths(6)
+                        }
+                    }
+                }
+            };
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => generator.Generate(document, []));
+            Assert.Contains("media secret key", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
     }
 
     [Fact]

--- a/src/Foundry.Core.Tests/WinPe/WinPeImageInternationalizationServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeImageInternationalizationServiceTests.cs
@@ -17,9 +17,11 @@ public sealed class WinPeImageInternationalizationServiceTests
         string languagePack = Path.Combine(ocRoot, "fr-fr", "lp.cab");
         string neutralWmi = Path.Combine(ocRoot, "WinPE-WMI.cab");
         string localizedWmi = Path.Combine(ocRoot, "fr-fr", "WinPE-WMI_fr-fr.cab");
+        string secureStartup = Path.Combine(ocRoot, "WinPE-SecureStartup.cab");
         File.WriteAllText(languagePack, string.Empty);
         File.WriteAllText(neutralWmi, string.Empty);
         File.WriteAllText(localizedWmi, string.Empty);
+        File.WriteAllText(secureStartup, string.Empty);
 
         var runner = new FakeInternationalizationRunner();
         var service = new WinPeImageInternationalizationService(runner);
@@ -47,8 +49,57 @@ public sealed class WinPeImageInternationalizationServiceTests
                 execution => Assert.Contains($"/PackagePath:{WinPeProcessRunner.Quote(languagePack)}", execution.Arguments),
                 execution => Assert.Contains($"/PackagePath:{WinPeProcessRunner.Quote(neutralWmi)}", execution.Arguments),
                 execution => Assert.Contains($"/PackagePath:{WinPeProcessRunner.Quote(localizedWmi)}", execution.Arguments),
+                execution => Assert.Contains($"/PackagePath:{WinPeProcessRunner.Quote(secureStartup)}", execution.Arguments),
                 execution => Assert.Contains("/Set-AllIntl:fr-FR", execution.Arguments),
                 execution => Assert.Contains("/Set-InputLocale:", execution.Arguments));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ApplyAsync_AddsSecureStartupOptionalComponentByDefault()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"foundry-intl-{Guid.NewGuid():N}");
+        string mountedImagePath = Path.Combine(root, "mount");
+        string workingDirectory = Path.Combine(root, "work");
+        string ocRoot = CreateOptionalComponentRoot(root, "amd64", "en-us");
+        Directory.CreateDirectory(mountedImagePath);
+        Directory.CreateDirectory(workingDirectory);
+
+        string languagePack = Path.Combine(ocRoot, "en-us", "lp.cab");
+        string wmi = Path.Combine(ocRoot, "WinPE-WMI.cab");
+        string secureStartup = Path.Combine(ocRoot, "WinPE-SecureStartup.cab");
+        File.WriteAllText(languagePack, string.Empty);
+        File.WriteAllText(wmi, string.Empty);
+        File.WriteAllText(secureStartup, string.Empty);
+
+        var runner = new FakeInternationalizationRunner();
+        var service = new WinPeImageInternationalizationService(runner);
+
+        try
+        {
+            WinPeResult result = await service.ApplyAsync(
+                new WinPeImageInternationalizationOptions
+                {
+                    MountedImagePath = mountedImagePath,
+                    Architecture = WinPeArchitecture.X64,
+                    Tools = new WinPeToolPaths
+                    {
+                        KitsRootPath = root,
+                        DismPath = "dism.exe"
+                    },
+                    WinPeLanguage = "en-US",
+                    WorkingDirectoryPath = workingDirectory
+                },
+                CancellationToken.None);
+
+            Assert.True(result.IsSuccess, result.Error?.Details);
+            Assert.Contains(
+                runner.Executions,
+                execution => execution.Arguments.Contains($"/PackagePath:{WinPeProcessRunner.Quote(secureStartup)}", StringComparison.Ordinal));
         }
         finally
         {
@@ -95,6 +146,95 @@ public sealed class WinPeImageInternationalizationServiceTests
     }
 
     [Fact]
+    public async Task ApplyAsync_WhenSecureStartupIsMissing_ReturnsToolNotFound()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"foundry-intl-{Guid.NewGuid():N}");
+        string mountedImagePath = Path.Combine(root, "mount");
+        string workingDirectory = Path.Combine(root, "work");
+        string ocRoot = CreateOptionalComponentRoot(root, "amd64", "en-us");
+        Directory.CreateDirectory(mountedImagePath);
+        Directory.CreateDirectory(workingDirectory);
+        File.WriteAllText(Path.Combine(ocRoot, "en-us", "lp.cab"), string.Empty);
+        File.WriteAllText(Path.Combine(ocRoot, "WinPE-WMI.cab"), string.Empty);
+
+        var service = new WinPeImageInternationalizationService(new FakeInternationalizationRunner());
+
+        try
+        {
+            WinPeResult result = await service.ApplyAsync(
+                new WinPeImageInternationalizationOptions
+                {
+                    MountedImagePath = mountedImagePath,
+                    Architecture = WinPeArchitecture.X64,
+                    Tools = new WinPeToolPaths
+                    {
+                        KitsRootPath = root,
+                        DismPath = "dism.exe"
+                    },
+                    WinPeLanguage = "en-US",
+                    WorkingDirectoryPath = workingDirectory
+                },
+                CancellationToken.None);
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(WinPeErrorCodes.ToolNotFound, result.Error?.Code);
+            Assert.Contains("WinPE-SecureStartup", result.Error?.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ApplyAsync_WhenSecureStartupIsNotApplicable_ReturnsBuildFailed()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"foundry-intl-{Guid.NewGuid():N}");
+        string mountedImagePath = Path.Combine(root, "mount");
+        string workingDirectory = Path.Combine(root, "work");
+        string ocRoot = CreateOptionalComponentRoot(root, "amd64", "en-us");
+        Directory.CreateDirectory(mountedImagePath);
+        Directory.CreateDirectory(workingDirectory);
+        File.WriteAllText(Path.Combine(ocRoot, "en-us", "lp.cab"), string.Empty);
+        File.WriteAllText(Path.Combine(ocRoot, "WinPE-SecureStartup.cab"), string.Empty);
+
+        var runner = new FakeInternationalizationRunner
+        {
+            PackageExitCode = 1,
+            PackageStandardOutput = "The specified package is not applicable to this image.",
+            FailPackagePathContains = "WinPE-SecureStartup"
+        };
+        var service = new WinPeImageInternationalizationService(runner);
+
+        try
+        {
+            WinPeResult result = await service.ApplyAsync(
+                new WinPeImageInternationalizationOptions
+                {
+                    MountedImagePath = mountedImagePath,
+                    Architecture = WinPeArchitecture.X64,
+                    Tools = new WinPeToolPaths
+                    {
+                        KitsRootPath = root,
+                        DismPath = "dism.exe"
+                    },
+                    WinPeLanguage = "en-US",
+                    WorkingDirectoryPath = workingDirectory
+                },
+                CancellationToken.None);
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(WinPeErrorCodes.BuildFailed, result.Error?.Code);
+            Assert.Contains("WinPE-SecureStartup", result.Error?.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+
+    [Fact]
     public async Task ApplyAsync_WhenNeutralComponentIsAlreadyInstalled_Continues()
     {
         string root = Path.Combine(Path.GetTempPath(), $"foundry-intl-{Guid.NewGuid():N}");
@@ -105,6 +245,7 @@ public sealed class WinPeImageInternationalizationServiceTests
         Directory.CreateDirectory(workingDirectory);
         File.WriteAllText(Path.Combine(ocRoot, "en-us", "lp.cab"), string.Empty);
         File.WriteAllText(Path.Combine(ocRoot, "WinPE-WMI.cab"), string.Empty);
+        File.WriteAllText(Path.Combine(ocRoot, "WinPE-SecureStartup.cab"), string.Empty);
 
         var runner = new FakeInternationalizationRunner
         {
@@ -195,6 +336,7 @@ public sealed class WinPeImageInternationalizationServiceTests
         public List<WinPeProcessExecution> Executions { get; } = [];
         public int PackageExitCode { get; init; }
         public string PackageStandardOutput { get; init; } = string.Empty;
+        public string? FailPackagePathContains { get; init; }
 
         public Task<WinPeProcessExecution> RunAsync(
             string fileName,
@@ -203,7 +345,10 @@ public sealed class WinPeImageInternationalizationServiceTests
             CancellationToken cancellationToken,
             IReadOnlyDictionary<string, string>? environmentOverrides = null)
         {
-            int exitCode = arguments.Contains("/Add-Package", StringComparison.OrdinalIgnoreCase)
+            bool shouldFailPackage = arguments.Contains("/Add-Package", StringComparison.OrdinalIgnoreCase) &&
+                                     (string.IsNullOrWhiteSpace(FailPackagePathContains) ||
+                                      arguments.Contains(FailPackagePathContains, StringComparison.OrdinalIgnoreCase));
+            int exitCode = shouldFailPackage
                 ? PackageExitCode
                 : 0;
 

--- a/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
@@ -125,6 +125,115 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
     }
 
     [Fact]
+    public async Task ProvisionAsync_WhenJsonProfileMode_WritesAutopilotProfileAssetsOnly()
+    {
+        using TempMountedImage image = TempMountedImage.Create();
+        string curlSourcePath = Path.Combine(image.RootPath, "curl.exe");
+        File.WriteAllText(curlSourcePath, "curl");
+
+        var service = new WinPeMountedImageAssetProvisioningService();
+
+        WinPeResult result = await service.ProvisionAsync(
+            new WinPeMountedImageAssetProvisioningOptions
+            {
+                MountedImagePath = image.MountedImagePath,
+                Architecture = WinPeArchitecture.X64,
+                BootstrapScriptContent = "bootstrap",
+                CurlExecutableSourcePath = curlSourcePath,
+                IanaWindowsTimeZoneMapJson = "{}",
+                AutopilotProvisioningMode = AutopilotProvisioningMode.JsonProfile,
+                AutopilotProfiles =
+                [
+                    new AutopilotProfileSettings
+                    {
+                        Id = "profile-1",
+                        DisplayName = "Profile 1",
+                        FolderName = "Profile1",
+                        Source = "test",
+                        ImportedAtUtc = DateTimeOffset.UnixEpoch,
+                        JsonContent = "{\"profile\":1}"
+                    }
+                ]
+            },
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Error?.Details);
+        Assert.True(File.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Autopilot", "Profile1", "AutopilotConfigurationFile.json")));
+        Assert.False(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Tools", "OA3")));
+        Assert.False(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Runtime", "AutopilotHash")));
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_WhenHardwareHashMode_WritesHashAssetsOnly()
+    {
+        using TempMountedImage image = TempMountedImage.Create();
+        string curlSourcePath = Path.Combine(image.RootPath, "curl.exe");
+        string oa3SourcePath = Path.Combine(image.RootPath, "oa3tool.exe");
+        File.WriteAllText(curlSourcePath, "curl");
+        File.WriteAllText(oa3SourcePath, "oa3");
+
+        var service = new WinPeMountedImageAssetProvisioningService();
+
+        WinPeResult result = await service.ProvisionAsync(
+            new WinPeMountedImageAssetProvisioningOptions
+            {
+                MountedImagePath = image.MountedImagePath,
+                Architecture = WinPeArchitecture.X64,
+                BootstrapScriptContent = "bootstrap",
+                CurlExecutableSourcePath = curlSourcePath,
+                IanaWindowsTimeZoneMapJson = "{}",
+                AutopilotProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+                Oa3ToolSourcePath = oa3SourcePath,
+                AutopilotProfiles =
+                [
+                    new AutopilotProfileSettings
+                    {
+                        Id = "profile-1",
+                        DisplayName = "Profile 1",
+                        FolderName = "Profile1",
+                        Source = "test",
+                        ImportedAtUtc = DateTimeOffset.UnixEpoch,
+                        JsonContent = "{\"profile\":1}"
+                    }
+                ]
+            },
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Error?.Details);
+        Assert.Equal("oa3", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Tools", "OA3", "oa3tool.exe")));
+        Assert.True(File.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Runtime", "AutopilotHash", "OA3.cfg")));
+        Assert.True(File.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Runtime", "AutopilotHash", "input.xml")));
+        Assert.False(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Autopilot")));
+        Assert.False(File.Exists(Path.Combine(image.System32Path, "PCPKsp.dll")));
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_WhenHardwareHashModeHasMissingOa3Tool_ReturnsFailure()
+    {
+        using TempMountedImage image = TempMountedImage.Create();
+        string curlSourcePath = Path.Combine(image.RootPath, "curl.exe");
+        File.WriteAllText(curlSourcePath, "curl");
+
+        var service = new WinPeMountedImageAssetProvisioningService();
+
+        WinPeResult result = await service.ProvisionAsync(
+            new WinPeMountedImageAssetProvisioningOptions
+            {
+                MountedImagePath = image.MountedImagePath,
+                Architecture = WinPeArchitecture.X64,
+                BootstrapScriptContent = "bootstrap",
+                CurlExecutableSourcePath = curlSourcePath,
+                IanaWindowsTimeZoneMapJson = "{}",
+                AutopilotProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+                Oa3ToolSourcePath = Path.Combine(image.RootPath, "missing", "oa3tool.exe")
+            },
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("OA3Tool", result.Error?.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task ProvisionAsync_DoesNotCreateRuntimeOwnedLogTempOrNetworkDirectories()
     {
         using TempMountedImage image = TempMountedImage.Create();

--- a/src/Foundry.Core.Tests/WinPe/WinPeOa3ToolResolverTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeOa3ToolResolverTests.cs
@@ -1,0 +1,56 @@
+using Foundry.Core.Services.WinPe;
+
+namespace Foundry.Core.Tests.WinPe;
+
+public sealed class WinPeOa3ToolResolverTests
+{
+    [Theory]
+    [InlineData(WinPeArchitecture.X64, "amd64")]
+    [InlineData(WinPeArchitecture.Arm64, "arm64")]
+    public void Resolve_ChoosesArchitectureSpecificAdkToolPath(WinPeArchitecture architecture, string adkArchitecture)
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"foundry-oa3-{Guid.NewGuid():N}");
+        string oa3ToolPath = Path.Combine(
+            root,
+            "Assessment and Deployment Kit",
+            "Deployment Tools",
+            adkArchitecture,
+            "Licensing",
+            "OA30",
+            "oa3tool.exe");
+        Directory.CreateDirectory(Path.GetDirectoryName(oa3ToolPath)!);
+        File.WriteAllText(oa3ToolPath, "oa3");
+
+        try
+        {
+            WinPeResult<string> result = WinPeOa3ToolResolver.Resolve(root, architecture);
+
+            Assert.True(result.IsSuccess, result.Error?.Details);
+            Assert.Equal(oa3ToolPath, result.Value);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Resolve_WhenOa3ToolIsMissing_ReturnsToolNotFound()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"foundry-oa3-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            WinPeResult<string> result = WinPeOa3ToolResolver.Resolve(root, WinPeArchitecture.X64);
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(WinPeErrorCodes.ToolNotFound, result.Error?.Code);
+            Assert.Contains("OA3Tool", result.Error?.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/src/Foundry.Core/Models/Configuration/Deploy/DeployAutopilotHardwareHashUploadSettings.cs
+++ b/src/Foundry.Core/Models/Configuration/Deploy/DeployAutopilotHardwareHashUploadSettings.cs
@@ -1,5 +1,7 @@
 namespace Foundry.Core.Models.Configuration.Deploy;
 
+using Foundry.Core.Models.Configuration;
+
 /// <summary>
 /// Carries non-secret tenant and certificate metadata needed by the WinPE hardware hash upload workflow.
 /// </summary>
@@ -39,4 +41,14 @@ public sealed record DeployAutopilotHardwareHashUploadSettings
     /// Gets the group tags discovered when the deployment media was generated.
     /// </summary>
     public IReadOnlyList<string> KnownGroupTags { get; init; } = [];
+
+    /// <summary>
+    /// Gets the encrypted PFX bytes injected into generated media for certificate-based Graph authentication.
+    /// </summary>
+    public SecretEnvelope? CertificatePfxSecret { get; init; }
+
+    /// <summary>
+    /// Gets the encrypted PFX password injected into generated media for certificate-based Graph authentication.
+    /// </summary>
+    public SecretEnvelope? CertificatePfxPasswordSecret { get; init; }
 }

--- a/src/Foundry.Core/Services/Configuration/DeployConfigurationGenerator.cs
+++ b/src/Foundry.Core/Services/Configuration/DeployConfigurationGenerator.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Foundry.Core.Models.Configuration;
 using Foundry.Core.Models.Configuration.Deploy;
+using Foundry.Core.Services.Autopilot;
 
 namespace Foundry.Core.Services.Configuration;
 
@@ -11,6 +12,17 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
 {
     /// <inheritdoc />
     public FoundryDeployConfigurationDocument Generate(FoundryConfigurationDocument document)
+    {
+        return Generate(document, mediaSecretsKey: null);
+    }
+
+    /// <summary>
+    /// Generates the reduced Foundry.Deploy runtime configuration and embeds encrypted media-only secrets when required.
+    /// </summary>
+    /// <param name="document">User-facing Foundry configuration.</param>
+    /// <param name="mediaSecretsKey">Media secret key used to encrypt boot-media-only secrets.</param>
+    /// <returns>Reduced Foundry.Deploy configuration document.</returns>
+    public FoundryDeployConfigurationDocument Generate(FoundryConfigurationDocument document, byte[]? mediaSecretsKey)
     {
         ArgumentNullException.ThrowIfNull(document);
         AutopilotConfigurationValidator.ThrowIfNotReady(document.Autopilot, DateTimeOffset.UtcNow);
@@ -62,7 +74,9 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
                         .FirstOrDefault(profile => string.Equals(profile.Id, document.Autopilot.DefaultProfileId, StringComparison.OrdinalIgnoreCase))
                         ?.FolderName
                     : null,
-                HardwareHashUpload = CreateDeployHardwareHashUploadSettings(document.Autopilot.HardwareHashUpload)
+                HardwareHashUpload = CreateDeployHardwareHashUploadSettings(
+                    document.Autopilot,
+                    mediaSecretsKey)
             },
             Telemetry = document.Telemetry
         };
@@ -103,11 +117,51 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
     }
 
     private static DeployAutopilotHardwareHashUploadSettings CreateDeployHardwareHashUploadSettings(
-        AutopilotHardwareHashUploadSettings? settings)
+        AutopilotSettings autopilot,
+        byte[]? mediaSecretsKey)
     {
+        AutopilotHardwareHashUploadSettings? settings = autopilot.HardwareHashUpload;
         if (settings?.Tenant is null)
         {
             return new DeployAutopilotHardwareHashUploadSettings();
+        }
+
+        SecretEnvelope? pfxSecret = null;
+        SecretEnvelope? pfxPasswordSecret = null;
+        if (autopilot.IsEnabled &&
+            autopilot.ProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload &&
+            mediaSecretsKey is not null)
+        {
+            if (mediaSecretsKey.Length == 0)
+            {
+                throw new InvalidOperationException("Autopilot hardware hash upload media generation requires a media secret key.");
+            }
+
+            AutopilotBootMediaCertificateSettings bootMediaCertificate = settings.BootMediaCertificate;
+            if (string.IsNullOrWhiteSpace(bootMediaCertificate.PfxPath) ||
+                !File.Exists(bootMediaCertificate.PfxPath))
+            {
+                throw new InvalidOperationException("Autopilot hardware hash upload media generation requires the selected PFX file.");
+            }
+
+            if (string.IsNullOrWhiteSpace(bootMediaCertificate.PfxPassword))
+            {
+                throw new InvalidOperationException("Autopilot hardware hash upload media generation requires the selected PFX password.");
+            }
+
+            byte[] pfxBytes = File.ReadAllBytes(bootMediaCertificate.PfxPath);
+            try
+            {
+                pfxSecret = MediaSecretEnvelopeProtector.EncryptBytes(pfxBytes, mediaSecretsKey);
+            }
+            finally
+            {
+                System.Security.Cryptography.CryptographicOperations.ZeroMemory(pfxBytes);
+            }
+
+            pfxPasswordSecret = MediaSecretEnvelopeProtector.EncryptString(
+                bootMediaCertificate.PfxPassword,
+                mediaSecretsKey);
         }
 
         return new DeployAutopilotHardwareHashUploadSettings
@@ -118,7 +172,9 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
             ActiveCertificateThumbprint = settings.ActiveCertificate?.Thumbprint,
             ActiveCertificateExpiresOnUtc = settings.ActiveCertificate?.ExpiresOnUtc,
             DefaultGroupTag = settings.DefaultGroupTag,
-            KnownGroupTags = CanonicalizeGroupTags(settings.KnownGroupTags)
+            KnownGroupTags = CanonicalizeGroupTags(settings.KnownGroupTags),
+            CertificatePfxSecret = pfxSecret,
+            CertificatePfxPasswordSecret = pfxPasswordSecret
         };
     }
 

--- a/src/Foundry.Core/Services/Configuration/IDeployConfigurationGenerator.cs
+++ b/src/Foundry.Core/Services/Configuration/IDeployConfigurationGenerator.cs
@@ -16,6 +16,14 @@ public interface IDeployConfigurationGenerator
     FoundryDeployConfigurationDocument Generate(FoundryConfigurationDocument document);
 
     /// <summary>
+    /// Generates the deployment runtime configuration and encrypts media-only secrets when a media key is provided.
+    /// </summary>
+    /// <param name="document">The Foundry configuration document.</param>
+    /// <param name="mediaSecretsKey">Optional media secret key used for generated boot media secrets.</param>
+    /// <returns>The deployment runtime configuration.</returns>
+    FoundryDeployConfigurationDocument Generate(FoundryConfigurationDocument document, byte[]? mediaSecretsKey);
+
+    /// <summary>
     /// Serializes a deployment runtime configuration document to JSON.
     /// </summary>
     /// <param name="document">The deployment runtime document.</param>

--- a/src/Foundry.Core/Services/WinPe/WinPeImageInternationalizationService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeImageInternationalizationService.cs
@@ -12,7 +12,12 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
         "WinPE-DismCmdlets",
         "WinPE-StorageWMI",
         "WinPE-Dot3Svc",
-        "WinPE-EnhancedStorage"
+        "WinPE-EnhancedStorage",
+        "WinPE-SecureStartup"
+    ];
+    private static readonly string[] BlockingOptionalComponents =
+    [
+        "WinPE-SecureStartup"
     ];
 
     private readonly IWinPeProcessRunner _processRunner;
@@ -107,6 +112,7 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
             workingDirectoryPath,
             "Failed to add the selected WinPE language pack.",
             "Applying language pack with DISM.",
+            allowNonBlockingPackageFailure: false,
             dismProgress,
             cancellationToken).ConfigureAwait(false);
 
@@ -118,6 +124,7 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
         int neutralComponentsFound = 0;
         foreach (string component in RequiredOptionalComponents)
         {
+            bool isBlockingComponent = BlockingOptionalComponents.Contains(component, StringComparer.OrdinalIgnoreCase);
             string neutralPackagePath = Path.Combine(optionalComponentsRoot, $"{component}.cab");
             if (File.Exists(neutralPackagePath))
             {
@@ -129,6 +136,7 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
                     workingDirectoryPath,
                     $"Failed to add the '{component}' WinPE optional component.",
                     "Applying optional components with DISM.",
+                    allowNonBlockingPackageFailure: !isBlockingComponent,
                     dismProgress,
                     cancellationToken).ConfigureAwait(false);
 
@@ -136,6 +144,13 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
                 {
                     return neutralResult;
                 }
+            }
+            else if (isBlockingComponent)
+            {
+                return WinPeResult.Failure(
+                    WinPeErrorCodes.ToolNotFound,
+                    $"The required '{component}' WinPE optional component was not found.",
+                    $"Expected path: '{neutralPackagePath}'.");
             }
 
             string localizedPackagePath = Path.Combine(optionalComponentsRoot, normalizedLocale, $"{component}_{normalizedLocale}.cab");
@@ -148,6 +163,7 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
                     workingDirectoryPath,
                     $"Failed to add the localized '{component}' WinPE optional component.",
                     "Applying optional components with DISM.",
+                    allowNonBlockingPackageFailure: !isBlockingComponent,
                     dismProgress,
                     cancellationToken).ConfigureAwait(false);
 
@@ -173,6 +189,7 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
         string workingDirectoryPath,
         string failureMessage,
         string progressStatus,
+        bool allowNonBlockingPackageFailure,
         IProgress<WinPeDismProgress>? dismProgress,
         CancellationToken cancellationToken)
     {
@@ -185,7 +202,9 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
             dismProgress,
             cancellationToken).ConfigureAwait(false);
 
-        if (execution.IsSuccess || IsIgnorablePackageFailure(execution))
+        if (execution.IsSuccess ||
+            IsAlreadyInstalledPackageFailure(execution) ||
+            allowNonBlockingPackageFailure && IsNonBlockingPackageFailure(execution))
         {
             return WinPeResult.Success();
         }
@@ -313,12 +332,17 @@ public sealed class WinPeImageInternationalizationService : IWinPeImageInternati
             "WinPE_OCs");
     }
 
-    private static bool IsIgnorablePackageFailure(WinPeProcessExecution execution)
+    private static bool IsAlreadyInstalledPackageFailure(WinPeProcessExecution execution)
+    {
+        string diagnostic = $"{execution.StandardOutput}{Environment.NewLine}{execution.StandardError}";
+        return diagnostic.Contains("already installed", StringComparison.OrdinalIgnoreCase) ||
+               diagnostic.Contains("already exists", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsNonBlockingPackageFailure(WinPeProcessExecution execution)
     {
         string diagnostic = $"{execution.StandardOutput}{Environment.NewLine}{execution.StandardError}";
         return diagnostic.Contains("0x800f081e", StringComparison.OrdinalIgnoreCase) ||
-               diagnostic.Contains("not applicable", StringComparison.OrdinalIgnoreCase) ||
-               diagnostic.Contains("already installed", StringComparison.OrdinalIgnoreCase) ||
-               diagnostic.Contains("already exists", StringComparison.OrdinalIgnoreCase);
+               diagnostic.Contains("not applicable", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningOptions.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningOptions.cs
@@ -14,6 +14,17 @@ public sealed record WinPeMountedImageAssetProvisioningOptions
     public string DeployConfigurationJson { get; init; } = string.Empty;
     public byte[]? MediaSecretsKey { get; init; }
     public IReadOnlyList<FoundryConnectProvisionedAssetFile> FoundryConnectAssetFiles { get; init; } = [];
+
+    /// <summary>
+    /// Gets the Autopilot mode that controls whether profile JSON or hash capture assets are staged.
+    /// </summary>
+    public AutopilotProvisioningMode AutopilotProvisioningMode { get; init; } = AutopilotProvisioningMode.JsonProfile;
+
+    /// <summary>
+    /// Gets the ADK OA3Tool source path copied into media when hardware hash upload mode is selected.
+    /// </summary>
+    public string? Oa3ToolSourcePath { get; init; }
+
     public IReadOnlyList<AutopilotProfileSettings> AutopilotProfiles { get; init; } = [];
     public WinPeProvisioningSource ConnectProvisioningSource { get; init; } = WinPeProvisioningSource.Release;
     public WinPeProvisioningSource DeployProvisioningSource { get; init; } = WinPeProvisioningSource.Release;

--- a/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningService.cs
@@ -11,6 +11,14 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
 {
     private const string BootstrapFileName = "FoundryBootstrap.ps1";
     private const string BootstrapInvocation = @"powershell.exe -ExecutionPolicy Bypass -NoProfile -File X:\Windows\System32\FoundryBootstrap.ps1";
+    private const string Oa3CfgTemplate = """
+        ; Foundry.Deploy rewrites this file with deployment-specific paths before running OA3Tool.
+        ; The template is staged so generated media has the expected Autopilot hash workspace.
+        """;
+    private const string Oa3InputTemplate = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <Key />
+        """;
     private static readonly UTF8Encoding Utf8NoBom = new(false);
 
     public async Task<WinPeResult> ProvisionAsync(
@@ -130,7 +138,17 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
             cancellationToken).ConfigureAwait(false);
 
         CopyConnectAssetFiles(mountedImagePath, options.FoundryConnectAssetFiles);
-        await WriteAutopilotProfilesAsync(foundryConfigPath, options.AutopilotProfiles, cancellationToken).ConfigureAwait(false);
+        if (options.AutopilotProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload)
+        {
+            await WriteAutopilotHardwareHashAssetsAsync(
+                mountedImagePath,
+                options,
+                cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            await WriteAutopilotProfilesAsync(foundryConfigPath, options.AutopilotProfiles, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     private static async Task WriteMediaSecretsKeyAsync(
@@ -219,6 +237,34 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
         File.Copy(sourceExecutablePath, Path.Combine(destinationRuntimePath, "7za.exe"), overwrite: true);
         File.Copy(sourceLicensePath, Path.Combine(destinationToolsRootPath, "License.txt"), overwrite: true);
         File.Copy(sourceReadmePath, Path.Combine(destinationToolsRootPath, "readme.txt"), overwrite: true);
+    }
+
+    private static async Task WriteAutopilotHardwareHashAssetsAsync(
+        string mountedImagePath,
+        WinPeMountedImageAssetProvisioningOptions options,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(options.Oa3ToolSourcePath) || !File.Exists(options.Oa3ToolSourcePath))
+        {
+            throw new IOException($"OA3Tool source file was not found: '{options.Oa3ToolSourcePath}'.");
+        }
+
+        string oa3ToolsPath = Path.Combine(mountedImagePath, "Foundry", "Tools", "OA3");
+        Directory.CreateDirectory(oa3ToolsPath);
+        File.Copy(options.Oa3ToolSourcePath, Path.Combine(oa3ToolsPath, "oa3tool.exe"), overwrite: true);
+
+        string runtimePath = Path.Combine(mountedImagePath, "Foundry", "Runtime", "AutopilotHash");
+        Directory.CreateDirectory(runtimePath);
+        await File.WriteAllTextAsync(
+            Path.Combine(runtimePath, "OA3.cfg"),
+            Oa3CfgTemplate,
+            Utf8NoBom,
+            cancellationToken).ConfigureAwait(false);
+        await File.WriteAllTextAsync(
+            Path.Combine(runtimePath, "input.xml"),
+            Oa3InputTemplate,
+            Utf8NoBom,
+            cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task WriteAutopilotProfilesAsync(
@@ -342,6 +388,23 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
                 WinPeErrorCodes.ValidationFailed,
                 "Provisioning source value is invalid.",
                 $"Connect: '{options.ConnectProvisioningSource}', Deploy: '{options.DeployProvisioningSource}'.");
+        }
+
+        if (!Enum.IsDefined(options.AutopilotProvisioningMode))
+        {
+            return new WinPeDiagnostic(
+                WinPeErrorCodes.ValidationFailed,
+                "Autopilot provisioning mode value is invalid.",
+                $"Value: '{options.AutopilotProvisioningMode}'.");
+        }
+
+        if (options.AutopilotProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload &&
+            (string.IsNullOrWhiteSpace(options.Oa3ToolSourcePath) || !File.Exists(options.Oa3ToolSourcePath)))
+        {
+            return new WinPeDiagnostic(
+                WinPeErrorCodes.ToolNotFound,
+                "OA3Tool source path is required for Autopilot hardware hash upload media.",
+                $"Expected file: '{options.Oa3ToolSourcePath}'.");
         }
 
         return null;

--- a/src/Foundry.Core/Services/WinPe/WinPeOa3ToolResolver.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeOa3ToolResolver.cs
@@ -1,0 +1,65 @@
+namespace Foundry.Core.Services.WinPe;
+
+/// <summary>
+/// Resolves the architecture-specific OA3Tool executable from the Windows ADK deployment tools.
+/// </summary>
+public static class WinPeOa3ToolResolver
+{
+    /// <summary>
+    /// Resolves the OA3Tool executable for the WinPE media architecture.
+    /// </summary>
+    /// <param name="kitsRootPath">Windows ADK KitsRoot10 path.</param>
+    /// <param name="architecture">Target WinPE architecture.</param>
+    /// <returns>The resolved OA3Tool path or a WinPE diagnostic.</returns>
+    public static WinPeResult<string> Resolve(string kitsRootPath, WinPeArchitecture architecture)
+    {
+        if (string.IsNullOrWhiteSpace(kitsRootPath))
+        {
+            return WinPeResult<string>.Failure(
+                WinPeErrorCodes.ValidationFailed,
+                "ADK kits root path is required to resolve OA3Tool.",
+                "Set the ADK KitsRoot10 path before generating media.");
+        }
+
+        if (!Enum.IsDefined(architecture))
+        {
+            return WinPeResult<string>.Failure(
+                WinPeErrorCodes.ValidationFailed,
+                "WinPE architecture value is invalid.",
+                $"Value: '{architecture}'.");
+        }
+
+        string adkArchitecture = architecture.ToCopypeArchitecture();
+        string[] candidates =
+        [
+            Path.Combine(
+                kitsRootPath,
+                "Assessment and Deployment Kit",
+                "Deployment Tools",
+                adkArchitecture,
+                "Licensing",
+                "OA30",
+                "oa3tool.exe"),
+            Path.Combine(
+                kitsRootPath,
+                "Deployment Tools",
+                adkArchitecture,
+                "Licensing",
+                "OA30",
+                "oa3tool.exe")
+        ];
+
+        foreach (string candidate in candidates)
+        {
+            if (File.Exists(candidate))
+            {
+                return WinPeResult<string>.Success(candidate);
+            }
+        }
+
+        return WinPeResult<string>.Failure(
+            WinPeErrorCodes.ToolNotFound,
+            "OA3Tool executable was not found for the selected WinPE architecture.",
+            $"Expected OA3Tool under ADK Deployment Tools for '{adkArchitecture}'.");
+    }
+}

--- a/src/Foundry/Services/Configuration/FoundryConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/FoundryConfigurationStateService.cs
@@ -1,4 +1,5 @@
 using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Autopilot;
 using Foundry.Core.Services.Configuration;
 using Foundry.Core.Services.WinPe;
 using Foundry.Services.Autopilot;
@@ -61,7 +62,11 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
         {
             try
             {
-                _ = GenerateDeployConfigurationJson();
+                byte[]? mediaSecretsKey = Current.Autopilot.IsEnabled &&
+                                          Current.Autopilot.ProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload
+                    ? MediaSecretEnvelopeProtector.GenerateMediaKey()
+                    : null;
+                _ = GenerateDeployConfigurationJson(mediaSecretsKey: mediaSecretsKey);
                 return true;
             }
             catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
@@ -159,11 +164,11 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
     }
 
     /// <inheritdoc />
-    public string GenerateDeployConfigurationJson(TelemetrySettings? telemetryOverride = null)
+    public string GenerateDeployConfigurationJson(TelemetrySettings? telemetryOverride = null, byte[]? mediaSecretsKey = null)
     {
         FoundryConfigurationDocument document = CreateDocumentForDeployGeneration(telemetryOverride);
 
-        return deployConfigurationGenerator.Serialize(deployConfigurationGenerator.Generate(document));
+        return deployConfigurationGenerator.Serialize(deployConfigurationGenerator.Generate(document, mediaSecretsKey));
     }
 
     /// <inheritdoc />

--- a/src/Foundry/Services/Configuration/IFoundryConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/IFoundryConfigurationStateService.cs
@@ -121,6 +121,7 @@ public interface IFoundryConfigurationStateService
     /// Generates the Deploy configuration JSON for the current Foundry configuration.
     /// </summary>
     /// <param name="telemetryOverride">Optional runtime telemetry settings used only for the generated Deploy document.</param>
+    /// <param name="mediaSecretsKey">Optional media secret key used for boot-media-only Deploy secrets.</param>
     /// <returns>Serialized Deploy configuration JSON.</returns>
-    string GenerateDeployConfigurationJson(TelemetrySettings? telemetryOverride = null);
+    string GenerateDeployConfigurationJson(TelemetrySettings? telemetryOverride = null, byte[]? mediaSecretsKey = null);
 }

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Autopilot;
 using Foundry.Core.Services.Application;
 using Foundry.Core.Services.Configuration;
 using Foundry.Core.Services.Media;
@@ -673,7 +674,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                     DriverVendors = options.DriverVendors,
                     CustomDriverDirectoryPath = options.CustomDriverDirectoryPath,
                     WinPeLanguage = options.WinPeLanguage,
-                    AssetProvisioning = CreateAssetProvisioningOptions(options, connectBundle, runtimePayloadProvisioning, deployTelemetrySettings),
+                    AssetProvisioning = CreateAssetProvisioningOptions(options, tools, connectBundle, runtimePayloadProvisioning, deployTelemetrySettings),
                     RuntimePayloadProvisioning = includeRuntimePayloadInImage ? artifactRuntimePayloadProvisioning : null,
                     WinReCacheDirectoryPath = Constants.WinReTempDirectoryPath,
                     Progress = workspacePreparationProgress,
@@ -708,10 +709,27 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private WinPeMountedImageAssetProvisioningOptions CreateAssetProvisioningOptions(
         MediaPreflightOptions options,
+        WinPeToolPaths tools,
         FoundryConnectProvisioningBundle connectBundle,
         WinPeRuntimePayloadProvisioningOptions runtimePayloadProvisioning,
         TelemetrySettings deployTelemetrySettings)
     {
+        bool isHardwareHashMode = options.IsAutopilotEnabled &&
+                                  options.AutopilotProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload;
+        byte[]? mediaSecretsKey = connectBundle.MediaSecretsKey;
+        if (isHardwareHashMode && mediaSecretsKey is null)
+        {
+            mediaSecretsKey = MediaSecretEnvelopeProtector.GenerateMediaKey();
+        }
+
+        string? oa3ToolSourcePath = null;
+        if (isHardwareHashMode)
+        {
+            WinPeResult<string> oa3ToolResult = WinPeOa3ToolResolver.Resolve(tools.KitsRootPath, options.Architecture);
+            EnsureSuccess(oa3ToolResult);
+            oa3ToolSourcePath = oa3ToolResult.Value;
+        }
+
         return new WinPeMountedImageAssetProvisioningOptions
         {
             BootstrapScriptContent = embeddedAssetService.GetBootstrapScriptContent(),
@@ -719,10 +737,14 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             SevenZipSourceDirectoryPath = embeddedAssetService.GetSevenZipSourceDirectoryPath(),
             IanaWindowsTimeZoneMapJson = embeddedAssetService.GetIanaWindowsTimeZoneMapJson(),
             FoundryConnectConfigurationJson = connectBundle.ConfigurationJson,
-            DeployConfigurationJson = foundryConfigurationStateService.GenerateDeployConfigurationJson(deployTelemetrySettings),
-            MediaSecretsKey = connectBundle.MediaSecretsKey,
+            DeployConfigurationJson = foundryConfigurationStateService.GenerateDeployConfigurationJson(deployTelemetrySettings, mediaSecretsKey),
+            MediaSecretsKey = mediaSecretsKey,
             FoundryConnectAssetFiles = connectBundle.AssetFiles,
-            AutopilotProfiles = options.IsAutopilotEnabled
+            AutopilotProvisioningMode = isHardwareHashMode
+                ? AutopilotProvisioningMode.HardwareHashUpload
+                : AutopilotProvisioningMode.JsonProfile,
+            Oa3ToolSourcePath = oa3ToolSourcePath,
+            AutopilotProfiles = options.IsAutopilotEnabled && options.AutopilotProvisioningMode == AutopilotProvisioningMode.JsonProfile
                 ? foundryConfigurationStateService.Current.Autopilot.Profiles
                 : [],
             ConnectProvisioningSource = ResolveProvisioningSource(runtimePayloadProvisioning.Connect),


### PR DESCRIPTION
Summary:
Stage the WinPE media assets required for Autopilot hardware hash upload while preserving the existing JSON profile media path.

Reason:
Phase 4 prepares generated boot media for later Deploy runtime phases by adding OA3Tool, hash workspace assets, SecureStartup, and encrypted certificate material without persisting private key material in ProgramData.

Main changes:
- Add WinPE-SecureStartup as a blocking default WinPE optional component.
- Resolve architecture-specific ADK OA3Tool paths for x64 and ARM64 and stage OA3 assets into generated media.
- Embed Autopilot PFX bytes and password as media secret envelopes in deploy config when hash upload media is generated.
- Stage JSON profile folders only for JSON profile mode and skip PCPKsp.dll during media build.
- Update Phase 4 implementation plan status and deferred manual media checks.

Testing notes:
- `dotnet test .\src\Foundry.Core.Tests\Foundry.Core.Tests.csproj --configuration Debug /p:Platform=x64 --no-restore --verbosity minimal` passed: 246 tests, 0 failures.
- `dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --configuration Debug /p:Platform=x64 --no-restore --verbosity minimal` passed: 162 tests, 0 failures.
- `dotnet build .\src\Foundry\Foundry.csproj --configuration Debug /p:Platform=x64 --no-restore --verbosity minimal` passed: 0 warnings, 0 errors.

Manual media validation for x64/ARM64 ISO contents, mounted SecureStartup package presence, and plaintext secret inspection is deferred to an operator ADK/test-tenant media pass.