### PR TITLE
feat(foundry): polish Autopilot page UI

### DIFF
--- a/src/Foundry/Controls/DocumentationButton.cs
+++ b/src/Foundry/Controls/DocumentationButton.cs
@@ -4,7 +4,7 @@ using Microsoft.UI.Xaml.Automation;
 
 namespace Foundry.Controls;
 
-public sealed partial class DocumentationButton : Button
+public sealed partial class DocumentationButton : UserControl
 {
     public static readonly DependencyProperty DocumentationUrlProperty = DependencyProperty.Register(
         nameof(DocumentationUrl),
@@ -14,6 +14,7 @@ public sealed partial class DocumentationButton : Button
 
     private readonly IApplicationLocalizationService localizationService;
     private readonly IExternalProcessLauncher externalProcessLauncher;
+    private readonly Button button = new();
     private readonly TextBlock labelTextBlock = new();
     private bool isLocalizationSubscribed;
 
@@ -21,10 +22,11 @@ public sealed partial class DocumentationButton : Button
     {
         localizationService = App.GetService<IApplicationLocalizationService>();
         externalProcessLauncher = App.GetService<IExternalProcessLauncher>();
-        Content = CreateContent();
+        button.Content = CreateContent();
+        Content = button;
         UpdateLocalizedText();
 
-        Click += OnClick;
+        button.Click += OnClick;
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
     }
@@ -81,7 +83,7 @@ public sealed partial class DocumentationButton : Button
     {
         string text = localizationService.GetString("Nav_DocumentationKey.Title");
         labelTextBlock.Text = text;
-        AutomationProperties.SetName(this, text);
+        AutomationProperties.SetName(button, text);
     }
 
     private async void OnClick(object sender, RoutedEventArgs e)

--- a/src/Foundry/Controls/DocumentationButton.cs
+++ b/src/Foundry/Controls/DocumentationButton.cs
@@ -1,0 +1,96 @@
+using Foundry.Core.Services.Application;
+using Foundry.Services.Localization;
+using Microsoft.UI.Xaml.Automation;
+
+namespace Foundry.Controls;
+
+public sealed partial class DocumentationButton : Button
+{
+    public static readonly DependencyProperty DocumentationUrlProperty = DependencyProperty.Register(
+        nameof(DocumentationUrl),
+        typeof(string),
+        typeof(DocumentationButton),
+        new PropertyMetadata(string.Empty));
+
+    private readonly IApplicationLocalizationService localizationService;
+    private readonly IExternalProcessLauncher externalProcessLauncher;
+    private readonly TextBlock labelTextBlock = new();
+    private bool isLocalizationSubscribed;
+
+    public DocumentationButton()
+    {
+        localizationService = App.GetService<IApplicationLocalizationService>();
+        externalProcessLauncher = App.GetService<IExternalProcessLauncher>();
+        Content = CreateContent();
+        UpdateLocalizedText();
+
+        Click += OnClick;
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+    }
+
+    public string DocumentationUrl
+    {
+        get => (string)GetValue(DocumentationUrlProperty);
+        set => SetValue(DocumentationUrlProperty, value);
+    }
+
+    private StackPanel CreateContent()
+    {
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = (double)Application.Current.Resources["FoundrySpace8"],
+            Children =
+            {
+                new FontIcon { Glyph = "\uE7C3" },
+                labelTextBlock
+            }
+        };
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        if (isLocalizationSubscribed)
+        {
+            return;
+        }
+
+        localizationService.LanguageChanged += OnLanguageChanged;
+        isLocalizationSubscribed = true;
+        UpdateLocalizedText();
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (!isLocalizationSubscribed)
+        {
+            return;
+        }
+
+        localizationService.LanguageChanged -= OnLanguageChanged;
+        isLocalizationSubscribed = false;
+    }
+
+    private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
+    {
+        UpdateLocalizedText();
+    }
+
+    private void UpdateLocalizedText()
+    {
+        string text = localizationService.GetString("Nav_DocumentationKey.Title");
+        labelTextBlock.Text = text;
+        AutomationProperties.SetName(this, text);
+    }
+
+    private async void OnClick(object sender, RoutedEventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(DocumentationUrl))
+        {
+            return;
+        }
+
+        await externalProcessLauncher.OpenUriAsync(new Uri(DocumentationUrl, UriKind.Absolute));
+    }
+}

--- a/src/Foundry/FoundryApplicationInfo.cs
+++ b/src/Foundry/FoundryApplicationInfo.cs
@@ -14,6 +14,11 @@ public static class FoundryApplicationInfo
     /// </summary>
     public const string DocumentationUrl = "https://foundry-osd.github.io/docs/start";
 
