### PR TITLE
feat(deploy): capture autopilot hardware hash in WinPE

### DIFF
--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -408,34 +408,38 @@ Manual UI/runtime validation remains deferred to an operator run with generated 
 PR title: `feat(deploy): capture autopilot hardware hash in WinPE`
 
 Implementation progress:
-- [ ] Phase branch created from `feature/autopilot-hash-upload-foundation`.
-- [ ] Implementation checklist complete.
-- [ ] Automated tests complete.
-- [ ] Manual checks complete or explicitly deferred.
+- [x] Phase branch created from `feature/autopilot-hash-upload-foundation`.
+- [x] Implementation checklist complete.
+- [x] Automated tests complete.
+- [x] Manual checks complete or explicitly deferred.
 - [ ] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
-- [ ] Add a C# service that runs OA3Tool with controlled working directory paths.
-- [ ] Add a C# service that copies `PCPKsp.dll` from `<target Windows>\Windows\System32` to `X:\Windows\System32`.
-- [ ] Validate source and destination architecture assumptions for x64 and ARM64.
-- [ ] Generate `OA3.cfg` and dummy input XML internally.
-- [ ] Validate `OA3.xml` exists.
-- [ ] Extract serial number and hardware hash.
-- [ ] Write a local CSV artifact for troubleshooting.
-- [ ] Preserve OA3 logs in Foundry deployment logs.
-- [ ] Return structured failure codes for missing tool, `PCPKsp.dll` copy/load failure, empty hash, invalid XML, missing serial, and OA3 exit failure.
-- [ ] Add XML documentation comments to new public hash capture, OA3Tool, parser, and artifact writer APIs.
+- [x] Add a C# service that runs OA3Tool with controlled working directory paths.
+- [x] Add a C# service that copies `PCPKsp.dll` from `<target Windows>\Windows\System32` to `X:\Windows\System32`.
+- [x] Validate source and destination architecture assumptions for x64 and ARM64.
+- [x] Generate `OA3.cfg` and dummy input XML internally.
+- [x] Validate `OA3.xml` exists.
+- [x] Extract serial number and hardware hash.
+- [x] Write a local CSV artifact for troubleshooting.
+- [x] Preserve OA3 logs in Foundry deployment logs.
+- [x] Return structured failure codes for missing tool, `PCPKsp.dll` copy/load failure, empty hash, invalid XML, missing serial, and OA3 exit failure.
+- [x] Add XML documentation comments to new public hash capture, OA3Tool, parser, and artifact writer APIs.
 
 Automated tests:
-- [ ] Resolves the applied Windows `System32` source path.
-- [ ] Copies `PCPKsp.dll` to `X:\Windows\System32` before OA3Tool execution.
-- [ ] Parses valid `OA3.xml`.
-- [ ] Rejects missing `HardwareHash`.
-- [ ] Rejects invalid XML.
-- [ ] Generates CSV without quotes, extra columns, or Unicode encoding.
-- [ ] Sanitizes commas from group tag and serial number.
+- [x] Resolves the applied Windows `System32` source path.
+- [x] Copies `PCPKsp.dll` to `X:\Windows\System32` before OA3Tool execution.
+- [x] Parses valid `OA3.xml`.
+- [x] Rejects missing `HardwareHash`.
+- [x] Rejects invalid XML.
+- [x] Generates CSV without quotes, extra columns, or Unicode encoding.
+- [x] Sanitizes commas from group tag and serial number.
+- [x] `dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --configuration Debug /p:Platform=x64 --no-restore --verbosity minimal` passed: 176 tests, 0 failures.
+- [x] `dotnet build .\src\Foundry.Deploy\Foundry.Deploy.csproj --configuration Debug /p:Platform=x64 --no-restore --verbosity minimal` passed: 0 warnings, 0 errors.
 
 Manual checks:
+Manual runtime validation remains deferred to physical x64 and ARM64 media runs. Graph import validation remains Phase 7.
+
 - [ ] Run on one x64 physical test device with Ethernet.
 - [ ] Run on one x64 physical test device with Wi-Fi.
 - [ ] Run on one ARM64 physical test device with Ethernet.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -412,7 +412,7 @@ Implementation progress:
 - [x] Implementation checklist complete.
 - [x] Automated tests complete.
 - [x] Manual checks complete or explicitly deferred.
-- [ ] PR opened with the planned title.
+- [x] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
 - [x] Add a C# service that runs OA3Tool with controlled working directory paths.

