### PR TITLE
docs(autopilot): document WinPE hardware hash upload

### DIFF
--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -510,8 +510,8 @@ Implementation progress:
 - [x] Implementation checklist complete.
 - [x] Documentation build or preview complete.
 - [x] Manual checks complete or explicitly deferred.
-- [ ] Foundry PR opened with the planned title.
-- [ ] Docusaurus PR opened with the planned title.
+- [x] Foundry PR opened with the planned title: https://github.com/foundry-osd/foundry/pull/193.
+- [x] Docusaurus PR opened with the planned title: https://github.com/foundry-osd/foundry-osd.github.io/pull/19.
 - [ ] Foundry and Docusaurus PRs merged.
 
 - [x] Add user documentation for hardware hash upload from WinPE.

--- a/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
+++ b/docs/implementation/autopilot-hash-upload/05-implementation-phases.md
@@ -241,7 +241,7 @@ Implementation progress:
 - [x] Automated tests complete.
 - [x] Manual checks complete or explicitly deferred.
 - [x] PR opened with the planned title.
-- [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
+- [x] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
 - [x] Render only the selected Autopilot provisioning mode from the OSD-generated deploy configuration.
 - [x] In disabled Autopilot mode, show only the media provisioning mode summary and no provisioning controls.
@@ -320,7 +320,7 @@ Implementation progress:
 - [x] Automated tests complete.
 - [x] Manual checks complete or explicitly deferred.
 - [x] PR opened with the planned title.
-- [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
+- [x] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
 - [x] Add `WinPE-SecureStartup` to the default required optional components for all generated WinPE media.
 - [x] Locate and stage architecture-specific `oa3tool.exe` from the ADK for x64 and ARM64.
@@ -363,7 +363,7 @@ Implementation progress:
 - [x] Automated tests complete.
 - [x] Manual checks complete or explicitly deferred.
 - [x] PR opened with the planned title.
-- [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
+- [x] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
 - [x] Load Autopilot provisioning mode from deploy config.
 - [x] Expose mode in startup snapshot, preparation view model, launch request, deployment context, and runtime state.
@@ -413,7 +413,7 @@ Implementation progress:
 - [x] Automated tests complete.
 - [x] Manual checks complete or explicitly deferred.
 - [x] PR opened with the planned title.
-- [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
+- [x] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
 - [x] Add a C# service that runs OA3Tool with controlled working directory paths.
 - [x] Add a C# service that copies `PCPKsp.dll` from `<target Windows>\Windows\System32` to `X:\Windows\System32`.
@@ -457,7 +457,7 @@ Implementation progress:
 - [x] Automated tests complete.
 - [x] Manual checks complete or explicitly deferred.
 - [x] PR opened with the planned title.
-- [ ] PR merged back into `feature/autopilot-hash-upload-foundation`.
+- [x] PR merged back into `feature/autopilot-hash-upload-foundation`.
 
 - [x] Add a minimal Graph Autopilot import client.
 - [x] Add certificate-based credential creation from decrypted in-memory certificate material.
@@ -505,37 +505,37 @@ Manual checks:
 PR title: `docs(autopilot): document WinPE hardware hash upload`
 
 Implementation progress:
-- [ ] Phase branch created from `feature/autopilot-hash-upload-foundation`.
-- [ ] Docusaurus worktree and branch created.
-- [ ] Implementation checklist complete.
-- [ ] Documentation build or preview complete.
-- [ ] Manual checks complete or explicitly deferred.
+- [x] Phase branch created from `feature/autopilot-hash-upload-foundation`.
+- [x] Docusaurus worktree and branch created.
+- [x] Implementation checklist complete.
+- [x] Documentation build or preview complete.
+- [x] Manual checks complete or explicitly deferred.
 - [ ] Foundry PR opened with the planned title.
 - [ ] Docusaurus PR opened with the planned title.
 - [ ] Foundry and Docusaurus PRs merged.
 
-- [ ] Add user documentation for hardware hash upload from WinPE.
-- [ ] Update the Docusaurus documentation if the implemented behavior affects user-facing OSD, Deploy, WinPE requirements, setup, troubleshooting, permissions, or release notes.
-- [ ] Use the Docusaurus repository at `E:\Github\Foundry Project\foundry-osd.github.io`.
-- [ ] Create a dedicated Docusaurus worktree before editing docs.
-- [ ] Create the Docusaurus branch `docs/autopilot-hash-upload` from the current documentation base branch.
-- [ ] Use the Docusaurus PR title `docs(autopilot): document WinPE hardware hash upload`.
-- [ ] Locate the Docusaurus documentation source inside that repository by searching for `docusaurus.config.*` or the docs package root before editing docs.
-- [ ] Mark WinPE hash capture as best-effort and not the Microsoft-standard method.
-- [ ] Document x64 and ARM64 scope.
-- [ ] Document that Foundry copies `PCPKsp.dll` from the applied OS to `X:\Windows\System32` late in deployment.
-- [ ] Document network requirements for Ethernet and Wi-Fi.
-- [ ] Document retained troubleshooting artifacts under `<target Windows>\Windows\Temp\Foundry\Logs\AutopilotHash` and the operator cleanup process after diagnostics are no longer needed.
-- [ ] Document unsupported or risky scenarios:
+- [x] Add user documentation for hardware hash upload from WinPE.
+- [x] Update the Docusaurus documentation if the implemented behavior affects user-facing OSD, Deploy, WinPE requirements, setup, troubleshooting, permissions, or release notes.
+- [x] Use the Docusaurus repository at `E:\Github\Foundry Project\foundry-osd.github.io`.
+- [x] Create a dedicated Docusaurus worktree before editing docs.
+- [x] Create the Docusaurus branch `docs/autopilot-hash-upload` from the current documentation base branch.
+- [x] Use the Docusaurus PR title `docs(autopilot): document WinPE hardware hash upload`.
+- [x] Locate the Docusaurus documentation source inside that repository by searching for `docusaurus.config.*` or the docs package root before editing docs.
+- [x] Mark WinPE hash capture as best-effort and not the Microsoft-standard method.
+- [x] Document x64 and ARM64 scope.
+- [x] Document that Foundry copies `PCPKsp.dll` from the applied OS to `X:\Windows\System32` late in deployment.
+- [x] Document network requirements for Ethernet and Wi-Fi.
+- [x] Document retained troubleshooting artifacts under `<target Windows>\Windows\Temp\Foundry\Logs\AutopilotHash` and the operator cleanup process after diagnostics are no longer needed.
+- [x] Document unsupported or risky scenarios:
   - self-deploying mode
   - pre-provisioning
   - missing TPM visibility
-- [ ] Update screenshots after UI implementation.
-- [ ] Update Docusaurus navigation/sidebar entries if a new Autopilot hardware hash page is added.
+- [x] Update screenshots after UI implementation. Existing screenshots remain unchanged for Phase 8 because this phase adds operator guidance, not new UI assets.
+- [x] Update Docusaurus navigation/sidebar entries if a new Autopilot hardware hash page is added.
 
 Manual checks:
-- [ ] Follow the docs on a clean test tenant.
-- [ ] Follow the docs on a clean x64 test device.
-- [ ] Follow the docs on a clean ARM64 test device.
-- [ ] Confirm fallback to OOBE/full OS instructions are clear.
-- [ ] Build or preview the Docusaurus docs with the command discovered from the docs package scripts if Docusaurus files are changed.
+- [ ] Follow the docs on a clean test tenant. Deferred to physical tenant validation before production rollout.
+- [ ] Follow the docs on a clean x64 test device. Deferred to physical media validation before production rollout.
+- [ ] Follow the docs on a clean ARM64 test device. Deferred until ARM64 validation hardware/media is available.
+- [x] Confirm fallback to OOBE/full OS instructions are clear.
+- [x] Build or preview the Docusaurus docs with the command discovered from the docs package scripts if Docusaurus files are changed: `npm run typecheck` and `npm run build` passed.

--- a/docs/implementation/autopilot-hash-upload/06-validation-risk-docs.md
+++ b/docs/implementation/autopilot-hash-upload/06-validation-risk-docs.md
@@ -93,3 +93,34 @@ Manual physical validation matrix:
 - Release notes:
   - Mark as x64 and ARM64 with Ethernet and Wi-Fi upload guidance.
   - Mention unsupported or risky self-deploying/pre-provisioning status.
+
+## Phase 8 Release Guardrail Status
+Phase 8 adds operator-facing Docusaurus documentation and updates the internal implementation plan. It does not change runtime code.
+
+Documentation validation commands:
+
+```powershell
+npm run typecheck
+npm run build
+```
+
+Release guardrails now documented for operators:
+- Hardware hash upload from WinPE is a Foundry-assisted best-effort workflow, not the Microsoft-standard Autopilot registration path.
+- Generated media is tenant-sensitive because the boot image contains encrypted certificate material and the media secret key needed to decrypt it in WinPE.
+- WinPE Microsoft Graph authentication uses certificate-based app-only authentication only.
+- The required Microsoft Graph application permission is `DeviceManagementServiceConfig.ReadWrite.All`.
+- `PCPKsp.dll` is copied from the applied Windows image into `X:\Windows\System32` late in deployment before OA3Tool capture.
+- Upload failures, expired certificate metadata, Graph errors, duplicate import errors, and Windows Autopilot device visibility timeouts do not fail the Windows deployment.
+- Local hash capture prerequisites can block only the Autopilot upload workflow because Foundry cannot produce a valid hash without them.
+- Retained diagnostics stay under `<target Windows>\Windows\Temp\Foundry\Logs\AutopilotHash` and must remain sanitized.
+- Self-deploying mode, pre-provisioning, and unvalidated TPM visibility from WinPE remain unsupported or risky scenarios.
+- Destructive duplicate-device cleanup is intentionally out of scope for the final workflow.
+
+Manual validation still required before broad production rollout:
+- Follow the published docs in a clean test tenant.
+- Validate one clean x64 physical device with Ethernet.
+- Validate one clean x64 physical device with Wi-Fi when Wi-Fi media is in scope.
+- Validate one clean ARM64 physical device with Ethernet.
+- Validate one clean ARM64 physical device with Wi-Fi when ARM64 media is in scope.
+- Confirm duplicate-device behavior is clear and does not delete existing Autopilot records.
+- Confirm retained diagnostics are present and do not contain tokens, authorization headers, PFX bytes, PFX passwords, decrypted private key material, encrypted secret blobs, media secret keys, or raw Graph payloads.


### PR DESCRIPTION
## Summary
- Updates the Autopilot hardware hash upload implementation plan for Phase 8.
- Records release guardrails and remaining physical validation requirements.

## Reason
Phase 8 tracks documentation and release guardrails after the implementation phases were squashed into the foundation branch.

## Main changes
- Marks Phases 4 through 7 as merged into the foundation branch.
- Marks completed Phase 8 documentation work and Docusaurus validation.
- Adds release guardrails for best-effort WinPE upload, tenant-sensitive media, Graph auth, diagnostics, and deferred physical validation.

## Testing
- git diff --check
- Docusaurus validation completed in foundry-osd.github.io: npm run typecheck, npm run build