+    /// <summary>
+    /// Gets the Autopilot documentation URL.
+    /// </summary>
+    public const string AutopilotDocumentationUrl = "https://foundry-osd.github.io/docs/autopilot";
+
     public const string RepositoryUrl = Constants.RepositoryUrl;
 
     /// <summary>

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>اختر طريقة توفير Autopilot لوسائط النشر: تجهيز ملف تعريف JSON أو تحميل تجزئة الأجهزة بدون لمس في WinPE أو تحميل تجزئة الأجهزة التفاعلي.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>قم بتكوين إعدادات تسجيل Windows Autopilot لوسائط النشر وتسجيل الأجهزة.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>تمكين Autopilot</value>
   </data>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Изберете метода за Autopilot подготовка за носителя за разполагане: подготовка на JSON профил, WinPE zero-touch качване на хардуерен хеш или интерактивно качване на хардуерен хеш.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Конфигурирайте настройките за записване в Windows Autopilot за носители за разполагане и регистрация на хардуер.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Активиране на Autopilot</value>
   </data>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Vyberte metodu zřizování Autopilotu pro instalační médium: přípravu profilu JSON, bezobslužné nahrání hardwarového hashe ve WinPE nebo interaktivní nahrání hardwarového hashe.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Nakonfigurujte nastavení registrace Windows Autopilot pro média nasazení a registraci hardwaru.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Povolit Autopilot</value>
   </data>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Vælg Autopilot-klargøringsmetode for installationsmediet: JSON-profilklargøring, WinPE zero-touch upload af hardwarehash eller interaktiv upload af hardwarehash.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Konfigurer indstillinger for Windows Autopilot-tilmelding til installationsmedier og hardwareregistrering.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Aktiver Autopilot</value>
   </data>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Wählen Sie die Autopilot-Bereitstellungsmethode für das Bereitstellungsmedium: JSON-Profil-Staging, WinPE-Zero-Touch-Hardware-Hash-Upload oder interaktiver Hardware-Hash-Upload.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Konfigurieren Sie Windows Autopilot-Registrierungseinstellungen für Bereitstellungsmedien und Hardwareregistrierung.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Autopilot aktivieren</value>
   </data>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Επιλέξτε τη μέθοδο προετοιμασίας Autopilot για το μέσο ανάπτυξης: προετοιμασία προφίλ JSON, μη αλληλεπιδραστική αποστολή κατακερματισμού υλικού στο WinPE ή διαδραστική αποστολή κατακερματισμού υλικού.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Ρυθμίστε τις ρυθμίσεις εγγραφής Windows Autopilot για μέσα ανάπτυξης και εγγραφή υλικού.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Ενεργοποίηση Autopilot</value>
   </data>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Choose the Autopilot provisioning method for deployment media: JSON profile staging, WinPE zero-touch hardware hash upload, or interactive hardware hash upload.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Configure Windows Autopilot enrollment settings for deployment media and hardware registration.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Enable Autopilot</value>
   </data>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Choose the Autopilot provisioning method for deployment media: JSON profile staging, WinPE zero-touch hardware hash upload, or interactive hardware hash upload.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Configure Windows Autopilot enrollment settings for deployment media and hardware registration.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Enable Autopilot</value>
   </data>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Elige el método de aprovisionamiento de Autopilot para el medio de implementación: preparación de perfil JSON, carga zero-touch del hash de hardware en WinPE o carga interactiva del hash de hardware.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Configura la inscripción de Windows Autopilot para medios de implementación y registro de hardware.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Habilitar Autopilot</value>
   </data>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Elige el método de aprovisionamiento de Autopilot para el medio de implementación: preparación de perfil JSON, carga zero-touch del hash de hardware en WinPE o carga interactiva del hash de hardware.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Configura la inscripción de Windows Autopilot para medios de implementación y registro de hardware.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Habilitar Autopilot</value>
   </data>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Vali juurutusmeedia Autopiloti ettevalmistusviis: JSON-profiili ettevalmistus, WinPE zero-touch riistvararäsi üleslaadimine või interaktiivne riistvararäsi üleslaadimine.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Konfigureerige Windows Autopiloti registreerimissätted juurutusmeediumi ja riistvara registreerimise jaoks.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Luba Autopilot</value>
   </data>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Valitse käyttöönottolevyn Autopilot-valmistelutapa: JSON-profiilin valmistelu, WinPE:n zero-touch-laitteiston hajautusarvon lataus tai vuorovaikutteinen laitteiston hajautusarvon lataus.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Määritä Windows Autopilot -rekisteröintiasetukset käyttöönoton tietovälineille ja laitteiston rekisteröinnille.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Ota Autopilot käyttöön</value>
   </data>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Choisissez la méthode de provisionnement Autopilot pour le média de déploiement : préparation du profil JSON, téléversement zero-touch du hachage matériel dans WinPE ou téléversement interactif du hachage matériel.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Configurez les paramètres d&apos;inscription Windows Autopilot pour les supports de déploiement et l&apos;enregistrement matériel.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Activer Autopilot</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Choisissez la méthode de provisionnement Autopilot pour le média de déploiement : préparation du profil JSON, envoi zero-touch du hash matériel dans WinPE ou envoi interactif du hash matériel.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Configurez les paramètres d&apos;inscription Windows Autopilot pour les supports de déploiement et l&apos;enregistrement matériel.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Activer Autopilot</value>
   </data>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>בחר את שיטת הקצאת Autopilot עבור מדיית הפריסה: הכנת פרופיל JSON, העלאת hash חומרה ללא מגע ב-WinPE או העלאה אינטראקטיבית של hash חומרה.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>קבע את תצורת הגדרות ההרשמה של Windows Autopilot עבור מדיית פריסה ורישום חומרה.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>אפשר Autopilot</value>
   </data>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Odaberite način Autopilot pripreme za medij za implementaciju: priprema JSON profila, WinPE zero-touch prijenos hardverskog hasha ili interaktivni prijenos hardverskog hasha.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Konfigurirajte postavke upisa za Windows Autopilot za medije za implementaciju i registraciju hardvera.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Omogući Autopilot</value>
   </data>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Válassza ki az üzembe helyezési adathordozó Autopilot-kiépítési módját: JSON-profil előkészítése, WinPE zero-touch hardverhash-feltöltés vagy interaktív hardverhash-feltöltés.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Konfigurálja a Windows Autopilot regisztrációs beállításait a telepítési adathordozókhoz és a hardverregisztrációhoz.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Autopilot engedélyezése</value>
   </data>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Scegli il metodo di provisioning Autopilot per il supporto di distribuzione: staging del profilo JSON, caricamento zero-touch dell’hash hardware in WinPE o caricamento interattivo dell’hash hardware.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Configura le impostazioni di registrazione di Windows Autopilot per i supporti di distribuzione e la registrazione hardware.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Abilita Autopilot</value>
   </data>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>展開メディアの Autopilot プロビジョニング方法を選択します: JSON プロファイルのステージング、WinPE でのゼロタッチ ハードウェア ハッシュ アップロード、または対話型ハードウェア ハッシュ アップロード。</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>展開メディアとハードウェア登録用の Windows Autopilot 登録設定を構成します。</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Autopilotを有効にする</value>
   </data>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>배포 미디어의 Autopilot 프로비저닝 방법을 선택합니다: JSON 프로필 스테이징, WinPE zero-touch 하드웨어 해시 업로드 또는 대화형 하드웨어 해시 업로드.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>배포 미디어 및 하드웨어 등록을 위한 Windows Autopilot 등록 설정을 구성합니다.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Autopilot 활성화</value>
   </data>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Pasirinkite diegimo laikmenos Autopilot parengimo metodą: JSON profilio parengimą, WinPE zero-touch aparatūros maišos įkėlimą arba interaktyvų aparatūros maišos įkėlimą.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Konfigūruokite Windows Autopilot registracijos parametrus diegimo laikmenai ir aparatūros registracijai.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Įgalinti Autopilot</value>
   </data>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Izvēlieties izvietošanas datu nesēja Autopilot sagatavošanas metodi: JSON profila sagatavošanu, WinPE zero-touch aparatūras jaucējkoda augšupielādi vai interaktīvu aparatūras jaucējkoda augšupielādi.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Konfigurējiet Windows Autopilot reģistrācijas iestatījumus izvietošanas datu nesējiem un aparatūras reģistrācijai.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Iespējot Autopilot</value>
   </data>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Velg Autopilot-klargjøringsmetode for distribusjonsmediet: JSON-profilklargjøring, WinPE zero-touch opplasting av maskinvarehash eller interaktiv opplasting av maskinvarehash.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Konfigurer registreringsinnstillinger for Windows Autopilot for distribusjonsmedier og maskinvareregistrering.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Aktiver Autopilot</value>
   </data>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Kies de Autopilot-inrichtingsmethode voor het implementatiemedium: JSON-profielstaging, WinPE zero-touch hardware-hash-upload of interactieve hardware-hash-upload.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Configureer Windows Autopilot-inschrijvingsinstellingen voor implementatiemedia en hardwareregistratie.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Schakel Autopilot in</value>
   </data>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Wybierz metodę aprowizowania Autopilot dla nośnika wdrożeniowego: przygotowanie profilu JSON, bezobsługowe przesyłanie skrótu sprzętowego w WinPE albo interaktywne przesyłanie skrótu sprzętowego.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Skonfiguruj ustawienia rejestracji Windows Autopilot dla nośników wdrażania i rejestracji sprzętu.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Włącz Autopilot</value>
   </data>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Escolha o método de provisionamento do Autopilot para a mídia de implantação: preparação de perfil JSON, upload zero-touch do hash de hardware no WinPE ou upload interativo do hash de hardware.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Configure as definições de registro do Windows Autopilot para mídia de implantação e registro de hardware.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Ativar Autopilot</value>
   </data>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Escolha o método de aprovisionamento Autopilot para o suporte de implementação: preparação do perfil JSON, carregamento zero-touch do hash de hardware no WinPE ou carregamento interativo do hash de hardware.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Configure as definições de inscrição do Windows Autopilot para suportes de implementação e registo de hardware.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Ativar Autopilot</value>
   </data>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Alegeți metoda de configurare Autopilot pentru mediul de implementare: pregătirea profilului JSON, încărcarea zero-touch a hashului hardware în WinPE sau încărcarea interactivă a hashului hardware.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Configurați setările de înscriere Windows Autopilot pentru mediile de implementare și înregistrarea hardware.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Activați Autopilot</value>
   </data>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Выберите метод подготовки Autopilot для носителя развертывания: размещение профиля JSON, zero-touch отправка аппаратного хеша в WinPE или интерактивная отправка аппаратного хеша.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Настройте параметры регистрации Windows Autopilot для носителей развертывания и регистрации оборудования.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Включить Autopilot</value>
   </data>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Vyberte metódu zriaďovania Autopilotu pre nasadzovacie médium: prípravu profilu JSON, bezobslužné nahratie hardvérového hashu vo WinPE alebo interaktívne nahratie hardvérového hashu.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Nakonfigurujte nastavenia registrácie Windows Autopilot pre médiá nasadenia a registráciu hardvéru.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Povoliť Autopilot</value>
   </data>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Izberite način priprave Autopilot za namestitveni medij: priprava profila JSON, WinPE zero-touch nalaganje zgoščene vrednosti strojne opreme ali interaktivno nalaganje zgoščene vrednosti strojne opreme.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Konfigurirajte nastavitve vpisa v Windows Autopilot za medije za uvedbo in registracijo strojne opreme.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Omogoči Autopilot</value>
   </data>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Izaberite metod Autopilot pripreme za medij za primenu: priprema JSON profila, WinPE zero-touch otpremanje hardverskog heša ili interaktivno otpremanje hardverskog heša.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Konfigurišite postavke upisa za Windows Autopilot za medije za primenu i registraciju hardvera.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Omogući Autopilot</value>
   </data>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Välj Autopilot-etableringsmetod för distributionsmediet: JSON-profilstaging, WinPE zero-touch-uppladdning av maskinvaruhash eller interaktiv uppladdning av maskinvaruhash.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Konfigurera registreringsinställningar för Windows Autopilot för distributionsmedia och maskinvaruregistrering.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Aktivera Autopilot</value>
   </data>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>เลือกวิธีการเตรียม Autopilot สำหรับสื่อการปรับใช้: การเตรียมโปรไฟล์ JSON, การอัปโหลดแฮชฮาร์ดแวร์แบบ zero-touch ใน WinPE หรือการอัปโหลดแฮชฮาร์ดแวร์แบบโต้ตอบ</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>กำหนดค่าการลงทะเบียน Windows Autopilot สำหรับสื่อการปรับใช้และการลงทะเบียนฮาร์ดแวร์</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>เปิดใช้งาน Autopilot</value>
   </data>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Dağıtım medyası için Autopilot sağlama yöntemini seçin: JSON profil hazırlama, WinPE zero-touch donanım karması yükleme veya etkileşimli donanım karması yükleme.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Dağıtım medyası ve donanım kaydı için Windows Autopilot kayıt ayarlarını yapılandırın.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Autopilot'yi etkinleştir</value>
   </data>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>Виберіть метод підготовки Autopilot для носія розгортання: підготовка профілю JSON, zero-touch завантаження апаратного хешу у WinPE або інтерактивне завантаження апаратного хешу.</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>Налаштуйте параметри реєстрації Windows Autopilot для носіїв розгортання та реєстрації обладнання.</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>Увімкнути Autopilot</value>
   </data>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>选择部署介质的 Autopilot 预配方法：JSON 配置文件暂存、WinPE zero-touch 硬件哈希上传，或交互式硬件哈希上传。</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>配置用于部署媒体和硬件注册的 Windows Autopilot 注册设置。</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>启用Autopilot</value>
   </data>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -171,6 +171,9 @@
   <data name="Autopilot.Description" xml:space="preserve">
     <value>選擇部署媒體的 Autopilot 佈建方法：JSON 設定檔暫存、WinPE zero-touch 硬體雜湊上傳，或互動式硬體雜湊上傳。</value>
   </data>
