### PR TITLE
test: migrate unit tests to xUnit v3

### DIFF
--- a/src/Foundry.Connect.Tests/Foundry.Connect.Tests.csproj
+++ b/src/Foundry.Connect.Tests/Foundry.Connect.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <UseWPF>false</UseWPF>
     <ApplicationIcon></ApplicationIcon>
@@ -12,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Foundry.Core.Tests/Foundry.Core.Tests.csproj
+++ b/src/Foundry.Core.Tests/Foundry.Core.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <UseWPF>false</UseWPF>
     <ApplicationIcon></ApplicationIcon>
@@ -12,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Foundry.Deploy.Tests/Foundry.Deploy.Tests.csproj
+++ b/src/Foundry.Deploy.Tests/Foundry.Deploy.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <UseWPF>false</UseWPF>
     <ApplicationIcon></ApplicationIcon>
@@ -12,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Foundry.Localization.Tests/Foundry.Localization.Tests.csproj
+++ b/src/Foundry.Localization.Tests/Foundry.Localization.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <UseWPF>false</UseWPF>
     <ApplicationIcon></ApplicationIcon>
@@ -13,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Foundry.Telemetry.Tests/Foundry.Telemetry.Tests.csproj
+++ b/src/Foundry.Telemetry.Tests/Foundry.Telemetry.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <UseWPF>false</UseWPF>
     <ApplicationIcon></ApplicationIcon>
@@ -11,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
Migrate the unit test projects from xUnit v2 to xUnit v3.

## Reason
xUnit v3 requires the renamed `xunit.v3` package and executable test projects.

## Main changes
- Replaced `xunit` 2.9.3 with `xunit.v3` 3.2.2 in all unit test projects.
- Added `OutputType` `Exe` to each test project.
- Kept `xunit.runner.visualstudio` on the existing v3-compatible 3.1.5 version.

## Testing notes
- `dotnet test .\src\Foundry.slnx`
- `dotnet test .\src\Foundry.slnx --no-restore`

Both commands passed with 679 tests and 0 failures. xUnit v3 analyzers now emit existing cancellation-token responsiveness warnings (`xUnit1051`) in test sources; no test failures were introduced.
