### PR TITLE
fix(deploy): streamline Autopilot hash card

### DIFF
--- a/src/Foundry.Deploy.Tests/DeploymentPreparationViewModelTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentPreparationViewModelTests.cs
@@ -112,7 +112,8 @@ public sealed class DeploymentPreparationViewModelTests
         Assert.True(viewModel.IsHardwareHashCertificateUsable);
         Assert.True(viewModel.IsHardwareHashGroupTagControlsVisible);
         Assert.False(string.IsNullOrWhiteSpace(viewModel.AutopilotHardwareHashUploadStatusText));
-        Assert.False(string.IsNullOrWhiteSpace(viewModel.AutopilotHardwareHashUploadMessage));
+        Assert.False(viewModel.IsHardwareHashUploadMessageVisible);
+        Assert.True(string.IsNullOrWhiteSpace(viewModel.AutopilotHardwareHashUploadMessage));
         Assert.Equal("tenant-id", viewModel.AutopilotHardwareHashTenantIdText);
         Assert.Equal("ABCDEF123456", viewModel.AutopilotHardwareHashCertificateThumbprintText);
         Assert.Equal("Sales", viewModel.SelectedHardwareHashGroupTag?.GroupTag);
@@ -139,6 +140,7 @@ public sealed class DeploymentPreparationViewModelTests
         Assert.False(viewModel.IsHardwareHashCertificateUsable);
         Assert.False(viewModel.IsHardwareHashGroupTagControlsVisible);
         Assert.False(string.IsNullOrWhiteSpace(viewModel.AutopilotHardwareHashUploadStatusText));
+        Assert.True(viewModel.IsHardwareHashUploadMessageVisible);
         Assert.False(string.IsNullOrWhiteSpace(viewModel.AutopilotHardwareHashUploadMessage));
     }
 
@@ -159,7 +161,7 @@ public sealed class DeploymentPreparationViewModelTests
         Assert.False(viewModel.HasHardwareHashUploadMetadata);
         Assert.False(viewModel.IsHardwareHashCertificateUsable);
         Assert.False(viewModel.IsHardwareHashGroupTagControlsVisible);
-        Assert.True(viewModel.IsHardwareHashMissingMetadataWarningVisible);
+        Assert.True(viewModel.IsHardwareHashUploadMessageVisible);
     }
 
     [Fact]

--- a/src/Foundry.Deploy/Strings/en-US/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-US/Resources.resx
@@ -57,9 +57,9 @@
   <data name="Preparation.AutopilotHardwareHashReadyStatus" xml:space="preserve"><value>Ready for hardware hash upload</value></data>
   <data name="Preparation.AutopilotHardwareHashNotReadyStatus" xml:space="preserve"><value>Not ready for hardware hash upload</value></data>
   <data name="Preparation.AutopilotHardwareHashExpiredStatus" xml:space="preserve"><value>Certificate expired</value></data>
-  <data name="Preparation.AutopilotHardwareHashReadyMessage" xml:space="preserve"><value>Upload will run automatically during deployment.</value></data>
   <data name="Preparation.AutopilotHardwareHashMissingMetadataMessage" xml:space="preserve"><value>Autopilot upload is unavailable on this media. Deployment can continue, but upload will be skipped.</value></data>
   <data name="Preparation.AutopilotHardwareHashExpiredMessage" xml:space="preserve"><value>The Autopilot certificate has expired. Deployment can continue, but upload will be skipped.</value></data>
+  <data name="Preparation.AutopilotHardwareHashDetails" xml:space="preserve"><value>Details</value></data>
   <data name="Preparation.AutopilotHardwareHashTenantId" xml:space="preserve"><value>Tenant ID</value></data>
   <data name="Preparation.AutopilotHardwareHashCertificateThumbprint" xml:space="preserve"><value>Certificate thumbprint</value></data>
   <data name="Preparation.AutopilotHardwareHashCertificateExpiration" xml:space="preserve"><value>Certificate expiration</value></data>

--- a/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
@@ -57,9 +57,9 @@
   <data name="Preparation.AutopilotHardwareHashReadyStatus" xml:space="preserve"><value>Prêt pour l'upload du hardware hash</value></data>
   <data name="Preparation.AutopilotHardwareHashNotReadyStatus" xml:space="preserve"><value>Pas prêt pour l'upload du hardware hash</value></data>
   <data name="Preparation.AutopilotHardwareHashExpiredStatus" xml:space="preserve"><value>Certificat expiré</value></data>