+  <data name="Autopilot.PageDescription" xml:space="preserve">
+    <value>設定用於部署媒體和硬體註冊的 Windows Autopilot 註冊設定。</value>
+  </data>
   <data name="Autopilot.EnableLabel" xml:space="preserve">
     <value>啟用Autopilot</value>
   </data>

--- a/src/Foundry/Themes/Styles.xaml
+++ b/src/Foundry/Themes/Styles.xaml
@@ -11,9 +11,8 @@
     <x:Double x:Key="FoundrySpace24">24</x:Double>
     <x:Double x:Key="FoundrySpace32">32</x:Double>
 
-    <Thickness x:Key="ContentPageMargin">40,32,0,0</Thickness>
-    <Thickness x:Key="ContentPagePadding">0,0,40,24</Thickness>
-    <Thickness x:Key="FoundryPageContentInset">8</Thickness>
+    <Thickness x:Key="ContentPageMargin">48,40,0,0</Thickness>
+    <Thickness x:Key="ContentPagePadding">0,0,48,32</Thickness>
     <Thickness x:Key="FoundryPageSectionSpacing">0,0,0,16</Thickness>
     <Thickness x:Key="FoundryCompactContentPadding">12</Thickness>
     <Thickness x:Key="FoundryDefaultContentPadding">16</Thickness>

