### PR TITLE
feat: add USB boot partition update flow

### DIFF
--- a/src/Foundry.Core.Tests/BootMediaTelemetryPropertyBuilderTests.cs
+++ b/src/Foundry.Core.Tests/BootMediaTelemetryPropertyBuilderTests.cs
@@ -97,6 +97,7 @@ public sealed class BootMediaTelemetryPropertyBuilderTests
 
         IReadOnlyDictionary<string, object?> result = BootMediaTelemetryPropertyBuilder.Build(
             TelemetryBootMediaTargets.Usb,
+            TelemetryBootMediaUsbOperations.Create,
             options,
             document,
             success: false,
@@ -106,6 +107,7 @@ public sealed class BootMediaTelemetryPropertyBuilderTests
             deployRuntimePayloadSource: TelemetryRuntimePayloadSources.Debug);
 
         Assert.Equal(TelemetryBootMediaTargets.Usb, result["boot_media_target"]);
+        Assert.Equal(TelemetryBootMediaUsbOperations.Create, result["boot_media_usb_operation"]);
         Assert.False((bool)result["boot_media_creation_success"]!);
         Assert.Equal(42.25, result["boot_media_creation_duration_seconds"]);
         Assert.Equal("Customize boot image", result["boot_media_creation_failed_step_name"]);
@@ -173,6 +175,7 @@ public sealed class BootMediaTelemetryPropertyBuilderTests
 
         IReadOnlyDictionary<string, object?> result = BootMediaTelemetryPropertyBuilder.Build(
             TelemetryBootMediaTargets.Iso,
+            TelemetryBootMediaUsbOperations.None,
             options,
             new FoundryConfigurationDocument(),
             success: true,
@@ -183,6 +186,25 @@ public sealed class BootMediaTelemetryPropertyBuilderTests
 
         Assert.False((bool)result["autopilot_enabled"]!);
         Assert.Equal("disabled", result["autopilot_provisioning_mode"]);
+        Assert.Equal(TelemetryBootMediaUsbOperations.None, result["boot_media_usb_operation"]);
+    }
+
+    [Fact]
+    public void Build_WhenUsbBootMediaIsUpdated_ReportsUpdateOperation()
+    {
+        IReadOnlyDictionary<string, object?> result = BootMediaTelemetryPropertyBuilder.Build(
+            TelemetryBootMediaTargets.Usb,
+            TelemetryBootMediaUsbOperations.Update,
+            new MediaPreflightOptions(),
+            new FoundryConfigurationDocument(),
+            success: true,
+            failedStepName: null,
+            duration: TimeSpan.Zero,
+            connectRuntimePayloadSource: TelemetryRuntimePayloadSources.Release,
+            deployRuntimePayloadSource: TelemetryRuntimePayloadSources.Release);
+
+        Assert.Equal(TelemetryBootMediaTargets.Usb, result["boot_media_target"]);
+        Assert.Equal(TelemetryBootMediaUsbOperations.Update, result["boot_media_usb_operation"]);
     }
 
     [Fact]