-  <data name="Preparation.AutopilotHardwareHashReadyMessage" xml:space="preserve"><value>L'upload s'exécutera automatiquement pendant le déploiement.</value></data>
   <data name="Preparation.AutopilotHardwareHashMissingMetadataMessage" xml:space="preserve"><value>L'upload Autopilot n'est pas disponible sur ce média. Le déploiement peut continuer, mais l'upload sera ignoré.</value></data>
   <data name="Preparation.AutopilotHardwareHashExpiredMessage" xml:space="preserve"><value>Le certificat Autopilot a expiré. Le déploiement peut continuer, mais l'upload sera ignoré.</value></data>
+  <data name="Preparation.AutopilotHardwareHashDetails" xml:space="preserve"><value>Détails</value></data>
   <data name="Preparation.AutopilotHardwareHashTenantId" xml:space="preserve"><value>ID du tenant</value></data>
   <data name="Preparation.AutopilotHardwareHashCertificateThumbprint" xml:space="preserve"><value>Empreinte du certificat</value></data>
   <data name="Preparation.AutopilotHardwareHashCertificateExpiration" xml:space="preserve"><value>Expiration du certificat</value></data>

--- a/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
@@ -123,7 +123,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         expiresOn <= DateTimeOffset.UtcNow;
     public bool IsHardwareHashCertificateUsable => HasHardwareHashUploadMetadata && !IsHardwareHashCertificateExpired;
     public bool IsHardwareHashGroupTagControlsVisible => IsHardwareHashUploadControlsVisible && IsHardwareHashCertificateUsable;
-    public bool IsHardwareHashMissingMetadataWarningVisible => IsHardwareHashUploadControlsVisible && !HasHardwareHashUploadMetadata;
+    public bool IsHardwareHashUploadMessageVisible => IsHardwareHashUploadControlsVisible && !IsHardwareHashCertificateUsable;
     public string AutopilotHardwareHashTenantIdText => NormalizeMetadataValue(AutopilotHardwareHashUpload.TenantId);
     public string AutopilotHardwareHashCertificateThumbprintText => NormalizeMetadataValue(AutopilotHardwareHashUpload.ActiveCertificateThumbprint);
     public string AutopilotHardwareHashCertificateExpirationText =>
@@ -167,7 +167,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         {
             if (IsHardwareHashCertificateUsable)
             {
-                return GetString("Preparation.AutopilotHardwareHashReadyMessage");
+                return string.Empty;
             }
 
             if (IsHardwareHashCertificateExpired)
@@ -826,7 +826,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         OnPropertyChanged(nameof(IsHardwareHashCertificateExpired));
         OnPropertyChanged(nameof(IsHardwareHashCertificateUsable));
         OnPropertyChanged(nameof(IsHardwareHashGroupTagControlsVisible));
-        OnPropertyChanged(nameof(IsHardwareHashMissingMetadataWarningVisible));
+        OnPropertyChanged(nameof(IsHardwareHashUploadMessageVisible));
         OnPropertyChanged(nameof(AutopilotHardwareHashTenantIdText));
         OnPropertyChanged(nameof(AutopilotHardwareHashCertificateThumbprintText));
         OnPropertyChanged(nameof(AutopilotHardwareHashCertificateExpirationText));

--- a/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/TargetStepView.xaml
@@ -184,7 +184,45 @@
                                         </TextBlock.Style>
                                     </TextBlock>
 
-                                    <Grid Margin="0,12,0,0">
+                                    <TextBlock
+                                        Margin="0,8,0,0"
+                                        Text="{Binding AutopilotHardwareHashUploadMessage}"
+                                        TextWrapping="Wrap"
+                                        Visibility="{Binding IsHardwareHashUploadMessageVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                        <TextBlock.Style>
+                                            <Style BasedOn="{StaticResource CaptionTextBlockStyle}" TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="#FFC42B1C" />
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+
+                                    <StackPanel
+                                        Margin="0,16,0,0"
+                                        Visibility="{Binding IsHardwareHashGroupTagControlsVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                        <TextBlock
+                                            Margin="0,0,0,8"
+                                            Style="{StaticResource BodyTextBlockStyle}"
+                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashGroupTagChoice], ElementName=ViewRoot}" />
+                                        <ComboBox
+                                            HorizontalAlignment="Stretch"
+                                            DisplayMemberPath="DisplayName"
+                                            ItemsSource="{Binding HardwareHashGroupTagOptions}"
+                                            SelectedItem="{Binding SelectedHardwareHashGroupTag}" />
+                                        <TextBlock
+                                            Margin="0,4,0,0"
+                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                            Style="{StaticResource CaptionTextBlockStyle}"
+                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashGroupTagHint], ElementName=ViewRoot}"
+                                            TextWrapping="Wrap" />
+                                    </StackPanel>
+
+                                    <TextBlock
+                                        Margin="0,16,0,0"
+                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                        Style="{StaticResource BodyTextBlockStyle}"
+                                        Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashDetails], ElementName=ViewRoot}" />
+
+                                    <Grid Margin="0,8,0,0">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" />
                                             <ColumnDefinition Width="16" />