--- a/src/Foundry/Themes/Styles.xaml
+++ b/src/Foundry/Themes/Styles.xaml
@@ -11,7 +11,7 @@
     <x:Double x:Key="FoundrySpace24">24</x:Double>
     <x:Double x:Key="FoundrySpace32">32</x:Double>
 
-    <Thickness x:Key="ContentPageMargin">40,40,0,0</Thickness>
+    <Thickness x:Key="ContentPageMargin">40,32,0,0</Thickness>
     <Thickness x:Key="ContentPagePadding">0,0,40,24</Thickness>
     <Thickness x:Key="FoundryPageContentInset">8</Thickness>
     <Thickness x:Key="FoundryPageSectionSpacing">0,0,0,16</Thickness>

--- a/src/Foundry/Themes/Styles.xaml
+++ b/src/Foundry/Themes/Styles.xaml
@@ -14,7 +14,6 @@
     <Thickness x:Key="ContentPageMargin">48,40,0,0</Thickness>
     <Thickness x:Key="ContentPagePadding">0,0,48,32</Thickness>
     <Thickness x:Key="FoundryPageHeaderMargin">0,0,0,48</Thickness>
-    <Thickness x:Key="FoundryPageSectionSpacing">0,0,0,16</Thickness>
     <Thickness x:Key="FoundryCompactContentPadding">12</Thickness>
     <Thickness x:Key="FoundryDefaultContentPadding">16</Thickness>
     <Thickness x:Key="FoundryDialogContentPadding">24</Thickness>

--- a/src/Foundry/Themes/Styles.xaml
+++ b/src/Foundry/Themes/Styles.xaml
@@ -13,7 +13,7 @@
 
     <Thickness x:Key="ContentPageMargin">48,40,0,0</Thickness>
     <Thickness x:Key="ContentPagePadding">0,0,48,32</Thickness>
-    <Thickness x:Key="FoundryPageHeaderMargin">0,0,0,24</Thickness>
+    <Thickness x:Key="FoundryPageHeaderMargin">0,0,0,48</Thickness>
     <Thickness x:Key="FoundryPageSectionSpacing">0,0,0,16</Thickness>
     <Thickness x:Key="FoundryCompactContentPadding">12</Thickness>
     <Thickness x:Key="FoundryDefaultContentPadding">16</Thickness>

--- a/src/Foundry/Themes/Styles.xaml
+++ b/src/Foundry/Themes/Styles.xaml
@@ -13,6 +13,7 @@
 
     <Thickness x:Key="ContentPageMargin">48,40,0,0</Thickness>
     <Thickness x:Key="ContentPagePadding">0,0,48,32</Thickness>
+    <Thickness x:Key="FoundryPageHeaderMargin">0,0,0,24</Thickness>
     <Thickness x:Key="FoundryPageSectionSpacing">0,0,0,16</Thickness>
     <Thickness x:Key="FoundryCompactContentPadding">12</Thickness>
     <Thickness x:Key="FoundryDefaultContentPadding">16</Thickness>

--- a/src/Foundry/Themes/Styles.xaml
+++ b/src/Foundry/Themes/Styles.xaml
@@ -11,7 +11,7 @@
     <x:Double x:Key="FoundrySpace24">24</x:Double>
     <x:Double x:Key="FoundrySpace32">32</x:Double>
 
-    <Thickness x:Key="ContentPageMargin">40,48,0,0</Thickness>
+    <Thickness x:Key="ContentPageMargin">40,40,0,0</Thickness>
     <Thickness x:Key="ContentPagePadding">0,0,40,24</Thickness>
     <Thickness x:Key="FoundryPageContentInset">8</Thickness>
     <Thickness x:Key="FoundryPageSectionSpacing">0,0,0,16</Thickness>

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -241,6 +241,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string PageTitle { get; set; }
 
     [ObservableProperty]
+    public partial string PageDescription { get; set; }
+
+    [ObservableProperty]
     public partial string AutopilotHeader { get; set; }
 
     [ObservableProperty]
