### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/src/Foundry.Connect.Tests/Foundry.Connect.Tests.csproj
+++ b/src/Foundry.Connect.Tests/Foundry.Connect.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Foundry.Connect/Foundry.Connect.csproj
+++ b/src/Foundry.Connect/Foundry.Connect.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />

--- a/src/Foundry.Core.Tests/Foundry.Core.Tests.csproj
+++ b/src/Foundry.Core.Tests/Foundry.Core.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Foundry.Deploy.Tests/Foundry.Deploy.Tests.csproj
+++ b/src/Foundry.Deploy.Tests/Foundry.Deploy.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Foundry.Deploy/Foundry.Deploy.csproj
+++ b/src/Foundry.Deploy/Foundry.Deploy.csproj
@@ -12,8 +12,8 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />

--- a/src/Foundry.Localization.Tests/Foundry.Localization.Tests.csproj
+++ b/src/Foundry.Localization.Tests/Foundry.Localization.Tests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Foundry.Telemetry.Tests/Foundry.Telemetry.Tests.csproj
+++ b/src/Foundry.Telemetry.Tests/Foundry.Telemetry.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Foundry.Telemetry/Foundry.Telemetry.csproj
+++ b/src/Foundry.Telemetry/Foundry.Telemetry.csproj
@@ -9,17 +9,14 @@
 
   <Target Name="GenerateTelemetryProjectToken" BeforeTargets="BeforeCompile">
     <MakeDir Directories="$(TelemetryGeneratedDirectory)" />
-    <WriteLinesToFile
-        File="$(TelemetryGeneratedDirectory)\TelemetryProjectToken.g.cs"
-        Overwrite="true"
-        Lines="namespace Foundry.Telemetry%3B%0A%0Ainternal static class TelemetryProjectToken%0A%7B%0A    public const string Value = &quot;$(FoundryPostHogProjectToken)&quot;%3B%0A%7D" />
+    <WriteLinesToFile File="$(TelemetryGeneratedDirectory)\TelemetryProjectToken.g.cs" Overwrite="true" Lines="namespace Foundry.Telemetry%3B%0A%0Ainternal static class TelemetryProjectToken%0A%7B%0A    public const string Value = &quot;$(FoundryPostHogProjectToken)&quot;%3B%0A%7D" />
     <ItemGroup>
       <Compile Include="$(TelemetryGeneratedDirectory)\TelemetryProjectToken.g.cs" />
     </ItemGroup>
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
   </ItemGroup>
 
 </Project>

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -59,11 +59,11 @@
     <PackageReference Include="DevWinUI.ContextMenu" Version="9.9.1" />
     <PackageReference Include="DevWinUI.Controls" Version="9.9.4" />
     <PackageReference Include="DevWinUI.SourceGenerator" Version="9.9.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />


### PR DESCRIPTION
## Summary
Update Foundry dependency versions across the app and test projects.

## Reason
Keep the project aligned with current servicing releases for .NET, Windows App SDK, and the .NET test platform.

## Main changes
- Update Microsoft.Extensions.DependencyInjection, Hosting, and Logging.Abstractions packages to 10.0.8.
- Update Microsoft.NET.Test.Sdk to 18.6.0 across test projects.
- Update Microsoft.WindowsAppSDK from 2.0.1 to 2.1.3.

## Testing notes
- `dotnet restore src\Foundry.slnx`
- `dotnet build src\Foundry.slnx --no-restore -m:1`
- `dotnet test src\Foundry.slnx --no-build --logger "trx;LogFileName=dependency-upgrade.trx"`
- `dotnet publish src\Foundry\Foundry.csproj -c Release -r win-x64 --no-restore`

Notes: Release publish completes with existing trim/XAML warnings, but no errors.