@@ -215,13 +253,13 @@
                                             Margin="0,6,0,0"
                                             FontWeight="SemiBold"
                                             Style="{StaticResource CaptionTextBlockStyle}"
-                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashCertificateThumbprint], ElementName=ViewRoot}" />
+                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashCertificateExpiration], ElementName=ViewRoot}" />
                                         <TextBlock
                                             Grid.Row="1"
                                             Grid.Column="2"
                                             Margin="0,6,0,0"
                                             Style="{StaticResource CaptionTextBlockStyle}"
-                                            Text="{Binding AutopilotHardwareHashCertificateThumbprintText}"
+                                            Text="{Binding AutopilotHardwareHashCertificateExpirationText}"
                                             TextTrimming="CharacterEllipsis" />
 
                                         <TextBlock
@@ -230,51 +268,15 @@
                                             Margin="0,6,0,0"
                                             FontWeight="SemiBold"
                                             Style="{StaticResource CaptionTextBlockStyle}"
-                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashCertificateExpiration], ElementName=ViewRoot}" />
+                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashCertificateThumbprint], ElementName=ViewRoot}" />
                                         <TextBlock
                                             Grid.Row="2"
                                             Grid.Column="2"
                                             Margin="0,6,0,0"
                                             Style="{StaticResource CaptionTextBlockStyle}"
-                                            Text="{Binding AutopilotHardwareHashCertificateExpirationText}"
+                                            Text="{Binding AutopilotHardwareHashCertificateThumbprintText}"
                                             TextTrimming="CharacterEllipsis" />
                                     </Grid>
-
-                                    <TextBlock
-                                        Margin="0,12,0,0"
-                                        Text="{Binding AutopilotHardwareHashUploadMessage}"
-                                        TextWrapping="Wrap">
-                                        <TextBlock.Style>
-                                            <Style BasedOn="{StaticResource CaptionTextBlockStyle}" TargetType="TextBlock">
-                                                <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}" />
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding IsHardwareHashCertificateUsable}" Value="False">
-                                                        <Setter Property="Foreground" Value="#FFC42B1C" />
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
-
-                                    <StackPanel
-                                        Margin="0,16,0,0"
-                                        Visibility="{Binding IsHardwareHashGroupTagControlsVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                        <TextBlock
-                                            Margin="0,0,0,8"
-                                            Style="{StaticResource BodyTextBlockStyle}"
-                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashGroupTagChoice], ElementName=ViewRoot}" />
-                                        <ComboBox
-                                            HorizontalAlignment="Stretch"
-                                            DisplayMemberPath="DisplayName"
-                                            ItemsSource="{Binding HardwareHashGroupTagOptions}"
-                                            SelectedItem="{Binding SelectedHardwareHashGroupTag}" />
-                                        <TextBlock
-                                            Margin="0,4,0,0"
-                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                            Style="{StaticResource CaptionTextBlockStyle}"
-                                            Text="{Binding DataContext.Strings[Preparation.AutopilotHardwareHashGroupTagHint], ElementName=ViewRoot}"
-                                            TextWrapping="Wrap" />
-                                    </StackPanel>
                                 </StackPanel>
                             </StackPanel>
                         </Border>


### PR DESCRIPTION
## Summary
- Move the hardware hash group tag control above technical certificate metadata.
- Remove the normal ready-state automatic-upload sentence from the Autopilot card.
- Keep upload messages only for not-ready and expired-certificate states.

## Reason
The group tag is the operator's primary choice in Deploy, while tenant and certificate metadata are secondary verification details.

## Main changes
- Reordered the hardware hash card to show status, actionable group tag selection, then details.
- Reordered details as tenant ID, certificate expiration, and certificate thumbprint.
- Replaced the old ready message with a visibility-backed warning/error message path.

## Testing
- `dotnet test src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --filter "FullyQualifiedName~DeploymentPreparationViewModelTests" --verbosity minimal`
- `dotnet build src\Foundry.Deploy\Foundry.Deploy.csproj --no-restore -p:Platform=x64`
- `dotnet test src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --no-restore --verbosity minimal`