@@ -954,6 +957,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private void RefreshLocalizedText()
     {
         PageTitle = localizationService.GetString("AutopilotPage_Title.Text");
+        PageDescription = localizationService.GetString("Autopilot.PageDescription");
         AutopilotHeader = localizationService.GetString("Autopilot.Header");
         AutopilotDescription = localizationService.GetString("Autopilot.Description");
         EnableAutopilotText = localizationService.GetString("Autopilot.EnableLabel");

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -241,9 +241,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string PageTitle { get; set; }
 
     [ObservableProperty]
-    public partial string DocumentationButtonText { get; set; }
-
-    [ObservableProperty]
     public partial string AutopilotHeader { get; set; }
 
     [ObservableProperty]
@@ -434,6 +431,8 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
 
     [ObservableProperty]
     public partial string ProfileFolderColumnHeader { get; set; }
+
+    public string DocumentationUrl => FoundryApplicationInfo.AutopilotDocumentationUrl;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsAutopilotSectionEnabled))]
@@ -955,7 +954,6 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private void RefreshLocalizedText()
     {
         PageTitle = localizationService.GetString("AutopilotPage_Title.Text");
-        DocumentationButtonText = localizationService.GetString("Nav_DocumentationKey.Title");
         AutopilotHeader = localizationService.GetString("Autopilot.Header");
         AutopilotDescription = localizationService.GetString("Autopilot.Description");
         EnableAutopilotText = localizationService.GetString("Autopilot.EnableLabel");

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -241,6 +241,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     public partial string PageTitle { get; set; }
 
     [ObservableProperty]
+    public partial string DocumentationButtonText { get; set; }
+
+    [ObservableProperty]
     public partial string AutopilotHeader { get; set; }
 
     [ObservableProperty]
@@ -952,6 +955,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private void RefreshLocalizedText()
     {
         PageTitle = localizationService.GetString("AutopilotPage_Title.Text");
+        DocumentationButtonText = localizationService.GetString("Nav_DocumentationKey.Title");
         AutopilotHeader = localizationService.GetString("Autopilot.Header");
         AutopilotDescription = localizationService.GetString("Autopilot.Description");
         EnableAutopilotText = localizationService.GetString("Autopilot.EnableLabel");

--- a/src/Foundry/Views/AdkPage.xaml
+++ b/src/Foundry/Views/AdkPage.xaml
@@ -7,8 +7,7 @@
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
                 Padding="{ThemeResource ContentPagePadding}"
                 VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="{ThemeResource FoundryPageContentInset}"
-                    dev:PanelAttach.ChildrenTransitions="Default"
+        <StackPanel dev:PanelAttach.ChildrenTransitions="Default"
                     Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
             <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
                        Style="{ThemeResource FoundryPageTitleTextBlockStyle}" />

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -30,7 +30,7 @@
                                   IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}"
                                   IsExpanded="{x:Bind ViewModel.UseJsonProfileProvisioning, Mode=OneWay}">
                 <wct:SettingsExpander.HeaderIcon>
-                    <FontIcon Glyph="&#xECA7;" />
+                    <FontIcon Glyph="&#xE7C3;" />
                 </wct:SettingsExpander.HeaderIcon>
                 <ToggleSwitch behaviors:LocalizedToggleSwitch.UseLocalizedStateContent="True" AutomationProperties.Name="{x:Bind ViewModel.JsonProfileEnableText, Mode=OneWay}"
                               IsOn="{x:Bind ViewModel.UseJsonProfileProvisioning, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
@@ -126,7 +126,7 @@
                                   IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}"
                                   IsExpanded="{x:Bind ViewModel.UseHardwareHashUploadProvisioning, Mode=OneWay}">
                 <wct:SettingsExpander.HeaderIcon>
-                    <FontIcon Glyph="&#xE8D4;" />
+                    <FontIcon Glyph="&#xEB95;" />
                 </wct:SettingsExpander.HeaderIcon>
                 <ToggleSwitch behaviors:LocalizedToggleSwitch.UseLocalizedStateContent="True" AutomationProperties.Name="{x:Bind ViewModel.HardwareHashEnableText, Mode=OneWay}"
                               IsOn="{x:Bind ViewModel.UseHardwareHashUploadProvisioning, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
@@ -303,7 +303,7 @@
                               Description="{x:Bind ViewModel.InteractiveHardwareHashDescription, Mode=OneWay}"
                               IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}">
                 <wct:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE8D4;" />
+                    <FontIcon Glyph="&#xE928;" />
                 </wct:SettingsCard.HeaderIcon>
                 <ToggleSwitch behaviors:LocalizedToggleSwitch.UseLocalizedStateContent="True" AutomationProperties.Name="{x:Bind ViewModel.InteractiveHardwareHashEnableText, Mode=OneWay}"
                               IsOn="{x:Bind ViewModel.UseInteractiveHardwareHashUploadProvisioning, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -13,8 +13,26 @@
                 VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="{ThemeResource FoundryPageContentInset}"
                     Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
-            <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
-                       Style="{ThemeResource FoundryPageTitleTextBlockStyle}" />
+            <Grid ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
+                           Style="{ThemeResource FoundryPageTitleTextBlockStyle}" />
+
+                <Button Grid.Column="1"
+                        VerticalAlignment="Center"
+                        AutomationProperties.Name="{x:Bind ViewModel.DocumentationButtonText, Mode=OneWay}"
+                        Click="DocumentationButton_Click">
+                    <StackPanel Orientation="Horizontal"
+                                Spacing="{ThemeResource FoundrySpace8}">
+                        <FontIcon Glyph="&#xE7C3;" />
+                        <TextBlock Text="{x:Bind ViewModel.DocumentationButtonText, Mode=OneWay}" />
+                    </StackPanel>
+                </Button>
+            </Grid>
 
             <wct:SettingsCard Header="{x:Bind ViewModel.AutopilotHeader, Mode=OneWay}"
                               Description="{x:Bind ViewModel.AutopilotDescription, Mode=OneWay}">

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -12,7 +12,7 @@
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
                 Padding="{ThemeResource ContentPagePadding}"
                 VerticalScrollBarVisibility="Auto">
