### PR TITLE
feat(runtime): warn about outdated boot media config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,18 @@ Pull request rules:
 - Reuse existing services, models, and patterns before creating new ones
 - Respect nullable reference types and existing analyzer warnings if enabled
 
+Configuration schema rules:
+- Treat Foundry authoring configuration, Foundry.Deploy runtime configuration, and Foundry.Connect runtime configuration as separate schema contracts
+- Keep schema versions monotonic within each contract
+- Bump a schema version only when the persisted or generated configuration contract changes in a way that affects runtime behavior or compatibility
+- Bump Foundry authoring schema when the user-facing persisted Foundry configuration shape, defaults, migration behavior, or semantic meaning changes
+- Bump Foundry.Deploy runtime schema when Deploy consumes new generated configuration, requires new boot media assets, changes the meaning of an existing Deploy field, or needs older boot media to show a compatibility warning
+- Bump Foundry.Connect runtime schema when Connect consumes new generated configuration, requires new network provisioning assets, changes the meaning of an existing Connect field, or needs older boot media to show a compatibility warning
+- Do not bump schema versions for UI-only changes, localization updates, documentation changes, styling changes, internal refactors, or bug fixes that do not change the configuration contract
+- When bumping Deploy schema, update both the generator model in Foundry.Core and the runtime model in Foundry.Deploy
+- When bumping Connect schema, update both the generator model in Foundry.Core and the runtime model in Foundry.Connect
+- When bumping any schema, update the smallest relevant tests and compatibility warning expectations
+
 Logging rules:
 - Use the existing logging system when one is already in place
 - Write logs only when they add operational or diagnostic value

--- a/src/Foundry.Connect.Tests/ConnectConfigurationServiceTests.cs
+++ b/src/Foundry.Connect.Tests/ConnectConfigurationServiceTests.cs
@@ -57,6 +57,9 @@ public sealed class ConnectConfigurationServiceTests
 
         Assert.True(service.IsLoadedFromDisk);
         Assert.Equal(System.IO.Path.GetFullPath(configurationPath), service.ConfigurationPath);