--- a/src/Foundry.Deploy.Tests/AutopilotHardwareHashCaptureServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/AutopilotHardwareHashCaptureServiceTests.cs
@@ -1,0 +1,240 @@
+using Foundry.Deploy.Services.Autopilot;
+using Foundry.Deploy.Services.System;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class AutopilotHardwareHashCaptureServiceTests
+{
+    [Fact]
+    public async Task CaptureAsync_WhenPcpKspExists_CopiesPcpKspBeforeRunningOa3Tool()
+    {
+        using TemporaryWorkspace workspace = TemporaryWorkspace.Create();
+        workspace.WriteTargetPcpKsp("pcp");
+        workspace.WriteOa3Tool();
+        var processRunner = new RecordingProcessRunner(workspace);
+        var service = CreateService(processRunner);
+
+        AutopilotHardwareHashCaptureResult result = await service.CaptureAsync(
+            workspace.CreateRequest(groupTag: "Sales"),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("SER123", result.Identity?.SerialNumber);
+        Assert.Equal("HASHVALUE", result.Identity?.HardwareHash);
+        Assert.True(processRunner.WasPcpKspPresentBeforeOa3Run);
+        Assert.Equal(workspace.RuntimeHashRootPath, processRunner.WorkingDirectory);
+        Assert.Equal(
+            Path.Combine(workspace.WinPeWindowsRootPath, "System32", "PCPKsp.dll"),
+            processRunner.CopiedPcpKspPath);
+        Assert.True(File.Exists(Path.Combine(workspace.DiagnosticsRootPath, "OA3.xml")));
+        Assert.True(File.Exists(Path.Combine(workspace.DiagnosticsRootPath, "OA3.log")));
+        Assert.True(File.Exists(Path.Combine(workspace.DiagnosticsRootPath, "AutopilotHWID.csv")));
+    }
+
+    [Fact]
+    public async Task CaptureAsync_WhenPcpKspIsMissing_ReturnsSupportLibraryMissingFailure()
+    {
+        using TemporaryWorkspace workspace = TemporaryWorkspace.Create();
+        workspace.WriteOa3Tool();
+        var processRunner = new RecordingProcessRunner(workspace);
+        var service = CreateService(processRunner);
+
+        AutopilotHardwareHashCaptureResult result = await service.CaptureAsync(
+            workspace.CreateRequest(groupTag: null),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(AutopilotHardwareHashCaptureFailureCode.SupportLibraryMissing, result.FailureCode);
+        Assert.False(processRunner.WasCalled);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_WhenOa3ToolIsMissing_ReturnsToolMissingFailure()
+    {
+        using TemporaryWorkspace workspace = TemporaryWorkspace.Create();
+        workspace.WriteTargetPcpKsp("pcp");
+        var processRunner = new RecordingProcessRunner(workspace);
+        var service = CreateService(processRunner);
+
+        AutopilotHardwareHashCaptureResult result = await service.CaptureAsync(
+            workspace.CreateRequest(groupTag: null),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(AutopilotHardwareHashCaptureFailureCode.ToolMissing, result.FailureCode);
+        Assert.False(processRunner.WasCalled);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_WhenOa3ToolExitsNonZero_ReturnsToolFailedFailure()
+    {
+        using TemporaryWorkspace workspace = TemporaryWorkspace.Create();
+        workspace.WriteTargetPcpKsp("pcp");
+        workspace.WriteOa3Tool();
+        var processRunner = new RecordingProcessRunner(workspace)
+        {
+            ExitCode = 5,
+            StandardError = "oa3 failed"
+        };
+        var service = CreateService(processRunner);
+
+        AutopilotHardwareHashCaptureResult result = await service.CaptureAsync(
+            workspace.CreateRequest(groupTag: null),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(AutopilotHardwareHashCaptureFailureCode.ToolFailed, result.FailureCode);
+        Assert.Contains("oa3 failed", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_WhenOa3ToolCannotLoadPcpKsp_ReturnsSupportLibraryLoadFailure()
+    {
+        using TemporaryWorkspace workspace = TemporaryWorkspace.Create();
+        workspace.WriteTargetPcpKsp("pcp");
+        workspace.WriteOa3Tool();
+        var processRunner = new RecordingProcessRunner(workspace)
+        {
+            ExitCode = 5,
+            StandardError = "Failed to load PCPKsp.dll"
+        };
+        var service = CreateService(processRunner);
+
+        AutopilotHardwareHashCaptureResult result = await service.CaptureAsync(
+            workspace.CreateRequest(groupTag: null),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(AutopilotHardwareHashCaptureFailureCode.SupportLibraryLoadFailed, result.FailureCode);
+    }
+
+    private static AutopilotHardwareHashCaptureService CreateService(IProcessRunner processRunner)
+    {
+        return new AutopilotHardwareHashCaptureService(
+            processRunner,
+            NullLogger<AutopilotHardwareHashCaptureService>.Instance);
+    }
+
+    private sealed class RecordingProcessRunner(TemporaryWorkspace workspace) : IProcessRunner
+    {
+        public bool WasCalled { get; private set; }
+        public bool WasPcpKspPresentBeforeOa3Run { get; private set; }
+        public string? CopiedPcpKspPath { get; private set; }
+        public string? WorkingDirectory { get; private set; }
+        public int ExitCode { get; init; }
+        public string StandardError { get; init; } = string.Empty;
+
+        public Task<ProcessExecutionResult> RunAsync(
+            string fileName,
+            string arguments,
+            string workingDirectory,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<ProcessExecutionResult> RunAsync(
+            string fileName,
+            IEnumerable<string> arguments,
+            string workingDirectory,
+            CancellationToken cancellationToken = default)
+        {
+            return RunAsync(fileName, arguments, workingDirectory, null, null, cancellationToken);
+        }
+
+        public Task<ProcessExecutionResult> RunAsync(
+            string fileName,
+            IEnumerable<string> arguments,
+            string workingDirectory,
+            Action<string>? onOutputData,
+            Action<string>? onErrorData,
+            CancellationToken cancellationToken = default)
+        {
+            WasCalled = true;
+            WorkingDirectory = workingDirectory;
+            CopiedPcpKspPath = Path.Combine(workspace.WinPeWindowsRootPath, "System32", "PCPKsp.dll");
+            WasPcpKspPresentBeforeOa3Run = File.Exists(CopiedPcpKspPath);
+
+            if (ExitCode == 0)
+            {
+                File.WriteAllText(
+                    Path.Combine(workingDirectory, "OA3.xml"),
+                    """
+                    <Key>
+                      <SerialNumber>SER123</SerialNumber>
+                      <HardwareHash>HASHVALUE</HardwareHash>
+                    </Key>
+                    """);
+                File.WriteAllText(Path.Combine(workingDirectory, "OA3.log"), "oa3 log");
+            }
+
+            return Task.FromResult(new ProcessExecutionResult
+            {
+                ExitCode = ExitCode,
+                FileName = fileName,
+                Arguments = string.Join(' ', arguments),
+                WorkingDirectory = workingDirectory,
+                StandardError = StandardError
+            });
+        }
+    }
+
+    private sealed class TemporaryWorkspace : IDisposable
+    {
+        private TemporaryWorkspace(string rootPath)
+        {
+            RootPath = rootPath;
+            TargetWindowsRootPath = Path.Combine(rootPath, "TargetWindows");
+            WinPeWindowsRootPath = Path.Combine(rootPath, "WinPeWindows");
+            WorkspaceRootPath = Path.Combine(rootPath, "Foundry");
+            DiagnosticsRootPath = Path.Combine(TargetWindowsRootPath, "Windows", "Temp", "Foundry", "Logs", "AutopilotHash");
+            RuntimeHashRootPath = Path.Combine(WorkspaceRootPath, "Runtime", "AutopilotHash");
+            Directory.CreateDirectory(Path.Combine(TargetWindowsRootPath, "Windows", "System32"));
+            Directory.CreateDirectory(Path.Combine(WinPeWindowsRootPath, "System32"));
+            Directory.CreateDirectory(Path.Combine(WorkspaceRootPath, "Tools", "OA3"));
+            Directory.CreateDirectory(RuntimeHashRootPath);
+        }
+
+        public string RootPath { get; }
+        public string TargetWindowsRootPath { get; }
+        public string WinPeWindowsRootPath { get; }
+        public string WorkspaceRootPath { get; }
+        public string DiagnosticsRootPath { get; }
+        public string RuntimeHashRootPath { get; }
+
+        public static TemporaryWorkspace Create()
+        {
+            string rootPath = Path.Combine(Path.GetTempPath(), $"foundry-hash-capture-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(rootPath);
+            return new TemporaryWorkspace(rootPath);
+        }
+
+        public void WriteTargetPcpKsp(string content)
+        {
+            File.WriteAllText(Path.Combine(TargetWindowsRootPath, "Windows", "System32", "PCPKsp.dll"), content);
+        }
+
+        public void WriteOa3Tool()
+        {
+            File.WriteAllText(Path.Combine(WorkspaceRootPath, "Tools", "OA3", "oa3tool.exe"), "oa3");
+        }
+
+        public AutopilotHardwareHashCaptureRequest CreateRequest(string? groupTag)
+        {
+            return new AutopilotHardwareHashCaptureRequest
+            {
+                TargetWindowsRootPath = TargetWindowsRootPath,
+                WinPeWindowsRootPath = WinPeWindowsRootPath,
+                WorkspaceRootPath = WorkspaceRootPath,
+                DiagnosticsRootPath = DiagnosticsRootPath,
+                GroupTag = groupTag
+            };
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(RootPath, recursive: true);
+        }
+    }
+}

--- a/src/Foundry.Deploy.Tests/AutopilotHardwareHashCsvWriterTests.cs
+++ b/src/Foundry.Deploy.Tests/AutopilotHardwareHashCsvWriterTests.cs
@@ -1,0 +1,61 @@
+using System.Text;
+using Foundry.Deploy.Services.Autopilot;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class AutopilotHardwareHashCsvWriterTests
+{
+    [Fact]
+    public async Task WriteAsync_WhenValuesContainCommas_SanitizesCsvFields()
+    {
+        using TemporaryWorkspace workspace = new();
+        string csvPath = Path.Combine(workspace.RootPath, "AutopilotHWID.csv");
+
+        await AutopilotHardwareHashCsvWriter.WriteAsync(
+            csvPath,
+            new AutopilotHardwareHashDeviceIdentity("SER,123", "HASHVALUE", "Sales, East"),
+            CancellationToken.None);
+
+        byte[] bytes = await File.ReadAllBytesAsync(csvPath);
+        string csv = Encoding.UTF8.GetString(bytes);
+
+        Assert.False(bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF);
+        Assert.Equal(
+            "Device Serial Number,Windows Product ID,Hardware Hash,Group Tag\r\nSER123,,HASHVALUE,Sales East\r\n",
+            csv);
+        Assert.DoesNotContain('"', csv);
+    }
+
+    [Fact]
+    public async Task WriteAsync_WhenGroupTagIsNull_WritesEmptyGroupTagColumn()
+    {
+        using TemporaryWorkspace workspace = new();
+        string csvPath = Path.Combine(workspace.RootPath, "AutopilotHWID.csv");
+
+        await AutopilotHardwareHashCsvWriter.WriteAsync(
+            csvPath,
+            new AutopilotHardwareHashDeviceIdentity("SER123", "HASHVALUE", null),
+            CancellationToken.None);
+
+        string[] lines = await File.ReadAllLinesAsync(csvPath);
+
+        Assert.Equal("Device Serial Number,Windows Product ID,Hardware Hash,Group Tag", lines[0]);
+        Assert.Equal("SER123,,HASHVALUE,", lines[1]);
+    }
+
+    private sealed class TemporaryWorkspace : IDisposable
+    {
+        public TemporaryWorkspace()
+        {
+            RootPath = Path.Combine(Path.GetTempPath(), $"foundry-hash-csv-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(RootPath);
+        }
+
+        public string RootPath { get; }
+
+        public void Dispose()
+        {
+            Directory.Delete(RootPath, recursive: true);
+        }
+    }
+}

--- a/src/Foundry.Deploy.Tests/Oa3XmlParserTests.cs
+++ b/src/Foundry.Deploy.Tests/Oa3XmlParserTests.cs
@@ -1,0 +1,57 @@
+using Foundry.Deploy.Services.Autopilot;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class Oa3XmlParserTests
+{
+    [Fact]
+    public void Parse_WhenOa3XmlIsValid_ReturnsSerialNumberAndHardwareHash()
+    {
+        AutopilotHardwareHashParseResult result = AutopilotOa3XmlParser.Parse("""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Key>
+              <SerialNumber>ABC123</SerialNumber>
+              <HardwareHash>HASHVALUE</HardwareHash>
+            </Key>
+            """);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("ABC123", result.Identity?.SerialNumber);
+        Assert.Equal("HASHVALUE", result.Identity?.HardwareHash);
+    }
+
+    [Fact]
+    public void Parse_WhenHardwareHashIsMissing_ReturnsHashMissingFailure()
+    {
+        AutopilotHardwareHashParseResult result = AutopilotOa3XmlParser.Parse("""
+            <Key>
+              <SerialNumber>ABC123</SerialNumber>
+            </Key>
+            """);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(AutopilotHardwareHashCaptureFailureCode.HashMissing, result.FailureCode);
+    }
+
+    [Fact]
+    public void Parse_WhenSerialNumberIsMissing_ReturnsSerialMissingFailure()
+    {
+        AutopilotHardwareHashParseResult result = AutopilotOa3XmlParser.Parse("""
+            <Key>
+              <HardwareHash>HASHVALUE</HardwareHash>
+            </Key>
+            """);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(AutopilotHardwareHashCaptureFailureCode.SerialMissing, result.FailureCode);
+    }
+
+    [Fact]
+    public void Parse_WhenXmlIsInvalid_ReturnsReportInvalidFailure()
+    {
+        AutopilotHardwareHashParseResult result = AutopilotOa3XmlParser.Parse("<Key>");
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(AutopilotHardwareHashCaptureFailureCode.ReportInvalid, result.FailureCode);
+    }
+}

--- a/src/Foundry.Deploy.Tests/ProvisionAutopilotStepTests.cs
+++ b/src/Foundry.Deploy.Tests/ProvisionAutopilotStepTests.cs
@@ -1,5 +1,6 @@
 using Foundry.Deploy.Models;
 using Foundry.Deploy.Models.Configuration;
+using Foundry.Deploy.Services.Autopilot;
 using Foundry.Deploy.Services.Deployment;
 using Foundry.Deploy.Services.Deployment.Steps;
 using Foundry.Deploy.Services.Hardware;
@@ -17,7 +18,7 @@ public sealed class ProvisionAutopilotStepTests
         using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
         string sourceConfigurationPath = Path.Combine(workspace.RootPath, "AutopilotConfigurationFile.json");
         await File.WriteAllTextAsync(sourceConfigurationPath, """{"profile":true}""");
-        ProvisionAutopilotStep step = new();
+        ProvisionAutopilotStep step = CreateStep();
         DeploymentStepExecutionContext context = CreateContext(
             workspace,
             isDryRun: false,
@@ -43,7 +44,7 @@ public sealed class ProvisionAutopilotStepTests
     public async Task ExecuteAsync_WhenLiveHardwareHashCertificateIsExpired_SkipsUpload()
     {
         using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
-        ProvisionAutopilotStep step = new();
+        ProvisionAutopilotStep step = CreateStep();
         DeploymentStepExecutionContext context = CreateContext(
             workspace,
             isDryRun: false,
@@ -69,7 +70,7 @@ public sealed class ProvisionAutopilotStepTests
     public async Task ExecuteAsync_WhenLiveHardwareHashModeIsConfigured_RecordsPlannedUploadWithoutJsonStaging()
     {
         using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
-        ProvisionAutopilotStep step = new();
+        ProvisionAutopilotStep step = CreateStep();
         DeploymentStepExecutionContext context = CreateContext(
             workspace,
             isDryRun: false,
@@ -87,7 +88,7 @@ public sealed class ProvisionAutopilotStepTests
         DeploymentStepResult result = await step.ExecuteAsync(context, CancellationToken.None);
 
         Assert.Equal(DeploymentStepState.Succeeded, result.State);
-        Assert.Equal(AutopilotHardwareHashUploadState.PendingHashCapture, context.RuntimeState.AutopilotHardwareHashUploadState);
+        Assert.Equal(AutopilotHardwareHashUploadState.HashCaptured, context.RuntimeState.AutopilotHardwareHashUploadState);
         Assert.Equal("Sales", context.RuntimeState.AutopilotHardwareHashGroupTag);
         Assert.Null(context.RuntimeState.StagedAutopilotConfigurationPath);
         Assert.False(Directory.Exists(Path.Combine(workspace.TargetWindowsRootPath, "Windows", "Provisioning", "Autopilot")));
@@ -98,7 +99,7 @@ public sealed class ProvisionAutopilotStepTests
     public async Task ExecuteAsync_WhenLiveHardwareHashModeRunsBeforeTargetWindowsRootExists_FailsBeforePlanningUpload()
     {
         using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
-        ProvisionAutopilotStep step = new();
+        ProvisionAutopilotStep step = CreateStep();
         DeploymentStepExecutionContext context = CreateContext(
             workspace,
             isDryRun: false,
@@ -117,7 +118,7 @@ public sealed class ProvisionAutopilotStepTests
     public async Task ExecuteAsync_WhenDryRunHardwareHashMode_WritesSanitizedHashManifest()
     {
         using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
-        ProvisionAutopilotStep step = new();
+        ProvisionAutopilotStep step = CreateStep();
         DeploymentStepExecutionContext context = CreateContext(
             workspace,
             isDryRun: true,
@@ -154,6 +155,11 @@ public sealed class ProvisionAutopilotStepTests
             ActiveCertificateThumbprint = "ABCDEF123456",
             ActiveCertificateExpiresOnUtc = DateTimeOffset.UtcNow.AddMonths(1)
         };
+    }
+
+    private static ProvisionAutopilotStep CreateStep()
+    {
+        return new ProvisionAutopilotStep(new FakeAutopilotHardwareHashCaptureService());
     }
 
     private static DeploymentStepExecutionContext CreateContext(
@@ -252,6 +258,24 @@ public sealed class ProvisionAutopilotStepTests
         public Task<int?> GetDiskNumberForPathAsync(string path, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<int?>(null);
+        }
+    }
+
+    private sealed class FakeAutopilotHardwareHashCaptureService : IAutopilotHardwareHashCaptureService
+    {
+        public Task<AutopilotHardwareHashCaptureResult> CaptureAsync(
+            AutopilotHardwareHashCaptureRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            Directory.CreateDirectory(request.DiagnosticsRootPath);
+            string oa3XmlPath = Path.Combine(request.DiagnosticsRootPath, "OA3.xml");
+            string oa3LogPath = Path.Combine(request.DiagnosticsRootPath, "OA3.log");
+            string csvPath = Path.Combine(request.DiagnosticsRootPath, "AutopilotHWID.csv");
+            File.WriteAllText(oa3XmlPath, "<Key />");
+            File.WriteAllText(oa3LogPath, "oa3");
+            File.WriteAllText(csvPath, "csv");
+            AutopilotHardwareHashDeviceIdentity identity = new("SER123", "HASHVALUE", request.GroupTag);
+            return Task.FromResult(AutopilotHardwareHashCaptureResult.Succeeded(identity, oa3XmlPath, oa3LogPath, csvPath));
         }
     }
 

--- a/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
@@ -97,6 +97,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IPreOobeScriptProvisioningService, PreOobeScriptProvisioningService>();
         services.AddSingleton<PreOobeScriptDefinitionBuilder>();
         services.AddSingleton<IAutopilotProfileCatalogService, AutopilotProfileCatalogService>();
+        services.AddSingleton<IAutopilotHardwareHashCaptureService, AutopilotHardwareHashCaptureService>();
         services.AddSingleton<IDeploymentStep, GatherDeploymentVariablesStep>();
         services.AddSingleton<IDeploymentStep, InitializeDeploymentWorkspaceStep>();
         services.AddSingleton<IDeploymentStep, ValidateTargetConfigurationStep>();

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashCaptureFailureCode.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashCaptureFailureCode.cs
@@ -1,0 +1,57 @@
+namespace Foundry.Deploy.Services.Autopilot;
+
+/// <summary>
+/// Describes the capture-stage failure that occurred before Microsoft Graph upload can run.
+/// </summary>
+public enum AutopilotHardwareHashCaptureFailureCode
+{
+    /// <summary>
+    /// The capture operation completed successfully.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// OA3Tool was not staged into the boot media runtime tools folder.
+    /// </summary>
+    ToolMissing,
+
+    /// <summary>
+    /// OA3Tool exited with a non-zero code.
+    /// </summary>
+    ToolFailed,
+
+    /// <summary>
+    /// The applied Windows image does not contain the required PCPKsp support library.
+    /// </summary>
+    SupportLibraryMissing,
+
+    /// <summary>
+    /// The PCPKsp support library could not be copied into the active WinPE System32 folder.
+    /// </summary>
+    SupportLibraryCopyFailed,
+
+    /// <summary>
+    /// OA3Tool could not load the copied PCPKsp support library.
+    /// </summary>
+    SupportLibraryLoadFailed,
+
+    /// <summary>
+    /// OA3Tool did not create the expected OA3 report XML.
+    /// </summary>
+    ReportMissing,
+
+    /// <summary>
+    /// The OA3 report XML could not be parsed.
+    /// </summary>
+    ReportInvalid,
+
+    /// <summary>
+    /// The OA3 report XML did not contain a hardware hash.
+    /// </summary>
+    HashMissing,
+
+    /// <summary>
+    /// The OA3 report XML did not contain a device serial number.
+    /// </summary>
+    SerialMissing
+}

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashCaptureRequest.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashCaptureRequest.cs
@@ -1,0 +1,32 @@
+namespace Foundry.Deploy.Services.Autopilot;
+
+/// <summary>
+/// Provides the file-system roots required to capture an Autopilot hardware hash in WinPE.
+/// </summary>
+public sealed record AutopilotHardwareHashCaptureRequest
+{
+    /// <summary>
+    /// Gets the root of the applied offline Windows image.
+    /// </summary>
+    public string TargetWindowsRootPath { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the active WinPE Windows root that receives PCPKsp.dll before OA3Tool runs.
+    /// </summary>
+    public string WinPeWindowsRootPath { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the active Foundry runtime root, normally X:\Foundry.
+    /// </summary>
+    public string WorkspaceRootPath { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the retained diagnostic artifact folder under the applied Windows image.
+    /// </summary>
+    public string DiagnosticsRootPath { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the optional group tag selected by the operator.
+    /// </summary>
+    public string? GroupTag { get; init; }
+}

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashCaptureResult.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashCaptureResult.cs
@@ -1,0 +1,76 @@
+namespace Foundry.Deploy.Services.Autopilot;
+
+/// <summary>
+/// Represents the sanitized result of the WinPE Autopilot hardware hash capture stage.
+/// </summary>
+public sealed record AutopilotHardwareHashCaptureResult
+{
+    /// <summary>
+    /// Gets whether OA3Tool produced a usable hardware hash report.
+    /// </summary>
+    public bool IsSuccess => FailureCode == AutopilotHardwareHashCaptureFailureCode.None;
+
+    /// <summary>
+    /// Gets the structured failure code when capture did not complete.
+    /// </summary>
+    public AutopilotHardwareHashCaptureFailureCode FailureCode { get; init; }
+
+    /// <summary>
+    /// Gets the operator-facing capture status message.
+    /// </summary>
+    public string Message { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the captured device identity when capture succeeds.
+    /// </summary>
+    public AutopilotHardwareHashDeviceIdentity? Identity { get; init; }
+
+    /// <summary>
+    /// Gets the retained OA3 XML path when available.
+    /// </summary>
+    public string? Oa3XmlPath { get; init; }
+
+    /// <summary>
+    /// Gets the retained OA3 log path when available.
+    /// </summary>
+    public string? Oa3LogPath { get; init; }
+
+    /// <summary>
+    /// Gets the retained CSV path when available.
+    /// </summary>
+    public string? CsvPath { get; init; }
+
+    /// <summary>
+    /// Creates a successful capture result.
+    /// </summary>
+    public static AutopilotHardwareHashCaptureResult Succeeded(
+        AutopilotHardwareHashDeviceIdentity identity,
+        string oa3XmlPath,
+        string? oa3LogPath,
+        string csvPath)
+    {
+        return new AutopilotHardwareHashCaptureResult
+        {
+            FailureCode = AutopilotHardwareHashCaptureFailureCode.None,
+            Message = "Autopilot hardware hash captured.",
+            Identity = identity,
+            Oa3XmlPath = oa3XmlPath,
+            Oa3LogPath = oa3LogPath,
+            CsvPath = csvPath
+        };
+    }
+
+    /// <summary>
+    /// Creates a failed capture result with no secret material.
+    /// </summary>
+    public static AutopilotHardwareHashCaptureResult Failed(
+        AutopilotHardwareHashCaptureFailureCode failureCode,
+        string message)
+    {
+        return new AutopilotHardwareHashCaptureResult
+        {
+            FailureCode = failureCode,
+            Message = message
+        };
+    }
+}

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashCaptureService.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashCaptureService.cs
@@ -1,0 +1,201 @@
+using System.IO;
+using System.Text;
+using Foundry.Deploy.Services.System;
+using Microsoft.Extensions.Logging;
+
+namespace Foundry.Deploy.Services.Autopilot;
+
+/// <summary>
+/// Orchestrates the local WinPE OA3Tool capture workflow and retains troubleshooting artifacts.
+/// </summary>
+public sealed class AutopilotHardwareHashCaptureService(
+    IProcessRunner processRunner,
+    ILogger<AutopilotHardwareHashCaptureService> logger) : IAutopilotHardwareHashCaptureService
+{
+    private const string PcpKspFileName = "PCPKsp.dll";
+    private const string Oa3ToolRelativePath = @"Tools\OA3\oa3tool.exe";
+    private const string RuntimeHashRelativePath = @"Runtime\AutopilotHash";
+    private const string Oa3ConfigFileName = "OA3.cfg";
+    private const string Oa3InputFileName = "input.xml";
+    private const string Oa3XmlFileName = "OA3.xml";
+    private const string Oa3LogFileName = "OA3.log";
+    private const string CsvFileName = "AutopilotHWID.csv";
+    private static readonly UTF8Encoding Utf8NoBom = new(false);
+
+    private static readonly string Oa3ConfigContent = """
+        [OA3Tool]
+        InputXML=input.xml
+        OutputXML=OA3.xml
+        """;
+
+    private static readonly string Oa3InputContent = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <Key />
+        """;
+
+    /// <inheritdoc />
+    public async Task<AutopilotHardwareHashCaptureResult> CaptureAsync(
+        AutopilotHardwareHashCaptureRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        string runtimeHashRoot = Path.Combine(request.WorkspaceRootPath, RuntimeHashRelativePath);
+        string oa3ToolPath = Path.Combine(request.WorkspaceRootPath, Oa3ToolRelativePath);
+        string sourcePcpKspPath = Path.Combine(request.TargetWindowsRootPath, "Windows", "System32", PcpKspFileName);
+        string destinationPcpKspPath = Path.Combine(request.WinPeWindowsRootPath, "System32", PcpKspFileName);
+
+        Directory.CreateDirectory(runtimeHashRoot);
+        Directory.CreateDirectory(request.DiagnosticsRootPath);
+
+        if (!File.Exists(oa3ToolPath))
+        {
+            return AutopilotHardwareHashCaptureResult.Failed(
+                AutopilotHardwareHashCaptureFailureCode.ToolMissing,
+                $"OA3Tool was not found at '{oa3ToolPath}'.");
+        }
+
+        if (!File.Exists(sourcePcpKspPath))
+        {
+            return AutopilotHardwareHashCaptureResult.Failed(
+                AutopilotHardwareHashCaptureFailureCode.SupportLibraryMissing,
+                $"Required support library was not found at '{sourcePcpKspPath}'.");
+        }
+
+        try
+        {
+            string? destinationDirectory = Path.GetDirectoryName(destinationPcpKspPath);
+            if (!string.IsNullOrWhiteSpace(destinationDirectory))
+            {
+                Directory.CreateDirectory(destinationDirectory);
+            }
+
+            File.Copy(sourcePcpKspPath, destinationPcpKspPath, overwrite: true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            logger.LogWarning(ex, "Failed to copy PCPKsp.dll into the active WinPE System32 folder.");
+            return AutopilotHardwareHashCaptureResult.Failed(
+                AutopilotHardwareHashCaptureFailureCode.SupportLibraryCopyFailed,
+                $"Required support library could not be copied to '{destinationPcpKspPath}': {ex.Message}");
+        }
+
+        await WriteOa3InputsAsync(runtimeHashRoot, cancellationToken).ConfigureAwait(false);
+
+        ProcessExecutionResult execution = await processRunner
+            .RunAsync(
+                oa3ToolPath,
+                ["/Report", "/ConfigFile=.\\OA3.cfg", "/NoKeyCheck", "/LogTrace=.\\OA3.log"],
+                runtimeHashRoot,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!execution.IsSuccess)
+        {
+            return AutopilotHardwareHashCaptureResult.Failed(
+                ResolveToolFailureCode(execution),
+                BuildProcessFailureMessage(execution));
+        }
+
+        string oa3XmlPath = Path.Combine(runtimeHashRoot, Oa3XmlFileName);
+        if (!File.Exists(oa3XmlPath))
+        {
+            return AutopilotHardwareHashCaptureResult.Failed(
+                AutopilotHardwareHashCaptureFailureCode.ReportMissing,
+                "OA3Tool did not create OA3.xml.");
+        }
+
+        string oa3Xml = await File.ReadAllTextAsync(oa3XmlPath, cancellationToken).ConfigureAwait(false);
+        AutopilotHardwareHashParseResult parseResult = AutopilotOa3XmlParser.Parse(oa3Xml);
+        if (!parseResult.IsSuccess || parseResult.Identity is null)
+        {
+            return AutopilotHardwareHashCaptureResult.Failed(parseResult.FailureCode, parseResult.Message);
+        }
+
+        AutopilotHardwareHashDeviceIdentity identity = parseResult.Identity with
+        {
+            GroupTag = request.GroupTag
+        };
+        string csvPath = Path.Combine(runtimeHashRoot, CsvFileName);
+        await AutopilotHardwareHashCsvWriter.WriteAsync(csvPath, identity, cancellationToken).ConfigureAwait(false);
+
+        string retainedOa3XmlPath = await CopyIfExistsAsync(oa3XmlPath, request.DiagnosticsRootPath, cancellationToken).ConfigureAwait(false);
+        string? retainedOa3LogPath = await CopyOptionalAsync(
+            Path.Combine(runtimeHashRoot, Oa3LogFileName),
+            request.DiagnosticsRootPath,
+            cancellationToken).ConfigureAwait(false);
+        string retainedCsvPath = await CopyIfExistsAsync(csvPath, request.DiagnosticsRootPath, cancellationToken).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "Autopilot hardware hash captured. DiagnosticsPath={DiagnosticsPath}, SerialNumber={SerialNumber}.",
+            request.DiagnosticsRootPath,
+            identity.SerialNumber);
+
+        return AutopilotHardwareHashCaptureResult.Succeeded(
+            identity,
+            retainedOa3XmlPath,
+            retainedOa3LogPath,
+            retainedCsvPath);
+    }
+
+    private static async Task WriteOa3InputsAsync(string runtimeHashRoot, CancellationToken cancellationToken)
+    {
+        await File.WriteAllTextAsync(
+            Path.Combine(runtimeHashRoot, Oa3ConfigFileName),
+            Oa3ConfigContent,
+            Utf8NoBom,
+            cancellationToken).ConfigureAwait(false);
+        await File.WriteAllTextAsync(
+            Path.Combine(runtimeHashRoot, Oa3InputFileName),
+            Oa3InputContent,
+            Utf8NoBom,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<string> CopyIfExistsAsync(
+        string sourcePath,
+        string destinationDirectory,
+        CancellationToken cancellationToken)
+    {
+        string? copiedPath = await CopyOptionalAsync(sourcePath, destinationDirectory, cancellationToken).ConfigureAwait(false);
+        return copiedPath ?? sourcePath;
+    }
+
+    private static async Task<string?> CopyOptionalAsync(
+        string sourcePath,
+        string destinationDirectory,
+        CancellationToken cancellationToken)
+    {
+        if (!File.Exists(sourcePath))
+        {
+            return null;
+        }
+
+        Directory.CreateDirectory(destinationDirectory);
+        string destinationPath = Path.Combine(destinationDirectory, Path.GetFileName(sourcePath));
+        await using FileStream source = File.OpenRead(sourcePath);
+        await using FileStream destination = File.Create(destinationPath);
+        await source.CopyToAsync(destination, cancellationToken).ConfigureAwait(false);
+        return destinationPath;
+    }
+
+    private static string BuildProcessFailureMessage(ProcessExecutionResult execution)
+    {
+        string details = string.IsNullOrWhiteSpace(execution.StandardError)
+            ? execution.StandardOutput
+            : execution.StandardError;
+        return string.IsNullOrWhiteSpace(details)
+            ? $"OA3Tool exited with code {execution.ExitCode}."
+            : $"OA3Tool exited with code {execution.ExitCode}: {details.Trim()}";
+    }
+
+    private static AutopilotHardwareHashCaptureFailureCode ResolveToolFailureCode(ProcessExecutionResult execution)
+    {
+        string combinedOutput = string.Concat(execution.StandardOutput, " ", execution.StandardError);
+        return combinedOutput.Contains(PcpKspFileName, StringComparison.OrdinalIgnoreCase) ||
+               combinedOutput.Contains("load", StringComparison.OrdinalIgnoreCase) &&
+               combinedOutput.Contains("provider", StringComparison.OrdinalIgnoreCase)
+            ? AutopilotHardwareHashCaptureFailureCode.SupportLibraryLoadFailed
+            : AutopilotHardwareHashCaptureFailureCode.ToolFailed;
+    }
+}

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashCsvWriter.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashCsvWriter.cs
@@ -1,0 +1,47 @@
+using System.IO;
+using System.Text;
+
+namespace Foundry.Deploy.Services.Autopilot;
+
+/// <summary>
+/// Writes the troubleshooting CSV in the Intune Autopilot hardware hash import shape.
+/// </summary>
+public static class AutopilotHardwareHashCsvWriter
+{
+    private static readonly UTF8Encoding Utf8NoBom = new(false);
+
+    /// <summary>
+    /// Writes a single-device Autopilot hardware hash CSV without quoting or additional columns.
+    /// </summary>
+    /// <param name="path">Destination CSV path.</param>
+    /// <param name="identity">Captured device identity.</param>
+    /// <param name="cancellationToken">Token that cancels the write.</param>
+    public static async Task WriteAsync(
+        string path,
+        AutopilotHardwareHashDeviceIdentity identity,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(identity);
+
+        string? directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        string csv = string.Join(
+            "\r\n",
+            "Device Serial Number,Windows Product ID,Hardware Hash,Group Tag",
+            $"{SanitizeCsvField(identity.SerialNumber)},,{SanitizeCsvField(identity.HardwareHash)},{SanitizeCsvField(identity.GroupTag)}",
+            string.Empty);
+
+        await File.WriteAllTextAsync(path, csv, Utf8NoBom, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string SanitizeCsvField(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value)
+            ? string.Empty
+            : value.Replace(",", string.Empty, StringComparison.Ordinal).Trim();
+    }
+}

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashDeviceIdentity.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashDeviceIdentity.cs
@@ -1,0 +1,12 @@
+namespace Foundry.Deploy.Services.Autopilot;
+
+/// <summary>
+/// Contains the device identity values captured by OA3Tool and used by Autopilot import.
+/// </summary>
+/// <param name="SerialNumber">Device serial number reported by the OA3 hardware report.</param>
+/// <param name="HardwareHash">Autopilot hardware hash reported by OA3Tool.</param>
+/// <param name="GroupTag">Optional Autopilot group tag selected by the operator.</param>
+public sealed record AutopilotHardwareHashDeviceIdentity(
+    string SerialNumber,
+    string HardwareHash,
+    string? GroupTag);

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashParseResult.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashParseResult.cs
@@ -1,0 +1,27 @@
+namespace Foundry.Deploy.Services.Autopilot;
+
+/// <summary>
+/// Represents OA3 XML parsing output without retaining the full report in memory longer than needed.
+/// </summary>
+public sealed record AutopilotHardwareHashParseResult
+{
+    /// <summary>
+    /// Gets whether the OA3 report contained the required values.
+    /// </summary>
+    public bool IsSuccess => FailureCode == AutopilotHardwareHashCaptureFailureCode.None;
+
+    /// <summary>
+    /// Gets the parser failure code.
+    /// </summary>
+    public AutopilotHardwareHashCaptureFailureCode FailureCode { get; init; }
+
+    /// <summary>
+    /// Gets the parsed identity when the report is valid.
+    /// </summary>
+    public AutopilotHardwareHashDeviceIdentity? Identity { get; init; }
+
+    /// <summary>
+    /// Gets a sanitized parser message.
+    /// </summary>
+    public string Message { get; init; } = string.Empty;
+}

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotOa3XmlParser.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotOa3XmlParser.cs
@@ -1,0 +1,80 @@
+using System.Xml.Linq;
+
+namespace Foundry.Deploy.Services.Autopilot;
+
+/// <summary>
+/// Parses the OA3Tool hardware report produced in WinPE.
+/// </summary>
+public static class AutopilotOa3XmlParser
+{
+    /// <summary>
+    /// Parses the required serial number and hardware hash from OA3.xml content.
+    /// </summary>
+    /// <param name="xml">OA3 report XML content.</param>
+    /// <returns>A structured parser result.</returns>
+    public static AutopilotHardwareHashParseResult Parse(string xml)
+    {
+        if (string.IsNullOrWhiteSpace(xml))
+        {
+            return Failed(AutopilotHardwareHashCaptureFailureCode.ReportInvalid, "OA3 report is empty.");
+        }
+
+        XDocument document;
+        try
+        {
+            document = XDocument.Parse(xml);
+        }
+        catch (Exception ex) when (ex is global::System.Xml.XmlException or InvalidOperationException)
+        {
+            return Failed(AutopilotHardwareHashCaptureFailureCode.ReportInvalid, $"OA3 report XML is invalid: {ex.Message}");
+        }
+
+        string serialNumber = FindValue(document, "SerialNumber", "DeviceSerialNumber", "Serial");
+        if (string.IsNullOrWhiteSpace(serialNumber))
+        {
+            return Failed(AutopilotHardwareHashCaptureFailureCode.SerialMissing, "OA3 report does not contain a serial number.");
+        }
+
+        string hardwareHash = FindValue(document, "HardwareHash", "HardwareIdentifier", "HardwareId");
+        if (string.IsNullOrWhiteSpace(hardwareHash))
+        {
+            return Failed(AutopilotHardwareHashCaptureFailureCode.HashMissing, "OA3 report does not contain a hardware hash.");
+        }
+
+        return new AutopilotHardwareHashParseResult
+        {
+            FailureCode = AutopilotHardwareHashCaptureFailureCode.None,
+            Identity = new AutopilotHardwareHashDeviceIdentity(serialNumber.Trim(), hardwareHash.Trim(), null),
+            Message = "OA3 report parsed."
+        };
+    }
+
+    private static AutopilotHardwareHashParseResult Failed(
+        AutopilotHardwareHashCaptureFailureCode failureCode,
+        string message)
+    {
+        return new AutopilotHardwareHashParseResult
+        {
+            FailureCode = failureCode,
+            Message = message
+        };
+    }
+
+    private static string FindValue(XDocument document, params string[] localNames)
+    {
+        foreach (string localName in localNames)
+        {
+            string? value = document
+                .Descendants()
+                .FirstOrDefault(element => element.Name.LocalName.Equals(localName, StringComparison.OrdinalIgnoreCase))
+                ?.Value;
+
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return string.Empty;
+    }
+}

--- a/src/Foundry.Deploy/Services/Autopilot/IAutopilotHardwareHashCaptureService.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/IAutopilotHardwareHashCaptureService.cs
@@ -1,0 +1,17 @@
+namespace Foundry.Deploy.Services.Autopilot;
+
+/// <summary>
+/// Captures an Autopilot hardware hash from WinPE without using PowerShell implementation logic.
+/// </summary>
+public interface IAutopilotHardwareHashCaptureService
+{
+    /// <summary>
+    /// Copies required support files, runs OA3Tool, parses OA3.xml, and retains sanitized diagnostics.
+    /// </summary>
+    /// <param name="request">Capture file-system roots and optional group tag.</param>
+    /// <param name="cancellationToken">Token that cancels file and process work.</param>
+    /// <returns>The structured capture result.</returns>
+    Task<AutopilotHardwareHashCaptureResult> CaptureAsync(
+        AutopilotHardwareHashCaptureRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Foundry.Deploy/Services/Deployment/AutopilotHardwareHashUploadState.cs
+++ b/src/Foundry.Deploy/Services/Deployment/AutopilotHardwareHashUploadState.cs
@@ -21,9 +21,9 @@ public enum AutopilotHardwareHashUploadState
     DryRunPrepared,
 
     /// <summary>
-    /// Runtime branching reached the hash path and later hash capture support must continue the workflow.
+    /// OA3Tool captured the hardware hash and retained local diagnostics; Graph upload is not yet complete.
     /// </summary>
-    PendingHashCapture,
+    HashCaptured,
 
     /// <summary>
     /// Hardware hash upload was skipped because the media certificate is expired.

--- a/src/Foundry.Deploy/Services/Deployment/Steps/ProvisionAutopilotStep.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Steps/ProvisionAutopilotStep.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Text.Json;
 using Foundry.Deploy.Models.Configuration;
+using Foundry.Deploy.Services.Autopilot;
 using Foundry.Deploy.Services.Logging;
 
 namespace Foundry.Deploy.Services.Deployment.Steps;
@@ -13,6 +14,14 @@ public sealed class ProvisionAutopilotStep : DeploymentStepBase
     private const string TargetConfigurationRelativePath = @"Windows\Provisioning\Autopilot\AutopilotConfigurationFile.json";
     private const string HardwareHashDiagnosticsFolderName = "AutopilotHash";
     private const string HardwareHashStatusFileName = "autopilot-hash-upload-status.json";
+    private const string WinPeWindowsFolderName = "Windows";
+
+    private readonly IAutopilotHardwareHashCaptureService _hardwareHashCaptureService;
+
+    public ProvisionAutopilotStep(IAutopilotHardwareHashCaptureService hardwareHashCaptureService)
+    {
+        _hardwareHashCaptureService = hardwareHashCaptureService;
+    }
 
     public override int Order => 18;
 
@@ -123,7 +132,7 @@ public sealed class ProvisionAutopilotStep : DeploymentStepBase
         return DeploymentStepResult.Succeeded("Autopilot profile staged (simulation).");
     }
 
-    private static async Task<DeploymentStepResult> PrepareHardwareHashUploadAsync(
+    private async Task<DeploymentStepResult> PrepareHardwareHashUploadAsync(
         DeploymentStepExecutionContext context,
         bool dryRun,
         CancellationToken cancellationToken)
@@ -166,17 +175,46 @@ public sealed class ProvisionAutopilotStep : DeploymentStepBase
             return await WriteDryRunHardwareHashManifestAsync(context, cancellationToken).ConfigureAwait(false);
         }
 
-        const string plannedMessage = "Autopilot hardware hash upload will run after hash capture support is available.";
+        string diagnosticsPath = ResolveHardwareHashDiagnosticsPath(context);
+        context.EmitCurrentStepIndeterminate("Capturing Autopilot hardware hash...", "Running OA3Tool...");
+        AutopilotHardwareHashCaptureResult captureResult = await _hardwareHashCaptureService
+            .CaptureAsync(
+                new AutopilotHardwareHashCaptureRequest
+                {
+                    TargetWindowsRootPath = context.RuntimeState.TargetWindowsPartitionRoot!,
+                    WinPeWindowsRootPath = ResolveWinPeWindowsRoot(context.RuntimeState.WorkspaceRoot),
+                    WorkspaceRootPath = context.RuntimeState.WorkspaceRoot,
+                    DiagnosticsRootPath = diagnosticsPath,
+                    GroupTag = context.RuntimeState.AutopilotHardwareHashGroupTag
+                },
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!captureResult.IsSuccess)
+        {
+            string failureMessage = $"Autopilot hardware hash capture failed: {captureResult.Message}";
+            await WriteHardwareHashStatusAsync(
+                context,
+                AutopilotHardwareHashUploadState.CaptureFailed,
+                failureMessage,
+                cancellationToken,
+                captureResult.FailureCode.ToString()).ConfigureAwait(false);
+            return DeploymentStepResult.Failed(failureMessage);
+        }
+
+        string capturedMessage = "Autopilot hardware hash captured. Graph upload will run in a later phase.";
         await WriteHardwareHashStatusAsync(
             context,
-            AutopilotHardwareHashUploadState.PendingHashCapture,
-            plannedMessage,
-            cancellationToken).ConfigureAwait(false);
+            AutopilotHardwareHashUploadState.HashCaptured,
+            capturedMessage,
+            cancellationToken,
+            failureCode: null,
+            captureResult).ConfigureAwait(false);
         await context.AppendLogAsync(
             DeploymentLogLevel.Info,
-            $"Autopilot hardware hash upload planned. DiagnosticsPath='{context.RuntimeState.AutopilotHardwareHashDiagnosticsPath}', GroupTag='{FormatGroupTagForLog(context.RuntimeState.AutopilotHardwareHashGroupTag)}'.",
+            $"Autopilot hardware hash captured. DiagnosticsPath='{context.RuntimeState.AutopilotHardwareHashDiagnosticsPath}', GroupTag='{FormatGroupTagForLog(context.RuntimeState.AutopilotHardwareHashGroupTag)}'.",
             cancellationToken).ConfigureAwait(false);
-        return DeploymentStepResult.Succeeded("Autopilot hardware hash upload planned.");
+        return DeploymentStepResult.Succeeded("Autopilot hardware hash captured.");
     }
 
     private static async Task<DeploymentStepResult> WriteDryRunHardwareHashManifestAsync(
@@ -225,7 +263,9 @@ public sealed class ProvisionAutopilotStep : DeploymentStepBase
         DeploymentStepExecutionContext context,
         AutopilotHardwareHashUploadState state,
         string message,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        string? failureCode = null,
+        AutopilotHardwareHashCaptureResult? captureResult = null)
     {
         string diagnosticsPath = ResolveHardwareHashDiagnosticsPath(context);
         Directory.CreateDirectory(diagnosticsPath);
@@ -240,7 +280,12 @@ public sealed class ProvisionAutopilotStep : DeploymentStepBase
             provisioningMode = "hardwareHashUpload",
             uploadState = state.ToString(),
             message,
+            failureCode,
             groupTag = context.RuntimeState.AutopilotHardwareHashGroupTag,
+            serialNumber = captureResult?.Identity?.SerialNumber,
+            oa3XmlPath = captureResult?.Oa3XmlPath,
+            oa3LogPath = captureResult?.Oa3LogPath,
+            autopilotHwidCsvPath = captureResult?.CsvPath,
             tenantId = context.Request.AutopilotHardwareHashUpload.TenantId,
             clientId = context.Request.AutopilotHardwareHashUpload.ClientId,
             activeCertificateThumbprint = context.Request.AutopilotHardwareHashUpload.ActiveCertificateThumbprint,
@@ -270,6 +315,15 @@ public sealed class ProvisionAutopilotStep : DeploymentStepBase
         }
 
         return Path.Combine(context.EnsureTargetFoundryRoot(), "Logs", HardwareHashDiagnosticsFolderName);
+    }
+
+    private static string ResolveWinPeWindowsRoot(string workspaceRoot)
+    {
+        string fullWorkspaceRoot = Path.GetFullPath(workspaceRoot);
+        string? driveRoot = Path.GetPathRoot(fullWorkspaceRoot);
+        return string.IsNullOrWhiteSpace(driveRoot)
+            ? Path.Combine(fullWorkspaceRoot, "..", WinPeWindowsFolderName)
+            : Path.Combine(driveRoot, WinPeWindowsFolderName);
     }
 
     private static bool HasRequiredHardwareHashMetadata(DeployAutopilotHardwareHashUploadSettings settings)


### PR DESCRIPTION
Summary
- Adds the C# WinPE hardware hash capture service for OA3Tool.
- Copies PCPKsp.dll from the applied Windows image into the active WinPE System32 folder before capture.
- Parses OA3.xml and retains OA3 XML, OA3 log, and AutopilotHWID.csv diagnostics.

Reason
- Phase 6 needs Foundry Deploy to capture a usable Autopilot hardware hash locally before Phase 7 adds Microsoft Graph import.

Main changes
- Adds Autopilot hardware hash capture request/result/failure contracts.
- Adds OA3Tool process orchestration, PCPKsp.dll copy, OA3.xml parsing, and CSV artifact writing.
- Wires ProvisionAutopilotStep to run capture in live hardware-hash mode.
- Updates runtime status to HashCaptured and records sanitized diagnostics metadata.
- Updates Phase 6 plan progress and adds focused tests.

Testing notes
- dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --configuration Debug /p:Platform=x64 --no-restore --filter "FullyQualifiedName~AutopilotHardwareHash|ProvisionAutopilotStepTests" --verbosity minimal
- dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --configuration Debug /p:Platform=x64 --no-restore --verbosity minimal
- dotnet build .\src\Foundry.Deploy\Foundry.Deploy.csproj --configuration Debug /p:Platform=x64 --no-restore --verbosity minimal
- git diff --check