-        <StackPanel Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
+        <StackPanel>
             <Grid Margin="{ThemeResource FoundryPageHeaderMargin}"
                   ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}">
                 <Grid.ColumnDefinitions>
@@ -48,34 +48,35 @@
                                               DocumentationUrl="{x:Bind ViewModel.DocumentationUrl, Mode=OneWay}" />
             </Grid>
 
-            <wct:SettingsCard Header="{x:Bind ViewModel.AutopilotHeader, Mode=OneWay}"
-                              Description="{x:Bind ViewModel.AutopilotDescription, Mode=OneWay}">
-                <wct:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE753;" />
-                </wct:SettingsCard.HeaderIcon>
-                <ToggleSwitch behaviors:LocalizedToggleSwitch.UseLocalizedStateContent="True" AutomationProperties.Name="{x:Bind ViewModel.EnableAutopilotText, Mode=OneWay}"
-                              IsOn="{x:Bind ViewModel.IsAutopilotEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-            </wct:SettingsCard>
+            <StackPanel Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
+                <wct:SettingsCard Header="{x:Bind ViewModel.AutopilotHeader, Mode=OneWay}"
+                                  Description="{x:Bind ViewModel.AutopilotDescription, Mode=OneWay}">
+                    <wct:SettingsCard.HeaderIcon>
+                        <FontIcon Glyph="&#xE753;" />
+                    </wct:SettingsCard.HeaderIcon>
+                    <ToggleSwitch behaviors:LocalizedToggleSwitch.UseLocalizedStateContent="True" AutomationProperties.Name="{x:Bind ViewModel.EnableAutopilotText, Mode=OneWay}"
+                                  IsOn="{x:Bind ViewModel.IsAutopilotEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </wct:SettingsCard>
 
-            <wct:SettingsExpander Header="{x:Bind ViewModel.JsonProfileHeader, Mode=OneWay}"
-                                  Description="{x:Bind ViewModel.JsonProfileDescription, Mode=OneWay}"
-                                  IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}"
-                                  IsExpanded="{x:Bind ViewModel.UseJsonProfileProvisioning, Mode=OneWay}">
-                <wct:SettingsExpander.HeaderIcon>
-                    <FontIcon Glyph="&#xE7C3;" />
-                </wct:SettingsExpander.HeaderIcon>
-                <ToggleSwitch behaviors:LocalizedToggleSwitch.UseLocalizedStateContent="True" AutomationProperties.Name="{x:Bind ViewModel.JsonProfileEnableText, Mode=OneWay}"
-                              IsOn="{x:Bind ViewModel.UseJsonProfileProvisioning, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                <wct:SettingsExpander.Items>
-                    <wct:SettingsCard Header="{x:Bind ViewModel.ActionsHeader, Mode=OneWay}"
-                                      Description="{x:Bind ViewModel.ActionsDescription, Mode=OneWay}"
-                                      HorizontalContentAlignment="Stretch"
-                                      Visibility="{x:Bind ViewModel.JsonProfileSettingsVisibility, Mode=OneWay}">
-                        <Grid ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
+                <wct:SettingsExpander Header="{x:Bind ViewModel.JsonProfileHeader, Mode=OneWay}"
+                                      Description="{x:Bind ViewModel.JsonProfileDescription, Mode=OneWay}"
+                                      IsEnabled="{x:Bind ViewModel.IsAutopilotSectionEnabled, Mode=OneWay}"
+                                      IsExpanded="{x:Bind ViewModel.UseJsonProfileProvisioning, Mode=OneWay}">
+                    <wct:SettingsExpander.HeaderIcon>
+                        <FontIcon Glyph="&#xE7C3;" />
+                    </wct:SettingsExpander.HeaderIcon>
+                    <ToggleSwitch behaviors:LocalizedToggleSwitch.UseLocalizedStateContent="True" AutomationProperties.Name="{x:Bind ViewModel.JsonProfileEnableText, Mode=OneWay}"
+                                  IsOn="{x:Bind ViewModel.UseJsonProfileProvisioning, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <wct:SettingsExpander.Items>
+                        <wct:SettingsCard Header="{x:Bind ViewModel.ActionsHeader, Mode=OneWay}"
+                                          Description="{x:Bind ViewModel.ActionsDescription, Mode=OneWay}"
+                                          HorizontalContentAlignment="Stretch"
+                                          Visibility="{x:Bind ViewModel.JsonProfileSettingsVisibility, Mode=OneWay}">
+                            <Grid ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
 
                             <StackPanel VerticalAlignment="Center"
                                         Orientation="Horizontal"
@@ -340,6 +341,7 @@
                 <ToggleSwitch behaviors:LocalizedToggleSwitch.UseLocalizedStateContent="True" AutomationProperties.Name="{x:Bind ViewModel.InteractiveHardwareHashEnableText, Mode=OneWay}"
                               IsOn="{x:Bind ViewModel.UseInteractiveHardwareHashUploadProvisioning, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </wct:SettingsCard>
+            </StackPanel>
         </StackPanel>
     </ScrollView>
 </Page>

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -12,8 +12,7 @@
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
                 Padding="{ThemeResource ContentPagePadding}"
                 VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="{ThemeResource FoundryPageContentInset}"
-                    Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
+        <StackPanel Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
             <Grid ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -20,7 +20,8 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <Grid VerticalAlignment="Center"
+                <Grid HorizontalAlignment="Left"
+                      VerticalAlignment="Center"
                       RowSpacing="{ThemeResource FoundryTextGroupSpacing}">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -28,12 +29,15 @@
                     </Grid.RowDefinitions>
 
                     <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
+                               HorizontalAlignment="Left"
                                Style="{ThemeResource FoundryPageTitleTextBlockStyle}" />
 
                     <TextBlock Grid.Row="1"
                                MaxWidth="{ThemeResource FoundrySummaryTextMaxWidth}"
