### PR TITLE
chore(packaging): update Velopack to 1.0.1

### DIFF
--- a/scripts/Publish-FoundryVelopack.ps1
+++ b/scripts/Publish-FoundryVelopack.ps1
@@ -9,7 +9,7 @@ param(
     [ValidateSet('Release', 'Debug')]
     [string]$Configuration = 'Release',
 
-    [string]$VpkVersion = '0.0.1589-ga2c5a97',
+    [string]$VpkVersion = '1.0.1',
 
     [string]$VelopackFeedUrl = 'https://github.com/foundry-osd/foundry',
 

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -67,7 +67,7 @@
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="Velopack" Version="0.0.1589-ga2c5a97" />
+    <PackageReference Include="Velopack" Version="1.0.1" />
     <PackageReference Include="WinUI.TableView" Version="1.4.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
Update Foundry's Velopack dependency and packaging tool pin to Velopack 1.0.1.

## Reason
Velopack 1.0.1 is the latest upstream release and the runtime SDK package should stay aligned with the `vpk` CLI used to create release assets.

## Main changes
- Updated the `Velopack` NuGet package reference in `src/Foundry/Foundry.csproj` to `1.0.1`.
- Updated the default `vpk` tool version in `scripts/Publish-FoundryVelopack.ps1` to `1.0.1`.

## Testing notes
- `dotnet restore src\Foundry.slnx`
- `dotnet tool install vpk --tool-path artifacts\tools\vpk --version 1.0.1`
- `dotnet build src\Foundry\Foundry.csproj -c Release -p:Platform=x64 --no-restore --nologo`
- `dotnet test src\Foundry.slnx -c Release --no-restore --nologo`
- `dotnet build src\Foundry\Foundry.csproj -c Release -p:Platform=ARM64 -r win-arm64 --no-restore --nologo`
- `scripts\Publish-FoundryVelopack.ps1 -RuntimeIdentifier win-x64 -PackVersion 26.5.26-build.1 -SkipPreviousReleaseDownload`