+        Assert.Equal(0, service.LoadedSchemaVersion);
+        Assert.Equal(FoundryConnectConfiguration.CurrentSchemaVersion, service.CurrentSchemaVersion);
+        Assert.True(service.IsBootMediaUpdateRecommended);
         Assert.Equal(FoundryConnectConfiguration.CurrentSchemaVersion, configuration.SchemaVersion);
         Assert.Equal(30, configuration.InternetProbe.TimeoutSeconds);
         Assert.Equal(
@@ -90,6 +93,9 @@ public sealed class ConnectConfigurationServiceTests
         FoundryConnectConfiguration configuration = service.Load();
 
         Assert.False(configuration.Telemetry.IsEnabled);
+        Assert.Equal(FoundryConnectConfiguration.CurrentSchemaVersion, service.LoadedSchemaVersion);
+        Assert.Equal(FoundryConnectConfiguration.CurrentSchemaVersion, service.CurrentSchemaVersion);
+        Assert.False(service.IsBootMediaUpdateRecommended);
         Assert.Equal("install-id", configuration.Telemetry.InstallId);
         Assert.Equal(TelemetryDefaults.PostHogEuHost, configuration.Telemetry.HostUrl);
         Assert.Equal("project-token", configuration.Telemetry.ProjectToken);

--- a/src/Foundry.Connect.Tests/ConnectConfigurationServiceTests.cs
+++ b/src/Foundry.Connect.Tests/ConnectConfigurationServiceTests.cs
@@ -57,8 +57,6 @@ public sealed class ConnectConfigurationServiceTests
 
         Assert.True(service.IsLoadedFromDisk);
         Assert.Equal(System.IO.Path.GetFullPath(configurationPath), service.ConfigurationPath);
-        Assert.Equal(0, service.LoadedSchemaVersion);
-        Assert.Equal(FoundryConnectConfiguration.CurrentSchemaVersion, service.CurrentSchemaVersion);
         Assert.True(service.IsBootMediaUpdateRecommended);
         Assert.Equal(FoundryConnectConfiguration.CurrentSchemaVersion, configuration.SchemaVersion);
         Assert.Equal(30, configuration.InternetProbe.TimeoutSeconds);
@@ -93,8 +91,6 @@ public sealed class ConnectConfigurationServiceTests
         FoundryConnectConfiguration configuration = service.Load();
 
         Assert.False(configuration.Telemetry.IsEnabled);
-        Assert.Equal(FoundryConnectConfiguration.CurrentSchemaVersion, service.LoadedSchemaVersion);
-        Assert.Equal(FoundryConnectConfiguration.CurrentSchemaVersion, service.CurrentSchemaVersion);
         Assert.False(service.IsBootMediaUpdateRecommended);
         Assert.Equal("install-id", configuration.Telemetry.InstallId);
         Assert.Equal(TelemetryDefaults.PostHogEuHost, configuration.Telemetry.HostUrl);

--- a/src/Foundry.Connect.Tests/MainWindowViewModelTelemetryTests.cs
+++ b/src/Foundry.Connect.Tests/MainWindowViewModelTelemetryTests.cs
@@ -213,10 +213,6 @@ public sealed class MainWindowViewModelTelemetryTests
 
         public bool IsLoadedFromDisk => false;
 
-        public int? LoadedSchemaVersion => null;
-
-        public int CurrentSchemaVersion => FoundryConnectConfiguration.CurrentSchemaVersion;
-
         public bool IsBootMediaUpdateRecommended => false;
 
         public FoundryConnectConfiguration Load()

--- a/src/Foundry.Connect.Tests/MainWindowViewModelTelemetryTests.cs
+++ b/src/Foundry.Connect.Tests/MainWindowViewModelTelemetryTests.cs
@@ -213,6 +213,12 @@ public sealed class MainWindowViewModelTelemetryTests
 
         public bool IsLoadedFromDisk => false;
 
+        public int? LoadedSchemaVersion => null;
+
+        public int CurrentSchemaVersion => FoundryConnectConfiguration.CurrentSchemaVersion;
+
+        public bool IsBootMediaUpdateRecommended => false;
+
         public FoundryConnectConfiguration Load()
         {
             return configuration;

--- a/src/Foundry.Connect/MainWindow.xaml
+++ b/src/Foundry.Connect/MainWindow.xaml
@@ -72,8 +72,15 @@
                 <StackPanel
                     Margin="0,0,12,0"
                     Orientation="Horizontal"
-                    ToolTip="{Binding BootMediaUpdateRecommendedToolTip}"
                     Visibility="{Binding IsBootMediaUpdateRecommended, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <StackPanel.ToolTip>
+                        <ToolTip>
+                            <TextBlock
+                                MaxWidth="480"
+                                Text="{Binding BootMediaUpdateRecommendedToolTip}"
+                                TextWrapping="Wrap" />
+                        </ToolTip>
+                    </StackPanel.ToolTip>
                     <TextBlock
                         Margin="0,0,4,0"
                         VerticalAlignment="Center"

--- a/src/Foundry.Connect/MainWindow.xaml
+++ b/src/Foundry.Connect/MainWindow.xaml
@@ -63,13 +63,36 @@
                 <MenuItem Command="{Binding ShowAboutCommand}" Header="{Binding Strings[Menu.About]}" />
             </Menu>
 
-            <TextBlock
+            <StackPanel
                 Grid.Column="1"
                 Margin="0,0,16,0"
+                HorizontalAlignment="Right"
                 VerticalAlignment="Center"
-                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{Binding VersionDisplay}" />
+                Orientation="Horizontal">
+                <StackPanel
+                    Margin="0,0,12,0"
+                    Orientation="Horizontal"
+                    ToolTip="{Binding BootMediaUpdateRecommendedToolTip}"
+                    Visibility="{Binding IsBootMediaUpdateRecommended, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <TextBlock
+                        Margin="0,0,4,0"
+                        VerticalAlignment="Center"
+                        FontFamily="{StaticResource SymbolThemeFontFamily}"
+                        Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="&#xE7BA;" />
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{Binding BootMediaUpdateRecommendedText}" />
+                </StackPanel>
+                <TextBlock
+                    VerticalAlignment="Center"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{Binding VersionDisplay}" />
+            </StackPanel>
         </Grid>
 
         <Grid

--- a/src/Foundry.Connect/Services/Configuration/ConnectConfigurationService.cs
+++ b/src/Foundry.Connect/Services/Configuration/ConnectConfigurationService.cs
@@ -41,6 +41,15 @@ public sealed class ConnectConfigurationService : IConnectConfigurationService
     public bool IsLoadedFromDisk { get; private set; }
 
     /// <inheritdoc />
+    public int? LoadedSchemaVersion { get; private set; }
+
+    /// <inheritdoc />
+    public int CurrentSchemaVersion => FoundryConnectConfiguration.CurrentSchemaVersion;
+
+    /// <inheritdoc />
+    public bool IsBootMediaUpdateRecommended { get; private set; }
+
+    /// <inheritdoc />
     public FoundryConnectConfiguration Load()
     {
         ConfigurationResolution resolution = ResolveConfigurationPath(_args);
@@ -48,6 +57,7 @@ public sealed class ConnectConfigurationService : IConnectConfigurationService
         if (string.IsNullOrWhiteSpace(ConfigurationPath))
         {
             IsLoadedFromDisk = false;
+            ResetSchemaCompatibilityState();
             _logger.LogInformation("No Foundry.Connect configuration file was resolved. Using built-in defaults.");
             return Normalize(new FoundryConnectConfiguration());
         }
@@ -59,6 +69,7 @@ public sealed class ConnectConfigurationService : IConnectConfigurationService
             {
                 ConfigurationPath = null;
                 IsLoadedFromDisk = false;
+                ResetSchemaCompatibilityState();
                 _logger.LogInformation("Foundry.Connect configuration file was not found. Using built-in defaults. ConfigurationPath={ConfigurationPath}", fullPath);
                 return Normalize(new FoundryConnectConfiguration());
             }
@@ -76,6 +87,7 @@ public sealed class ConnectConfigurationService : IConnectConfigurationService
                 throw new FoundryConnectConfigurationException($"Configuration file is empty or invalid: {fullPath}");
             }
 
+            ApplySchemaCompatibilityState(configuration.SchemaVersion);
             configuration = DecryptEmbeddedSecrets(configuration, fullPath);
             ConfigurationPath = fullPath;
             IsLoadedFromDisk = true;
@@ -89,6 +101,25 @@ public sealed class ConnectConfigurationService : IConnectConfigurationService
         catch (Exception ex)
         {
             throw new FoundryConnectConfigurationException($"Configuration file could not be parsed: {fullPath}", ex);
+        }
+    }
+
+    private void ResetSchemaCompatibilityState()
+    {
+        LoadedSchemaVersion = null;
+        IsBootMediaUpdateRecommended = false;
+    }
+
+    private void ApplySchemaCompatibilityState(int schemaVersion)
+    {
+        LoadedSchemaVersion = schemaVersion;
+        IsBootMediaUpdateRecommended = schemaVersion < FoundryConnectConfiguration.CurrentSchemaVersion;
+        if (IsBootMediaUpdateRecommended)
+        {
+            _logger.LogWarning(
+                "Foundry.Connect configuration uses schema version {SchemaVersion}, older than current schema version {CurrentSchemaVersion}. Boot media update is recommended.",
+                schemaVersion,
+                FoundryConnectConfiguration.CurrentSchemaVersion);
         }
     }
 

--- a/src/Foundry.Connect/Services/Configuration/ConnectConfigurationService.cs
+++ b/src/Foundry.Connect/Services/Configuration/ConnectConfigurationService.cs
@@ -41,12 +41,6 @@ public sealed class ConnectConfigurationService : IConnectConfigurationService
     public bool IsLoadedFromDisk { get; private set; }
 
     /// <inheritdoc />
-    public int? LoadedSchemaVersion { get; private set; }
-
-    /// <inheritdoc />
-    public int CurrentSchemaVersion => FoundryConnectConfiguration.CurrentSchemaVersion;
-
-    /// <inheritdoc />
     public bool IsBootMediaUpdateRecommended { get; private set; }
 
     /// <inheritdoc />
@@ -106,13 +100,11 @@ public sealed class ConnectConfigurationService : IConnectConfigurationService
 
     private void ResetSchemaCompatibilityState()
     {
-        LoadedSchemaVersion = null;
         IsBootMediaUpdateRecommended = false;
     }
 
     private void ApplySchemaCompatibilityState(int schemaVersion)
     {
-        LoadedSchemaVersion = schemaVersion;
         IsBootMediaUpdateRecommended = schemaVersion < FoundryConnectConfiguration.CurrentSchemaVersion;
         if (IsBootMediaUpdateRecommended)
         {

--- a/src/Foundry.Connect/Services/Configuration/IConnectConfigurationService.cs
+++ b/src/Foundry.Connect/Services/Configuration/IConnectConfigurationService.cs
@@ -18,6 +18,21 @@ public interface IConnectConfigurationService
     bool IsLoadedFromDisk { get; }
 
     /// <summary>
+    /// Gets the schema version read from the configuration file before normalization.
+    /// </summary>
+    int? LoadedSchemaVersion { get; }
+
+    /// <summary>
+    /// Gets the current runtime schema version supported by Foundry.Connect.
+    /// </summary>
+    int CurrentSchemaVersion { get; }
+
+    /// <summary>
+    /// Gets whether the loaded boot media should be updated for best compatibility.
+    /// </summary>
+    bool IsBootMediaUpdateRecommended { get; }
+
+    /// <summary>
     /// Loads configuration from command-line, environment, or WinPE media locations.
     /// </summary>
     /// <returns>The normalized runtime configuration.</returns>

--- a/src/Foundry.Connect/Services/Configuration/IConnectConfigurationService.cs
+++ b/src/Foundry.Connect/Services/Configuration/IConnectConfigurationService.cs
@@ -18,16 +18,6 @@ public interface IConnectConfigurationService
     bool IsLoadedFromDisk { get; }
 
     /// <summary>
-    /// Gets the schema version read from the configuration file before normalization.
-    /// </summary>
-    int? LoadedSchemaVersion { get; }
-
-    /// <summary>
-    /// Gets the current runtime schema version supported by Foundry.Connect.
-    /// </summary>
-    int CurrentSchemaVersion { get; }
-
-    /// <summary>
     /// Gets whether the loaded boot media should be updated for best compatibility.
     /// </summary>
     bool IsBootMediaUpdateRecommended { get; }

--- a/src/Foundry.Connect/Strings/ar-SA/Resources.resx
+++ b/src/Foundry.Connect/Strings/ar-SA/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>قطع الاتصال</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>يوصى بتحديث وسيط التمهيد</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>تم إنشاء وسيط التمهيد هذا بتنسيق تكوين قديم لـ Foundry OSD. حدّث وسيط التمهيد لضمان التوافق مع أحدث الميزات.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>الإصدار: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/ar-SA/Resources.resx
+++ b/src/Foundry.Connect/Strings/ar-SA/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>قطع الاتصال</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>الإصدار: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/bg-BG/Resources.resx
+++ b/src/Foundry.Connect/Strings/bg-BG/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Прекъснете връзката</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Препоръчва се актуализация на носителя за стартиране</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Този носител за стартиране е генериран с по-стар формат за конфигурация на Foundry OSD. Актуализирайте носителя за стартиране, за да осигурите съвместимост с най-новите функции.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Версия: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/bg-BG/Resources.resx
+++ b/src/Foundry.Connect/Strings/bg-BG/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Прекъснете връзката</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Версия: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/cs-CZ/Resources.resx
+++ b/src/Foundry.Connect/Strings/cs-CZ/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Odpojit</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Verze: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/cs-CZ/Resources.resx
+++ b/src/Foundry.Connect/Strings/cs-CZ/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Odpojit</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Doporučuje se aktualizovat spouštěcí médium</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Toto spouštěcí médium bylo vygenerováno pomocí staršího formátu konfigurace Foundry OSD. Aktualizujte spouštěcí médium, aby byla zajištěna kompatibilita s nejnovějšími funkcemi.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Verze: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/da-DK/Resources.resx
+++ b/src/Foundry.Connect/Strings/da-DK/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Afbryd forbindelsen</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Version: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/da-DK/Resources.resx
+++ b/src/Foundry.Connect/Strings/da-DK/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Afbryd forbindelsen</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Opdatering af startmedie anbefales</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Dette startmedie blev genereret med et ældre Foundry OSD-konfigurationsformat. Opdater startmediet for at sikre kompatibilitet med de nyeste funktioner.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Version: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/de-DE/Resources.resx
+++ b/src/Foundry.Connect/Strings/de-DE/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Trennen</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Aktualisierung des Startmediums empfohlen</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Dieses Startmedium wurde mit einem älteren Foundry OSD-Konfigurationsformat erstellt. Aktualisieren Sie das Startmedium, um die Kompatibilität mit den neuesten Funktionen sicherzustellen.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Version: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/de-DE/Resources.resx
+++ b/src/Foundry.Connect/Strings/de-DE/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Trennen</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Version: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/el-GR/Resources.resx
+++ b/src/Foundry.Connect/Strings/el-GR/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Αποσύνδεση</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Συνιστάται ενημέρωση του μέσου εκκίνησης</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Αυτό το μέσο εκκίνησης δημιουργήθηκε με παλαιότερη μορφή ρύθμισης παραμέτρων Foundry OSD. Ενημερώστε το μέσο εκκίνησης για να διασφαλίσετε τη συμβατότητα με τις πιο πρόσφατες δυνατότητες.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Έκδοση: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/el-GR/Resources.resx
+++ b/src/Foundry.Connect/Strings/el-GR/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Αποσύνδεση</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Έκδοση: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/en-GB/Resources.resx
+++ b/src/Foundry.Connect/Strings/en-GB/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Disconnect</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Version: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/en-US/Resources.resx
+++ b/src/Foundry.Connect/Strings/en-US/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Disconnect</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Version: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/es-ES/Resources.resx
+++ b/src/Foundry.Connect/Strings/es-ES/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Desconectar</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versión: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/es-ES/Resources.resx
+++ b/src/Foundry.Connect/Strings/es-ES/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Desconectar</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Actualización del medio de arranque recomendada</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Este medio de arranque se generó con un formato de configuración anterior de Foundry OSD. Actualice el medio de arranque para garantizar la compatibilidad con las funciones más recientes.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versión: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/es-MX/Resources.resx
+++ b/src/Foundry.Connect/Strings/es-MX/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Desconectar</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Actualización del medio de arranque recomendada</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Este medio de arranque se generó con un formato de configuración anterior de Foundry OSD. Actualiza el medio de arranque para garantizar la compatibilidad con las funciones más recientes.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versión: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/es-MX/Resources.resx
+++ b/src/Foundry.Connect/Strings/es-MX/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Desconectar</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versión: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/et-EE/Resources.resx
+++ b/src/Foundry.Connect/Strings/et-EE/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Katkesta ühendus</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versioon: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/et-EE/Resources.resx
+++ b/src/Foundry.Connect/Strings/et-EE/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Katkesta ühendus</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Soovitatav on algkandja värskendamine</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>See algkandja loodi vanema Foundry OSD konfiguratsioonivorminguga. Värskendage algkandjat, et tagada ühilduvus uusimate funktsioonidega.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versioon: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/fi-FI/Resources.resx
+++ b/src/Foundry.Connect/Strings/fi-FI/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Katkaise yhteys</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versio: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/fi-FI/Resources.resx
+++ b/src/Foundry.Connect/Strings/fi-FI/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Katkaise yhteys</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Käynnistysmedian päivitystä suositellaan</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Tämä käynnistysmedia luotiin vanhemmalla Foundry OSD -määritysmuodolla. Päivitä käynnistysmedia varmistaaksesi yhteensopivuuden uusimpien ominaisuuksien kanssa.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versio: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/fr-CA/Resources.resx
+++ b/src/Foundry.Connect/Strings/fr-CA/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Déconnecter</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Version: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/fr-CA/Resources.resx
+++ b/src/Foundry.Connect/Strings/fr-CA/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Déconnecter</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Mise à jour du support de démarrage recommandée</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Ce support de démarrage a été généré avec un ancien format de configuration Foundry OSD. Mettez à jour le support de démarrage pour garantir la compatibilité avec les dernières fonctionnalités.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Version: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Connect/Strings/fr-FR/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Se déconnecter</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Version : {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Connect/Strings/fr-FR/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Se déconnecter</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Mise à jour du support de démarrage recommandée</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Ce support de démarrage a été généré avec un ancien format de configuration Foundry OSD. Mettez à jour le support de démarrage pour garantir la compatibilité avec les dernières fonctionnalités.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Version : {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/he-IL/Resources.resx
+++ b/src/Foundry.Connect/Strings/he-IL/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>התנתק</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>גרסה: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/he-IL/Resources.resx
+++ b/src/Foundry.Connect/Strings/he-IL/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>התנתק</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>מומלץ לעדכן את מדיית האתחול</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>מדיית האתחול הזו נוצרה באמצעות תבנית תצורה ישנה יותר של Foundry OSD. עדכן את מדיית האתחול כדי להבטיח תאימות לתכונות העדכניות ביותר.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>גרסה: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/hr-HR/Resources.resx
+++ b/src/Foundry.Connect/Strings/hr-HR/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Prekini vezu</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Preporučuje se ažuriranje medija za pokretanje</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Ovaj medij za pokretanje generiran je starijim formatom konfiguracije Foundry OSD. Ažurirajte medij za pokretanje kako biste osigurali kompatibilnost s najnovijim značajkama.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Verzija: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/hr-HR/Resources.resx
+++ b/src/Foundry.Connect/Strings/hr-HR/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Prekini vezu</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Verzija: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/hu-HU/Resources.resx
+++ b/src/Foundry.Connect/Strings/hu-HU/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Leválasztás</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Verzió: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/hu-HU/Resources.resx
+++ b/src/Foundry.Connect/Strings/hu-HU/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Leválasztás</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>A rendszerindító adathordozó frissítése ajánlott</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Ez a rendszerindító adathordozó egy régebbi Foundry OSD konfigurációs formátummal készült. Frissítse a rendszerindító adathordozót a legújabb funkciókkal való kompatibilitás biztosításához.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Verzió: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/it-IT/Resources.resx
+++ b/src/Foundry.Connect/Strings/it-IT/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Disconnetti</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versione: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/it-IT/Resources.resx
+++ b/src/Foundry.Connect/Strings/it-IT/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Disconnetti</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Aggiornamento del supporto di avvio consigliato</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Questo supporto di avvio è stato generato con un formato di configurazione Foundry OSD precedente. Aggiorna il supporto di avvio per garantire la compatibilità con le funzionalità più recenti.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versione: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/ja-JP/Resources.resx
+++ b/src/Foundry.Connect/Strings/ja-JP/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>切断する</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>バージョン: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/ja-JP/Resources.resx
+++ b/src/Foundry.Connect/Strings/ja-JP/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>切断する</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>ブート メディアの更新を推奨</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>このブート メディアは古い Foundry OSD 構成形式で生成されています。最新機能との互換性を確保するため、ブート メディアを更新してください。</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>バージョン: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/ko-KR/Resources.resx
+++ b/src/Foundry.Connect/Strings/ko-KR/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>연결 끊기</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>버전: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/ko-KR/Resources.resx
+++ b/src/Foundry.Connect/Strings/ko-KR/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>연결 끊기</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>부팅 미디어 업데이트 권장</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>이 부팅 미디어는 이전 Foundry OSD 구성 형식으로 생성되었습니다. 최신 기능과의 호환성을 보장하려면 부팅 미디어를 업데이트하세요.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>버전: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/lt-LT/Resources.resx
+++ b/src/Foundry.Connect/Strings/lt-LT/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Atsijungti</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Rekomenduojama atnaujinti įkrovos laikmeną</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Ši įkrovos laikmena buvo sugeneruota naudojant senesnį Foundry OSD konfigūracijos formatą. Atnaujinkite įkrovos laikmeną, kad užtikrintumėte suderinamumą su naujausiomis funkcijomis.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versija: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/lt-LT/Resources.resx
+++ b/src/Foundry.Connect/Strings/lt-LT/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Atsijungti</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versija: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/lv-LV/Resources.resx
+++ b/src/Foundry.Connect/Strings/lv-LV/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Atvienot</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Ieteicams atjaunināt sāknēšanas datu nesēju</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Šis sāknēšanas datu nesējs tika ģenerēts ar vecāku Foundry OSD konfigurācijas formātu. Atjauniniet sāknēšanas datu nesēju, lai nodrošinātu saderību ar jaunākajiem līdzekļiem.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versija: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/lv-LV/Resources.resx
+++ b/src/Foundry.Connect/Strings/lv-LV/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Atvienot</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versija: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/nb-NO/Resources.resx
+++ b/src/Foundry.Connect/Strings/nb-NO/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Koble fra</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versjon: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/nb-NO/Resources.resx
+++ b/src/Foundry.Connect/Strings/nb-NO/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Koble fra</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Oppdatering av oppstartsmediet anbefales</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Dette oppstartsmediet ble generert med et eldre Foundry OSD-konfigurasjonsformat. Oppdater oppstartsmediet for å sikre kompatibilitet med de nyeste funksjonene.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versjon: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/nl-NL/Resources.resx
+++ b/src/Foundry.Connect/Strings/nl-NL/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Verbreek de verbinding</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Update van opstartmedium aanbevolen</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Dit opstartmedium is gegenereerd met een ouder Foundry OSD-configuratieformaat. Werk het opstartmedium bij om compatibiliteit met de nieuwste functies te garanderen.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versie: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/nl-NL/Resources.resx
+++ b/src/Foundry.Connect/Strings/nl-NL/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Verbreek de verbinding</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versie: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/pl-PL/Resources.resx
+++ b/src/Foundry.Connect/Strings/pl-PL/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Rozłącz</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Wersja: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/pl-PL/Resources.resx
+++ b/src/Foundry.Connect/Strings/pl-PL/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Rozłącz</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Zalecana aktualizacja nośnika rozruchowego</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Ten nośnik rozruchowy został wygenerowany przy użyciu starszego formatu konfiguracji Foundry OSD. Zaktualizuj nośnik rozruchowy, aby zapewnić zgodność z najnowszymi funkcjami.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Wersja: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/pt-BR/Resources.resx
+++ b/src/Foundry.Connect/Strings/pt-BR/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Desconectar</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versão: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/pt-BR/Resources.resx
+++ b/src/Foundry.Connect/Strings/pt-BR/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Desconectar</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Atualização da mídia de inicialização recomendada</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Esta mídia de inicialização foi gerada com um formato de configuração mais antigo do Foundry OSD. Atualize a mídia de inicialização para garantir compatibilidade com os recursos mais recentes.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versão: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/pt-PT/Resources.resx
+++ b/src/Foundry.Connect/Strings/pt-PT/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Desconectar</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versão: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/pt-PT/Resources.resx
+++ b/src/Foundry.Connect/Strings/pt-PT/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Desconectar</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Atualização do suporte de arranque recomendada</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Este suporte de arranque foi gerado com um formato de configuração Foundry OSD mais antigo. Atualize o suporte de arranque para garantir compatibilidade com as funcionalidades mais recentes.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versão: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/ro-RO/Resources.resx
+++ b/src/Foundry.Connect/Strings/ro-RO/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Deconectați-vă</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Se recomandă actualizarea suportului de pornire</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Acest suport de pornire a fost generat cu un format de configurare Foundry OSD mai vechi. Actualizați suportul de pornire pentru a asigura compatibilitatea cu cele mai recente caracteristici.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versiune: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/ro-RO/Resources.resx
+++ b/src/Foundry.Connect/Strings/ro-RO/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Deconectați-vă</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Versiune: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/ru-RU/Resources.resx
+++ b/src/Foundry.Connect/Strings/ru-RU/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Отключить</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Версия: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/ru-RU/Resources.resx
+++ b/src/Foundry.Connect/Strings/ru-RU/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Отключить</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Рекомендуется обновить загрузочный носитель</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Этот загрузочный носитель был создан с использованием более старого формата конфигурации Foundry OSD. Обновите загрузочный носитель, чтобы обеспечить совместимость с новейшими функциями.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Версия: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/sk-SK/Resources.resx
+++ b/src/Foundry.Connect/Strings/sk-SK/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Odpojiť</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Odporúča sa aktualizovať zavádzacie médium</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Toto zavádzacie médium bolo vygenerované pomocou staršieho formátu konfigurácie Foundry OSD. Aktualizujte zavádzacie médium, aby ste zabezpečili kompatibilitu s najnovšími funkciami.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Verzia: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/sk-SK/Resources.resx
+++ b/src/Foundry.Connect/Strings/sk-SK/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Odpojiť</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Verzia: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/sl-SI/Resources.resx
+++ b/src/Foundry.Connect/Strings/sl-SI/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Prekini povezavo</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Različica: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/sl-SI/Resources.resx
+++ b/src/Foundry.Connect/Strings/sl-SI/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Prekini povezavo</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Priporočena je posodobitev zagonskega medija</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Ta zagonski medij je bil ustvarjen s starejšo obliko konfiguracije Foundry OSD. Posodobite zagonski medij, da zagotovite združljivost z najnovejšimi funkcijami.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Različica: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/sr-Latn-RS/Resources.resx
+++ b/src/Foundry.Connect/Strings/sr-Latn-RS/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Prekini vezu</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Preporučuje se ažuriranje medija za pokretanje</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Ovaj medij za pokretanje je generisan starijim formatom konfiguracije Foundry OSD. Ažurirajte medij za pokretanje da biste obezbedili kompatibilnost sa najnovijim funkcijama.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Verzija: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/sr-Latn-RS/Resources.resx
+++ b/src/Foundry.Connect/Strings/sr-Latn-RS/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Prekini vezu</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Verzija: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/sv-SE/Resources.resx
+++ b/src/Foundry.Connect/Strings/sv-SE/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Koppla från</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Uppdatering av startmedia rekommenderas</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Detta startmedia skapades med ett äldre Foundry OSD-konfigurationsformat. Uppdatera startmediet för att säkerställa kompatibilitet med de senaste funktionerna.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Version: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/sv-SE/Resources.resx
+++ b/src/Foundry.Connect/Strings/sv-SE/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Koppla från</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Version: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/th-TH/Resources.resx
+++ b/src/Foundry.Connect/Strings/th-TH/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>ตัดการเชื่อมต่อ</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>แนะนำให้อัปเดตสื่อบูต</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>สื่อบูตนี้ถูกสร้างด้วยรูปแบบการกำหนดค่า Foundry OSD รุ่นเก่า อัปเดตสื่อบูตเพื่อให้เข้ากันได้กับฟีเจอร์ล่าสุด</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>เวอร์ชัน: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/th-TH/Resources.resx
+++ b/src/Foundry.Connect/Strings/th-TH/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>ตัดการเชื่อมต่อ</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>เวอร์ชัน: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/tr-TR/Resources.resx
+++ b/src/Foundry.Connect/Strings/tr-TR/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Bağlantıyı kes</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Önyükleme medyası güncellemesi önerilir</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Bu önyükleme medyası daha eski bir Foundry OSD yapılandırma biçimiyle oluşturuldu. En son özelliklerle uyumluluğu sağlamak için önyükleme medyasını güncelleyin.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Sürüm: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/tr-TR/Resources.resx
+++ b/src/Foundry.Connect/Strings/tr-TR/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Bağlantıyı kes</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Sürüm: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/uk-UA/Resources.resx
+++ b/src/Foundry.Connect/Strings/uk-UA/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Відключити</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Рекомендовано оновити завантажувальний носій</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Цей завантажувальний носій створено зі старішим форматом конфігурації Foundry OSD. Оновіть завантажувальний носій, щоб забезпечити сумісність із найновішими функціями.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Версія: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/uk-UA/Resources.resx
+++ b/src/Foundry.Connect/Strings/uk-UA/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>Відключити</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>Версія: {0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/zh-CN/Resources.resx
+++ b/src/Foundry.Connect/Strings/zh-CN/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>断开连接</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>版本：{0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/zh-CN/Resources.resx
+++ b/src/Foundry.Connect/Strings/zh-CN/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>断开连接</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>建议更新启动介质</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>此启动介质是使用较旧的 Foundry OSD 配置格式生成的。请更新启动介质，以确保与最新功能兼容。</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>版本：{0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/zh-TW/Resources.resx
+++ b/src/Foundry.Connect/Strings/zh-TW/Resources.resx
@@ -81,8 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>斷開連接</value>
   </data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>建議更新開機媒體</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>此開機媒體是使用較舊的 Foundry OSD 設定格式產生的。請更新開機媒體，以確保與最新功能相容。</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>版本：{0}</value>
   </data>

--- a/src/Foundry.Connect/Strings/zh-TW/Resources.resx
+++ b/src/Foundry.Connect/Strings/zh-TW/Resources.resx
@@ -81,6 +81,8 @@
   <data name="Action.Disconnect" xml:space="preserve">
     <value>斷開連接</value>
   </data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve">
     <value>版本：{0}</value>
   </data>

--- a/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
@@ -196,6 +196,9 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     public ConnectThemeMode CurrentTheme => _themeService.CurrentTheme;
 
     public string VersionDisplay => Format("Common.VersionFormat", FoundryConnectApplicationInfo.Version);
+    public bool IsBootMediaUpdateRecommended => _configurationService.IsBootMediaUpdateRecommended;
+    public string BootMediaUpdateRecommendedText => GetString("BootMedia.UpdateRecommended");
+    public string BootMediaUpdateRecommendedToolTip => GetString("BootMedia.UpdateRecommendedToolTip");
 
     /// <summary>
     /// Gets the configuration source text shown in the footer.
@@ -1016,6 +1019,8 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
             CurrentConnectionChipText = BuildCurrentConnectionChipText(IsEthernetConnected);
             OnPropertyChanged(nameof(CurrentCulture));
             OnPropertyChanged(nameof(VersionDisplay));
+            OnPropertyChanged(nameof(BootMediaUpdateRecommendedText));
+            OnPropertyChanged(nameof(BootMediaUpdateRecommendedToolTip));
             OnPropertyChanged(nameof(ConfigurationSourceText));
             OnPropertyChanged(nameof(RefreshIntervalText));
             OnPropertyChanged(nameof(WindowTitle));

--- a/src/Foundry.Deploy.Tests/DeployConfigurationServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeployConfigurationServiceTests.cs
@@ -1,0 +1,86 @@
+using Foundry.Deploy.Models.Configuration;
+using Foundry.Deploy.Services.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class DeployConfigurationServiceTests
+{
+    [Fact]
+    public void LoadOptional_WhenSchemaIsOlderThanCurrent_RecommendsBootMediaUpdate()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        string configurationPath = CreateJsonFile(
+            tempDirectory.Path,
+            "foundry.deploy.config.json",
+            $$"""
+            {
+              "schemaVersion": {{FoundryDeployConfigurationDocument.CurrentSchemaVersion - 1}}
+            }
+            """);
+
+        var service = new DeployConfigurationService(
+            NullLogger<DeployConfigurationService>.Instance,
+            configurationPath);
+
+        DeployConfigurationLoadResult result = service.LoadOptional();
+
+        Assert.True(result.Exists);
+        Assert.NotNull(result.Document);
+        Assert.Equal(FoundryDeployConfigurationDocument.CurrentSchemaVersion - 1, result.SchemaVersion);
+        Assert.Equal(FoundryDeployConfigurationDocument.CurrentSchemaVersion, result.CurrentSchemaVersion);
+        Assert.True(result.IsBootMediaUpdateRecommended);
+    }
+
+    [Fact]
+    public void LoadOptional_WhenSchemaIsCurrent_DoesNotRecommendBootMediaUpdate()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        string configurationPath = CreateJsonFile(
+            tempDirectory.Path,
+            "foundry.deploy.config.json",
+            $$"""
+            {
+              "schemaVersion": {{FoundryDeployConfigurationDocument.CurrentSchemaVersion}}
+            }
+            """);
+
+        var service = new DeployConfigurationService(
+            NullLogger<DeployConfigurationService>.Instance,
+            configurationPath);
+
+        DeployConfigurationLoadResult result = service.LoadOptional();
+
+        Assert.True(result.Exists);
+        Assert.NotNull(result.Document);
+        Assert.Equal(FoundryDeployConfigurationDocument.CurrentSchemaVersion, result.SchemaVersion);
+        Assert.Equal(FoundryDeployConfigurationDocument.CurrentSchemaVersion, result.CurrentSchemaVersion);
+        Assert.False(result.IsBootMediaUpdateRecommended);
+    }
+
+    private static string CreateJsonFile(string directoryPath, string fileName, string contents)
+    {
+        string filePath = Path.Combine(directoryPath, fileName);
+        File.WriteAllText(filePath, contents);
+        return filePath;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "Foundry.Deploy.Tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}

--- a/src/Foundry.Deploy.Tests/DeployConfigurationServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeployConfigurationServiceTests.cs
@@ -27,8 +27,7 @@ public sealed class DeployConfigurationServiceTests
 
         Assert.True(result.Exists);
         Assert.NotNull(result.Document);
-        Assert.Equal(FoundryDeployConfigurationDocument.CurrentSchemaVersion - 1, result.SchemaVersion);
-        Assert.Equal(FoundryDeployConfigurationDocument.CurrentSchemaVersion, result.CurrentSchemaVersion);
+        Assert.Equal(FoundryDeployConfigurationDocument.CurrentSchemaVersion - 1, result.Document.SchemaVersion);
         Assert.True(result.IsBootMediaUpdateRecommended);
     }
 
@@ -53,8 +52,7 @@ public sealed class DeployConfigurationServiceTests
 
         Assert.True(result.Exists);
         Assert.NotNull(result.Document);
-        Assert.Equal(FoundryDeployConfigurationDocument.CurrentSchemaVersion, result.SchemaVersion);
-        Assert.Equal(FoundryDeployConfigurationDocument.CurrentSchemaVersion, result.CurrentSchemaVersion);
+        Assert.Equal(FoundryDeployConfigurationDocument.CurrentSchemaVersion, result.Document.SchemaVersion);
         Assert.False(result.IsBootMediaUpdateRecommended);
     }
 

--- a/src/Foundry.Deploy/MainWindow.xaml
+++ b/src/Foundry.Deploy/MainWindow.xaml
@@ -126,8 +126,15 @@
                 <StackPanel
                     Margin="0,0,12,0"
                     Orientation="Horizontal"
-                    ToolTip="{Binding BootMediaUpdateRecommendedToolTip}"
                     Visibility="{Binding IsBootMediaUpdateRecommended, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <StackPanel.ToolTip>
+                        <ToolTip>
+                            <TextBlock
+                                MaxWidth="480"
+                                Text="{Binding BootMediaUpdateRecommendedToolTip}"
+                                TextWrapping="Wrap" />
+                        </ToolTip>
+                    </StackPanel.ToolTip>
                     <TextBlock
                         Margin="0,0,4,0"
                         VerticalAlignment="Center"

--- a/src/Foundry.Deploy/MainWindow.xaml
+++ b/src/Foundry.Deploy/MainWindow.xaml
@@ -117,13 +117,36 @@
                 <MenuItem Command="{Binding ShowAboutCommand}" Header="{Binding Strings[Menu.About]}" />
             </Menu>
 
-            <TextBlock
+            <StackPanel
                 Grid.Column="1"
                 Margin="0,0,16,0"
+                HorizontalAlignment="Right"
                 VerticalAlignment="Center"
-                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{Binding VersionDisplay}" />
+                Orientation="Horizontal">
+                <StackPanel
+                    Margin="0,0,12,0"
+                    Orientation="Horizontal"
+                    ToolTip="{Binding BootMediaUpdateRecommendedToolTip}"
+                    Visibility="{Binding IsBootMediaUpdateRecommended, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <TextBlock
+                        Margin="0,0,4,0"
+                        VerticalAlignment="Center"
+                        FontFamily="{StaticResource SymbolThemeFontFamily}"
+                        Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="&#xE7BA;" />
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Foreground="{DynamicResource SystemFillColorCautionBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{Binding BootMediaUpdateRecommendedText}" />
+                </StackPanel>
+                <TextBlock
+                    VerticalAlignment="Center"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{Binding VersionDisplay}" />
+            </StackPanel>
         </Grid>
 
         <Grid

--- a/src/Foundry.Deploy/Services/Configuration/DeployConfigurationLoadResult.cs
+++ b/src/Foundry.Deploy/Services/Configuration/DeployConfigurationLoadResult.cs
@@ -7,8 +7,6 @@ public sealed record DeployConfigurationLoadResult
     public string ConfigurationPath { get; init; } = DeployConfigurationService.DefaultConfigurationPath;
     public bool Exists { get; init; }
     public FoundryDeployConfigurationDocument? Document { get; init; }
-    public int? SchemaVersion { get; init; }
-    public int CurrentSchemaVersion { get; init; } = FoundryDeployConfigurationDocument.CurrentSchemaVersion;
     public bool IsBootMediaUpdateRecommended { get; init; }
     public string? FailureMessage { get; init; }
 }

--- a/src/Foundry.Deploy/Services/Configuration/DeployConfigurationLoadResult.cs
+++ b/src/Foundry.Deploy/Services/Configuration/DeployConfigurationLoadResult.cs
@@ -7,5 +7,8 @@ public sealed record DeployConfigurationLoadResult
     public string ConfigurationPath { get; init; } = DeployConfigurationService.DefaultConfigurationPath;
     public bool Exists { get; init; }
     public FoundryDeployConfigurationDocument? Document { get; init; }
+    public int? SchemaVersion { get; init; }
+    public int CurrentSchemaVersion { get; init; } = FoundryDeployConfigurationDocument.CurrentSchemaVersion;
+    public bool IsBootMediaUpdateRecommended { get; init; }
     public string? FailureMessage { get; init; }
 }

--- a/src/Foundry.Deploy/Services/Configuration/DeployConfigurationService.cs
+++ b/src/Foundry.Deploy/Services/Configuration/DeployConfigurationService.cs
@@ -5,31 +5,44 @@ using Microsoft.Extensions.Logging;
 
 namespace Foundry.Deploy.Services.Configuration;
 
-public sealed class DeployConfigurationService(
-    ILogger<DeployConfigurationService> logger) : IDeployConfigurationService
+public sealed class DeployConfigurationService : IDeployConfigurationService
 {
     public const string DefaultConfigurationPath = @"X:\Foundry\Config\foundry.deploy.config.json";
 
-    private readonly ILogger<DeployConfigurationService> _logger = logger;
+    private readonly ILogger<DeployConfigurationService> _logger;
+    private readonly string _configurationPath;
+
+    public DeployConfigurationService(ILogger<DeployConfigurationService> logger)
+        : this(logger, DefaultConfigurationPath)
+    {
+    }
+
+    internal DeployConfigurationService(ILogger<DeployConfigurationService> logger, string configurationPath)
+    {
+        _logger = logger;
+        _configurationPath = string.IsNullOrWhiteSpace(configurationPath)
+            ? DefaultConfigurationPath
+            : configurationPath;
+    }
 
     public DeployConfigurationLoadResult LoadOptional()
     {
-        if (!File.Exists(DefaultConfigurationPath))
+        if (!File.Exists(_configurationPath))
         {
             _logger.LogInformation(
                 "No deploy configuration was found at '{ConfigurationPath}'.",
-                DefaultConfigurationPath);
+                _configurationPath);
 
             return new DeployConfigurationLoadResult
             {
-                ConfigurationPath = DefaultConfigurationPath,
+                ConfigurationPath = _configurationPath,
                 Exists = false
             };
         }
 
         try
         {
-            using FileStream stream = File.OpenRead(DefaultConfigurationPath);
+            using FileStream stream = File.OpenRead(_configurationPath);
             FoundryDeployConfigurationDocument? document = JsonSerializer.Deserialize<FoundryDeployConfigurationDocument>(
                 stream,
                 ConfigurationJsonDefaults.SerializerOptions);
@@ -39,12 +52,12 @@ public sealed class DeployConfigurationService(
                 const string failureMessage = "The configuration file was empty or could not be parsed.";
                 _logger.LogWarning(
                     "Deploy configuration at '{ConfigurationPath}' could not be parsed: {FailureMessage}",
-                    DefaultConfigurationPath,
+                    _configurationPath,
                     failureMessage);
 
                 return new DeployConfigurationLoadResult
                 {
-                    ConfigurationPath = DefaultConfigurationPath,
+                    ConfigurationPath = _configurationPath,
                     Exists = true,
                     FailureMessage = failureMessage
                 };
@@ -54,21 +67,33 @@ public sealed class DeployConfigurationService(
             {
                 _logger.LogWarning(
                     "Deploy configuration at '{ConfigurationPath}' uses schema version {SchemaVersion}, newer than supported schema version {SupportedSchemaVersion}. Unknown properties will be ignored.",
-                    DefaultConfigurationPath,
+                    _configurationPath,
+                    document.SchemaVersion,
+                    FoundryDeployConfigurationDocument.CurrentSchemaVersion);
+            }
+
+            bool isBootMediaUpdateRecommended = document.SchemaVersion < FoundryDeployConfigurationDocument.CurrentSchemaVersion;
+            if (isBootMediaUpdateRecommended)
+            {
+                _logger.LogWarning(
+                    "Deploy configuration at '{ConfigurationPath}' uses schema version {SchemaVersion}, older than current schema version {CurrentSchemaVersion}. Boot media update is recommended.",
+                    _configurationPath,
                     document.SchemaVersion,
                     FoundryDeployConfigurationDocument.CurrentSchemaVersion);
             }
 
             _logger.LogInformation(
                 "Loaded deploy configuration from '{ConfigurationPath}' (SchemaVersion={SchemaVersion}).",
-                DefaultConfigurationPath,
+                _configurationPath,
                 document.SchemaVersion);
 
             return new DeployConfigurationLoadResult
             {
-                ConfigurationPath = DefaultConfigurationPath,
+                ConfigurationPath = _configurationPath,
                 Exists = true,
-                Document = document
+                Document = document,
+                SchemaVersion = document.SchemaVersion,
+                IsBootMediaUpdateRecommended = isBootMediaUpdateRecommended
             };
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
@@ -76,11 +101,11 @@ public sealed class DeployConfigurationService(
             _logger.LogWarning(
                 ex,
                 "Failed to load deploy configuration from '{ConfigurationPath}'.",
-                DefaultConfigurationPath);
+                _configurationPath);
 
             return new DeployConfigurationLoadResult
             {
-                ConfigurationPath = DefaultConfigurationPath,
+                ConfigurationPath = _configurationPath,
                 Exists = true,
                 FailureMessage = ex.Message
             };

--- a/src/Foundry.Deploy/Services/Configuration/DeployConfigurationService.cs
+++ b/src/Foundry.Deploy/Services/Configuration/DeployConfigurationService.cs
@@ -92,7 +92,6 @@ public sealed class DeployConfigurationService : IDeployConfigurationService
                 ConfigurationPath = _configurationPath,
                 Exists = true,
                 Document = document,
-                SchemaVersion = document.SchemaVersion,
                 IsBootMediaUpdateRecommended = isBootMediaUpdateRecommended
             };
         }

--- a/src/Foundry.Deploy/Services/Startup/DeploymentStartupCoordinator.cs
+++ b/src/Foundry.Deploy/Services/Startup/DeploymentStartupCoordinator.cs
@@ -68,6 +68,7 @@ public sealed class DeploymentStartupCoordinator : IDeploymentStartupCoordinator
         {
             CacheRootPath = cacheRootPath,
             DeployConfigurationDocument = deployConfigurationDocument,
+            IsBootMediaUpdateRecommended = deployConfigLoadResult.IsBootMediaUpdateRecommended,
             AutopilotProfiles = autopilotProfiles,
             EffectiveComputerName = computerNameTask.Result,
             DetectedHardware = hardwareTask.Result.Profile,

--- a/src/Foundry.Deploy/Services/Startup/DeploymentStartupSnapshot.cs
+++ b/src/Foundry.Deploy/Services/Startup/DeploymentStartupSnapshot.cs
@@ -8,6 +8,7 @@ public sealed record DeploymentStartupSnapshot
 {
     public required string CacheRootPath { get; init; }
     public required FoundryDeployConfigurationDocument? DeployConfigurationDocument { get; init; }
+    public required bool IsBootMediaUpdateRecommended { get; init; }
     public required IReadOnlyList<AutopilotProfileCatalogItem> AutopilotProfiles { get; init; }
     public required string EffectiveComputerName { get; init; }
     public required HardwareProfile? DetectedHardware { get; init; }

--- a/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
@@ -121,8 +121,8 @@
 التفاصيل: تم رفض الوصول أثناء تثبيت الصورة على المسار المستهدف.
 الإجراء: تحقق من سمات القرص وأعد محاولة النشر.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>تحديث</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>يوصى بتحديث وسيط التمهيد</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>تم إنشاء وسيط التمهيد هذا بتنسيق تكوين قديم لـ Foundry OSD. حدّث وسيط التمهيد لضمان التوافق مع أحدث الميزات.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>الإصدار: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>السابق</value></data>
   <data name="Common.Next" xml:space="preserve"><value>التالي</value></data>

--- a/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
@@ -121,6 +121,8 @@
 التفاصيل: تم رفض الوصول أثناء تثبيت الصورة على المسار المستهدف.
 الإجراء: تحقق من سمات القرص وأعد محاولة النشر.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>تحديث</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>الإصدار: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>السابق</value></data>
   <data name="Common.Next" xml:space="preserve"><value>التالي</value></data>

--- a/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
+++ b/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
@@ -121,6 +121,8 @@
 Подробности: Достъпът е отказан при монтиране на изображение към целевия път.
 Действие: Проверете атрибутите на диска и опитайте повторно внедряване.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Опресняване</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Версия: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Предишен</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Следваща</value></data>

--- a/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
+++ b/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
@@ -121,8 +121,8 @@
 Подробности: Достъпът е отказан при монтиране на изображение към целевия път.
 Действие: Проверете атрибутите на диска и опитайте повторно внедряване.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Опресняване</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Препоръчва се актуализация на носителя за стартиране</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Този носител за стартиране е генериран с по-стар формат за конфигурация на Foundry OSD. Актуализирайте носителя за стартиране, за да осигурите съвместимост с най-новите функции.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Версия: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Предишен</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Следваща</value></data>

--- a/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
+++ b/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
@@ -121,6 +121,8 @@ ErrorCode=0x80070005
 Podrobnosti: Přístup odepřen při připojování obrazu k cílové cestě.
 Akce: Ověřte atributy disku a opakujte nasazení.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Obnovit</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Verze: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Předchozí</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Další</value></data>

--- a/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
+++ b/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
@@ -121,8 +121,8 @@ ErrorCode=0x80070005
 Podrobnosti: Přístup odepřen při připojování obrazu k cílové cestě.
 Akce: Ověřte atributy disku a opakujte nasazení.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Obnovit</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Doporučuje se aktualizovat spouštěcí médium</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Toto spouštěcí médium bylo vygenerováno pomocí staršího formátu konfigurace Foundry OSD. Aktualizujte spouštěcí médium, aby byla zajištěna kompatibilita s nejnovějšími funkcemi.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Verze: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Předchozí</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Další</value></data>

--- a/src/Foundry.Deploy/Strings/da-DK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/da-DK/Resources.resx
@@ -121,8 +121,8 @@ ErrorCode=0x80070005
 Detaljer: Adgang nægtet under montering af billedet til målstien.
 Handling: Bekræft diskattributter, og prøv implementeringen igen.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Opdater</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Opdatering af startmedie anbefales</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Dette startmedie blev genereret med et ældre Foundry OSD-konfigurationsformat. Opdater startmediet for at sikre kompatibilitet med de nyeste funktioner.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Version: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Forrige</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Næste</value></data>

--- a/src/Foundry.Deploy/Strings/da-DK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/da-DK/Resources.resx
@@ -121,6 +121,8 @@ ErrorCode=0x80070005
 Detaljer: Adgang nægtet under montering af billedet til målstien.
 Handling: Bekræft diskattributter, og prøv implementeringen igen.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Opdater</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Version: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Forrige</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Næste</value></data>

--- a/src/Foundry.Deploy/Strings/de-DE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/de-DE/Resources.resx
@@ -121,8 +121,8 @@ Fehlercode=0x80070005
 Details: Zugriff verweigert, während das Image im Zielpfad gemountet wird.
 Aktion: Überprüfen Sie die Festplattenattribute und wiederholen Sie die Bereitstellung.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Aktualisieren</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Aktualisierung des Startmediums empfohlen</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Dieses Startmedium wurde mit einem älteren Foundry OSD-Konfigurationsformat erstellt. Aktualisieren Sie das Startmedium, um die Kompatibilität mit den neuesten Funktionen sicherzustellen.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Version: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Zurück</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Als nächstes</value></data>

--- a/src/Foundry.Deploy/Strings/de-DE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/de-DE/Resources.resx
@@ -121,6 +121,8 @@ Fehlercode=0x80070005
 Details: Zugriff verweigert, während das Image im Zielpfad gemountet wird.
 Aktion: Überprüfen Sie die Festplattenattribute und wiederholen Sie die Bereitstellung.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Aktualisieren</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Version: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Zurück</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Als nächstes</value></data>

--- a/src/Foundry.Deploy/Strings/el-GR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/el-GR/Resources.resx
@@ -121,6 +121,8 @@
 Λεπτομέρειες: Δεν επιτρέπεται η πρόσβαση κατά την προσάρτηση της εικόνας στη διαδρομή προορισμού.
 Ενέργεια: Επαληθεύστε τα χαρακτηριστικά του δίσκου και δοκιμάστε ξανά την ανάπτυξη.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Ανανέωση</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Έκδοση: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Προηγούμενο</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Επόμενο</value></data>

--- a/src/Foundry.Deploy/Strings/el-GR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/el-GR/Resources.resx
@@ -121,8 +121,8 @@
 Λεπτομέρειες: Δεν επιτρέπεται η πρόσβαση κατά την προσάρτηση της εικόνας στη διαδρομή προορισμού.
 Ενέργεια: Επαληθεύστε τα χαρακτηριστικά του δίσκου και δοκιμάστε ξανά την ανάπτυξη.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Ανανέωση</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Συνιστάται ενημέρωση του μέσου εκκίνησης</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Αυτό το μέσο εκκίνησης δημιουργήθηκε με παλαιότερη μορφή ρύθμισης παραμέτρων Foundry OSD. Ενημερώστε το μέσο εκκίνησης για να διασφαλίσετε τη συμβατότητα με τις πιο πρόσφατες δυνατότητες.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Έκδοση: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Προηγούμενο</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Επόμενο</value></data>

--- a/src/Foundry.Deploy/Strings/en-GB/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-GB/Resources.resx
@@ -121,6 +121,8 @@ ErrorCode=0x80070005
 Details: Access denied while mounting image to target path.
 Action: Verify disk attributes and retry deployment.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Refresh</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Version: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Previous</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Next</value></data>

--- a/src/Foundry.Deploy/Strings/en-US/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-US/Resources.resx
@@ -121,6 +121,8 @@ ErrorCode=0x80070005
 Details: Access denied while mounting image to target path.
 Action: Verify disk attributes and retry deployment.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Refresh</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Version: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Previous</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Next</value></data>

--- a/src/Foundry.Deploy/Strings/es-ES/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-ES/Resources.resx
@@ -121,8 +121,8 @@ Código de error=0x80070005
 Detalles: acceso denegado al montar la imagen en la ruta de destino.
 Acción: Verifique los atributos del disco y vuelva a intentar la implementación.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Refrescar</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Actualización del medio de arranque recomendada</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Este medio de arranque se generó con un formato de configuración anterior de Foundry OSD. Actualice el medio de arranque para garantizar la compatibilidad con las funciones más recientes.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versión: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Anterior</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Próximo</value></data>

--- a/src/Foundry.Deploy/Strings/es-ES/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-ES/Resources.resx
@@ -121,6 +121,8 @@ Código de error=0x80070005
 Detalles: acceso denegado al montar la imagen en la ruta de destino.
 Acción: Verifique los atributos del disco y vuelva a intentar la implementación.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Refrescar</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versión: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Anterior</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Próximo</value></data>

--- a/src/Foundry.Deploy/Strings/es-MX/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-MX/Resources.resx
@@ -121,8 +121,8 @@ Código de error=0x80070005
 Detalles: acceso denegado al montar la imagen en la ruta de destino.
 Acción: Verifique los atributos del disco y vuelva a intentar la implementación.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Refrescar</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Actualización del medio de arranque recomendada</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Este medio de arranque se generó con un formato de configuración anterior de Foundry OSD. Actualiza el medio de arranque para garantizar la compatibilidad con las funciones más recientes.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versión: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Anterior</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Próximo</value></data>

--- a/src/Foundry.Deploy/Strings/es-MX/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-MX/Resources.resx
@@ -121,6 +121,8 @@ Código de error=0x80070005
 Detalles: acceso denegado al montar la imagen en la ruta de destino.
 Acción: Verifique los atributos del disco y vuelva a intentar la implementación.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Refrescar</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versión: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Anterior</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Próximo</value></data>

--- a/src/Foundry.Deploy/Strings/et-EE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/et-EE/Resources.resx
@@ -121,8 +121,8 @@ ErrorCode=0x80070005
 Üksikasjad. Juurdepääs on keelatud pildi paigaldamisel sihtteele.
 Toiming: kontrollige ketta atribuute ja proovige juurutamist uuesti.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Värskenda</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Soovitatav on algkandja värskendamine</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>See algkandja loodi vanema Foundry OSD konfiguratsioonivorminguga. Värskendage algkandjat, et tagada ühilduvus uusimate funktsioonidega.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versioon: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Eelmine</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Edasi</value></data>

--- a/src/Foundry.Deploy/Strings/et-EE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/et-EE/Resources.resx
@@ -121,6 +121,8 @@ ErrorCode=0x80070005
 Üksikasjad. Juurdepääs on keelatud pildi paigaldamisel sihtteele.
 Toiming: kontrollige ketta atribuute ja proovige juurutamist uuesti.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Värskenda</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versioon: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Eelmine</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Edasi</value></data>

--- a/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
@@ -121,6 +121,8 @@ ErrorCode=0x80070005
 Tiedot: Pääsy estetty, kun kuvaa liitetään kohdepolkuun.
 Toimi: Tarkista levyn attribuutit ja yritä käyttöönottoa uudelleen.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Päivitä</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versio: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Edellinen</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Seuraavaksi</value></data>

--- a/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
@@ -121,8 +121,8 @@ ErrorCode=0x80070005
 Tiedot: Pääsy estetty, kun kuvaa liitetään kohdepolkuun.
 Toimi: Tarkista levyn attribuutit ja yritä käyttöönottoa uudelleen.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Päivitä</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Käynnistysmedian päivitystä suositellaan</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Tämä käynnistysmedia luotiin vanhemmalla Foundry OSD -määritysmuodolla. Päivitä käynnistysmedia varmistaaksesi yhteensopivuuden uusimpien ominaisuuksien kanssa.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versio: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Edellinen</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Seuraavaksi</value></data>

--- a/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
@@ -121,8 +121,8 @@ Code d'erreur = 0x80070005
 Détails: accès refusé lors du montage de l'image sur le chemin cible.
 Action: Vérifiez les attributs du disque et réessayez le déploiement.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Actualiser</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Mise à jour du support de démarrage recommandée</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Ce support de démarrage a été généré avec un ancien format de configuration Foundry OSD. Mettez à jour le support de démarrage pour garantir la compatibilité avec les dernières fonctionnalités.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Version: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Précédent</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Suivant</value></data>

--- a/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
@@ -121,6 +121,8 @@ Code d'erreur = 0x80070005
 Détails: accès refusé lors du montage de l'image sur le chemin cible.
 Action: Vérifiez les attributs du disque et réessayez le déploiement.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Actualiser</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Version: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Précédent</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Suivant</value></data>

--- a/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
@@ -121,8 +121,8 @@ ErrorCode=0x80070005
 Détails : accès refusé lors du montage de l’image sur le chemin cible.
 Action : vérifiez les attributs du disque puis relancez le déploiement.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Actualiser</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Mise à jour du support de démarrage recommandée</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Ce support de démarrage a été généré avec un ancien format de configuration Foundry OSD. Mettez à jour le support de démarrage pour garantir la compatibilité avec les dernières fonctionnalités.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Version : {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Précédent</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Suivant</value></data>

--- a/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
@@ -121,6 +121,8 @@ ErrorCode=0x80070005
 Détails : accès refusé lors du montage de l’image sur le chemin cible.
 Action : vérifiez les attributs du disque puis relancez le déploiement.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Actualiser</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Version : {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Précédent</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Suivant</value></data>

--- a/src/Foundry.Deploy/Strings/he-IL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/he-IL/Resources.resx
@@ -121,8 +121,8 @@ ErrorCode=0x80070005
 פרטים: הגישה נדחתה בעת הרכבת התמונה לנתיב היעד.
 פעולה: אמת את תכונות הדיסק ונסה שוב לפרוס.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>רענן</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>מומלץ לעדכן את מדיית האתחול</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>מדיית האתחול הזו נוצרה באמצעות תבנית תצורה ישנה יותר של Foundry OSD. עדכן את מדיית האתחול כדי להבטיח תאימות לתכונות העדכניות ביותר.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>גרסה: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>הקודם</value></data>
   <data name="Common.Next" xml:space="preserve"><value>הבא</value></data>

--- a/src/Foundry.Deploy/Strings/he-IL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/he-IL/Resources.resx
@@ -121,6 +121,8 @@ ErrorCode=0x80070005
 פרטים: הגישה נדחתה בעת הרכבת התמונה לנתיב היעד.
 פעולה: אמת את תכונות הדיסק ונסה שוב לפרוס.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>רענן</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>גרסה: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>הקודם</value></data>
   <data name="Common.Next" xml:space="preserve"><value>הבא</value></data>

--- a/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
@@ -121,8 +121,8 @@
 Pojedinosti: Pristup odbijen tijekom montiranja slike na ciljnu putanju.
 Radnja: Provjerite atribute diska i ponovno pokušajte implementaciju.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Osvježiti</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Preporučuje se ažuriranje medija za pokretanje</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Ovaj medij za pokretanje generiran je starijim formatom konfiguracije Foundry OSD. Ažurirajte medij za pokretanje kako biste osigurali kompatibilnost s najnovijim značajkama.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Verzija: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Prethodno</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Sljedeći</value></data>

--- a/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
@@ -121,6 +121,8 @@
 Pojedinosti: Pristup odbijen tijekom montiranja slike na ciljnu putanju.
 Radnja: Provjerite atribute diska i ponovno pokušajte implementaciju.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Osvježiti</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Verzija: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Prethodno</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Sljedeći</value></data>

--- a/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
@@ -121,8 +121,8 @@ ErrorCode=0x80070005
 Részletek: A hozzáférés megtagadva a kép célútvonalhoz való csatlakoztatása közben.
 Művelet: Ellenőrizze a lemezattribútumokat, és próbálkozzon újra a központi telepítéssel.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Frissítés</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>A rendszerindító adathordozó frissítése ajánlott</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Ez a rendszerindító adathordozó egy régebbi Foundry OSD konfigurációs formátummal készült. Frissítse a rendszerindító adathordozót a legújabb funkciókkal való kompatibilitás biztosításához.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Verzió: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Előző</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Következő</value></data>

--- a/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
@@ -121,6 +121,8 @@ ErrorCode=0x80070005
 Részletek: A hozzáférés megtagadva a kép célútvonalhoz való csatlakoztatása közben.
 Művelet: Ellenőrizze a lemezattribútumokat, és próbálkozzon újra a központi telepítéssel.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Frissítés</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Verzió: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Előző</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Következő</value></data>

--- a/src/Foundry.Deploy/Strings/it-IT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/it-IT/Resources.resx
@@ -121,6 +121,8 @@ Codice errore=0x80070005
 Dettagli: accesso negato durante il montaggio dell'immagine sul percorso di destinazione.
 Azione: verificare gli attributi del disco e riprovare la distribuzione.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Aggiorna</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versione: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Precedente</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Avanti</value></data>

--- a/src/Foundry.Deploy/Strings/it-IT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/it-IT/Resources.resx
@@ -121,8 +121,8 @@ Codice errore=0x80070005
 Dettagli: accesso negato durante il montaggio dell'immagine sul percorso di destinazione.
 Azione: verificare gli attributi del disco e riprovare la distribuzione.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Aggiorna</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Aggiornamento del supporto di avvio consigliato</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Questo supporto di avvio è stato generato con un formato di configurazione Foundry OSD precedente. Aggiorna il supporto di avvio per garantire la compatibilità con le funzionalità più recenti.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versione: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Precedente</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Avanti</value></data>

--- a/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
@@ -121,8 +121,8 @@
 詳細: イメージをターゲット パスにマウント中にアクセスが拒否されました。
 処置: ディスク属性を確認し、デプロイメントを再試行してください。</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>リフレッシュ</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>ブート メディアの更新を推奨</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>このブート メディアは古い Foundry OSD 構成形式で生成されています。最新機能との互換性を確保するため、ブート メディアを更新してください。</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>バージョン: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>前へ</value></data>
   <data name="Common.Next" xml:space="preserve"><value>次へ</value></data>

--- a/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
@@ -121,6 +121,8 @@
 詳細: イメージをターゲット パスにマウント中にアクセスが拒否されました。
 処置: ディスク属性を確認し、デプロイメントを再試行してください。</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>リフレッシュ</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>バージョン: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>前へ</value></data>
   <data name="Common.Next" xml:space="preserve"><value>次へ</value></data>

--- a/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
@@ -121,6 +121,8 @@
 세부정보: 대상 경로에 이미지를 마운트하는 동안 액세스가 거부되었습니다.
 조치: 디스크 속성을 확인하고 배포를 다시 시도하십시오.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>새로고침</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>버전: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>이전</value></data>
   <data name="Common.Next" xml:space="preserve"><value>다음</value></data>

--- a/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
@@ -121,8 +121,8 @@
 세부정보: 대상 경로에 이미지를 마운트하는 동안 액세스가 거부되었습니다.
 조치: 디스크 속성을 확인하고 배포를 다시 시도하십시오.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>새로고침</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>부팅 미디어 업데이트 권장</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>이 부팅 미디어는 이전 Foundry OSD 구성 형식으로 생성되었습니다. 최신 기능과의 호환성을 보장하려면 부팅 미디어를 업데이트하세요.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>버전: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>이전</value></data>
   <data name="Common.Next" xml:space="preserve"><value>다음</value></data>

--- a/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
@@ -121,8 +121,8 @@ ErrorCode=0x80070005
 Išsami informacija: prieiga uždrausta montuojant vaizdą į tikslinį kelią.
 Veiksmas: patikrinkite disko atributus ir bandykite iš naujo įdiegti.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Atnaujinti</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Rekomenduojama atnaujinti įkrovos laikmeną</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Ši įkrovos laikmena buvo sugeneruota naudojant senesnį Foundry OSD konfigūracijos formatą. Atnaujinkite įkrovos laikmeną, kad užtikrintumėte suderinamumą su naujausiomis funkcijomis.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versija: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Ankstesnis</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Kitas</value></data>

--- a/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
@@ -121,6 +121,8 @@ ErrorCode=0x80070005
 Išsami informacija: prieiga uždrausta montuojant vaizdą į tikslinį kelią.
 Veiksmas: patikrinkite disko atributus ir bandykite iš naujo įdiegti.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Atnaujinti</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versija: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Ankstesnis</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Kitas</value></data>

--- a/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
@@ -121,8 +121,8 @@ ErrorCode=0x80070005
 Detalizēta informācija: Piekļuve liegta, pievienojot attēlu mērķa ceļam.
 Darbība: pārbaudiet diska atribūtus un mēģiniet atkārtoti izvietot.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Atsvaidzināt</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Ieteicams atjaunināt sāknēšanas datu nesēju</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Šis sāknēšanas datu nesējs tika ģenerēts ar vecāku Foundry OSD konfigurācijas formātu. Atjauniniet sāknēšanas datu nesēju, lai nodrošinātu saderību ar jaunākajiem līdzekļiem.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versija: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Iepriekšējais</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Tālāk</value></data>

--- a/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
@@ -121,6 +121,8 @@ ErrorCode=0x80070005
 Detalizēta informācija: Piekļuve liegta, pievienojot attēlu mērķa ceļam.
 Darbība: pārbaudiet diska atribūtus un mēģiniet atkārtoti izvietot.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Atsvaidzināt</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versija: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Iepriekšējais</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Tālāk</value></data>

--- a/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
@@ -121,8 +121,8 @@ ErrorCode=0x80070005
 Detaljer: Tilgang nektet under montering av bildet til målbanen.
 Handling: Bekreft diskattributter og prøv distribusjon på nytt.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Oppdater</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Oppdatering av oppstartsmediet anbefales</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Dette oppstartsmediet ble generert med et eldre Foundry OSD-konfigurasjonsformat. Oppdater oppstartsmediet for å sikre kompatibilitet med de nyeste funksjonene.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versjon: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Forrige</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Neste</value></data>

--- a/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
@@ -121,6 +121,8 @@ ErrorCode=0x80070005
 Detaljer: Tilgang nektet under montering av bildet til målbanen.
 Handling: Bekreft diskattributter og prøv distribusjon på nytt.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Oppdater</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versjon: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Forrige</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Neste</value></data>

--- a/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
@@ -121,8 +121,8 @@ Foutcode=0x80070005
 Details: Toegang geweigerd tijdens het koppelen van de afbeelding aan het doelpad.
 Actie: controleer de schijfkenmerken en probeer de implementatie opnieuw.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Vernieuwen</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Update van opstartmedium aanbevolen</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Dit opstartmedium is gegenereerd met een ouder Foundry OSD-configuratieformaat. Werk het opstartmedium bij om compatibiliteit met de nieuwste functies te garanderen.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versie: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Vorige</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Volgende</value></data>

--- a/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
@@ -121,6 +121,8 @@ Foutcode=0x80070005
 Details: Toegang geweigerd tijdens het koppelen van de afbeelding aan het doelpad.
 Actie: controleer de schijfkenmerken en probeer de implementatie opnieuw.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Vernieuwen</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versie: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Vorige</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Volgende</value></data>

--- a/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
@@ -121,8 +121,8 @@ Kod błędu=0x80070005
 Szczegóły: Odmowa dostępu podczas montowania obrazu na ścieżce docelowej.
 Akcja: Sprawdź atrybuty dysku i ponów próbę wdrożenia.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Odśwież</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Zalecana aktualizacja nośnika rozruchowego</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Ten nośnik rozruchowy został wygenerowany przy użyciu starszego formatu konfiguracji Foundry OSD. Zaktualizuj nośnik rozruchowy, aby zapewnić zgodność z najnowszymi funkcjami.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Wersja: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Poprzedni</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Następny</value></data>

--- a/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
@@ -121,6 +121,8 @@ Kod błędu=0x80070005
 Szczegóły: Odmowa dostępu podczas montowania obrazu na ścieżce docelowej.
 Akcja: Sprawdź atrybuty dysku i ponów próbę wdrożenia.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Odśwież</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Wersja: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Poprzedni</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Następny</value></data>

--- a/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
@@ -121,6 +121,8 @@ Código de erro = 0x80070005
 Detalhes: Acesso negado durante a montagem da imagem no caminho de destino.
 Ação: Verifique os atributos do disco e tente novamente a implantação.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Atualizar</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versão: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Anterior</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Próximo</value></data>

--- a/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
@@ -121,8 +121,8 @@ Código de erro = 0x80070005
 Detalhes: Acesso negado durante a montagem da imagem no caminho de destino.
 Ação: Verifique os atributos do disco e tente novamente a implantação.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Atualizar</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Atualização da mídia de inicialização recomendada</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Esta mídia de inicialização foi gerada com um formato de configuração mais antigo do Foundry OSD. Atualize a mídia de inicialização para garantir compatibilidade com os recursos mais recentes.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versão: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Anterior</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Próximo</value></data>

--- a/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
@@ -121,6 +121,8 @@ Código de erro = 0x80070005
 Detalhes: Acesso negado durante a montagem da imagem no caminho de destino.
 Ação: Verifique os atributos do disco e tente novamente a implantação.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Atualizar</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versão: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Anterior</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Próximo</value></data>

--- a/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
@@ -121,8 +121,8 @@ Código de erro = 0x80070005
 Detalhes: Acesso negado durante a montagem da imagem no caminho de destino.
 Ação: Verifique os atributos do disco e tente novamente a implantação.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Atualizar</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Atualização do suporte de arranque recomendada</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Este suporte de arranque foi gerado com um formato de configuração Foundry OSD mais antigo. Atualize o suporte de arranque para garantir compatibilidade com as funcionalidades mais recentes.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versão: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Anterior</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Próximo</value></data>

--- a/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
@@ -121,6 +121,8 @@ ErrorCode=0x80070005
 Detalii: Accesul a fost interzis la montarea imaginii pe calea țintă.
 Acțiune: Verificați atributele discului și reîncercați implementarea.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Reîmprospătați</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versiune: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Anterior</value></data>
   <data name="Common.Next" xml:space="preserve"><value>În continuare</value></data>

--- a/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
@@ -121,8 +121,8 @@ ErrorCode=0x80070005
 Detalii: Accesul a fost interzis la montarea imaginii pe calea țintă.
 Acțiune: Verificați atributele discului și reîncercați implementarea.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Reîmprospătați</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Se recomandă actualizarea suportului de pornire</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Acest suport de pornire a fost generat cu un format de configurare Foundry OSD mai vechi. Actualizați suportul de pornire pentru a asigura compatibilitatea cu cele mai recente caracteristici.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Versiune: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Anterior</value></data>
   <data name="Common.Next" xml:space="preserve"><value>În continuare</value></data>

--- a/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
@@ -121,8 +121,8 @@
 Подробности: Доступ запрещен при подключении образа к целевому пути.
 Действие: Проверьте атрибуты диска и повторите развертывание.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Обновить</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Рекомендуется обновить загрузочный носитель</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Этот загрузочный носитель был создан с использованием более старого формата конфигурации Foundry OSD. Обновите загрузочный носитель, чтобы обеспечить совместимость с новейшими функциями.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Версия: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Предыдущий</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Далее</value></data>

--- a/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
@@ -121,6 +121,8 @@
 Подробности: Доступ запрещен при подключении образа к целевому пути.
 Действие: Проверьте атрибуты диска и повторите развертывание.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Обновить</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Версия: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Предыдущий</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Далее</value></data>

--- a/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
@@ -121,6 +121,8 @@ ErrorCode=0x80070005
 Podrobnosti: Prístup bol odmietnutý pri pripájaní obrazu k cieľovej ceste.
 Akcia: Overte atribúty disku a zopakujte nasadenie.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Obnoviť</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Verzia: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Predchádzajúce</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Ďalej</value></data>

--- a/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
@@ -121,8 +121,8 @@ ErrorCode=0x80070005
 Podrobnosti: Prístup bol odmietnutý pri pripájaní obrazu k cieľovej ceste.
 Akcia: Overte atribúty disku a zopakujte nasadenie.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Obnoviť</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Odporúča sa aktualizovať zavádzacie médium</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Toto zavádzacie médium bolo vygenerované pomocou staršieho formátu konfigurácie Foundry OSD. Aktualizujte zavádzacie médium, aby ste zabezpečili kompatibilitu s najnovšími funkciami.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Verzia: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Predchádzajúce</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Ďalej</value></data>

--- a/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
@@ -121,6 +121,8 @@ Koda napake=0x80070005
 Podrobnosti: dostop zavrnjen med nameščanjem slike na ciljno pot.
 Ukrep: Preverite atribute diska in znova poskusite razmestiti.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Osveži</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Različica: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Prejšnja</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Naprej</value></data>

--- a/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
@@ -121,8 +121,8 @@ Koda napake=0x80070005
 Podrobnosti: dostop zavrnjen med nameščanjem slike na ciljno pot.
 Ukrep: Preverite atribute diska in znova poskusite razmestiti.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Osveži</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Priporočena je posodobitev zagonskega medija</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Ta zagonski medij je bil ustvarjen s starejšo obliko konfiguracije Foundry OSD. Posodobite zagonski medij, da zagotovite združljivost z najnovejšimi funkcijami.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Različica: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Prejšnja</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Naprej</value></data>

--- a/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
@@ -121,6 +121,8 @@ ErrorCode=0k80070005
 Detalji: Pristup odbijen dok se slika montira na ciljnu putanju.
 Radnja: Proverite atribute diska i pokušajte ponovo da ga primenite.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Osveži</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Verzija: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Prethodno</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Sledeće</value></data>

--- a/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
@@ -121,8 +121,8 @@ ErrorCode=0k80070005
 Detalji: Pristup odbijen dok se slika montira na ciljnu putanju.
 Radnja: Proverite atribute diska i pokušajte ponovo da ga primenite.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Osveži</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Preporučuje se ažuriranje medija za pokretanje</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Ovaj medij za pokretanje je generisan starijim formatom konfiguracije Foundry OSD. Ažurirajte medij za pokretanje da biste obezbedili kompatibilnost sa najnovijim funkcijama.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Verzija: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Prethodno</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Sledeće</value></data>

--- a/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
@@ -121,6 +121,8 @@ ErrorCode=0x80070005
 Detaljer: Åtkomst nekad vid montering av bild till målsökväg.
 Åtgärd: Verifiera diskattribut och försök distribuera igen.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Uppdatera</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Version: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Föregående</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Nästa</value></data>

--- a/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
@@ -121,8 +121,8 @@ ErrorCode=0x80070005
 Detaljer: Åtkomst nekad vid montering av bild till målsökväg.
 Åtgärd: Verifiera diskattribut och försök distribuera igen.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Uppdatera</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Uppdatering av startmedia rekommenderas</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Detta startmedia skapades med ett äldre Foundry OSD-konfigurationsformat. Uppdatera startmediet för att säkerställa kompatibilitet med de senaste funktionerna.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Version: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Föregående</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Nästa</value></data>

--- a/src/Foundry.Deploy/Strings/th-TH/Resources.resx
+++ b/src/Foundry.Deploy/Strings/th-TH/Resources.resx
@@ -121,8 +121,8 @@
 รายละเอียด: การเข้าถึงถูกปฏิเสธขณะติดตั้งรูปภาพไปยังเส้นทางเป้าหมาย
 การดำเนินการ: ตรวจสอบแอตทริบิวต์ของดิสก์และลองปรับใช้อีกครั้ง</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>รีเฟรช</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>แนะนำให้อัปเดตสื่อบูต</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>สื่อบูตนี้ถูกสร้างด้วยรูปแบบการกำหนดค่า Foundry OSD รุ่นเก่า อัปเดตสื่อบูตเพื่อให้เข้ากันได้กับฟีเจอร์ล่าสุด</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>เวอร์ชัน: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>ก่อนหน้า</value></data>
   <data name="Common.Next" xml:space="preserve"><value>ถัดไป</value></data>

--- a/src/Foundry.Deploy/Strings/th-TH/Resources.resx
+++ b/src/Foundry.Deploy/Strings/th-TH/Resources.resx
@@ -121,6 +121,8 @@
 รายละเอียด: การเข้าถึงถูกปฏิเสธขณะติดตั้งรูปภาพไปยังเส้นทางเป้าหมาย
 การดำเนินการ: ตรวจสอบแอตทริบิวต์ของดิสก์และลองปรับใช้อีกครั้ง</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>รีเฟรช</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>เวอร์ชัน: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>ก่อนหน้า</value></data>
   <data name="Common.Next" xml:space="preserve"><value>ถัดไป</value></data>

--- a/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
@@ -121,6 +121,8 @@ HataKodu=0x80070005
 Ayrıntılar: Görüntü hedef yola eklenirken erişim reddedildi.
 Eylem: Disk özniteliklerini doğrulayın ve dağıtımı yeniden deneyin.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Yenile</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Sürüm: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Önceki</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Sonraki</value></data>

--- a/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
@@ -121,8 +121,8 @@ HataKodu=0x80070005
 Ayrıntılar: Görüntü hedef yola eklenirken erişim reddedildi.
 Eylem: Disk özniteliklerini doğrulayın ve dağıtımı yeniden deneyin.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Yenile</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Önyükleme medyası güncellemesi önerilir</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Bu önyükleme medyası daha eski bir Foundry OSD yapılandırma biçimiyle oluşturuldu. En son özelliklerle uyumluluğu sağlamak için önyükleme medyasını güncelleyin.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Sürüm: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Önceki</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Sonraki</value></data>

--- a/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
@@ -121,8 +121,8 @@ ErrorCode=0x80070005
 Подробиці: доступ заборонено під час монтування образу до цільового шляху.
 Дія: перевірте атрибути диска та повторіть розгортання.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Оновити</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Рекомендовано оновити завантажувальний носій</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>Цей завантажувальний носій створено зі старішим форматом конфігурації Foundry OSD. Оновіть завантажувальний носій, щоб забезпечити сумісність із найновішими функціями.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Версія: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Попередній</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Далі</value></data>

--- a/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
@@ -121,6 +121,8 @@ ErrorCode=0x80070005
 Подробиці: доступ заборонено під час монтування образу до цільового шляху.
 Дія: перевірте атрибути диска та повторіть розгортання.</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>Оновити</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>Версія: {0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>Попередній</value></data>
   <data name="Common.Next" xml:space="preserve"><value>Далі</value></data>

--- a/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
@@ -121,8 +121,8 @@
 详细信息：将映像安装到目标路径时访问被拒绝。
 操作：验证磁盘属性并重试部署。</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>刷新</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>建议更新启动介质</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>此启动介质是使用较旧的 Foundry OSD 配置格式生成的。请更新启动介质，以确保与最新功能兼容。</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>版本：{0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>上一页</value></data>
   <data name="Common.Next" xml:space="preserve"><value>下一步</value></data>

--- a/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
@@ -121,6 +121,8 @@
 详细信息：将映像安装到目标路径时访问被拒绝。
 操作：验证磁盘属性并重试部署。</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>刷新</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>版本：{0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>上一页</value></data>
   <data name="Common.Next" xml:space="preserve"><value>下一步</value></data>

--- a/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
@@ -121,8 +121,8 @@
 詳細資訊：將映像安裝到目標路徑時存取被拒絕。
 操作：驗證磁碟屬性並重試部署。</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>重新整理</value></data>
-  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
-  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>建議更新開機媒體</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>此開機媒體是使用較舊的 Foundry OSD 設定格式產生的。請更新開機媒體，以確保與最新功能相容。</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>版本：{0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>上一頁</value></data>
   <data name="Common.Next" xml:space="preserve"><value>下一步</value></data>

--- a/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
@@ -121,6 +121,8 @@
 詳細資訊：將映像安裝到目標路徑時存取被拒絕。
 操作：驗證磁碟屬性並重試部署。</value></data>
   <data name="Common.Refresh" xml:space="preserve"><value>重新整理</value></data>
+  <data name="BootMedia.UpdateRecommended" xml:space="preserve"><value>Boot media update recommended</value></data>
+  <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve"><value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value></data>
   <data name="Common.VersionFormat" xml:space="preserve"><value>版本：{0}</value></data>
   <data name="Common.Previous" xml:space="preserve"><value>上一頁</value></data>
   <data name="Common.Next" xml:space="preserve"><value>下一步</value></data>

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -63,6 +63,9 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     [NotifyCanExecuteChangedFor(nameof(SetDebugAutopilotModeCommand))]
     private bool isDeploymentRunning;
 
+    [ObservableProperty]
+    private bool isBootMediaUpdateRecommended;
+
     public DeploymentPreparationViewModel Preparation { get; }
     public DeploymentSessionViewModel Session { get; }
     public OperatingSystemCatalogViewModel OperatingSystemCatalog { get; }
@@ -76,6 +79,8 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     public OperatingSystemCatalogItem? SelectedOperatingSystem => OperatingSystemCatalog.SelectedOperatingSystem;
     public string WindowTitle => GetString("App.WindowTitle");
     public string VersionDisplay => Format("Common.VersionFormat", FoundryDeployApplicationInfo.Version);
+    public string BootMediaUpdateRecommendedText => GetString("BootMedia.UpdateRecommended");
+    public string BootMediaUpdateRecommendedToolTip => GetString("BootMedia.UpdateRecommendedToolTip");
     public string OperatingSystemArchitectureDisplay => Format("Catalog.ArchitectureFormat", OperatingSystemCatalog.EffectiveOsArchitecture);
     public string SummaryTargetDiskText => Preparation.SelectedTargetDisk?.DisplayLabel ?? GetString("Summary.NoDiskSelected");
     public string SummaryOperatingSystemText => SelectedOperatingSystem is null
@@ -457,6 +462,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         ArgumentNullException.ThrowIfNull(startupSnapshot);
 
         _wizardContext.ApplyStartupSnapshot(startupSnapshot);
+        IsBootMediaUpdateRecommended = startupSnapshot.IsBootMediaUpdateRecommended;
         Session.SetComputerName(Preparation.TargetComputerName);
         Session.CompleteStartupInitialization();
     }
@@ -496,6 +502,8 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
             OnPropertyChanged(nameof(CurrentCulture));
             OnPropertyChanged(nameof(WindowTitle));
             OnPropertyChanged(nameof(VersionDisplay));
+            OnPropertyChanged(nameof(BootMediaUpdateRecommendedText));
+            OnPropertyChanged(nameof(BootMediaUpdateRecommendedToolTip));
             OnPropertyChanged(nameof(OperatingSystemArchitectureDisplay));
             OnPropertyChanged(nameof(SummaryTargetDiskText));
             OnPropertyChanged(nameof(SummaryOperatingSystemText));


### PR DESCRIPTION
## Summary
Add a non-blocking boot media compatibility warning in Foundry.Deploy and Foundry.Connect when the loaded runtime config schema is older than the current runtime schema.

## Reason
Runtime boot media can be generated by an older Foundry OSD version and miss newer generated configuration contracts. Users need a small, contextual prompt to update the boot media without blocking deployment or network bootstrap.

## Main changes
- Compute schema compatibility state in Deploy and Connect configuration loading services.
- Show the warning beside the app version in Deploy and Connect when the loaded schema is older.
- Translate the warning label and tooltip across all supported Deploy and Connect cultures.
- Wrap warning tooltips with a 480px maximum width.
- Add schema bump rules to `AGENTS.md`.
- Add tests for older/current schema warning behavior.

## Testing
- `dotnet test .\src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --filter "DeployConfigurationServiceTests"`
- `dotnet test .\src\Foundry.Connect.Tests\Foundry.Connect.Tests.csproj --filter "ConnectConfigurationServiceTests"`
- `dotnet test .\src\Foundry.slnx`