+                               HorizontalAlignment="Left"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                               Text="{x:Bind ViewModel.AutopilotDescription, Mode=OneWay}"
+                               Text="{x:Bind ViewModel.PageDescription, Mode=OneWay}"
+                               TextAlignment="Left"
                                TextWrapping="WrapWholeWords"
                                Style="{ThemeResource FoundryBodyTextBlockStyle}" />
                 </Grid>

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -13,16 +13,33 @@
                 Padding="{ThemeResource ContentPagePadding}"
                 VerticalScrollBarVisibility="Auto">
         <StackPanel Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
-            <Grid ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}">
+            <Grid Margin="{ThemeResource FoundryPageHeaderMargin}"
+                  ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
-                           Style="{ThemeResource FoundryPageTitleTextBlockStyle}" />
+                <Grid VerticalAlignment="Center"
+                      RowSpacing="{ThemeResource FoundryTextGroupSpacing}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
+                               Style="{ThemeResource FoundryPageTitleTextBlockStyle}" />
+
+                    <TextBlock Grid.Row="1"
+                               MaxWidth="{ThemeResource FoundrySummaryTextMaxWidth}"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               Text="{x:Bind ViewModel.AutopilotDescription, Mode=OneWay}"
+                               TextWrapping="WrapWholeWords"
+                               Style="{ThemeResource FoundryBodyTextBlockStyle}" />
+                </Grid>
 
                 <controls:DocumentationButton Grid.Column="1"
+                                              HorizontalAlignment="Right"
                                               VerticalAlignment="Center"
                                               DocumentationUrl="{x:Bind ViewModel.DocumentationUrl, Mode=OneWay}" />
             </Grid>

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -3,6 +3,7 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:behaviors="using:Foundry.Behaviors"
+      xmlns:controls="using:Foundry.Controls"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:tv="using:WinUI.TableView"
@@ -22,16 +23,9 @@
                 <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
                            Style="{ThemeResource FoundryPageTitleTextBlockStyle}" />
 
-                <Button Grid.Column="1"
-                        VerticalAlignment="Center"
-                        AutomationProperties.Name="{x:Bind ViewModel.DocumentationButtonText, Mode=OneWay}"
-                        Click="DocumentationButton_Click">
-                    <StackPanel Orientation="Horizontal"
-                                Spacing="{ThemeResource FoundrySpace8}">
-                        <FontIcon Glyph="&#xE7C3;" />
-                        <TextBlock Text="{x:Bind ViewModel.DocumentationButtonText, Mode=OneWay}" />
-                    </StackPanel>
-                </Button>
+                <controls:DocumentationButton Grid.Column="1"
+                                              VerticalAlignment="Center"
+                                              DocumentationUrl="{x:Bind ViewModel.DocumentationUrl, Mode=OneWay}" />
             </Grid>
 
             <wct:SettingsCard Header="{x:Bind ViewModel.AutopilotHeader, Mode=OneWay}"

