### PR TITLE
chore: remove obsolete deploy UI code

### DIFF
--- a/src/Foundry.Deploy.Tests/DeploymentLaunchPreparationServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentLaunchPreparationServiceTests.cs
@@ -32,7 +32,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
         DeploymentLaunchPreparationResult result = service.Prepare(CreateRequest(selectedTargetDisk: blockedDisk));
 
         Assert.False(result.IsReadyToStart);
-        Assert.Equal("Selected disk is blocked: System disk", result.StatusMessage);
+        Assert.Null(result.Context);
         Assert.Equal(0, shell.ConfirmationCallCount);
     }
 
@@ -49,7 +49,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
                 selectedDriverPack: null));
 
         Assert.False(result.IsReadyToStart);
-        Assert.Equal("Select a valid OEM model/version before starting deployment.", result.StatusMessage);
+        Assert.Null(result.Context);
     }
 
     [Fact]
@@ -201,7 +201,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
                 selectedAutopilotProfile: null));
 
         Assert.False(result.IsReadyToStart);
-        Assert.Equal("Select an Autopilot profile or disable Autopilot before starting deployment.", result.StatusMessage);
+        Assert.Null(result.Context);
         Assert.Equal(0, shell.ConfirmationCallCount);
     }
 

--- a/src/Foundry.Deploy.Tests/DeploymentPreparationViewModelTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentPreparationViewModelTests.cs
@@ -344,7 +344,6 @@ public sealed class DeploymentPreparationViewModelTests
     private static DeploymentPreparationViewModel CreateViewModel()
     {
         return new DeploymentPreparationViewModel(
-            new FakeTargetDiskService(),
             new FakeHardwareProfileService(),
             new FakeOfflineWindowsComputerNameService(),
             new LocalizationService(),
@@ -379,19 +378,6 @@ public sealed class DeploymentPreparationViewModelTests
                 KnownGroupTags = ["Kiosk", "Sales"]
             }
         };
-    }
-
-    private sealed class FakeTargetDiskService : ITargetDiskService
-    {
-        public Task<IReadOnlyList<TargetDiskInfo>> GetDisksAsync(CancellationToken cancellationToken = default)
-        {
-            return Task.FromResult<IReadOnlyList<TargetDiskInfo>>([]);
-        }
-
-        public Task<int?> GetDiskNumberForPathAsync(string path, CancellationToken cancellationToken = default)
-        {
-            return Task.FromResult<int?>(null);
-        }
     }
 
     private sealed class FakeHardwareProfileService : IHardwareProfileService

--- a/src/Foundry.Deploy/MainWindow.xaml
+++ b/src/Foundry.Deploy/MainWindow.xaml
@@ -39,7 +39,6 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <Grid Grid.Row="0" Panel.ZIndex="1">
@@ -66,11 +65,6 @@
                     </MenuItem.ItemContainerStyle>
                 </MenuItem>
                 <MenuItem Header="{Binding Strings[Menu.Tools]}">
-                    <MenuItem Command="{Binding RefreshCatalogsCommand}" Header="{Binding Strings[Tools.RefreshCatalogs]}" />
-                    <MenuItem
-                        Command="{Binding Preparation.RefreshTargetDisksCommand}"
-                        Header="{Binding Strings[Tools.RefreshTargetDisks]}"
-                        IsEnabled="{Binding Session.IsStartupReady}" />
                     <MenuItem Command="{Binding Session.OpenLogFileCommand}" Header="{Binding Strings[Tools.OpenLogFile]}" />
                 </MenuItem>
                 <MenuItem Header="{Binding Strings[Menu.Debug]}" Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -152,7 +146,7 @@
         <Grid
             x:Name="MainContentHost"
             Grid.Row="1"
-            Margin="32"
+            Margin="16"
             Visibility="{Binding Session.IsSplashPage, Converter={StaticResource InverseBooleanConverter}}">
             <Grid
                 Width="{Binding ElementName=MainContentHost, Path=ActualWidth}"
@@ -185,40 +179,5 @@
             </Grid>
         </Grid>
 
-        <Grid
-            Grid.Row="2"
-            Height="52"
-            Background="{DynamicResource CardBackgroundFillColorDefaultBrush}">
-            <Grid.Style>
-                <Style TargetType="Grid">
-                    <Setter Property="Visibility" Value="Collapsed" />
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding Session.CurrentPage}" Value="{x:Static local:DeploymentPage.Wizard}">
-                            <Setter Property="Visibility" Value="Visible" />
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </Grid.Style>
-
-            <Grid Margin="12,8,12,8">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-
-                <TextBlock
-                    Grid.Column="0"
-                    Margin="0,0,8,0"
-                    VerticalAlignment="Center"
-                    Text="{Binding Session.DeploymentStatus}"
-                    TextTrimming="CharacterEllipsis" />
-                <Button
-                    Grid.Column="1"
-                    Width="200"
-                    VerticalAlignment="Center"
-                    Command="{Binding Session.OpenLogFileCommand}"
-                    Content="{Binding Strings[Common.OpenLog]}" />
-            </Grid>
-        </Grid>
     </Grid>
 </Window>

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchPreparationResult.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchPreparationResult.cs
@@ -5,23 +5,20 @@ namespace Foundry.Deploy.Services.Deployment;
 public sealed record DeploymentLaunchPreparationResult
 {
     public required bool IsReadyToStart { get; init; }
-    public required string StatusMessage { get; init; }
     public required string NormalizedComputerName { get; init; }
     public TargetDiskInfo? EffectiveTargetDisk { get; init; }
     public DeploymentContext? Context { get; init; }
 
-    public static DeploymentLaunchPreparationResult Failure(string statusMessage, string normalizedComputerName)
+    public static DeploymentLaunchPreparationResult Failure(string normalizedComputerName)
     {
         return new DeploymentLaunchPreparationResult
         {
             IsReadyToStart = false,
-            StatusMessage = statusMessage,
             NormalizedComputerName = normalizedComputerName
         };
     }
 
     public static DeploymentLaunchPreparationResult Success(
-        string statusMessage,
         string normalizedComputerName,
         TargetDiskInfo effectiveTargetDisk,
         DeploymentContext context)
@@ -29,7 +26,6 @@ public sealed record DeploymentLaunchPreparationResult
         return new DeploymentLaunchPreparationResult
         {
             IsReadyToStart = true,
-            StatusMessage = statusMessage,
             NormalizedComputerName = normalizedComputerName,
             EffectiveTargetDisk = effectiveTargetDisk,
             Context = context

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchPreparationService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchPreparationService.cs
@@ -29,15 +29,13 @@ public sealed class DeploymentLaunchPreparationService : IDeploymentLaunchPrepar
 
         if (request.SelectedOperatingSystem is null)
         {
-            return DeploymentLaunchPreparationResult.Failure(
-                "Select an operating system.",
-                ComputerNameRules.Normalize(request.TargetComputerName));
+            return DeploymentLaunchPreparationResult.Failure(ComputerNameRules.Normalize(request.TargetComputerName));
         }
 
         string normalizedComputerName = ComputerNameRules.Normalize(request.TargetComputerName);
         if (!ComputerNameRules.IsValid(normalizedComputerName))
         {
-            return DeploymentLaunchPreparationResult.Failure("Enter a valid computer name.", normalizedComputerName);
+            return DeploymentLaunchPreparationResult.Failure(normalizedComputerName);
         }
 
         TargetDiskInfo? effectiveTargetDisk = request.SelectedTargetDisk;
@@ -48,36 +46,30 @@ public sealed class DeploymentLaunchPreparationService : IDeploymentLaunchPrepar
 
         if (effectiveTargetDisk is null)
         {
-            return DeploymentLaunchPreparationResult.Failure("Select a target disk.", normalizedComputerName);
+            return DeploymentLaunchPreparationResult.Failure(normalizedComputerName);
         }
 
         if (!request.IsDryRun && !effectiveTargetDisk.IsSelectable)
         {
-            return DeploymentLaunchPreparationResult.Failure(
-                $"Selected disk is blocked: {effectiveTargetDisk.SelectionWarning}",
-                normalizedComputerName);
+            return DeploymentLaunchPreparationResult.Failure(normalizedComputerName);
         }
 
         if (request.DriverPackSelectionKind == DriverPackSelectionKind.OemCatalog &&
             request.SelectedDriverPack is null)
         {
-            return DeploymentLaunchPreparationResult.Failure(
-                "Select a valid OEM model/version before starting deployment.",
-                normalizedComputerName);
+            return DeploymentLaunchPreparationResult.Failure(normalizedComputerName);
         }
 
         if (request.IsAutopilotEnabled &&
             request.AutopilotProvisioningMode == AutopilotProvisioningMode.JsonProfile &&
             request.SelectedAutopilotProfile is null)
         {
-            return DeploymentLaunchPreparationResult.Failure(
-                "Select an Autopilot profile or disable Autopilot before starting deployment.",
-                normalizedComputerName);
+            return DeploymentLaunchPreparationResult.Failure(normalizedComputerName);
         }
 
         if (!request.IsDryRun && !ConfirmDestructiveDeployment(effectiveTargetDisk, request.SelectedOperatingSystem))
         {
-            return DeploymentLaunchPreparationResult.Failure("Deployment cancelled by user.", normalizedComputerName);
+            return DeploymentLaunchPreparationResult.Failure(normalizedComputerName);
         }
 
         DeploymentContext context = new()
@@ -102,7 +94,6 @@ public sealed class DeploymentLaunchPreparationService : IDeploymentLaunchPrepar
         };
 
         return DeploymentLaunchPreparationResult.Success(
-            "Deployment preparation completed.",
             normalizedComputerName,
             effectiveTargetDisk,
             context);

--- a/src/Foundry.Deploy/Services/Localization/DeploymentUiTextLocalizer.cs
+++ b/src/Foundry.Deploy/Services/Localization/DeploymentUiTextLocalizer.cs
@@ -53,18 +53,10 @@ public static partial class DeploymentUiTextLocalizer
 
         return value switch
         {
-            "Ready" => LocalizationText.GetString("Status.Ready"),
             "Waiting for deployment..." => LocalizationText.GetString("Status.WaitingForDeployment"),
             "Waiting for progress..." => LocalizationText.GetString("Status.WaitingForProgress"),
             "Preparing deployment..." => LocalizationText.GetString("Status.PreparingDeployment"),
-            "Deployment started." => LocalizationText.GetString("Status.DeploymentStarted"),
-            "Deployment completed." => LocalizationText.GetString("Status.DeploymentCompleted"),
-            "Deployment orchestration completed." => LocalizationText.GetString("Status.DeploymentOrchestrationCompleted"),
             "Deployment cancelled." => LocalizationText.GetString("Status.DeploymentCancelled"),
-            "Deployment failed." => LocalizationText.GetString("Status.DeploymentFailed"),
-            "Debug preview: progress page." => LocalizationText.GetString("Debug.ProgressPage"),
-            "Debug preview: success page." => LocalizationText.GetString("Debug.SuccessPage"),
-            "Debug preview: error page." => LocalizationText.GetString("Debug.ErrorPage"),
             "Starting step..." => LocalizationText.GetString("Status.StartingStep"),
             "Step completed." => LocalizationText.GetString("Status.StepCompleted"),
             "Step failed." => LocalizationText.GetString("Status.StepFailed"),
@@ -74,17 +66,7 @@ public static partial class DeploymentUiTextLocalizer
             "Detecting hardware..." => LocalizationText.GetString("Preparation.DetectingHardware"),
             "Hardware detection failed." => LocalizationText.GetString("Preparation.HardwareDetectionFailed"),
             "Loading target disks..." => LocalizationText.GetString("Preparation.LoadingTargetDisks"),
-            "No disks detected." => LocalizationText.GetString("Preparation.NoDisksDetected"),
-            "Select an operating system." => LocalizationText.GetString("Launch.SelectOperatingSystem"),
-            "Enter a valid computer name." => LocalizationText.GetString("Launch.EnterValidComputerName"),
-            "Select a target disk." => LocalizationText.GetString("Launch.SelectTargetDisk"),
-            "Select a valid OEM model/version before starting deployment." => LocalizationText.GetString("Launch.SelectValidOemDriverPack"),
-            "Select an Autopilot profile or disable Autopilot before starting deployment." => LocalizationText.GetString("Launch.SelectAutopilotProfile"),
-            "Deployment cancelled by user." => LocalizationText.GetString("Launch.CancelledByUser"),
-            "Deployment preparation completed." => LocalizationText.GetString("Launch.PreparationCompleted"),
             "Another operation is already running." => LocalizationText.GetString("Status.AnotherOperationRunning"),
-            "Debug Safe Mode enabled: deployment actions are simulated." => LocalizationText.GetString("Status.DebugSafeModeEnabled"),
-            "Starting Foundry.Deploy orchestration." => LocalizationText.GetString("Status.StartingOrchestration"),
             "Gathering deployment variables..." => LocalizationText.GetString("StepMessage.GatheringDeploymentVariables"),
             "Collecting deployment context..." => LocalizationText.GetString("StepMessage.CollectingDeploymentContext"),
             "Deployment variables gathered." => LocalizationText.GetString("StepResult.DeploymentVariablesGathered"),
@@ -244,8 +226,6 @@ public static partial class DeploymentUiTextLocalizer
             "Interactive Autopilot registration assistant staged (simulation)." => LocalizationText.GetString("StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation"),
             "Autopilot profile staged." => LocalizationText.GetString("StepResult.AutopilotProfileStaged"),
             "Autopilot profile staged (simulation)." => LocalizationText.GetString("StepResult.AutopilotProfileStagedSimulation"),
-            "Rebooting now..." => LocalizationText.GetString("Status.RebootingNow"),
-            "Reboot command failed." => LocalizationText.GetString("Status.RebootCommandFailed"),
             "System reboot" => LocalizationText.GetString("Status.SystemReboot"),
             "Required reboot executable 'wpeutil.exe' was not found." => LocalizationText.GetString("Status.RequiredRebootExecutableMissing"),
             "Unknown step" => LocalizationText.GetString("Status.UnknownStep"),
@@ -293,16 +273,6 @@ public static partial class DeploymentUiTextLocalizer
             return localized;
         }
 
-        if (TryLocalizeSingleSuffix(value, "Selected disk blocked: ", "Disk.SelectedBlockedFormat", out localized))
-        {
-            return localized;
-        }
-
-        if (TryLocalizeSingleSuffix(value, "Selected disk is blocked: ", "Disk.SelectedBlockedFormat", out localized))
-        {
-            return localized;
-        }
-
         match = TargetDiskMissingRegex().Match(value);
         if (match.Success)
         {
@@ -316,21 +286,6 @@ public static partial class DeploymentUiTextLocalizer
                 "Disk.TargetBlockedFormat",
                 int.Parse(match.Groups["disk"].Value),
                 LocalizeMessage(match.Groups["warning"].Value));
-        }
-
-        if (TryLocalizeSingleSuffix(value, "Deployment failed: ", "Status.DeploymentFailedFormat", out localized))
-        {
-            return localized;
-        }
-
-        if (TryLocalizeSingleSuffix(value, "Unable to open log file: ", "Status.UnableToOpenLogFileFormat", out localized))
-        {
-            return localized;
-        }
-
-        if (TryLocalizeSingleSuffix(value, "Reboot command failed: ", "Status.RebootCommandFailedFormat", out localized))
-        {
-            return localized;
         }
 
         if (TryLocalizeSingleSuffix(value, "Selected Autopilot profile file was not found: ", "StepResult.SelectedAutopilotProfileFileMissingFormat", out localized))
@@ -389,12 +344,6 @@ public static partial class DeploymentUiTextLocalizer
         if (match.Success)
         {
             return LocalizationText.Format("StepProgress.DownloadedBytesFormat", match.Groups["size"].Value);
-        }
-
-        match = TargetDisksLoadedRegex().Match(value);
-        if (match.Success)
-        {
-            return LocalizationText.Format("Preparation.TargetDisksLoadedFormat", int.Parse(match.Groups["count"].Value));
         }
 
         match = StepCounterRegex().Match(value);
@@ -497,9 +446,6 @@ public static partial class DeploymentUiTextLocalizer
 
     [GeneratedRegex(@"^Catalogs loaded: (?<os>\d+) OS entries, (?<drivers>\d+) driver packs\.$")]
     private static partial Regex CatalogLoadedRegex();
-
-    [GeneratedRegex(@"^Target disks loaded: (?<count>\d+) detected\.$")]
-    private static partial Regex TargetDisksLoadedRegex();
 
     [GeneratedRegex(@"^Target disk (?<disk>\d+) is no longer present\.$")]
     private static partial Regex TargetDiskMissingRegex();

--- a/src/Foundry.Deploy/Services/Startup/DeploymentStartupCoordinator.cs
+++ b/src/Foundry.Deploy/Services/Startup/DeploymentStartupCoordinator.cs
@@ -56,9 +56,6 @@ public sealed class DeploymentStartupCoordinator : IDeploymentStartupCoordinator
         FoundryDeployConfigurationDocument? deployConfigurationDocument = deployConfigLoadResult.Document is null
             ? null
             : await RefreshAutopilotGroupTagsAsync(deployConfigLoadResult.Document, cacheRootPath).ConfigureAwait(false);
-        string? startupStatusMessage = request.IsDebugSafeMode
-            ? "Debug Safe Mode enabled: deployment actions are simulated."
-            : null;
 
         Task<string> computerNameTask = ResolveComputerNameAsync(request.FallbackComputerName);
         Task<HardwareLoadResult> hardwareTask = LoadHardwareAsync();
@@ -70,14 +67,12 @@ public sealed class DeploymentStartupCoordinator : IDeploymentStartupCoordinator
         return new DeploymentStartupSnapshot
         {
             CacheRootPath = cacheRootPath,
-            StartupStatusMessage = startupStatusMessage,
             DeployConfigurationDocument = deployConfigurationDocument,
             AutopilotProfiles = autopilotProfiles,
             EffectiveComputerName = computerNameTask.Result,
             DetectedHardware = hardwareTask.Result.Profile,
             HardwareDetectionFailureMessage = hardwareTask.Result.ErrorMessage,
             TargetDisks = targetDisksTask.Result.Disks,
-            TargetDiskStatusMessage = targetDisksTask.Result.StatusMessage,
             CatalogSnapshot = catalogTask.Result
         };
     }
@@ -121,12 +116,12 @@ public sealed class DeploymentStartupCoordinator : IDeploymentStartupCoordinator
         try
         {
             IReadOnlyList<TargetDiskInfo> disks = await _targetDiskService.GetDisksAsync().ConfigureAwait(false);
-            return new TargetDiskLoadResult(disks, null);
+            return new TargetDiskLoadResult(disks);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Target disk discovery failed during startup.");
-            return new TargetDiskLoadResult([], $"Target disk discovery failed: {ex.Message}");
+            return new TargetDiskLoadResult([]);
         }
     }
 
@@ -224,5 +219,5 @@ public sealed class DeploymentStartupCoordinator : IDeploymentStartupCoordinator
     }
 
     private sealed record HardwareLoadResult(HardwareProfile? Profile, string? ErrorMessage);
-    private sealed record TargetDiskLoadResult(IReadOnlyList<TargetDiskInfo> Disks, string? StatusMessage);
+    private sealed record TargetDiskLoadResult(IReadOnlyList<TargetDiskInfo> Disks);
 }

--- a/src/Foundry.Deploy/Services/Startup/DeploymentStartupSnapshot.cs
+++ b/src/Foundry.Deploy/Services/Startup/DeploymentStartupSnapshot.cs
@@ -7,13 +7,11 @@ namespace Foundry.Deploy.Services.Startup;
 public sealed record DeploymentStartupSnapshot
 {
     public required string CacheRootPath { get; init; }
-    public required string? StartupStatusMessage { get; init; }
     public required FoundryDeployConfigurationDocument? DeployConfigurationDocument { get; init; }
     public required IReadOnlyList<AutopilotProfileCatalogItem> AutopilotProfiles { get; init; }
     public required string EffectiveComputerName { get; init; }
     public required HardwareProfile? DetectedHardware { get; init; }
     public required string? HardwareDetectionFailureMessage { get; init; }
     public required IReadOnlyList<TargetDiskInfo> TargetDisks { get; init; }
-    public required string? TargetDiskStatusMessage { get; init; }
     public required DeploymentCatalogSnapshot CatalogSnapshot { get; init; }
 }

--- a/src/Foundry.Deploy/Services/Wizard/DeploymentWizardContext.cs
+++ b/src/Foundry.Deploy/Services/Wizard/DeploymentWizardContext.cs
@@ -8,22 +8,18 @@ namespace Foundry.Deploy.Services.Wizard;
 
 public sealed class DeploymentWizardContext : IDisposable
 {
-    private readonly bool _isDebugSafeMode;
     private bool _isDisposed;
 
     public DeploymentWizardContext(
         DeploymentPreparationViewModel preparation,
         OperatingSystemCatalogViewModel operatingSystemCatalog,
-        DriverPackSelectionViewModel driverPackSelection,
-        bool isDebugSafeMode)
+        DriverPackSelectionViewModel driverPackSelection)
     {
         Preparation = preparation ?? throw new ArgumentNullException(nameof(preparation));
         OperatingSystemCatalog = operatingSystemCatalog ?? throw new ArgumentNullException(nameof(operatingSystemCatalog));
         DriverPackSelection = driverPackSelection ?? throw new ArgumentNullException(nameof(driverPackSelection));
-        _isDebugSafeMode = isDebugSafeMode;
 
         Preparation.StateChanged += OnPreparationStateChanged;
-        Preparation.StatusMessageGenerated += OnPreparationStatusMessageGenerated;
         OperatingSystemCatalog.StateChanged += OnOperatingSystemCatalogStateChanged;
         DriverPackSelection.StateChanged += OnDriverPackSelectionStateChanged;
 
@@ -39,9 +35,8 @@ public sealed class DeploymentWizardContext : IDisposable
     public DeployAiComponentRemovalSettings AiComponentRemoval { get; private set; } = new();
 
     public event EventHandler? StateChanged;
-    public event Action<string>? StatusMessageGenerated;
 
-    public string ApplyStartupSnapshot(DeploymentStartupSnapshot startupSnapshot)
+    public void ApplyStartupSnapshot(DeploymentStartupSnapshot startupSnapshot)
     {
         ArgumentNullException.ThrowIfNull(startupSnapshot);
 
@@ -71,12 +66,8 @@ public sealed class DeploymentWizardContext : IDisposable
             Preparation.SetHardwareDetectionFailure(startupSnapshot.HardwareDetectionFailureMessage);
         }
 
-        string targetDiskStatusMessage = Preparation.ApplyTargetDisks(startupSnapshot.TargetDisks);
+        Preparation.ApplyTargetDisks(startupSnapshot.TargetDisks);
         ApplyCatalogSnapshot(startupSnapshot.CatalogSnapshot);
-
-        return !string.IsNullOrWhiteSpace(startupSnapshot.TargetDiskStatusMessage)
-            ? startupSnapshot.TargetDiskStatusMessage
-            : targetDiskStatusMessage;
     }
 
     public void ApplyCatalogSnapshot(DeploymentCatalogSnapshot snapshot)