@@ -207,6 +229,7 @@ public sealed class BootMediaTelemetryPropertyBuilderTests
 
         IReadOnlyDictionary<string, object?> result = BootMediaTelemetryPropertyBuilder.Build(
             TelemetryBootMediaTargets.Iso,
+            TelemetryBootMediaUsbOperations.None,
             options,
             document,
             success: true,
@@ -245,6 +268,7 @@ public sealed class BootMediaTelemetryPropertyBuilderTests
 
         IReadOnlyDictionary<string, object?> result = BootMediaTelemetryPropertyBuilder.Build(
             TelemetryBootMediaTargets.Iso,
+            TelemetryBootMediaUsbOperations.None,
             options,
             document,
             success: true,
@@ -288,6 +312,7 @@ public sealed class BootMediaTelemetryPropertyBuilderTests
 
         IReadOnlyDictionary<string, object?> result = BootMediaTelemetryPropertyBuilder.Build(
             TelemetryBootMediaTargets.Iso,
+            TelemetryBootMediaUsbOperations.None,
             options,
             document,
             success: true,
@@ -324,6 +349,7 @@ public sealed class BootMediaTelemetryPropertyBuilderTests
 
         IReadOnlyDictionary<string, object?> result = BootMediaTelemetryPropertyBuilder.Build(
             TelemetryBootMediaTargets.Iso,
+            TelemetryBootMediaUsbOperations.None,
             options,
             document,
             success: true,
@@ -361,6 +387,7 @@ public sealed class BootMediaTelemetryPropertyBuilderTests
 
         IReadOnlyDictionary<string, object?> result = BootMediaTelemetryPropertyBuilder.Build(
             TelemetryBootMediaTargets.Iso,
+            TelemetryBootMediaUsbOperations.None,
             options,
             document,
             success: true,

--- a/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
@@ -317,6 +317,25 @@ public sealed class WinPeUsbMediaServiceTests
     }
 
     [Fact]
+    public async Task GetUsbCandidatesAsync_WhenDiskHasFoundryBootAndCacheVolumes_MarksFoundryMedia()
+    {
+        string payload = """
+                         {"Number":9,"FriendlyName":"Safe USB","DriveLetters":"S:, T:","SerialNumber":"SERIAL","UniqueId":"UNIQUE","BusType":"USB","IsRemovable":true,"IsSystem":false,"IsBoot":false,"Size":64000000000,"IsFoundryMedia":true}
+                         """;
+        var service = new WinPeUsbMediaService(new FakeRunner(payload));
+        using TempWorkspace workspace = TempWorkspace.Create();
+
+        WinPeResult<IReadOnlyList<WinPeUsbDiskCandidate>> result = await service.GetUsbCandidatesAsync(
+            new WinPeToolPaths { PowerShellPath = "pwsh.exe" },
+            workspace.RootPath,
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Error?.Details);
+        WinPeUsbDiskCandidate candidate = Assert.Single(result.Value!);
+        Assert.True(candidate.IsFoundryMedia);
+    }
+
+    [Fact]
     public void BuildPowerShellProvisioningScript_WhenMbrCompleteFormat_MarksBootPartitionActiveAndFullFormat()
     {
         string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(
@@ -334,6 +353,25 @@ public sealed class WinPeUsbMediaServiceTests
         Assert.DoesNotContain("Set-Partition -DiskNumber $diskNumber -PartitionNumber $bootPartition.PartitionNumber -IsActive $true", script, StringComparison.Ordinal);
         Assert.Contains("if ($fullFormat) { $bootFormatArguments['Full'] = $true }", script, StringComparison.Ordinal);
         Assert.Contains("if ($fullFormat) { $cacheFormatArguments['Full'] = $true }", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildPowerShellBootPartitionUpdateScript_WhenUpdatingUsb_FormatsOnlyExistingBootVolume()
+    {
+        string script = WinPeUsbMediaService.BuildPowerShellBootPartitionUpdateScript(
+            diskNumber: 9,
+            bootDriveLetter: "S:",
+            formatMode: UsbFormatMode.Quick);
+
+        Assert.Contains("$diskNumber = 9", script, StringComparison.Ordinal);
+        Assert.Contains("$bootDriveLetter = 'S'", script, StringComparison.Ordinal);
+        Assert.Contains("Get-Partition -DiskNumber $diskNumber", script, StringComparison.Ordinal);
+        Assert.Contains("Format-Volume @bootFormatArguments", script, StringComparison.Ordinal);
+        Assert.Contains("NewFileSystemLabel = 'BOOT'", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("Clear-Disk", script, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Initialize-Disk", script, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("New-Partition", script, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Foundry Cache", script, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -568,6 +606,81 @@ public sealed class WinPeUsbMediaServiceTests
                       report.Status == "Formatting BOOT partition." &&
                       report.LogDetail == "BOOT partition formatted. DriveLetter=S, FileSystem=FAT32, Label=BOOT.");
         Assert.DoesNotContain(progress.Reports, report => report.LogDetail?.StartsWith('{') == true);
+    }
+
+    [Fact]
+    public async Task UpdateBootPartitionAsync_WhenSelectedDiskIsFoundryMedia_FormatsOnlyBootPartitionAndCopiesMedia()
+    {
+        string diskIdentity = """
+                              {"Number":9,"FriendlyName":"Safe USB","SerialNumber":"SERIAL","UniqueId":"UNIQUE","BusType":"USB","IsRemovable":true,"IsSystem":false,"IsBoot":false,"Size":64000000000}
+                              """;
+        string layout = """
+                        {"DiskNumber":9,"BootDriveLetter":"S:","CacheDriveLetter":"T:"}
+                        """;
+        string formatResult = """
+                              FOUNDRY_USB_PROGRESS|35|Formatting BOOT partition.
+                              {"DiskNumber":9,"BootDriveLetter":"S:","CacheDriveLetter":"T:"}
+                              """;
+        var runner = new FakeSequenceRunner(diskIdentity, layout, formatResult, string.Empty);
+        using TempWorkspace workspace = TempWorkspace.Create();
+        var progress = new RecordingProgress();
+        var service = new WinPeUsbMediaService(runner);
+
+        await service.UpdateBootPartitionAsync(
+            new UsbOutputOptions
+            {
+                TargetDiskNumber = 9,
+                ExpectedDiskFriendlyName = "Safe USB",
+                Progress = progress
+            },
+            new WinPeBuildArtifact
+            {
+                WorkingDirectoryPath = workspace.RootPath,
+                MediaDirectoryPath = Path.Combine(workspace.RootPath, "media"),
+                Architecture = WinPeArchitecture.X64
+            },
+            new WinPeToolPaths { PowerShellPath = "pwsh.exe" },
+            useBootEx: false,
+            CancellationToken.None);
+
+        Assert.Equal(3, runner.Executions.Count(execution => execution.FileName == "pwsh.exe"));
+        Assert.Contains(runner.Executions, execution => execution.FileName.EndsWith("robocopy.exe", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(runner.Executions, execution => execution.Arguments.Contains("Clear-Disk", StringComparison.Ordinal));
+        Assert.DoesNotContain(runner.Executions, execution => execution.Arguments.Contains("Foundry Cache", StringComparison.Ordinal));
+        Assert.Contains(progress.Reports, report => report is { Percent: 35, Status: "Formatting BOOT partition." });
+        Assert.DoesNotContain(progress.Reports, report => report.Status.Contains("cache", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task UpdateBootPartitionAsync_WhenSelectedDiskIsNotFoundryMedia_ReturnsVerificationFailureBeforeFormatting()
+    {
+        string diskIdentity = """
+                              {"Number":9,"FriendlyName":"Safe USB","SerialNumber":"SERIAL","UniqueId":"UNIQUE","BusType":"USB","IsRemovable":true,"IsSystem":false,"IsBoot":false,"Size":64000000000}
+                              """;
+        var runner = new FakeSequenceRunner(diskIdentity, string.Empty);
+        using TempWorkspace workspace = TempWorkspace.Create();
+        var service = new WinPeUsbMediaService(runner);
+
+        WinPeResult<WinPeUsbProvisionResult> result = await service.UpdateBootPartitionAsync(
+            new UsbOutputOptions
+            {
+                TargetDiskNumber = 9,
+                ExpectedDiskFriendlyName = "Safe USB"
+            },
+            new WinPeBuildArtifact
+            {
+                WorkingDirectoryPath = workspace.RootPath,
+                MediaDirectoryPath = Path.Combine(workspace.RootPath, "media"),
+                Architecture = WinPeArchitecture.X64
+            },
+            new WinPeToolPaths { PowerShellPath = "pwsh.exe" },
+            useBootEx: false,
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(WinPeErrorCodes.UsbVerificationFailed, result.Error?.Code);
+        Assert.Equal(2, runner.Executions.Count);
+        Assert.DoesNotContain(runner.Executions, execution => execution.FileName.EndsWith("robocopy.exe", StringComparison.OrdinalIgnoreCase));
     }
 
     private class FakeRunner(string output) : IWinPeProcessRunner

--- a/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeUsbMediaServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Foundry.Core.Services.WinPe;
 
 namespace Foundry.Core.Tests.WinPe;
@@ -336,6 +337,35 @@ public sealed class WinPeUsbMediaServiceTests
     }
 
     [Fact]
+    public async Task GetUsbCandidatesAsync_QueryDetectsGptEfiBootPartitionWithoutDriveLetter()
+    {
+        string payload = """
+                         {"Number":9,"FriendlyName":"Safe USB","DriveLetters":"T:","SerialNumber":"SERIAL","UniqueId":"UNIQUE","BusType":"USB","IsRemovable":true,"IsSystem":false,"IsBoot":false,"Size":64000000000,"IsFoundryMedia":true}
+                         """;
+        var runner = new FakeRunner(payload);
+        var service = new WinPeUsbMediaService(runner);
+        using TempWorkspace workspace = TempWorkspace.Create();
+
+        WinPeResult<IReadOnlyList<WinPeUsbDiskCandidate>> result = await service.GetUsbCandidatesAsync(
+            new WinPeToolPaths { PowerShellPath = "pwsh.exe" },
+            workspace.RootPath,
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Error?.Details);
+        WinPeUsbDiskCandidate candidate = Assert.Single(result.Value!);
+        Assert.True(candidate.IsFoundryMedia);
+        Assert.Equal("T:", candidate.DriveLetters);
+
+        string script = DecodePowerShellEncodedCommand(runner.Executions[0].Arguments);
+        Assert.Contains("$hasGptBootPartition", script, StringComparison.Ordinal);
+        Assert.Contains("Get-Volume -Partition", script, StringComparison.Ordinal);
+        Assert.Contains("GptType", script, StringComparison.Ordinal);
+        Assert.Contains("{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}", script, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("$_.FileSystemLabel -eq 'BOOT' -and $_.FileSystem -eq 'FAT32'", script, StringComparison.Ordinal);
+        Assert.Contains("$hasCacheVolume", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BuildPowerShellProvisioningScript_WhenMbrCompleteFormat_MarksBootPartitionActiveAndFullFormat()
     {
         string script = WinPeUsbMediaService.BuildPowerShellProvisioningScript(
@@ -647,6 +677,12 @@ public sealed class WinPeUsbMediaServiceTests
         Assert.Contains(runner.Executions, execution => execution.FileName.EndsWith("robocopy.exe", StringComparison.OrdinalIgnoreCase));
         Assert.DoesNotContain(runner.Executions, execution => execution.Arguments.Contains("Clear-Disk", StringComparison.Ordinal));
         Assert.DoesNotContain(runner.Executions, execution => execution.Arguments.Contains("Foundry Cache", StringComparison.Ordinal));
+        string layoutScript = DecodePowerShellEncodedCommand(runner.Executions[1].Arguments);
+        Assert.Contains("Add-PartitionAccessPath", layoutScript, StringComparison.Ordinal);
+        Assert.Contains("-AssignDriveLetter", layoutScript, StringComparison.Ordinal);
+        Assert.Contains("Get-Volume -Partition", layoutScript, StringComparison.Ordinal);
+        Assert.Contains("GptType", layoutScript, StringComparison.Ordinal);
+        Assert.Contains("{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}", layoutScript, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(progress.Reports, report => report is { Percent: 35, Status: "Formatting BOOT partition." });
         Assert.DoesNotContain(progress.Reports, report => report.Status.Contains("cache", StringComparison.OrdinalIgnoreCase));
     }
@@ -797,6 +833,16 @@ public sealed class WinPeUsbMediaServiceTests
             Executions.Add(execution);
             return Task.FromResult(execution);
         }
+    }
+
+    private static string DecodePowerShellEncodedCommand(string arguments)
+    {
+        const string marker = "-EncodedCommand ";
+        int markerIndex = arguments.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(markerIndex >= 0, arguments);
+
+        string encodedCommand = arguments[(markerIndex + marker.Length)..].Trim();
+        return Encoding.Unicode.GetString(Convert.FromBase64String(encodedCommand));
     }
 
     private sealed class RecordingProgress : IProgress<WinPeMediaProgress>

--- a/src/Foundry.Core/Services/Telemetry/BootMediaTelemetryPropertyBuilder.cs
+++ b/src/Foundry.Core/Services/Telemetry/BootMediaTelemetryPropertyBuilder.cs
@@ -16,6 +16,7 @@ public static class BootMediaTelemetryPropertyBuilder
     /// Creates the low-cardinality `osd:boot_media_finished` property set without sensitive configuration values.
     /// </summary>
     /// <param name="bootMediaTarget">Final media target value.</param>
+    /// <param name="bootMediaUsbOperation">USB operation value.</param>
     /// <param name="options">Resolved media creation options.</param>
     /// <param name="document">Current Foundry configuration document.</param>
     /// <param name="success">Whether media creation completed successfully.</param>
@@ -26,6 +27,7 @@ public static class BootMediaTelemetryPropertyBuilder
     /// <returns>Telemetry properties approved for `osd:boot_media_finished`.</returns>
     public static IReadOnlyDictionary<string, object?> Build(
         string bootMediaTarget,
+        string bootMediaUsbOperation,
         MediaPreflightOptions options,
         FoundryConfigurationDocument document,
         bool success,
@@ -40,6 +42,9 @@ public static class BootMediaTelemetryPropertyBuilder
         var properties = new Dictionary<string, object?>
         {
             ["boot_media_target"] = bootMediaTarget,
+            ["boot_media_usb_operation"] = bootMediaTarget == TelemetryBootMediaTargets.Usb
+                ? bootMediaUsbOperation
+                : TelemetryBootMediaUsbOperations.None,
             ["boot_media_creation_success"] = success,
             ["boot_media_creation_duration_seconds"] = Math.Round(duration.TotalSeconds, 2),
             ["boot_media_creation_failed_step_name"] = failedStepName,

--- a/src/Foundry.Core/Services/WinPe/IWinPeUsbMediaService.cs
+++ b/src/Foundry.Core/Services/WinPe/IWinPeUsbMediaService.cs
@@ -13,4 +13,11 @@ public interface IWinPeUsbMediaService
         WinPeToolPaths tools,
         bool useBootEx,
         CancellationToken cancellationToken = default);
+
+    Task<WinPeResult<WinPeUsbProvisionResult>> UpdateBootPartitionAsync(
+        UsbOutputOptions options,
+        WinPeBuildArtifact artifact,
+        WinPeToolPaths tools,
+        bool useBootEx,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Foundry.Core/Services/WinPe/WinPeUsbDiskCandidate.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeUsbDiskCandidate.cs
@@ -12,4 +12,5 @@ public sealed record WinPeUsbDiskCandidate
     public bool IsSystem { get; init; }
     public bool IsBoot { get; init; }
     public ulong SizeBytes { get; init; }
+    public bool IsFoundryMedia { get; init; }
 }

--- a/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
@@ -56,27 +56,58 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
         Directory.CreateDirectory(workingDirectoryPath);
 
         const string script = """
+                              $foundryGptBootPartitionType = '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'
+
+                              function Get-FoundryUsbDriveLetter($DriveLetter) {
+                                  if ($null -eq $DriveLetter) { return $null }
+                                  if ($DriveLetter -is [char] -and [int][char]$DriveLetter -eq 0) { return $null }
+
+                                  $text = ([string]$DriveLetter).Trim()
+                                  if ($text.Length -eq 2 -and $text[1] -eq ':') { $text = $text.Substring(0, 1) }
+                                  if ($text -match '^[A-Za-z]$') { return $text.ToUpperInvariant() }
+
+                                  return $null
+                              }
+
+                              function Get-FoundryUsbDriveLetterText($DriveLetter) {
+                                  $letter = Get-FoundryUsbDriveLetter $DriveLetter
+                                  if ($null -eq $letter) { return '' }
+                                  return "$($letter):"
+                              }
+
+                              function Get-FoundryUsbPartitionVolume($Partition) {
+                                  $driveLetter = Get-FoundryUsbDriveLetter $Partition.DriveLetter
+                                  if ($null -ne $driveLetter) {
+                                      $volume = Get-Volume -DriveLetter $driveLetter -ErrorAction SilentlyContinue
+                                  }
+                                  else {
+                                      $volume = Get-Volume -Partition $Partition -ErrorAction SilentlyContinue
+                                  }
+
+                                  if ($null -eq $volume) { return $null }
+
+                                  [pscustomobject]@{
+                                      PartitionNumber = [int]$Partition.PartitionNumber
+                                      DriveLetter = Get-FoundryUsbDriveLetterText $Partition.DriveLetter
+                                      FileSystemLabel = [string]$volume.FileSystemLabel
+                                      FileSystem = [string]$volume.FileSystem
+                                      GptType = [string]$Partition.GptType
+                                      MbrType = [string]$Partition.MbrType
+                                      IsActive = [bool]$Partition.IsActive
+                                  }
+                              }
+
                               $disks = Get-Disk | Where-Object { $_.BusType -eq 'USB' }
                               $result = @(
                               foreach ($disk in $disks) {
-                                  $volumes = @(
-                                      Get-Partition -DiskNumber $disk.Number -ErrorAction SilentlyContinue |
-                                          Where-Object { $null -ne $_.DriveLetter } |
-                                          ForEach-Object {
-                                              $volume = Get-Volume -DriveLetter $_.DriveLetter -ErrorAction SilentlyContinue
-                                              if ($null -ne $volume) {
-                                                  [pscustomobject]@{
-                                                      DriveLetter = "$($_.DriveLetter):"
-                                                      FileSystemLabel = [string]$volume.FileSystemLabel
-                                                      FileSystem = [string]$volume.FileSystem
-                                                  }
-                                              }
-                                          }
-                                  )
+                                  $partitions = @(Get-Partition -DiskNumber $disk.Number -ErrorAction SilentlyContinue)
+                                  $volumes = @($partitions | ForEach-Object { Get-FoundryUsbPartitionVolume $_ })
                                   $letters = @(
-                                      $volumes | ForEach-Object { $_.DriveLetter }
+                                      $volumes | Where-Object { $_.DriveLetter -ne '' } | ForEach-Object { $_.DriveLetter }
                                   )
                                   $hasBootVolume = @($volumes | Where-Object { $_.FileSystemLabel -eq 'BOOT' -and $_.FileSystem -eq 'FAT32' }).Count -gt 0
+                                  $hasGptBootPartition = @($partitions | Where-Object { [string]$_.GptType -eq $foundryGptBootPartitionType }).Count -gt 0
+                                  $hasMbrBootPartition = @($partitions | Where-Object { [string]$_.MbrType -eq 'FAT32' -and [bool]$_.IsActive }).Count -gt 0
                                   $hasCacheVolume = @($volumes | Where-Object { $_.FileSystemLabel -eq 'Foundry Cache' -and $_.FileSystem -eq 'NTFS' }).Count -gt 0
 
                                   [pscustomobject]@{
@@ -90,7 +121,7 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
                                       IsSystem = [bool]$disk.IsSystem
                                       IsBoot = [bool]$disk.IsBoot
                                       Size = [uint64]$disk.Size
-                                      IsFoundryMedia = [bool]($hasBootVolume -and $hasCacheVolume)
+                                      IsFoundryMedia = [bool](($hasBootVolume -or $hasGptBootPartition -or $hasMbrBootPartition) -and $hasCacheVolume)
                                   }
                               }
                               )
@@ -659,25 +690,91 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
     {
         string script = $$"""
                           $diskNumber = {{diskNumber}}
-                          $volumes = @(
-                              Get-Partition -DiskNumber $diskNumber -ErrorAction Stop |
-                                  Where-Object { $null -ne $_.DriveLetter } |
-                                  ForEach-Object {
-                                      $volume = Get-Volume -DriveLetter $_.DriveLetter -ErrorAction SilentlyContinue
-                                      if ($null -ne $volume) {
-                                          [pscustomobject]@{
-                                              DriveLetter = "$($_.DriveLetter):"
-                                              FileSystemLabel = [string]$volume.FileSystemLabel
-                                              FileSystem = [string]$volume.FileSystem
-                                          }
-                                      }
-                                  }
-                          )
+                          $foundryGptBootPartitionType = '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'
+
+                          function Get-FoundryUsbDriveLetter($DriveLetter) {
+                              if ($null -eq $DriveLetter) { return $null }
+                              if ($DriveLetter -is [char] -and [int][char]$DriveLetter -eq 0) { return $null }
+
+                              $text = ([string]$DriveLetter).Trim()
+                              if ($text.Length -eq 2 -and $text[1] -eq ':') { $text = $text.Substring(0, 1) }
+                              if ($text -match '^[A-Za-z]$') { return $text.ToUpperInvariant() }
+
+                              return $null
+                          }
+
+                          function Test-FoundryUsbDriveLetter($DriveLetter) {
+                              return $null -ne (Get-FoundryUsbDriveLetter $DriveLetter)
+                          }
+
+                          function Get-FoundryUsbDriveLetterText($DriveLetter) {
+                              $letter = Get-FoundryUsbDriveLetter $DriveLetter
+                              if ($null -eq $letter) { return '' }
+                              return "$($letter):"
+                          }
+
+                          function Get-FoundryUsbPartitionVolume($Partition) {
+                              $driveLetter = Get-FoundryUsbDriveLetter $Partition.DriveLetter
+                              if ($null -ne $driveLetter) {
+                                  $volume = Get-Volume -DriveLetter $driveLetter -ErrorAction SilentlyContinue
+                              }
+                              else {
+                                  $volume = Get-Volume -Partition $Partition -ErrorAction SilentlyContinue
+                              }
+
+                              if ($null -eq $volume) { return $null }
+
+                              [pscustomobject]@{
+                                  PartitionNumber = [int]$Partition.PartitionNumber
+                                  DriveLetter = Get-FoundryUsbDriveLetterText $Partition.DriveLetter
+                                  FileSystemLabel = [string]$volume.FileSystemLabel
+                                  FileSystem = [string]$volume.FileSystem
+                                  GptType = [string]$Partition.GptType
+                                  MbrType = [string]$Partition.MbrType
+                                  IsActive = [bool]$Partition.IsActive
+                              }
+                          }
+
+                          $partitions = @(Get-Partition -DiskNumber $diskNumber -ErrorAction Stop)
+                          $volumes = @($partitions | ForEach-Object { Get-FoundryUsbPartitionVolume $_ })
 
                           $bootVolume = @($volumes | Where-Object { $_.FileSystemLabel -eq 'BOOT' -and $_.FileSystem -eq 'FAT32' } | Select-Object -First 1)
                           $cacheVolume = @($volumes | Where-Object { $_.FileSystemLabel -eq 'Foundry Cache' -and $_.FileSystem -eq 'NTFS' } | Select-Object -First 1)
-                          if ($bootVolume.Count -eq 0 -or $cacheVolume.Count -eq 0) {
-                              throw "Disk $diskNumber is not a Foundry USB media. Expected BOOT FAT32 and Foundry Cache NTFS volumes."
+                          if ($cacheVolume.Count -eq 0) {
+                              throw "Disk $diskNumber is not a Foundry USB media. Expected Foundry Cache NTFS volume."
+                          }
+
+                          if ($bootVolume.Count -gt 0) {
+                              $bootPartition = @($partitions | Where-Object { $_.PartitionNumber -eq $bootVolume[0].PartitionNumber } | Select-Object -First 1)
+                          }
+                          else {
+                              $bootPartition = @($partitions | Where-Object { [string]$_.GptType -eq $foundryGptBootPartitionType } | Select-Object -First 1)
+                              if ($bootPartition.Count -eq 0) {
+                                  $bootPartition = @($partitions | Where-Object { [string]$_.MbrType -eq 'FAT32' -and [bool]$_.IsActive } | Select-Object -First 1)
+                              }
+
+                              if ($bootPartition.Count -eq 0) {
+                                  throw "Disk $diskNumber is not a Foundry USB media. Expected BOOT FAT32 partition."
+                              }
+                          }
+
+                          $hasFoundryBootPartitionType = ([string]$bootPartition[0].GptType -eq $foundryGptBootPartitionType) -or ([string]$bootPartition[0].MbrType -eq 'FAT32' -and [bool]$bootPartition[0].IsActive)
+                          if (-not $hasFoundryBootPartitionType) {
+                              throw "Disk $diskNumber is not a Foundry USB media. Expected BOOT FAT32 partition."
+                          }
+
+                          if (-not (Test-FoundryUsbDriveLetter $bootPartition[0].DriveLetter)) {
+                              Add-PartitionAccessPath -DiskNumber $diskNumber -PartitionNumber $bootPartition[0].PartitionNumber -AssignDriveLetter -ErrorAction Stop
+                              Update-HostStorageCache -ErrorAction SilentlyContinue
+                              Update-Disk -Number $diskNumber -ErrorAction SilentlyContinue
+
+                              $partitions = @(Get-Partition -DiskNumber $diskNumber -ErrorAction Stop)
+                              $bootPartition = @($partitions | Where-Object { $_.PartitionNumber -eq $bootPartition[0].PartitionNumber } | Select-Object -First 1)
+                          }
+
+                          $bootVolume = @(Get-FoundryUsbPartitionVolume $bootPartition[0])
+                          if ($bootVolume.Count -eq 0 -or $bootVolume[0].FileSystemLabel -ne 'BOOT' -or $bootVolume[0].FileSystem -ne 'FAT32') {
+                              throw "Disk $diskNumber is not a Foundry USB media. Expected BOOT FAT32 volume."
                           }
 
                           [pscustomobject]@{

--- a/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
@@ -59,11 +59,25 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
                               $disks = Get-Disk | Where-Object { $_.BusType -eq 'USB' }
                               $result = @(
                               foreach ($disk in $disks) {
-                                  $letters = @(
+                                  $volumes = @(
                                       Get-Partition -DiskNumber $disk.Number -ErrorAction SilentlyContinue |
                                           Where-Object { $null -ne $_.DriveLetter } |
-                                          ForEach-Object { "$($_.DriveLetter):" }
+                                          ForEach-Object {
+                                              $volume = Get-Volume -DriveLetter $_.DriveLetter -ErrorAction SilentlyContinue
+                                              if ($null -ne $volume) {
+                                                  [pscustomobject]@{
+                                                      DriveLetter = "$($_.DriveLetter):"
+                                                      FileSystemLabel = [string]$volume.FileSystemLabel
+                                                      FileSystem = [string]$volume.FileSystem
+                                                  }
+                                              }
+                                          }
                                   )
+                                  $letters = @(
+                                      $volumes | ForEach-Object { $_.DriveLetter }
+                                  )
+                                  $hasBootVolume = @($volumes | Where-Object { $_.FileSystemLabel -eq 'BOOT' -and $_.FileSystem -eq 'FAT32' }).Count -gt 0
+                                  $hasCacheVolume = @($volumes | Where-Object { $_.FileSystemLabel -eq 'Foundry Cache' -and $_.FileSystem -eq 'NTFS' }).Count -gt 0
 
                                   [pscustomobject]@{
                                       Number = [int]$disk.Number
@@ -76,6 +90,7 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
                                       IsSystem = [bool]$disk.IsSystem
                                       IsBoot = [bool]$disk.IsBoot
                                       Size = [uint64]$disk.Size
+                                      IsFoundryMedia = [bool]($hasBootVolume -and $hasCacheVolume)
                                   }
                               }
                               )
@@ -233,6 +248,111 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
         return WinPeResult<WinPeUsbProvisionResult>.Success(provisionedUsb);
     }
 
+    public async Task<WinPeResult<WinPeUsbProvisionResult>> UpdateBootPartitionAsync(
+        UsbOutputOptions options,
+        WinPeBuildArtifact artifact,
+        WinPeToolPaths tools,
+        bool useBootEx,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(artifact);
+        ArgumentNullException.ThrowIfNull(tools);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!options.TargetDiskNumber.HasValue)
+        {
+            return WinPeResult<WinPeUsbProvisionResult>.Failure(
+                WinPeErrorCodes.ValidationFailed,
+                "USB target disk number is required.",
+                "Set UsbOutputOptions.TargetDiskNumber to the physical disk number you intend to update.");
+        }
+
+        int diskNumber = options.TargetDiskNumber.Value;
+        ReportProgress(options.Progress, 0, "Validating USB target.");
+        WinPeResult<WinPeUsbDiskIdentity> diskResult = await GetDiskIdentityAsync(
+            diskNumber,
+            tools,
+            artifact.WorkingDirectoryPath,
+            cancellationToken).ConfigureAwait(false);
+        if (!diskResult.IsSuccess)
+        {
+            return WinPeResult<WinPeUsbProvisionResult>.Failure(diskResult.Error!);
+        }
+
+        ReportProgress(options.Progress, 10, "Checking USB target safety.");
+        WinPeResult safetyValidation = ValidateDiskSafety(options, diskResult.Value!);
+        if (!safetyValidation.IsSuccess)
+        {
+            return WinPeResult<WinPeUsbProvisionResult>.Failure(safetyValidation.Error!);
+        }
+
+        ReportProgress(options.Progress, 20, "Inspecting USB media layout.");
+        WinPeResult<WinPeUsbProvisionResult> layoutResult = await GetFoundryUsbMediaLayoutAsync(
+            diskNumber,
+            tools,
+            artifact.WorkingDirectoryPath,
+            cancellationToken).ConfigureAwait(false);
+        if (!layoutResult.IsSuccess)
+        {
+            return WinPeResult<WinPeUsbProvisionResult>.Failure(layoutResult.Error!);
+        }
+
+        WinPeUsbProvisionResult layout = layoutResult.Value!;
+        ReportProgress(options.Progress, 35, "Formatting BOOT partition.");
+        WinPeResult formatResult = await FormatBootPartitionAsync(
+            diskNumber,
+            layout.BootDriveLetter,
+            options.FormatMode,
+            tools,
+            artifact.WorkingDirectoryPath,
+            options.Progress,
+            cancellationToken).ConfigureAwait(false);
+        if (!formatResult.IsSuccess)
+        {
+            return WinPeResult<WinPeUsbProvisionResult>.Failure(formatResult.Error!);
+        }
+
+        string bootRootPath = $"{layout.BootDriveLetter}\\";
+        ReportProgress(options.Progress, 55, "Copying WinPE media to USB.");
+        WinPeResult copyResult = await CopyMediaAsync(
+            artifact.MediaDirectoryPath,
+            bootRootPath,
+            artifact.WorkingDirectoryPath,
+            cancellationToken).ConfigureAwait(false);
+        if (!copyResult.IsSuccess)
+        {
+            return WinPeResult<WinPeUsbProvisionResult>.Failure(copyResult.Error!);
+        }
+
+        if (useBootEx)
+        {
+            ReportProgress(options.Progress, 75, "Configuring USB boot files.");
+            WinPeResult bootConfigurationResult = ConfigureBootFiles(bootRootPath, artifact);
+            if (!bootConfigurationResult.IsSuccess)
+            {
+                return WinPeResult<WinPeUsbProvisionResult>.Failure(bootConfigurationResult.Error!);
+            }
+        }
+
+        ReportProgress(options.Progress, 90, "Verifying USB boot media.");
+        WinPeResult verificationResult = VerifyBootArtifacts(bootRootPath, artifact.Architecture);
+        if (!verificationResult.IsSuccess)
+        {
+            return WinPeResult<WinPeUsbProvisionResult>.Failure(verificationResult.Error!);
+        }
+
+        WinPeResult bootLayoutResult = VerifyBootPartitionLayout(bootRootPath);
+        if (!bootLayoutResult.IsSuccess)
+        {
+            return WinPeResult<WinPeUsbProvisionResult>.Failure(bootLayoutResult.Error!);
+        }
+
+        ReportProgress(options.Progress, 100, "USB boot partition updated.");
+        return WinPeResult<WinPeUsbProvisionResult>.Success(layout);
+    }
+
     internal static WinPeResult ValidateDiskSafety(UsbOutputOptions options, WinPeUsbDiskIdentity disk)
     {
         if (!disk.BusType.Equals("USB", StringComparison.OrdinalIgnoreCase))
@@ -326,6 +446,58 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
             .Replace("{{PARTITION_STYLE}}", partitionStyleText)
             .Replace("{{FULL_FORMAT}}", fullFormatValue)
             .ReplaceLineEndings(Environment.NewLine);
+    }
+
+    internal static string BuildPowerShellBootPartitionUpdateScript(
+        int diskNumber,
+        string bootDriveLetter,
+        UsbFormatMode formatMode)
+    {
+        string normalizedBootDriveLetter = NormalizeDriveLetter(bootDriveLetter).TrimEnd(':');
+        string fullFormatValue = formatMode == UsbFormatMode.Complete ? "$true" : "$false";
+
+        return $$"""
+                 $ErrorActionPreference = 'Stop'
+
+                 Import-Module Storage
+
+                 function Write-FoundryUsbProgress([int]$Percent, [string]$Status) {
+                     Write-Output ("FOUNDRY_USB_PROGRESS|{0}|{1}" -f $Percent, $Status)
+                 }
+
+                 function Write-FoundryUsbVerbose([string]$Message) {
+                     Write-Output ("FOUNDRY_USB_VERBOSE|{0}" -f $Message)
+                 }
+
+                 $diskNumber = {{diskNumber}}
+                 $bootDriveLetter = '{{normalizedBootDriveLetter}}'
+                 $fullFormat = {{fullFormatValue}}
+
+                 Write-FoundryUsbProgress 35 'Formatting BOOT partition.'
+                 $bootPartition = Get-Partition -DiskNumber $diskNumber -ErrorAction Stop |
+                     Where-Object { $_.DriveLetter -eq $bootDriveLetter } |
+                     Select-Object -First 1
+                 if ($null -eq $bootPartition) {
+                     throw "BOOT partition $bootDriveLetter`: was not found on disk $diskNumber."
+                 }
+
+                 $bootVolume = Get-Volume -DriveLetter $bootDriveLetter -ErrorAction Stop
+                 if ($bootVolume.FileSystemLabel -ne 'BOOT' -or $bootVolume.FileSystem -ne 'FAT32') {
+                     throw "Volume $bootDriveLetter`: is not a Foundry BOOT volume. Label=$($bootVolume.FileSystemLabel), FileSystem=$($bootVolume.FileSystem)."
+                 }
+
+                 $bootFormatArguments = @{
+                     DriveLetter = $bootDriveLetter
+                     FileSystem = 'FAT32'
+                     NewFileSystemLabel = 'BOOT'
+                     Confirm = $false
+                     Force = $true
+                     ErrorAction = 'Stop'
+                 }
+                 if ($fullFormat) { $bootFormatArguments['Full'] = $true }
+                 Format-Volume @bootFormatArguments | Out-Null
+                 Write-FoundryUsbVerbose "BOOT partition formatted. DriveLetter=$bootDriveLetter, FileSystem=FAT32, Label=BOOT."
+                 """.ReplaceLineEndings(Environment.NewLine);
     }
 
     internal static void InitializeCachePartitionDirectories(string cacheRootPath)
@@ -476,6 +648,109 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
         return WinPeResult<WinPeUsbProvisionResult>.Failure(
             WinPeErrorCodes.UsbProvisioningFailed,
             "Failed to partition and format the USB disk.",
+            diagnostic);
+    }
+
+    private async Task<WinPeResult<WinPeUsbProvisionResult>> GetFoundryUsbMediaLayoutAsync(
+        int diskNumber,
+        WinPeToolPaths tools,
+        string workingDirectoryPath,
+        CancellationToken cancellationToken)
+    {
+        string script = $$"""
+                          $diskNumber = {{diskNumber}}
+                          $volumes = @(
+                              Get-Partition -DiskNumber $diskNumber -ErrorAction Stop |
+                                  Where-Object { $null -ne $_.DriveLetter } |
+                                  ForEach-Object {
+                                      $volume = Get-Volume -DriveLetter $_.DriveLetter -ErrorAction SilentlyContinue
+                                      if ($null -ne $volume) {
+                                          [pscustomobject]@{
+                                              DriveLetter = "$($_.DriveLetter):"
+                                              FileSystemLabel = [string]$volume.FileSystemLabel
+                                              FileSystem = [string]$volume.FileSystem
+                                          }
+                                      }
+                                  }
+                          )
+
+                          $bootVolume = @($volumes | Where-Object { $_.FileSystemLabel -eq 'BOOT' -and $_.FileSystem -eq 'FAT32' } | Select-Object -First 1)
+                          $cacheVolume = @($volumes | Where-Object { $_.FileSystemLabel -eq 'Foundry Cache' -and $_.FileSystem -eq 'NTFS' } | Select-Object -First 1)
+                          if ($bootVolume.Count -eq 0 -or $cacheVolume.Count -eq 0) {
+                              throw "Disk $diskNumber is not a Foundry USB media. Expected BOOT FAT32 and Foundry Cache NTFS volumes."
+                          }
+
+                          [pscustomobject]@{
+                              DiskNumber = $diskNumber
+                              BootDriveLetter = [string]$bootVolume[0].DriveLetter
+                              CacheDriveLetter = [string]$cacheVolume[0].DriveLetter
+                          } | ConvertTo-Json -Compress
+                          """;
+
+        WinPeResult<string> result = await RunPowerShellAsync(
+            script,
+            tools,
+            workingDirectoryPath,
+            cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            return WinPeResult<WinPeUsbProvisionResult>.Failure(
+                WinPeErrorCodes.UsbVerificationFailed,
+                "Selected USB media is not a Foundry USB media.",
+                result.Error?.Details ?? result.Error?.Message ?? string.Empty);
+        }
+
+        var execution = new WinPeProcessExecution
+        {
+            ExitCode = 0,
+            StandardOutput = result.Value!
+        };
+        return ParseUsbProvisionResult(execution);
+    }
+
+    private async Task<WinPeResult> FormatBootPartitionAsync(
+        int diskNumber,
+        string bootDriveLetter,
+        UsbFormatMode formatMode,
+        WinPeToolPaths tools,
+        string workingDirectoryPath,
+        IProgress<WinPeMediaProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        string script = BuildPowerShellBootPartitionUpdateScript(
+            diskNumber,
+            bootDriveLetter,
+            formatMode);
+
+        Directory.CreateDirectory(workingDirectoryPath);
+        string encodedScript = Convert.ToBase64String(Encoding.Unicode.GetBytes(script));
+        string arguments = $"-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand {encodedScript}";
+        var provisioningOutput = new UsbProvisioningOutputForwarder(progress);
+        WinPeProcessExecution execution = _processRunner is IWinPeProcessOutputRunner outputRunner
+            ? await outputRunner.RunWithOutputAsync(
+                tools.PowerShellPath,
+                arguments,
+                workingDirectoryPath,
+                provisioningOutput.Report,
+                null,
+                cancellationToken).ConfigureAwait(false)
+            : await _processRunner.RunAsync(
+                tools.PowerShellPath,
+                arguments,
+                workingDirectoryPath,
+                cancellationToken).ConfigureAwait(false);
+
+        if (execution.IsSuccess)
+        {
+            return WinPeResult.Success();
+        }
+
+        string diagnostic = $"{execution.ToDiagnosticText()}{Environment.NewLine}" +
+                            "PowerShellBootPartitionUpdateScript:" + Environment.NewLine +
+                            script;
+        return WinPeResult.Failure(
+            WinPeErrorCodes.UsbProvisioningFailed,
+            "Failed to format the USB BOOT partition.",
             diagnostic);
     }
 
@@ -746,7 +1021,8 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
             IsRemovable = GetNullableBool(element, "IsRemovable"),
             IsSystem = GetBool(element, "IsSystem"),
             IsBoot = GetBool(element, "IsBoot"),
-            SizeBytes = GetUInt64(element, "Size")
+            SizeBytes = GetUInt64(element, "Size"),
+            IsFoundryMedia = GetBool(element, "IsFoundryMedia")
         };
     }
 

--- a/src/Foundry.Telemetry.Tests/PostHogTelemetryServiceTests.cs
+++ b/src/Foundry.Telemetry.Tests/PostHogTelemetryServiceTests.cs
@@ -40,6 +40,7 @@ public sealed class PostHogTelemetryServiceTests
             new Dictionary<string, object?>
             {
                 ["boot_media_target"] = "iso",
+                ["boot_media_usb_operation"] = "none",
                 ["boot_media_architecture"] = "arm64",
                 ["boot_media_creation_failed_step_name"] = "Customize boot image",
                 ["ssid"] = "CorpWifi"
@@ -56,6 +57,7 @@ public sealed class PostHogTelemetryServiceTests
         JsonElement properties = root.GetProperty("properties");
         Assert.False(properties.TryGetProperty("timestamp", out _));
         Assert.Equal("iso", properties.GetProperty("boot_media_target").GetString());
+        Assert.Equal("none", properties.GetProperty("boot_media_usb_operation").GetString());
         Assert.Equal("arm64", properties.GetProperty("boot_media_architecture").GetString());
         Assert.Equal("Customize boot image", properties.GetProperty("boot_media_creation_failed_step_name").GetString());
         Assert.False(properties.TryGetProperty("failed_step_name", out _));
@@ -65,6 +67,7 @@ public sealed class PostHogTelemetryServiceTests
         Assert.Equal(TelemetryRuntimeModes.Desktop, properties.GetProperty("app_runtime").GetString());
         Assert.Equal("x64", properties.GetProperty("app_runtime_architecture").GetString());
         Assert.Equal("en-US", properties.GetProperty("app_locale").GetString());
+        Assert.Equal(TelemetryDefaults.SchemaVersion, properties.GetProperty("telemetry_schema_version").GetInt32());
         Assert.False(properties.TryGetProperty("runtime", out _));
         Assert.False(properties.TryGetProperty("runtime_payload_source", out _));
         Assert.False(properties.TryGetProperty("runtime_architecture", out _));

--- a/src/Foundry.Telemetry.Tests/TelemetryEventPropertyPolicyTests.cs
+++ b/src/Foundry.Telemetry.Tests/TelemetryEventPropertyPolicyTests.cs
@@ -10,6 +10,7 @@ public sealed class TelemetryEventPropertyPolicyTests
         Dictionary<string, object?> input = new()
         {
             ["boot_media_target"] = "iso",
+            ["boot_media_usb_operation"] = "update",
             ["boot_media_creation_success"] = true,
             ["boot_media_creation_duration_seconds"] = 12.5,
             ["boot_media_architecture"] = "x64",
@@ -80,6 +81,7 @@ public sealed class TelemetryEventPropertyPolicyTests
         IReadOnlyDictionary<string, object?> result = TelemetryEventPropertyPolicy.Sanitize(TelemetryEvents.OsdBootMediaFinished, input);
 
         Assert.Equal("iso", result["boot_media_target"]);
+        Assert.Equal("update", result["boot_media_usb_operation"]);
         Assert.True((bool)result["boot_media_creation_success"]!);
         Assert.Equal(12.5, result["boot_media_creation_duration_seconds"]);
         Assert.Equal("x64", result["boot_media_architecture"]);

--- a/src/Foundry.Telemetry/TelemetryBootMediaUsbOperations.cs
+++ b/src/Foundry.Telemetry/TelemetryBootMediaUsbOperations.cs
@@ -1,0 +1,11 @@
+namespace Foundry.Telemetry;
+
+/// <summary>
+/// Defines stable USB operation categories for OSD boot media telemetry.
+/// </summary>
+public static class TelemetryBootMediaUsbOperations
+{
+    public const string None = "none";
+    public const string Create = "create";
+    public const string Update = "update";
+}

--- a/src/Foundry.Telemetry/TelemetryDefaults.cs
+++ b/src/Foundry.Telemetry/TelemetryDefaults.cs
@@ -8,7 +8,7 @@ public static class TelemetryDefaults
     /// <summary>
     /// Gets the current telemetry event contract version.
     /// </summary>
-    public const int SchemaVersion = 2;
+    public const int SchemaVersion = 3;
 
     /// <summary>
     /// Gets the PostHog EU ingestion host used by official Foundry telemetry.

--- a/src/Foundry.Telemetry/TelemetryDefaults.cs
+++ b/src/Foundry.Telemetry/TelemetryDefaults.cs
@@ -8,7 +8,7 @@ public static class TelemetryDefaults
     /// <summary>
     /// Gets the current telemetry event contract version.
     /// </summary>
-    public const int SchemaVersion = 3;
+    public const int SchemaVersion = 2;
 
     /// <summary>
     /// Gets the PostHog EU ingestion host used by official Foundry telemetry.

--- a/src/Foundry.Telemetry/TelemetryEventPropertyPolicy.cs
+++ b/src/Foundry.Telemetry/TelemetryEventPropertyPolicy.cs
@@ -46,6 +46,7 @@ public static class TelemetryEventPropertyPolicy
             [TelemetryEvents.OsdBootMediaFinished] = new(StringComparer.Ordinal)
             {
                 "boot_media_target",
+                "boot_media_usb_operation",
                 "boot_media_creation_success",
                 "boot_media_creation_duration_seconds",
                 "boot_media_creation_failed_step_name",

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>إنشاء USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>تحديث USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>تنسيق سريع</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>إنشاء وسائط USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>تحديث وسيط USB.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>تم الانتهاء من إنشاء الوسائط النهائية.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>التحقق من USB سلامة الهدف.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>فحص تخطيط وسيط USB.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>التقسيم والتنسيق USB الهدف.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB اكتملت الوسائط.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>تم تحديث قسم تمهيد USB.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>تصدير صورة Windows باستخدام DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>تم إنشاء الوسائط USB بنجاح. حجم التمهيد: {0}. حجم ذاكرة التخزين المؤقت: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>تم تحديث قسم تمهيد USB بنجاح. وحدة التمهيد: {0}. وحدة التخزين المؤقتة: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>حدد ISO مسار الإخراج</value>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Създаване на USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Актуализиране на USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Бърз формат</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Създаване на USB медия.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Актуализиране на USB носител.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Окончателното създаване на медия е завършено.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Проверка на безопасността на целта USB.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Проверка на оформлението на USB носителя.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Разделяне и форматиране USB цел.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB медиите са завършени.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>Дялът за зареждане на USB е актуализиран.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Експортиране на Windows изображение с DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB медията е създадена успешно. Обем на зареждане: {0}. Обем на кеша: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>Дялът за зареждане на USB беше актуализиран успешно. Том за зареждане: {0}. Кеш том: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Изберете ISO изходен път</value>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Vytvořit USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Aktualizovat USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Rychlé formátování</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Vytváření médií USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Aktualizace média USB.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Finální vytvoření média dokončeno.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Kontrola cílové bezpečnosti USB.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Kontrola rozložení média USB.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Rozdělení a formátování USB target.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>Médium USB bylo dokončeno.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>Spouštěcí oddíl USB byl aktualizován.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Export obrázku Windows pomocí DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>Médium USB bylo úspěšně vytvořeno. Spouštěcí hlasitost: {0}. Objem mezipaměti: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>Spouštěcí oddíl USB byl úspěšně aktualizován. Spouštěcí svazek: {0}. Svazek mezipaměti: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Vyberte výstupní cestu ISO</value>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Opret USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Opdater USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Hurtigt format</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Oprettelse af USB medier.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Opdaterer USB-medie.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Den endelige medieoprettelse afsluttet.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Kontrollerer USB målsikkerhed.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Undersøger USB-mediets layout.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Partitionering og formatering USB mål.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB medie afsluttet.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB-startpartitionen blev opdateret.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Eksporterer Windows billede med DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB mediet blev oprettet. Bootvolumen: {0}. Cachevolumen: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>USB-startpartitionen blev opdateret. Startdiskenhed: {0}. Cache-diskenhed: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Vælg ISO outputsti</value>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Erstellen Sie USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>USB aktualisieren</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Schnellformatierung</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>USB Medien erstellen.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>USB-Medium wird aktualisiert.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Die endgültige Medienerstellung ist abgeschlossen.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Überprüfung der USB-Zielsicherheit.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>USB-Medienlayout wird überprüft.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Partitionierung und Formatierung des USB Ziels.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB Medien abgeschlossen.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB-Startpartition wurde aktualisiert.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Windows Bild mit DISM exportieren.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB Medien wurden erfolgreich erstellt. Boot-Volume: {0}. Cache-Volumen: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>Die USB-Startpartition wurde erfolgreich aktualisiert. Startvolume: {0}. Cachevolume: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Wählen Sie ISO Ausgabepfad</value>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Δημιουργία USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Ενημέρωση USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Γρήγορη μορφή</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Δημιουργία πολυμέσων USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Ενημέρωση μέσου USB.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Η τελική δημιουργία μέσων ολοκληρώθηκε.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Έλεγχος της ασφάλειας στόχου USB.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Έλεγχος διάταξης μέσου USB.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Διαμέριση και μορφοποίηση στόχου USB.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>Τα μέσα USB ολοκληρώθηκαν.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>Το διαμέρισμα εκκίνησης USB ενημερώθηκε.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Εξαγωγή εικόνας Windows με DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>Τα μέσα USB δημιουργήθηκαν με επιτυχία. Όγκος εκκίνησης: {0}. Όγκος προσωρινής μνήμης: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>Το διαμέρισμα εκκίνησης USB ενημερώθηκε με επιτυχία. Τόμος εκκίνησης: {0}. Τόμος cache: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Επιλέξτε διαδρομή εξόδου ISO</value>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Create USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Update USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Quick format</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Creating USB media.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Updating USB media.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Final media creation completed.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Checking USB target safety.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Inspecting USB media layout.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Partitioning and formatting USB target.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB media completed.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB boot partition updated.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Exporting Windows image with DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB media was created successfully. Boot volume: {0}. Cache volume: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>USB boot partition was updated successfully. Boot volume: {0}. Cache volume: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Select ISO output path</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Create USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Update USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Quick format</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Creating USB media.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Updating USB media.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Final media creation completed.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Checking USB target safety.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Inspecting USB media layout.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Partitioning and formatting USB target.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB media completed.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB boot partition updated.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Exporting Windows image with DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB media was created successfully. Boot volume: {0}. Cache volume: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>USB boot partition was updated successfully. Boot volume: {0}. Cache volume: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Select ISO output path</value>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Crear USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Actualizar USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>formato rápido</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Creando medios USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Actualizando medio USB.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Creación final de medios completada.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Comprobando USB la seguridad del objetivo.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Inspeccionando el diseño del medio USB.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Particionar y formatear el objetivo USB.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB medios completados.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>La partición de arranque USB se actualizó.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Exportando imagen Windows con DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB los medios se crearon correctamente. Volumen de arranque: {0}. Volumen de caché: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>La partición de arranque USB se actualizó correctamente. Volumen de arranque: {0}. Volumen de caché: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Seleccione ISO ruta de salida</value>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Crear USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Actualizar USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>formato rápido</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Creando medios USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Actualizando medio USB.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Creación final de medios completada.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Comprobando USB la seguridad del objetivo.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Inspeccionando el diseño del medio USB.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Particionar y formatear el objetivo USB.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB medios completados.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>La partición de arranque USB se actualizó.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Exportando imagen Windows con DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB los medios se crearon correctamente. Volumen de arranque: {0}. Volumen de caché: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>La partición de arranque USB se actualizó correctamente. Volumen de arranque: {0}. Volumen de caché: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Seleccione ISO ruta de salida</value>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Loo USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Värskenda USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Kiire vormindamine</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>USB meedia loomine.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>USB-meediumi värskendamine.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Lõplik meedia loomine on lõpetatud.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>USB sihtmärgi ohutuse kontrollimine.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>USB-meediumi paigutuse kontrollimine.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Jaotamine ja vormindamine USB sihtmärk.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB meedia valmis.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB alglaadimispartitsioon värskendati.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Windows kujutise eksportimine DISM-ga.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB meediumi loomine õnnestus. Alglaadimise helitugevus: {0}. Vahemälu maht: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>USB alglaadimispartitsioon värskendati edukalt. Alglaadimisköide: {0}. Vahemäluköide: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Valige ISO väljundtee</value>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Luo USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Päivitä USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Nopea muotoilu</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Luodaan USB mediaa.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Päivitetään USB-mediaa.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Lopullinen median luominen valmis.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Tarkistetaan USB kohteen turvallisuutta.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Tarkistetaan USB-median asettelua.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Osio ja muotoilu USB kohde.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB media valmis.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB-käynnistysosio päivitettiin.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Viedään Windows-kuvaa DISM:lla.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB media luotiin onnistuneesti. Käynnistysvoimakkuus: {0}. Välimuistin määrä: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>USB-käynnistysosio päivitettiin onnistuneesti. Käynnistystaltion nimi: {0}. Välimuistitaltion nimi: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Valitse ISO lähtöpolku</value>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Créer USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Mettre à jour USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Formatage rapide</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Création du média USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Mise à jour du support USB.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Création finale du média terminée.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Vérification de la sécurité de la cible USB.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Inspection de la disposition du support USB.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Partitionnement et formatage USB cible.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB média terminé.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>La partition de démarrage USB a été mise à jour.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Exportation de l'image Windows avec DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>Le média USB a été créé avec succès. Volume de démarrage: {0}. Volume de cache: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>La partition de démarrage USB a été mise à jour avec succès. Volume de démarrage : {0}. Volume de cache : {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Sélectionnez ISO chemin de sortie</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Créer l'USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Mettre à jour USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Formatage rapide</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Création du média USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Mise à jour du support USB.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Création du média final terminée.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Contrôle de sécurité de la cible USB.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Inspection de la disposition du support USB.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Partitionnement et formatage de la cible USB.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>Média USB terminé.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>La partition de démarrage USB a été mise à jour.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Export de l'image Windows avec DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>Le média USB a été créé avec succès. Volume de démarrage : {0}. Volume cache : {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>La partition de démarrage USB a été mise à jour avec succès. Volume de démarrage : {0}. Volume de cache : {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Sélectionner le chemin de sortie ISO</value>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>צור USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>עדכן USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>פורמט מהיר</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>יצירת מדיה USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>מעדכן מדיית USB.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>יצירת המדיה הסופית הושלמה.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>בדיקת USB בטיחות היעד.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>בודק את פריסת מדיית ה-USB.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>חלוקה ועיצוב USB target.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>מדיה USB הושלמה.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>מחיצת האתחול של USB עודכנה.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>מייצא תמונה Windows עם DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>המדיה USB נוצרה בהצלחה. עוצמת הקול של האתחול: {0}. נפח מטמון: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>מחיצת האתחול של USB עודכנה בהצלחה. אמצעי האחסון לאתחול: {0}. אמצעי האחסון למטמון: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>בחר נתיב פלט ISO</value>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Stvori USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Ažuriraj USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Brzi format</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Stvaranje USB medija.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Ažuriranje USB medija.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Završna izrada medija dovršena.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Provjera sigurnosti mete USB.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Provjera rasporeda USB medija.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Particioniranje i formatiranje USB cilja.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB mediji dovršeni.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB particija za pokretanje je ažurirana.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Izvoz Windows slike pomoću DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB medij je uspješno kreiran. Volumen pokretanja: {0}. Volumen predmemorije: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>USB particija za pokretanje uspješno je ažurirana. Volumen za pokretanje: {0}. Volumen predmemorije: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Odaberite ISO izlazni put</value>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>USB létrehozása</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>USB frissítése</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Gyors formázás</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>USB média létrehozása.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>USB adathordozó frissítése.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>A média végleges létrehozása befejeződött.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>USB célbiztonság ellenőrzése.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>USB adathordozó elrendezésének ellenőrzése.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>A USB cél particionálása és formázása.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB média kész.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>Az USB rendszerindító partíció frissült.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Windows kép exportálása DISM-val.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB média sikeresen létrejött. Rendszerindítási hangerő: {0}. Gyorsítótár mennyisége: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>Az USB rendszerindító partíció sikeresen frissült. Rendszerindító kötet: {0}. Gyorsítótár-kötet: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Válassza ki a ISO kimeneti útvonalat</value>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Crea USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Aggiorna USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Formato rapido</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Creazione del supporto USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Aggiornamento del supporto USB.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Creazione multimediale finale completata.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Controllo della sicurezza del target USB.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Ispezione del layout del supporto USB.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Partizionamento e formattazione USB target.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB supporto completato.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>Partizione di avvio USB aggiornata.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Esportazione dell'immagine Windows con DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>Il supporto USB è stato creato correttamente. Volume di avvio: {0}. Volume della cache: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>La partizione di avvio USB è stata aggiornata correttamente. Volume di avvio: {0}. Volume cache: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Selezionare il percorso di uscita ISO</value>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>USB を作成します</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>USB を更新</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>クイックフォーマット</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>USB メディアを作成しています。</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>USB メディアを更新しています。</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>最終的なメディアの作成が完了しました。</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>USB ターゲットの安全性を確認しています。</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>USB メディアのレイアウトを検査しています。</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>USB ターゲットのパーティショニングとフォーマット。</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB メディアが完成しました。</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB ブート パーティションが更新されました。</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>DISM を使用して Windows 画像をエクスポートしています。</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB メディアが正常に作成されました。ブート ボリューム: {0}。キャッシュ ボリューム: {1}。</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>USB ブート パーティションが正常に更新されました。ブート ボリューム: {0}。キャッシュ ボリューム: {1}。</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>ISO 出力パスを選択してください</value>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>USB 생성</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>USB 업데이트</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>빠른 포맷</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>USB 미디어를 만드는 중입니다.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>USB 미디어를 업데이트하는 중입니다.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>최종 미디어 생성이 완료되었습니다.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>USB 대상의 안전성을 확인하는 중입니다.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>USB 미디어 레이아웃을 검사하는 중입니다.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>USB 대상을 분할하고 포맷합니다.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB 미디어가 완료되었습니다.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB 부팅 파티션이 업데이트되었습니다.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>DISM을 사용하여 Windows 이미지를 내보내는 중입니다.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB 미디어가 성공적으로 생성되었습니다. 부팅 볼륨: {0}. 캐시 볼륨: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>USB 부팅 파티션이 성공적으로 업데이트되었습니다. 부팅 볼륨: {0}. 캐시 볼륨: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>ISO 출력 경로 선택</value>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Sukurti USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Atnaujinti USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Greitas formatas</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>USB medijos kūrimas.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Atnaujinama USB laikmena.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Baigtas galutinis žiniasklaidos kūrimas.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Tikrinama USB tikslo sauga.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Tikrinamas USB laikmenos išdėstymas.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Skirstymas ir formatavimas USB tikslas.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB laikmena baigta.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB įkrovos skaidinys atnaujintas.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Eksportuojamas Windows vaizdas su DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB laikmena sėkmingai sukurta. Įkrovos garsumas: {0}. Talpyklos tūris: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>USB įkrovos skaidinys sėkmingai atnaujintas. Įkrovos tomas: {0}. Talpyklos tomas: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Pasirinkite ISO išvesties kelią</value>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Izveidot USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Atjaunināt USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Ātrs formāts</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>USB multivides izveide.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Atjaunina USB datu nesēju.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Pēdējā multivides izveide ir pabeigta.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Pārbauda USB mērķa drošību.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Pārbauda USB datu nesēja izkārtojumu.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Sadalīšana un formatēšana USB mērķis.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB multivide ir pabeigta.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB sāknēšanas nodalījums ir atjaunināts.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Notiek Windows attēla eksportēšana ar DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB multivide tika veiksmīgi izveidota. Sāknēšanas skaļums: {0}. Kešatmiņas apjoms: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>USB sāknēšanas nodalījums tika veiksmīgi atjaunināts. Sāknēšanas sējums: {0}. Kešatmiņas sējums: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Izvēlieties ISO izvades ceļu</value>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Opprett USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Oppdater USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Rask formatering</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Opprette USB media.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Oppdaterer USB-medie.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Endelig medieoppretting fullført.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Kontrollerer USB målsikkerhet.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Kontrollerer oppsettet for USB-mediet.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Partisjonering og formatering USB mål.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB media fullført.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB-oppstartspartisjonen ble oppdatert.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Eksporterer Windows-bilde med DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB media ble opprettet. Oppstartsvolum: {0}. Buffervolum: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>USB-oppstartspartisjonen ble oppdatert. Oppstartsvolum: {0}. Hurtigbuffervolum: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Velg ISO utgangsbane</value>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Maak USB aan</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>USB bijwerken</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Snel formatteren</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>USB-media maken.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>USB-media bijwerken.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Definitieve mediacreatie voltooid.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>USB doelveiligheid controleren.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Indeling van USB-media controleren.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Partitioneren en formatteren USB doel.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB media voltooid.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB-opstartpartitie is bijgewerkt.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Windows afbeelding exporteren met DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB media is succesvol aangemaakt. Opstartvolume: {0}. Cachevolume: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>De USB-opstartpartitie is bijgewerkt. Opstartvolume: {0}. Cachevolume: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Selecteer ISO uitvoerpad</value>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Utwórz USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Aktualizuj USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Szybki format</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Tworzenie nośnika USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Aktualizowanie nośnika USB.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Zakończono końcowe tworzenie multimediów.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Sprawdzanie bezpieczeństwa celu USB.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Sprawdzanie układu nośnika USB.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Partycjonowanie i formatowanie celu USB.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB multimedia ukończone.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>Partycja rozruchowa USB została zaktualizowana.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Eksportowanie obrazu Windows z DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>Nośnik USB został pomyślnie utworzony. Wolumin rozruchowy: {0}. Pojemność pamięci podręcznej: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>Partycja rozruchowa USB została pomyślnie zaktualizowana. Wolumin rozruchowy: {0}. Wolumin pamięci podręcznej: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Wybierz ścieżkę wyjściową ISO</value>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Crie USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Atualizar USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Formatação rápida</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Criando mídia USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Atualizando mídia USB.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Criação final da mídia concluída.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Verificando a segurança do alvo USB.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Inspecionando o layout da mídia USB.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Particionando e formatando o destino USB.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB mídia concluída.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>A partição de inicialização USB foi atualizada.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Exportando imagem Windows com DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>A mídia USB foi criada com sucesso. Volume de inicialização: {0}. Volume do cache: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>A partição de inicialização USB foi atualizada com êxito. Volume de inicialização: {0}. Volume de cache: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Selecione ISO caminho de saída</value>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Crie USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Atualizar USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Formatação rápida</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Criando mídia USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>A atualizar o suporte USB.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Criação final da mídia concluída.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Verificando a segurança do alvo USB.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>A inspecionar o esquema do suporte USB.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Particionando e formatando o destino USB.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB mídia concluída.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>A partição de arranque USB foi atualizada.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Exportando imagem Windows com DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>A mídia USB foi criada com sucesso. Volume de inicialização: {0}. Volume do cache: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>A partição de arranque USB foi atualizada com êxito. Volume de arranque: {0}. Volume de cache: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Selecione ISO caminho de saída</value>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Creați USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Actualizare USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Format rapid</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Se creează USB media.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Se actualizează suportul USB.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Crearea media finală a fost finalizată.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Se verifică USB siguranța țintei.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Se inspectează aspectul suportului USB.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Partiționare și formatare USB țintă.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB media finalizată.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>Partiția de pornire USB a fost actualizată.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Se exportă imaginea Windows cu DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB media a fost creată cu succes. Volumul de pornire: {0}. Volumul cache: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>Partiția de pornire USB a fost actualizată cu succes. Volum de pornire: {0}. Volum cache: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Selectați calea de ieșire ISO</value>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Создать USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Обновить USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Быстрое форматирование</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Создание носителя USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Обновление USB-носителя.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Окончательное создание носителя завершено.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Проверяем безопасность цели USB.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Проверка разметки USB-носителя.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Разбиение и форматирование цели USB.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB носитель завершен.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>Загрузочный раздел USB обновлен.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Экспорт изображения Windows с помощью DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB носитель успешно создан. Загрузочный том: {0}. Объем кэша: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>Загрузочный раздел USB успешно обновлен. Загрузочный том: {0}. Том кэша: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Выберите путь вывода ISO</value>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Vytvoriť USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Aktualizovať USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Rýchly formát</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Vytváranie médií USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Aktualizuje sa médium USB.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Finálne vytváranie médií dokončené.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Kontrola cieľovej bezpečnosti USB.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Kontroluje sa rozloženie média USB.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Rozdelenie a formátovanie cieľa USB.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>Médium USB dokončené.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>Spúšťacia partícia USB bola aktualizovaná.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Exportuje sa obrázok Windows pomocou DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>Médium USB bolo úspešne vytvorené. Spúšťacia hlasitosť: {0}. Objem vyrovnávacej pamäte: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>Spúšťacia partícia USB bola úspešne aktualizovaná. Spúšťací zväzok: {0}. Zväzok vyrovnávacej pamäte: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Vyberte výstupnú cestu ISO</value>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Ustvari USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Posodobi USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Hitra oblika</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Ustvarjanje medija USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Posodabljanje medija USB.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Ustvarjanje končnega medija je končano.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Preverjanje varnosti cilja USB.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Preverjanje postavitve medija USB.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Particioniranje in oblikovanje cilja USB.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB mediji končani.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>Zagonska particija USB je bila posodobljena.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Izvažanje Windows slike z DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>Medij USB je bil uspešno ustvarjen. Glasnost zagona: {0}. Prostornina predpomnilnika: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>Zagonska particija USB je bila uspešno posodobljena. Zagonski nosilec: {0}. Predpomnilniški nosilec: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Izberite ISO izhodno pot</value>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Kreiraj USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Ažuriraj USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Brzo formatiranje</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Kreiranje medija USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Ažuriranje USB medija.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Završeno kreiranje medija.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Provera USB bezbednosti mete.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Provera rasporeda USB medija.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Particionisanje i formatiranje USB cilj.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB mediji su završeni.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB particija za pokretanje je ažurirana.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Izvoz Windows slike sa DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB medij je uspešno kreiran. Jačina pokretanja: {0}. Volumen keša: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>USB particija za pokretanje je uspešno ažurirana. Volumen za pokretanje: {0}. Volumen keša: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Izaberite izlaznu putanju ISO</value>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Skapa USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Uppdatera USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Snabbformatering</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Skapa USB media.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Uppdaterar USB-media.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Det sista medieskapandet avslutat.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Kontrollerar USB målsäkerhet.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Kontrollerar USB-mediets layout.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Partitionering och formatering av USB mål.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB media slutfört.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB-startpartitionen har uppdaterats.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Exporterar Windows-bild med DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB media skapades framgångsrikt. Startvolym: {0}. Cachevolym: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>USB-startpartitionen uppdaterades. Startvolym: {0}. Cachevolym: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Välj ISO utdatasökväg</value>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>สร้าง USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>อัปเดต USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>รูปแบบด่วน</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>การสร้างสื่อ USB</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>กำลังอัปเดตสื่อ USB</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>การสร้างสื่อขั้นสุดท้ายเสร็จสมบูรณ์</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>กำลังตรวจสอบความปลอดภัยของเป้าหมาย USB</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>กำลังตรวจสอบเค้าโครงสื่อ USB</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>การแบ่งพาร์ติชันและการจัดรูปแบบเป้าหมาย USB</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB สื่อเสร็จเรียบร้อย</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>อัปเดตพาร์ติชันบูต USB แล้ว</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>กำลังส่งออกรูปภาพ Windows ด้วย DISM</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB สร้างสื่อสำเร็จแล้ว ปริมาณการบูต: {0} ปริมาณแคช: {1}</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>อัปเดตพาร์ติชันบูต USB สำเร็จแล้ว โวลุ่มบูต: {0} โวลุ่มแคช: {1}</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>เลือก ISO เส้นทางเอาต์พุต</value>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>USB oluştur</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>USB güncelle</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Hızlı format</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>USB ortamı oluşturma.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>USB medyası güncelleniyor.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Nihai medya oluşturma işlemi tamamlandı.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>USB hedef güvenliği kontrol ediliyor.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>USB medya düzeni inceleniyor.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>USB hedefi bölümleme ve biçimlendirme.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB medya tamamlandı.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB önyükleme bölümü güncellendi.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Windows görüntüsü DISM ile dışa aktarılıyor.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB medya başarıyla oluşturuldu. Önyükleme birimi: {0}. Önbellek birimi: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>USB önyükleme bölümü başarıyla güncellendi. Önyükleme birimi: {0}. Önbellek birimi: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>ISO çıkış yolunu seçin</value>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>Створити USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>Оновити USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>Швидке форматування</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>Створення носіїв USB.</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>Оновлення USB-носія.</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>Остаточне створення медіафайлів завершено.</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>Перевірка безпеки цілі USB.</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>Перевірка розмітки USB-носія.</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>Розбиття та форматування USB target.</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB медіа завершено.</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>Розділ завантаження USB оновлено.</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>Експорт Windows зображення за допомогою DISM.</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>Медіа USB створено успішно. Завантажувальний том: {0}. Обсяг кешу: {1}.</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>Розділ завантаження USB успішно оновлено. Том завантаження: {0}. Том кешу: {1}.</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>Виберіть вихідний шлях ISO</value>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>创建USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>更新 USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>快速格式化</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>创建 USB 媒体。</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>正在更新 USB 介质。</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>最终媒体创建完成。</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>检查USB目标安全。</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>正在检查 USB 介质布局。</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>对USB目标进行分区和格式化。</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB媒体已完成。</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB 启动分区已更新。</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>使用DISM 导出Windows 图像。</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB媒体已成功创建。启动卷：{0}。缓存卷：{1}。</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>USB 启动分区已成功更新。启动卷: {0}。缓存卷: {1}。</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>选择ISO输出路径</value>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -1014,6 +1014,9 @@
   <data name="StartMedia.CreateUsbButton" xml:space="preserve">
     <value>創建USB</value>
   </data>
+  <data name="StartMedia.UpdateUsbButton" xml:space="preserve">
+    <value>更新 USB</value>
+  </data>
   <data name="StartMedia.FormatMode.Quick" xml:space="preserve">
     <value>快速格式化</value>
   </data>
@@ -1088,6 +1091,9 @@
   </data>
   <data name="StartMedia.Operation.CreatingUsb" xml:space="preserve">
     <value>建立 USB 媒體。</value>
+  </data>
+  <data name="StartMedia.Operation.UpdatingUsb" xml:space="preserve">
+    <value>正在更新 USB 媒體。</value>
   </data>
   <data name="StartMedia.Operation.Completed" xml:space="preserve">
     <value>最終媒體創建完成。</value>
@@ -1164,6 +1170,9 @@
   <data name="StartMedia.Operation.CheckingUsbTargetSafety" xml:space="preserve">
     <value>檢查USB目標安全。</value>
   </data>
+  <data name="StartMedia.Operation.InspectingUsbMediaLayout" xml:space="preserve">
+    <value>正在檢查 USB 媒體配置。</value>
+  </data>
   <data name="StartMedia.Operation.PartitioningUsbTarget" xml:space="preserve">
     <value>對USB目標進行分割和格式化。</value>
   </data>
@@ -1212,6 +1221,9 @@
   <data name="StartMedia.Operation.UsbMediaCompleted" xml:space="preserve">
     <value>USB媒體完成。</value>
   </data>
+  <data name="StartMedia.Operation.UsbBootPartitionUpdated" xml:space="preserve">
+    <value>USB 開機分割區已更新。</value>
+  </data>
   <data name="StartMedia.Operation.DismExportingWindowsImage" xml:space="preserve">
     <value>使用DISM 匯出Windows 影像。</value>
   </data>
@@ -1241,6 +1253,9 @@
   </data>
   <data name="StartMedia.Operation.UsbSuccessMessage" xml:space="preserve">
     <value>USB媒體已成功建立。啟動磁碟區：{0}。快取卷：{1}。</value>
+  </data>
+  <data name="StartMedia.Operation.UsbUpdateSuccessMessage" xml:space="preserve">
+    <value>USB 開機分割區已成功更新。開機磁碟區: {0}。快取磁碟區: {1}。</value>
   </data>
   <data name="StartMedia.IsoPicker.Title" xml:space="preserve">
     <value>選擇ISO輸出路徑</value>

--- a/src/Foundry/ViewModels/MediaCreationTelemetryProgressTracker.cs
+++ b/src/Foundry/ViewModels/MediaCreationTelemetryProgressTracker.cs
@@ -217,4 +217,5 @@ internal static class MediaCreationStepNames
     public const string CreateFinalMedia = "Create final media";
     public const string CreateIsoMedia = "Create ISO media";
     public const string CreateUsbMedia = "Create USB media";
+    public const string UpdateUsbMedia = "Update USB media";
 }

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -1382,8 +1382,15 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         string bootMediaTarget = target == FinalMediaTarget.Iso
             ? TelemetryBootMediaTargets.Iso
             : TelemetryBootMediaTargets.Usb;
+        string bootMediaUsbOperation = target switch
+        {
+            FinalMediaTarget.Usb => TelemetryBootMediaUsbOperations.Create,
+            FinalMediaTarget.UsbUpdate => TelemetryBootMediaUsbOperations.Update,
+            _ => TelemetryBootMediaUsbOperations.None
+        };
         IReadOnlyDictionary<string, object?> properties = BootMediaTelemetryPropertyBuilder.Build(
             bootMediaTarget,
+            bootMediaUsbOperation,
             options,
             foundryConfigurationStateService.Current,
             success,
@@ -1393,8 +1400,9 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             ResolveRuntimePayloadSource(runtimePayloadProvisioning.Deploy));
 
         logger.Debug(
-            "Tracking media telemetry event. Target={Target}, Success={Success}, FailedStepName={FailedStepName}, DurationSeconds={DurationSeconds}, Architecture={Architecture}, BootImageSource={BootImageSource}, SignatureMode={SignatureMode}, ConnectRuntimePayloadSource={ConnectRuntimePayloadSource}, DeployRuntimePayloadSource={DeployRuntimePayloadSource}.",
+            "Tracking media telemetry event. Target={Target}, UsbOperation={UsbOperation}, Success={Success}, FailedStepName={FailedStepName}, DurationSeconds={DurationSeconds}, Architecture={Architecture}, BootImageSource={BootImageSource}, SignatureMode={SignatureMode}, ConnectRuntimePayloadSource={ConnectRuntimePayloadSource}, DeployRuntimePayloadSource={DeployRuntimePayloadSource}.",
             properties["boot_media_target"],
+            properties["boot_media_usb_operation"],
             success,
             failedStepName,
             properties["boot_media_creation_duration_seconds"],

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -178,6 +178,9 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     public partial SelectionOption<WinPeUsbDiskCandidate>? SelectedUsbDisk { get; set; }
 
     [ObservableProperty]
+    public partial bool IsSelectedUsbFoundryMedia { get; set; }
+
+    [ObservableProperty]
     public partial bool IsRefreshingUsbCandidates { get; set; }
 
     [ObservableProperty]
@@ -357,6 +360,12 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             return;
         }
 
+        if (IsSelectedUsbFoundryMedia)
+        {
+            await RunFinalMediaOperationAsync(FinalMediaTarget.UsbUpdate, options);
+            return;
+        }
+
         WinPeUsbDiskCandidate selectedDisk = options.SelectedUsbDisk;
         bool confirmed = await dialogService.ConfirmAsync(new ConfirmationDialogRequest(
             localizationService.GetString("StartMedia.CreateUsb.ConfirmTitle"),
@@ -399,9 +408,12 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
         try
         {
-            string startStatus = target == FinalMediaTarget.Iso
-                ? localizationService.GetString("StartMedia.Operation.CreatingIso")
-                : localizationService.GetString("StartMedia.Operation.CreatingUsb");
+            string startStatus = target switch
+            {
+                FinalMediaTarget.Iso => localizationService.GetString("StartMedia.Operation.CreatingIso"),
+                FinalMediaTarget.UsbUpdate => localizationService.GetString("StartMedia.Operation.UpdatingUsb"),
+                _ => localizationService.GetString("StartMedia.Operation.CreatingUsb")
+            };
 
             operationProgressService.Start(OperationKind.MediaCreation, startStatus);
             logger.Information(
@@ -410,13 +422,22 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 options.Architecture,
                 NormalizeCultureName(options.WinPeLanguage),
                 target == FinalMediaTarget.Iso ? options.IsoOutputPath : null,
-                target == FinalMediaTarget.Usb ? options.SelectedUsbDisk?.DiskNumber : null,
-                target == FinalMediaTarget.Usb ? options.SelectedUsbDisk?.FriendlyName : null);
+                target is FinalMediaTarget.Usb or FinalMediaTarget.UsbUpdate ? options.SelectedUsbDisk?.DiskNumber : null,
+                target is FinalMediaTarget.Usb or FinalMediaTarget.UsbUpdate ? options.SelectedUsbDisk?.FriendlyName : null);
 
             if (target == FinalMediaTarget.Iso)
             {
                 _ = await CreateIsoMediaAsync(options, telemetryProgressTracker, CancellationToken.None);
                 successMessage = localizationService.GetString("StartMedia.Operation.IsoSuccessMessage");
+            }
+            else if (target == FinalMediaTarget.UsbUpdate)
+            {
+                WinPeUsbProvisionResult usbResult = await UpdateUsbMediaAsync(options, telemetryProgressTracker, CancellationToken.None);
+                successMessage = string.Format(
+                    CultureInfo.CurrentCulture,
+                    localizationService.GetString("StartMedia.Operation.UsbUpdateSuccessMessage"),
+                    usbResult.BootDriveLetter,
+                    usbResult.CacheDriveLetter);
             }
             else
             {
@@ -562,6 +583,67 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             EnsureSuccess(result);
             logger.Debug(
                 "USB media service completed. DiskNumber={DiskNumber}, BootVolume={BootVolume}, CacheVolume={CacheVolume}",
+                selectedDisk.DiskNumber,
+                result.Value?.BootDriveLetter,
+                result.Value?.CacheDriveLetter);
+            return result.Value!;
+        }
+        finally
+        {
+            CleanupPreparedWorkspace(workspace?.PreparedWorkspace.Artifact.WorkingDirectoryPath);
+        }
+    }
+
+    private async Task<WinPeUsbProvisionResult> UpdateUsbMediaAsync(
+        MediaPreflightOptions options,
+        MediaCreationTelemetryProgressTracker telemetryProgressTracker,
+        CancellationToken cancellationToken)
+    {
+        telemetryProgressTracker.SetCurrentStep(MediaCreationStepNames.ValidateUsbTarget);
+        if (options.SelectedUsbDisk is null)
+        {
+            throw new InvalidOperationException(localizationService.GetString("StartMedia.BlockingReason.NoUsbTarget"));
+        }
+
+        PreparedMediaWorkspace? workspace = null;
+
+        try
+        {
+            workspace = await PrepareMediaWorkspaceAsync(
+                options,
+                includeRuntimePayloadInImage: false,
+                telemetryProgressTracker: telemetryProgressTracker,
+                cancellationToken);
+
+            WinPeUsbDiskCandidate selectedDisk = options.SelectedUsbDisk;
+            telemetryProgressTracker.SetCurrentStep(MediaCreationStepNames.UpdateUsbMedia);
+            logger.Debug(
+                "Updating USB boot partition. DiskNumber={DiskNumber}, DiskName={DiskName}, FormatMode={FormatMode}, MediaDirectoryPath={MediaDirectoryPath}, UseBootEx={UseBootEx}",
+                selectedDisk.DiskNumber,
+                selectedDisk.FriendlyName,
+                options.UsbFormatMode,
+                workspace.PreparedWorkspace.Artifact.MediaDirectoryPath,
+                workspace.PreparedWorkspace.UseBootEx);
+
+            WinPeResult<WinPeUsbProvisionResult> result = await usbMediaService.UpdateBootPartitionAsync(
+                new UsbOutputOptions
+                {
+                    TargetDiskNumber = selectedDisk.DiskNumber,
+                    ExpectedDiskFriendlyName = selectedDisk.FriendlyName,
+                    ExpectedDiskSerialNumber = selectedDisk.SerialNumber,
+                    ExpectedDiskUniqueId = selectedDisk.UniqueId,
+                    FormatMode = options.UsbFormatMode,
+                    Progress = telemetryProgressTracker.CreateFinalMediaProgress(
+                        new Progress<WinPeMediaProgress>(ReportFinalMediaProgress))
+                },
+                workspace.PreparedWorkspace.Artifact,
+                workspace.Tools,
+                workspace.PreparedWorkspace.UseBootEx,
+                cancellationToken);
+
+            EnsureSuccess(result);
+            logger.Debug(
+                "USB boot partition update service completed. DiskNumber={DiskNumber}, BootVolume={BootVolume}, CacheVolume={CacheVolume}",
                 selectedDisk.DiskNumber,
                 result.Value?.BootDriveLetter,
                 result.Value?.CacheDriveLetter);
@@ -953,6 +1035,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             "ISO media completed." => "StartMedia.Operation.IsoMediaCompleted",
             "Validating USB target." => "StartMedia.Operation.ValidatingUsbTarget",
             "Checking USB target safety." => "StartMedia.Operation.CheckingUsbTargetSafety",
+            "Inspecting USB media layout." => "StartMedia.Operation.InspectingUsbMediaLayout",
             "Partitioning and formatting USB target." => "StartMedia.Operation.PartitioningUsbTarget",
             "Opening USB disk." => "StartMedia.Operation.OpeningUsbDisk",
             "Preparing USB disk attributes." => "StartMedia.Operation.PreparingUsbDiskAttributes",
@@ -969,6 +1052,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             "Preparing USB cache partition." => "StartMedia.Operation.PreparingUsbCache",
             "Provisioning USB runtime payloads." => "StartMedia.Operation.ProvisioningUsbRuntimePayloads",
             "USB media completed." => "StartMedia.Operation.UsbMediaCompleted",
+            "USB boot partition updated." => "StartMedia.Operation.UsbBootPartitionUpdated",
             _ => string.Empty
         };
 
@@ -1088,6 +1172,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     partial void OnSelectedUsbDiskChanged(SelectionOption<WinPeUsbDiskCandidate>? value)
     {
+        IsSelectedUsbFoundryMedia = value?.Value.IsFoundryMedia == true;
         RefreshEvaluation();
     }
 
@@ -1187,6 +1272,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         availableWinPeLanguages = GetAvailableWinPeLanguages();
         MediaPreflightOptions options = CreatePreflightOptions();
         MediaPreflightEvaluation evaluation = MediaPreflightService.Evaluate(options);
+        IsSelectedUsbFoundryMedia = options.SelectedUsbDisk?.IsFoundryMedia == true;
         CanGenerateIsoSummary = evaluation.CanGenerateIsoSummary;
         CanGenerateUsbSummary = evaluation.CanGenerateUsbSummary;
         CanCreateIso = evaluation.CanCreateIso && !IsMediaOperationRunning;
@@ -2040,7 +2126,8 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     private enum FinalMediaTarget
     {
         Iso,
-        Usb
+        Usb,
+        UsbUpdate
     }
 
     private enum StartReadinessState

--- a/src/Foundry/Views/StartPage.xaml.cs
+++ b/src/Foundry/Views/StartPage.xaml.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Foundry.Services.Localization;
 
 namespace Foundry.Views;
@@ -14,6 +15,7 @@ public sealed partial class StartPage : Page
         ViewModel = App.GetService<StartMediaViewModel>();
         InitializeComponent();
         ApplyLocalizedText();
+        ViewModel.PropertyChanged += OnViewModelPropertyChanged;
         localizationService.LanguageChanged += OnLanguageChanged;
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
@@ -47,7 +49,17 @@ public sealed partial class StartPage : Page
         FinalCommandsCard.Header = localizationService.GetString("StartMedia.FinalCommands.Header");
         FinalCommandsCard.Description = localizationService.GetString("StartMedia.FinalCommands.Description");
         CreateIsoButton.Content = localizationService.GetString("StartMedia.CreateIsoButton");
-        CreateUsbButton.Content = localizationService.GetString("StartMedia.CreateUsbButton");
+        ApplyUsbActionButtonState();
+    }
+
+    private void ApplyUsbActionButtonState()
+    {
+        CreateUsbButton.Content = localizationService.GetString(ViewModel.IsSelectedUsbFoundryMedia
+            ? "StartMedia.UpdateUsbButton"
+            : "StartMedia.CreateUsbButton");
+        CreateUsbButton.Style = ViewModel.IsSelectedUsbFoundryMedia
+            ? (Style)Microsoft.UI.Xaml.Application.Current.Resources["AccentButtonStyle"]
+            : null;
     }
 
     private void ReadinessActionButton_Click(object sender, RoutedEventArgs e)
@@ -88,8 +100,25 @@ public sealed partial class StartPage : Page
         _ = DispatcherQueue.TryEnqueue(ApplyLocalizedText);
     }
 
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(StartMediaViewModel.IsSelectedUsbFoundryMedia))
+        {
+            return;
+        }
+
+        if (DispatcherQueue.HasThreadAccess)
+        {
+            ApplyUsbActionButtonState();
+            return;
+        }
+
+        _ = DispatcherQueue.TryEnqueue(ApplyUsbActionButtonState);
+    }
+
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
+        ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
         ViewModel.Dispose();
         localizationService.LanguageChanged -= OnLanguageChanged;
         Loaded -= OnLoaded;

--- a/src/Foundry/Views/StartPage.xaml.cs
+++ b/src/Foundry/Views/StartPage.xaml.cs
@@ -57,9 +57,13 @@ public sealed partial class StartPage : Page
         CreateUsbButton.Content = localizationService.GetString(ViewModel.IsSelectedUsbFoundryMedia
             ? "StartMedia.UpdateUsbButton"
             : "StartMedia.CreateUsbButton");
-        CreateUsbButton.Style = ViewModel.IsSelectedUsbFoundryMedia
-            ? (Style)Microsoft.UI.Xaml.Application.Current.Resources["AccentButtonStyle"]
-            : null;
+        if (ViewModel.IsSelectedUsbFoundryMedia)
+        {
+            CreateUsbButton.Style = (Style)Microsoft.UI.Xaml.Application.Current.Resources["AccentButtonStyle"];
+            return;
+        }
+
+        CreateUsbButton.ClearValue(Control.StyleProperty);
     }
 
     private void ReadinessActionButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
Adds an Update USB flow for Foundry-created USB media so the BOOT partition can be refreshed without repartitioning the device or formatting the Foundry Cache partition.

## Reason
Re-running Create USB on an existing Foundry USB currently clears the whole disk and removes cached deployment content. The new flow preserves the cache partition while updating boot media changes and keeps telemetry able to distinguish full USB creation from USB boot updates.

## Main changes
- Detect Foundry USB media from the selected disk when it has BOOT FAT32 and Foundry Cache NTFS volumes.
- Detect reconnected GPT Foundry USB media when Windows keeps the EFI BOOT partition but no longer assigns it a drive letter.
- Remount the BOOT partition during Update USB when a drive letter is missing, then validate BOOT/FAT32 before formatting it.
- Switch the USB action button between Create USB and Update USB when USB selection changes.
- Add a non-destructive USB update service path that formats only the BOOT partition, copies WinPE boot media, applies boot file configuration, and verifies boot artifacts.
- Keep the destructive confirmation only for Create USB.
- Track `boot_media_usb_operation` as `none`, `create`, or `update` without changing `telemetry_schema_version`.
- Restore the normal Create USB button style after switching back from Update USB.
- Add localized Update USB strings for all existing Foundry UI resource languages.
- Add regression coverage for detection, reconnected GPT BOOT handling, update flow, non-destructive script shape, non-Foundry media rejection, telemetry allowlisting, and payload serialization.

## Testing
- `dotnet test src\Foundry.Core.Tests\Foundry.Core.Tests.csproj --no-restore --logger "console;verbosity=minimal"`
- `dotnet test src\Foundry.Telemetry.Tests\Foundry.Telemetry.Tests.csproj --no-restore --logger "console;verbosity=minimal"`
- `dotnet test src\Foundry.Localization.Tests\Foundry.Localization.Tests.csproj --no-restore --logger "console;verbosity=minimal"`
- `dotnet build src\Foundry\Foundry.csproj --no-restore -v minimal`
- `git diff --check`
- Read-only host check confirmed the connected GPT USB still has the EFI BOOT partition marker and Foundry Cache NTFS after BOOT lost its drive letter.