--- a/src/Foundry/Views/AutopilotPage.xaml.cs
+++ b/src/Foundry/Views/AutopilotPage.xaml.cs
@@ -1,17 +1,12 @@
-using Foundry.Core.Services.Application;
-
 namespace Foundry.Views;
 
 public sealed partial class AutopilotPage : Page
 {
-    private readonly IExternalProcessLauncher externalProcessLauncher;
-
     public AutopilotConfigurationViewModel ViewModel { get; }
 
     public AutopilotPage()
     {
         ViewModel = App.GetService<AutopilotConfigurationViewModel>();
-        externalProcessLauncher = App.GetService<IExternalProcessLauncher>();
         InitializeComponent();
         ViewModel.PropertyChanged += OnViewModelPropertyChanged;
         Unloaded += OnUnloaded;
@@ -30,11 +25,6 @@ public sealed partial class AutopilotPage : Page
         {
             ViewModel.ReplaceSelectedProfiles(tableView.SelectedItems.OfType<AutopilotProfileEntryViewModel>());
         }
-    }
-
-    private async void DocumentationButton_Click(object sender, RoutedEventArgs e)
-    {
-        await externalProcessLauncher.OpenUriAsync(new Uri(FoundryApplicationInfo.AutopilotDocumentationUrl));
     }
 
     private void CertificatesTable_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/src/Foundry/Views/AutopilotPage.xaml.cs
+++ b/src/Foundry/Views/AutopilotPage.xaml.cs
@@ -1,12 +1,17 @@
+using Foundry.Core.Services.Application;
+
 namespace Foundry.Views;
 
 public sealed partial class AutopilotPage : Page
 {
+    private readonly IExternalProcessLauncher externalProcessLauncher;
+
     public AutopilotConfigurationViewModel ViewModel { get; }
 
     public AutopilotPage()
     {
         ViewModel = App.GetService<AutopilotConfigurationViewModel>();
+        externalProcessLauncher = App.GetService<IExternalProcessLauncher>();
         InitializeComponent();
         ViewModel.PropertyChanged += OnViewModelPropertyChanged;
         Unloaded += OnUnloaded;
@@ -25,6 +30,11 @@ public sealed partial class AutopilotPage : Page
         {
             ViewModel.ReplaceSelectedProfiles(tableView.SelectedItems.OfType<AutopilotProfileEntryViewModel>());
         }
+    }
+
+    private async void DocumentationButton_Click(object sender, RoutedEventArgs e)
+    {
+        await externalProcessLauncher.OpenUriAsync(new Uri(FoundryApplicationInfo.AutopilotDocumentationUrl));
     }
 
     private void CertificatesTable_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/src/Foundry/Views/CustomizationPage.xaml
+++ b/src/Foundry/Views/CustomizationPage.xaml
@@ -11,8 +11,7 @@
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
                 Padding="{ThemeResource ContentPagePadding}"
                 VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="{ThemeResource FoundryPageContentInset}"
-                    Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
+        <StackPanel Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
             <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
                        Style="{ThemeResource FoundryPageTitleTextBlockStyle}" />
 

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml
@@ -10,8 +10,7 @@
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
                 Padding="{ThemeResource ContentPagePadding}"
                 VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="{ThemeResource FoundryPageContentInset}"
-                    dev:PanelAttach.ChildrenTransitions="Default"
+        <StackPanel dev:PanelAttach.ChildrenTransitions="Default"
                     Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
             <TextBlock x:Uid="GeneralConfigurationPage_Title"
                        Style="{ThemeResource FoundryPageTitleTextBlockStyle}" />

--- a/src/Foundry/Views/LocalizationPage.xaml
+++ b/src/Foundry/Views/LocalizationPage.xaml
@@ -10,8 +10,7 @@
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
                 Padding="{ThemeResource ContentPagePadding}"
                 VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="{ThemeResource FoundryPageContentInset}"
-                    Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
+        <StackPanel Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
             <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
                        Style="{ThemeResource FoundryPageTitleTextBlockStyle}" />
 

--- a/src/Foundry/Views/NetworkPage.xaml
+++ b/src/Foundry/Views/NetworkPage.xaml
@@ -10,8 +10,7 @@
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
                 Padding="{ThemeResource ContentPagePadding}"
                 VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="{ThemeResource FoundryPageContentInset}"
-                    Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
+        <StackPanel Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
             <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
                        Style="{ThemeResource FoundryPageTitleTextBlockStyle}" />
 

--- a/src/Foundry/Views/Settings/AppUpdateSettingPage.xaml
+++ b/src/Foundry/Views/Settings/AppUpdateSettingPage.xaml
@@ -13,8 +13,7 @@
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
                 Padding="{ThemeResource ContentPagePadding}"
                 VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="{ThemeResource FoundryPageContentInset}"
-                    dev:PanelAttach.ChildrenTransitions="Default"
+        <StackPanel dev:PanelAttach.ChildrenTransitions="Default"
                     Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
             <Border Background="{ThemeResource FoundrySurfaceSecondaryBrush}"
                     BorderBrush="{ThemeResource FoundrySurfaceBorderBrush}"

--- a/src/Foundry/Views/Settings/GeneralSettingPage.xaml
+++ b/src/Foundry/Views/Settings/GeneralSettingPage.xaml
@@ -14,8 +14,7 @@
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
                 Padding="{ThemeResource ContentPagePadding}"
                 VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="{ThemeResource FoundryPageContentInset}"
-                    dev:PanelAttach.ChildrenTransitions="Default"
+        <StackPanel dev:PanelAttach.ChildrenTransitions="Default"
                     Spacing="{ThemeResource FoundryCompactStackSpacing}">
 
             <wct:SettingsCard x:Name="StartupCard"

--- a/src/Foundry/Views/Settings/ThemeSettingPage.xaml
+++ b/src/Foundry/Views/Settings/ThemeSettingPage.xaml
@@ -13,8 +13,7 @@
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
                 Padding="{ThemeResource ContentPagePadding}"
                 VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="{ThemeResource FoundryPageContentInset}"
-                    dev:PanelAttach.ChildrenTransitions="Default"
+        <StackPanel dev:PanelAttach.ChildrenTransitions="Default"
                     Spacing="{ThemeResource FoundryCompactStackSpacing}">
             <wct:SettingsCard x:Uid="ThemeSetting_AppThemeCard">
                 <wct:SettingsCard.HeaderIcon>

--- a/src/Foundry/Views/SettingsPage.xaml
+++ b/src/Foundry/Views/SettingsPage.xaml
@@ -15,8 +15,7 @@
                 Padding="{ThemeResource ContentPagePadding}"
                 HorizontalAlignment="Stretch"
                 VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="{ThemeResource FoundryPageContentInset}"
-                    dev:PanelAttach.ChildrenTransitions="Default"
+        <StackPanel dev:PanelAttach.ChildrenTransitions="Default"
                     Spacing="{ThemeResource FoundryCompactStackSpacing}">
             <wct:SettingsCard x:Name="GeneralSettingsCard"
                               x:Uid="SettingsPage_GeneralCard"

--- a/src/Foundry/Views/StartPage.xaml
+++ b/src/Foundry/Views/StartPage.xaml
@@ -52,8 +52,7 @@
 
     <Grid Margin="{ThemeResource ContentPageMargin}"
           Padding="{ThemeResource ContentPagePadding}">
-        <Grid Margin="{ThemeResource FoundryPageContentInset}"
-              RowSpacing="{ThemeResource FoundrySettingsSectionSpacing}">
+        <Grid RowSpacing="{ThemeResource FoundrySettingsSectionSpacing}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />


### PR DESCRIPTION
## Summary
- Polishes the Autopilot page layout with a dedicated page header, description, and documentation action.
- Adds a reusable localized Documentation button control for future pages.
- Updates Autopilot provisioning glyphs and cleans up obsolete spacing resources.

## Reason
- Improve the Autopilot page visual hierarchy by separating the page header from the settings content.
- Keep documentation entry points consistent and reusable while allowing each page to provide its own URL.
- Make page spacing easier to reason about by removing unused or redundant spacing resources.

## Main changes
- Adds `Foundry.Controls.DocumentationButton` with shared glyph, localization, automation name, and external URI launch behavior.
- Adds `FoundryApplicationInfo.AutopilotDocumentationUrl` and exposes it through the Autopilot view model.
- Adds a two-column Autopilot page header with title/description on the left and the Documentation button on the right.
- Adds `Autopilot.PageDescription` and localizes it across all Foundry UI languages.
- Sets the Autopilot header-to-content gap through `FoundryPageHeaderMargin` at 48px.
- Keeps `FoundrySettingsSectionSpacing` scoped to spacing between settings cards and expanders.
- Replaces the Autopilot option glyphs for JSON profile provisioning, zero-touch hardware hash upload, and interactive hardware hash upload.
- Removes `FoundryPageContentInset` and updates main content pages to use `ContentPageMargin` / `ContentPagePadding` directly.
- Removes the unused `FoundryPageSectionSpacing` resource.

## Testing notes
- Passed: `dotnet build src\Foundry\Foundry.csproj -p:OutDir="E:\Github\Foundry Project\foundry-worktrees\autopilot-osd-ui-polish\.verify\Foundry\"` (96 existing XAML trim warnings, 0 errors).
- Passed: `dotnet test src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj` (285 passed, existing xUnit cancellation-token warnings).