@@ -96,7 +87,6 @@ public sealed class DeploymentWizardContext : IDisposable
         }
 
         Preparation.StateChanged -= OnPreparationStateChanged;
-        Preparation.StatusMessageGenerated -= OnPreparationStatusMessageGenerated;
         OperatingSystemCatalog.StateChanged -= OnOperatingSystemCatalogStateChanged;
         DriverPackSelection.StateChanged -= OnDriverPackSelectionStateChanged;
         Preparation.Dispose();
@@ -131,19 +121,7 @@ public sealed class DeploymentWizardContext : IDisposable
     {
         RefreshDriverPackSelectionContext();
 
-        if (Preparation.SelectedTargetDisk is not null &&
-            !_isDebugSafeMode &&
-            !Preparation.SelectedTargetDisk.IsSelectable)
-        {
-            StatusMessageGenerated?.Invoke($"Selected disk blocked: {Preparation.SelectedTargetDisk.SelectionWarning}");
-        }
-
         StateChanged?.Invoke(this, EventArgs.Empty);
-    }
-
-    private void OnPreparationStatusMessageGenerated(string message)
-    {
-        StatusMessageGenerated?.Invoke(message);
     }
 
     private void OnOperatingSystemCatalogStateChanged(object? sender, EventArgs e)

--- a/src/Foundry.Deploy/Services/Wizard/DeploymentWizardContextFactory.cs
+++ b/src/Foundry.Deploy/Services/Wizard/DeploymentWizardContextFactory.cs
@@ -8,7 +8,6 @@ namespace Foundry.Deploy.Services.Wizard;
 
 public sealed class DeploymentWizardContextFactory : IDeploymentWizardContextFactory
 {
-    private readonly ITargetDiskService _targetDiskService;
     private readonly IHardwareProfileService _hardwareProfileService;
     private readonly IOfflineWindowsComputerNameService _offlineWindowsComputerNameService;
     private readonly IDriverPackSelectionService _driverPackSelectionService;
@@ -16,14 +15,12 @@ public sealed class DeploymentWizardContextFactory : IDeploymentWizardContextFac
     private readonly ILoggerFactory _loggerFactory;
 
     public DeploymentWizardContextFactory(
-        ITargetDiskService targetDiskService,
         IHardwareProfileService hardwareProfileService,
         IOfflineWindowsComputerNameService offlineWindowsComputerNameService,
         IDriverPackSelectionService driverPackSelectionService,
         ILocalizationService localizationService,
         ILoggerFactory loggerFactory)
     {
-        _targetDiskService = targetDiskService;
         _hardwareProfileService = hardwareProfileService;
         _offlineWindowsComputerNameService = offlineWindowsComputerNameService;
         _driverPackSelectionService = driverPackSelectionService;
@@ -34,7 +31,6 @@ public sealed class DeploymentWizardContextFactory : IDeploymentWizardContextFac
     public DeploymentWizardContext Create(bool isDebugSafeMode)
     {
         DeploymentPreparationViewModel preparation = new(
-            _targetDiskService,
             _hardwareProfileService,
             _offlineWindowsComputerNameService,
             _localizationService,
@@ -51,7 +47,6 @@ public sealed class DeploymentWizardContextFactory : IDeploymentWizardContextFac
         return new DeploymentWizardContext(
             preparation,
             operatingSystemCatalog,
-            driverPackSelection,
-            isDebugSafeMode);
+            driverPackSelection);
     }
 }

--- a/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>الظلام</value></data>
   <data name="Language.English" xml:space="preserve"><value>الإنجليزية</value></data>
   <data name="Language.French" xml:space="preserve"><value>الفرنسية</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>تحديث الكتالوجات</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>تحديث الأقراص المستهدفة</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>فتح ملف السجل</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>وضع المحاكاة نشط: تتم محاكاة إجراءات النشر ولا يتم تنفيذ أي عمليات كتابة على القرص أو الصورة.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. الهدف</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. نظام التشغيل</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. حزمة السائق</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>تكييف</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>جارٍ تحميل الأقراص المستهدفة...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>فشل اكتشاف القرص الهدف: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>لم يتم اكتشاف أي أقراص.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>الأقراص الهدف المحملة: تم اكتشاف {0}.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>نظام التشغيل</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>الإصدار</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>اللغة</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>صفحة التقدم</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>صفحة النجاح</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>صفحة الخطأ</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>معاينة التصحيح: صفحة التقدم.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>معاينة التصحيح: صفحة النجاح.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>معاينة التصحيح: صفحة الخطأ.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>معاينة التصحيح: فشل تطبيق DISM لأن القسم الهدف للقراءة فقط.
 
 رمز الخطأ = 0x80070005
@@ -144,7 +136,6 @@
   <data name="Common.Previous" xml:space="preserve"><value>السابق</value></data>
   <data name="Common.Next" xml:space="preserve"><value>التالي</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>نشر</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>فتح السجل</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>لا يوجد</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>غير متاح</value></data>
   <data name="Common.None" xml:space="preserve"><value>لا شيء</value></data>
@@ -176,7 +167,6 @@
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>محظور: للقراءة فقط</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>محظور: غير متصل</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>تصحيح الهدف الظاهري</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>القرص المحدد محظور: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>القرص الهدف {0} لم يعد موجودًا.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>القرص الهدف {0} محظور: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>تأكيد مسح القرص</value></data>
@@ -190,26 +180,11 @@
 نظام التشغيل: {4}
 
 هل تريد الاستمرار في النشر؟</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>حدد نظام التشغيل.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>أدخل اسمًا صالحًا للكمبيوتر.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>حدد القرص الهدف.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>حدد طرازًا أو إصدارًا صالحًا لـ OEM قبل بدء النشر.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>حدد ملف تعريف Autopilot أو قم بتعطيل Autopilot قبل بدء النشر.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>تم إلغاء النشر من قبل المستخدم.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>تم الانتهاء من إعداد النشر.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>جاهز</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>في انتظار النشر...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>في انتظار التقدم...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>جارٍ التحضير للنشر...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>بدأ النشر.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>اكتمل النشر.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>اكتمل سير عمل النشر.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>تم إلغاء النشر.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>فشل النشر.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>فشل النشر: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>هناك عملية أخرى قيد التشغيل بالفعل.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>تم تمكين الوضع الآمن لتصحيح الأخطاء: تتم محاكاة إجراءات النشر.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>بدء سير عمل النشر.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>خطوة البداية...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>البدء {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>البدء {0}...</value></data>
@@ -219,10 +194,6 @@
   <data name="Status.InProgress" xml:space="preserve"><value>قيد التقدم...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>الخطوة: ؟ ل ؟</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>الخطوة: {0} من {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>إعادة التشغيل الآن...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>فشل أمر إعادة التشغيل.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>فشل أمر إعادة التشغيل: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>غير قادر على فتح ملف السجل: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>فشل wpeutil.exe مع رمز الخروج {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>إعادة تشغيل النظام</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>لم يتم العثور على الملف القابل للتنفيذ لإعادة التشغيل "wpeutil.exe".</value></data>

--- a/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
+++ b/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Тъмно</value></data>
   <data name="Language.English" xml:space="preserve"><value>английски</value></data>
   <data name="Language.French" xml:space="preserve"><value>френски</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Обновяване на каталози</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Обновяване на целевите дискове</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Отворете регистрационния файл</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Режимът на симулация е активен: действията по внедряване се симулират и не се извършва запис на диск или изображение.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Цел</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Операционна система</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Пакет драйвери</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Целевите дискове се зареждат...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Неуспешно откриване на целевия диск: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Няма открити дискове.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Заредени целеви дискове: открити са {0}.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Операционна система</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Версия</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>език</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Страница за напредък</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Страница за успех</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Страница с грешки</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Визуализация на отстраняване на грешки: страница за напредък.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Визуализация на отстраняване на грешки: страница за успех.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Визуализация на отстраняване на грешки: страница за грешка.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Визуализация на отстраняване на грешки: прилагането на DISM не бе успешно, защото целевият дял е само за четене.
 
 Код на грешка=0x80070005
@@ -144,7 +136,6 @@
   <data name="Common.Previous" xml:space="preserve"><value>Предишен</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Следваща</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Разположете</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Отворен дневник</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Недостъпен</value></data>
   <data name="Common.None" xml:space="preserve"><value>Няма</value></data>
@@ -176,7 +167,6 @@
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Блокиран: само за четене</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Блокиран: офлайн</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>ОТСТРАНЯВАНЕ НА ГРЕШКИ ВИРТУАЛНА ЦЕЛ</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Избраният диск е блокиран: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Целевият диск {0} вече не присъства.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Целевият диск {0} е блокиран: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Потвърдете изтриването на диска</value></data>
@@ -190,26 +180,11 @@
 Операционна система: {4}
 
 Да продължите с внедряването?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Изберете операционна система.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Въведете валидно име на компютър.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Изберете целеви диск.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Изберете валиден OEM модел или версия, преди да започнете внедряването.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Изберете Autopilot профил или деактивирайте Autopilot преди да започнете внедряването.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Внедряването е отменено от потребителя.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Подготовката за внедряване е завършена.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Готови</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>В очакване на внедряване...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>В очакване на напредък...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Подготвя се разполагане...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Внедряването започна.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Внедряването е завършено.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Работният процес по внедряването е завършен.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Внедряването е отменено.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Внедряването не бе успешно.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Неуспешно внедряване: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Друга операция вече тече.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Безопасният режим за отстраняване на грешки е активиран: действията по внедряване се симулират.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Стартиране на работния процес на внедряване.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Начална стъпка...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Стартиране на {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Стартиране на {0}...</value></data>
@@ -219,10 +194,6 @@
   <data name="Status.InProgress" xml:space="preserve"><value>В ход...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Стъпка:? от?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Стъпка: {0} от {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Рестартира се сега...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Командата за рестартиране е неуспешна.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Командата за рестартиране е неуспешна: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Не може да се отвори лог файл: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe се провали с изходен код {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Рестартиране на системата</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Изискваният изпълним файл за рестартиране 'wpeutil.exe' не е намерен.</value></data>

--- a/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
+++ b/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Tmavý</value></data>
   <data name="Language.English" xml:space="preserve"><value>anglicky</value></data>
   <data name="Language.French" xml:space="preserve"><value>francouzsky</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Aktualizujte katalogy</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Obnovte cílové disky</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Otevřete soubor protokolu</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Režim simulace je aktivní: akce nasazení jsou simulovány a neprovádí se žádné zápisy na disk nebo bitovou kopii.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Cíl</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operační systém</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Sada ovladačů</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Načítání cílových disků...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Zjištění cílového disku se nezdařilo: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Nebyly zjištěny žádné disky.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Načtené cílové disky: Zjištěno {0}.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Operační systém</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Verze</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Jazyk</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Stránka pokroku</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Stránka úspěchu</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Chybová stránka</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Náhled ladění: stránka průběhu.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Náhled ladění: stránka úspěchu.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Náhled ladění: chybová stránka.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Náhled ladění: Aplikace DISM se nezdařila, protože cílový oddíl je pouze pro čtení.
 
 ErrorCode=0x80070005
@@ -144,7 +136,6 @@ Akce: Ověřte atributy disku a opakujte nasazení.</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Předchozí</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Další</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Nasadit</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Otevřete protokol</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Není k dispozici</value></data>
   <data name="Common.None" xml:space="preserve"><value>žádný</value></data>
@@ -176,7 +167,6 @@ Akce: Ověřte atributy disku a opakujte nasazení.</value></data>
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Blokováno: pouze pro čtení</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Blokováno: offline</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>LADIT VIRTUÁLNÍ CÍL</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Vybraný disk je zablokován: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Cílový disk {0} již není přítomen.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Cílový disk {0} je blokován: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Potvrďte vymazání disku</value></data>
@@ -190,26 +180,11 @@ Velikost: {3}
 Operační systém: {4}
 
 Pokračovat v nasazování?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Vyberte operační systém.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Zadejte platný název počítače.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Vyberte cílový disk.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Před zahájením nasazení vyberte platný model nebo verzi OEM.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Před zahájením nasazení vyberte profil Autopilot nebo vypněte Autopilot.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Nasazení zrušeno uživatelem.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Příprava nasazení dokončena.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Připraveno</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Čekání na nasazení...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Čekání na pokrok...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Příprava nasazení...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Nasazování zahájeno.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Nasazení dokončeno.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Pracovní postup nasazení byl dokončen.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Nasazení zrušeno.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Nasazení se nezdařilo.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Nasazení se nezdařilo: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Další operace již běží.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Povolen nouzový režim ladění: akce nasazení jsou simulovány.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Spuštění pracovního postupu nasazení.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Počáteční krok...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Počínaje {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Začíná {0}...</value></data>
@@ -219,10 +194,6 @@ Pokračovat v nasazování?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>Probíhá...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Krok:? z?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Krok: {0} z {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Nyní se restartuje...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Příkaz restartu se nezdařil.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Příkaz restartu se nezdařil: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Nelze otevřít soubor protokolu: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe se nezdařil s kódem ukončení {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Restart systému</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Požadovaný restartovací spustitelný soubor 'wpeutil.exe' nebyl nalezen.</value></data>

--- a/src/Foundry.Deploy/Strings/da-DK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/da-DK/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Mørk</value></data>
   <data name="Language.English" xml:space="preserve"><value>engelsk</value></data>
   <data name="Language.French" xml:space="preserve"><value>fransk</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Opdater kataloger</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Opdater måldiske</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Åbn logfil</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Simuleringstilstand er aktiv: implementeringshandlinger simuleres, og der udføres ingen disk- eller billedskrivning.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Mål</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operativsystem</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Driverpakke</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Indlæser måldiske...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Måldiskopdagelse mislykkedes: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Ingen diske fundet.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Måldiske indlæst: {0} fundet.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Operativsystem</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>version</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Sprog</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Fremskridtsside</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Successide</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Fejlside</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Forhåndsvisning af fejlretning: statusside.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Forhåndsvisning af fejlretning: successide.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Forhåndsvisning af fejlretning: fejlside.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Fejlfindingseksempel: DISM anvendelse mislykkedes, fordi målpartitionen er skrivebeskyttet.
 
 ErrorCode=0x80070005
@@ -144,7 +136,6 @@ Handling: Bekræft diskattributter, og prøv implementeringen igen.</value></dat
   <data name="Common.Previous" xml:space="preserve"><value>Forrige</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Næste</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Implementer</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Åbn log</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Ikke tilgængelig</value></data>
   <data name="Common.None" xml:space="preserve"><value>Ingen</value></data>
@@ -176,7 +167,6 @@ Handling: Bekræft diskattributter, og prøv implementeringen igen.</value></dat
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Blokeret: skrivebeskyttet</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Blokeret: offline</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>DEBUG VIRTUELLT MÅL</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Valgt disk blokeret: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Måldisken {0} er ikke længere til stede.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Måldisk {0} er blokeret: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Bekræft sletning af disk</value></data>
@@ -190,26 +180,11 @@ Størrelse: {3}
 Operativsystem: {4}
 
 Vil du fortsætte med implementeringen?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Vælg et operativsystem.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Indtast et gyldigt computernavn.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Vælg en måldisk.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Vælg en gyldig OEM-model eller -version, før du starter implementeringen.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Vælg en Autopilot-profil, eller deaktiver Autopilot, før du starter implementeringen.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Implementering annulleret af bruger.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Udrulningsforberedelse afsluttet.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Klar</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Venter på implementering...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Venter på fremskridt...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Forbereder implementering...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Implementeringen startede.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Implementeringen afsluttet.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Implementeringsarbejdsgang afsluttet.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Implementeringen blev annulleret.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Implementeringen mislykkedes.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Implementering mislykkedes: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>En anden operation kører allerede.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Fejlfinding i sikker tilstand aktiveret: implementeringshandlinger simuleres.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Starter implementeringsworkflow.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Starttrin...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Starter {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Starter {0}...</value></data>
@@ -219,10 +194,6 @@ Vil du fortsætte med implementeringen?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>I gang...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Trin:? af?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Trin: {0} af {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Genstarter nu...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Genstart kommando mislykkedes.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Genstart kommando mislykkedes: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Kan ikke åbne logfil: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe mislykkedes med udgangskode {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>System genstart</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Påkrævet genstart eksekverbar 'wpeutil.exe' blev ikke fundet.</value></data>

--- a/src/Foundry.Deploy/Strings/de-DE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/de-DE/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Dunkel</value></data>
   <data name="Language.English" xml:space="preserve"><value>Englisch</value></data>
   <data name="Language.French" xml:space="preserve"><value>Französisch</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Kataloge aktualisieren</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Zielfestplatten aktualisieren</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Protokolldatei öffnen</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Der Simulationsmodus ist aktiv: Bereitstellungsaktionen werden simuliert und es werden keine Festplatten- oder Image-Schreibvorgänge durchgeführt.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Ziel</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Betriebssystem</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Treiberpaket</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>Wechselstrom</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Zieldatenträger werden geladen...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Erkennung des Ziellaufwerks fehlgeschlagen: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Keine Festplatten erkannt.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Zieldatenträger geladen: {0} erkannt.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Betriebssystem</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Version</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Sprache</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Fortschrittsseite</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Erfolgsseite</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Fehlerseite</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Debug-Vorschau: Fortschrittsseite.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Debug-Vorschau: Erfolgsseite.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Debug-Vorschau: Fehlerseite.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Debug-Vorschau: Die Anwendung von DISM ist fehlgeschlagen, da die Zielpartition schreibgeschützt ist.
 
 Fehlercode=0x80070005
@@ -144,7 +136,6 @@ Aktion: Überprüfen Sie die Festplattenattribute und wiederholen Sie die Bereit
   <data name="Common.Previous" xml:space="preserve"><value>Zurück</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Als nächstes</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Bereitstellen</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Protokoll öffnen</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Nicht verfügbar</value></data>
   <data name="Common.None" xml:space="preserve"><value>Keine</value></data>
@@ -176,7 +167,6 @@ Aktion: Überprüfen Sie die Festplattenattribute und wiederholen Sie die Bereit
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Gesperrt: schreibgeschützt</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Gesperrt: offline</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>VIRTUELLES ZIEL DEBUGIEREN</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Ausgewählte Festplatte blockiert: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Zielfestplatte {0} ist nicht mehr vorhanden.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Zielfestplatte {0} ist blockiert: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Bestätigen Sie das Löschen der Festplatte</value></data>
@@ -190,26 +180,11 @@ Größe: {3}
 Betriebssystem: {4}
 
 Mit der Bereitstellung fortfahren?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Wählen Sie ein Betriebssystem aus.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Geben Sie einen gültigen Computernamen ein.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Wählen Sie eine Zielfestplatte aus.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Wählen Sie ein gültiges OEM-Modell oder eine gültige OEM-Version aus, bevor Sie mit der Bereitstellung beginnen.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Wählen Sie ein Autopilot-Profil aus oder deaktivieren Sie Autopilot, bevor Sie mit der Bereitstellung beginnen.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Bereitstellung vom Benutzer abgebrochen.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Bereitstellungsvorbereitung abgeschlossen.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Bereit</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Warten auf Bereitstellung...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Warten auf Fortschritte...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Bereitstellung wird vorbereitet...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Die Bereitstellung wurde gestartet.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Bereitstellung abgeschlossen.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Bereitstellungsworkflow abgeschlossen.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Bereitstellung abgebrochen.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Die Bereitstellung ist fehlgeschlagen.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Bereitstellung fehlgeschlagen: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Ein anderer Vorgang läuft bereits.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Debug-Sicherheitsmodus aktiviert: Bereitstellungsaktionen werden simuliert.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Bereitstellungsworkflow wird gestartet.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Startschritt...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Beginnend mit {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Beginnend mit {0}...</value></data>
@@ -219,10 +194,6 @@ Mit der Bereitstellung fortfahren?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>In Bearbeitung...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Schritt:? von?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Schritt: {0} von {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Jetzt neu starten...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Der Neustartbefehl ist fehlgeschlagen.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Neustartbefehl fehlgeschlagen: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Protokolldatei kann nicht geöffnet werden: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe ist mit dem Exit-Code {0} fehlgeschlagen. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Systemneustart</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Die erforderliche ausführbare Neustartdatei „wpeutil.exe“ wurde nicht gefunden.</value></data>

--- a/src/Foundry.Deploy/Strings/el-GR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/el-GR/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Σκοτεινό</value></data>
   <data name="Language.English" xml:space="preserve"><value>Αγγλικά</value></data>
   <data name="Language.French" xml:space="preserve"><value>Γαλλικά</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Ανανέωση καταλόγων</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Ανανεώστε τους δίσκους προορισμού</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Ανοίξτε το αρχείο καταγραφής</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Η λειτουργία προσομοίωσης είναι ενεργή: οι ενέργειες ανάπτυξης προσομοιώνονται και δεν εκτελούνται εγγραφές δίσκου ή εικόνας.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Στόχος</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Λειτουργικό σύστημα</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Driver pack</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Φόρτωση δίσκων προορισμού...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Ο εντοπισμός δίσκου στόχου απέτυχε: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Δεν εντοπίστηκαν δίσκοι.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Δίσκοι στόχου που φορτώθηκαν: εντοπίστηκαν {0}.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Λειτουργικό σύστημα</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Έκδοση</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Γλώσσα</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Σελίδα προόδου</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Σελίδα επιτυχίας</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Σελίδα σφάλματος</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Προεπισκόπηση εντοπισμού σφαλμάτων: σελίδα προόδου.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Προεπισκόπηση εντοπισμού σφαλμάτων: σελίδα επιτυχίας.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Προεπισκόπηση εντοπισμού σφαλμάτων: σελίδα σφάλματος.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Προεπισκόπηση εντοπισμού σφαλμάτων: Η εφαρμογή DISM απέτυχε επειδή το διαμέρισμα προορισμού είναι μόνο για ανάγνωση.
 
 Κωδικός σφάλματος=0x80070005
@@ -144,7 +136,6 @@
   <data name="Common.Previous" xml:space="preserve"><value>Προηγούμενο</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Επόμενο</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Ανάπτυξη</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Ανοίξτε το αρχείο καταγραφής</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Μη διαθέσιμο</value></data>
   <data name="Common.None" xml:space="preserve"><value>Κανένα</value></data>
@@ -176,7 +167,6 @@
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Αποκλεισμένο: μόνο για ανάγνωση</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Αποκλείστηκε: εκτός σύνδεσης</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>ΕΝΤΟΠΙΣΜΟΣ ΣΦΑΛΜΑΤΩΝ ΕΙΚΟΝΙΚΟΥ ΣΤΟΧΟΥ</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Αποκλείστηκε ο επιλεγμένος δίσκος: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Ο δίσκος στόχος {0} δεν υπάρχει πλέον.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Ο δίσκος στόχος {0} είναι αποκλεισμένος: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Επιβεβαιώστε τη διαγραφή του δίσκου</value></data>
@@ -190,26 +180,11 @@
 Λειτουργικό σύστημα: {4}
 
 Συνέχεια με την ανάπτυξη;</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Επιλέξτε ένα λειτουργικό σύστημα.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Εισαγάγετε ένα έγκυρο όνομα υπολογιστή.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Επιλέξτε έναν δίσκο προορισμού.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Επιλέξτε ένα έγκυρο μοντέλο ή έκδοση OEM πριν ξεκινήσετε την ανάπτυξη.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Επιλέξτε ένα προφίλ Autopilot ή απενεργοποιήστε το Autopilot πριν ξεκινήσετε την ανάπτυξη.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Η ανάπτυξη ακυρώθηκε από τον χρήστη.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Ολοκληρώθηκε η προετοιμασία της ανάπτυξης.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Έτοιμοι</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Αναμονή για ανάπτυξη...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Αναμονή για πρόοδο...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Προετοιμασία ανάπτυξης...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Η ανάπτυξη ξεκίνησε.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Η ανάπτυξη ολοκληρώθηκε.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Η ροή εργασιών ανάπτυξης ολοκληρώθηκε.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Η ανάπτυξη ακυρώθηκε.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Η ανάπτυξη απέτυχε.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Η ανάπτυξη απέτυχε: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Μια άλλη λειτουργία εκτελείται ήδη.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Ενεργοποιήθηκε η ασφαλής λειτουργία εντοπισμού σφαλμάτων: προσομοιώνονται οι ενέργειες ανάπτυξης.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Έναρξη ροής εργασιών ανάπτυξης.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Βήμα εκκίνησης...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Έναρξη {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Έναρξη {0}...</value></data>
@@ -219,10 +194,6 @@
   <data name="Status.InProgress" xml:space="preserve"><value>Σε εξέλιξη...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Βήμα:? από?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Βήμα: {0} του {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Επανεκκίνηση τώρα...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Η εντολή επανεκκίνησης απέτυχε.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Η εντολή επανεκκίνησης απέτυχε: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Δεν είναι δυνατό το άνοιγμα του αρχείου καταγραφής: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>Το wpeutil.exe απέτυχε με τον κωδικό εξόδου {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Επανεκκίνηση συστήματος</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Το απαιτούμενο εκτελέσιμο αρχείο επανεκκίνησης 'wpeutil.exe' δεν βρέθηκε.</value></data>

--- a/src/Foundry.Deploy/Strings/en-GB/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-GB/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Dark</value></data>
   <data name="Language.English" xml:space="preserve"><value>English</value></data>
   <data name="Language.French" xml:space="preserve"><value>French</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Refresh catalogues</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Refresh target disks</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Open log file</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Simulation mode is active: deployment actions are simulated and no disk or image writes are performed.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Target</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operating system</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Driver pack</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Loading target disks...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Target disk discovery failed: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>No disks detected.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Target disks loaded: {0} detected.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Operating system</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Version</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Language</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Progress page</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Success page</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Error page</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Debug preview: progress page.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Debug preview: success page.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Debug preview: error page.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Debug preview: DISM apply failed because the target partition is read-only.
 
 ErrorCode=0x80070005
@@ -144,7 +136,6 @@ Action: Verify disk attributes and retry deployment.</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Previous</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Next</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Deploy</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Open log</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Unavailable</value></data>
   <data name="Common.None" xml:space="preserve"><value>None</value></data>
@@ -176,7 +167,6 @@ Action: Verify disk attributes and retry deployment.</value></data>
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Blocked: read-only</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Blocked: offline</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>DEBUG VIRTUAL TARGET</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Selected disk blocked: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Target disk {0} is no longer present.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Target disk {0} is blocked: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Confirm disk erase</value></data>
@@ -190,26 +180,11 @@ Size: {3}
 Operating system: {4}
 
 Continue with deployment?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Select an operating system.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Enter a valid computer name.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Select a target disk.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Select a valid OEM model or version before starting deployment.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Select an Autopilot profile or disable Autopilot before starting deployment.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Deployment cancelled by user.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Deployment preparation completed.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Ready</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Waiting for deployment...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Waiting for progress...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Preparing deployment...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Deployment started.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Deployment completed.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Deployment workflow completed.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Deployment cancelled.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Deployment failed.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Deployment failed: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Another operation is already running.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Debug safe mode enabled: deployment actions are simulated.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Starting deployment workflow.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Starting step...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Starting {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Starting {0}...</value></data>
@@ -219,10 +194,6 @@ Continue with deployment?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>In progress...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Step: ? of ?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Step: {0} of {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Rebooting now...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Reboot command failed.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Reboot command failed: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Unable to open log file: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe failed with exit code {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>System reboot</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Required reboot executable 'wpeutil.exe' was not found.</value></data>

--- a/src/Foundry.Deploy/Strings/en-US/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-US/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Dark</value></data>
   <data name="Language.English" xml:space="preserve"><value>English</value></data>
   <data name="Language.French" xml:space="preserve"><value>French</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Refresh catalogs</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Refresh target disks</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Open log file</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Simulation mode is active: deployment actions are simulated and no disk or image writes are performed.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Target</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operating system</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Driver pack</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Loading target disks...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Target disk discovery failed: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>No disks detected.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Target disks loaded: {0} detected.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Operating system</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Version</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Language</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Progress page</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Success page</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Error page</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Debug preview: progress page.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Debug preview: success page.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Debug preview: error page.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Debug preview: DISM apply failed because the target partition is read-only.
 
 ErrorCode=0x80070005
@@ -144,7 +136,6 @@ Action: Verify disk attributes and retry deployment.</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Previous</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Next</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Deploy</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Open log</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Unavailable</value></data>
   <data name="Common.None" xml:space="preserve"><value>None</value></data>
@@ -176,7 +167,6 @@ Action: Verify disk attributes and retry deployment.</value></data>
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Blocked: read-only</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Blocked: offline</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>DEBUG VIRTUAL TARGET</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Selected disk blocked: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Target disk {0} is no longer present.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Target disk {0} is blocked: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Confirm disk erase</value></data>
@@ -190,26 +180,11 @@ Size: {3}
 Operating system: {4}
 
 Continue with deployment?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Select an operating system.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Enter a valid computer name.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Select a target disk.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Select a valid OEM model or version before starting deployment.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Select an Autopilot profile or disable Autopilot before starting deployment.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Deployment cancelled by user.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Deployment preparation completed.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Ready</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Waiting for deployment...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Waiting for progress...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Preparing deployment...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Deployment started.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Deployment completed.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Deployment workflow completed.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Deployment cancelled.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Deployment failed.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Deployment failed: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Another operation is already running.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Debug safe mode enabled: deployment actions are simulated.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Starting deployment workflow.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Starting step...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Starting {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Starting {0}...</value></data>
@@ -219,10 +194,6 @@ Continue with deployment?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>In progress...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Step: ? of ?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Step: {0} of {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Rebooting now...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Reboot command failed.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Reboot command failed: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Unable to open log file: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe failed with exit code {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>System reboot</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Required reboot executable 'wpeutil.exe' was not found.</value></data>

--- a/src/Foundry.Deploy/Strings/es-ES/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-ES/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Oscuro</value></data>
   <data name="Language.English" xml:space="preserve"><value>Inglés</value></data>
   <data name="Language.French" xml:space="preserve"><value>Francés</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Actualizar catálogos</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Actualizar discos de destino</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Abrir archivo de registro</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>El modo de simulación está activo: las acciones de implementación se simulan y no se realizan escrituras en el disco ni en la imagen.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Objetivo</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Sistema operativo</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Paquete de controladores</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>C.A.</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Cargando discos de destino...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Error al descubrir el disco de destino: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>No se detectaron discos.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Discos de destino cargados: {0} detectados.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Sistema operativo</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Versión</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Idioma</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Página de progreso</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>página de éxito</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>página de errores</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Vista previa de depuración: página de progreso.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Vista previa de depuración: página de éxito.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Vista previa de depuración: página de error.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Vista previa de depuración: DISM la aplicación falló porque la partición de destino es de solo lectura.
 
 Código de error=0x80070005
@@ -144,7 +136,6 @@ Acción: Verifique los atributos del disco y vuelva a intentar la implementació
   <data name="Common.Previous" xml:space="preserve"><value>Anterior</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Próximo</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Desplegar</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Abrir registro</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N / A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Indisponible</value></data>
   <data name="Common.None" xml:space="preserve"><value>Ninguno</value></data>
@@ -176,7 +167,6 @@ Acción: Verifique los atributos del disco y vuelva a intentar la implementació
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Bloqueado: solo lectura</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Bloqueado: desconectado</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>DEPURAR OBJETIVO VIRTUAL</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Disco seleccionado bloqueado: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>El disco de destino {0} ya no está presente.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>El disco de destino {0} está bloqueado: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Confirmar borrado del disco</value></data>
@@ -190,26 +180,11 @@ Tamaño: {3}
 Sistema operativo: {4}
 
 ¿Continuar con la implementación?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Seleccione un sistema operativo.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Ingrese un nombre de computadora válido.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Seleccione un disco de destino.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Seleccione un modelo o versión OEM válido antes de comenzar la implementación.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Seleccione un perfil Autopilot o desactive Autopilot antes de comenzar la implementación.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Implementación cancelada por el usuario.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Preparación para la implementación completada.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Listo</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Esperando el despliegue...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Esperando avances....</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Preparando el despliegue...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Comenzó el despliegue.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Implementación completada.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Flujo de trabajo de implementación completado.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Despliegue cancelado.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>La implementación falló.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Error en la implementación: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Ya se está ejecutando otra operación.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Modo seguro de depuración habilitado: se simulan acciones de implementación.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Iniciando el flujo de trabajo de implementación.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Paso inicial...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Iniciando {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Iniciando {0}...</value></data>
@@ -219,10 +194,6 @@ Sistema operativo: {4}
   <data name="Status.InProgress" xml:space="preserve"><value>En curso...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Paso:? de?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Paso: {0} de {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Reiniciando ahora...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>El comando de reinicio falló.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>El comando de reinicio falló: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>No se puede abrir el archivo de registro: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe falló con el código de salida {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Reinicio del sistema</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>No se encontró el ejecutable de reinicio requerido 'wpeutil.exe'.</value></data>

--- a/src/Foundry.Deploy/Strings/es-MX/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-MX/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Oscuro</value></data>
   <data name="Language.English" xml:space="preserve"><value>Inglés</value></data>
   <data name="Language.French" xml:space="preserve"><value>Francés</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Actualizar catálogos</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Actualizar discos de destino</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Abrir archivo de registro</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>El modo de simulación está activo: las acciones de implementación se simulan y no se realizan escrituras en el disco ni en la imagen.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Objetivo</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Sistema operativo</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Paquete de controladores</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>C.A.</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Cargando discos de destino...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Error al descubrir el disco de destino: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>No se detectaron discos.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Discos de destino cargados: {0} detectados.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Sistema operativo</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Versión</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Idioma</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Página de progreso</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>página de éxito</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>página de errores</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Vista previa de depuración: página de progreso.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Vista previa de depuración: página de éxito.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Vista previa de depuración: página de error.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Vista previa de depuración: DISM la aplicación falló porque la partición de destino es de solo lectura.
 
 Código de error=0x80070005
@@ -144,7 +136,6 @@ Acción: Verifique los atributos del disco y vuelva a intentar la implementació
   <data name="Common.Previous" xml:space="preserve"><value>Anterior</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Próximo</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Desplegar</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Abrir registro</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N / A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Indisponible</value></data>
   <data name="Common.None" xml:space="preserve"><value>Ninguno</value></data>
@@ -176,7 +167,6 @@ Acción: Verifique los atributos del disco y vuelva a intentar la implementació
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Bloqueado: solo lectura</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Bloqueado: desconectado</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>DEPURAR OBJETIVO VIRTUAL</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Disco seleccionado bloqueado: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>El disco de destino {0} ya no está presente.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>El disco de destino {0} está bloqueado: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Confirmar borrado del disco</value></data>
@@ -190,26 +180,11 @@ Tamaño: {3}
 Sistema operativo: {4}
 
 ¿Continuar con la implementación?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Seleccione un sistema operativo.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Ingrese un nombre de computadora válido.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Seleccione un disco de destino.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Seleccione un modelo o versión OEM válido antes de comenzar la implementación.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Seleccione un perfil Autopilot o desactive Autopilot antes de comenzar la implementación.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Implementación cancelada por el usuario.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Preparación para la implementación completada.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Listo</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Esperando el despliegue...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Esperando avances....</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Preparando el despliegue...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Comenzó el despliegue.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Implementación completada.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Flujo de trabajo de implementación completado.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Despliegue cancelado.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>La implementación falló.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Error en la implementación: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Ya se está ejecutando otra operación.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Modo seguro de depuración habilitado: se simulan acciones de implementación.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Iniciando el flujo de trabajo de implementación.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Paso inicial...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Iniciando {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Iniciando {0}...</value></data>
@@ -219,10 +194,6 @@ Sistema operativo: {4}
   <data name="Status.InProgress" xml:space="preserve"><value>En curso...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Paso:? de?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Paso: {0} de {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Reiniciando ahora...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>El comando de reinicio falló.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>El comando de reinicio falló: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>No se puede abrir el archivo de registro: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe falló con el código de salida {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Reinicio del sistema</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>No se encontró el ejecutable de reinicio requerido 'wpeutil.exe'.</value></data>

--- a/src/Foundry.Deploy/Strings/et-EE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/et-EE/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Tume</value></data>
   <data name="Language.English" xml:space="preserve"><value>inglise keel</value></data>
   <data name="Language.French" xml:space="preserve"><value>prantsuse keel</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Värskenda katalooge</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Värskendage sihtkettaid</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Ava logifail</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Simulatsioonirežiim on aktiivne: juurutustoiminguid simuleeritakse ja kettale või kujutisele ei kirjutata.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Sihtmärk</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operatsioonisüsteem</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Juhipakett</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Sihtketaste laadimine...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Sihtketta leidmine ebaõnnestus: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Ühtegi ketast ei tuvastatud.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Laaditud sihtkettad: {0} tuvastati.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Operatsioonisüsteem</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Versioon</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Keel</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Edenemise leht</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Edu leht</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Vealeht</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Silumise eelvaade: edenemise leht.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Silumise eelvaade: edu leht.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Silumise eelvaade: vealeht.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Silumise eelvaade: DISM rakendamine nurjus, kuna sihtpartitsioon on kirjutuskaitstud.
 
 ErrorCode=0x80070005
@@ -144,7 +136,6 @@ Toiming: kontrollige ketta atribuute ja proovige juurutamist uuesti.</value></da
   <data name="Common.Previous" xml:space="preserve"><value>Eelmine</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Edasi</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Kasutusele võtta</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Ava logi</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>Ei kehti</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Pole saadaval</value></data>
   <data name="Common.None" xml:space="preserve"><value>Mitte ühtegi</value></data>
@@ -176,7 +167,6 @@ Toiming: kontrollige ketta atribuute ja proovige juurutamist uuesti.</value></da
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Blokeeritud: kirjutuskaitstud</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Blokeeritud: võrguühenduseta</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>SILU VIRTUAALNE SIHT</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Valitud ketas blokeeritud: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Sihtketast {0} pole enam.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Sihtketas {0} on blokeeritud: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Kinnitage ketta kustutamine</value></data>
@@ -190,26 +180,11 @@ Suurus: {3}
 Operatsioonisüsteem: {4}
 
 Kas jätkata juurutamisega?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Valige operatsioonisüsteem.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Sisestage kehtiv arvuti nimi.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Valige sihtketas.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Valige enne juurutamise alustamist kehtiv OEM-mudel või versioon.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Enne juurutamise alustamist valige Autopilot profiil või keelake Autopilot.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Kasutaja tühistas juurutamise.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Kasutuselevõtu ettevalmistamine on lõpetatud.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Valmis</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Ootan kasutuselevõttu...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Ootan edusamme...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Juurutamise ettevalmistamine...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Kasutuselevõtt algas.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Juurutamine lõpetatud.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Juurutamise töövoog on lõpetatud.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Kasutuselevõtt tühistati.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Juurutamine ebaõnnestus.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Juurutamine ebaõnnestus: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Teine operatsioon on juba käimas.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Silumise turvarežiim lubatud: juurutamistoiminguid simuleeritakse.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Juurutamise töövoo käivitamine.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Algusaste...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Algus {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Algus {0}...</value></data>
@@ -219,10 +194,6 @@ Kas jätkata juurutamisega?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>Pooleli...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>samm:??</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Samm: {0} {1}-st</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Taaskäivitamine kohe...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Taaskäivitamise käsk ebaõnnestus.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Taaskäivitamise käsk ebaõnnestus: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Logifaili ei saa avada: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe ebaõnnestus väljumiskoodiga {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Süsteemi taaskäivitamine</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Nõutavat taaskäivitusfaili 'wpeutil.exe' ei leitud.</value></data>

--- a/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Tumma</value></data>
   <data name="Language.English" xml:space="preserve"><value>englanti</value></data>
   <data name="Language.French" xml:space="preserve"><value>ranskalainen</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Päivitä luettelot</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Päivitä kohdelevyt</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Avaa lokitiedosto</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Simulointitila on aktiivinen: käyttöönottotoiminnot simuloidaan, eikä levylle tai kuville kirjoiteta.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Kohde</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Käyttöjärjestelmä</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Ohjainpaketti</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Ladataan kohdelevyjä...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Kohdelevyn etsintä epäonnistui: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Levyjä ei havaittu.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Ladatut kohdelevyt: {0} havaittu.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Käyttöjärjestelmä</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Versio</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Kieli</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Edistyssivu</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Menestyssivu</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Virhesivu</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Virheenkorjauksen esikatselu: edistymissivu.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Virheenkorjauksen esikatselu: menestyssivu.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Virheenkorjauksen esikatselu: virhesivu.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Virheenkorjauksen esikatselu: DISM soveltaminen epäonnistui, koska kohdeosio on vain luku -tilassa.
 
 ErrorCode=0x80070005
@@ -144,7 +136,6 @@ Toimi: Tarkista levyn attribuutit ja yritä käyttöönottoa uudelleen.</value><
   <data name="Common.Previous" xml:space="preserve"><value>Edellinen</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Seuraavaksi</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Ota käyttöön</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Avaa loki</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>Ei käytössä</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Ei saatavilla</value></data>
   <data name="Common.None" xml:space="preserve"><value>Ei mitään</value></data>
@@ -176,7 +167,6 @@ Toimi: Tarkista levyn attribuutit ja yritä käyttöönottoa uudelleen.</value><
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Estetty: vain luku</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Estetty: offline-tilassa</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>VIRTUAALINEN KOHDE</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Valittu levy estetty: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Kohdelevy {0} ei ole enää läsnä.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Kohdelevy {0} on estetty: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Vahvista levyn tyhjennys</value></data>
@@ -190,26 +180,11 @@ Koko: {3}
 Käyttöjärjestelmä: {4}
 
 Jatketaanko käyttöönottoa?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Valitse käyttöjärjestelmä.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Anna kelvollinen tietokoneen nimi.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Valitse kohdelevy.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Valitse kelvollinen OEM-malli tai -versio ennen käyttöönoton aloittamista.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Valitse Autopilot-profiili tai poista Autopilot käytöstä ennen käyttöönoton aloittamista.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Käyttäjä peruutti käyttöönoton.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Käyttöönoton valmistelu valmis.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Valmis</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Odotetaan käyttöönottoa...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Edistystä odotellessa...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Valmistellaan käyttöönottoa...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Käyttöönotto aloitettu.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Käyttöönotto valmis.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Käyttöönoton työnkulku valmis.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Käyttöönotto peruttu.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Käyttöönotto epäonnistui.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Käyttöönotto epäonnistui: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Toinen operaatio on jo käynnissä.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Vianetsintä vikasietotila käytössä: käyttöönottotoiminnot simuloidaan.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Käyttöönoton työnkulku aloitetaan.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Aloitusvaihe...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Alkaen {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Alkaen {0}...</value></data>
@@ -219,10 +194,6 @@ Jatketaanko käyttöönottoa?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>Meneillään...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Vaihe:? /?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Vaihe: {0} / {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Käynnistetään uudelleen nyt...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Reboot-komento epäonnistui.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Uudelleenkäynnistyskomento epäonnistui: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Lokitiedostoa ei voi avata: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe epäonnistui poistumiskoodilla {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Järjestelmän uudelleenkäynnistys</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Vaadittua uudelleenkäynnistyssuoritettavaa tiedostoa 'wpeutil.exe' ei löytynyt.</value></data>

--- a/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Sombre</value></data>
   <data name="Language.English" xml:space="preserve"><value>Anglais</value></data>
   <data name="Language.French" xml:space="preserve"><value>Français</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Actualiser les catalogues</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Actualiser les disques cibles</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Ouvrir le fichier journal</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Le mode simulation est actif: les actions de déploiement sont simulées et aucune écriture de disque ou d'image n'est effectuée.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Cible</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Système d'exploitation</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Pack de pilotes</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>CA</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Chargement des disques cibles...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Échec de la découverte du disque cible: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Aucun disque détecté.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Disques cibles chargés: {0} détectés.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Système d'exploitation</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Version</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Langue</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Page de progression</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Page de réussite</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Page d'erreur</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Aperçu du débogage: page de progression.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Aperçu du débogage: page de réussite.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Aperçu du débogage: page d'erreur.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Aperçu du débogage: DISM l'application a échoué car la partition cible est en lecture seule.
 
 Code d'erreur = 0x80070005
@@ -144,7 +136,6 @@ Action: Vérifiez les attributs du disque et réessayez le déploiement.</value>
   <data name="Common.Previous" xml:space="preserve"><value>Précédent</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Suivant</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Déployer</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Ouvrir le journal</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/D</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Indisponible</value></data>
   <data name="Common.None" xml:space="preserve"><value>Aucun</value></data>
@@ -176,7 +167,6 @@ Action: Vérifiez les attributs du disque et réessayez le déploiement.</value>
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Bloqué: lecture seule</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Bloqué: hors ligne</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>DÉBOGAGE DE LA CIBLE VIRTUELLE</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Disque sélectionné bloqué: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Le disque cible {0} n'est plus présent.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Le disque cible {0} est bloqué: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Confirmer l'effacement du disque</value></data>
@@ -190,26 +180,11 @@ Taille: {3}
 Système d'exploitation: {4}
 
 Continuer le déploiement?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Sélectionnez un système d'exploitation.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Entrez un nom d'ordinateur valide.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Sélectionnez un disque cible.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Sélectionnez un modèle ou une version OEM valide avant de commencer le déploiement.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Sélectionnez un profil Autopilot ou désactivez Autopilot avant de démarrer le déploiement.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Déploiement annulé par l'utilisateur.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Préparation du déploiement terminée.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Prêt</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>En attente de déploiement...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>En attendant des progrès...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Préparation du déploiement...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Le déploiement a commencé.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Déploiement terminé.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Workflow de déploiement terminé.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Déploiement annulé.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Le déploiement a échoué.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Échec du déploiement: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Une autre opération est déjà en cours.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Mode sans échec de débogage activé: les actions de déploiement sont simulées.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Démarrage du workflow de déploiement.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Étape de départ...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Démarrage de {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Démarrage de {0}...</value></data>
@@ -219,10 +194,6 @@ Continuer le déploiement?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>En cours...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Étape:? de?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Étape: {0} de {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Redémarrage maintenant...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>La commande de redémarrage a échoué.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Échec de la commande de redémarrage: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Impossible d'ouvrir le fichier journal: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe a échoué avec le code de sortie {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Redémarrage du système</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>L'exécutable de redémarrage requis « wpeutil.exe » est introuvable.</value></data>

--- a/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Sombre</value></data>
   <data name="Language.English" xml:space="preserve"><value>Anglais</value></data>
   <data name="Language.French" xml:space="preserve"><value>Français</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Actualiser les catalogues</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Actualiser les disques cibles</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Ouvrir le fichier journal</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Le mode simulation est actif : les actions de déploiement sont simulées et aucune écriture disque ou image n’est effectuée.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Cible</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Système d’exploitation</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Pack de pilotes</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>Secteur</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Chargement des disques cibles...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Échec de la détection des disques cibles : {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Aucun disque détecté.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Disques cibles chargés : {0} détecté(s).</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Système d’exploitation</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Version</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Langue</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Page de progression</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Page de succès</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Page d’erreur</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Aperçu de débogage : page de progression.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Aperçu de débogage : page de succès.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Aperçu de débogage : page d’erreur.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Aperçu de débogage : l’application DISM a échoué car la partition cible est en lecture seule.
 
 ErrorCode=0x80070005
@@ -144,7 +136,6 @@ Action : vérifiez les attributs du disque puis relancez le déploiement.</value
   <data name="Common.Previous" xml:space="preserve"><value>Précédent</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Suivant</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Déployer</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Ouvrir journal</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/D</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Indisponible</value></data>
   <data name="Common.None" xml:space="preserve"><value>Aucun</value></data>
@@ -176,7 +167,6 @@ Action : vérifiez les attributs du disque puis relancez le déploiement.</value
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Bloqué : lecture seule</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Bloqué : hors ligne</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>CIBLE VIRTUELLE DE DÉBOGAGE</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Disque sélectionné bloqué : {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Le disque cible {0} n’est plus présent.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Le disque cible {0} est bloqué : {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Confirmer l’effacement du disque</value></data>
@@ -190,26 +180,11 @@ Taille : {3}
 Système d’exploitation : {4}
 
 Continuer le déploiement ?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Sélectionnez un système d’exploitation.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Saisissez un nom d’ordinateur valide.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Sélectionnez un disque cible.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Sélectionnez un modèle ou une version OEM valide avant de démarrer le déploiement.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Sélectionnez un profil Autopilot ou désactivez Autopilot avant de démarrer le déploiement.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Déploiement annulé par l’utilisateur.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Préparation du déploiement terminée.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Prêt</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>En attente du déploiement...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>En attente de progression...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Préparation du déploiement...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Déploiement démarré.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Déploiement terminé.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Workflow de déploiement terminé.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Déploiement annulé.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Le déploiement a échoué.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Le déploiement a échoué : {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Une autre opération est déjà en cours.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Mode simulation activé : les actions de déploiement sont simulées.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Démarrage du workflow de déploiement.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Démarrage de l’étape...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Démarrage de {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Démarrage de {0}...</value></data>
@@ -219,10 +194,6 @@ Continuer le déploiement ?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>En cours...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Étape : ? sur ?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Étape : {0} sur {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Redémarrage en cours...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>La commande de redémarrage a échoué.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>La commande de redémarrage a échoué : {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Impossible d’ouvrir le fichier journal : {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe a échoué avec le code de sortie {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Redémarrage système</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>L’exécutable de redémarrage requis 'wpeutil.exe' est introuvable.</value></data>

--- a/src/Foundry.Deploy/Strings/he-IL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/he-IL/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>כהה</value></data>
   <data name="Language.English" xml:space="preserve"><value>אנגלית</value></data>
   <data name="Language.French" xml:space="preserve"><value>צרפתית</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>רענון קטלוגים</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>רענן דיסקי יעד</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>פתח קובץ יומן</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>מצב סימולציה פעיל: פעולות פריסה מדומה ולא מבוצעות כתיבת דיסק או תמונה.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. יעד</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. מערכת הפעלה</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. חבילת דרייברים</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>טוען דיסקי יעד...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>גילוי דיסק יעד נכשל: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>לא זוהו דיסקים.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>דיסקים יעד נטענו: {0} זוהו.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>מערכת הפעלה</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>גרסה</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>שפה</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>דף התקדמות</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>דף הצלחה</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>דף שגיאה</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>תצוגה מקדימה של ניפוי באגים: דף התקדמות.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>תצוגה מקדימה של ניפוי באגים: דף הצלחה.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>תצוגה מקדימה של ניפוי באגים: דף שגיאה.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>תצוגה מקדימה של ניפוי באגים: יישום DISM נכשל מכיוון שמחיצת היעד היא לקריאה בלבד.
 
 ErrorCode=0x80070005
@@ -144,7 +136,6 @@ ErrorCode=0x80070005
   <data name="Common.Previous" xml:space="preserve"><value>הקודם</value></data>
   <data name="Common.Next" xml:space="preserve"><value>הבא</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>פרוס</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>פתח יומן</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>לא</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>לא זמין</value></data>
   <data name="Common.None" xml:space="preserve"><value>אין</value></data>
@@ -176,7 +167,6 @@ ErrorCode=0x80070005
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>חסום: לקריאה בלבד</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>חסום: לא מקוון</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>ניפוי יעד וירטואלי</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>דיסק שנבחר חסום: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>דיסק היעד {0} אינו קיים יותר.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>דיסק היעד {0} חסום: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>אשר את מחיקת הדיסק</value></data>
@@ -190,26 +180,11 @@ ErrorCode=0x80070005
 מערכת הפעלה: {4}
 
 האם להמשיך בפריסה?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>בחר מערכת הפעלה.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>הזן שם מחשב חוקי.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>בחר דיסק יעד.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>בחר דגם או גרסה חוקית של OEM לפני תחילת הפריסה.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>בחר פרופיל Autopilot או השבת את Autopilot לפני תחילת הפריסה.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>הפריסה בוטלה על ידי המשתמש.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>הכנת הפריסה הושלמה.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>מוכן</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>ממתין לפריסה...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>מחכה להתקדמות...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>מכין פריסה...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>החלה הפריסה.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>הפריסה הושלמה.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>זרימת העבודה של הפריסה הושלמה.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>הפריסה בוטלה.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>הפריסה נכשלה.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>הפריסה נכשלה: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>פעולה נוספת כבר פועלת.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>ניפוי באגים במצב בטוח מופעל: פעולות פריסה מדומות.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>התחלת זרימת עבודה בפריסה.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>שלב מתחיל...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>מתחיל {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>מתחיל {0}...</value></data>
@@ -219,10 +194,6 @@ ErrorCode=0x80070005
   <data name="Status.InProgress" xml:space="preserve"><value>בתהליך...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>שלב:? של?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>שלב: {0} של {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>מאתחל עכשיו...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>פקודת אתחול מחדש נכשלה.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>פקודת אתחול מחדש נכשלה: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>לא ניתן לפתוח קובץ יומן: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe נכשל עם קוד יציאה {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>אתחול המערכת</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>קובץ ההפעלה 'wpeutil.exe' הנדרש לא נמצא.</value></data>

--- a/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>tamno</value></data>
   <data name="Language.English" xml:space="preserve"><value>engleski</value></data>
   <data name="Language.French" xml:space="preserve"><value>francuski</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Osvježite kataloge</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Osvježi ciljne diskove</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Otvori datoteku dnevnika</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Način simulacije je aktivan: radnje postavljanja se simuliraju i ne izvode se zapisi na disk ili slike.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Cilj</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operativni sustav</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Paket vozača</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Učitavanje ciljnih diskova...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Otkrivanje ciljnog diska nije uspjelo: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Diskovi nisu otkriveni.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Učitani ciljni diskovi: otkriven {0}.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Operativni sustav</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Verzija</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Jezik</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Stranica s napretkom</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Stranica uspjeha</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Stranica s pogreškom</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Pregled otklanjanja pogrešaka: stranica napretka.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Pregled otklanjanja pogrešaka: uspješna stranica.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Pregled otklanjanja pogrešaka: stranica pogreške.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Pregled otklanjanja pogrešaka: primjena DISM nije uspjela jer je ciljna particija samo za čitanje.
 
 Šifra greške=0x80070005
@@ -144,7 +136,6 @@ Radnja: Provjerite atribute diska i ponovno pokušajte implementaciju.</value></
   <data name="Common.Previous" xml:space="preserve"><value>Prethodno</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Sljedeći</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Rasporedi</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Otvori dnevnik</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Nedostupan</value></data>
   <data name="Common.None" xml:space="preserve"><value>Nijedan</value></data>
@@ -176,7 +167,6 @@ Radnja: Provjerite atribute diska i ponovno pokušajte implementaciju.</value></
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Blokirano: samo za čitanje</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Blokirano: izvan mreže</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>OTKLONITE POGREŠKE VIRTUALNOG CILJA</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Odabrani disk blokiran: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Ciljni disk {0} više nije prisutan.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Ciljni disk {0} je blokiran: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Potvrdite brisanje diska</value></data>
@@ -190,26 +180,11 @@ Veličina: {3}
 Operativni sustav: {4}
 
 Nastaviti s implementacijom?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Odaberite operativni sustav.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Unesite važeći naziv računala.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Odaberite ciljni disk.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Odaberite važeći OEM model ili verziju prije početka implementacije.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Odaberite Autopilot profil ili onemogućite Autopilot prije početka implementacije.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Korisnik je otkazao implementaciju.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Priprema za implementaciju dovršena.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Spreman</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Čeka se implementacija...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Čekajući napredak...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Priprema implementacije...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Implementacija je započela.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Implementacija dovršena.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Tijek rada implementacije dovršen.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Implementacija je otkazana.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Implementacija nije uspjela.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Implementacija nije uspjela: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Druga operacija je već u tijeku.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Omogućen je siguran način otklanjanja pogrešaka: simuliraju se radnje implementacije.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Pokretanje tijeka rada implementacije.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Početni korak...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Počinje {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Počinje {0}...</value></data>
@@ -219,10 +194,6 @@ Nastaviti s implementacijom?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>U tijeku...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>korak:? od?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Korak: {0} od {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Sada ponovno pokretanje...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Naredba ponovnog pokretanja nije uspjela.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Naredba ponovnog pokretanja nije uspjela: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Nije moguće otvoriti datoteku dnevnika: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe nije uspio s izlaznim kodom {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Ponovno pokretanje sustava</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Potrebna izvršna datoteka za ponovno pokretanje 'wpeutil.exe' nije pronađena.</value></data>

--- a/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Sötét</value></data>
   <data name="Language.English" xml:space="preserve"><value>angolul</value></data>
   <data name="Language.French" xml:space="preserve"><value>francia</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Katalógusok frissítése</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Frissítse a céllemezeket</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Nyissa meg a naplófájlt</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>A szimulációs mód aktív: a telepítési műveletek szimulálva vannak, és nem történik lemez- vagy képírás.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Cél</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operációs rendszer</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Driver csomag</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Céllemezek betöltése...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>A céllemez felderítése nem sikerült: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Nem észlelhető lemez.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Betöltött céllemezek: {0} észlelve.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Operációs rendszer</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Verzió</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Nyelv</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Haladás oldal</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Siker oldal</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Hiba oldal</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Hibakeresési előnézet: folyamatoldal.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Hibakeresési előnézet: sikeroldal.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Hibakeresési előnézet: hibaoldal.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Hibakeresési előnézet: DISM alkalmazás sikertelen, mert a célpartíció írásvédett.
 
 ErrorCode=0x80070005
@@ -144,7 +136,6 @@ Művelet: Ellenőrizze a lemezattribútumokat, és próbálkozzon újra a közpo
   <data name="Common.Previous" xml:space="preserve"><value>Előző</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Következő</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Telepítés</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Napló megnyitása</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Nem elérhető</value></data>
   <data name="Common.None" xml:space="preserve"><value>Egyik sem</value></data>
@@ -176,7 +167,6 @@ Művelet: Ellenőrizze a lemezattribútumokat, és próbálkozzon újra a közpo
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Letiltva: csak olvasható</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Letiltva: offline</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>HIBAHIBA VIRTUÁLIS CÉL</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>A kiválasztott lemez blokkolva: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>A {0} céllemez már nincs jelen.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>A {0} céllemez le van tiltva: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Erősítse meg a lemez törlését</value></data>
@@ -190,26 +180,11 @@ Méret: {3}
 Operációs rendszer: {4}
 
 Folytatja a telepítést?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Válasszon ki egy operációs rendszert.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Adjon meg egy érvényes számítógépnevet.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Válasszon ki egy céllemezt.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>A telepítés megkezdése előtt válasszon egy érvényes OEM-modellt vagy -verziót.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>A telepítés megkezdése előtt válasszon Autopilot profilt, vagy tiltsa le az Autopilot profilt.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>A telepítést a felhasználó megszakította.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>A telepítés előkészítése befejeződött.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Kész</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Várakozás a telepítésre...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Várjuk a fejleményeket...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Telepítés előkészítése...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Megkezdődött a telepítés.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>A telepítés befejeződött.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>A telepítési munkafolyamat befejeződött.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>A telepítés megszakadt.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>A telepítés nem sikerült.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>A telepítés sikertelen: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Egy másik művelet már fut.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Hibakeresés csökkentett mód engedélyezve: a telepítési műveletek szimulálva vannak.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>A telepítési munkafolyamat indítása.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Kezdő lépés...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Kezdve: {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Kezdés: {0}...</value></data>
@@ -219,10 +194,6 @@ Folytatja a telepítést?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>Folyamatban...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>lépés:? a?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Lépés: {0}/{1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Újraindítás most...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Az újraindítási parancs nem sikerült.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Az újraindítási parancs sikertelen: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Nem lehet megnyitni a naplófájlt: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe nem sikerült a {0} kilépési kóddal. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Rendszer újraindítás</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>A szükséges újraindítási végrehajtható "wpeutil.exe" nem található.</value></data>

--- a/src/Foundry.Deploy/Strings/it-IT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/it-IT/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Buio</value></data>
   <data name="Language.English" xml:space="preserve"><value>Inglese</value></data>
   <data name="Language.French" xml:space="preserve"><value>francese</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Aggiorna cataloghi</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Aggiorna i dischi di destinazione</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Apri il file di registro</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>La modalità di simulazione è attiva: le azioni di distribuzione vengono simulate e non vengono eseguite scritture su disco o immagini.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Obiettivo</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Sistema operativo</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Pacchetto driver</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Caricamento dei dischi di destinazione...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Individuazione del disco di destinazione non riuscita: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Nessun disco rilevato.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Dischi di destinazione caricati: {0} rilevati.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Sistema operativo</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Versione</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Lingua</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Pagina di avanzamento</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Pagina del successo</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Pagina di errore</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Anteprima del debug: pagina di avanzamento.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Anteprima del debug: pagina di successo.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Anteprima del debug: pagina di errore.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Anteprima del debug: DISM applicazione non riuscita perché la partizione di destinazione è di sola lettura.
 
 Codice errore=0x80070005
@@ -144,7 +136,6 @@ Azione: verificare gli attributi del disco e riprovare la distribuzione.</value>
   <data name="Common.Previous" xml:space="preserve"><value>Precedente</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Avanti</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Distribuire</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Apri registro</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/D</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Non disponibile</value></data>
   <data name="Common.None" xml:space="preserve"><value>Nessuno</value></data>
@@ -176,7 +167,6 @@ Azione: verificare gli attributi del disco e riprovare la distribuzione.</value>
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Bloccato: sola lettura</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Bloccato: offline</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>DEBUG BERSAGLI VIRTUALI</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Disco selezionato bloccato: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Il disco di destinazione {0} non è più presente.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Il disco di destinazione {0} è bloccato: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Conferma la cancellazione del disco</value></data>
@@ -190,26 +180,11 @@ Dimensioni: {3}
 Sistema operativo: {4}
 
 Continuare con la distribuzione?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Seleziona un sistema operativo.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Immettere un nome computer valido.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Seleziona un disco di destinazione.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Seleziona un modello o una versione OEM valida prima di iniziare la distribuzione.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Selezionare un profilo Autopilot o disabilitare Autopilot prima di iniziare la distribuzione.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Distribuzione annullata dall'utente.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Preparazione della distribuzione completata.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Pronto</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>In attesa di distribuzione...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>In attesa di progressi...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Preparazione della distribuzione in corso...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>La distribuzione è iniziata.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Distribuzione completata.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Flusso di lavoro di distribuzione completato.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Distribuzione annullata.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Distribuzione non riuscita.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Distribuzione non riuscita: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Un'altra operazione è già in corso.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Modalità provvisoria di debug abilitata: le azioni di distribuzione vengono simulate.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Avvio del flusso di lavoro di distribuzione.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Passo iniziale...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Inizio {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Inizio {0}...</value></data>
@@ -219,10 +194,6 @@ Continuare con la distribuzione?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>In corso...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Passo:? Di?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Passo: {0} di {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Riavvio ora...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Il comando di riavvio non è riuscito.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Comando di riavvio non riuscito: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Impossibile aprire il file di registro: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe non è riuscito con il codice di uscita {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Riavvio del sistema</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>L'eseguibile di riavvio richiesto "wpeutil.exe" non è stato trovato.</value></data>

--- a/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>暗い</value></data>
   <data name="Language.English" xml:space="preserve"><value>英語</value></data>
   <data name="Language.French" xml:space="preserve"><value>フランス語</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>カタログを更新する</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>ターゲットディスクをリフレッシュする</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>ログファイルを開く</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>シミュレーション モードがアクティブです。展開アクションがシミュレートされ、ディスクまたはイメージの書き込みは実行されません。</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. ターゲット</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. オペレーティングシステム</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3.ドライバーパック</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>交流</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>ターゲットディスクをロードしています...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>ターゲット ディスクの検出に失敗しました: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>ディスクが検出されませんでした。</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>ロードされたターゲット ディスク: {0} が検出されました。</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>オペレーティングシステム</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>バージョン</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>言語</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>進捗ページ</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>成功ページ</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>エラーページ</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>デバッグ プレビュー: 進行状況ページ。</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>デバッグ プレビュー: 成功ページ。</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>デバッグ プレビュー: エラー ページ。</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>デバッグ プレビュー: DISM ターゲット パーティションが読み取り専用であるため、適用に失敗しました。
 
 エラーコード=0x80070005
@@ -144,7 +136,6 @@
   <data name="Common.Previous" xml:space="preserve"><value>前へ</value></data>
   <data name="Common.Next" xml:space="preserve"><value>次へ</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>デプロイ</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>ログを開く</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>該当なし</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>利用不可</value></data>
   <data name="Common.None" xml:space="preserve"><value>なし</value></data>
@@ -176,7 +167,6 @@
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>ブロック済み: 読み取り専用</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>ブロック中: オフライン</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>仮想ターゲットのデバッグ</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>選択したディスクがブロックされました: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>ターゲット ディスク {0} は存在しません。</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>ターゲット ディスク {0} がブロックされています: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>ディスク消去の確認</value></data>
@@ -190,26 +180,11 @@
 オペレーティング システム: {4}
 
 導入を続行しますか?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>オペレーティング システムを選択します。</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>有効なコンピュータ名を入力してください。</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>ターゲットディスクを選択します。</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>導入を開始する前に、有効な OEM モデルまたはバージョンを選択してください。</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>展開を開始する前に、Autopilot プロファイルを選択するか、Autopilot を無効にします。</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>デプロイメントはユーザーによってキャンセルされました。</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>導入準備が完了しました。</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>準備完了</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>導入を待っています...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>進展を待っています...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>導入を準備しています...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>展開が開始されました。</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>導入が完了しました。</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>導入ワークフローが完了しました。</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>デプロイメントがキャンセルされました。</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>デプロイメントに失敗しました。</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>デプロイメントに失敗しました: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>別の操作がすでに実行中です。</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>デバッグ セーフ モードが有効になっています: 展開アクションがシミュレートされます。</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>導入ワークフローを開始します。</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>開始ステップ...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>{0} を開始します。</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>{0} を開始します...</value></data>
@@ -219,10 +194,6 @@
   <data name="Status.InProgress" xml:space="preserve"><value>進行中...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>ステップ:?の ？</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>ステップ: {0} の {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>今再起動しています...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>再起動コマンドが失敗しました。</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>再起動コマンドが失敗しました: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>ログ ファイルを開けません: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe は終了コード {0} で失敗しました。 {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>システムの再起動</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>必要な再起動実行可能ファイル「wpeutil.exe」が見つかりませんでした。</value></data>

--- a/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>어둠</value></data>
   <data name="Language.English" xml:space="preserve"><value>영어</value></data>
   <data name="Language.French" xml:space="preserve"><value>프랑스어</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>카탈로그 새로 고침</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>대상 디스크 새로 고침</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>로그 파일 열기</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>시뮬레이션 모드가 활성 상태입니다. 배포 작업이 시뮬레이션되고 디스크 또는 이미지 쓰기가 수행되지 않습니다.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. 대상</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. 운영 체제</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. 드라이버 팩</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>교류</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>대상 디스크 로드 중...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>대상 디스크 검색 실패: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>디스크가 감지되지 않았습니다.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>로드된 대상 디스크: {0}이 감지되었습니다.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>운영 체제</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>버전</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>언어</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>진행상황 페이지</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>성공 페이지</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>오류 페이지</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>디버그 미리보기: 진행률 페이지.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>디버그 미리보기: 성공 페이지.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>디버그 미리보기: 오류 페이지.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>디버그 미리 보기: 대상 파티션이 읽기 전용이므로 DISM 적용에 실패했습니다.
 
 오류코드=0x80070005
@@ -144,7 +136,6 @@
   <data name="Common.Previous" xml:space="preserve"><value>이전</value></data>
   <data name="Common.Next" xml:space="preserve"><value>다음</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>배포</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>로그 열기</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>해당 없음</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>이용 불가</value></data>
   <data name="Common.None" xml:space="preserve"><value>없음</value></data>
@@ -176,7 +167,6 @@
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>차단됨: 읽기 전용</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>차단됨: 오프라인</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>가상 타겟 디버그</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>선택한 디스크가 차단됨: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>대상 디스크 {0}이(가) 더 이상 존재하지 않습니다.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>대상 디스크 {0}이 차단되었습니다: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>디스크 삭제 확인</value></data>
@@ -190,26 +180,11 @@
 운영 체제: {4}
 
 배포를 계속하시겠습니까?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>운영 체제를 선택합니다.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>유효한 컴퓨터 이름을 입력하세요.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>대상 디스크를 선택합니다.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>배포를 시작하기 전에 유효한 OEM 모델 또는 버전을 선택하세요.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>배포를 시작하기 전에 Autopilot 프로필을 선택하거나 Autopilot을 비활성화합니다.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>사용자가 배포를 취소했습니다.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>배포 준비가 완료되었습니다.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>준비</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>배포를 기다리는 중...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>진전을 기다리는 중...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>배포 준비 중...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>배포가 시작되었습니다.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>배포가 완료되었습니다.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>배포 워크플로가 완료되었습니다.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>배포가 취소되었습니다.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>배포에 실패했습니다.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>배포 실패: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>다른 작업이 이미 실행 중입니다.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>디버그 안전 모드 활성화: 배포 작업이 시뮬레이션됩니다.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>배포 워크플로를 시작합니다.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>시작 단계...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>{0}부터 시작됩니다.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>{0} 시작 중...</value></data>
@@ -219,10 +194,6 @@
   <data name="Status.InProgress" xml:space="preserve"><value>진행중...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>단계:? 의?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>단계: {0}의 {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>지금 재부팅 중입니다...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>재부팅 명령이 실패했습니다.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>재부팅 명령 실패: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>로그 파일을 열 수 없습니다: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>종료 코드 {0}으로 인해 wpeutil.exe가 실패했습니다. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>시스템 재부팅</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>재부팅이 필요한 실행 파일 'wpeutil.exe'를 찾을 수 없습니다.</value></data>

--- a/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Tamsus</value></data>
   <data name="Language.English" xml:space="preserve"><value>anglų kalba</value></data>
   <data name="Language.French" xml:space="preserve"><value>prancūzų</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Atnaujinti katalogus</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Atnaujinkite tikslinius diskus</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Atidaryti žurnalo failą</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Modeliavimo režimas yra aktyvus: modeliuojami diegimo veiksmai ir neįrašoma į diską ar vaizdą.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Taikinys</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operacinė sistema</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Vairuotojo paketas</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Įkeliami tiksliniai diskai...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Nepavyko aptikti tikslinio disko: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Nerasta jokių diskų.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Įkelti tiksliniai diskai: aptikta {0}.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Operacinė sistema</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Versija</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Kalba</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Pažangos puslapis</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Sėkmės puslapis</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Klaidos puslapis</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Derinimo peržiūra: eigos puslapis.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Derinimo peržiūra: sėkmės puslapis.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Derinimo peržiūra: klaidos puslapis.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Derinimo peržiūra: DISM taikyti nepavyko, nes tikslinis skaidinys yra tik skaitomas.
 
 ErrorCode=0x80070005
@@ -144,7 +136,6 @@ Veiksmas: patikrinkite disko atributus ir bandykite iš naujo įdiegti.</value><
   <data name="Common.Previous" xml:space="preserve"><value>Ankstesnis</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Kitas</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Dislokuoti</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Atidaryti žurnalą</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Nepasiekiamas</value></data>
   <data name="Common.None" xml:space="preserve"><value>Nėra</value></data>
@@ -176,7 +167,6 @@ Veiksmas: patikrinkite disko atributus ir bandykite iš naujo įdiegti.</value><
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Užblokuota: tik skaitoma</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Užblokuota: neprisijungus</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>DERINTI VIRTUALUS TIKSLAS</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Pasirinktas diskas užblokuotas: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Tikslinio disko {0} nebėra.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Tikslinis diskas {0} užblokuotas: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Patvirtinkite disko ištrynimą</value></data>
@@ -190,26 +180,11 @@ Dydis: {3}
 Operacinė sistema: {4}
 
 Tęsti diegimą?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Pasirinkite operacinę sistemą.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Įveskite galiojantį kompiuterio pavadinimą.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Pasirinkite tikslinį diską.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Prieš pradėdami diegti, pasirinkite tinkamą OĮG modelį arba versiją.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Prieš pradėdami diegti, pasirinkite Autopilot profilį arba išjunkite Autopilot.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Diegimą atšaukė vartotojas.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Pasirengimas diegimui baigtas.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Paruošta</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Laukiama diegimo...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Laukiam progreso...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Ruošiamas diegimas...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Pradėtas dislokavimas.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Diegimas baigtas.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Diegimo darbo eiga baigta.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Diegimas atšauktas.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Diegimas nepavyko.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Diegimas nepavyko: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Jau vykdoma kita operacija.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Derinimo saugus režimas įjungtas: modeliuojami diegimo veiksmai.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Pradedama diegimo darbo eiga.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Pradinis žingsnis...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Nuo {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Pradedama {0}...</value></data>
@@ -219,10 +194,6 @@ Tęsti diegimą?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>Vykdoma...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Žingsnis:? iš?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Žingsnis: {0} iš {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Dabar paleidžiama iš naujo...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Perkrovimo komanda nepavyko.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Perkrovimo komanda nepavyko: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Nepavyko atidaryti žurnalo failo: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe nepavyko su išėjimo kodu {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Sistemos paleidimas iš naujo</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Reikalingas iš naujo paleisti vykdomasis failas „wpeutil.exe“ nerastas.</value></data>

--- a/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Tumšs</value></data>
   <data name="Language.English" xml:space="preserve"><value>angļu valoda</value></data>
   <data name="Language.French" xml:space="preserve"><value>franču valoda</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Atsvaidziniet katalogus</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Atsvaidziniet mērķa diskus</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Atveriet žurnāla failu</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Simulācijas režīms ir aktīvs: tiek simulētas izvietošanas darbības un netiek veikta diska vai attēla rakstīšana.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Mērķis</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operētājsistēma</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Vadītāja pakotne</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Notiek mērķa disku ielāde...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Mērķa diska atklāšana neizdevās: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Nav atrasts neviens disks.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Ielādēti mērķa diski: konstatēti {0}.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Operētājsistēma</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Versija</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Valoda</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Progresa lapa</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Veiksmes lapa</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Kļūdas lapa</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Atkļūdošanas priekšskatījums: norises lapa.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Atkļūdošanas priekšskatījums: veiksmes lapa.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Atkļūdošanas priekšskatījums: kļūdas lapa.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Atkļūdošanas priekšskatījums: DISM pieteikšanās neizdevās, jo mērķa nodalījums ir tikai lasāms.
 
 ErrorCode=0x80070005
@@ -144,7 +136,6 @@ Darbība: pārbaudiet diska atribūtus un mēģiniet atkārtoti izvietot.</value
   <data name="Common.Previous" xml:space="preserve"><value>Iepriekšējais</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Tālāk</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Izvietot</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Atvērt žurnālu</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Nav pieejams</value></data>
   <data name="Common.None" xml:space="preserve"><value>Nav</value></data>
@@ -176,7 +167,6 @@ Darbība: pārbaudiet diska atribūtus un mēģiniet atkārtoti izvietot.</value
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Bloķēts: tikai lasāms</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Bloķēts: bezsaistē</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>VIRTUĀLĀ MĒRĶA ATKLĀŠANA</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Atlasītais disks ir bloķēts: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Mērķa disks {0} vairs nav pieejams.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Mērķa disks {0} ir bloķēts: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Apstipriniet diska dzēšanu</value></data>
@@ -190,26 +180,11 @@ Izmērs: {3}
 Operētājsistēma: {4}
 
 Vai turpināt izvietošanu?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Izvēlieties operētājsistēmu.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Ievadiet derīgu datora nosaukumu.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Izvēlieties mērķa disku.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Pirms izvietošanas sākuma atlasiet derīgu OEM modeli vai versiju.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Pirms izvietošanas sākuma atlasiet Autopilot profilu vai atspējojiet Autopilot.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Lietotājs atcēla izvietošanu.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Izvēršanas sagatavošana pabeigta.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Gatavs</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Gaida izvietošanu...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Gaidām progresu...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Notiek izvietošanas sagatavošana...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Sākta izvietošana.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Izvietošana pabeigta.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Izvietošanas darbplūsma ir pabeigta.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Izvietošana atcelta.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Izvietošana neizdevās.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Izvietošana neizdevās: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Jau notiek cita operācija.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Atkļūdošanas drošais režīms ir iespējots: tiek simulētas izvietošanas darbības.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Tiek sākta izvietošanas darbplūsma.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Sākuma solis...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Sākot ar {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Sākot ar {0}...</value></data>
@@ -219,10 +194,6 @@ Vai turpināt izvietošanu?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>Notiek...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>solis:? no?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Darbība: {0} no {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Tagad notiek atsāknēšana...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Atsāknēšanas komanda neizdevās.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Atsāknēšanas komanda neizdevās: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Nevar atvērt žurnāla failu: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe neizdevās ar izejas kodu {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Sistēmas atsāknēšana</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Nepieciešamais atsāknēšanas izpildāmais fails “wpeutil.exe” netika atrasts.</value></data>

--- a/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Mørkt</value></data>
   <data name="Language.English" xml:space="preserve"><value>engelsk</value></data>
   <data name="Language.French" xml:space="preserve"><value>fransk</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Oppdater kataloger</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Oppdater måldisker</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Åpne loggfilen</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Simuleringsmodus er aktiv: distribusjonshandlinger simuleres og ingen disk- eller bildeskriving utføres.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Mål</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operativsystem</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Driverpakke</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Laster inn måldisker...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Oppdaging av måldisk mislyktes: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Ingen disker oppdaget.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Måldisker lastet: {0} oppdaget.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Operativsystem</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Versjon</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Språk</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Fremdriftsside</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Suksessside</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Feilside</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Forhåndsvisning av feilsøking: fremdriftsside.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Forhåndsvisning av feilsøking: suksessside.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Forhåndsvisning av feilsøking: feilside.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Forhåndsvisning av feilsøking: DISM påføring mislyktes fordi målpartisjonen er skrivebeskyttet.
 
 ErrorCode=0x80070005
@@ -144,7 +136,6 @@ Handling: Bekreft diskattributter og prøv distribusjon på nytt.</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Forrige</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Neste</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Distribuer</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Åpne logg</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Utilgjengelig</value></data>
   <data name="Common.None" xml:space="preserve"><value>Ingen</value></data>
@@ -176,7 +167,6 @@ Handling: Bekreft diskattributter og prøv distribusjon på nytt.</value></data>
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Blokkert: skrivebeskyttet</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Blokkert: offline</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>FEIL VIRTUELLT MÅL</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Valgt disk blokkert: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Måldisken {0} er ikke lenger til stede.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Måldisken {0} er blokkert: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Bekreft sletting av disk</value></data>
@@ -190,26 +180,11 @@ Størrelse: {3}
 Operativsystem: {4}
 
 Vil du fortsette med distribusjonen?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Velg et operativsystem.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Skriv inn et gyldig datamaskinnavn.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Velg en måldisk.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Velg en gyldig OEM-modell eller -versjon før du starter distribusjonen.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Velg en Autopilot-profil eller deaktiver Autopilot før du starter distribusjonen.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Implementeringen kansellert av brukeren.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Forberedelse av distribusjon fullført.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Klar</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Venter på distribusjon...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Venter på fremgang...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Forbereder distribusjon...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Utrullingen startet.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Utrullingen fullført.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Arbeidsflyt for distribusjon fullført.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Implementeringen kansellert.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Implementeringen mislyktes.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Implementering mislyktes: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>En annen operasjon kjører allerede.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Feilsøking i sikker modus aktivert: distribusjonshandlinger simuleres.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Starter arbeidsflyt for distribusjon.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Starttrinn...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Starter {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Starter {0}...</value></data>
@@ -219,10 +194,6 @@ Vil du fortsette med distribusjonen?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>Pågår...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Trinn:? av?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Trinn: {0} av {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Starter på nytt nå...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Reboot-kommandoen mislyktes.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Reboot-kommandoen mislyktes: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Kan ikke åpne loggfilen: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe mislyktes med utgangskode {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Systemet starter på nytt</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Nødvendig omstart kjørbar 'wpeutil.exe' ble ikke funnet.</value></data>

--- a/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Donker</value></data>
   <data name="Language.English" xml:space="preserve"><value>Engels</value></data>
   <data name="Language.French" xml:space="preserve"><value>Frans</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Catalogi vernieuwen</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Doelschijven vernieuwen</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Logbestand openen</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>De simulatiemodus is actief: implementatieacties worden gesimuleerd en er worden geen schijf- of image-schrijfbewerkingen uitgevoerd.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Doel</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Besturingssysteem</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Driverpakket</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Doelschijven laden...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Detectie van doelschijf mislukt: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Geen schijven gedetecteerd.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Doelschijven geladen: {0} gedetecteerd.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Besturingssysteem</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Versie</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Taal</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Voortgangspagina</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Succes pagina</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Foutpagina</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Voorbeeld van foutopsporing: voortgangspagina.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Voorbeeld van foutopsporing: succespagina.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Voorbeeld van foutopsporing: foutpagina.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Voorbeeld van foutopsporing: DISM toepassen mislukt omdat de doelpartitie alleen-lezen is.
 
 Foutcode=0x80070005
@@ -144,7 +136,6 @@ Actie: controleer de schijfkenmerken en probeer de implementatie opnieuw.</value
   <data name="Common.Previous" xml:space="preserve"><value>Vorige</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Volgende</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Implementeren</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Logboek openen</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N.v.t</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Niet beschikbaar</value></data>
   <data name="Common.None" xml:space="preserve"><value>Geen</value></data>
@@ -176,7 +167,6 @@ Actie: controleer de schijfkenmerken en probeer de implementatie opnieuw.</value
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Geblokkeerd: alleen-lezen</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Geblokkeerd: offline</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>DEBUG VIRTUEEL DOEL</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Geselecteerde schijf geblokkeerd: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Doelschijf {0} is niet langer aanwezig.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Doelschijf {0} is geblokkeerd: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Bevestig het wissen van de schijf</value></data>
@@ -190,26 +180,11 @@ Grootte: {3}
 Besturingssysteem: {4}
 
 Doorgaan met de implementatie?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Selecteer een besturingssysteem.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Voer een geldige computernaam in.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Selecteer een doelschijf.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Selecteer een geldig OEM-model of -versie voordat u met de implementatie begint.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Selecteer een Autopilot-profiel of schakel Autopilot uit voordat u met de implementatie begint.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Implementatie geannuleerd door gebruiker.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Voorbereiding voor implementatie voltooid.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Klaar</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Wachten op implementatie...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Wachten op vooruitgang...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Implementatie voorbereiden...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>De implementatie is gestart.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Implementatie voltooid.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Implementatieworkflow voltooid.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Implementatie geannuleerd.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Implementatie is mislukt.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Implementatie mislukt: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Er loopt al een andere operatie.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Foutopsporing in veilige modus ingeschakeld: implementatieacties worden gesimuleerd.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Implementatieworkflow starten.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Beginstap...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Beginnen met {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>{0} starten...</value></data>
@@ -219,10 +194,6 @@ Doorgaan met de implementatie?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>In uitvoering...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Stap:? van?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Stap: {0} of {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Nu opnieuw opstarten...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Herstartopdracht mislukt.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Herstartopdracht mislukt: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Kan logbestand niet openen: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe mislukt met afsluitcode {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Systeem opnieuw opstarten</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Het vereiste herstartbare uitvoerbare bestand 'wpeutil.exe' is niet gevonden.</value></data>

--- a/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Ciemny</value></data>
   <data name="Language.English" xml:space="preserve"><value>Angielski</value></data>
   <data name="Language.French" xml:space="preserve"><value>Francuski</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Odśwież katalogi</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Odśwież dyski docelowe</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Otwórz plik dziennika</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Tryb symulacji jest aktywny: symulowane są akcje wdrażania i nie są wykonywane żadne zapisy na dysku lub obrazie.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Cel</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. System operacyjny</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Pakiet sterowników</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Ładowanie dysków docelowych...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Wykrycie dysku docelowego nie powiodło się: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Nie wykryto dysków.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Załadowane dyski docelowe: wykryto {0}.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>System operacyjny</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Wersja</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Język</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Strona postępu</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Strona sukcesu</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Strona błędu</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Podgląd debugowania: strona postępu.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Podgląd debugowania: strona sukcesu.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Podgląd debugowania: strona błędu.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Podgląd debugowania: DISM zastosowanie nie powiodło się, ponieważ partycja docelowa jest tylko do odczytu.
 
 Kod błędu=0x80070005
@@ -144,7 +136,6 @@ Akcja: Sprawdź atrybuty dysku i ponów próbę wdrożenia.</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Poprzedni</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Następny</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Wdróż</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Otwórz dziennik</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>Nie dotyczy</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Niedostępne</value></data>
   <data name="Common.None" xml:space="preserve"><value>Żadne</value></data>
@@ -176,7 +167,6 @@ Akcja: Sprawdź atrybuty dysku i ponów próbę wdrożenia.</value></data>
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Zablokowano: tylko do odczytu</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Zablokowano: offline</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>DEBUGUJ WIRTUALNY CEL</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Wybrany dysk zablokowany: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Dysk docelowy {0} nie jest już obecny.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Dysk docelowy {0} jest zablokowany: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Potwierdź usunięcie dysku</value></data>
@@ -190,26 +180,11 @@ Rozmiar: {3}
 System operacyjny: {4}
 
 Kontynuować wdrażanie?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Wybierz system operacyjny.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Wprowadź prawidłową nazwę komputera.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Wybierz dysk docelowy.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Przed rozpoczęciem wdrażania wybierz prawidłowy model lub wersję OEM.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Wybierz profil Autopilot lub wyłącz Autopilot przed rozpoczęciem wdrażania.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Wdrożenie anulowane przez użytkownika.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Zakończono przygotowania do wdrożenia.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Gotowy</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Oczekiwanie na wdrożenie...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Czekam na postęp...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Przygotowuję wdrożenie...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Rozpoczęto wdrażanie.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Wdrożenie zakończone.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Przepływ pracy wdrożeniowej został ukończony.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Wdrożenie anulowane.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Wdrożenie nie powiodło się.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Wdrożenie nie powiodło się: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Inna operacja już trwa.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Włączono tryb awaryjny debugowania: symulowane są działania wdrożeniowe.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Rozpoczęcie procesu wdrażania.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Krok początkowy...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Rozpoczęcie {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Rozpoczęcie {0}...</value></data>
@@ -219,10 +194,6 @@ Kontynuować wdrażanie?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>W toku...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Krok:? z?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Krok: {0} z {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Ponowne uruchamianie teraz...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Polecenie ponownego uruchomienia nie powiodło się.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Polecenie ponownego uruchomienia nie powiodło się: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Nie można otworzyć pliku dziennika: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe nie powiodło się z kodem zakończenia {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Ponowne uruchomienie systemu</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Nie znaleziono wymaganego pliku wykonywalnego ponownego uruchomienia „wpeutil.exe”.</value></data>

--- a/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Escuro</value></data>
   <data name="Language.English" xml:space="preserve"><value>Inglês</value></data>
   <data name="Language.French" xml:space="preserve"><value>Francês</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Atualizar catálogos</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Atualizar discos de destino</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Abrir arquivo de registro</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>O modo de simulação está ativo: as ações de implantação são simuladas e nenhuma gravação de disco ou imagem é executada.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Alvo</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Sistema operacional</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Pacote de driver</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Carregando discos de destino...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Falha na descoberta do disco de destino: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Nenhum disco detectado.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Discos de destino carregados: {0} detectados.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Sistema operacional</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Versão</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Idioma</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Página de progresso</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Página de sucesso</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Página de erro</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Visualização de depuração: página de progresso.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Visualização de depuração: página de sucesso.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Visualização de depuração: página de erro.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Visualização de depuração: DISM aplicação falhou porque a partição de destino é somente leitura.
 
 Código de erro = 0x80070005
@@ -144,7 +136,6 @@ Ação: Verifique os atributos do disco e tente novamente a implantação.</valu
   <data name="Common.Previous" xml:space="preserve"><value>Anterior</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Próximo</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Implantar</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Abrir registro</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Indisponível</value></data>
   <data name="Common.None" xml:space="preserve"><value>Nenhum</value></data>
@@ -176,7 +167,6 @@ Ação: Verifique os atributos do disco e tente novamente a implantação.</valu
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Bloqueado: somente leitura</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Bloqueado: off-line</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>DEBUGAR ALVO VIRTUAL</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Disco selecionado bloqueado: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>O disco de destino {0} não está mais presente.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>O disco de destino {0} está bloqueado: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Confirme o apagamento do disco</value></data>
@@ -190,26 +180,11 @@ Tamanho: {3}
 Sistema operacional: {4}
 
 Continuar com a implantação?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Selecione um sistema operacional.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Insira um nome de computador válido.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Selecione um disco de destino.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Selecione um modelo ou versão OEM válido antes de iniciar a implantação.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Selecione um perfil Autopilot ou desative Autopilot antes de iniciar a implantação.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Implantação cancelada pelo usuário.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Preparação de implantação concluída.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Pronto</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Aguardando implantação...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Aguardando progresso...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Preparando implantação...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>A implantação foi iniciada.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Implantação concluída.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Fluxo de trabalho de implantação concluído.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Implantação cancelada.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>A implantação falhou.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Falha na implantação: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Outra operação já está em execução.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Modo de segurança de depuração ativado: ações de implantação são simuladas.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Iniciando o fluxo de trabalho de implantação.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Etapa inicial...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Iniciando {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Iniciando {0}...</value></data>
@@ -219,10 +194,6 @@ Continuar com a implantação?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>Em andamento...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Etapa:? de?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Etapa: {0} de {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Reiniciando agora...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>O comando de reinicialização falhou.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Falha no comando de reinicialização: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Não foi possível abrir o arquivo de log: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe falhou com o código de saída {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Reinicialização do sistema</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>O executável de reinicialização necessária 'wpeutil.exe' não foi encontrado.</value></data>

--- a/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Escuro</value></data>
   <data name="Language.English" xml:space="preserve"><value>Inglês</value></data>
   <data name="Language.French" xml:space="preserve"><value>Francês</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Atualizar catálogos</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Atualizar discos de destino</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Abrir arquivo de registro</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>O modo de simulação está ativo: as ações de implantação são simuladas e nenhuma gravação de disco ou imagem é executada.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Alvo</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Sistema operacional</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Pacote de driver</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Carregando discos de destino...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Falha na descoberta do disco de destino: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Nenhum disco detectado.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Discos de destino carregados: {0} detectados.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Sistema operacional</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Versão</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Idioma</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Página de progresso</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Página de sucesso</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Página de erro</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Visualização de depuração: página de progresso.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Visualização de depuração: página de sucesso.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Visualização de depuração: página de erro.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Visualização de depuração: DISM aplicação falhou porque a partição de destino é somente leitura.
 
 Código de erro = 0x80070005
@@ -144,7 +136,6 @@ Ação: Verifique os atributos do disco e tente novamente a implantação.</valu
   <data name="Common.Previous" xml:space="preserve"><value>Anterior</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Próximo</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Implantar</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Abrir registro</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Indisponível</value></data>
   <data name="Common.None" xml:space="preserve"><value>Nenhum</value></data>
@@ -176,7 +167,6 @@ Ação: Verifique os atributos do disco e tente novamente a implantação.</valu
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Bloqueado: somente leitura</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Bloqueado: off-line</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>DEBUGAR ALVO VIRTUAL</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Disco selecionado bloqueado: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>O disco de destino {0} não está mais presente.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>O disco de destino {0} está bloqueado: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Confirme o apagamento do disco</value></data>
@@ -190,26 +180,11 @@ Tamanho: {3}
 Sistema operacional: {4}
 
 Continuar com a implantação?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Selecione um sistema operacional.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Insira um nome de computador válido.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Selecione um disco de destino.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Selecione um modelo ou versão OEM válido antes de iniciar a implantação.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Selecione um perfil Autopilot ou desative Autopilot antes de iniciar a implantação.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Implantação cancelada pelo usuário.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Preparação de implantação concluída.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Pronto</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Aguardando implantação...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Aguardando progresso...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Preparando implantação...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>A implantação foi iniciada.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Implantação concluída.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Fluxo de trabalho de implantação concluído.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Implantação cancelada.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>A implantação falhou.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Falha na implantação: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Outra operação já está em execução.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Modo de segurança de depuração ativado: ações de implantação são simuladas.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Iniciando o fluxo de trabalho de implantação.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Etapa inicial...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Iniciando {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Iniciando {0}...</value></data>
@@ -219,10 +194,6 @@ Continuar com a implantação?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>Em andamento...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Etapa:? de?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Etapa: {0} de {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Reiniciando agora...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>O comando de reinicialização falhou.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Falha no comando de reinicialização: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Não foi possível abrir o arquivo de log: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe falhou com o código de saída {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Reinicialização do sistema</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>O executável de reinicialização necessária 'wpeutil.exe' não foi encontrado.</value></data>

--- a/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Întuneric</value></data>
   <data name="Language.English" xml:space="preserve"><value>engleză</value></data>
   <data name="Language.French" xml:space="preserve"><value>francez</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Actualizează cataloagele</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Actualizează discurile țintă</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Deschideți fișierul jurnal</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Modul de simulare este activ: acțiunile de implementare sunt simulate și nu sunt efectuate scrieri pe disc sau imagini.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Țintă</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Sistem de operare</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Pachet de șoferi</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Se încarcă discurile țintă...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Descoperirea discului țintă a eșuat: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Nu au fost detectate discuri.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Discuri țintă încărcate: {0} detectate.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Sistem de operare</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Versiune</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Limba</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Pagina de progres</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Pagina de succes</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Pagina de eroare</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Previzualizare depanare: pagina de progres.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Previzualizare depanare: pagina de succes.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Previzualizare depanare: pagina de eroare.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Previzualizare depanare: DISM aplicarea eșuată deoarece partiția țintă este doar pentru citire.
 
 ErrorCode=0x80070005
@@ -144,7 +136,6 @@ Acțiune: Verificați atributele discului și reîncercați implementarea.</valu
   <data name="Common.Previous" xml:space="preserve"><value>Anterior</value></data>
   <data name="Common.Next" xml:space="preserve"><value>În continuare</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Implementează</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Deschideți jurnalul</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Indisponibil</value></data>
   <data name="Common.None" xml:space="preserve"><value>Niciuna</value></data>
@@ -176,7 +167,6 @@ Acțiune: Verificați atributele discului și reîncercați implementarea.</valu
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Blocat: numai pentru citire</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Blocat: offline</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>DEBUG ȚINTĂ VIRTUALĂ</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Discul selectat blocat: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Discul țintă {0} nu mai este prezent.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Discul țintă {0} este blocat: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Confirmați ștergerea discului</value></data>
@@ -190,26 +180,11 @@ Dimensiune: {3}
 Sistem de operare: {4}
 
 Continuați cu implementarea?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Selectați un sistem de operare.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Introduceți un nume valid de computer.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Selectați un disc țintă.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Selectați un model sau o versiune OEM validă înainte de a începe implementarea.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Selectați un profil Autopilot sau dezactivați Autopilot înainte de a începe implementarea.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Implementarea a fost anulată de utilizator.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Pregătirea pentru desfășurare a fost finalizată.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Gata</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Se așteaptă implementarea...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>În așteptarea progresului...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Se pregătește implementarea...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>A început implementarea.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Implementare finalizată.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Flux de lucru de implementare finalizat.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Implementarea a fost anulată.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Implementarea a eșuat.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Implementarea a eșuat: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>O altă operațiune este deja în curs de desfășurare.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Modul sigur de depanare activat: acțiunile de implementare sunt simulate.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Se începe fluxul de lucru de implementare.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Începe pasul...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Începând cu {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Începând cu {0}...</value></data>
@@ -219,10 +194,6 @@ Continuați cu implementarea?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>În curs...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Pasul:? de?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Pas: {0} din {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Se repornește acum...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Comanda de repornire a eșuat.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Comanda de repornire a eșuat: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Nu se poate deschide fișierul jurnal: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe a eșuat cu codul de ieșire {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Repornirea sistemului</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Executabilul de repornire obligatoriu „wpeutil.exe” nu a fost găsit.</value></data>

--- a/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Темный</value></data>
   <data name="Language.English" xml:space="preserve"><value>английский</value></data>
   <data name="Language.French" xml:space="preserve"><value>французский</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Обновить каталоги</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Обновить целевые диски</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Открыть файл журнала</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Режим моделирования активен: действия по развертыванию моделируются, запись на диск или образ не выполняется.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Цель</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Операционная система</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Пакет драйверов</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>переменного тока</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Загрузка целевых дисков...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Не удалось обнаружить целевой диск: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Диски не обнаружены.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Загружены целевые диски: обнаружен {0}.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Операционная система</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Версия</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Язык</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Страница прогресса</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Страница успеха</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Страница ошибки</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Предварительный просмотр отладки: страница прогресса.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Предварительный просмотр отладки: страница успеха.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Предварительный просмотр отладки: страница ошибки.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Предварительный просмотр отладки: DISM применить не удалось, поскольку целевой раздел доступен только для чтения.
 
 Код ошибки=0x80070005
@@ -144,7 +136,6 @@
   <data name="Common.Previous" xml:space="preserve"><value>Предыдущий</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Далее</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Развертывание</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Открыть журнал</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>Н/Д</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Недоступно</value></data>
   <data name="Common.None" xml:space="preserve"><value>Нет</value></data>
@@ -176,7 +167,6 @@
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Заблокировано: только чтение</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Заблокировано: офлайн</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>ОТЛАДКА ВИРТУАЛЬНОЙ ЦЕЛИ</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Выбранный диск заблокирован: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Целевой диск {0} больше не существует.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Целевой диск {0} заблокирован: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Подтвердить очистку диска</value></data>
@@ -190,26 +180,11 @@
 Операционная система: {4}
 
 Продолжить развертывание?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Выберите операционную систему.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Введите допустимое имя компьютера.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Выберите целевой диск.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Перед началом развертывания выберите действующую OEM-модель или версию.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Выберите профиль Autopilot или отключите Autopilot перед началом развертывания.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Развертывание отменено пользователем.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Подготовка к развертыванию завершена.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Готово</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Ожидание развертывания...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Ждем прогресса...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Подготовка развертывания...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Развертывание началось.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Развертывание завершено.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Рабочий процесс развертывания завершен.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Развертывание отменено.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Развертывание не удалось.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Развертывание не удалось: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Другая операция уже выполняется.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Включен безопасный режим отладки: действия по развертыванию моделируются.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Запуск рабочего процесса развертывания.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Начальный шаг...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Начинаем {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Начинаем {0}...</value></data>
@@ -219,10 +194,6 @@
   <data name="Status.InProgress" xml:space="preserve"><value>В процессе...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Шаг:? из?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Шаг: {0} из {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Перезагружаюсь сейчас...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Команда перезагрузки не удалась.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Не удалось выполнить команду перезагрузки: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Невозможно открыть файл журнала: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe завершился с ошибкой с кодом завершения {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Перезагрузка системы</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Требуемый исполняемый файл перезагрузки «wpeutil.exe» не найден.</value></data>

--- a/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Tmavý</value></data>
   <data name="Language.English" xml:space="preserve"><value>angličtina</value></data>
   <data name="Language.French" xml:space="preserve"><value>francúzsky</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Obnoviť katalógy</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Obnovte cieľové disky</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Otvorte súbor denníka</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Režim simulácie je aktívny: akcie nasadenia sa simulujú a nevykonávajú sa žiadne zápisy na disk alebo obraz.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Cieľ</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operačný systém</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Balík ovládačov</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Načítavam cieľové disky...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Zistenie cieľového disku zlyhalo: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Neboli zistené žiadne disky.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Načítané cieľové disky: Zistil sa {0}.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Operačný systém</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Verzia</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Jazyk</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Stránka pokroku</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Úspešná stránka</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Chybová stránka</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Ukážka ladenia: stránka priebehu.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Ukážka ladenia: stránka úspechu.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Ukážka ladenia: chybová stránka.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Ukážka ladenia: Aplikácia DISM zlyhala, pretože cieľový oddiel je len na čítanie.
 
 ErrorCode=0x80070005
@@ -144,7 +136,6 @@ Akcia: Overte atribúty disku a zopakujte nasadenie.</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Predchádzajúce</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Ďalej</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Nasadiť</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Otvorte denník</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>nedostupné</value></data>
   <data name="Common.None" xml:space="preserve"><value>žiadne</value></data>
@@ -176,7 +167,6 @@ Akcia: Overte atribúty disku a zopakujte nasadenie.</value></data>
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Blokované: iba na čítanie</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Blokované: offline</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>LADIŤ VIRTUÁLNY CIEĽ</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Vybraný disk je zablokovaný: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Cieľový disk {0} už nie je prítomný.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Cieľový disk {0} je zablokovaný: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Potvrďte vymazanie disku</value></data>
@@ -190,26 +180,11 @@ Veľkosť: {3}
 Operačný systém: {4}
 
 Pokračovať v nasadzovaní?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Vyberte operačný systém.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Zadajte platný názov počítača.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Vyberte cieľový disk.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Pred spustením nasadenia vyberte platný model alebo verziu OEM.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Pred spustením nasadenia vyberte profil Autopilot alebo zakážte Autopilot.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Nasadenie bolo zrušené používateľom.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Príprava na nasadenie dokončená.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Pripravený</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Čaká sa na nasadenie...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Čakanie na pokrok...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Pripravuje sa nasadenie...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Nasadzovanie začalo.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Nasadenie dokončené.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Pracovný postup nasadenia bol dokončený.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Nasadenie bolo zrušené.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Nasadenie zlyhalo.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Nasadenie zlyhalo: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Ďalšia operácia už prebieha.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Povolený bezpečný režim ladenia: akcie nasadenia sú simulované.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Spustenie pracovného postupu nasadenia.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Začiatočný krok...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Začína {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Začína {0}...</value></data>
@@ -219,10 +194,6 @@ Pokračovať v nasadzovaní?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>Prebieha...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Krok:? z?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Krok: {0} z {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Teraz sa reštartuje...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Príkaz reštartu zlyhal.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Príkaz reštartu zlyhal: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Nie je možné otvoriť súbor denníka: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe zlyhal s kódom ukončenia {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Reštart systému</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Požadovaný reštartovací spustiteľný súbor „wpeutil.exe“ sa nenašiel.</value></data>

--- a/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Temno</value></data>
   <data name="Language.English" xml:space="preserve"><value>angleščina</value></data>
   <data name="Language.French" xml:space="preserve"><value>francosko</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Osvežite kataloge</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Osveži ciljne diske</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Odpri datoteko dnevnika</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Način simulacije je aktiven: dejanja uvajanja so simulirana in zapisovanje na disk ali sliko se ne izvaja.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Tarča</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operacijski sistem</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Paket voznikov</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Nalaganje ciljnih diskov...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Odkrivanje ciljnega diska ni uspelo: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Ni zaznanih diskov.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Naloženi ciljni diski: {0} zaznan.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Operacijski sistem</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Različica</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Jezik</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Stran napredka</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Uspešna stran</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Stran z napako</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Predogled odpravljanja napak: stran napredka.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Predogled odpravljanja napak: uspešna stran.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Predogled odpravljanja napak: stran z napako.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Predogled odpravljanja napak: uporaba DISM ni uspela, ker je ciljna particija samo za branje.
 
 Koda napake=0x80070005
@@ -144,7 +136,6 @@ Ukrep: Preverite atribute diska in znova poskusite razmestiti.</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Prejšnja</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Naprej</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Razporedi</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Odpri dnevnik</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Ni na voljo</value></data>
   <data name="Common.None" xml:space="preserve"><value>Noben</value></data>
@@ -176,7 +167,6 @@ Ukrep: Preverite atribute diska in znova poskusite razmestiti.</value></data>
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Blokirano: samo za branje</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Blokirano: brez povezave</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>RAZHROŠČEVANJE VIRTUALNEGA CILJA</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Izbrani disk blokiran: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Ciljni disk {0} ni več prisoten.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Ciljni disk {0} je blokiran: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Potrdite brisanje diska</value></data>
@@ -190,26 +180,11 @@ Velikost: {3}
 Operacijski sistem: {4}
 
 Ali želite nadaljevati z uvajanjem?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Izberite operacijski sistem.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Vnesite veljavno ime računalnika.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Izberite ciljni disk.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Pred začetkom uvajanja izberite veljaven model ali različico OEM.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Pred začetkom uvajanja izberite profil Autopilot ali onemogočite Autopilot.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Uporabnik je preklical uvajanje.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Priprave na uvedbo so končane.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>pripravljena</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Čakanje na uvedbo...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Čakanje na napredek...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Priprava uvajanja...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Uvajanje se je začelo.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Razmestitev končana.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Delovni tok uvajanja je končan.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Razporeditev preklicana.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Razmestitev ni uspela.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Namestitev ni uspela: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Druga operacija že poteka.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Varni način za odpravljanje napak je omogočen: dejanja uvajanja so simulirana.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Začetek delovnega toka uvajanja.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Začetni korak...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Zagon {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Zagon {0}...</value></data>
@@ -219,10 +194,6 @@ Ali želite nadaljevati z uvajanjem?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>V teku...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>korak:? od?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Korak: {0} od {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Ponovni zagon zdaj...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Ukaz za ponovni zagon ni uspel.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Ukaz za ponovni zagon ni uspel: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Datoteke dnevnika ni mogoče odpreti: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe ni uspelo z izhodno kodo {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Ponovni zagon sistema</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Zahtevane izvedljive datoteke za ponovni zagon 'wpeutil.exe' ni bilo mogoče najti.</value></data>

--- a/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Dark</value></data>
   <data name="Language.English" xml:space="preserve"><value>engleski</value></data>
   <data name="Language.French" xml:space="preserve"><value>francuski</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Osvežite kataloge</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Osvežite ciljne diskove</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Otvorite datoteku evidencije</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Režim simulacije je aktivan: radnje primene se simuliraju i ne vrši se upis na disk ili sliku.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Target</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operativni sistem</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Paket drajvera</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Učitavanje ciljnih diskova...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Otkrivanje ciljnog diska nije uspelo: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Nije otkriven nijedan disk.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Učitani ciljni diskovi: {0} otkriven.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Operativni sistem</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Version</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Jezik</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Stranica napretka</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Stranica uspeha</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Stranica sa greškom</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Pregled otklanjanja grešaka: stranica napretka.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Pregled otklanjanja grešaka: stranica o uspehu.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Pregled otklanjanja grešaka: stranica sa greškom.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Pregled otklanjanja grešaka: DISM primena nije uspela jer je ciljna particija samo za čitanje.
 
 ErrorCode=0k80070005
@@ -144,7 +136,6 @@ Radnja: Proverite atribute diska i pokušajte ponovo da ga primenite.</value></d
   <data name="Common.Previous" xml:space="preserve"><value>Prethodno</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Sledeće</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Deploi</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Otvori dnevnik</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Nedostupno</value></data>
   <data name="Common.None" xml:space="preserve"><value>Nijedan</value></data>
@@ -176,7 +167,6 @@ Radnja: Proverite atribute diska i pokušajte ponovo da ga primenite.</value></d
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Blokirano: samo za čitanje</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Blokirano: van mreže</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>DEBUG VIRTUAL TARGET</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Izabrani disk blokiran: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Ciljni disk {0} više nije prisutan.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Ciljni disk {0} je blokiran: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Potvrdite brisanje diska</value></data>
@@ -190,26 +180,11 @@ Veličina: {3}
 Operativni sistem: {4}
 
 Želite li da nastavite sa primenom?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Izaberite operativni sistem.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Unesite važeće ime računara.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Izaberite ciljni disk.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Izaberite važeći OEM model ili verziju pre početka primene.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Izaberite Autopilot profil ili onemogućite Autopilot pre početka primene.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Korisnik je otkazao primenu.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Priprema za raspoređivanje je završena.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Spreman</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Čeka se raspoređivanje...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Čeka se napredak...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Priprema raspoređivanja...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Raspoređivanje je počelo.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Raspoređivanje je završeno.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Radni tok implementacije je završen.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Primena je otkazana.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Primena nije uspela.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Primena nije uspela: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Druga operacija je već u toku.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Bezbedan režim za otklanjanje grešaka je omogućen: radnje primene su simulirane.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Pokretanje radnog toka implementacije.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Početni korak...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Počinje {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Počinje {0}...</value></data>
@@ -219,10 +194,6 @@ Operativni sistem: {4}
   <data name="Status.InProgress" xml:space="preserve"><value>U toku...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Korak:? od?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Korak: {0} od {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Ponovno pokretanje sada...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Komanda za ponovno pokretanje nije uspela.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Komanda za ponovno pokretanje nije uspela: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Nije moguće otvoriti datoteku evidencije: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe nije uspeo sa izlaznim kodom {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Ponovno pokretanje sistema</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Potrebna izvršna datoteka za ponovno pokretanje „wpeutil.exe“ nije pronađena.</value></data>

--- a/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Mörkt</value></data>
   <data name="Language.English" xml:space="preserve"><value>engelska</value></data>
   <data name="Language.French" xml:space="preserve"><value>franska</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Uppdatera kataloger</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Uppdatera måldiskar</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Öppna loggfilen</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Simuleringsläget är aktivt: distributionsåtgärder simuleras och inga disk- eller bildskrivningar utförs.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Mål</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Operativsystem</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Förarpaket</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Laddar måldiskar...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Måldiskupptäckt misslyckades: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Inga diskar upptäckts.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Måldiskar laddade: {0} upptäckt.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Operativsystem</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Version</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Språk</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Framstegssida</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Framgångssida</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Felsida</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Förhandsgranskning av felsökning: förloppssida.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Förhandsvisning av felsökning: framgångssida.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Felsökningsförhandsgranskning: felsida.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Felsökningsförhandsgranskning: DISM applikationen misslyckades eftersom målpartitionen är skrivskyddad.
 
 ErrorCode=0x80070005
@@ -144,7 +136,6 @@ Detaljer: Åtkomst nekad vid montering av bild till målsökväg.
   <data name="Common.Previous" xml:space="preserve"><value>Föregående</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Nästa</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Distribuera</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Öppna loggen</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Ej tillgänglig</value></data>
   <data name="Common.None" xml:space="preserve"><value>Inga</value></data>
@@ -176,7 +167,6 @@ Detaljer: Åtkomst nekad vid montering av bild till målsökväg.
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Blockerad: skrivskyddad</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Blockerad: offline</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>DEBUGA VIRTUELLT MÅL</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Vald disk blockerad: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Måldisken {0} finns inte längre.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Måldisken {0} är blockerad: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Bekräfta diskradering</value></data>
@@ -190,26 +180,11 @@ Storlek: {3}
 Operativsystem: {4}
 
 Fortsätt med implementeringen?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Välj ett operativsystem.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Ange ett giltigt datornamn.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Välj en måldisk.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Välj en giltig OEM-modell eller -version innan du startar distributionen.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Välj en Autopilot-profil eller inaktivera Autopilot innan du startar distributionen.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Implementeringen avbröts av användaren.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Implementeringsförberedelserna slutförda.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Klar</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Väntar på implementering...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>Väntar på framsteg...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Förbereder implementering...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Implementeringen startade.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Implementeringen slutförd.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Implementeringsarbetsflödet slutfört.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Implementeringen avbröts.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Implementeringen misslyckades.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Implementeringen misslyckades: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>En annan operation körs redan.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Felsökning av felsäkert läge aktiverat: implementeringsåtgärder simuleras.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Startar implementeringsarbetsflödet.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Startsteg...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Startar {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Startar {0}...</value></data>
@@ -219,10 +194,6 @@ Fortsätt med implementeringen?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>Pågår...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Steg:? av?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Steg: {0} av {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Startar om nu...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Reboot-kommandot misslyckades.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Omstartskommandot misslyckades: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Det går inte att öppna loggfilen: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe misslyckades med utgångskoden {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Systemstart</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Krävd omstart körbar "wpeutil.exe" hittades inte.</value></data>

--- a/src/Foundry.Deploy/Strings/th-TH/Resources.resx
+++ b/src/Foundry.Deploy/Strings/th-TH/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>มืด</value></data>
   <data name="Language.English" xml:space="preserve"><value>อังกฤษ</value></data>
   <data name="Language.French" xml:space="preserve"><value>ฝรั่งเศส</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>รีเฟรชแคตตาล็อก</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>รีเฟรชดิสก์เป้าหมาย</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>เปิดไฟล์บันทึก</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>โหมดการจำลองทำงานอยู่: มีการจำลองการดำเนินการปรับใช้และไม่มีการเขียนดิสก์หรืออิมเมจ</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. เป้าหมาย</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. ระบบปฏิบัติการ</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. ชุดไดรเวอร์</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>เครื่องปรับอากาศ</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>กำลังโหลดดิสก์เป้าหมาย...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>การค้นพบดิสก์เป้าหมายล้มเหลว: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>ไม่พบดิสก์</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>โหลดดิสก์เป้าหมาย: ตรวจพบ {0}</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>ระบบปฏิบัติการ</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>เวอร์ชัน</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>ภาษา</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>หน้าความคืบหน้า</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>หน้าความสำเร็จ</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>หน้าข้อผิดพลาด</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>ตัวอย่างการแก้ไขข้อบกพร่อง: หน้าความคืบหน้า</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>ตัวอย่างการแก้ไขข้อบกพร่อง: หน้าความสำเร็จ</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>ตัวอย่างการแก้ไขข้อบกพร่อง: หน้าข้อผิดพลาด</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>ตัวอย่างการแก้ไขข้อบกพร่อง: DISM ใช้ล้มเหลวเนื่องจากพาร์ติชันเป้าหมายเป็นแบบอ่านอย่างเดียว
 
 รหัสข้อผิดพลาด=0x80070005
@@ -144,7 +136,6 @@
   <data name="Common.Previous" xml:space="preserve"><value>ก่อนหน้า</value></data>
   <data name="Common.Next" xml:space="preserve"><value>ถัดไป</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>ปรับใช้</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>เปิดบันทึก</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>ไม่มี</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>ไม่พร้อมใช้งาน</value></data>
   <data name="Common.None" xml:space="preserve"><value>ไม่มี</value></data>
@@ -176,7 +167,6 @@
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>ถูกบล็อก: อ่านอย่างเดียว</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>ถูกบล็อก: ออฟไลน์</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>แก้ไขข้อบกพร่องเป้าหมายเสมือน</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>ดิสก์ที่เลือกถูกบล็อก: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>ดิสก์เป้าหมาย {0} ไม่มีอยู่อีกต่อไป</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>ดิสก์เป้าหมาย {0} ถูกบล็อก: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>ยืนยันการลบดิสก์</value></data>
@@ -190,26 +180,11 @@
 ระบบปฏิบัติการ: {4}
 
 ดำเนินการปรับใช้ต่อไปหรือไม่</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>เลือกระบบปฏิบัติการ</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>ป้อนชื่อคอมพิวเตอร์ที่ถูกต้อง</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>เลือกดิสก์เป้าหมาย</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>เลือกรุ่นหรือเวอร์ชัน OEM ที่ถูกต้องก่อนเริ่มการปรับใช้</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>เลือกโปรไฟล์ Autopilot หรือปิดใช้งาน Autopilot ก่อนที่จะเริ่มการปรับใช้</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>การทำให้ใช้งานได้ถูกยกเลิกโดยผู้ใช้</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>การเตรียมการปรับใช้เสร็จสมบูรณ์</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>พร้อม</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>กำลังรอการทำให้ใช้งานได้...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>รอความคืบหน้า...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>กำลังเตรียมการทำให้ใช้งานได้...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>เริ่มปรับใช้แล้ว</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>การปรับใช้เสร็จสมบูรณ์</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>เวิร์กโฟลว์การทำให้ใช้งานได้เสร็จสมบูรณ์</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>ยกเลิกการทำให้ใช้งานได้แล้ว</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>การทำให้ใช้งานได้ล้มเหลว</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>การปรับใช้ล้มเหลว: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>การดำเนินการอื่นกำลังทำงานอยู่แล้ว</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>เปิดใช้งานการแก้ไขข้อบกพร่องในโหมดปลอดภัยแล้ว: มีการจำลองการดำเนินการปรับใช้</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>กำลังเริ่มเวิร์กโฟลว์การทำให้ใช้งานได้</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>ขั้นเริ่มต้น...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>เริ่ม {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>เริ่ม {0}...</value></data>
@@ -219,10 +194,6 @@
   <data name="Status.InProgress" xml:space="preserve"><value>อยู่ระหว่างดำเนินการ...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>ขั้นตอน:? ของ?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>ขั้นตอน: {0} จาก {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>กำลังรีบูตตอนนี้...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>คำสั่งรีบูตล้มเหลว</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>คำสั่งการรีบูตล้มเหลว: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>ไม่สามารถเปิดไฟล์บันทึกได้: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe ล้มเหลวด้วยรหัสออก {0} {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>รีบูตระบบ</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>ไม่พบไฟล์ปฏิบัติการรีบูตที่จำเป็น 'wpeutil.exe'</value></data>

--- a/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Karanlık</value></data>
   <data name="Language.English" xml:space="preserve"><value>İngilizce</value></data>
   <data name="Language.French" xml:space="preserve"><value>Fransızca</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Katalogları yenile</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Hedef diskleri yenile</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Günlük dosyasını aç</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Simülasyon modu etkin: dağıtım eylemleri simüle edilir ve herhangi bir disk veya görüntü yazma işlemi gerçekleştirilmez.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Hedef</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. İşletim sistemi</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Sürücü paketi</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>klima</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Hedef diskler yükleniyor...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Hedef disk keşfi başarısız oldu: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Hiçbir disk algılanmadı.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Yüklenen hedef diskler: {0} algılandı.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>İşletim sistemi</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Sürüm</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Dil</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>İlerleme sayfası</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Başarı sayfası</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Hata sayfası</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Hata ayıklama önizlemesi: ilerleme sayfası.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Hata ayıklama önizlemesi: başarı sayfası.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Hata ayıklama önizlemesi: hata sayfası.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Hata ayıklama önizlemesi: DISM uygulaması, hedef bölüm salt okunur olduğundan başarısız oldu.
 
 HataKodu=0x80070005
@@ -144,7 +136,6 @@ Eylem: Disk özniteliklerini doğrulayın ve dağıtımı yeniden deneyin.</valu
   <data name="Common.Previous" xml:space="preserve"><value>Önceki</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Sonraki</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Dağıt</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Günlüğü aç</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>Yok</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Kullanılamıyor</value></data>
   <data name="Common.None" xml:space="preserve"><value>Yok</value></data>
@@ -176,7 +167,6 @@ Eylem: Disk özniteliklerini doğrulayın ve dağıtımı yeniden deneyin.</valu
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Engellendi: salt okunur</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Engellendi: çevrimdışı</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>SANAL HEDEFTE HATA AYIKLAMA</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Seçilen disk engellendi: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Hedef disk {0} artık mevcut değil.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Hedef disk {0} engellendi: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Disk silmeyi onayla</value></data>
@@ -190,26 +180,11 @@ Boyut: {3}
 İşletim sistemi: {4}
 
 Dağıtıma devam edilsin mi?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Bir işletim sistemi seçin.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Geçerli bir bilgisayar adı girin.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Bir hedef disk seçin.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Dağıtıma başlamadan önce geçerli bir OEM modeli veya sürümü seçin.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Dağıtıma başlamadan önce bir Autopilot profili seçin veya Autopilot'yi devre dışı bırakın.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Dağıtım kullanıcı tarafından iptal edildi.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Dağıtım hazırlığı tamamlandı.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Hazır</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Dağıtım bekleniyor...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>İlerleme bekleniyor...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Dağıtım hazırlanıyor...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Dağıtım başladı.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Dağıtım tamamlandı.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Dağıtım iş akışı tamamlandı.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Dağıtım iptal edildi.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Dağıtım başarısız oldu.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Dağıtım başarısız oldu: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Başka bir işlem zaten çalışıyor.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Hata ayıklama güvenli modu etkin: dağıtım eylemleri simüle edilir.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Dağıtım iş akışı başlatılıyor.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Başlangıç adımı...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>{0} başlatılıyor.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>{0} başlatılıyor...</value></data>
@@ -219,10 +194,6 @@ Dağıtıma devam edilsin mi?</value></data>
   <data name="Status.InProgress" xml:space="preserve"><value>Devam ediyor...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Adım:? ile ilgili?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Adım: {0} / {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Şimdi yeniden başlatılıyor...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Yeniden başlatma komutu başarısız oldu.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Yeniden başlatma komutu başarısız oldu: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Günlük dosyası açılamıyor: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe {0} çıkış koduyla başarısız oldu. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Sistem yeniden başlat</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Gerekli yeniden başlatma yürütülebilir dosyası 'wpeutil.exe' bulunamadı.</value></data>

--- a/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>Темний</value></data>
   <data name="Language.English" xml:space="preserve"><value>англійська</value></data>
   <data name="Language.French" xml:space="preserve"><value>французька</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>Оновити каталоги</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>Оновити цільові диски</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>Відкрити файл журналу</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>Режим симуляції активний: імітуються дії розгортання, а запис на диск або образ не виконується.</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. Цільовий</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2. Операційна система</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3. Пакет драйверів</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>AC</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>Завантаження цільових дисків...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>Не вдалося знайти цільовий диск: {0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>Дисків не виявлено.</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>Завантажено цільові диски: виявлено {0}.</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>Операційна система</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>Версія</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>Мова</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>Сторінка прогресу</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>Сторінка успіху</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>Сторінка помилки</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>Попередній перегляд налагодження: сторінка прогресу.</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>Попередній перегляд налагодження: успішна сторінка.</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>Попередній перегляд налагодження: сторінка помилки.</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>Попередній перегляд налагодження: не вдалося застосувати DISM, оскільки цільовий розділ доступний лише для читання.
 
 ErrorCode=0x80070005
@@ -144,7 +136,6 @@ ErrorCode=0x80070005
   <data name="Common.Previous" xml:space="preserve"><value>Попередній</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Далі</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>Розгорнути</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>Відкрити журнал</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>N/A</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>Недоступний</value></data>
   <data name="Common.None" xml:space="preserve"><value>Жодного</value></data>
@@ -176,7 +167,6 @@ ErrorCode=0x80070005
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>Заблоковано: лише для читання</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>Заблоковано: офлайн</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>НАЛАДУВАННЯ ВІРТУАЛЬНОЇ ЦІЛІ</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>Вибраний диск заблоковано: {0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>Цільового диска {0} більше немає.</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>Цільовий диск {0} заблоковано: {1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>Підтвердити стирання диска</value></data>
@@ -190,26 +180,11 @@ ErrorCode=0x80070005
 Операційна система: {4}
 
 Продовжити розгортання?</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>Виберіть операційну систему.</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>Введіть дійсне ім’я комп’ютера.</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>Виберіть цільовий диск.</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>Виберіть дійсну модель або версію OEM перед початком розгортання.</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>Виберіть профіль Autopilot або вимкніть Autopilot перед початком розгортання.</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>Розгортання скасовано користувачем.</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>Підготовку до розгортання завершено.</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>Готовий</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>Очікування розгортання...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>В очікуванні прогресу...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>Підготовка до розгортання...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>Розгортання розпочато.</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>Розгортання завершено.</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>Робочий процес розгортання завершено.</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>Розгортання скасовано.</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>Помилка розгортання.</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>Помилка розгортання: {0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>Інша операція вже виконується.</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>Увімкнено безпечний режим налагодження: імітуються дії розгортання.</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>Початок процесу розгортання.</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>Початковий крок...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>Починаючи з {0}.</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>Запуск {0}...</value></data>
@@ -219,10 +194,6 @@ ErrorCode=0x80070005
   <data name="Status.InProgress" xml:space="preserve"><value>В процесі...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>Крок:? з?</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>Крок: {0} з {1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>Перезавантаження зараз...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>Не вдалося виконати команду перезавантаження.</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>Помилка команди перезавантаження: {0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>Не вдається відкрити файл журналу: {0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>Помилка wpeutil.exe із кодом виходу {0}. {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>Перезавантаження системи</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>Виконуваний файл wpeutil.exe, необхідний для перезавантаження, не знайдено.</value></data>

--- a/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>黑暗</value></data>
   <data name="Language.English" xml:space="preserve"><value>英语</value></data>
   <data name="Language.French" xml:space="preserve"><value>法语</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>刷新目录</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>刷新目标磁盘</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>打开日志文件</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>模拟模式处于活动状态：模拟部署操作，并且不执行磁盘或映像写入。</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. 目标</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2、操作系统</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3.驱动包</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>交流电</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>正在加载目标磁盘...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>目标磁盘发现失败：{0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>未检测到磁盘。</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>已加载目标磁盘：检测到{0}。</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>操作系统</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>版本</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>语言</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>进度页面</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>成功页面</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>错误页面</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>调试预览：进度页面。</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>调试预览：成功页面。</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>调试预览：错误页面。</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>调试预览：DISM 应用失败，因为目标分区是只读的。
 
 错误代码=0x80070005
@@ -144,7 +136,6 @@
   <data name="Common.Previous" xml:space="preserve"><value>上一页</value></data>
   <data name="Common.Next" xml:space="preserve"><value>下一步</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>部署</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>打开日志</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>不适用</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>不可用</value></data>
   <data name="Common.None" xml:space="preserve"><value>无</value></data>
@@ -176,7 +167,6 @@
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>已阻止：只读</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>已阻止：离线</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>调试虚拟目标</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>选定的磁盘被阻止：{0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>目标磁盘{0} 不再存在。</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>目标磁盘{0}被阻止：{1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>确认磁盘擦除</value></data>
@@ -190,26 +180,11 @@
 操作系统：{4}
 
 继续部署吗？</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>选择操作系统。</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>输入有效的计算机名称。</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>选择目标磁盘。</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>在开始部署之前选择有效的 OEM 型号或版本。</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>在开始部署之前，选择Autopilot 配置文件或禁用Autopilot。</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>部署已被用户取消。</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>部署准备工作完成。</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>准备好</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>等待部署...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>等待进展...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>正在准备部署...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>部署开始。</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>部署完成。</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>部署工作流程已完成。</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>部署已取消。</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>部署失败。</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>部署失败：{0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>另一个操作已经在运行。</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>启用调试安全模式：模拟部署操作。</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>开始部署工作流程。</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>开始步骤...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>开始{0}。</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>开始{0}...</value></data>
@@ -219,10 +194,6 @@
   <data name="Status.InProgress" xml:space="preserve"><value>进行中...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>步骤：?的 ？</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>步骤：{0}的{1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>现在正在重新启动...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>重新启动命令失败。</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>重启命令失败：{0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>无法打开日志文件：{0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe 失败，退出代码{0}。 {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>系统重启</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>未找到所需的重新启动可执行文件“wpeutil.exe”。</value></data>

--- a/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
@@ -28,10 +28,7 @@
   <data name="Theme.Dark" xml:space="preserve"><value>黑暗</value></data>
   <data name="Language.English" xml:space="preserve"><value>英語</value></data>
   <data name="Language.French" xml:space="preserve"><value>法語</value></data>
-  <data name="Tools.RefreshCatalogs" xml:space="preserve"><value>刷新目錄</value></data>
-  <data name="Tools.RefreshTargetDisks" xml:space="preserve"><value>刷新目標磁碟</value></data>
   <data name="Tools.OpenLogFile" xml:space="preserve"><value>打開日誌文件</value></data>
-  <data name="Wizard.DebugSafeModeBanner" xml:space="preserve"><value>模擬模式處於活動狀態：模擬部署操作，且不執行磁碟或映像寫入。</value></data>
   <data name="Wizard.StepTarget" xml:space="preserve"><value>1. 目標</value></data>
   <data name="Wizard.StepOperatingSystemCatalog" xml:space="preserve"><value>2、作業系統</value></data>
   <data name="Wizard.StepDriverPack" xml:space="preserve"><value>3.驅動包</value></data>
@@ -74,8 +71,6 @@
   <data name="Preparation.PowerAc" xml:space="preserve"><value>交流電</value></data>
   <data name="Preparation.LoadingTargetDisks" xml:space="preserve"><value>正在載入目標磁碟...</value></data>
   <data name="Preparation.TargetDiskDiscoveryFailedFormat" xml:space="preserve"><value>目標磁碟發現失敗：{0}</value></data>
-  <data name="Preparation.NoDisksDetected" xml:space="preserve"><value>未偵測到磁碟。</value></data>
-  <data name="Preparation.TargetDisksLoadedFormat" xml:space="preserve"><value>已載入目標磁碟：偵測到{0}。</value></data>
   <data name="Catalog.OperatingSystem" xml:space="preserve"><value>作業系統</value></data>
   <data name="Catalog.Version" xml:space="preserve"><value>版本</value></data>
   <data name="Catalog.Language" xml:space="preserve"><value>語言</value></data>
@@ -131,9 +126,6 @@
   <data name="Debug.ProgressPageCommand" xml:space="preserve"><value>進度頁面</value></data>
   <data name="Debug.SuccessPageCommand" xml:space="preserve"><value>成功頁面</value></data>
   <data name="Debug.ErrorPageCommand" xml:space="preserve"><value>錯誤頁面</value></data>
-  <data name="Debug.ProgressPage" xml:space="preserve"><value>調試預覽：進度頁面。</value></data>
-  <data name="Debug.SuccessPage" xml:space="preserve"><value>調試預覽：成功頁面。</value></data>
-  <data name="Debug.ErrorPage" xml:space="preserve"><value>調試預覽：錯誤頁面。</value></data>
   <data name="Debug.ErrorPreviewMessage" xml:space="preserve"><value>偵錯預覽：DISM 應用程式失敗，因為目標分區是唯讀的。
 
 錯誤代碼=0x80070005
@@ -144,7 +136,6 @@
   <data name="Common.Previous" xml:space="preserve"><value>上一頁</value></data>
   <data name="Common.Next" xml:space="preserve"><value>下一步</value></data>
   <data name="Common.Deploy" xml:space="preserve"><value>部署</value></data>
-  <data name="Common.OpenLog" xml:space="preserve"><value>打開日誌</value></data>
   <data name="Common.NotAvailable" xml:space="preserve"><value>不適用</value></data>
   <data name="Common.Unavailable" xml:space="preserve"><value>不可用</value></data>
   <data name="Common.None" xml:space="preserve"><value>無</value></data>
@@ -176,7 +167,6 @@
   <data name="Disk.BlockedReadOnly" xml:space="preserve"><value>已阻止：唯讀</value></data>
   <data name="Disk.BlockedOffline" xml:space="preserve"><value>已阻止：離線</value></data>
   <data name="Disk.DebugVirtualTarget" xml:space="preserve"><value>調試虛擬目標</value></data>
-  <data name="Disk.SelectedBlockedFormat" xml:space="preserve"><value>選定的磁碟被封鎖：{0}</value></data>
   <data name="Disk.TargetMissingFormat" xml:space="preserve"><value>目標磁碟{0} 不再存在。</value></data>
   <data name="Disk.TargetBlockedFormat" xml:space="preserve"><value>目標磁碟{0}被封鎖：{1}</value></data>
   <data name="Launch.ConfirmDiskEraseTitle" xml:space="preserve"><value>確認磁碟清除</value></data>
@@ -190,26 +180,11 @@
 作業系統：{4}
 
 繼續部署嗎？</value></data>
-  <data name="Launch.SelectOperatingSystem" xml:space="preserve"><value>選擇作業系統。</value></data>
-  <data name="Launch.EnterValidComputerName" xml:space="preserve"><value>輸入有效的電腦名稱。</value></data>
-  <data name="Launch.SelectTargetDisk" xml:space="preserve"><value>選擇目標磁碟。</value></data>
-  <data name="Launch.SelectValidOemDriverPack" xml:space="preserve"><value>在開始部署之前選擇有效的 OEM 型號或版本。</value></data>
-  <data name="Launch.SelectAutopilotProfile" xml:space="preserve"><value>在開始部署之前，選擇Autopilot 設定檔或停用Autopilot。</value></data>
-  <data name="Launch.CancelledByUser" xml:space="preserve"><value>部署已被使用者取消。</value></data>
-  <data name="Launch.PreparationCompleted" xml:space="preserve"><value>部署準備工作完成。</value></data>
-  <data name="Status.Ready" xml:space="preserve"><value>準備好</value></data>
   <data name="Status.WaitingForDeployment" xml:space="preserve"><value>等待部署...</value></data>
   <data name="Status.WaitingForProgress" xml:space="preserve"><value>等待進展...</value></data>
   <data name="Status.PreparingDeployment" xml:space="preserve"><value>正在準備部署...</value></data>
-  <data name="Status.DeploymentStarted" xml:space="preserve"><value>部署開始。</value></data>
-  <data name="Status.DeploymentCompleted" xml:space="preserve"><value>部署完成。</value></data>
-  <data name="Status.DeploymentOrchestrationCompleted" xml:space="preserve"><value>部署工作流程已完成。</value></data>
   <data name="Status.DeploymentCancelled" xml:space="preserve"><value>部署已取消。</value></data>
-  <data name="Status.DeploymentFailed" xml:space="preserve"><value>部署失敗。</value></data>
-  <data name="Status.DeploymentFailedFormat" xml:space="preserve"><value>部署失敗：{0}</value></data>
   <data name="Status.AnotherOperationRunning" xml:space="preserve"><value>另一個操作已經在運作。</value></data>
-  <data name="Status.DebugSafeModeEnabled" xml:space="preserve"><value>啟用調試安全模式：模擬部署操作。</value></data>
-  <data name="Status.StartingOrchestration" xml:space="preserve"><value>開始部署工作流程。</value></data>
   <data name="Status.StartingStep" xml:space="preserve"><value>開始步驟...</value></data>
   <data name="Status.StartingStepFormat" xml:space="preserve"><value>開始{0}。</value></data>
   <data name="Status.StartingStepSubProgressFormat" xml:space="preserve"><value>開始{0}...</value></data>
@@ -219,10 +194,6 @@
   <data name="Status.InProgress" xml:space="preserve"><value>進行中...</value></data>
   <data name="Status.StepCounterUnknown" xml:space="preserve"><value>步驟：?的 ？</value></data>
   <data name="Status.StepCounterFormat" xml:space="preserve"><value>步驟：{0}的{1}</value></data>
-  <data name="Status.RebootingNow" xml:space="preserve"><value>現在正在重新啟動...</value></data>
-  <data name="Status.RebootCommandFailed" xml:space="preserve"><value>重新啟動命令失敗。</value></data>
-  <data name="Status.RebootCommandFailedFormat" xml:space="preserve"><value>重啟命令失敗：{0}</value></data>
-  <data name="Status.UnableToOpenLogFileFormat" xml:space="preserve"><value>無法開啟日誌檔：{0}</value></data>
   <data name="Status.WpeUtilFailureFormat" xml:space="preserve"><value>wpeutil.exe 失敗，退出程式碼{0}。 {1}</value></data>
   <data name="Status.SystemReboot" xml:space="preserve"><value>系統重啟</value></data>
   <data name="Status.RequiredRebootExecutableMissing" xml:space="preserve"><value>未找到所需的重新啟動可執行檔“wpeutil.exe”。</value></data>

--- a/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentPreparationViewModel.cs
@@ -25,7 +25,6 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
     private const string DebugAutopilotProfileDisplayName = "Debug Autopilot Profile";
     private const string DebugAutopilotGroupTag = "Debug";
 
-    private readonly ITargetDiskService _targetDiskService;
     private readonly IHardwareProfileService _hardwareProfileService;
     private readonly IOfflineWindowsComputerNameService _offlineWindowsComputerNameService;
     private readonly ILogger _logger;
@@ -40,7 +39,6 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
     private bool _firmwareUpdatesPreference = true;
 
     public DeploymentPreparationViewModel(
-        ITargetDiskService targetDiskService,
         IHardwareProfileService hardwareProfileService,
         IOfflineWindowsComputerNameService offlineWindowsComputerNameService,
         ILocalizationService localizationService,
@@ -48,7 +46,6 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         bool isDebugSafeMode)
         : base(localizationService)
     {
-        _targetDiskService = targetDiskService;
         _hardwareProfileService = hardwareProfileService;
         _offlineWindowsComputerNameService = offlineWindowsComputerNameService;
         _logger = logger;
@@ -57,7 +54,6 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
     }
 
     public event EventHandler? StateChanged;
-    public event Action<string>? StatusMessageGenerated;
 
     [ObservableProperty]
     private string targetComputerName = string.Empty;
@@ -96,7 +92,6 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
     private string detectedHardwareSummary = LocalizationText.GetString("Preparation.DetectingHardware");
 
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(RefreshTargetDisksCommand))]
     private bool isTargetDiskLoading;
 
     public ObservableCollection<TargetDiskInfo> TargetDisks { get; } = [];
@@ -205,36 +200,6 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         {
             DefaultGroupTag = ResolveEffectiveHardwareHashGroupTag()
         };
-    }
-
-    [RelayCommand(CanExecute = nameof(CanRefreshTargetDisks))]
-    private async Task RefreshTargetDisksAsync()
-    {
-        _logger.LogInformation("Refreshing target disk list.");
-        if (IsTargetDiskLoading)
-        {
-            return;
-        }
-
-        IsTargetDiskLoading = true;
-        PublishStatus("Loading target disks...");
-
-        try
-        {
-            IReadOnlyList<TargetDiskInfo> disks = await _targetDiskService.GetDisksAsync();
-            string statusMessage = ApplyTargetDisks(disks);
-            PublishStatus(statusMessage);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Target disk discovery failed.");
-            PublishStatus($"Target disk discovery failed: {ex.Message}");
-        }
-        finally
-        {
-            IsTargetDiskLoading = false;
-            RaiseStateChanged();
-        }
     }
 
     public async Task LoadHardwareProfileAsync()
@@ -360,7 +325,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         RaiseStateChanged();
     }
 
-    public string ApplyTargetDisks(IReadOnlyList<TargetDiskInfo> disks)
+    public void ApplyTargetDisks(IReadOnlyList<TargetDiskInfo> disks)
     {
         ArgumentNullException.ThrowIfNull(disks);
 
@@ -379,7 +344,7 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         {
             SelectedTargetDisk = null;
             RaiseStateChanged();
-            return "No disks detected.";
+            return;
         }
 
         TargetDiskInfo? currentSelection = SelectedTargetDisk is null
@@ -392,7 +357,6 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
             ?? TargetDisks.FirstOrDefault();
 
         RaiseStateChanged();
-        return $"Target disks loaded: {TargetDisks.Count} detected.";
     }
 
     partial void OnTargetComputerNameChanged(string value)
@@ -728,11 +692,6 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 
-    private void PublishStatus(string message)
-    {
-        StatusMessageGenerated?.Invoke(message);
-    }
-
     public override void Dispose()
     {
         LocalizationService.LanguageChanged -= OnLocalizationLanguageChanged;
@@ -836,11 +795,6 @@ public sealed partial class DeploymentPreparationViewModel : LocalizedViewModelB
         OnPropertyChanged(nameof(AutopilotHardwareHashUploadStatusText));
         OnPropertyChanged(nameof(AutopilotHardwareHashUploadMessage));
         OnPropertyChanged(nameof(EffectiveHardwareHashGroupTagText));
-    }
-
-    private bool CanRefreshTargetDisks()
-    {
-        return !IsTargetDiskLoading;
     }
 
 }

--- a/src/Foundry.Deploy/ViewModels/DeploymentSessionViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentSessionViewModel.cs
@@ -22,7 +22,6 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
     private readonly IDeploymentOrchestrator _deploymentOrchestrator;
     private readonly IProcessRunner _processRunner;
     private readonly bool _isDebugSafeMode;
-    private string _rawDeploymentStatus = "Ready";
     private string _rawCurrentStepName = "Waiting for deployment...";
     private string _rawCurrentStepProgressText = "Waiting for progress...";
     private string _rawFailedStepName = string.Empty;
@@ -67,9 +66,6 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
     [NotifyPropertyChangedFor(nameof(IsSplashPage))]
     [NotifyPropertyChangedFor(nameof(IsSuccessPage))]
     private DeploymentPage currentPage = DeploymentPage.Splash;
-
-    [ObservableProperty]
-    private string deploymentStatus = LocalizationText.GetString("Status.Ready");
 
     [ObservableProperty]
     private int deploymentProgress;
@@ -136,12 +132,6 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
     public int PlannedStepCount => _deploymentOrchestrator.PlannedSteps.Count;
     public string RebootCountdownText => Format("Success.RebootCountdownFormat", RebootCountdownSeconds);
 
-    public void SetStatus(string status)
-    {
-        _rawDeploymentStatus = status;
-        DeploymentStatus = DeploymentUiTextLocalizer.LocalizeMessage(status);
-    }
-
     public void SetComputerName(string computerName)
     {
         ComputerNameText = computerName;
@@ -186,24 +176,21 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
         ElapsedTimeText = "00:00:00";
         StartElapsedTimeTracking();
 
-        SetStatus("Deployment started.");
         CurrentPage = DeploymentPage.Progress;
     }
 
-    public void CompleteDeployment(string status, string? logsDirectoryPath)
+    public void CompleteDeployment(string? logsDirectoryPath)
     {
         _isDeploymentInProgress = false;
         _lastLogsDirectoryPath = logsDirectoryPath ?? string.Empty;
-        SetStatus(status);
         CurrentPage = DeploymentPage.Success;
     }
 
-    public void FailDeployment(string status, string? stepName, string? errorMessage, string? logsDirectoryPath = null)
+    public void FailDeployment(string? stepName, string? errorMessage, string? logsDirectoryPath = null)
     {
         _isDeploymentInProgress = false;
         _lastLogsDirectoryPath = logsDirectoryPath ?? _lastLogsDirectoryPath;
         SetFailureDetails(stepName, errorMessage);
-        SetStatus(status);
         CurrentPage = DeploymentPage.Error;
     }
 
@@ -213,7 +200,7 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
 
         if (executionRunResult.IsSuccess)
         {
-            CompleteDeployment("Deployment completed.", executionRunResult.LogsDirectoryPath);
+            CompleteDeployment(executionRunResult.LogsDirectoryPath);
             return;
         }
 
@@ -224,11 +211,7 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
             ? executionRunResult.Message
             : FailedStepErrorMessage;
 
-        FailDeployment(
-            $"Deployment failed: {executionRunResult.Message}",
-            fallbackStep,
-            fallbackMessage,
-            executionRunResult.LogsDirectoryPath);
+        FailDeployment(fallbackStep, fallbackMessage, executionRunResult.LogsDirectoryPath);
     }
 
     public void ShowDebugProgress(string computerName, int currentStepIndex, int plannedStepCount, string currentStepName, int progressPercent)
@@ -250,7 +233,6 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
         StartTimeText = FormatDeploymentStartTime(_deploymentStartTimeUtc.Value);
         ElapsedTimeText = "00:00:00";
         StartElapsedTimeTracking();
-        SetStatus("Debug preview: progress page.");
         CurrentPage = DeploymentPage.Progress;
     }
 
@@ -268,7 +250,6 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
         CurrentStepProgress = 100;
         IsCurrentStepProgressIndeterminate = false;
         SetCurrentStepProgressText("Step completed.");
-        SetStatus("Debug preview: success page.");
         CurrentPage = DeploymentPage.Success;
     }
 
@@ -279,7 +260,6 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
         ComputerNameText = computerName;
         StepCounterText = BuildStepCounterText(currentStepIndex);
         SetFailureDetails(failedStepName, failedStepErrorMessage);
-        SetStatus("Debug preview: error page.");
         CurrentPage = DeploymentPage.Error;
     }
 
@@ -300,7 +280,6 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to open log file.");
-            SetStatus($"Unable to open log file: {ex.Message}");
         }
     }
 
@@ -325,10 +304,6 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
             DeploymentProgress = Math.Max(DeploymentProgress, normalizedProgress);
             UpdateGlobalProgressVisuals(DeploymentProgress);
 
-            if (!string.IsNullOrWhiteSpace(_operationProgressService.Status))
-            {
-                SetStatus(_operationProgressService.Status!);
-            }
         });
     }
 
@@ -350,11 +325,6 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
             DeploymentProgress = Math.Max(DeploymentProgress, stepProgress.ProgressPercent);
             UpdateGlobalProgressVisuals(DeploymentProgress);
             UpdateCurrentStepProgressVisuals(stepProgress);
-
-            if (!string.IsNullOrWhiteSpace(stepProgress.Message))
-            {
-                SetStatus(stepProgress.Message);
-            }
 
             if (stepProgress.State == DeploymentStepState.Failed)
             {
@@ -556,8 +526,6 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
                 throw new FileNotFoundException("Required reboot executable 'wpeutil.exe' was not found.", rebootExecutablePath);
             }
 
-            SetStatus("Rebooting now...");
-
             ProcessExecutionResult result = await _processRunner
                 .RunAsync(rebootExecutablePath, "Reboot", Path.GetTempPath())
                 .ConfigureAwait(false);
@@ -573,7 +541,6 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
                     ? result.StandardOutput
                     : result.StandardError;
                 SetFailureDetails("System reboot", $"wpeutil.exe failed with exit code {result.ExitCode}. {diagnostic}".Trim());
-                SetStatus("Reboot command failed.");
                 CurrentPage = DeploymentPage.Error;
             });
         }
@@ -582,7 +549,6 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
             RunOnUi(() =>
             {
                 SetFailureDetails("System reboot", ex.Message);
-                SetStatus($"Reboot command failed: {ex.Message}");
                 CurrentPage = DeploymentPage.Error;
             });
         }
@@ -709,7 +675,6 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
     {
         RunOnUiThread(() =>
         {
-            DeploymentStatus = DeploymentUiTextLocalizer.LocalizeMessage(_rawDeploymentStatus);
             CurrentStepName = DeploymentUiTextLocalizer.LocalizeStepName(_rawCurrentStepName);
             CurrentStepProgressText = DeploymentUiTextLocalizer.LocalizeMessage(_rawCurrentStepProgressText);
             FailedStepName = string.IsNullOrWhiteSpace(_rawFailedStepName)

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -9,7 +9,6 @@ using CommunityToolkit.Mvvm.Input;
 using Foundry.Deploy;
 using Foundry.Deploy.Models;
 using Foundry.Deploy.Models.Configuration;
-using Foundry.Deploy.Services.Catalog;
 using Foundry.Deploy.Services.Deployment;
 using Foundry.Deploy.Services.Operations;
 using Foundry.Deploy.Services.Runtime;
@@ -30,7 +29,6 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
 {
     private readonly IThemeService _themeService;
     private readonly IDeploymentStartupCoordinator _deploymentStartupCoordinator;
-    private readonly IDeploymentCatalogLoadService _deploymentCatalogLoadService;
     private readonly IDeploymentLaunchPreparationService _deploymentLaunchPreparationService;
     private readonly IDeploymentExecutionService _deploymentExecutionService;
     private readonly IDeploymentWizardStateService _deploymentWizardStateService;
@@ -52,7 +50,6 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     private int wizardStepIndex;
 
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(RefreshCatalogsCommand))]
     [NotifyCanExecuteChangedFor(nameof(NextWizardStepCommand))]
     private bool isCatalogLoading;
 
@@ -102,7 +99,6 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         IOperationProgressService operationProgressService,
         IDeploymentStartupCoordinator deploymentStartupCoordinator,
         IDeploymentRuntimeContextService deploymentRuntimeContextService,
-        IDeploymentCatalogLoadService deploymentCatalogLoadService,
         IDeploymentLaunchPreparationService deploymentLaunchPreparationService,
         IDeploymentExecutionService deploymentExecutionService,
         IDeploymentWizardStateService deploymentWizardStateService,
@@ -115,7 +111,6 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     {
         _themeService = themeService;
         _deploymentStartupCoordinator = deploymentStartupCoordinator;
-        _deploymentCatalogLoadService = deploymentCatalogLoadService;
         _deploymentLaunchPreparationService = deploymentLaunchPreparationService;
         _deploymentExecutionService = deploymentExecutionService;
         _deploymentWizardStateService = deploymentWizardStateService;
@@ -126,7 +121,6 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         _deploymentRuntimeContext = deploymentRuntimeContextService.Resolve();
         _wizardContext = deploymentWizardContextFactory.Create(IsDebugSafeMode);
         _wizardContext.StateChanged += OnWizardContextStateChanged;
-        _wizardContext.StatusMessageGenerated += OnWizardContextStatusMessageGenerated;
         Preparation = _wizardContext.Preparation;
         OperatingSystemCatalog = _wizardContext.OperatingSystemCatalog;
         DriverPackSelection = _wizardContext.DriverPackSelection;
@@ -230,43 +224,6 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         StartDeploymentCommand.NotifyCanExecuteChanged();
     }
 
-    [RelayCommand(CanExecute = nameof(CanRefreshCatalogs))]
-    private async Task RefreshCatalogsAsync()
-    {
-        _logger.LogInformation("Refreshing deployment catalogs.");
-        if (IsCatalogLoading)
-        {
-            return;
-        }
-
-        IsCatalogLoading = true;
-        Session.SetStatus("Loading catalogs...");
-
-        try
-        {
-            DeploymentCatalogSnapshot snapshot = await _deploymentCatalogLoadService.LoadAsync().ConfigureAwait(false);
-            _logger.LogInformation(
-                "Deployment catalogs refreshed successfully. OperatingSystemCount={OperatingSystemCount}, DriverPackCount={DriverPackCount}",
-                snapshot.OperatingSystems.Count,
-                snapshot.DriverPacks.Count);
-
-            RunOnUi(() =>
-            {
-                _wizardContext.ApplyCatalogSnapshot(snapshot);
-                Session.SetStatus($"Catalogs loaded: {OperatingSystemCatalog.OperatingSystems.Count} OS entries, {DriverPackSelection.CatalogCount} driver packs.");
-            });
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Catalog refresh failed.");
-            RunOnUi(() => Session.SetStatus($"Catalog load failed: {ex.Message}"));
-        }
-        finally
-        {
-            RunOnUi(() => IsCatalogLoading = false);
-        }
-    }
-
     [RelayCommand(CanExecute = nameof(CanGoPrevious))]
     private void PreviousWizardStep()
     {
@@ -326,7 +283,6 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
 
         if (!launchPreparation.IsReadyToStart || launchPreparation.Context is null)
         {
-            Session.SetStatus(launchPreparation.StatusMessage);
             return;
         }
 
@@ -403,11 +359,6 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         StartDeploymentCommand.NotifyCanExecuteChanged();
     }
 
-    private void OnWizardContextStatusMessageGenerated(string message)
-    {
-        Session.SetStatus(message);
-    }
-
     private void OnSessionPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (!string.IsNullOrWhiteSpace(e.PropertyName) &&
@@ -417,7 +368,6 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
             return;
         }
 
-        RefreshCatalogsCommand.NotifyCanExecuteChanged();
         BeginWizardCommand.NotifyCanExecuteChanged();
     }
 
@@ -444,11 +394,6 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         OnPropertyChanged(nameof(IsDebugAutopilotHardwareHashUploadExpiredCertificateMode));
         OnPropertyChanged(nameof(IsDebugAutopilotHardwareHashUploadMissingCertificateMetadataMode));
         OnPropertyChanged(nameof(IsDebugAutopilotHardwareHashUploadNoDefaultGroupTagMode));
-    }
-
-    private bool CanRefreshCatalogs()
-    {
-        return Session.IsStartupReady && !IsCatalogLoading && !IsDeploymentRunning;
     }
 
     private bool CanBeginWizard()
@@ -511,13 +456,8 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     {
         ArgumentNullException.ThrowIfNull(startupSnapshot);
 
-        string startupStatusMessage = _wizardContext.ApplyStartupSnapshot(startupSnapshot);
+        _wizardContext.ApplyStartupSnapshot(startupSnapshot);
         Session.SetComputerName(Preparation.TargetComputerName);
-
-        Session.SetStatus(
-            !string.IsNullOrWhiteSpace(startupSnapshot.TargetDiskStatusMessage)
-                ? startupSnapshot.TargetDiskStatusMessage
-                : startupStatusMessage);
         Session.CompleteStartupInitialization();
     }
 
@@ -539,7 +479,6 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
             return;
         }
 
-        _wizardContext.StatusMessageGenerated -= OnWizardContextStatusMessageGenerated;
         _wizardContext.StateChanged -= OnWizardContextStateChanged;
         Session.PropertyChanged -= OnSessionPropertyChanged;
         LocalizationService.LanguageChanged -= OnLocalizationLanguageChanged;

--- a/src/Foundry.Deploy/Views/WizardView.xaml
+++ b/src/Foundry.Deploy/Views/WizardView.xaml
@@ -44,25 +44,11 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <StackPanel Grid.Row="0" Margin="0,0,0,12">
-            <Border
-                Margin="0,0,0,8"
-                Padding="8"
-                Background="#33FFAA00"
-                BorderBrush="#FFFFAA00"
-                BorderThickness="1"
-                CornerRadius="4"
-                Visibility="{Binding IsDebugSafeMode, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Strings[Wizard.DebugSafeModeBanner]}" />
-            </Border>
-        </StackPanel>
-
-        <Grid Grid.Row="1" Margin="0,0,0,16">
+        <Grid Grid.Row="0" Margin="0,0,0,16">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="8" />
@@ -142,7 +128,7 @@
             </Border>
         </Grid>
 
-        <Border Grid.Row="2" Style="{StaticResource SectionCardBorderStyle}">
+        <Border Grid.Row="1" Style="{StaticResource SectionCardBorderStyle}">
             <ContentControl Content="{Binding}">
                 <ContentControl.Style>
                     <Style TargetType="ContentControl">
@@ -172,7 +158,7 @@
             </ContentControl>
         </Border>
 
-        <Grid Grid.Row="3" Margin="0,12,0,0">
+        <Grid Grid.Row="2" Margin="0,12,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>


### PR DESCRIPTION
## Summary
- Remove obsolete Foundry.Deploy debug banner, bottom infobar, and refresh menu plumbing.
- Remove hidden deployment status propagation and localization entries that no longer have UI consumers.
- Keep fullscreen behavior and the 16px global content margin from the UI update.

## Reason
These code paths only supported UI elements that were removed, so keeping them would leave unused view-model/service state and stale localization keys.

## Main changes
- Cleaned up WPF bindings, view models, startup/wizard status plumbing, and launch preparation result data.
- Removed obsolete localization keys across all Foundry.Deploy resource files.
- Updated unit tests to assert remaining behavior instead of removed status text.

## Testing notes
- `dotnet build src\Foundry.Deploy\Foundry.Deploy.csproj --no-restore`
- `dotnet test src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --no-restore`
