### PR TITLE
fix(deploy): cache verified deployment artifacts

### DIFF
--- a/src/Foundry.Deploy.Tests/ArtifactDownloadServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/ArtifactDownloadServiceTests.cs
@@ -1,0 +1,228 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Foundry.Deploy.Services.Download;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class ArtifactDownloadServiceTests
+{
+    [Fact]
+    public async Task DownloadAsync_WhenLegacyCacheIsHashValid_WritesManifestAndReusesCache()
+    {
+        using TempDirectory temp = TempDirectory.Create();
+        string destinationPath = Path.Combine(temp.Path, "install.esd");
+        byte[] content = Encoding.UTF8.GetBytes("valid cached content");
+        await File.WriteAllBytesAsync(destinationPath, content, TestContext.Current.CancellationToken);
+        string expectedHash = ComputeSha256(content);
+
+        var service = new ArtifactDownloadService(NullLogger<ArtifactDownloadService>.Instance);
+
+        ArtifactDownloadResult result = await service.DownloadAsync(
+            "https://example.test/install.esd",
+            destinationPath,
+            expectedHash,
+            expectedSizeBytes: content.Length,
+            artifactKind: "OperatingSystemImage",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        string manifestPath = $"{destinationPath}.manifest.json";
+        Assert.False(result.Downloaded);
+        Assert.Equal("cache-hit", result.Method);
+        Assert.True(File.Exists(manifestPath));
+
+        using FileStream stream = File.OpenRead(manifestPath);
+        ArtifactCacheManifest? manifest = await JsonSerializer.DeserializeAsync<ArtifactCacheManifest>(
+            stream,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(manifest);
+        Assert.Equal(1, manifest.Version);
+        Assert.Equal("OperatingSystemImage", manifest.ArtifactKind);
+        Assert.Equal("SHA256", manifest.HashAlgorithm);
+        Assert.Equal(expectedHash, manifest.ExpectedHash);
+        Assert.Equal(content.Length, manifest.ExpectedSizeBytes);
+        Assert.Equal(content.Length, manifest.FileSizeBytes);
+    }
+
+    [Fact]
+    public async Task DownloadAsync_WhenManifestMatches_UsesFastCacheHitWithoutRehashing()
+    {
+        using TempDirectory temp = TempDirectory.Create();
+        string destinationPath = Path.Combine(temp.Path, "install.esd");
+        byte[] content = Encoding.UTF8.GetBytes("tampered-content");
+        await File.WriteAllBytesAsync(destinationPath, content, TestContext.Current.CancellationToken);
+        DateTimeOffset lastWriteTime = DateTimeOffset.UtcNow.AddMinutes(-3);
+        File.SetLastWriteTimeUtc(destinationPath, lastWriteTime.UtcDateTime);
+
+        await WriteManifestAsync(
+            destinationPath,
+            new ArtifactCacheManifest
+            {
+                ArtifactKind = "OperatingSystemImage",
+                SourceUrl = "https://example.test/install.esd",
+                HashAlgorithm = "SHA256",
+                ExpectedHash = new string('A', 64),
+                ExpectedSizeBytes = content.Length,
+                FileSizeBytes = content.Length,
+                FileLastWriteTimeUtc = lastWriteTime,
+                ValidatedAtUtc = DateTimeOffset.UtcNow.AddMinutes(-2)
+            });
+
+        var handler = new ThrowingHttpMessageHandler();
+        var service = new ArtifactDownloadService(
+            NullLogger<ArtifactDownloadService>.Instance,
+            new HttpClient(handler));
+
+        ArtifactDownloadResult result = await service.DownloadAsync(
+            "https://example.test/install.esd",
+            destinationPath,
+            new string('A', 64),
+            expectedSizeBytes: content.Length,
+            artifactKind: "OperatingSystemImage",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(result.Downloaded);
+        Assert.Equal("cache-hit", result.Method);
+        Assert.Equal(0, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task DownloadAsync_WhenExistingFileSizeDiffers_RedownloadsWithoutHashingCache()
+    {
+        using TempDirectory temp = TempDirectory.Create();
+        string destinationPath = Path.Combine(temp.Path, "driver.cab");
+        await File.WriteAllTextAsync(destinationPath, "bad", TestContext.Current.CancellationToken);
+
+        byte[] downloadedContent = Encoding.UTF8.GetBytes("valid driver payload");
+        string expectedHash = ComputeSha256(downloadedContent);
+        var handler = new StaticHttpMessageHandler(downloadedContent);
+        var service = new ArtifactDownloadService(
+            NullLogger<ArtifactDownloadService>.Instance,
+            new HttpClient(handler));
+
+        ArtifactDownloadResult result = await service.DownloadAsync(
+            "https://example.test/driver.cab",
+            destinationPath,
+            expectedHash,
+            expectedSizeBytes: downloadedContent.Length,
+            artifactKind: "OemDriverPack",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(result.Downloaded);
+        Assert.Equal("httpclient", result.Method);
+        Assert.Equal(1, handler.RequestCount);
+        Assert.Equal(downloadedContent, await File.ReadAllBytesAsync(destinationPath, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task DownloadAsync_WhenDownloadedHashMatches_WritesManifestWithoutSecondFileHashPass()
+    {
+        using TempDirectory temp = TempDirectory.Create();
+        string destinationPath = Path.Combine(temp.Path, "firmware.cab");
+        byte[] downloadedContent = Encoding.UTF8.GetBytes("firmware payload");
+        string expectedHash = ComputeSha256(downloadedContent);
+        var service = new ArtifactDownloadService(
+            NullLogger<ArtifactDownloadService>.Instance,
+            new HttpClient(new StaticHttpMessageHandler(downloadedContent)));
+
+        ArtifactDownloadResult result = await service.DownloadAsync(
+            "https://example.test/firmware.cab",
+            destinationPath,
+            expectedHash,
+            expectedSizeBytes: downloadedContent.Length,
+            artifactKind: "MicrosoftUpdateCatalogFirmware",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(result.Downloaded);
+        Assert.True(File.Exists($"{destinationPath}.manifest.json"));
+    }
+
+    [Fact]
+    public async Task DownloadAsync_WhenDownloadedHashDiffers_ThrowsHashVerificationError()
+    {
+        using TempDirectory temp = TempDirectory.Create();
+        string destinationPath = Path.Combine(temp.Path, "driver.cab");
+        byte[] downloadedContent = Encoding.UTF8.GetBytes("unexpected payload");
+        var service = new ArtifactDownloadService(
+            NullLogger<ArtifactDownloadService>.Instance,
+            new HttpClient(new StaticHttpMessageHandler(downloadedContent)));
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.DownloadAsync(
+                "https://example.test/driver.cab",
+                destinationPath,
+                new string('B', 64),
+                expectedSizeBytes: downloadedContent.Length,
+                artifactKind: "MicrosoftUpdateCatalogDriver",
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Contains("Hash verification failed", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task WriteManifestAsync(string destinationPath, ArtifactCacheManifest manifest)
+    {
+        await using FileStream stream = File.Create($"{destinationPath}.manifest.json");
+        await JsonSerializer.SerializeAsync(
+            stream,
+            manifest,
+            new JsonSerializerOptions { WriteIndented = true },
+            TestContext.Current.CancellationToken);
+    }
+
+    private static string ComputeSha256(byte[] content)
+    {
+        return Convert.ToHexString(SHA256.HashData(content));
+    }
+
+    private sealed class StaticHttpMessageHandler(byte[] content) : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(content)
+            });
+        }
+    }
+
+    private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            throw new InvalidOperationException("HTTP should not be used for a manifest-backed cache hit.");
+        }
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        private TempDirectory(string path)
+        {
+            Path = path;
+            Directory.CreateDirectory(path);
+        }
+
+        public string Path { get; }
+
+        public static TempDirectory Create()
+        {
+            return new TempDirectory(System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"foundry-artifact-cache-{Guid.NewGuid():N}"));
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}

--- a/src/Foundry.Deploy.Tests/DeploymentPayloadCacheFallbackTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentPayloadCacheFallbackTests.cs
@@ -143,6 +143,8 @@ public sealed class DeploymentPayloadCacheFallbackTests
             string sourceUrl,
             string destinationPath,
             string? expectedHash = null,
+            long? expectedSizeBytes = null,
+            string? artifactKind = null,
             CancellationToken cancellationToken = default,
             IProgress<DownloadProgress>? progress = null)
         {
@@ -163,6 +165,7 @@ public sealed class DeploymentPayloadCacheFallbackTests
             HardwareProfile hardwareProfile,
             OperatingSystemCatalogItem operatingSystem,
             string destinationDirectory,
+            string cacheDirectory,
             CancellationToken cancellationToken = default,
             IProgress<double>? progress = null)
         {

--- a/src/Foundry.Deploy.Tests/MicrosoftUpdateCatalogClientTests.cs
+++ b/src/Foundry.Deploy.Tests/MicrosoftUpdateCatalogClientTests.cs
@@ -1,0 +1,65 @@
+using Foundry.Deploy.Services.DriverPacks;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class MicrosoftUpdateCatalogClientTests
+{
+    [Fact]
+    public void ParseDownloads_DecodesBase64HashesAndFileName()
+    {
+        const string html = """
+                            <script type="text/javascript">
+                            downloadInformation[0].files[0] = new Object();
+                            downloadInformation[0].files[0].url = 'https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2026/03/sample.cab';
+                            downloadInformation[0].files[0].digest = 'iH8eDpa5pkZtyW2IzGWCDGhJ0e0=';
+                            downloadInformation[0].files[0].sha256 = 'yxqvwrIfOgfWwAIVL2K6czq0FTGN7ZTA/iSmlyNZbO8=';
+                            downloadInformation[0].files[0].fileName = 'sample.cab';
+                            downloadInformation[0].files[0].architectures = 'AMD64';
+                            downloadInformation[0].files[0].languages = 'en';
+                            </script>
+                            """;
+
+        IReadOnlyList<MicrosoftUpdateCatalogDownload> downloads = MicrosoftUpdateCatalogClient.ParseDownloads(html, NullLogger<MicrosoftUpdateCatalogClient>.Instance);
+
+        MicrosoftUpdateCatalogDownload download = Assert.Single(downloads);
+        Assert.Equal("https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2026/03/sample.cab", download.DownloadUrl);
+        Assert.Equal("sample.cab", download.FileName);
+        Assert.Equal("887F1E0E96B9A6466DC96D88CC65820C6849D1ED", download.Sha1);
+        Assert.Equal("CB1AAFC2B21F3A07D6C002152F62BA733AB415318DED94C0FE24A69723596CEF", download.Sha256);
+        Assert.Equal("AMD64", download.Architectures);
+        Assert.Equal("en", download.Languages);
+    }
+
+    [Fact]
+    public void ParseDownloads_WhenSha256IsEmpty_KeepsSha1()
+    {
+        const string html = """
+                            downloadInformation[0].files[0].url = 'https://example.test/driver.cab';
+                            downloadInformation[0].files[0].digest = 'iH8eDpa5pkZtyW2IzGWCDGhJ0e0=';
+                            downloadInformation[0].files[0].sha256 = '';
+                            downloadInformation[0].files[0].fileName = 'driver.cab';
+                            """;
+
+        MicrosoftUpdateCatalogDownload download = Assert.Single(
+            MicrosoftUpdateCatalogClient.ParseDownloads(html, NullLogger<MicrosoftUpdateCatalogClient>.Instance));
+
+        Assert.Equal("887F1E0E96B9A6466DC96D88CC65820C6849D1ED", download.Sha1);
+        Assert.Equal(string.Empty, download.Sha256);
+    }
+
+    [Fact]
+    public void ParseDownloads_ParsesMultipleFiles()
+    {
+        const string html = """
+                            downloadInformation[0].files[0].url = 'https://example.test/driver-x64.cab';
+                            downloadInformation[0].files[0].fileName = 'driver-x64.cab';
+                            downloadInformation[0].files[1].url = 'https://example.test/driver-arm64.cab';
+                            downloadInformation[0].files[1].fileName = 'driver-arm64.cab';
+                            """;
+
+        IReadOnlyList<MicrosoftUpdateCatalogDownload> downloads = MicrosoftUpdateCatalogClient.ParseDownloads(html, NullLogger<MicrosoftUpdateCatalogClient>.Instance);
+
+        Assert.Equal(["driver-x64.cab", "driver-arm64.cab"], downloads.Select(download => download.FileName));
+    }
+}

--- a/src/Foundry.Deploy.Tests/MicrosoftUpdateCatalogServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/MicrosoftUpdateCatalogServiceTests.cs
@@ -1,0 +1,201 @@
+using Foundry.Deploy.Models;
+using Foundry.Deploy.Services.Download;
+using Foundry.Deploy.Services.DriverPacks;
+using Foundry.Deploy.Services.System;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class MicrosoftUpdateCatalogServiceTests
+{
+    [Fact]
+    public async Task DriverDownload_WhenCatalogHashExists_UsesPersistentCacheAndStagesCab()
+    {
+        using TempDirectory temp = TempDirectory.Create();
+        string rawDirectory = Path.Combine(temp.Path, "raw");
+        string cacheDirectory = Path.Combine(temp.Path, "cache");
+        var catalogClient = new FakeMicrosoftUpdateCatalogClient();
+        var downloadService = new CapturingArtifactDownloadService();
+        var service = new MicrosoftUpdateCatalogDriverService(
+            new FakeArchiveExtractionService(),
+            catalogClient,
+            downloadService,
+            NullLogger<MicrosoftUpdateCatalogDriverService>.Instance);
+
+        MicrosoftUpdateCatalogDriverResult result = await service.DownloadAsync(
+            CreateHardwareProfile(),
+            new OperatingSystemCatalogItem { ReleaseId = "24H2", Architecture = "x64" },
+            rawDirectory,
+            cacheDirectory,
+            TestContext.Current.CancellationToken);
+
+        string expectedCachePath = Path.Combine(cacheDirectory, "update-1", "driver-amd64.cab");
+        string expectedRawPath = Path.Combine(rawDirectory, "update-1", "driver-amd64.cab");
+        Assert.True(result.IsPayloadAvailable);
+        Assert.Equal(expectedCachePath, downloadService.DestinationPath);
+        Assert.Equal(new string('B', 64), downloadService.ExpectedHash);
+        Assert.Equal("MicrosoftUpdateCatalogDriver", downloadService.ArtifactKind);
+        Assert.True(File.Exists(expectedRawPath));
+    }
+
+    [Fact]
+    public async Task FirmwareDownload_WhenCatalogHashExists_UsesPersistentCacheAndStagesCab()
+    {
+        using TempDirectory temp = TempDirectory.Create();
+        string rawDirectory = Path.Combine(temp.Path, "raw");
+        string extractedDirectory = Path.Combine(temp.Path, "extracted");
+        string cacheDirectory = Path.Combine(temp.Path, "cache");
+        var catalogClient = new FakeMicrosoftUpdateCatalogClient();
+        var downloadService = new CapturingArtifactDownloadService();
+        var service = new MicrosoftUpdateCatalogFirmwareService(
+            new FakeArchiveExtractionService(),
+            catalogClient,
+            downloadService,
+            NullLogger<MicrosoftUpdateCatalogFirmwareService>.Instance);
+
+        MicrosoftUpdateCatalogFirmwareResult result = await service.DownloadAsync(
+            new HardwareProfile { SystemFirmwareHardwareId = "UEFI\\RES_{FIRMWARE}" },
+            "x64",
+            rawDirectory,
+            extractedDirectory,
+            cacheDirectory,
+            TestContext.Current.CancellationToken);
+
+        string expectedCachePath = Path.Combine(cacheDirectory, "update-1", "driver-amd64.cab");
+        string expectedRawPath = Path.Combine(rawDirectory, "update-1", "driver-amd64.cab");
+        Assert.True(result.IsUpdateAvailable);
+        Assert.Equal(expectedCachePath, downloadService.DestinationPath);
+        Assert.Equal(new string('B', 64), downloadService.ExpectedHash);
+        Assert.Equal("MicrosoftUpdateCatalogFirmware", downloadService.ArtifactKind);
+        Assert.True(File.Exists(expectedRawPath));
+    }
+
+    private static HardwareProfile CreateHardwareProfile()
+    {
+        return new HardwareProfile
+        {
+            PnpDevices =
+            [
+                new PnpDeviceInfo
+                {
+                    Name = "Network adapter",
+                    DeviceId = @"PCI\VEN_8086&DEV_15B7&SUBSYS_00000000",
+                    HardwareIds = [@"PCI\VEN_8086&DEV_15B7"],
+                    PnpClass = "Net"
+                }
+            ]
+        };
+    }
+
+    private sealed class FakeMicrosoftUpdateCatalogClient : IMicrosoftUpdateCatalogClient
+    {
+        public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(true);
+        }
+
+        public Task<IReadOnlyList<MicrosoftUpdateCatalogUpdate>> SearchAsync(
+            string searchQuery,
+            bool descending = true,
+            CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<MicrosoftUpdateCatalogUpdate> updates =
+            [
+                new MicrosoftUpdateCatalogUpdate
+                {
+                    UpdateId = "update-1",
+                    Title = "Driver update",
+                    Version = "1.0",
+                    Size = "1 MB"
+                }
+            ];
+
+            return Task.FromResult(updates);
+        }
+
+        public Task<IReadOnlyList<MicrosoftUpdateCatalogDownload>> GetDownloadsAsync(
+            string updateId,
+            CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<MicrosoftUpdateCatalogDownload> downloads =
+            [
+                new MicrosoftUpdateCatalogDownload
+                {
+                    DownloadUrl = "https://example.test/driver-amd64.cab",
+                    FileName = "driver-amd64.cab",
+                    Sha1 = new string('A', 40),
+                    Sha256 = new string('B', 64)
+                }
+            ];
+
+            return Task.FromResult(downloads);
+        }
+    }
+
+    private sealed class CapturingArtifactDownloadService : IArtifactDownloadService
+    {
+        public string? DestinationPath { get; private set; }
+        public string? ExpectedHash { get; private set; }
+        public string? ArtifactKind { get; private set; }
+
+        public async Task<ArtifactDownloadResult> DownloadAsync(
+            string sourceUrl,
+            string destinationPath,
+            string? expectedHash = null,
+            long? expectedSizeBytes = null,
+            string? artifactKind = null,
+            CancellationToken cancellationToken = default,
+            IProgress<DownloadProgress>? progress = null)
+        {
+            DestinationPath = destinationPath;
+            ExpectedHash = expectedHash;
+            ArtifactKind = artifactKind;
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+            await File.WriteAllTextAsync(destinationPath, "cab", cancellationToken).ConfigureAwait(false);
+
+            return new ArtifactDownloadResult
+            {
+                DestinationPath = destinationPath,
+                Downloaded = true,
+                Method = "test",
+                SizeBytes = 3
+            };
+        }
+    }
+
+    private sealed class FakeArchiveExtractionService : IArchiveExtractionService
+    {
+        public Task ExtractWithSevenZipAsync(
+            string archivePath,
+            string extractedPath,
+            string workingDirectory,
+            CancellationToken cancellationToken = default,
+            IProgress<double>? progress = null)
+        {
+            Directory.CreateDirectory(extractedPath);
+            File.WriteAllText(Path.Combine(extractedPath, "driver.inf"), "; test");
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        private TempDirectory(string path)
+        {
+            Path = path;
+            Directory.CreateDirectory(path);
+        }
+
+        public string Path { get; }
+
+        public static TempDirectory Create()
+        {
+            return new TempDirectory(System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"foundry-muc-{Guid.NewGuid():N}"));
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/src/Foundry.Deploy.Tests/MicrosoftUpdateCatalogSupportTests.cs
+++ b/src/Foundry.Deploy.Tests/MicrosoftUpdateCatalogSupportTests.cs
@@ -36,29 +36,54 @@ public sealed class MicrosoftUpdateCatalogSupportTests
     }
 
     [Fact]
-    public void SelectPreferredCabUrl_PrefersExactArchitectureMatch()
+    public void SelectPreferredCab_PrefersExactArchitectureMatch()
     {
-        string? url = MicrosoftUpdateCatalogSupport.SelectPreferredCabUrl(
+        MicrosoftUpdateCatalogDownload? download = MicrosoftUpdateCatalogSupport.SelectPreferredCab(
             [
-                "https://example.test/driver-x86.cab",
-                "https://example.test/driver-amd64.cab",
-                "https://example.test/readme.txt"
+                CreateDownload("https://example.test/driver-x86.cab"),
+                CreateDownload("https://example.test/driver-amd64.cab"),
+                CreateDownload("https://example.test/readme.txt")
             ],
             "x64");
 
-        Assert.Equal("https://example.test/driver-amd64.cab", url);
+        Assert.Equal("https://example.test/driver-amd64.cab", download?.DownloadUrl);
     }
 
     [Fact]
-    public void SelectPreferredCabUrl_WhenNoExactMatch_FallsBackToCompatibleCab()
+    public void SelectPreferredCab_WhenNoExactMatch_FallsBackToCompatibleCab()
     {
-        string? url = MicrosoftUpdateCatalogSupport.SelectPreferredCabUrl(
+        MicrosoftUpdateCatalogDownload? download = MicrosoftUpdateCatalogSupport.SelectPreferredCab(
             [
-                "https://example.test/driver-generic.cab",
-                "https://example.test/driver-arm64.cab"
+                CreateDownload("https://example.test/driver-generic.cab"),
+                CreateDownload("https://example.test/driver-arm64.cab")
             ],
             "x64");
 
-        Assert.Equal("https://example.test/driver-generic.cab", url);
+        Assert.Equal("https://example.test/driver-generic.cab", download?.DownloadUrl);
+    }
+
+    [Fact]
+    public void ResolvePreferredHash_PrefersSha256OverSha1()
+    {
+        var download = new MicrosoftUpdateCatalogDownload
+        {
+            DownloadUrl = "https://example.test/driver.cab",
+            FileName = "driver.cab",
+            Sha1 = new string('A', 40),
+            Sha256 = new string('B', 64)
+        };
+
+        string hash = MicrosoftUpdateCatalogSupport.ResolvePreferredHash(download);
+
+        Assert.Equal(new string('B', 64), hash);
+    }
+
+    private static MicrosoftUpdateCatalogDownload CreateDownload(string url)
+    {
+        return new MicrosoftUpdateCatalogDownload
+        {
+            DownloadUrl = url,
+            FileName = MicrosoftUpdateCatalogSupport.ResolveFileNameFromUrl(url)
+        };
     }
 }

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentStepExecutionContext.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentStepExecutionContext.cs
@@ -22,6 +22,9 @@ public sealed class DeploymentStepExecutionContext
     private const string CacheFolderName = "Cache";
     private const string OperatingSystemsFolderName = "OperatingSystems";
     private const string DriverPacksFolderName = "DriverPacks";
+    private const string MicrosoftUpdateCatalogFolderName = "MicrosoftUpdateCatalog";
+    private const string DriversFolderName = "Drivers";
+    private const string FirmwareFolderName = "Firmware";
     private const string DryRunWorkspaceFolderName = "DryRun";
     private const string RuntimeWorkspaceFolderName = "Runtime";
     private const long UnknownTotalDownloadProgressIncrementBytes = 16L * 1024 * 1024;
@@ -326,6 +329,16 @@ public sealed class DeploymentStepExecutionContext
     public string ResolveDriverPackCacheRoot(long requiredBytes)
     {
         return ResolvePayloadCacheRoot(DriverPacksFolderName, requiredBytes);
+    }
+
+    public string ResolveMicrosoftUpdateCatalogDriverCacheRoot()
+    {
+        return Path.Combine(ResolvePayloadCacheRoot(MicrosoftUpdateCatalogFolderName, requiredBytes: 0), DriversFolderName);
+    }
+
+    public string ResolveMicrosoftUpdateCatalogFirmwareCacheRoot()
+    {
+        return Path.Combine(ResolvePayloadCacheRoot(MicrosoftUpdateCatalogFolderName, requiredBytes: 0), FirmwareFolderName);
     }
 
     /// <summary>

--- a/src/Foundry.Deploy/Services/Deployment/Steps/DownloadDriverPackStep.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Steps/DownloadDriverPackStep.cs
@@ -38,12 +38,13 @@ public sealed class DownloadDriverPackStep : DeploymentStepBase
                 HardwareProfile hardwareProfile = context.RuntimeState.HardwareProfile
                     ?? throw new InvalidOperationException("Hardware profile is unavailable for Microsoft Update Catalog lookup.");
                 string rawDirectory = context.ResolveWorkspaceTempPath("DriverPack", "MicrosoftUpdateCatalog", "Raw");
+                string cacheDirectory = context.ResolveMicrosoftUpdateCatalogDriverCacheRoot();
                 ResetDirectory(rawDirectory);
                 context.EmitCurrentStepIndeterminate("Downloading driver pack...", "Preparing download...");
                 IProgress<double> progress = context.CreateStepPercentProgressReporter("Downloading driver pack...", "Downloading");
 
                 MicrosoftUpdateCatalogDriverResult result = await _microsoftUpdateCatalogDriverService
-                    .DownloadAsync(hardwareProfile, context.Request.OperatingSystem, rawDirectory, cancellationToken, progress)
+                    .DownloadAsync(hardwareProfile, context.Request.OperatingSystem, rawDirectory, cacheDirectory, cancellationToken, progress)
                     .ConfigureAwait(false);
 
                 context.RuntimeState.DriverPackName = "Microsoft Update Catalog";
@@ -93,6 +94,8 @@ public sealed class DownloadDriverPackStep : DeploymentStepBase
                         driverPack.DownloadUrl,
                         archivePath,
                         expectedHash: driverPack.Sha256,
+                        expectedSizeBytes: driverPack.SizeBytes,
+                        artifactKind: "OemDriverPack",
                         cancellationToken: cancellationToken,
                         progress: driverPackDownloadProgress)
                     .ConfigureAwait(false);

--- a/src/Foundry.Deploy/Services/Deployment/Steps/DownloadFirmwareUpdateStep.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Steps/DownloadFirmwareUpdateStep.cs
@@ -48,12 +48,13 @@ public sealed class DownloadFirmwareUpdateStep : DeploymentStepBase
         string targetFoundryRoot = context.EnsureTargetFoundryRoot();
         string rawDirectory = Path.Combine(targetFoundryRoot, "Temp", "FirmwareUpdate", "Raw");
         string extractedDirectory = Path.Combine(targetFoundryRoot, "Extracted", "Firmware");
+        string cacheDirectory = context.ResolveMicrosoftUpdateCatalogFirmwareCacheRoot();
 
         context.EmitCurrentStepIndeterminate("Downloading firmware update...", "Preparing Microsoft Update Catalog lookup...");
         IProgress<double> progress = context.CreateStepPercentProgressReporter("Downloading firmware update...", "Downloading");
 
         MicrosoftUpdateCatalogFirmwareResult result = await _firmwareService
-            .DownloadAsync(hardwareProfile, context.Request.OperatingSystem.Architecture, rawDirectory, extractedDirectory, cancellationToken, progress)
+            .DownloadAsync(hardwareProfile, context.Request.OperatingSystem.Architecture, rawDirectory, extractedDirectory, cacheDirectory, cancellationToken, progress)
             .ConfigureAwait(false);
 
         await context.AppendLogAsync(DeploymentLogLevel.Info, result.Message, cancellationToken).ConfigureAwait(false);

--- a/src/Foundry.Deploy/Services/Deployment/Steps/DownloadOperatingSystemImageStep.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Steps/DownloadOperatingSystemImageStep.cs
@@ -38,6 +38,8 @@ public sealed class DownloadOperatingSystemImageStep : DeploymentStepBase
                 context.Request.OperatingSystem.Url,
                 destinationPath,
                 expectedHash: expectedOsHash,
+                expectedSizeBytes: context.Request.OperatingSystem.SizeBytes,
+                artifactKind: "OperatingSystemImage",
                 cancellationToken: cancellationToken,
                 progress: osDownloadProgress)
             .ConfigureAwait(false);

--- a/src/Foundry.Deploy/Services/Download/ArtifactCacheManifest.cs
+++ b/src/Foundry.Deploy/Services/Download/ArtifactCacheManifest.cs
@@ -1,0 +1,15 @@
+namespace Foundry.Deploy.Services.Download;
+
+internal sealed record ArtifactCacheManifest
+{
+    public int Version { get; init; } = 1;
+    public string? ArtifactKind { get; init; }
+    public string? SourceUrl { get; init; }
+    public required string HashAlgorithm { get; init; }
+    public required string ExpectedHash { get; init; }
+    public long? ExpectedSizeBytes { get; init; }
+    public required long FileSizeBytes { get; init; }
+    public required DateTimeOffset FileLastWriteTimeUtc { get; init; }
+    public required DateTimeOffset ValidatedAtUtc { get; init; }
+    public string ValidatedBy { get; init; } = "Foundry.Deploy";
+}

--- a/src/Foundry.Deploy/Services/Download/ArtifactCacheManifestService.cs
+++ b/src/Foundry.Deploy/Services/Download/ArtifactCacheManifestService.cs
@@ -1,0 +1,98 @@
+using System.IO;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Foundry.Deploy.Services.Download;
+
+internal static class ArtifactCacheManifestService
+{
+    private const int CurrentVersion = 1;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    public static bool TryValidate(
+        string artifactPath,
+        string expectedHash,
+        string hashAlgorithm,
+        long? expectedSizeBytes,
+        ILogger logger,
+        out ArtifactCacheManifest? manifest)
+    {
+        manifest = null;
+        string manifestPath = GetManifestPath(artifactPath);
+        if (!File.Exists(manifestPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            string json = File.ReadAllText(manifestPath);
+            manifest = JsonSerializer.Deserialize<ArtifactCacheManifest>(json, SerializerOptions);
+        }
+        catch (Exception ex) when (ex is IOException or JsonException or UnauthorizedAccessException)
+        {
+            logger.LogWarning(ex, "Unable to read artifact cache manifest. ManifestPath={ManifestPath}", manifestPath);
+            return false;
+        }
+
+        if (manifest is null ||
+            manifest.Version != CurrentVersion ||
+            !string.Equals(manifest.HashAlgorithm, hashAlgorithm, StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(manifest.ExpectedHash, expectedHash, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (expectedSizeBytes is > 0 && manifest.ExpectedSizeBytes != expectedSizeBytes.Value)
+        {
+            return false;
+        }
+
+        FileInfo artifact = new(artifactPath);
+        if (!artifact.Exists ||
+            manifest.FileSizeBytes != artifact.Length ||
+            manifest.FileLastWriteTimeUtc != new DateTimeOffset(artifact.LastWriteTimeUtc, TimeSpan.Zero))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static async Task WriteAsync(
+        string artifactPath,
+        string sourceUrl,
+        string? artifactKind,
+        string expectedHash,
+        string hashAlgorithm,
+        long? expectedSizeBytes,
+        CancellationToken cancellationToken)
+    {
+        FileInfo artifact = new(artifactPath);
+        var manifest = new ArtifactCacheManifest
+        {
+            ArtifactKind = artifactKind,
+            SourceUrl = sourceUrl,
+            HashAlgorithm = hashAlgorithm,
+            ExpectedHash = expectedHash,
+            ExpectedSizeBytes = expectedSizeBytes,
+            FileSizeBytes = artifact.Length,
+            FileLastWriteTimeUtc = new DateTimeOffset(artifact.LastWriteTimeUtc, TimeSpan.Zero),
+            ValidatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        await using FileStream stream = File.Create(GetManifestPath(artifactPath));
+        await JsonSerializer
+            .SerializeAsync(stream, manifest, SerializerOptions, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public static string GetManifestPath(string artifactPath)
+    {
+        return $"{artifactPath}.manifest.json";
+    }
+}

--- a/src/Foundry.Deploy/Services/Download/ArtifactDownloadService.cs
+++ b/src/Foundry.Deploy/Services/Download/ArtifactDownloadService.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using System.Net.Http;
 using System.Security.Cryptography;
-using System.IO;
 using Foundry.Deploy.Services.Http;
 using Microsoft.Extensions.Logging;
 
@@ -8,21 +8,30 @@ namespace Foundry.Deploy.Services.Download;
 
 public sealed class ArtifactDownloadService : IArtifactDownloadService
 {
-    private static readonly HttpClient HttpClient = InsecureHttpClientFactory.Create(TimeSpan.FromMinutes(30));
+    private static readonly HttpClient DefaultHttpClient = InsecureHttpClientFactory.Create(TimeSpan.FromMinutes(30));
     private static readonly TimeSpan ProgressReportInterval = TimeSpan.FromMilliseconds(100);
     private const int CopyBufferSize = 80 * 1024;
 
+    private readonly HttpClient _httpClient;
     private readonly ILogger<ArtifactDownloadService> _logger;
 
     public ArtifactDownloadService(ILogger<ArtifactDownloadService> logger)
+        : this(logger, DefaultHttpClient)
+    {
+    }
+
+    internal ArtifactDownloadService(ILogger<ArtifactDownloadService> logger, HttpClient httpClient)
     {
         _logger = logger;
+        _httpClient = httpClient;
     }
 
     public async Task<ArtifactDownloadResult> DownloadAsync(
         string sourceUrl,
         string destinationPath,
         string? expectedHash = null,
+        long? expectedSizeBytes = null,
+        string? artifactKind = null,
         CancellationToken cancellationToken = default,
         IProgress<DownloadProgress>? progress = null)
     {
@@ -56,10 +65,26 @@ public sealed class ArtifactDownloadService : IArtifactDownloadService
 
         try
         {
-            if (File.Exists(destinationPath) && await ValidateHashIfRequestedAsync(destinationPath, expectedHash, cancellationToken).ConfigureAwait(false))
+            string? normalizedExpectedHash = null;
+            HashAlgorithmName? hashAlgorithm = null;
+            if (!string.IsNullOrWhiteSpace(expectedHash))
+            {
+                normalizedExpectedHash = NormalizeHash(expectedHash);
+                hashAlgorithm = ResolveHashAlgorithm(normalizedExpectedHash);
+            }
+
+            if (File.Exists(destinationPath) &&
+                await TryUseExistingArtifactAsync(
+                    sourceUrl,
+                    destinationPath,
+                    normalizedExpectedHash,
+                    hashAlgorithm,
+                    expectedSizeBytes,
+                    artifactKind,
+                    cancellationToken,
+                    progress).ConfigureAwait(false))
             {
                 long cachedSize = new FileInfo(destinationPath).Length;
-                progress?.Report(new DownloadProgress(cachedSize, cachedSize));
                 _logger.LogInformation("Artifact cache hit for DestinationPath={DestinationPath}.", destinationPath);
                 return new ArtifactDownloadResult
                 {
@@ -70,14 +95,38 @@ public sealed class ArtifactDownloadService : IArtifactDownloadService
                 };
             }
 
+            DownloadedArtifact downloadedArtifact = new(null);
             await HttpRetryPolicy
                 .ExecuteAsync(
-                    ct => DownloadWithHttpClientAsync(effectiveSourceUrl, destinationPath, progress, ct),
+                    async ct =>
+                    {
+                        downloadedArtifact = await DownloadWithHttpClientAsync(
+                                effectiveSourceUrl,
+                                destinationPath,
+                                hashAlgorithm,
+                                progress,
+                                ct)
+                            .ConfigureAwait(false);
+                    },
                     _logger,
                     "Artifact download",
                     cancellationToken)
                 .ConfigureAwait(false);
-            await EnsureHashAsync(destinationPath, expectedHash, cancellationToken).ConfigureAwait(false);
+            await EnsureDownloadedHashAsync(destinationPath, normalizedExpectedHash, hashAlgorithm, downloadedArtifact, cancellationToken).ConfigureAwait(false);
+
+            if (normalizedExpectedHash is not null && hashAlgorithm is not null)
+            {
+                await ArtifactCacheManifestService
+                    .WriteAsync(
+                        destinationPath,
+                        sourceUrl,
+                        artifactKind,
+                        normalizedExpectedHash,
+                        hashAlgorithm.Value.Name ?? string.Empty,
+                        expectedSizeBytes,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
 
             _logger.LogInformation("Artifact downloaded via HttpClient. DestinationPath={DestinationPath}", destinationPath);
             return new ArtifactDownloadResult
@@ -101,13 +150,74 @@ public sealed class ArtifactDownloadService : IArtifactDownloadService
         }
     }
 
-    private static async Task DownloadWithHttpClientAsync(
+    private async Task<bool> TryUseExistingArtifactAsync(
         string sourceUrl,
         string destinationPath,
+        string? normalizedExpectedHash,
+        HashAlgorithmName? hashAlgorithm,
+        long? expectedSizeBytes,
+        string? artifactKind,
+        CancellationToken cancellationToken,
+        IProgress<DownloadProgress>? progress)
+    {
+        FileInfo artifact = new(destinationPath);
+        if (expectedSizeBytes is > 0 && artifact.Length != expectedSizeBytes.Value)
+        {
+            _logger.LogInformation(
+                "Artifact cache file size mismatch. DestinationPath={DestinationPath}, ExpectedSizeBytes={ExpectedSizeBytes}, ActualSizeBytes={ActualSizeBytes}",
+                destinationPath,
+                expectedSizeBytes.Value,
+                artifact.Length);
+            return false;
+        }
+
+        if (normalizedExpectedHash is null || hashAlgorithm is null)
+        {
+            progress?.Report(new DownloadProgress(artifact.Length, artifact.Length));
+            return true;
+        }
+
+        if (ArtifactCacheManifestService.TryValidate(
+                destinationPath,
+                normalizedExpectedHash,
+                hashAlgorithm.Value.Name ?? string.Empty,
+                expectedSizeBytes,
+                _logger,
+                out _))
+        {
+            progress?.Report(new DownloadProgress(artifact.Length, artifact.Length));
+            return true;
+        }
+
+        string actualHash = await ComputeHashAsync(destinationPath, hashAlgorithm.Value, cancellationToken).ConfigureAwait(false);
+        if (!string.Equals(normalizedExpectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        await ArtifactCacheManifestService
+            .WriteAsync(
+                destinationPath,
+                sourceUrl,
+                artifactKind,
+                normalizedExpectedHash,
+                hashAlgorithm.Value.Name ?? string.Empty,
+                expectedSizeBytes,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        progress?.Report(new DownloadProgress(artifact.Length, artifact.Length));
+        return true;
+    }
+
+    private async Task<DownloadedArtifact> DownloadWithHttpClientAsync(
+        string sourceUrl,
+        string destinationPath,
+        HashAlgorithmName? hashAlgorithm,
         IProgress<DownloadProgress>? progress,
         CancellationToken cancellationToken)
     {
-        using HttpResponseMessage response = await HttpClient
+        using HttpResponseMessage response = await _httpClient
             .GetAsync(sourceUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);
 
@@ -116,6 +226,9 @@ public sealed class ArtifactDownloadService : IArtifactDownloadService
 
         await using Stream sourceStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         await using FileStream destinationStream = new(destinationPath, FileMode.Create, FileAccess.Write, FileShare.None, CopyBufferSize, useAsync: true);
+        using IncrementalHash? incrementalHash = hashAlgorithm is null
+            ? null
+            : IncrementalHash.CreateHash(hashAlgorithm.Value);
         byte[] buffer = new byte[CopyBufferSize];
         long bytesDownloaded = 0;
         DateTimeOffset nextReportAt = DateTimeOffset.UtcNow;
@@ -130,6 +243,7 @@ public sealed class ArtifactDownloadService : IArtifactDownloadService
                 break;
             }
 
+            incrementalHash?.AppendData(buffer.AsSpan(0, bytesRead));
             await destinationStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken).ConfigureAwait(false);
             bytesDownloaded += bytesRead;
 
@@ -142,36 +256,30 @@ public sealed class ArtifactDownloadService : IArtifactDownloadService
         }
 
         progress?.Report(new DownloadProgress(bytesDownloaded, totalBytes));
+        string? actualHash = incrementalHash is null
+            ? null
+            : Convert.ToHexString(incrementalHash.GetHashAndReset());
+        return new DownloadedArtifact(actualHash);
     }
 
-    private static async Task EnsureHashAsync(string filePath, string? expectedHash, CancellationToken cancellationToken)
+    private static async Task EnsureDownloadedHashAsync(
+        string filePath,
+        string? normalizedExpectedHash,
+        HashAlgorithmName? hashAlgorithm,
+        DownloadedArtifact downloadedArtifact,
+        CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(expectedHash))
+        if (normalizedExpectedHash is null || hashAlgorithm is null)
         {
             return;
         }
 
-        string expected = NormalizeHash(expectedHash);
-        HashAlgorithmName algorithm = ResolveHashAlgorithm(expected);
-        string actual = await ComputeHashAsync(filePath, algorithm, cancellationToken).ConfigureAwait(false);
-        if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
+        string actual = downloadedArtifact.Hash ?? await ComputeHashAsync(filePath, hashAlgorithm.Value, cancellationToken).ConfigureAwait(false);
+        if (!string.Equals(normalizedExpectedHash, actual, StringComparison.OrdinalIgnoreCase))
         {
             throw new InvalidOperationException(
-                $"Hash verification failed for '{filePath}' ({algorithm.Name}). Expected '{expected}', actual '{actual}'.");
+                $"Hash verification failed for '{filePath}' ({hashAlgorithm.Value.Name}). Expected '{normalizedExpectedHash}', actual '{actual}'.");
         }
-    }
-
-    private static async Task<bool> ValidateHashIfRequestedAsync(string filePath, string? expectedHash, CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrWhiteSpace(expectedHash))
-        {
-            return true;
-        }
-
-        string expected = NormalizeHash(expectedHash);
-        HashAlgorithmName algorithm = ResolveHashAlgorithm(expected);
-        string actual = await ComputeHashAsync(filePath, algorithm, cancellationToken).ConfigureAwait(false);
-        return string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string NormalizeHash(string hash)
@@ -249,4 +357,5 @@ public sealed class ArtifactDownloadService : IArtifactDownloadService
                host.EndsWith(".dl.delivery.mp.microsoft.com", StringComparison.OrdinalIgnoreCase);
     }
 
+    private sealed record DownloadedArtifact(string? Hash);
 }

--- a/src/Foundry.Deploy/Services/Download/IArtifactDownloadService.cs
+++ b/src/Foundry.Deploy/Services/Download/IArtifactDownloadService.cs
@@ -6,6 +6,8 @@ public interface IArtifactDownloadService
         string sourceUrl,
         string destinationPath,
         string? expectedHash = null,
+        long? expectedSizeBytes = null,
+        string? artifactKind = null,
         CancellationToken cancellationToken = default,
         IProgress<DownloadProgress>? progress = null);
 }

--- a/src/Foundry.Deploy/Services/DriverPacks/IMicrosoftUpdateCatalogClient.cs
+++ b/src/Foundry.Deploy/Services/DriverPacks/IMicrosoftUpdateCatalogClient.cs
@@ -9,7 +9,7 @@ public interface IMicrosoftUpdateCatalogClient
         bool descending = true,
         CancellationToken cancellationToken = default);
 
-    Task<IReadOnlyList<string>> GetDownloadUrlsAsync(
+    Task<IReadOnlyList<MicrosoftUpdateCatalogDownload>> GetDownloadsAsync(
         string updateId,
         CancellationToken cancellationToken = default);
 }

--- a/src/Foundry.Deploy/Services/DriverPacks/IMicrosoftUpdateCatalogDriverService.cs
+++ b/src/Foundry.Deploy/Services/DriverPacks/IMicrosoftUpdateCatalogDriverService.cs
@@ -8,6 +8,7 @@ public interface IMicrosoftUpdateCatalogDriverService
         HardwareProfile hardwareProfile,
         OperatingSystemCatalogItem operatingSystem,
         string destinationDirectory,
+        string cacheDirectory,
         CancellationToken cancellationToken = default,
         IProgress<double>? progress = null);
 

--- a/src/Foundry.Deploy/Services/DriverPacks/IMicrosoftUpdateCatalogFirmwareService.cs
+++ b/src/Foundry.Deploy/Services/DriverPacks/IMicrosoftUpdateCatalogFirmwareService.cs
@@ -9,6 +9,7 @@ public interface IMicrosoftUpdateCatalogFirmwareService
         string targetArchitecture,
         string rawDirectory,
         string extractedDirectory,
+        string cacheDirectory,
         CancellationToken cancellationToken = default,
         IProgress<double>? progress = null);
 }

--- a/src/Foundry.Deploy/Services/DriverPacks/MicrosoftUpdateCatalogClient.cs
+++ b/src/Foundry.Deploy/Services/DriverPacks/MicrosoftUpdateCatalogClient.cs
@@ -13,8 +13,8 @@ public sealed class MicrosoftUpdateCatalogClient : IMicrosoftUpdateCatalogClient
     private static readonly HttpClient HttpClient = InsecureHttpClientFactory.Create(TimeSpan.FromMinutes(5));
     private static readonly Uri HomeUri = new("https://www.catalog.update.microsoft.com/Home.aspx");
     private static readonly Uri DownloadDialogUri = new("https://www.catalog.update.microsoft.com/DownloadDialog.aspx");
-    private static readonly Regex DownloadUrlRegex = new(
-        "(http[s]?://dl\\.delivery\\.mp\\.microsoft\\.com/[^\\'\\\"]*)|(http[s]?://download\\.windowsupdate\\.com/[^\\'\\\"]*)|(http[s]?://catalog\\.s\\.download\\.windowsupdate\\.com/[^\\'\\\"]*)",
+    private static readonly Regex DownloadPropertyRegex = new(
+        "downloadInformation\\[\\d+\\]\\.files\\[(?<index>\\d+)\\]\\.(?<name>[A-Za-z0-9_]+)\\s*=\\s*'(?<value>(?:\\\\'|[^'])*)'",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     private readonly ILogger<MicrosoftUpdateCatalogClient> _logger;
@@ -109,7 +109,7 @@ public sealed class MicrosoftUpdateCatalogClient : IMicrosoftUpdateCatalogClient
             : parsed.ToArray();
     }
 
-    public async Task<IReadOnlyList<string>> GetDownloadUrlsAsync(
+    public async Task<IReadOnlyList<MicrosoftUpdateCatalogDownload>> GetDownloadsAsync(
         string updateId,
         CancellationToken cancellationToken = default)
     {
@@ -123,14 +123,84 @@ public sealed class MicrosoftUpdateCatalogClient : IMicrosoftUpdateCatalogClient
                 cancellationToken)
             .ConfigureAwait(false);
 
-        string normalizedHtml = html.Replace("www.download.windowsupdate", "download.windowsupdate", StringComparison.OrdinalIgnoreCase);
-        MatchCollection matches = DownloadUrlRegex.Matches(normalizedHtml);
+        return ParseDownloads(html, _logger);
+    }
 
-        return matches
-            .Select(match => match.Value)
-            .Where(value => !string.IsNullOrWhiteSpace(value))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
+    internal static IReadOnlyList<MicrosoftUpdateCatalogDownload> ParseDownloads(string html, ILogger<MicrosoftUpdateCatalogClient> logger)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+        {
+            return [];
+        }
+
+        Dictionary<int, Dictionary<string, string>> files = [];
+        foreach (Match match in DownloadPropertyRegex.Matches(html))
+        {
+            if (!int.TryParse(match.Groups["index"].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int index))
+            {
+                continue;
+            }
+
+            if (!files.TryGetValue(index, out Dictionary<string, string>? properties))
+            {
+                properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                files[index] = properties;
+            }
+
+            properties[match.Groups["name"].Value] = UnescapeJavascriptString(match.Groups["value"].Value);
+        }
+
+        return files
+            .OrderBy(pair => pair.Key)
+            .Select(pair => CreateDownload(pair.Value, logger))
+            .Where(download => download is not null)
+            .Cast<MicrosoftUpdateCatalogDownload>()
             .ToArray();
+    }
+
+    private static MicrosoftUpdateCatalogDownload? CreateDownload(Dictionary<string, string> properties, ILogger<MicrosoftUpdateCatalogClient> logger)
+    {
+        string downloadUrl = properties.GetValueOrDefault("url") ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(downloadUrl))
+        {
+            return null;
+        }
+
+        string fileName = properties.GetValueOrDefault("fileName") ?? MicrosoftUpdateCatalogSupport.ResolveFileNameFromUrl(downloadUrl);
+        return new MicrosoftUpdateCatalogDownload
+        {
+            DownloadUrl = downloadUrl.Replace("www.download.windowsupdate", "download.windowsupdate", StringComparison.OrdinalIgnoreCase),
+            FileName = MicrosoftUpdateCatalogSupport.SanitizePathSegment(fileName),
+            Sha1 = DecodeBase64Hash(properties.GetValueOrDefault("digest"), "SHA1", logger),
+            Sha256 = DecodeBase64Hash(properties.GetValueOrDefault("sha256"), "SHA256", logger),
+            Architectures = properties.GetValueOrDefault("architectures") ?? string.Empty,
+            Languages = properties.GetValueOrDefault("languages") ?? string.Empty
+        };
+    }
+
+    private static string DecodeBase64Hash(string? value, string algorithm, ILogger<MicrosoftUpdateCatalogClient> logger)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            return Convert.ToHexString(Convert.FromBase64String(value));
+        }
+        catch (FormatException ex)
+        {
+            logger.LogWarning(ex, "Microsoft Update Catalog returned an invalid {HashAlgorithm} hash.", algorithm);
+            return string.Empty;
+        }
+    }
+
+    private static string UnescapeJavascriptString(string value)
+    {
+        return value
+            .Replace("\\'", "'", StringComparison.Ordinal)
+            .Replace("\\\\", "\\", StringComparison.Ordinal);
     }
 
     private async Task<HttpResponseMessage> SendAsync(

--- a/src/Foundry.Deploy/Services/DriverPacks/MicrosoftUpdateCatalogDownload.cs
+++ b/src/Foundry.Deploy/Services/DriverPacks/MicrosoftUpdateCatalogDownload.cs
@@ -1,0 +1,16 @@
+namespace Foundry.Deploy.Services.DriverPacks;
+
+public sealed record MicrosoftUpdateCatalogDownload
+{
+    public string DownloadUrl { get; init; } = string.Empty;
+
+    public string FileName { get; init; } = string.Empty;
+
+    public string Sha1 { get; init; } = string.Empty;
+
+    public string Sha256 { get; init; } = string.Empty;
+
+    public string Architectures { get; init; } = string.Empty;
+
+    public string Languages { get; init; } = string.Empty;
+}

--- a/src/Foundry.Deploy/Services/DriverPacks/MicrosoftUpdateCatalogDriverService.cs
+++ b/src/Foundry.Deploy/Services/DriverPacks/MicrosoftUpdateCatalogDriverService.cs
@@ -37,6 +37,7 @@ public sealed class MicrosoftUpdateCatalogDriverService : IMicrosoftUpdateCatalo
         HardwareProfile hardwareProfile,
         OperatingSystemCatalogItem operatingSystem,
         string destinationDirectory,
+        string cacheDirectory,
         CancellationToken cancellationToken = default,
         IProgress<double>? progress = null)
     {
@@ -46,6 +47,11 @@ public sealed class MicrosoftUpdateCatalogDriverService : IMicrosoftUpdateCatalo
         if (string.IsNullOrWhiteSpace(destinationDirectory))
         {
             throw new ArgumentException("Destination directory is required.", nameof(destinationDirectory));
+        }
+
+        if (string.IsNullOrWhiteSpace(cacheDirectory))
+        {
+            throw new ArgumentException("Cache directory is required.", nameof(cacheDirectory));
         }
 
         ResetDirectory(destinationDirectory);
@@ -124,11 +130,14 @@ public sealed class MicrosoftUpdateCatalogDriverService : IMicrosoftUpdateCatalo
             string updateDirectory = Path.Combine(destinationDirectory, MicrosoftUpdateCatalogSupport.SanitizePathSegment(candidate.Update.UpdateId));
             Directory.CreateDirectory(updateDirectory);
 
-            string fileName = MicrosoftUpdateCatalogSupport.ResolveFileNameFromUrl(candidate.DownloadUrl);
+            string fileName = ResolveFileName(candidate.Download);
             string destinationPath = Path.Combine(updateDirectory, fileName);
 
-            await _artifactDownloadService
-                .DownloadAsync(candidate.DownloadUrl, destinationPath, cancellationToken: cancellationToken)
+            await DownloadToStagingAsync(
+                    candidate,
+                    destinationPath,
+                    cacheDirectory,
+                    cancellationToken)
                 .ConfigureAwait(false);
 
             downloadedDrivers.Add(new MicrosoftUpdateCatalogDownloadedDriver
@@ -137,7 +146,7 @@ public sealed class MicrosoftUpdateCatalogDriverService : IMicrosoftUpdateCatalo
                 Title = candidate.Update.Title,
                 Version = candidate.Update.Version,
                 Size = candidate.Update.Size,
-                DownloadUrl = candidate.DownloadUrl
+                DownloadUrl = candidate.Download.DownloadUrl
             });
 
             downloadIndex++;
@@ -268,12 +277,12 @@ public sealed class MicrosoftUpdateCatalogDriverService : IMicrosoftUpdateCatalo
             return null;
         }
 
-        IReadOnlyList<string> downloadUrls = await _catalogClient
-            .GetDownloadUrlsAsync(update.UpdateId, cancellationToken)
+        IReadOnlyList<MicrosoftUpdateCatalogDownload> downloads = await _catalogClient
+            .GetDownloadsAsync(update.UpdateId, cancellationToken)
             .ConfigureAwait(false);
 
-        string? selectedUrl = MicrosoftUpdateCatalogSupport.SelectPreferredCabUrl(downloadUrls, targetArchitecture);
-        if (string.IsNullOrWhiteSpace(selectedUrl))
+        MicrosoftUpdateCatalogDownload? selectedDownload = MicrosoftUpdateCatalogSupport.SelectPreferredCab(downloads, targetArchitecture);
+        if (selectedDownload is null)
         {
             _logger.LogInformation(
                 "Microsoft Update Catalog update '{Title}' ({UpdateId}) has no CAB payload compatible with architecture '{Architecture}'.",
@@ -286,8 +295,40 @@ public sealed class MicrosoftUpdateCatalogDriverService : IMicrosoftUpdateCatalo
         return new CatalogDownloadCandidate
         {
             Update = update,
-            DownloadUrl = selectedUrl
+            Download = selectedDownload
         };
+    }
+
+    private async Task DownloadToStagingAsync(
+        CatalogDownloadCandidate candidate,
+        string destinationPath,
+        string cacheDirectory,
+        CancellationToken cancellationToken)
+    {
+        string expectedHash = MicrosoftUpdateCatalogSupport.ResolvePreferredHash(candidate.Download);
+        if (string.IsNullOrWhiteSpace(expectedHash))
+        {
+            await _artifactDownloadService
+                .DownloadAsync(candidate.Download.DownloadUrl, destinationPath, artifactKind: "MicrosoftUpdateCatalogDriver", cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        string cachePath = Path.Combine(
+            cacheDirectory,
+            MicrosoftUpdateCatalogSupport.SanitizePathSegment(candidate.Update.UpdateId),
+            ResolveFileName(candidate.Download));
+
+        await _artifactDownloadService
+            .DownloadAsync(
+                candidate.Download.DownloadUrl,
+                cachePath,
+                expectedHash: expectedHash,
+                artifactKind: "MicrosoftUpdateCatalogDriver",
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        CopyFile(cachePath, destinationPath);
     }
 
     private async Task<MicrosoftUpdateCatalogUpdate?> SearchByReleaseAsync(
@@ -426,6 +467,24 @@ public sealed class MicrosoftUpdateCatalogDriverService : IMicrosoftUpdateCatalo
             : "Unknown device";
     }
 
+    private static string ResolveFileName(MicrosoftUpdateCatalogDownload download)
+    {
+        return string.IsNullOrWhiteSpace(download.FileName)
+            ? MicrosoftUpdateCatalogSupport.ResolveFileNameFromUrl(download.DownloadUrl)
+            : MicrosoftUpdateCatalogSupport.SanitizePathSegment(download.FileName);
+    }
+
+    private static void CopyFile(string sourcePath, string destinationPath)
+    {
+        string? destinationDirectory = Path.GetDirectoryName(destinationPath);
+        if (!string.IsNullOrWhiteSpace(destinationDirectory))
+        {
+            Directory.CreateDirectory(destinationDirectory);
+        }
+
+        File.Copy(sourcePath, destinationPath, overwrite: true);
+    }
+
     private static void ResetDirectory(string path)
     {
         if (Directory.Exists(path))
@@ -446,7 +505,7 @@ public sealed class MicrosoftUpdateCatalogDriverService : IMicrosoftUpdateCatalo
     private sealed record CatalogDownloadCandidate
     {
         public required MicrosoftUpdateCatalogUpdate Update { get; init; }
-        public required string DownloadUrl { get; init; }
+        public required MicrosoftUpdateCatalogDownload Download { get; init; }
     }
 
     private static IProgress<double>? CreateMappedProgress(IProgress<double>? progress, double start, double end)

--- a/src/Foundry.Deploy/Services/DriverPacks/MicrosoftUpdateCatalogFirmwareService.cs
+++ b/src/Foundry.Deploy/Services/DriverPacks/MicrosoftUpdateCatalogFirmwareService.cs
@@ -30,12 +30,14 @@ public sealed class MicrosoftUpdateCatalogFirmwareService : IMicrosoftUpdateCata
         string targetArchitecture,
         string rawDirectory,
         string extractedDirectory,
+        string cacheDirectory,
         CancellationToken cancellationToken = default,
         IProgress<double>? progress = null)
     {
         ArgumentNullException.ThrowIfNull(hardwareProfile);
         ArgumentException.ThrowIfNullOrWhiteSpace(rawDirectory);
         ArgumentException.ThrowIfNullOrWhiteSpace(extractedDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(cacheDirectory);
 
         string firmwareHardwareId = hardwareProfile.SystemFirmwareHardwareId.Trim();
         if (string.IsNullOrWhiteSpace(firmwareHardwareId))
@@ -77,12 +79,12 @@ public sealed class MicrosoftUpdateCatalogFirmwareService : IMicrosoftUpdateCata
         }
 
         progress?.Report(35d);
-        IReadOnlyList<string> downloadUrls = await _catalogClient
-            .GetDownloadUrlsAsync(update.UpdateId, cancellationToken)
+        IReadOnlyList<MicrosoftUpdateCatalogDownload> downloads = await _catalogClient
+            .GetDownloadsAsync(update.UpdateId, cancellationToken)
             .ConfigureAwait(false);
 
-        string? selectedUrl = MicrosoftUpdateCatalogSupport.SelectPreferredCabUrl(downloadUrls, targetArchitecture);
-        if (string.IsNullOrWhiteSpace(selectedUrl))
+        MicrosoftUpdateCatalogDownload? selectedDownload = MicrosoftUpdateCatalogSupport.SelectPreferredCab(downloads, targetArchitecture);
+        if (selectedDownload is null)
         {
             return new MicrosoftUpdateCatalogFirmwareResult
             {
@@ -97,12 +99,11 @@ public sealed class MicrosoftUpdateCatalogFirmwareService : IMicrosoftUpdateCata
         string updateDirectory = Path.Combine(rawDirectory, MicrosoftUpdateCatalogSupport.SanitizePathSegment(update.UpdateId));
         Directory.CreateDirectory(updateDirectory);
 
-        string fileName = MicrosoftUpdateCatalogSupport.ResolveFileNameFromUrl(selectedUrl);
+        string fileName = ResolveFileName(selectedDownload);
         string destinationPath = Path.Combine(updateDirectory, fileName);
 
         progress?.Report(50d);
-        await _artifactDownloadService
-            .DownloadAsync(selectedUrl, destinationPath, cancellationToken: cancellationToken)
+        await DownloadToStagingAsync(update, selectedDownload, destinationPath, cacheDirectory, cancellationToken)
             .ConfigureAwait(false);
 
         progress?.Report(75d);
@@ -165,6 +166,57 @@ public sealed class MicrosoftUpdateCatalogFirmwareService : IMicrosoftUpdateCata
         }
 
         return Directory.EnumerateFiles(destinationDirectory, "*.inf", SearchOption.AllDirectories).Count();
+    }
+
+    private async Task DownloadToStagingAsync(
+        MicrosoftUpdateCatalogUpdate update,
+        MicrosoftUpdateCatalogDownload download,
+        string destinationPath,
+        string cacheDirectory,
+        CancellationToken cancellationToken)
+    {
+        string expectedHash = MicrosoftUpdateCatalogSupport.ResolvePreferredHash(download);
+        if (string.IsNullOrWhiteSpace(expectedHash))
+        {
+            await _artifactDownloadService
+                .DownloadAsync(download.DownloadUrl, destinationPath, artifactKind: "MicrosoftUpdateCatalogFirmware", cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        string cachePath = Path.Combine(
+            cacheDirectory,
+            MicrosoftUpdateCatalogSupport.SanitizePathSegment(update.UpdateId),
+            ResolveFileName(download));
+
+        await _artifactDownloadService
+            .DownloadAsync(
+                download.DownloadUrl,
+                cachePath,
+                expectedHash: expectedHash,
+                artifactKind: "MicrosoftUpdateCatalogFirmware",
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        CopyFile(cachePath, destinationPath);
+    }
+
+    private static string ResolveFileName(MicrosoftUpdateCatalogDownload download)
+    {
+        return string.IsNullOrWhiteSpace(download.FileName)
+            ? MicrosoftUpdateCatalogSupport.ResolveFileNameFromUrl(download.DownloadUrl)
+            : MicrosoftUpdateCatalogSupport.SanitizePathSegment(download.FileName);
+    }
+
+    private static void CopyFile(string sourcePath, string destinationPath)
+    {
+        string? destinationDirectory = Path.GetDirectoryName(destinationPath);
+        if (!string.IsNullOrWhiteSpace(destinationDirectory))
+        {
+            Directory.CreateDirectory(destinationDirectory);
+        }
+
+        File.Copy(sourcePath, destinationPath, overwrite: true);
     }
 
     private static string ResolveExpandedFolderName(string cabPath, string sourceDirectory)

--- a/src/Foundry.Deploy/Services/DriverPacks/MicrosoftUpdateCatalogSupport.cs
+++ b/src/Foundry.Deploy/Services/DriverPacks/MicrosoftUpdateCatalogSupport.cs
@@ -90,37 +90,47 @@ internal static partial class MicrosoftUpdateCatalogSupport
         };
     }
 
-    public static string? SelectPreferredCabUrl(IReadOnlyList<string> downloadUrls, string targetArchitecture)
+    public static MicrosoftUpdateCatalogDownload? SelectPreferredCab(IReadOnlyList<MicrosoftUpdateCatalogDownload> downloads, string targetArchitecture)
     {
-        if (downloadUrls.Count == 0)
+        if (downloads.Count == 0)
         {
             return null;
         }
 
         string normalizedArchitecture = NormalizeArchitecture(targetArchitecture);
-        string[] cabUrls = downloadUrls
-            .Where(IsCabUrl)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
+        MicrosoftUpdateCatalogDownload[] cabDownloads = downloads
+            .Where(download => IsCabUrl(download.DownloadUrl))
+            .GroupBy(download => download.DownloadUrl, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
             .ToArray();
 
-        if (cabUrls.Length == 0)
+        if (cabDownloads.Length == 0)
         {
             return null;
         }
 
         if (string.IsNullOrWhiteSpace(normalizedArchitecture))
         {
-            return cabUrls[0];
+            return cabDownloads[0];
         }
 
-        string? exactMatch = cabUrls.FirstOrDefault(url => MatchesArchitecture(url, normalizedArchitecture));
-        if (!string.IsNullOrWhiteSpace(exactMatch))
+        MicrosoftUpdateCatalogDownload? exactMatch = cabDownloads.FirstOrDefault(download => MatchesArchitecture(download, normalizedArchitecture));
+        if (exactMatch is not null)
         {
             return exactMatch;
         }
 
-        string? compatibleFallback = cabUrls.FirstOrDefault(url => !HasConflictingArchitecture(url, normalizedArchitecture));
-        return compatibleFallback ?? cabUrls[0];
+        MicrosoftUpdateCatalogDownload? compatibleFallback = cabDownloads.FirstOrDefault(download => !HasConflictingArchitecture(download, normalizedArchitecture));
+        return compatibleFallback ?? cabDownloads[0];
+    }
+
+    public static string ResolvePreferredHash(MicrosoftUpdateCatalogDownload download)
+    {
+        ArgumentNullException.ThrowIfNull(download);
+
+        return !string.IsNullOrWhiteSpace(download.Sha256)
+            ? download.Sha256
+            : download.Sha1;
     }
 
     public static string ResolveFileNameFromUrl(string downloadUrl)
@@ -159,9 +169,9 @@ internal static partial class MicrosoftUpdateCatalogSupport
         return Path.GetExtension(uri.AbsolutePath).Equals(".cab", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static bool MatchesArchitecture(string downloadUrl, string targetArchitecture)
+    private static bool MatchesArchitecture(MicrosoftUpdateCatalogDownload download, string targetArchitecture)
     {
-        string fileName = ResolveFileNameFromUrl(downloadUrl).ToLowerInvariant();
+        string fileName = ResolveComparableName(download);
         return targetArchitecture switch
         {
             "x64" => fileName.Contains("x64", StringComparison.Ordinal) || fileName.Contains("amd64", StringComparison.Ordinal),
@@ -171,9 +181,9 @@ internal static partial class MicrosoftUpdateCatalogSupport
         };
     }
 
-    private static bool HasConflictingArchitecture(string downloadUrl, string targetArchitecture)
+    private static bool HasConflictingArchitecture(MicrosoftUpdateCatalogDownload download, string targetArchitecture)
     {
-        string fileName = ResolveFileNameFromUrl(downloadUrl).ToLowerInvariant();
+        string fileName = ResolveComparableName(download);
         return targetArchitecture switch
         {
             "x64" => fileName.Contains("arm64", StringComparison.Ordinal) || fileName.Contains("x86", StringComparison.Ordinal),
@@ -185,6 +195,15 @@ internal static partial class MicrosoftUpdateCatalogSupport
                      fileName.Contains("amd64", StringComparison.Ordinal),
             _ => false
         };
+    }
+
+    private static string ResolveComparableName(MicrosoftUpdateCatalogDownload download)
+    {
+        string fileName = string.IsNullOrWhiteSpace(download.FileName)
+            ? ResolveFileNameFromUrl(download.DownloadUrl)
+            : download.FileName;
+
+        return $"{fileName} {download.Architectures}".ToLowerInvariant();
     }
 
     [GeneratedRegex("v[ei][dn]_([0-9a-f]){4}&[pd][ie][dv]_([0-9a-f]){4}", RegexOptions.IgnoreCase)]


### PR DESCRIPTION
## Summary
- Adds sidecar manifest validation for cached deployment artifacts.
- Parses Microsoft Update Catalog download metadata, including SHA1/SHA256 validation hashes.
- Uses persistent MUC caches for driver and firmware CAB payloads while staging raw CABs for extraction.

## Reason
USB cache checks were slow because Foundry Deploy rehashed large cached payloads on each run. The manifest path keeps the first validation strong while making later cache hits fast.

Closes #224

## Main changes
- Stream artifact hashes during download and write `<artifact>.manifest.json` after successful validation.
- Reuse valid manifests by checking expected hash, file size, source metadata, and file timestamps before falling back to a one-time full hash.
- Replace URL-only MUC download parsing with structured downloads carrying file name, architecture, language, SHA1, and SHA256 metadata.
- Cache MUC driver and firmware CABs under persistent cache roots, then copy validated CABs into transient raw folders for the existing extraction flow.
- Remove obsolete URL-only MUC selection code paths.

## Testing
- `dotnet build src\Foundry.slnx --no-restore` passes. Existing xUnit1051 warnings remain in older tests.
- `dotnet test src\Foundry.slnx --no-build` passes: 719 tests.