### PR TITLE
feat(autopilot): import hardware hashes with Graph

### DIFF
--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -456,7 +456,7 @@ Implementation progress:
 - [x] Implementation checklist complete.
 - [x] Automated tests complete.
 - [x] Manual checks complete or explicitly deferred.
-- [ ] PR opened with the planned title.
+- [x] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
 - [x] Add a minimal Graph Autopilot import client.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -452,41 +452,43 @@ Manual runtime validation remains deferred to physical x64 and ARM64 media runs.
 PR title: `feat(autopilot): import hardware hashes with Graph`
 
 Implementation progress:
-- [ ] Phase branch created from `feature/autopilot-hash-upload-foundation`.
-- [ ] Implementation checklist complete.
-- [ ] Automated tests complete.
-- [ ] Manual checks complete or explicitly deferred.
+- [x] Phase branch created from `feature/autopilot-hash-upload-foundation`.
+- [x] Implementation checklist complete.
+- [x] Automated tests complete.
+- [x] Manual checks complete or explicitly deferred.
 - [ ] PR opened with the planned title.
 - [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
-- [ ] Add a minimal Graph Autopilot import client.
-- [ ] Add certificate-based credential creation from decrypted in-memory certificate material.
-- [ ] Reject any non-certificate authentication mode in WinPE.
-- [ ] Implement import request.
-- [ ] Implement polling for import completion.
-- [ ] Implement polling until the uploaded serial number appears in Windows Autopilot devices.
-- [ ] Add a 10-minute default timeout for Windows Autopilot device visibility polling.
-- [ ] Map Graph errors to operator-readable messages.
-- [ ] Add retry/backoff for transient HTTP failures.
-- [ ] Treat certificate, tenant, token, consent, permission, Conditional Access, Intune availability, Graph connectivity, `ImportFailed`, duplicate import, and `ImportTimedOut` states as non-blocking Autopilot failures that continue OS deployment.
-- [ ] Keep destructive cleanup out of the final hash upload workflow.
-- [ ] Sanitize `AutopilotUploadResult.json` before retaining it in `Windows\Temp\Foundry`.
-- [ ] Add XML documentation comments to new public Graph client, import polling, and retry-policy APIs.
+- [x] Add a minimal Graph Autopilot import client.
+- [x] Add certificate-based credential creation from decrypted in-memory certificate material.
+- [x] Reject any non-certificate authentication mode in WinPE.
+- [x] Implement import request.
+- [x] Implement polling for import completion.
+- [x] Implement polling until the uploaded serial number appears in Windows Autopilot devices.
+- [x] Add a 10-minute default timeout for Windows Autopilot device visibility polling.
+- [x] Map Graph errors to operator-readable messages.
+- [x] Add retry/backoff for transient HTTP failures.
+- [x] Treat certificate, tenant, token, consent, permission, Conditional Access, Intune availability, Graph connectivity, `ImportFailed`, duplicate import, and `ImportTimedOut` states as non-blocking Autopilot failures that continue OS deployment.
+- [x] Keep destructive cleanup out of the final hash upload workflow.
+- [x] Sanitize `AutopilotUploadResult.json` before retaining it in `Windows\Temp\Foundry`.
+- [x] Add XML documentation comments to new public Graph client, import polling, and retry-policy APIs.
 
 Automated tests:
-- [ ] Serializes import payload correctly.
-- [ ] Sends hardware identifier in the expected Graph format.
-- [ ] Decrypts PFX material in memory and does not write a decrypted PFX, PFX password, or private key to disk.
-- [ ] Fails clearly when tenant ID, client ID, certificate thumbprint, or encrypted certificate material is missing.
-- [ ] Treats certificate, tenant, token, permission, consent, Conditional Access, Intune availability, and Graph connectivity failures as skipped Autopilot, not failed deployment.
-- [ ] Treats duplicate import errors, `ImportFailed`, and `ImportTimedOut` as Autopilot warnings/failures that do not stop OS deployment.
-- [ ] Handles `complete`.
-- [ ] Handles imported identity completion followed by Windows Autopilot device visibility.
-- [ ] Handles Windows Autopilot device visibility timeout as an automatic warning/non-blocking continuation to the next deployment step.
-- [ ] Handles `error` with device error code/name.
-- [ ] Times out with a clear message.
-- [ ] Retries transient failures only.
-- [ ] Sanitized upload result omits access tokens, authorization headers, raw request bodies, raw response bodies, PFX bytes, passwords, private key material, and full certificate data.
+- [x] Serializes import payload correctly.
+- [x] Sends hardware identifier in the expected Graph format.
+- [x] Decrypts PFX material in memory and does not write a decrypted PFX, PFX password, or private key to disk.
+- [x] Fails clearly when tenant ID, client ID, certificate thumbprint, or encrypted certificate material is missing.
+- [x] Treats certificate, tenant, token, permission, consent, Conditional Access, Intune availability, and Graph connectivity failures as skipped Autopilot, not failed deployment.
+- [x] Treats duplicate import errors, `ImportFailed`, and `ImportTimedOut` as Autopilot warnings/failures that do not stop OS deployment.
+- [x] Handles `complete`.
+- [x] Handles imported identity completion followed by Windows Autopilot device visibility.
+- [x] Handles Windows Autopilot device visibility timeout as an automatic warning/non-blocking continuation to the next deployment step.
+- [x] Handles `error` with device error code/name.
+- [x] Times out with a clear message.
+- [x] Retries transient failures only.
+- [x] Sanitized upload result omits access tokens, authorization headers, raw request bodies, raw response bodies, PFX bytes, passwords, private key material, and full certificate data.
+
+Manual checks are deferred until a physical WinPE run against a test Intune tenant is available. The automated Phase 7 coverage validates Graph payload shape, retry behavior, import/device polling states, non-blocking deployment continuation, certificate assertion creation, media secret decryption, and sanitized retained result output.
 
 Manual checks:
 - [ ] Import one test device into a test tenant.

--- a/src/Foundry.Deploy.Tests/AutopilotGraphImportClientTests.cs
+++ b/src/Foundry.Deploy.Tests/AutopilotGraphImportClientTests.cs
@@ -1,0 +1,288 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Foundry.Deploy.Services.Autopilot;
+using Foundry.Deploy.Services.Deployment;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class AutopilotGraphImportClientTests
+{
+    [Fact]
+    public async Task ImportHardwareHashAsync_SerializesGraphImportPayload()
+    {
+        var handler = new QueuedGraphHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            {
+              "value": [
+                {
+                  "id": "imported-id",
+                  "serialNumber": "SER123",
+                  "importId": "import-123",
+                  "state": { "deviceImportStatus": "complete" }
+                }
+              ]
+            }
+            """);
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            {
+              "value": [
+                { "id": "device-id", "serialNumber": "SER123" }
+              ]
+            }
+            """);
+
+        AutopilotGraphImportClient client = CreateClient(handler);
+
+        AutopilotHardwareHashUploadResult result = await client.ImportHardwareHashAsync(
+            new AutopilotGraphImportRequest(
+                "access-token",
+                "SER123",
+                "aGFyZHdhcmVIYXNo",
+                "Sales",
+                null,
+                "import-123"),
+            CancellationToken.None);
+
+        Assert.Equal(AutopilotHardwareHashUploadState.Completed, result.State);
+        RecordedGraphRequest importRequest = handler.Requests[0];
+        Assert.Equal(HttpMethod.Post, importRequest.Method);
+        Assert.Equal("/v1.0/deviceManagement/importedWindowsAutopilotDeviceIdentities/import", importRequest.PathAndQuery);
+        Assert.Equal(new AuthenticationHeaderValue("Bearer", "access-token").ToString(), importRequest.Authorization);
+
+        using JsonDocument body = JsonDocument.Parse(importRequest.Body!);
+        JsonElement importedDevice = body.RootElement
+            .GetProperty("importedWindowsAutopilotDeviceIdentities")[0];
+        Assert.Equal("#microsoft.graph.importedWindowsAutopilotDeviceIdentity", importedDevice.GetProperty("@odata.type").GetString());
+        Assert.Equal("SER123", importedDevice.GetProperty("serialNumber").GetString());
+        Assert.Equal("aGFyZHdhcmVIYXNo", importedDevice.GetProperty("hardwareIdentifier").GetString());
+        Assert.Equal("Sales", importedDevice.GetProperty("groupTag").GetString());
+        Assert.Equal("import-123", importedDevice.GetProperty("importId").GetString());
+        Assert.DoesNotContain("access-token", importRequest.Body, StringComparison.Ordinal);
+        Assert.DoesNotContain("pfx", importRequest.Body, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("password", importRequest.Body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ImportHardwareHashAsync_WhenTransientGraphFailureOccurs_RetriesAndSucceeds()
+    {
+        var handler = new QueuedGraphHandler();
+        handler.EnqueueText(HttpStatusCode.ServiceUnavailable, "temporary");
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            {
+              "value": [
+                {
+                  "id": "imported-id",
+                  "serialNumber": "SER123",
+                  "importId": "import-123",
+                  "state": { "deviceImportStatus": "complete" }
+                }
+              ]
+            }
+            """);
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            { "value": [ { "id": "device-id", "serialNumber": "SER123" } ] }
+            """);
+
+        AutopilotGraphImportClient client = CreateClient(handler);
+
+        AutopilotHardwareHashUploadResult result = await client.ImportHardwareHashAsync(
+            new AutopilotGraphImportRequest(
+                "access-token",
+                "SER123",
+                "aGFyZHdhcmVIYXNo",
+                null,
+                null,
+                "import-123"),
+            CancellationToken.None);
+
+        Assert.Equal(AutopilotHardwareHashUploadState.Completed, result.State);
+        Assert.Equal(2, handler.Requests.Count(request =>
+            request.Method == HttpMethod.Post &&
+            request.PathAndQuery == "/v1.0/deviceManagement/importedWindowsAutopilotDeviceIdentities/import"));
+    }
+
+    [Fact]
+    public async Task ImportHardwareHashAsync_WhenGraphValidationFails_DoesNotRetry()
+    {
+        var handler = new QueuedGraphHandler();
+        handler.EnqueueJson(HttpStatusCode.BadRequest, """
+            {
+              "error": {
+                "code": "BadRequest",
+                "message": "Invalid hardware identifier."
+              }
+            }
+            """);
+
+        AutopilotGraphImportClient client = CreateClient(handler);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.ImportHardwareHashAsync(
+            new AutopilotGraphImportRequest(
+                "access-token",
+                "SER123",
+                "invalid",
+                null,
+                null,
+                "import-123"),
+            CancellationToken.None));
+
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task ImportHardwareHashAsync_WhenImportFails_ReturnsNonBlockingUploadFailure()
+    {
+        var handler = new QueuedGraphHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            {
+              "value": [
+                {
+                  "id": "imported-id",
+                  "serialNumber": "SER123",
+                  "importId": "import-123",
+                  "state": {
+                    "deviceImportStatus": "error",
+                    "deviceErrorCode": 806,
+                    "deviceErrorName": "ZtdDeviceAlreadyAssigned"
+                  }
+                }
+              ]
+            }
+            """);
+
+        AutopilotGraphImportClient client = CreateClient(handler);
+
+        AutopilotHardwareHashUploadResult result = await client.ImportHardwareHashAsync(
+            new AutopilotGraphImportRequest(
+                "access-token",
+                "SER123",
+                "aGFyZHdhcmVIYXNo",
+                null,
+                null,
+                "import-123"),
+            CancellationToken.None);
+
+        Assert.Equal(AutopilotHardwareHashUploadState.UploadFailed, result.State);
+        Assert.Contains("ZtdDeviceAlreadyAssigned", result.Message, StringComparison.Ordinal);
+        Assert.Equal("806", result.FailureCode);
+    }
+
+    [Fact]
+    public async Task ImportHardwareHashAsync_WhenDeviceVisibilityTimesOut_ReturnsTimedOutWithoutThrowing()
+    {
+        var handler = new QueuedGraphHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            {
+              "value": [
+                {
+                  "id": "imported-id",
+                  "serialNumber": "SER123",
+                  "importId": "import-123",
+                  "state": { "deviceImportStatus": "complete" }
+                }
+              ]
+            }
+            """);
+        handler.EnqueueJson(HttpStatusCode.OK, """{ "value": [] }""");
+
+        AutopilotGraphImportClient client = CreateClient(
+            handler,
+            new AutopilotGraphImportClientOptions
+            {
+                RetryDelay = TimeSpan.Zero,
+                ImportPollInterval = TimeSpan.Zero,
+                DeviceVisibilityPollInterval = TimeSpan.Zero,
+                DeviceVisibilityTimeout = TimeSpan.Zero
+            });
+        List<AutopilotHardwareHashUploadProgress> progressReports = [];
+
+        AutopilotHardwareHashUploadResult result = await client.ImportHardwareHashAsync(
+            new AutopilotGraphImportRequest(
+                "access-token",
+                "SER123",
+                "aGFyZHdhcmVIYXNo",
+                null,
+                null,
+                "import-123"),
+            new Progress<AutopilotHardwareHashUploadProgress>(progressReports.Add),
+            CancellationToken.None);
+
+        Assert.Equal(AutopilotHardwareHashUploadState.UploadTimedOut, result.State);
+        Assert.Contains("did not appear", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(progressReports, progress =>
+            progress.IsIndeterminate &&
+            progress.Detail?.Contains("remaining", StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    private static AutopilotGraphImportClient CreateClient(
+        QueuedGraphHandler handler,
+        AutopilotGraphImportClientOptions? options = null)
+    {
+        return new AutopilotGraphImportClient(
+            new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://graph.microsoft.com/", UriKind.Absolute)
+            },
+            NullLogger<AutopilotGraphImportClient>.Instance,
+            options ?? new AutopilotGraphImportClientOptions
+            {
+                RetryDelay = TimeSpan.Zero,
+                ImportPollInterval = TimeSpan.Zero,
+                DeviceVisibilityPollInterval = TimeSpan.Zero
+            });
+    }
+
+    private sealed class QueuedGraphHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> responses = new();
+
+        public List<RecordedGraphRequest> Requests { get; } = [];
+
+        public void EnqueueJson(HttpStatusCode statusCode, string json)
+        {
+            HttpResponseMessage response = new(statusCode)
+            {
+                Content = new StringContent(json)
+            };
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            responses.Enqueue(response);
+        }
+
+        public void EnqueueText(HttpStatusCode statusCode, string text)
+        {
+            responses.Enqueue(new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(text)
+            });
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            string? body = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            Requests.Add(new RecordedGraphRequest(
+                request.Method,
+                request.RequestUri?.PathAndQuery ?? string.Empty,
+                request.Headers.Authorization?.ToString(),
+                body));
+
+            if (responses.Count == 0)
+            {
+                throw new InvalidOperationException("No queued response for Graph request.");
+            }
+
+            return responses.Dequeue();
+        }
+    }
+
+    private sealed record RecordedGraphRequest(
+        HttpMethod Method,
+        string PathAndQuery,
+        string? Authorization,
+        string? Body);
+}

--- a/src/Foundry.Deploy.Tests/AutopilotGraphTokenServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/AutopilotGraphTokenServiceTests.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Foundry.Deploy.Services.Autopilot;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class AutopilotGraphTokenServiceTests
+{
+    [Fact]
+    public async Task AcquireAccessTokenAsync_WhenTransientFailureOccurs_RetriesWithCertificateAssertion()
+    {
+        var handler = new RecordingTokenHandler();
+        handler.Enqueue(HttpStatusCode.ServiceUnavailable, """{ "error": "temporarily_unavailable" }""");
+        handler.Enqueue(HttpStatusCode.OK, """{ "access_token": "graph-token", "token_type": "Bearer" }""");
+        using X509Certificate2 certificate = CreateCertificate();
+        var service = new AutopilotGraphTokenService(
+            new HttpClient(handler),
+            NullLogger<AutopilotGraphTokenService>.Instance,
+            new AutopilotGraphTokenServiceOptions
+            {
+                RetryDelay = TimeSpan.Zero
+            });
+
+        string token = await service.AcquireAccessTokenAsync(
+            "tenant-id",
+            "client-id",
+            certificate,
+            CancellationToken.None);
+
+        Assert.Equal("graph-token", token);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.All(handler.Requests, request =>
+        {
+            Assert.Equal("https://login.microsoftonline.com/tenant-id/oauth2/v2.0/token", request.Uri.ToString());
+            Assert.Contains("client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer", request.Body, StringComparison.Ordinal);
+            Assert.Contains("scope=https%3A%2F%2Fgraph.microsoft.com%2F.default", request.Body, StringComparison.Ordinal);
+            Assert.DoesNotContain("PRIVATE", request.Body, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("password", request.Body, StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    [Fact]
+    public void CreateClientAssertion_UsesPs256AndSha256CertificateThumbprint()
+    {
+        using X509Certificate2 certificate = CreateCertificate();
+
+        string assertion = AutopilotGraphTokenService.CreateClientAssertion(
+            "https://login.microsoftonline.com/tenant-id/oauth2/v2.0/token",
+            "client-id",
+            certificate);
+
+        string[] parts = assertion.Split('.');
+        Assert.Equal(3, parts.Length);
+        string headerJson = DecodeBase64Url(parts[0]);
+        Assert.Contains("\"alg\":\"PS256\"", headerJson, StringComparison.Ordinal);
+        Assert.Contains("\"x5t#S256\"", headerJson, StringComparison.Ordinal);
+        Assert.DoesNotContain(certificate.ExportCertificatePem(), assertion, StringComparison.Ordinal);
+    }
+
+    private static X509Certificate2 CreateCertificate()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "CN=Foundry OSD Autopilot Registration",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddMonths(12));
+    }
+
+    private static string DecodeBase64Url(string value)
+    {
+        string base64 = value.Replace('-', '+').Replace('_', '/');
+        int padding = (4 - base64.Length % 4) % 4;
+        return System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(base64.PadRight(base64.Length + padding, '=')));
+    }
+
+    private sealed class RecordingTokenHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> responses = new();
+
+        public List<RecordedTokenRequest> Requests { get; } = [];
+
+        public void Enqueue(HttpStatusCode statusCode, string body)
+        {
+            responses.Enqueue(new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(body)
+            });
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(new RecordedTokenRequest(
+                request.RequestUri!,
+                request.Content is null
+                    ? string.Empty
+                    : await request.Content.ReadAsStringAsync(cancellationToken)));
+
+            return responses.Dequeue();
+        }
+    }
+
+    private sealed record RecordedTokenRequest(Uri Uri, string Body);
+}

--- a/src/Foundry.Deploy.Tests/AutopilotHardwareHashUploadServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/AutopilotHardwareHashUploadServiceTests.cs
@@ -1,0 +1,188 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using Foundry.Deploy.Models.Configuration;
+using Foundry.Deploy.Services.Autopilot;
+using Foundry.Deploy.Services.Deployment;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class AutopilotHardwareHashUploadServiceTests
+{
+    [Fact]
+    public async Task UploadAsync_WhenEncryptedCertificateMaterialIsMissing_ReturnsNonBlockingFailureAndSanitizedResult()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"foundry-upload-service-{Guid.NewGuid():N}");
+        string diagnosticsRoot = Path.Combine(root, "Diagnostics");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var service = new AutopilotHardwareHashUploadService(
+                new StaticMediaSecretKeyReader(),
+                new ThrowingTokenService(),
+                new AutopilotGraphImportClient(
+                    new HttpClient(new ThrowingGraphHandler())
+                    {
+                        BaseAddress = new Uri("https://graph.microsoft.com/", UriKind.Absolute)
+                    },
+                    NullLogger<AutopilotGraphImportClient>.Instance),
+                NullLogger<AutopilotHardwareHashUploadService>.Instance);
+
+            AutopilotHardwareHashUploadResult result = await service.UploadAsync(
+                new AutopilotHardwareHashUploadRequest
+                {
+                    Settings = new DeployAutopilotHardwareHashUploadSettings
+                    {
+                        TenantId = "tenant-id",
+                        ClientId = "client-id",
+                        ActiveCertificateThumbprint = "ABCDEF123456"
+                    },
+                    Identity = new AutopilotHardwareHashDeviceIdentity("SER123", "HASHVALUE", null),
+                    WorkspaceRootPath = root,
+                    DiagnosticsRootPath = diagnosticsRoot
+                },
+                cancellationToken: CancellationToken.None);
+
+            Assert.Equal(AutopilotHardwareHashUploadState.UploadFailed, result.State);
+            Assert.NotNull(result.ArtifactPath);
+            string json = await File.ReadAllTextAsync(result.ArtifactPath);
+            Assert.DoesNotContain("access_token", json, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("authorization", json, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("pfx", json, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("password", json, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("private", json, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("SER123", json, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task UploadAsync_WhenGraphPermissionFailsAfterPfxDecrypt_ReturnsNonBlockingPermissionFailure()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"foundry-upload-service-{Guid.NewGuid():N}");
+        string diagnosticsRoot = Path.Combine(root, "Diagnostics");
+        Directory.CreateDirectory(root);
+        byte[] mediaKey = RandomNumberGenerator.GetBytes(DeployMediaSecretEnvelopeProtector.KeySizeBytes);
+        using X509Certificate2 certificate = CreateCertificate();
+        const string pfxPassword = "correct-password";
+        byte[] pfxBytes = certificate.Export(X509ContentType.Pfx, pfxPassword);
+        try
+        {
+            var service = new AutopilotHardwareHashUploadService(
+                new StaticMediaSecretKeyReader(mediaKey),
+                new ThrowingTokenService(new HttpRequestException("Graph permission missing.", null, HttpStatusCode.Forbidden)),
+                new AutopilotGraphImportClient(
+                    new HttpClient(new ThrowingGraphHandler())
+                    {
+                        BaseAddress = new Uri("https://graph.microsoft.com/", UriKind.Absolute)
+                    },
+                    NullLogger<AutopilotGraphImportClient>.Instance),
+                NullLogger<AutopilotHardwareHashUploadService>.Instance);
+
+            AutopilotHardwareHashUploadResult result = await service.UploadAsync(
+                new AutopilotHardwareHashUploadRequest
+                {
+                    Settings = new DeployAutopilotHardwareHashUploadSettings
+                    {
+                        TenantId = "tenant-id",
+                        ClientId = "client-id",
+                        ActiveCertificateThumbprint = certificate.Thumbprint,
+                        CertificatePfxSecret = Encrypt(pfxBytes, mediaKey),
+                        CertificatePfxPasswordSecret = Encrypt(Encoding.UTF8.GetBytes(pfxPassword), mediaKey)
+                    },
+                    Identity = new AutopilotHardwareHashDeviceIdentity("SER123", "HASHVALUE", null),
+                    WorkspaceRootPath = root,
+                    DiagnosticsRootPath = diagnosticsRoot
+                },
+                cancellationToken: CancellationToken.None);
+
+            Assert.Equal(AutopilotHardwareHashUploadState.UploadFailed, result.State);
+            Assert.Equal("PermissionMissing", result.FailureCode);
+            Assert.NotNull(result.ArtifactPath);
+            string json = await File.ReadAllTextAsync(result.ArtifactPath);
+            Assert.DoesNotContain(Convert.ToBase64String(pfxBytes), json, StringComparison.Ordinal);
+            Assert.DoesNotContain(pfxPassword, json, StringComparison.Ordinal);
+            Assert.DoesNotContain(certificate.ExportCertificatePem(), json, StringComparison.Ordinal);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(pfxBytes);
+            CryptographicOperations.ZeroMemory(mediaKey);
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static X509Certificate2 CreateCertificate()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "CN=Foundry OSD Autopilot Registration",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddMonths(12));
+    }
+
+    private static SecretEnvelope Encrypt(byte[] plaintext, byte[] key)
+    {
+        byte[] nonce = RandomNumberGenerator.GetBytes(12);
+        byte[] tag = new byte[16];
+        byte[] ciphertext = new byte[plaintext.Length];
+        using var aes = new AesGcm(key, 16);
+        aes.Encrypt(nonce, plaintext, ciphertext, tag);
+
+        return new SecretEnvelope
+        {
+            Kind = DeployMediaSecretEnvelopeProtector.Kind,
+            Algorithm = DeployMediaSecretEnvelopeProtector.Algorithm,
+            KeyId = DeployMediaSecretEnvelopeProtector.KeyId,
+            Nonce = Base64UrlEncode(nonce),
+            Tag = Base64UrlEncode(tag),
+            Ciphertext = Base64UrlEncode(ciphertext)
+        };
+    }
+
+    private static string Base64UrlEncode(byte[] value)
+    {
+        return Convert.ToBase64String(value)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    private sealed class StaticMediaSecretKeyReader(byte[]? key = null) : IMediaSecretKeyReader
+    {
+        public Task<byte[]> ReadAsync(string workspaceRootPath, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult((key ?? new byte[DeployMediaSecretEnvelopeProtector.KeySizeBytes]).ToArray());
+        }
+    }
+
+    private sealed class ThrowingTokenService(Exception? exception = null) : IAutopilotGraphTokenService
+    {
+        public Task<string> AcquireAccessTokenAsync(
+            string tenantId,
+            string clientId,
+            System.Security.Cryptography.X509Certificates.X509Certificate2 certificate,
+            CancellationToken cancellationToken = default)
+        {
+            throw exception ?? new InvalidOperationException("Token service should not be called.");
+        }
+    }
+
+    private sealed class ThrowingGraphHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            throw new InvalidOperationException("Graph client should not be called.");
+        }
+    }
+}

--- a/src/Foundry.Deploy.Tests/DeployMediaSecretEnvelopeProtectorTests.cs
+++ b/src/Foundry.Deploy.Tests/DeployMediaSecretEnvelopeProtectorTests.cs
@@ -1,0 +1,66 @@
+using System.Security.Cryptography;
+using System.Text;
+using Foundry.Deploy.Models.Configuration;
+using Foundry.Deploy.Services.Autopilot;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class DeployMediaSecretEnvelopeProtectorTests
+{
+    [Fact]
+    public void DecryptBytes_RoundTripsBinaryPayloadWithoutWritingSecretFile()
+    {
+        byte[] key = RandomNumberGenerator.GetBytes(DeployMediaSecretEnvelopeProtector.KeySizeBytes);
+        byte[] payload = [0, 1, 2, 255, 128, 127];
+        SecretEnvelope envelope = Encrypt(payload, key);
+
+        byte[] decrypted = DeployMediaSecretEnvelopeProtector.DecryptBytes(envelope, key);
+
+        Assert.Equal(payload, decrypted);
+        Assert.NotEqual(Convert.ToBase64String(payload), envelope.Ciphertext);
+    }
+
+    [Fact]
+    public void DecryptString_WhenEnvelopeIsTampered_ThrowsWithoutLeakingSecret()
+    {
+        byte[] key = RandomNumberGenerator.GetBytes(DeployMediaSecretEnvelopeProtector.KeySizeBytes);
+        const string secret = "PfxPassword-DoNotLeak";
+        SecretEnvelope envelope = Encrypt(Encoding.UTF8.GetBytes(secret), key) with
+        {
+            Ciphertext = "AAAA"
+        };
+
+        CryptographicException exception = Assert.Throws<CryptographicException>(
+            () => DeployMediaSecretEnvelopeProtector.DecryptString(envelope, key));
+
+        Assert.DoesNotContain(secret, exception.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(Convert.ToBase64String(Encoding.UTF8.GetBytes(secret)), exception.ToString(), StringComparison.Ordinal);
+    }
+
+    private static SecretEnvelope Encrypt(byte[] plaintext, byte[] key)
+    {
+        byte[] nonce = RandomNumberGenerator.GetBytes(12);
+        byte[] tag = new byte[16];
+        byte[] ciphertext = new byte[plaintext.Length];
+        using var aes = new AesGcm(key, 16);
+        aes.Encrypt(nonce, plaintext, ciphertext, tag);
+
+        return new SecretEnvelope
+        {
+            Kind = DeployMediaSecretEnvelopeProtector.Kind,
+            Algorithm = DeployMediaSecretEnvelopeProtector.Algorithm,
+            KeyId = DeployMediaSecretEnvelopeProtector.KeyId,
+            Nonce = Base64UrlEncode(nonce),
+            Tag = Base64UrlEncode(tag),
+            Ciphertext = Base64UrlEncode(ciphertext)
+        };
+    }
+
+    private static string Base64UrlEncode(byte[] value)
+    {
+        return Convert.ToBase64String(value)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+}

--- a/src/Foundry.Deploy.Tests/ProvisionAutopilotStepTests.cs
+++ b/src/Foundry.Deploy.Tests/ProvisionAutopilotStepTests.cs
@@ -70,7 +70,9 @@ public sealed class ProvisionAutopilotStepTests
     public async Task ExecuteAsync_WhenLiveHardwareHashModeIsConfigured_RecordsPlannedUploadWithoutJsonStaging()
     {
         using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
-        ProvisionAutopilotStep step = CreateStep();
+        var uploadService = new FakeAutopilotHardwareHashUploadService(
+            AutopilotHardwareHashUploadResult.Completed("Device imported."));
+        ProvisionAutopilotStep step = CreateStep(uploadService: uploadService);
         DeploymentStepExecutionContext context = CreateContext(
             workspace,
             isDryRun: false,
@@ -88,11 +90,51 @@ public sealed class ProvisionAutopilotStepTests
         DeploymentStepResult result = await step.ExecuteAsync(context, CancellationToken.None);
 
         Assert.Equal(DeploymentStepState.Succeeded, result.State);
-        Assert.Equal(AutopilotHardwareHashUploadState.HashCaptured, context.RuntimeState.AutopilotHardwareHashUploadState);
+        Assert.Equal(AutopilotHardwareHashUploadState.Completed, context.RuntimeState.AutopilotHardwareHashUploadState);
         Assert.Equal("Sales", context.RuntimeState.AutopilotHardwareHashGroupTag);
         Assert.Null(context.RuntimeState.StagedAutopilotConfigurationPath);
         Assert.False(Directory.Exists(Path.Combine(workspace.TargetWindowsRootPath, "Windows", "Provisioning", "Autopilot")));
         Assert.True(File.Exists(Path.Combine(context.RuntimeState.AutopilotHardwareHashDiagnosticsPath!, "autopilot-hash-upload-status.json")));
+        Assert.Single(uploadService.Requests);
+        Assert.Equal("SER123", uploadService.Requests[0].Identity.SerialNumber);
+        Assert.Equal("HASHVALUE", uploadService.Requests[0].Identity.HardwareHash);
+        Assert.Equal("Sales", uploadService.Requests[0].Identity.GroupTag);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenGraphUploadFailsAfterCapture_ContinuesDeployment()
+    {
+        using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
+        ProvisionAutopilotStep step = CreateStep(
+            uploadService: new FakeAutopilotHardwareHashUploadService(
+                AutopilotHardwareHashUploadResult.Failed(
+                    AutopilotHardwareHashUploadState.UploadFailed,
+                    "Autopilot hardware hash upload failed: consent is missing.",
+                    "ConsentMissing")));
+        DeploymentStepExecutionContext context = CreateContext(
+            workspace,
+            isDryRun: false,
+            provisioningMode: AutopilotProvisioningMode.HardwareHashUpload,
+            hardwareHashUpload: new DeployAutopilotHardwareHashUploadSettings
+            {
+                TenantId = "tenant-id",
+                ClientId = "client-id",
+                ActiveCertificateKeyId = "key-id",
+                ActiveCertificateThumbprint = "ABCDEF123456",
+                ActiveCertificateExpiresOnUtc = DateTimeOffset.UtcNow.AddMonths(1)
+            });
+
+        DeploymentStepResult result = await step.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.NotEqual(DeploymentStepState.Failed, result.State);
+        Assert.Equal(DeploymentStepState.Skipped, result.State);
+        Assert.Equal(AutopilotHardwareHashUploadState.UploadFailed, context.RuntimeState.AutopilotHardwareHashUploadState);
+        Assert.Contains("consent", result.Message, StringComparison.OrdinalIgnoreCase);
+
+        string statusPath = Path.Combine(context.RuntimeState.AutopilotHardwareHashDiagnosticsPath!, "autopilot-hash-upload-status.json");
+        using JsonDocument status = JsonDocument.Parse(await File.ReadAllTextAsync(statusPath));
+        Assert.Equal("UploadFailed", status.RootElement.GetProperty("uploadState").GetString());
+        Assert.Equal("ConsentMissing", status.RootElement.GetProperty("failureCode").GetString());
     }
 
     [Fact]
@@ -157,9 +199,14 @@ public sealed class ProvisionAutopilotStepTests
         };
     }
 
-    private static ProvisionAutopilotStep CreateStep()
+    private static ProvisionAutopilotStep CreateStep(
+        IAutopilotHardwareHashCaptureService? captureService = null,
+        IAutopilotHardwareHashUploadService? uploadService = null)
     {
-        return new ProvisionAutopilotStep(new FakeAutopilotHardwareHashCaptureService());
+        return new ProvisionAutopilotStep(
+            captureService ?? new FakeAutopilotHardwareHashCaptureService(),
+            uploadService ?? new FakeAutopilotHardwareHashUploadService(
+                AutopilotHardwareHashUploadResult.Completed("Device imported.")));
     }
 
     private static DeploymentStepExecutionContext CreateContext(
@@ -276,6 +323,20 @@ public sealed class ProvisionAutopilotStepTests
             File.WriteAllText(csvPath, "csv");
             AutopilotHardwareHashDeviceIdentity identity = new("SER123", "HASHVALUE", request.GroupTag);
             return Task.FromResult(AutopilotHardwareHashCaptureResult.Succeeded(identity, oa3XmlPath, oa3LogPath, csvPath));
+        }
+    }
+
+    private sealed class FakeAutopilotHardwareHashUploadService(AutopilotHardwareHashUploadResult result) : IAutopilotHardwareHashUploadService
+    {
+        public List<AutopilotHardwareHashUploadRequest> Requests { get; } = [];
+
+        public Task<AutopilotHardwareHashUploadResult> UploadAsync(
+            AutopilotHardwareHashUploadRequest request,
+            IProgress<AutopilotHardwareHashUploadProgress>? progress = null,
+            CancellationToken cancellationToken = default)
+        {
+            Requests.Add(request);
+            return Task.FromResult(result);
         }
     }
 

--- a/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
@@ -98,6 +98,19 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<PreOobeScriptDefinitionBuilder>();
         services.AddSingleton<IAutopilotProfileCatalogService, AutopilotProfileCatalogService>();
         services.AddSingleton<IAutopilotHardwareHashCaptureService, AutopilotHardwareHashCaptureService>();
+        services.AddSingleton<IMediaSecretKeyReader, MediaSecretKeyReader>();
+        services.AddSingleton<IAutopilotGraphTokenService>(sp =>
+            new AutopilotGraphTokenService(
+                new HttpClient(),
+                sp.GetRequiredService<ILogger<AutopilotGraphTokenService>>()));
+        services.AddSingleton(sp =>
+            new AutopilotGraphImportClient(
+                new HttpClient
+                {
+                    BaseAddress = new Uri("https://graph.microsoft.com/", UriKind.Absolute)
+                },
+                sp.GetRequiredService<ILogger<AutopilotGraphImportClient>>()));
+        services.AddSingleton<IAutopilotHardwareHashUploadService, AutopilotHardwareHashUploadService>();
         services.AddSingleton<IDeploymentStep, GatherDeploymentVariablesStep>();
         services.AddSingleton<IDeploymentStep, InitializeDeploymentWorkspaceStep>();
         services.AddSingleton<IDeploymentStep, ValidateTargetConfigurationStep>();

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotCertificateCredential.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotCertificateCredential.cs
@@ -1,0 +1,49 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Foundry.Deploy.Services.Autopilot;
+
+/// <summary>
+/// Loads the media PFX with an ephemeral private key and validates it against the configured app certificate thumbprint.
+/// </summary>
+public static class AutopilotCertificateCredential
+{
+    public static X509Certificate2 Load(byte[] pfxBytes, string password, string expectedThumbprint)
+    {
+        ArgumentNullException.ThrowIfNull(pfxBytes);
+        ArgumentException.ThrowIfNullOrWhiteSpace(password);
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedThumbprint);
+
+        try
+        {
+            X509Certificate2 certificate = X509CertificateLoader.LoadPkcs12(
+                pfxBytes,
+                password,
+                X509KeyStorageFlags.EphemeralKeySet);
+            string actualThumbprint = NormalizeThumbprint(certificate.Thumbprint);
+            if (!string.Equals(actualThumbprint, NormalizeThumbprint(expectedThumbprint), StringComparison.Ordinal))
+            {
+                certificate.Dispose();
+                throw new InvalidOperationException("The embedded PFX certificate does not match the configured app certificate thumbprint.");
+            }
+
+            if (!certificate.HasPrivateKey)
+            {
+                certificate.Dispose();
+                throw new InvalidOperationException("The embedded PFX certificate does not contain private key material.");
+            }
+
+            return certificate;
+        }
+        catch (CryptographicException ex)
+        {
+            throw new InvalidOperationException("The embedded PFX certificate could not be loaded.", ex);
+        }
+    }
+
+    private static string NormalizeThumbprint(string? thumbprint)
+    {
+        string? normalized = thumbprint?.Replace(" ", string.Empty, StringComparison.Ordinal).Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? string.Empty : normalized.ToUpperInvariant();
+    }
+}

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotGraphImportClient.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotGraphImportClient.cs
@@ -1,0 +1,407 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Foundry.Deploy.Services.Deployment;
+using Foundry.Deploy.Services.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Foundry.Deploy.Services.Autopilot;
+
+/// <summary>
+/// Imports hardware hashes through Microsoft Graph and waits for Intune Autopilot visibility.
+/// </summary>
+public sealed class AutopilotGraphImportClient(
+    HttpClient httpClient,
+    ILogger<AutopilotGraphImportClient> logger,
+    AutopilotGraphImportClientOptions? options = null)
+{
+    private const string ImportedIdentitiesImportPath = "v1.0/deviceManagement/importedWindowsAutopilotDeviceIdentities/import";
+    private const string ImportedIdentitiesPath = "v1.0/deviceManagement/importedWindowsAutopilotDeviceIdentities";
+    private const string WindowsAutopilotDevicesPath = "v1.0/deviceManagement/windowsAutopilotDeviceIdentities";
+    private const string ODataType = "#microsoft.graph.importedWindowsAutopilotDeviceIdentity";
+
+    private readonly HttpClient httpClient = httpClient;
+    private readonly ILogger logger = logger;
+    private readonly AutopilotGraphImportClientOptions options = options ?? new AutopilotGraphImportClientOptions();
+
+    public Task<AutopilotHardwareHashUploadResult> ImportHardwareHashAsync(
+        AutopilotGraphImportRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        return ImportHardwareHashAsync(request, progress: null, cancellationToken);
+    }
+
+    public async Task<AutopilotHardwareHashUploadResult> ImportHardwareHashAsync(
+        AutopilotGraphImportRequest request,
+        IProgress<AutopilotHardwareHashUploadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        progress?.Report(new AutopilotHardwareHashUploadProgress(
+            "Uploading Autopilot hardware hash...",
+            "Submitting import request to Microsoft Graph..."));
+        ImportedWindowsAutopilotDeviceIdentity importedIdentity = await ImportAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+        importedIdentity = await WaitForImportCompletionAsync(request, importedIdentity, progress, cancellationToken)
+            .ConfigureAwait(false);
+
+        string importStatus = importedIdentity.State?.DeviceImportStatus ?? "unknown";
+        if (string.Equals(importStatus, "error", StringComparison.OrdinalIgnoreCase))
+        {
+            string failureCode = importedIdentity.State?.DeviceErrorCode?.ToString() ?? "ImportFailed";
+            string deviceErrorName = importedIdentity.State?.DeviceErrorName ?? "ImportFailed";
+            return AutopilotHardwareHashUploadResult.Failed(
+                AutopilotHardwareHashUploadState.UploadFailed,
+                $"Autopilot hardware hash import failed: {deviceErrorName}.",
+                failureCode,
+                request.ImportId,
+                importedIdentity.Id);
+        }
+
+        if (!string.Equals(importStatus, "complete", StringComparison.OrdinalIgnoreCase))
+        {
+            return AutopilotHardwareHashUploadResult.Failed(
+                AutopilotHardwareHashUploadState.UploadTimedOut,
+                "Autopilot hardware hash import did not complete before the timeout.",
+                "ImportTimedOut",
+                request.ImportId,
+                importedIdentity.Id);
+        }
+
+        WindowsAutopilotDeviceIdentity? autopilotDevice = await WaitForAutopilotDeviceVisibilityAsync(
+            request,
+            progress,
+            cancellationToken).ConfigureAwait(false);
+        if (autopilotDevice is null)
+        {
+            return AutopilotHardwareHashUploadResult.Failed(
+                AutopilotHardwareHashUploadState.UploadTimedOut,
+                "Imported Autopilot device did not appear in Windows Autopilot devices before the visibility timeout.",
+                "AutopilotDeviceTimedOut",
+                request.ImportId,
+                importedIdentity.Id);
+        }
+
+        return AutopilotHardwareHashUploadResult.Completed(
+            "Autopilot hardware hash imported and visible in Windows Autopilot devices.",
+            request.ImportId,
+            importedIdentity.Id,
+            autopilotDevice.Id);
+    }
+
+    private async Task<ImportedWindowsAutopilotDeviceIdentity> ImportAsync(
+        AutopilotGraphImportRequest request,
+        CancellationToken cancellationToken)
+    {
+        ImportRequestBody body = new([
+            new ImportRequestDevice(
+                ODataType,
+                request.SerialNumber,
+                request.HardwareIdentifier,
+                request.GroupTag,
+                request.AssignedUserPrincipalName,
+                request.ImportId)
+        ]);
+
+        GraphCollectionResponse<ImportedWindowsAutopilotDeviceIdentity>? response =
+            await SendGraphAsync<ImportRequestBody, GraphCollectionResponse<ImportedWindowsAutopilotDeviceIdentity>>(
+                HttpMethod.Post,
+                ImportedIdentitiesImportPath,
+                request.AccessToken,
+                body,
+                "Autopilot hardware hash import",
+                cancellationToken).ConfigureAwait(false);
+
+        return response?.Value?.FirstOrDefault()
+            ?? throw new InvalidOperationException("Microsoft Graph did not return an imported Autopilot device identity.");
+    }
+
+    private async Task<ImportedWindowsAutopilotDeviceIdentity> WaitForImportCompletionAsync(
+        AutopilotGraphImportRequest request,
+        ImportedWindowsAutopilotDeviceIdentity importedIdentity,
+        IProgress<AutopilotHardwareHashUploadProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        if (IsTerminalImportStatus(importedIdentity.State?.DeviceImportStatus))
+        {
+            return importedIdentity;
+        }
+
+        DateTimeOffset deadline = DateTimeOffset.UtcNow.Add(options.ImportTimeout);
+        while (DateTimeOffset.UtcNow <= deadline)
+        {
+            progress?.Report(new AutopilotHardwareHashUploadProgress(
+                "Waiting for Autopilot import...",
+                "Waiting for Microsoft Graph import completion..."));
+            await DelayAsync(options.ImportPollInterval, cancellationToken).ConfigureAwait(false);
+            ImportedWindowsAutopilotDeviceIdentity? current = await GetImportedIdentityAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            if (current is not null)
+            {
+                importedIdentity = current;
+            }
+
+            if (IsTerminalImportStatus(importedIdentity.State?.DeviceImportStatus))
+            {
+                return importedIdentity;
+            }
+        }
+
+        return importedIdentity;
+    }
+
+    private async Task<ImportedWindowsAutopilotDeviceIdentity?> GetImportedIdentityAsync(
+        AutopilotGraphImportRequest request,
+        CancellationToken cancellationToken)
+    {
+        string filter = EscapeODataFilter($"importId eq '{EscapeODataString(request.ImportId)}'");
+        string path = $"{ImportedIdentitiesPath}?$filter={filter}";
+        GraphCollectionResponse<ImportedWindowsAutopilotDeviceIdentity>? response =
+            await SendGraphAsync<object, GraphCollectionResponse<ImportedWindowsAutopilotDeviceIdentity>>(
+                HttpMethod.Get,
+                path,
+                request.AccessToken,
+                body: null,
+                "Autopilot import status polling",
+                cancellationToken).ConfigureAwait(false);
+
+        return response?.Value?.FirstOrDefault(identity =>
+            string.Equals(identity.ImportId, request.ImportId, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(identity.SerialNumber, request.SerialNumber, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private async Task<WindowsAutopilotDeviceIdentity?> WaitForAutopilotDeviceVisibilityAsync(
+        AutopilotGraphImportRequest request,
+        IProgress<AutopilotHardwareHashUploadProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow.Add(options.DeviceVisibilityTimeout);
+        do
+        {
+            TimeSpan remaining = deadline - DateTimeOffset.UtcNow;
+            if (remaining < TimeSpan.Zero)
+            {
+                remaining = TimeSpan.Zero;
+            }
+
+            progress?.Report(new AutopilotHardwareHashUploadProgress(
+                "Waiting for Autopilot device visibility...",
+                $"Waiting for device to appear in Windows Autopilot devices ({FormatRemaining(remaining)} remaining)..."));
+            WindowsAutopilotDeviceIdentity? device = await FindAutopilotDeviceAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            if (device is not null)
+            {
+                return device;
+            }
+
+            if (DateTimeOffset.UtcNow > deadline)
+            {
+                return null;
+            }
+
+            await DelayAsync(options.DeviceVisibilityPollInterval, cancellationToken).ConfigureAwait(false);
+        }
+        while (true);
+    }
+
+    private async Task<WindowsAutopilotDeviceIdentity?> FindAutopilotDeviceAsync(
+        AutopilotGraphImportRequest request,
+        CancellationToken cancellationToken)
+    {
+        string filter = EscapeODataFilter($"serialNumber eq '{EscapeODataString(request.SerialNumber)}'");
+        string path = $"{WindowsAutopilotDevicesPath}?$filter={filter}";
+        GraphCollectionResponse<WindowsAutopilotDeviceIdentity>? response =
+            await SendGraphAsync<object, GraphCollectionResponse<WindowsAutopilotDeviceIdentity>>(
+                HttpMethod.Get,
+                path,
+                request.AccessToken,
+                body: null,
+                "Windows Autopilot device visibility polling",
+                cancellationToken).ConfigureAwait(false);
+
+        return response?.Value?.FirstOrDefault(device =>
+            string.Equals(device.SerialNumber, request.SerialNumber, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private async Task<TResponse?> SendGraphAsync<TBody, TResponse>(
+        HttpMethod method,
+        string path,
+        string accessToken,
+        TBody? body,
+        string operationName,
+        CancellationToken cancellationToken)
+        where TBody : class
+    {
+        return await HttpRetryPolicy.ExecuteAsync(
+            async ct =>
+            {
+                using var request = new HttpRequestMessage(method, path);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                if (body is not null)
+                {
+                    request.Content = JsonContent.Create(body, options: AutopilotGraphJson.Options);
+                }
+
+                using HttpResponseMessage response = await httpClient.SendAsync(request, ct).ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode)
+                {
+                    string graphError = await ReadGraphErrorAsync(response, ct).ConfigureAwait(false);
+                    throw new HttpRequestException(
+                        string.IsNullOrWhiteSpace(graphError)
+                            ? $"Microsoft Graph request failed with status code {(int)response.StatusCode}."
+                            : $"Microsoft Graph request failed with status code {(int)response.StatusCode}: {graphError}.",
+                        null,
+                        response.StatusCode);
+                }
+
+                await using Stream responseStream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+                return await JsonSerializer.DeserializeAsync<TResponse>(
+                    responseStream,
+                    AutopilotGraphJson.Options,
+                    ct).ConfigureAwait(false);
+            },
+            logger,
+            operationName,
+            cancellationToken,
+            options.RetryCount,
+            options.RetryDelay).ConfigureAwait(false);
+    }
+
+    private Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+    {
+        return delay <= TimeSpan.Zero
+            ? Task.CompletedTask
+            : Task.Delay(delay, cancellationToken);
+    }
+
+    private static bool IsTerminalImportStatus(string? status)
+    {
+        return string.Equals(status, "complete", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(status, "error", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string FormatRemaining(TimeSpan remaining)
+    {
+        return remaining.TotalMinutes >= 1
+            ? $"{Math.Ceiling(remaining.TotalMinutes):0} minutes"
+            : $"{Math.Ceiling(remaining.TotalSeconds):0} seconds";
+    }
+
+    private static string EscapeODataFilter(string filter)
+    {
+        return Uri.EscapeDataString(filter);
+    }
+
+    private static string EscapeODataString(string value)
+    {
+        return value.Replace("'", "''", StringComparison.Ordinal);
+    }
+
+    private static async Task<string> ReadGraphErrorAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        string body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(body);
+            if (document.RootElement.TryGetProperty("error", out JsonElement error))
+            {
+                string? code = error.TryGetProperty("code", out JsonElement codeElement)
+                    ? codeElement.GetString()
+                    : null;
+                string? message = error.TryGetProperty("message", out JsonElement messageElement)
+                    ? messageElement.GetString()
+                    : null;
+                return string.Join(
+                    ": ",
+                    new[] { code, message }
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value!.Trim()));
+            }
+        }
+        catch (JsonException)
+        {
+        }
+
+        return body.Length <= 500 ? body : body[..500];
+    }
+
+    private sealed record ImportRequestBody(
+        IReadOnlyList<ImportRequestDevice> ImportedWindowsAutopilotDeviceIdentities);
+
+    private sealed record ImportRequestDevice(
+        [property: JsonPropertyName("@odata.type")] string ODataType,
+        string SerialNumber,
+        string HardwareIdentifier,
+        string? GroupTag,
+        string? AssignedUserPrincipalName,
+        string ImportId);
+}
+
+/// <summary>
+/// Controls Graph retry and polling bounds for the Autopilot import workflow.
+/// </summary>
+public sealed record AutopilotGraphImportClientOptions
+{
+    public int RetryCount { get; init; } = HttpRetryPolicy.DefaultRetryCount;
+    public TimeSpan RetryDelay { get; init; } = HttpRetryPolicy.DefaultRetryDelay;
+    public TimeSpan ImportPollInterval { get; init; } = TimeSpan.FromSeconds(10);
+    public TimeSpan ImportTimeout { get; init; } = TimeSpan.FromMinutes(10);
+    public TimeSpan DeviceVisibilityPollInterval { get; init; } = TimeSpan.FromSeconds(10);
+    public TimeSpan DeviceVisibilityTimeout { get; init; } = TimeSpan.FromMinutes(10);
+}
+
+public sealed record AutopilotGraphImportRequest(
+    string AccessToken,
+    string SerialNumber,
+    string HardwareIdentifier,
+    string? GroupTag,
+    string? AssignedUserPrincipalName,
+    string ImportId);
+
+internal sealed record GraphCollectionResponse<TItem>
+{
+    public List<TItem>? Value { get; init; }
+
+    [JsonPropertyName("@odata.nextLink")]
+    public string? NextLink { get; init; }
+}
+
+internal sealed record ImportedWindowsAutopilotDeviceIdentity
+{
+    public string? Id { get; init; }
+    public string? SerialNumber { get; init; }
+    public string? ImportId { get; init; }
+    public ImportedWindowsAutopilotDeviceIdentityState? State { get; init; }
+}
+
+internal sealed record ImportedWindowsAutopilotDeviceIdentityState
+{
+    public string? DeviceImportStatus { get; init; }
+    public int? DeviceErrorCode { get; init; }
+    public string? DeviceErrorName { get; init; }
+}
+
+internal sealed record WindowsAutopilotDeviceIdentity
+{
+    public string? Id { get; init; }
+    public string? SerialNumber { get; init; }
+}
+
+internal static class AutopilotGraphJson
+{
+    public static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotGraphTokenService.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotGraphTokenService.cs
@@ -1,0 +1,164 @@
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Text.Json;
+using Foundry.Deploy.Services.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Foundry.Deploy.Services.Autopilot;
+
+public interface IAutopilotGraphTokenService
+{
+    Task<string> AcquireAccessTokenAsync(
+        string tenantId,
+        string clientId,
+        X509Certificate2 certificate,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Acquires app-only Graph tokens with a certificate client assertion; no client secrets or interactive flows are supported.
+/// </summary>
+public sealed class AutopilotGraphTokenService(
+    HttpClient httpClient,
+    ILogger<AutopilotGraphTokenService> logger,
+    AutopilotGraphTokenServiceOptions? options = null) : IAutopilotGraphTokenService
+{
+    private const string Scope = "https://graph.microsoft.com/.default";
+    private const string ClientAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+
+    private readonly HttpClient httpClient = httpClient;
+    private readonly ILogger logger = logger;
+    private readonly AutopilotGraphTokenServiceOptions options = options ?? new AutopilotGraphTokenServiceOptions();
+
+    public async Task<string> AcquireAccessTokenAsync(
+        string tenantId,
+        string clientId,
+        X509Certificate2 certificate,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+        ArgumentNullException.ThrowIfNull(certificate);
+
+        string tokenEndpoint = $"https://login.microsoftonline.com/{tenantId.Trim()}/oauth2/v2.0/token";
+        string clientAssertion = CreateClientAssertion(tokenEndpoint, clientId.Trim(), certificate);
+
+        return await HttpRetryPolicy.ExecuteAsync(
+            async ct =>
+            {
+                using var content = new FormUrlEncodedContent(new Dictionary<string, string>
+                {
+                    ["client_id"] = clientId.Trim(),
+                    ["scope"] = Scope,
+                    ["grant_type"] = "client_credentials",
+                    ["client_assertion_type"] = ClientAssertionType,
+                    ["client_assertion"] = clientAssertion
+                });
+                using HttpResponseMessage response = await httpClient.PostAsync(tokenEndpoint, content, ct)
+                    .ConfigureAwait(false);
+                string responseBody = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw new HttpRequestException(
+                        $"Microsoft Entra token request failed with status code {(int)response.StatusCode}: {ReadOAuthError(responseBody)}.",
+                        null,
+                        response.StatusCode);
+                }
+
+                using JsonDocument document = JsonDocument.Parse(responseBody);
+                if (!document.RootElement.TryGetProperty("access_token", out JsonElement tokenElement) ||
+                    string.IsNullOrWhiteSpace(tokenElement.GetString()))
+                {
+                    throw new InvalidOperationException("Microsoft Entra token response did not contain an access token.");
+                }
+
+                return tokenElement.GetString()!;
+            },
+            logger,
+            "Autopilot Graph token acquisition",
+            cancellationToken,
+            options.RetryCount,
+            options.RetryDelay).ConfigureAwait(false);
+    }
+
+    internal static string CreateClientAssertion(
+        string tokenEndpoint,
+        string clientId,
+        X509Certificate2 certificate)
+    {
+        long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        string header = JsonSerializer.Serialize(new Dictionary<string, string>
+        {
+            ["alg"] = "PS256",
+            ["typ"] = "JWT",
+            ["x5t#S256"] = Base64UrlEncode(SHA256.HashData(certificate.RawData))
+        }, AutopilotGraphJson.Options);
+        string payload = JsonSerializer.Serialize(new Dictionary<string, object>
+        {
+            ["aud"] = tokenEndpoint,
+            ["exp"] = now + 600,
+            ["iss"] = clientId,
+            ["jti"] = Guid.NewGuid().ToString("D"),
+            ["nbf"] = now,
+            ["iat"] = now,
+            ["sub"] = clientId
+        }, AutopilotGraphJson.Options);
+
+        string unsignedToken = $"{Base64UrlEncode(Encoding.UTF8.GetBytes(header))}.{Base64UrlEncode(Encoding.UTF8.GetBytes(payload))}";
+        using RSA? rsa = certificate.GetRSAPrivateKey();
+        if (rsa is null)
+        {
+            throw new InvalidOperationException("The embedded PFX certificate does not expose an RSA private key.");
+        }
+
+        byte[] signature = rsa.SignData(
+            Encoding.ASCII.GetBytes(unsignedToken),
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pss);
+        return $"{unsignedToken}.{Base64UrlEncode(signature)}";
+    }
+
+    private static string ReadOAuthError(string responseBody)
+    {
+        if (string.IsNullOrWhiteSpace(responseBody))
+        {
+            return "No error body was returned";
+        }
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(responseBody);
+            string? code = document.RootElement.TryGetProperty("error", out JsonElement error)
+                ? error.GetString()
+                : null;
+            string? description = document.RootElement.TryGetProperty("error_description", out JsonElement descriptionElement)
+                ? descriptionElement.GetString()
+                : null;
+            return string.Join(
+                ": ",
+                new[] { code, description }
+                    .Where(value => !string.IsNullOrWhiteSpace(value))
+                    .Select(value => value!.Trim()));
+        }
+        catch (JsonException)
+        {
+            return responseBody.Length <= 500 ? responseBody : responseBody[..500];
+        }
+    }
+
+    private static string Base64UrlEncode(byte[] value)
+    {
+        return Convert.ToBase64String(value)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+}
+
+public sealed record AutopilotGraphTokenServiceOptions
+{
+    public int RetryCount { get; init; } = HttpRetryPolicy.DefaultRetryCount;
+    public TimeSpan RetryDelay { get; init; } = HttpRetryPolicy.DefaultRetryDelay;
+}

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashUploadContracts.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashUploadContracts.cs
@@ -1,0 +1,75 @@
+using Foundry.Deploy.Models.Configuration;
+using Foundry.Deploy.Services.Deployment;
+
+namespace Foundry.Deploy.Services.Autopilot;
+
+/// <summary>
+/// Uploads a captured Autopilot hardware hash through the WinPE certificate-based Graph path.
+/// </summary>
+public interface IAutopilotHardwareHashUploadService
+{
+    Task<AutopilotHardwareHashUploadResult> UploadAsync(
+        AutopilotHardwareHashUploadRequest request,
+        IProgress<AutopilotHardwareHashUploadProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record AutopilotHardwareHashUploadRequest
+{
+    public required DeployAutopilotHardwareHashUploadSettings Settings { get; init; }
+    public required AutopilotHardwareHashDeviceIdentity Identity { get; init; }
+    public required string WorkspaceRootPath { get; init; }
+    public required string DiagnosticsRootPath { get; init; }
+}
+
+public sealed record AutopilotHardwareHashUploadProgress(
+    string Message,
+    string? Detail = null,
+    bool IsIndeterminate = true);
+
+public sealed record AutopilotHardwareHashUploadResult
+{
+    public required AutopilotHardwareHashUploadState State { get; init; }
+    public required string Message { get; init; }
+    public string? FailureCode { get; init; }
+    public string? ImportId { get; init; }
+    public string? ImportedIdentityId { get; init; }
+    public string? AutopilotDeviceId { get; init; }
+    public string? ArtifactPath { get; init; }
+
+    public bool IsCompleted => State == AutopilotHardwareHashUploadState.Completed;
+    public bool IsTimedOut => State == AutopilotHardwareHashUploadState.UploadTimedOut;
+
+    public static AutopilotHardwareHashUploadResult Completed(
+        string message,
+        string? importId = null,
+        string? importedIdentityId = null,
+        string? autopilotDeviceId = null)
+    {
+        return new AutopilotHardwareHashUploadResult
+        {
+            State = AutopilotHardwareHashUploadState.Completed,
+            Message = message,
+            ImportId = importId,
+            ImportedIdentityId = importedIdentityId,
+            AutopilotDeviceId = autopilotDeviceId
+        };
+    }
+
+    public static AutopilotHardwareHashUploadResult Failed(
+        AutopilotHardwareHashUploadState state,
+        string message,
+        string? failureCode = null,
+        string? importId = null,
+        string? importedIdentityId = null)
+    {
+        return new AutopilotHardwareHashUploadResult
+        {
+            State = state,
+            Message = message,
+            FailureCode = failureCode,
+            ImportId = importId,
+            ImportedIdentityId = importedIdentityId
+        };
+    }
+}

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashUploadContracts.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashUploadContracts.cs
@@ -38,7 +38,6 @@ public sealed record AutopilotHardwareHashUploadResult
     public string? ArtifactPath { get; init; }
 
     public bool IsCompleted => State == AutopilotHardwareHashUploadState.Completed;
-    public bool IsTimedOut => State == AutopilotHardwareHashUploadState.UploadTimedOut;
 
     public static AutopilotHardwareHashUploadResult Completed(
         string message,

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashUploadService.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashUploadService.cs
@@ -1,0 +1,191 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Foundry.Deploy.Services.Deployment;
+using Microsoft.Extensions.Logging;
+
+namespace Foundry.Deploy.Services.Autopilot;
+
+/// <summary>
+/// Decrypts media certificate material in memory, authenticates to Graph, and imports the captured hardware hash.
+/// </summary>
+public sealed class AutopilotHardwareHashUploadService(
+    IMediaSecretKeyReader mediaSecretKeyReader,
+    IAutopilotGraphTokenService tokenService,
+    AutopilotGraphImportClient graphImportClient,
+    ILogger<AutopilotHardwareHashUploadService> logger) : IAutopilotHardwareHashUploadService
+{
+    private const string UploadResultFileName = "AutopilotUploadResult.json";
+
+    private readonly IMediaSecretKeyReader mediaSecretKeyReader = mediaSecretKeyReader;
+    private readonly IAutopilotGraphTokenService tokenService = tokenService;
+    private readonly AutopilotGraphImportClient graphImportClient = graphImportClient;
+    private readonly ILogger logger = logger;
+
+    public async Task<AutopilotHardwareHashUploadResult> UploadAsync(
+        AutopilotHardwareHashUploadRequest request,
+        IProgress<AutopilotHardwareHashUploadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        Directory.CreateDirectory(request.DiagnosticsRootPath);
+
+        AutopilotHardwareHashUploadResult result;
+        try
+        {
+            result = await UploadCoreAsync(request, progress, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or ArgumentException or FileNotFoundException or CryptographicException or HttpRequestException or JsonException)
+        {
+            logger.LogWarning(ex, "Autopilot hardware hash upload failed and OS deployment will continue.");
+            result = AutopilotHardwareHashUploadResult.Failed(
+                AutopilotHardwareHashUploadState.UploadFailed,
+                $"Autopilot hardware hash upload skipped: {ex.Message}",
+                ResolveFailureCode(ex));
+        }
+
+        return await WriteSanitizedResultAsync(request, result, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<AutopilotHardwareHashUploadResult> UploadCoreAsync(
+        AutopilotHardwareHashUploadRequest request,
+        IProgress<AutopilotHardwareHashUploadProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        ValidateRequest(request);
+        progress?.Report(new AutopilotHardwareHashUploadProgress(
+            "Preparing Autopilot hardware hash upload...",
+            "Decrypting media certificate..."));
+
+        byte[] mediaKey = await mediaSecretKeyReader.ReadAsync(request.WorkspaceRootPath, cancellationToken)
+            .ConfigureAwait(false);
+        byte[]? pfxBytes = null;
+        try
+        {
+            pfxBytes = DeployMediaSecretEnvelopeProtector.DecryptBytes(
+                request.Settings.CertificatePfxSecret!,
+                mediaKey);
+            string pfxPassword = DeployMediaSecretEnvelopeProtector.DecryptString(
+                request.Settings.CertificatePfxPasswordSecret!,
+                mediaKey);
+
+            progress?.Report(new AutopilotHardwareHashUploadProgress(
+                "Authenticating Autopilot hardware hash upload...",
+                "Requesting Microsoft Graph token..."));
+            using X509Certificate2 certificate = AutopilotCertificateCredential.Load(
+                pfxBytes,
+                pfxPassword,
+                request.Settings.ActiveCertificateThumbprint!);
+            string accessToken = await tokenService.AcquireAccessTokenAsync(
+                request.Settings.TenantId!,
+                request.Settings.ClientId!,
+                certificate,
+                cancellationToken).ConfigureAwait(false);
+
+            progress?.Report(new AutopilotHardwareHashUploadProgress(
+                "Uploading Autopilot hardware hash...",
+                "Importing hardware hash into Microsoft Graph..."));
+            return await graphImportClient.ImportHardwareHashAsync(
+                new AutopilotGraphImportRequest(
+                    accessToken,
+                    request.Identity.SerialNumber,
+                    request.Identity.HardwareHash,
+                    request.Identity.GroupTag,
+                    null,
+                    Guid.NewGuid().ToString("D")),
+                progress,
+                cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(mediaKey);
+            if (pfxBytes is not null)
+            {
+                CryptographicOperations.ZeroMemory(pfxBytes);
+            }
+        }
+    }
+
+    private static void ValidateRequest(AutopilotHardwareHashUploadRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Settings.TenantId))
+        {
+            throw new InvalidOperationException("Tenant ID is missing from the Autopilot upload configuration.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Settings.ClientId))
+        {
+            throw new InvalidOperationException("Client ID is missing from the Autopilot upload configuration.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Settings.ActiveCertificateThumbprint))
+        {
+            throw new InvalidOperationException("Certificate thumbprint is missing from the Autopilot upload configuration.");
+        }
+
+        if (request.Settings.CertificatePfxSecret is null || request.Settings.CertificatePfxPasswordSecret is null)
+        {
+            throw new InvalidOperationException("Encrypted certificate material is missing from the Autopilot upload configuration.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Identity.SerialNumber))
+        {
+            throw new InvalidOperationException("Captured Autopilot serial number is empty.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Identity.HardwareHash))
+        {
+            throw new InvalidOperationException("Captured Autopilot hardware hash is empty.");
+        }
+    }
+
+    private static string ResolveFailureCode(Exception exception)
+    {
+        return exception switch
+        {
+            FileNotFoundException => "CertificateMissing",
+            CryptographicException => "AuthenticationFailed",
+            HttpRequestException { StatusCode: HttpStatusCode.Unauthorized } => "AuthenticationFailed",
+            HttpRequestException { StatusCode: HttpStatusCode.Forbidden } => "PermissionMissing",
+            HttpRequestException { StatusCode: HttpStatusCode.TooManyRequests } => "GraphUnavailable",
+            HttpRequestException { StatusCode: >= HttpStatusCode.InternalServerError } => "IntuneUnavailable",
+            HttpRequestException => "GraphUnavailable",
+            _ => "UploadFailed"
+        };
+    }
+
+    private static async Task<AutopilotHardwareHashUploadResult> WriteSanitizedResultAsync(
+        AutopilotHardwareHashUploadRequest request,
+        AutopilotHardwareHashUploadResult result,
+        CancellationToken cancellationToken)
+    {
+        string resultPath = Path.Combine(request.DiagnosticsRootPath, UploadResultFileName);
+        string json = JsonSerializer.Serialize(new
+        {
+            createdAtUtc = DateTimeOffset.UtcNow,
+            result.State,
+            result.Message,
+            result.FailureCode,
+            result.ImportId,
+            result.ImportedIdentityId,
+            result.AutopilotDeviceId,
+            request.Identity.SerialNumber,
+            request.Identity.GroupTag,
+            tenantId = request.Settings.TenantId,
+            clientId = request.Settings.ClientId,
+            activeCertificateThumbprint = request.Settings.ActiveCertificateThumbprint,
+            activeCertificateExpiresOnUtc = request.Settings.ActiveCertificateExpiresOnUtc
+        }, new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        });
+
+        await File.WriteAllTextAsync(resultPath, json, cancellationToken).ConfigureAwait(false);
+        return result with { ArtifactPath = resultPath };
+    }
+}

--- a/src/Foundry.Deploy/Services/Autopilot/DeployMediaSecretEnvelopeProtector.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/DeployMediaSecretEnvelopeProtector.cs
@@ -1,0 +1,98 @@
+using System.Security.Cryptography;
+using System.Text;
+using Foundry.Deploy.Models.Configuration;
+
+namespace Foundry.Deploy.Services.Autopilot;
+
+/// <summary>
+/// Decrypts the shared Foundry media secret envelope format inside WinPE without depending on Foundry.Core.
+/// </summary>
+public static class DeployMediaSecretEnvelopeProtector
+{
+    public const string Kind = "encrypted";
+    public const string Algorithm = "aes-gcm-v1";
+    public const string KeyId = "media";
+    public const int KeySizeBytes = 32;
+    private const int NonceSizeBytes = 12;
+    private const int TagSizeBytes = 16;
+
+    public static byte[] DecryptBytes(SecretEnvelope envelope, byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+        ValidateEnvelope(envelope);
+        ValidateKey(key);
+
+        byte[] nonce = Base64UrlDecode(envelope.Nonce);
+        byte[] tag = Base64UrlDecode(envelope.Tag);
+        byte[] ciphertext = Base64UrlDecode(envelope.Ciphertext);
+        byte[] plaintext = new byte[ciphertext.Length];
+
+        if (nonce.Length != NonceSizeBytes)
+        {
+            throw new CryptographicException("Encrypted secret nonce has an invalid length.");
+        }
+
+        if (tag.Length != TagSizeBytes)
+        {
+            throw new CryptographicException("Encrypted secret tag has an invalid length.");
+        }
+
+        try
+        {
+            using var aes = new AesGcm(key, TagSizeBytes);
+            aes.Decrypt(nonce, ciphertext, tag, plaintext);
+            return plaintext;
+        }
+        catch (CryptographicException ex)
+        {
+            CryptographicOperations.ZeroMemory(plaintext);
+            throw new CryptographicException("Encrypted secret could not be decrypted.", ex);
+        }
+    }
+
+    public static string DecryptString(SecretEnvelope envelope, byte[] key)
+    {
+        byte[] plaintext = DecryptBytes(envelope, key);
+        try
+        {
+            return Encoding.UTF8.GetString(plaintext);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(plaintext);
+        }
+    }
+
+    private static void ValidateEnvelope(SecretEnvelope envelope)
+    {
+        if (!string.Equals(envelope.Kind, Kind, StringComparison.Ordinal) ||
+            !string.Equals(envelope.Algorithm, Algorithm, StringComparison.Ordinal) ||
+            !string.Equals(envelope.KeyId, KeyId, StringComparison.Ordinal))
+        {
+            throw new CryptographicException("Encrypted secret envelope is not supported.");
+        }
+
+        if (string.IsNullOrWhiteSpace(envelope.Nonce) ||
+            string.IsNullOrWhiteSpace(envelope.Tag) ||
+            string.IsNullOrWhiteSpace(envelope.Ciphertext))
+        {
+            throw new CryptographicException("Encrypted secret envelope is incomplete.");
+        }
+    }
+
+    private static void ValidateKey(byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        if (key.Length != KeySizeBytes)
+        {
+            throw new ArgumentException($"Media secret key must be {KeySizeBytes} bytes.", nameof(key));
+        }
+    }
+
+    private static byte[] Base64UrlDecode(string value)
+    {
+        string base64 = value.Replace('-', '+').Replace('_', '/');
+        int padding = (4 - base64.Length % 4) % 4;
+        return Convert.FromBase64String(base64.PadRight(base64.Length + padding, '='));
+    }
+}

--- a/src/Foundry.Deploy/Services/Autopilot/MediaSecretKeyReader.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/MediaSecretKeyReader.cs
@@ -1,0 +1,35 @@
+using System.IO;
+
+namespace Foundry.Deploy.Services.Autopilot;
+
+public interface IMediaSecretKeyReader
+{
+    Task<byte[]> ReadAsync(string workspaceRootPath, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Reads the generated boot media secret key from X:\Foundry\Config\Secrets\media-secrets.key.
+/// </summary>
+public sealed class MediaSecretKeyReader : IMediaSecretKeyReader
+{
+    private const string KeyRelativePath = @"Config\Secrets\media-secrets.key";
+
+    public async Task<byte[]> ReadAsync(string workspaceRootPath, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRootPath);
+
+        string keyPath = Path.Combine(workspaceRootPath, KeyRelativePath);
+        if (!File.Exists(keyPath))
+        {
+            throw new FileNotFoundException("Autopilot media secret key was not found in the boot media configuration.", keyPath);
+        }
+
+        byte[] key = await File.ReadAllBytesAsync(keyPath, cancellationToken).ConfigureAwait(false);
+        if (key.Length != DeployMediaSecretEnvelopeProtector.KeySizeBytes)
+        {
+            throw new InvalidOperationException("Autopilot media secret key has an invalid length.");
+        }
+
+        return key;
+    }
+}

--- a/src/Foundry.Deploy/Services/Deployment/AutopilotHardwareHashUploadState.cs
+++ b/src/Foundry.Deploy/Services/Deployment/AutopilotHardwareHashUploadState.cs
@@ -21,11 +21,6 @@ public enum AutopilotHardwareHashUploadState
     DryRunPrepared,
 
     /// <summary>
-    /// OA3Tool captured the hardware hash and retained local diagnostics; Graph upload is not yet complete.
-    /// </summary>
-    HashCaptured,
-
-    /// <summary>
     /// Hardware hash upload was skipped because the media certificate is expired.
     /// </summary>
     SkippedCertificateExpired,

--- a/src/Foundry.Deploy/Services/Deployment/Steps/ProvisionAutopilotStep.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Steps/ProvisionAutopilotStep.cs
@@ -17,10 +17,14 @@ public sealed class ProvisionAutopilotStep : DeploymentStepBase
     private const string WinPeWindowsFolderName = "Windows";
 
     private readonly IAutopilotHardwareHashCaptureService _hardwareHashCaptureService;
+    private readonly IAutopilotHardwareHashUploadService _hardwareHashUploadService;
 
-    public ProvisionAutopilotStep(IAutopilotHardwareHashCaptureService hardwareHashCaptureService)
+    public ProvisionAutopilotStep(
+        IAutopilotHardwareHashCaptureService hardwareHashCaptureService,
+        IAutopilotHardwareHashUploadService hardwareHashUploadService)
     {
         _hardwareHashCaptureService = hardwareHashCaptureService;
+        _hardwareHashUploadService = hardwareHashUploadService;
     }
 
     public override int Order => 18;
@@ -202,19 +206,42 @@ public sealed class ProvisionAutopilotStep : DeploymentStepBase
             return DeploymentStepResult.Failed(failureMessage);
         }
 
-        string capturedMessage = "Autopilot hardware hash captured. Graph upload will run in a later phase.";
+        context.EmitCurrentStepIndeterminate("Uploading Autopilot hardware hash...", "Preparing Microsoft Graph import...");
+        AutopilotHardwareHashUploadResult uploadResult = await _hardwareHashUploadService.UploadAsync(
+            new AutopilotHardwareHashUploadRequest
+            {
+                Settings = settings,
+                Identity = captureResult.Identity!,
+                WorkspaceRootPath = context.RuntimeState.WorkspaceRoot,
+                DiagnosticsRootPath = diagnosticsPath
+            },
+            new Progress<AutopilotHardwareHashUploadProgress>(progress =>
+            {
+                context.EmitCurrentStep(
+                    DeploymentStepState.Running,
+                    progress.Message,
+                    stepSubProgressPercent: null,
+                    stepSubProgressIndeterminate: progress.IsIndeterminate,
+                    stepSubProgressLabel: progress.Detail);
+            }),
+            cancellationToken).ConfigureAwait(false);
+
         await WriteHardwareHashStatusAsync(
             context,
-            AutopilotHardwareHashUploadState.HashCaptured,
-            capturedMessage,
+            uploadResult.State,
+            uploadResult.Message,
             cancellationToken,
-            failureCode: null,
-            captureResult).ConfigureAwait(false);
+            uploadResult.FailureCode,
+            captureResult,
+            uploadResult).ConfigureAwait(false);
         await context.AppendLogAsync(
-            DeploymentLogLevel.Info,
-            $"Autopilot hardware hash captured. DiagnosticsPath='{context.RuntimeState.AutopilotHardwareHashDiagnosticsPath}', GroupTag='{FormatGroupTagForLog(context.RuntimeState.AutopilotHardwareHashGroupTag)}'.",
+            uploadResult.IsCompleted ? DeploymentLogLevel.Info : DeploymentLogLevel.Warning,
+            $"Autopilot hardware hash upload state '{uploadResult.State}'. DiagnosticsPath='{context.RuntimeState.AutopilotHardwareHashDiagnosticsPath}', GroupTag='{FormatGroupTagForLog(context.RuntimeState.AutopilotHardwareHashGroupTag)}'.",
             cancellationToken).ConfigureAwait(false);
-        return DeploymentStepResult.Succeeded("Autopilot hardware hash captured.");
+
+        return uploadResult.IsCompleted
+            ? DeploymentStepResult.Succeeded(uploadResult.Message)
+            : DeploymentStepResult.Skipped(uploadResult.Message);
     }
 
     private static async Task<DeploymentStepResult> WriteDryRunHardwareHashManifestAsync(
@@ -265,7 +292,8 @@ public sealed class ProvisionAutopilotStep : DeploymentStepBase
         string message,
         CancellationToken cancellationToken,
         string? failureCode = null,
-        AutopilotHardwareHashCaptureResult? captureResult = null)
+        AutopilotHardwareHashCaptureResult? captureResult = null,
+        AutopilotHardwareHashUploadResult? uploadResult = null)
     {
         string diagnosticsPath = ResolveHardwareHashDiagnosticsPath(context);
         Directory.CreateDirectory(diagnosticsPath);
@@ -286,6 +314,10 @@ public sealed class ProvisionAutopilotStep : DeploymentStepBase
             oa3XmlPath = captureResult?.Oa3XmlPath,
             oa3LogPath = captureResult?.Oa3LogPath,
             autopilotHwidCsvPath = captureResult?.CsvPath,
+            autopilotUploadResultPath = uploadResult?.ArtifactPath,
+            importId = uploadResult?.ImportId,
+            importedIdentityId = uploadResult?.ImportedIdentityId,
+            autopilotDeviceId = uploadResult?.AutopilotDeviceId,
             tenantId = context.Request.AutopilotHardwareHashUpload.TenantId,
             clientId = context.Request.AutopilotHardwareHashUpload.ClientId,
             activeCertificateThumbprint = context.Request.AutopilotHardwareHashUpload.ActiveCertificateThumbprint,


### PR DESCRIPTION
## Summary
Implements Phase 7 Graph upload support for Autopilot hardware hash upload in Foundry Deploy.

## Reason
Foundry Deploy needs to import captured WinPE hardware hashes into Windows Autopilot using only the certificate material embedded in generated boot media, then continue OS deployment on non-blocking Graph/auth/import failures.

## Main changes
- Added Deploy-side media secret decryption and media secret key reading for encrypted PFX material.
- Added certificate assertion token acquisition using PS256 and app-only Microsoft Graph authentication.
- Added Microsoft Graph Autopilot import, import-state polling, Windows Autopilot device visibility polling, transient retry handling, and sanitized upload result output.
- Wired the upload service into `ProvisionAutopilotStep` after hardware hash capture, with non-blocking deployment continuation for upload failures/timeouts.
- Updated the Phase 7 implementation checklist and deferred live tenant/manual validation notes.

## Testing
- `dotnet test src/Foundry.Deploy.Tests/Foundry.Deploy.Tests.csproj --no-restore --verbosity minimal`
- `dotnet build src/Foundry.Deploy/Foundry.Deploy.csproj -p:Platform=x64 --no-restore --verbosity minimal`
- `dotnet build src/Foundry.Deploy/Foundry.Deploy.csproj -p:Platform=ARM64 --no-restore --verbosity minimal`

Manual WinPE/Intune tenant validation remains deferred until physical media and a test tenant device import run are available.