### PR TITLE
fix: clarify ADK 24H2 compatibility

### DIFF
--- a/src/Foundry.Core.Tests/Adk/AdkInstallationDetectorTests.cs
+++ b/src/Foundry.Core.Tests/Adk/AdkInstallationDetectorTests.cs
@@ -78,8 +78,8 @@ public sealed class AdkInstallationDetectorTests
     }
 
     [Theory]
-    [InlineData("10.1.26100.1", false)]
-    [InlineData("10.1.26100.2453", false)]
+    [InlineData("10.1.26100.1", true)]
+    [InlineData("10.1.26100.2453", true)]
     [InlineData("10.1.26100.2454", true)]
     [InlineData("10.1.26100.3000", true)]
     [InlineData("10.1.28000.1", false)]
@@ -94,6 +94,23 @@ public sealed class AdkInstallationDetectorTests
 
         Assert.Equal(expectedCompatible, status.IsCompatible);
         Assert.Equal(expectedCompatible, status.CanCreateMedia);
+    }
+
+    [Theory]
+    [InlineData("10.1.22621.1", AdkVersionRelation.BelowSupported)]
+    [InlineData("10.1.26100.1", AdkVersionRelation.Supported)]
+    [InlineData("10.1.26100.2453", AdkVersionRelation.Supported)]
+    [InlineData("10.1.28000.1", AdkVersionRelation.AboveSupported)]
+    [InlineData("bad-version", AdkVersionRelation.Unknown)]
+    public void Detect_ClassifiesInstalledVersionAgainstSupportedBuildLine(
+        string installedVersion,
+        AdkVersionRelation expectedRelation)
+    {
+        FakeAdkInstallationProbe probe = CreateInstalledProbe(installedVersion);
+
+        AdkInstallationStatus status = new AdkInstallationDetector(probe).Detect();
+
+        Assert.Equal(expectedRelation, status.VersionRelation);
     }
 
     [Fact]

--- a/src/Foundry.Core/Services/Adk/AdkInstallationDetector.cs
+++ b/src/Foundry.Core/Services/Adk/AdkInstallationDetector.cs
@@ -5,8 +5,8 @@ public sealed class AdkInstallationDetector(IAdkInstallationProbe probe)
     public const string DeploymentToolsRelativePath = @"Assessment and Deployment Kit\Deployment Tools";
     public const string WinPeRelativePath = @"Assessment and Deployment Kit\Windows Preinstallation Environment";
 
-    private const string RequiredVersionPolicyText = "Windows ADK 10.1.26100.2454+ with the latest ADK servicing patch";
-    private static readonly Version MinimumWindows11AdkVersion = new(10, 1, 26100, 2454);
+    private const string RequiredVersionPolicyText = "Windows ADK 24H2 / 10.1.26100";
+    private static readonly Version SupportedWindows11AdkBuild = new(10, 1, 26100);
 
     public AdkInstallationStatus Detect()
     {
@@ -17,13 +17,15 @@ public sealed class AdkInstallationDetector(IAdkInstallationProbe probe)
         bool hasWinPeAddon = hasKitsRoot && HasUsableWinPeAddon(kitsRootPath!);
         string? installedVersion = ResolveInstalledVersion(probe.GetInstalledProducts());
         bool isInstalled = hasDeploymentTools;
-        bool isCompatible = isInstalled && IsCompatibleVersion(installedVersion);
+        AdkVersionRelation versionRelation = GetVersionRelation(installedVersion);
+        bool isCompatible = isInstalled && versionRelation == AdkVersionRelation.Supported;
 
         return new(
             isInstalled,
             isCompatible,
             hasWinPeAddon,
             installedVersion,
+            versionRelation,
             kitsRootPath,
             RequiredVersionPolicyText);
     }
@@ -35,12 +37,35 @@ public sealed class AdkInstallationDetector(IAdkInstallationProbe probe)
             return false;
         }
 
-        if (Version.TryParse(versionText, out Version? version))
+        return GetVersionRelation(versionText) == AdkVersionRelation.Supported;
+    }
+
+    public static AdkVersionRelation GetVersionRelation(string? versionText)
+    {
+        if (string.IsNullOrWhiteSpace(versionText) || !Version.TryParse(versionText, out Version? version))
         {
-            return IsVersionAtLeast(version, MinimumWindows11AdkVersion);
+            return AdkVersionRelation.Unknown;
         }
 
-        return false;
+        int majorComparison = version.Major.CompareTo(SupportedWindows11AdkBuild.Major);
+        if (majorComparison != 0)
+        {
+            return majorComparison < 0 ? AdkVersionRelation.BelowSupported : AdkVersionRelation.AboveSupported;
+        }
+
+        int minorComparison = version.Minor.CompareTo(SupportedWindows11AdkBuild.Minor);
+        if (minorComparison != 0)
+        {
+            return minorComparison < 0 ? AdkVersionRelation.BelowSupported : AdkVersionRelation.AboveSupported;
+        }
+
+        int buildComparison = version.Build.CompareTo(SupportedWindows11AdkBuild.Build);
+        if (buildComparison != 0)
+        {
+            return buildComparison < 0 ? AdkVersionRelation.BelowSupported : AdkVersionRelation.AboveSupported;
+        }
+
+        return AdkVersionRelation.Supported;
     }
 
     private bool HasUsableWinPeAddon(string kitsRootPath)
@@ -101,11 +126,4 @@ public sealed class AdkInstallationDetector(IAdkInstallationProbe probe)
         return Version.TryParse(versionText, out Version? version) ? version : new Version();
     }
 
-    private static bool IsVersionAtLeast(Version version, Version minimumVersion)
-    {
-        return version.Major == minimumVersion.Major
-            && version.Minor == minimumVersion.Minor
-            && version.Build == minimumVersion.Build
-            && version.Revision >= minimumVersion.Revision;
-    }
 }

--- a/src/Foundry.Core/Services/Adk/AdkInstallationStatus.cs
+++ b/src/Foundry.Core/Services/Adk/AdkInstallationStatus.cs
@@ -7,6 +7,7 @@ namespace Foundry.Core.Services.Adk;
 /// <param name="IsCompatible">Whether the detected ADK version satisfies Foundry requirements.</param>
 /// <param name="IsWinPeAddonInstalled">Whether the WinPE add-on is installed.</param>
 /// <param name="InstalledVersion">The detected ADK version, when available.</param>
+/// <param name="VersionRelation">How the detected ADK version compares to the supported build line.</param>
 /// <param name="KitsRootPath">The detected Windows Kits root path, when available.</param>
 /// <param name="RequiredVersionPolicy">The version policy used to evaluate compatibility.</param>
 public sealed record AdkInstallationStatus(
@@ -14,6 +15,7 @@ public sealed record AdkInstallationStatus(
     bool IsCompatible,
     bool IsWinPeAddonInstalled,
     string? InstalledVersion,
+    AdkVersionRelation VersionRelation,
     string? KitsRootPath,
     string RequiredVersionPolicy)
 {

--- a/src/Foundry.Core/Services/Adk/AdkVersionRelation.cs
+++ b/src/Foundry.Core/Services/Adk/AdkVersionRelation.cs
@@ -1,0 +1,9 @@
+namespace Foundry.Core.Services.Adk;
+
+public enum AdkVersionRelation
+{
+    Unknown,
+    BelowSupported,
+    Supported,
+    AboveSupported
+}

--- a/src/Foundry/Services/Adk/AdkService.cs
+++ b/src/Foundry/Services/Adk/AdkService.cs
@@ -36,8 +36,9 @@ internal sealed class AdkService(
         false,
         false,
         null,
+        AdkVersionRelation.Unknown,
         null,
-        "Windows ADK 10.1.26100.2454+ with the latest ADK servicing patch");
+        "Windows ADK 24H2 / 10.1.26100");
 
     /// <inheritdoc />
     public Task<AdkInstallationStatus> RefreshStatusAsync(CancellationToken cancellationToken = default)

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>الإصدار ADK غير مدعوم</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>ثبّت إصدار Windows ADK 24H2 (10.1.26100) المدعوم.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE الوظيفة الإضافية مفقودة</value>
@@ -1852,7 +1852,7 @@
     <value>سياسة الإصدار المطلوبة</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>يتطلب Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE الوظيفة الإضافية</value>
@@ -1876,7 +1876,7 @@
     <value>تثبيت Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>جارٍ تحضير تثبيت Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>جارٍ تنزيل برنامج التثبيت ADK</value>
@@ -1915,7 +1915,7 @@
     <value>قم بترقية Windows ADK وWindows PE الوظيفة الإضافية</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>الرجوع إلى إصدار أقدم من Windows ADK و Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>العربية (المملكة العربية السعودية)</value>

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>الإصدار ADK غير مدعوم</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>قم بترقية Windows ADK إلى الإصدار 10.1.26100 المدعوم.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE الوظيفة الإضافية مفقودة</value>
@@ -1852,7 +1852,7 @@
     <value>سياسة الإصدار المطلوبة</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>يتطلب Windows ADK 10.1.26100.2454+ مع أحدث تصحيح للخدمة ADK.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE الوظيفة الإضافية</value>
@@ -1876,7 +1876,7 @@
     <value>تثبيت Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>ترقية Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>جارٍ تنزيل برنامج التثبيت ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>قم بترقية Windows ADK وWindows PE الوظيفة الإضافية</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>العربية (المملكة العربية السعودية)</value>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK версията не се поддържа</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Инсталирайте поддържаната версия Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Липсва добавка</value>
@@ -1852,7 +1852,7 @@
     <value>Правила за задължителна версия</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Изисква Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Добавка</value>
@@ -1876,7 +1876,7 @@
     <value>Инсталиране на Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Подготовка на инсталирането на Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Изтегля се инсталационна програма ADK</value>
@@ -1915,7 +1915,7 @@
     <value>Надстройте добавката Windows ADK и Windows PE</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Понижаване на Windows ADK и Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>арабски (Саудитска Арабия)</value>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK версията не се поддържа</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Надстройте Windows ADK до поддържана версия 10.1.26100.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Липсва добавка</value>
@@ -1852,7 +1852,7 @@
     <value>Правила за задължителна версия</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Изисква Windows ADK 10.1.26100.2454+ с най-новата ADK обслужваща корекция.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Добавка</value>
@@ -1876,7 +1876,7 @@
     <value>Инсталиране на Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Надграждане на Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Изтегля се инсталационна програма ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Надстройте добавката Windows ADK и Windows PE</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>арабски (Саудитска Арабия)</value>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Verze ADK není podporována</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Upgradujte Windows ADK na podporované sestavení 10.1.26100.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Chybí doplněk Windows PE</value>
@@ -1852,7 +1852,7 @@
     <value>Zásady požadované verze</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Vyžaduje Windows ADK 10.1.26100.2454+ s nejnovější servisní opravou ADK.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE doplněk</value>
@@ -1876,7 +1876,7 @@
     <value>Instalace Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Upgrade Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Stažení instalačního programu ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Upgradujte doplněk Windows ADK a Windows PE</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arabština (Saúdská Arábie)</value>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Verze ADK není podporována</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Nainstalujte podporovanou verzi Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Chybí doplněk Windows PE</value>
@@ -1852,7 +1852,7 @@
     <value>Zásady požadované verze</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Vyžaduje Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE doplněk</value>
@@ -1876,7 +1876,7 @@
     <value>Instalace Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Příprava instalace Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Stažení instalačního programu ADK</value>
@@ -1915,7 +1915,7 @@
     <value>Upgradujte doplněk Windows ADK a Windows PE</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Přejít na nižší verzi Windows ADK a Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arabština (Saúdská Arábie)</value>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK version er ikke understøttet</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Opgrader Windows ADK til en understøttet 10.1.26100 build.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Tilføjelse mangler</value>
@@ -1852,7 +1852,7 @@
     <value>Påkrævet versionspolitik</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Kræver Windows ADK 10.1.26100.2454+ med den seneste ADK servicepatch.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Tilføjelse</value>
@@ -1876,7 +1876,7 @@
     <value>Installerer Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Opgraderer Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Downloader ADK installationsprogrammet</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Opgrader Windows ADK og Windows PE Add-on</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arabisk (Saudi-Arabien)</value>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK version er ikke understøttet</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Installer den understøttede Windows ADK 24H2-version (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Tilføjelse mangler</value>
@@ -1852,7 +1852,7 @@
     <value>Påkrævet versionspolitik</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Kræver Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Tilføjelse</value>
@@ -1876,7 +1876,7 @@
     <value>Installerer Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Forbereder installation af Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Downloader ADK installationsprogrammet</value>
@@ -1915,7 +1915,7 @@
     <value>Opgrader Windows ADK og Windows PE Add-on</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Nedgrader Windows ADK og Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arabisk (Saudi-Arabien)</value>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Die ADK-Version wird nicht unterstützt</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Aktualisieren Sie Windows ADK auf einen unterstützten Build 10.1.26100.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Add-on fehlt</value>
@@ -1852,7 +1852,7 @@
     <value>Erforderliche Versionsrichtlinie</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Erfordert Windows ADK 10.1.26100.2454+ mit dem neuesten ADK Wartungspatch.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Add-on</value>
@@ -1876,7 +1876,7 @@
     <value>Installieren von Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Aktualisieren Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Das ADK-Installationsprogramm wird heruntergeladen</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Aktualisieren Sie das Add-on Windows ADK und Windows PE</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arabisch (Saudi-Arabien)</value>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Die ADK-Version wird nicht unterstützt</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Installieren Sie die unterstützte Windows ADK 24H2-Version (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Add-on fehlt</value>
@@ -1852,7 +1852,7 @@
     <value>Erforderliche Versionsrichtlinie</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Erfordert Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Add-on</value>
@@ -1876,7 +1876,7 @@
     <value>Installieren von Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Installation von Windows ADK 24H2 wird vorbereitet</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Das ADK-Installationsprogramm wird heruntergeladen</value>
@@ -1915,7 +1915,7 @@
     <value>Aktualisieren Sie das Add-on Windows ADK und Windows PE</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Windows ADK und Windows PE Add-on downgraden</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arabisch (Saudi-Arabien)</value>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Η έκδοση ADK δεν υποστηρίζεται</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Εγκαταστήστε την υποστηριζόμενη έκδοση Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Το πρόσθετο Windows PE λείπει</value>
@@ -1852,7 +1852,7 @@
     <value>Πολιτική απαιτούμενης έκδοσης</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Απαιτείται Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Πρόσθετο</value>
@@ -1876,7 +1876,7 @@
     <value>Εγκατάσταση Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Προετοιμασία εγκατάστασης Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Λήψη του προγράμματος εγκατάστασης ADK</value>
@@ -1915,7 +1915,7 @@
     <value>Αναβάθμιση Windows ADK και Windows PE πρόσθετο</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Υποβάθμιση Windows ADK και Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Αραβικά (Σαουδική Αραβία)</value>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Η έκδοση ADK δεν υποστηρίζεται</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Αναβαθμίστε το Windows ADK σε μια υποστηριζόμενη έκδοση 10.1.26100.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Το πρόσθετο Windows PE λείπει</value>
@@ -1852,7 +1852,7 @@
     <value>Πολιτική απαιτούμενης έκδοσης</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Απαιτείται Windows ADK 10.1.26100.2454+ με την πιο πρόσφατη ενημέρωση κώδικα σέρβις ADK.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Πρόσθετο</value>
@@ -1876,7 +1876,7 @@
     <value>Εγκατάσταση Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Αναβάθμιση Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Λήψη του προγράμματος εγκατάστασης ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Αναβάθμιση Windows ADK και Windows PE πρόσθετο</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Αραβικά (Σαουδική Αραβία)</value>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK version is unsupported</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Upgrade the Windows ADK to a supported 10.1.26100 build.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Add-on is missing</value>
@@ -1852,7 +1852,7 @@
     <value>Required version policy</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 10.1.26100.2454+ with the latest ADK servicing patch.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Add-on</value>
@@ -1876,7 +1876,7 @@
     <value>Installing Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Upgrading Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Downloading ADK installer</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Upgrade Windows ADK and Windows PE Add-on</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arabic (Saudi Arabia)</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -1840,7 +1840,7 @@
     <value>ADK version is unsupported</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Upgrade the Windows ADK to a supported 10.1.26100 build.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Add-on is missing</value>
@@ -1867,7 +1867,7 @@
     <value>Required version policy</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 10.1.26100.2454+ with the latest ADK servicing patch.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Add-on</value>
@@ -1891,7 +1891,7 @@
     <value>Installing Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Upgrading Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Downloading ADK installer</value>
@@ -1928,6 +1928,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Upgrade Windows ADK and Windows PE Add-on</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arabic (Saudi Arabia)</value>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>La versión ADK no es compatible</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Actualice Windows ADK a una versión 10.1.26100 compatible.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Falta el complemento</value>
@@ -1852,7 +1852,7 @@
     <value>Política de versión requerida</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requiere Windows ADK 10.1.26100.2454+ con el último parche de servicio ADK.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Complemento</value>
@@ -1876,7 +1876,7 @@
     <value>Instalando Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Actualizando Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Descargando el instalador ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Actualizar el complemento Windows ADK y Windows PE</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Árabe (Arabia Saudita)</value>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>La versión ADK no es compatible</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Instala la versión compatible de Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Falta el complemento</value>
@@ -1852,7 +1852,7 @@
     <value>Política de versión requerida</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Requiere Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Complemento</value>
@@ -1876,7 +1876,7 @@
     <value>Instalando Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Preparando la instalación de Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Descargando el instalador ADK</value>
@@ -1915,7 +1915,7 @@
     <value>Actualizar el complemento Windows ADK y Windows PE</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Cambiar a una versión anterior de Windows ADK y Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Árabe (Arabia Saudita)</value>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>La versión ADK no es compatible</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Actualice Windows ADK a una versión 10.1.26100 compatible.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Falta el complemento</value>
@@ -1852,7 +1852,7 @@
     <value>Política de versión requerida</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requiere Windows ADK 10.1.26100.2454+ con el último parche de servicio ADK.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Complemento</value>
@@ -1876,7 +1876,7 @@
     <value>Instalando Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Actualizando Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Descargando el instalador ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Actualizar el complemento Windows ADK y Windows PE</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Árabe (Arabia Saudita)</value>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>La versión ADK no es compatible</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Instala la versión compatible de Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Falta el complemento</value>
@@ -1852,7 +1852,7 @@
     <value>Política de versión requerida</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Requiere Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Complemento</value>
@@ -1876,7 +1876,7 @@
     <value>Instalando Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Preparando la instalación de Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Descargando el instalador ADK</value>
@@ -1915,7 +1915,7 @@
     <value>Actualizar el complemento Windows ADK y Windows PE</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Cambiar a una versión anterior de Windows ADK y Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Árabe (Arabia Saudita)</value>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK versiooni ei toetata</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Installige toetatud Windows ADK 24H2 (10.1.26100) väljalase.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Lisandmoodul puudub</value>
@@ -1852,7 +1852,7 @@
     <value>Nõutav versioonipoliitika</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Nõutav on Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Lisand</value>
@@ -1876,7 +1876,7 @@
     <value>Installimine Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Windows ADK 24H2 installimise ettevalmistamine</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>ADK installeri allalaadimine</value>
@@ -1915,7 +1915,7 @@
     <value>Täiendage Windows ADK ja Windows PE pistikprogrammi</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Mine üle vanemale Windows ADK ja Windows PE Add-on versioonile</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>araabia (Saudi Araabia)</value>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK versiooni ei toetata</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Täiendage Windows ADK toetatud versioonile 10.1.26100.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Lisandmoodul puudub</value>
@@ -1852,7 +1852,7 @@
     <value>Nõutav versioonipoliitika</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Nõuab Windows ADK 10.1.26100.2454+ koos uusima ADK hoolduspaigaga.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Lisand</value>
@@ -1876,7 +1876,7 @@
     <value>Installimine Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Täiendamine Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>ADK installeri allalaadimine</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Täiendage Windows ADK ja Windows PE pistikprogrammi</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>araabia (Saudi Araabia)</value>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK-versiota ei tueta</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Asenna tuettu Windows ADK 24H2 -versio (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Lisäosa puuttuu</value>
@@ -1852,7 +1852,7 @@
     <value>Vaadittu versiokäytäntö</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Edellyttää Windows ADK 24H2 -versiota (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Lisäosa</value>
@@ -1876,7 +1876,7 @@
     <value>Asennetaan Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Valmistellaan Windows ADK 24H2 -asennusta</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Ladataan ADK asennusohjelmaa</value>
@@ -1915,7 +1915,7 @@
     <value>Päivitä Windows ADK ja Windows PE -lisäosa</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Päivitä Windows ADK ja Windows PE Add-on vanhempaan versioon</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arabia (Saudi-Arabia)</value>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK-versiota ei tueta</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Päivitä Windows ADK tuettuun koontiversioon 10.1.26100.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Lisäosa puuttuu</value>
@@ -1852,7 +1852,7 @@
     <value>Vaadittu versiokäytäntö</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Vaatii Windows ADK 10.1.26100.2454+, jossa on uusin ADK huoltokorjaus.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Lisäosa</value>
@@ -1876,7 +1876,7 @@
     <value>Asennetaan Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Päivitetään Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Ladataan ADK asennusohjelmaa</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Päivitä Windows ADK ja Windows PE -lisäosa</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arabia (Saudi-Arabia)</value>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>La version ADK n'est pas prise en charge</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Mettez à niveau Windows ADK vers une version 10.1.26100 prise en charge.</value>
+    <value>Installez la version Windows ADK 24H2 (10.1.26100) prise en charge.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Le module complémentaire est manquant</value>
@@ -1852,7 +1852,7 @@
     <value>Politique de version requise</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Nécessite Windows ADK 10.1.26100.2454+ avec le dernier correctif de maintenance ADK.</value>
+    <value>Nécessite Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Module complémentaire</value>
@@ -1876,7 +1876,7 @@
     <value>Installation de Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Mise à niveau de Windows ADK</value>
+    <value>Préparation de l&apos;installation de Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Téléchargement du programme d'installation ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Mettre à niveau Windows ADK et le module complémentaire Windows PE</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Rétrograder Windows ADK et le Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arabe (Arabie Saoudite)</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -1840,7 +1840,7 @@
     <value>La version de l'ADK n'est pas prise en charge</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Mettez à niveau Windows ADK vers une version 10.1.26100 prise en charge.</value>
+    <value>Installez la version Windows ADK 24H2 (10.1.26100) prise en charge.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Le module complémentaire Windows PE est manquant</value>
@@ -1867,7 +1867,7 @@
     <value>Politique de version requise</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Nécessite Windows ADK 10.1.26100.2454+ avec le dernier correctif de maintenance ADK.</value>
+    <value>Nécessite Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Module complémentaire Windows PE</value>
@@ -1891,7 +1891,7 @@
     <value>Installation de Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Mise à niveau de Windows ADK</value>
+    <value>Préparation de l&apos;installation de Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Téléchargement du programme d'installation ADK</value>
@@ -1928,6 +1928,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Mettre à niveau Windows ADK et le Windows PE Add-on</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Rétrograder Windows ADK et le Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arabe (Arabie Saoudite)</value>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>גרסת ADK אינה נתמכת</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>שדרג את ה-Windows ADK לגירסה נתמכת של 10.1.26100.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>חסרה תוסף Windows PE</value>
@@ -1852,7 +1852,7 @@
     <value>מדיניות גרסה נדרשת</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>דורש Windows ADK 10.1.26100.2454+ עם תיקון השירות האחרון של ADK.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE תוסף</value>
@@ -1876,7 +1876,7 @@
     <value>מתקין Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>משדרג Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>מוריד את תוכנית ההתקנה ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>שדרג את התוסף Windows ADK ו-Windows PE</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>ערבית (ערב הסעודית)</value>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>גרסת ADK אינה נתמכת</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>התקן את גרסת Windows ADK 24H2 (10.1.26100) הנתמכת.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>חסרה תוסף Windows PE</value>
@@ -1852,7 +1852,7 @@
     <value>מדיניות גרסה נדרשת</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>נדרש Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE תוסף</value>
@@ -1876,7 +1876,7 @@
     <value>מתקין Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>מכין את התקנת Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>מוריד את תוכנית ההתקנה ADK</value>
@@ -1915,7 +1915,7 @@
     <value>שדרג את התוסף Windows ADK ו-Windows PE</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>שדרג לאחור את Windows ADK ואת Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>ערבית (ערב הסעודית)</value>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK verzija nije podržana</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Instalirajte podržano izdanje Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Nedostaje dodatak</value>
@@ -1852,7 +1852,7 @@
     <value>Pravila obavezne verzije</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Zahtijeva Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Dodatak</value>
@@ -1876,7 +1876,7 @@
     <value>Instaliranje Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Priprema instalacije Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Preuzimanje ADK instalacijskog programa</value>
@@ -1915,7 +1915,7 @@
     <value>Nadogradite dodatke Windows ADK i Windows PE</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Vrati Windows ADK i Windows PE Add-on na stariju verziju</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arapski (Saudijska Arabija)</value>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK verzija nije podržana</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Nadogradite Windows ADK na podržanu verziju 10.1.26100.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Nedostaje dodatak</value>
@@ -1852,7 +1852,7 @@
     <value>Pravila obavezne verzije</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Zahtijeva Windows ADK 10.1.26100.2454+ s najnovijom ADK servisnom zakrpom.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Dodatak</value>
@@ -1876,7 +1876,7 @@
     <value>Instaliranje Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Nadogradnja Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Preuzimanje ADK instalacijskog programa</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Nadogradite dodatke Windows ADK i Windows PE</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arapski (Saudijska Arabija)</value>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>A ADK verzió nem támogatott</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Frissítse a Windows ADK-t egy támogatott 10.1.26100 buildre.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE A kiegészítő hiányzik</value>
@@ -1852,7 +1852,7 @@
     <value>Kötelező verzió házirend</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Windows ADK 10.1.26100.2454+ szükséges a legújabb ADK szervizjavítással.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Kiegészítő</value>
@@ -1876,7 +1876,7 @@
     <value>Windows ADK telepítése</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Frissítés Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>A ADK telepítő letöltése</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Frissítés Windows ADK és Windows PE bővítmény</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arab (Szaúd-Arábia)</value>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>A ADK verzió nem támogatott</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Telepítse a támogatott Windows ADK 24H2 (10.1.26100) kiadást.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE A kiegészítő hiányzik</value>
@@ -1852,7 +1852,7 @@
     <value>Kötelező verzió házirend</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Windows ADK 24H2 (10.1.26100) szükséges.</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Kiegészítő</value>
@@ -1876,7 +1876,7 @@
     <value>Windows ADK telepítése</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Windows ADK 24H2 telepítésének előkészítése</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>A ADK telepítő letöltése</value>
@@ -1915,7 +1915,7 @@
     <value>Frissítés Windows ADK és Windows PE bővítmény</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Windows ADK és Windows PE Add-on visszaváltása korábbi verzióra</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arab (Szaúd-Arábia)</value>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>La versione ADK non è supportata</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Aggiorna Windows ADK a una build 10.1.26100 supportata.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Manca il componente aggiuntivo</value>
@@ -1852,7 +1852,7 @@
     <value>Criteri di versione obbligatori</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Richiede Windows ADK 10.1.26100.2454+ con l'ultima patch di manutenzione ADK.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Componente aggiuntivo</value>
@@ -1876,7 +1876,7 @@
     <value>Installazione Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Aggiornamento Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Download del programma di installazione ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Aggiorna il componente aggiuntivo Windows ADK e Windows PE</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arabo (Arabia Saudita)</value>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>La versione ADK non è supportata</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Installa la versione supportata di Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Manca il componente aggiuntivo</value>
@@ -1852,7 +1852,7 @@
     <value>Criteri di versione obbligatori</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Richiede Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Componente aggiuntivo</value>
@@ -1876,7 +1876,7 @@
     <value>Installazione Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Preparazione dell&apos;installazione di Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Download del programma di installazione ADK</value>
@@ -1915,7 +1915,7 @@
     <value>Aggiorna il componente aggiuntivo Windows ADK e Windows PE</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Esegui il downgrade di Windows ADK e Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arabo (Arabia Saudita)</value>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK バージョンはサポートされていません</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Windows ADK をサポートされている 10.1.26100 ビルドにアップグレードします。</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE アドオンがありません</value>
@@ -1852,7 +1852,7 @@
     <value>必要なバージョンポリシー</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>最新の ADK サービス パッチを適用した Windows ADK 10.1.26100.2454+ が必要です。</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE アドオン</value>
@@ -1876,7 +1876,7 @@
     <value>インストール中 Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Windows ADK をアップグレードしています</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>ADK インストーラーをダウンロードしています</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Windows ADK および Windows PE アドオンをアップグレードする</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>アラビア語 (サウジアラビア)</value>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK バージョンはサポートされていません</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>サポートされている Windows ADK 24H2 (10.1.26100) リリースをインストールしてください。</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE アドオンがありません</value>
@@ -1852,7 +1852,7 @@
     <value>必要なバージョンポリシー</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Windows ADK 24H2 (10.1.26100) が必要です。</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE アドオン</value>
@@ -1876,7 +1876,7 @@
     <value>インストール中 Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Windows ADK 24H2 のインストールを準備しています</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>ADK インストーラーをダウンロードしています</value>
@@ -1915,7 +1915,7 @@
     <value>Windows ADK および Windows PE アドオンをアップグレードする</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Windows ADK と Windows PE Add-on をダウングレード</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>アラビア語 (サウジアラビア)</value>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK 버전은 지원되지 않습니다.</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>지원되는 Windows ADK 24H2(10.1.26100) 릴리스를 설치하세요.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE 부가기능이 없습니다</value>
@@ -1852,7 +1852,7 @@
     <value>필수 버전 정책</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Windows ADK 24H2(10.1.26100)가 필요합니다.</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE 부가기능</value>
@@ -1876,7 +1876,7 @@
     <value>Windows ADK 설치</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Windows ADK 24H2 설치 준비 중</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>ADK 설치 프로그램 다운로드 중</value>
@@ -1915,7 +1915,7 @@
     <value>Windows ADK 및 Windows PE 추가 기능 업그레이드</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Windows ADK 및 Windows PE Add-on 다운그레이드</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>아랍어(사우디아라비아)</value>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK 버전은 지원되지 않습니다.</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Windows ADK을 지원되는 10.1.26100 빌드로 업그레이드하세요.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE 부가기능이 없습니다</value>
@@ -1852,7 +1852,7 @@
     <value>필수 버전 정책</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>최신 ADK 서비스 패치가 포함된 Windows ADK 10.1.26100.2454+가 필요합니다.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE 부가기능</value>
@@ -1876,7 +1876,7 @@
     <value>Windows ADK 설치</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Windows ADK 업그레이드 중</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>ADK 설치 프로그램 다운로드 중</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Windows ADK 및 Windows PE 추가 기능 업그레이드</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>아랍어(사우디아라비아)</value>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK versija nepalaikoma</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Įdiekite palaikomą Windows ADK 24H2 (10.1.26100) leidimą.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Trūksta priedo</value>
@@ -1852,7 +1852,7 @@
     <value>Būtina versijos politika</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Reikia Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Priedas</value>
@@ -1876,7 +1876,7 @@
     <value>Diegimas Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Ruošiamas Windows ADK 24H2 diegimas</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Atsisiunčiama ADK diegimo programa</value>
@@ -1915,7 +1915,7 @@
     <value>Atnaujinkite Windows ADK ir Windows PE priedas</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Grąžinti Windows ADK ir Windows PE Add-on į ankstesnę versiją</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arabų (Saudo Arabija)</value>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK versija nepalaikoma</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Atnaujinkite Windows ADK į palaikomą 10.1.26100 versiją.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Trūksta priedo</value>
@@ -1852,7 +1852,7 @@
     <value>Būtina versijos politika</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Reikia Windows ADK 10.1.26100.2454+ su naujausia ADK priežiūros pataisa.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Priedas</value>
@@ -1876,7 +1876,7 @@
     <value>Diegimas Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Naujovinimas Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Atsisiunčiama ADK diegimo programa</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Atnaujinkite Windows ADK ir Windows PE priedas</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arabų (Saudo Arabija)</value>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK versija netiek atbalstīta</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Jauniniet Windows ADK uz atbalstītu 10.1.26100 būvējumu.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Trūkst papildinājuma</value>
@@ -1852,7 +1852,7 @@
     <value>Nepieciešamā versijas politika</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Nepieciešams Windows ADK 10.1.26100.2454+ ar jaunāko ADK apkopes ielāpu.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Papildinājums</value>
@@ -1876,7 +1876,7 @@
     <value>Notiek Windows ADK instalēšana</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Jaunināšana Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Notiek ADK instalēšanas programmas lejupielāde</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Jauniniet Windows ADK un Windows PE papildinājumu</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arābu (Saūda Arābija)</value>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK versija netiek atbalstīta</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Instalējiet atbalstīto Windows ADK 24H2 (10.1.26100) laidienu.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Trūkst papildinājuma</value>
@@ -1852,7 +1852,7 @@
     <value>Nepieciešamā versijas politika</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Nepieciešams Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Papildinājums</value>
@@ -1876,7 +1876,7 @@
     <value>Notiek Windows ADK instalēšana</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Windows ADK 24H2 instalēšanas sagatavošana</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Notiek ADK instalēšanas programmas lejupielāde</value>
@@ -1915,7 +1915,7 @@
     <value>Jauniniet Windows ADK un Windows PE papildinājumu</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Pazemināt Windows ADK un Windows PE Add-on versiju</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arābu (Saūda Arābija)</value>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK-versjonen støttes ikke</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Oppgrader Windows ADK til en støttet 10.1.26100 build.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Tillegg mangler</value>
@@ -1852,7 +1852,7 @@
     <value>Nødvendig versjonspolicy</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Krever Windows ADK 10.1.26100.2454+ med den nyeste ADK serviceoppdateringen.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE tillegg</value>
@@ -1876,7 +1876,7 @@
     <value>Installerer Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Oppgraderer Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Laster ned ADK installasjonsprogrammet</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Oppgrader Windows ADK og Windows PE tillegg</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arabisk (Saudi-Arabia)</value>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK-versjonen støttes ikke</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Installer den støttede Windows ADK 24H2-versjonen (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Tillegg mangler</value>
@@ -1852,7 +1852,7 @@
     <value>Nødvendig versjonspolicy</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Krever Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE tillegg</value>
@@ -1876,7 +1876,7 @@
     <value>Installerer Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Forbereder installasjon av Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Laster ned ADK installasjonsprogrammet</value>
@@ -1915,7 +1915,7 @@
     <value>Oppgrader Windows ADK og Windows PE tillegg</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Nedgrader Windows ADK og Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arabisk (Saudi-Arabia)</value>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK-versie wordt niet ondersteund</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Installeer de ondersteunde Windows ADK 24H2-release (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Add-on ontbreekt</value>
@@ -1852,7 +1852,7 @@
     <value>Vereist versiebeleid</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Vereist Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE-add-on</value>
@@ -1876,7 +1876,7 @@
     <value>Windows ADK installeren</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Installatie van Windows ADK 24H2 voorbereiden</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>ADK installatieprogramma downloaden</value>
@@ -1915,7 +1915,7 @@
     <value>Upgrade Windows ADK en Windows PE Add-on</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Windows ADK en Windows PE Add-on downgraden</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arabisch (Saoedi-Arabië)</value>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK-versie wordt niet ondersteund</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Upgrade de Windows ADK naar een ondersteunde 10.1.26100-build.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Add-on ontbreekt</value>
@@ -1852,7 +1852,7 @@
     <value>Vereist versiebeleid</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Vereist Windows ADK 10.1.26100.2454+ met de nieuwste ADK onderhoudspatch.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE-add-on</value>
@@ -1876,7 +1876,7 @@
     <value>Windows ADK installeren</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Upgraden van Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>ADK installatieprogramma downloaden</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Upgrade Windows ADK en Windows PE Add-on</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arabisch (Saoedi-Arabië)</value>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Wersja ADK nie jest obsługiwana</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Zaktualizuj Windows ADK do obsługiwanej wersji 10.1.26100.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Brakuje dodatku</value>
@@ -1852,7 +1852,7 @@
     <value>Wymagane zasady dotyczące wersji</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Wymaga Windows ADK 10.1.26100.2454+ z najnowszą poprawką serwisową ADK.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Dodatek</value>
@@ -1876,7 +1876,7 @@
     <value>Instalowanie Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Aktualizacja Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Pobieranie instalatora ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Uaktualnij dodatek Windows ADK i Windows PE</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arabski (Arabia Saudyjska)</value>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Wersja ADK nie jest obsługiwana</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Zainstaluj obsługiwaną wersję Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Brakuje dodatku</value>
@@ -1852,7 +1852,7 @@
     <value>Wymagane zasady dotyczące wersji</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Wymaga Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Dodatek</value>
@@ -1876,7 +1876,7 @@
     <value>Instalowanie Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Przygotowywanie instalacji Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Pobieranie instalatora ADK</value>
@@ -1915,7 +1915,7 @@
     <value>Uaktualnij dodatek Windows ADK i Windows PE</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Obniż wersję Windows ADK i Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arabski (Arabia Saudyjska)</value>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>A versão ADK não é suportada</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Atualize Windows ADK para uma versão 10.1.26100 compatível.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>O complemento Windows PE está faltando</value>
@@ -1852,7 +1852,7 @@
     <value>Política de versão obrigatória</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requer Windows ADK 10.1.26100.2454+ com o patch de manutenção ADK mais recente.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Complemento</value>
@@ -1876,7 +1876,7 @@
     <value>Instalando Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Atualizando Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Baixando o instalador ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Atualizar Windows ADK e Windows PE complemento</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Árabe (Arábia Saudita)</value>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>A versão ADK não é suportada</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Instale a versão compatível do Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>O complemento Windows PE está faltando</value>
@@ -1852,7 +1852,7 @@
     <value>Política de versão obrigatória</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Requer Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Complemento</value>
@@ -1876,7 +1876,7 @@
     <value>Instalando Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Preparando a instalação do Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Baixando o instalador ADK</value>
@@ -1915,7 +1915,7 @@
     <value>Atualizar Windows ADK e Windows PE complemento</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Fazer downgrade do Windows ADK e do Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Árabe (Arábia Saudita)</value>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>A versão ADK não é suportada</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Instale a versão suportada do Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>O complemento Windows PE está faltando</value>
@@ -1852,7 +1852,7 @@
     <value>Política de versão obrigatória</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Requer Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Complemento</value>
@@ -1876,7 +1876,7 @@
     <value>Instalando Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>A preparar a instalação do Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Baixando o instalador ADK</value>
@@ -1915,7 +1915,7 @@
     <value>Atualizar Windows ADK e Windows PE complemento</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Reverter o Windows ADK e o Windows PE Add-on para uma versão anterior</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Árabe (Arábia Saudita)</value>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>A versão ADK não é suportada</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Atualize Windows ADK para uma versão 10.1.26100 compatível.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>O complemento Windows PE está faltando</value>
@@ -1852,7 +1852,7 @@
     <value>Política de versão obrigatória</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requer Windows ADK 10.1.26100.2454+ com o patch de manutenção ADK mais recente.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Complemento</value>
@@ -1876,7 +1876,7 @@
     <value>Instalando Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Atualizando Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Baixando o instalador ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Atualizar Windows ADK e Windows PE complemento</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Árabe (Arábia Saudita)</value>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Versiunea ADK nu este acceptată</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Actualizați Windows ADK la o versiune 10.1.26100 acceptată.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Lipsește suplimentul</value>
@@ -1852,7 +1852,7 @@
     <value>Politica de versiune necesară</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Necesită Windows ADK 10.1.26100.2454+ cu cel mai recent patch de service ADK.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Supliment</value>
@@ -1876,7 +1876,7 @@
     <value>Instalarea Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Se actualizează Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Se descarcă programul de instalare ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Upgrade Windows ADK și Windows PE Add-on</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arabă (Arabia Saudită)</value>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Versiunea ADK nu este acceptată</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Instalați versiunea acceptată Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Lipsește suplimentul</value>
@@ -1852,7 +1852,7 @@
     <value>Politica de versiune necesară</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Necesită Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Supliment</value>
@@ -1876,7 +1876,7 @@
     <value>Instalarea Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Se pregătește instalarea Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Se descarcă programul de instalare ADK</value>
@@ -1915,7 +1915,7 @@
     <value>Upgrade Windows ADK și Windows PE Add-on</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Reveniți Windows ADK și Windows PE Add-on la o versiune anterioară</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arabă (Arabia Saudită)</value>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Версия ADK не поддерживается</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Установите поддерживаемый выпуск Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Дополнение отсутствует</value>
@@ -1852,7 +1852,7 @@
     <value>Требуемая политика версий</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Требуется Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Дополнение</value>
@@ -1876,7 +1876,7 @@
     <value>Установка Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Подготовка установки Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Загрузка установщика ADK</value>
@@ -1915,7 +1915,7 @@
     <value>Обновите Windows ADK и дополнение Windows PE</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Понизить версию Windows ADK и Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Арабский (Саудовская Аравия)</value>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Версия ADK не поддерживается</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Обновите Windows ADK до поддерживаемой сборки 10.1.26100.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Дополнение отсутствует</value>
@@ -1852,7 +1852,7 @@
     <value>Требуемая политика версий</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Требуется Windows ADK 10.1.26100.2454+ с последним сервисным патчем ADK.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Дополнение</value>
@@ -1876,7 +1876,7 @@
     <value>Установка Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Обновление Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Загрузка установщика ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Обновите Windows ADK и дополнение Windows PE</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Арабский (Саудовская Аравия)</value>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Verzia ADK nie je podporovaná</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Nainštalujte podporované vydanie Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Doplnok chýba</value>
@@ -1852,7 +1852,7 @@
     <value>Politika požadovanej verzie</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Vyžaduje Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Doplnok Windows PE</value>
@@ -1876,7 +1876,7 @@
     <value>Inštalácia Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Príprava inštalácie Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Sťahovanie inštalačného programu ADK</value>
@@ -1915,7 +1915,7 @@
     <value>Inovujte doplnok Windows ADK a Windows PE</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Prejsť na nižšiu verziu Windows ADK a Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arabčina (Saudská Arábia)</value>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Verzia ADK nie je podporovaná</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Inovujte Windows ADK na podporovanú zostavu 10.1.26100.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Doplnok chýba</value>
@@ -1852,7 +1852,7 @@
     <value>Politika požadovanej verzie</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Vyžaduje Windows ADK 10.1.26100.2454+ s najnovšou servisnou záplatou ADK.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Doplnok Windows PE</value>
@@ -1876,7 +1876,7 @@
     <value>Inštalácia Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Inovácia Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Sťahovanie inštalačného programu ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Inovujte doplnok Windows ADK a Windows PE</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arabčina (Saudská Arábia)</value>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Različica ADK ni podprta</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Namestite podprto izdajo Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Manjka dodatek</value>
@@ -1852,7 +1852,7 @@
     <value>Politika zahtevane različice</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Zahteva Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Dodatek</value>
@@ -1876,7 +1876,7 @@
     <value>Namestitev Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Priprava namestitve Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Prenašanje namestitvenega programa ADK</value>
@@ -1915,7 +1915,7 @@
     <value>Nadgradite dodatka Windows ADK in Windows PE</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Povrni Windows ADK in Windows PE Add-on na starejšo različico</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arabščina (Saudova Arabija)</value>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Različica ADK ni podprta</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Nadgradite Windows ADK na podprto različico 10.1.26100.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Manjka dodatek</value>
@@ -1852,7 +1852,7 @@
     <value>Politika zahtevane različice</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Zahteva Windows ADK 10.1.26100.2454+ z najnovejšim servisnim popravkom ADK.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Dodatek</value>
@@ -1876,7 +1876,7 @@
     <value>Namestitev Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Nadgradnja Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Prenašanje namestitvenega programa ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Nadgradite dodatka Windows ADK in Windows PE</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arabščina (Saudova Arabija)</value>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK verzija nije podržana</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Nadogradite Windows ADK na podržanu verziju 10.1.26100.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Nedostaje dodatak</value>
@@ -1852,7 +1852,7 @@
     <value>Obavezna politika verzije</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Zahteva Windows ADK 10.1.26100.2454+ sa najnovijom ADK servisnom zakrpom.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Dodatak</value>
@@ -1876,7 +1876,7 @@
     <value>Instaliranje Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Nadogradnja Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Preuzimanje ADK instalatera</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Nadogradite Windows ADK i Windows PE dodatak</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arapski (Saudijska Arabija)</value>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK verzija nije podržana</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Instalirajte podržano izdanje Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Nedostaje dodatak</value>
@@ -1852,7 +1852,7 @@
     <value>Obavezna politika verzije</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Zahteva Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Dodatak</value>
@@ -1876,7 +1876,7 @@
     <value>Instaliranje Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Priprema instalacije Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Preuzimanje ADK instalatera</value>
@@ -1915,7 +1915,7 @@
     <value>Nadogradite Windows ADK i Windows PE dodatak</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Vrati Windows ADK i Windows PE Add-on na stariju verziju</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>arapski (Saudijska Arabija)</value>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK-versionen stöds inte</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Uppgradera Windows ADK till en 10.1.26100-version som stöds.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Tillägg saknas</value>
@@ -1852,7 +1852,7 @@
     <value>Obligatorisk versionspolicy</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Kräver Windows ADK 10.1.26100.2454+ med den senaste ADK servicepatchen.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Tillägg</value>
@@ -1876,7 +1876,7 @@
     <value>Installerar Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Uppgraderar Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Laddar ner ADK installationsprogrammet</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Uppgradera Windows ADK och Windows PE tillägg</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arabiska (Saudiarabien)</value>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK-versionen stöds inte</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Installera den stödda Windows ADK 24H2-versionen (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Tillägg saknas</value>
@@ -1852,7 +1852,7 @@
     <value>Obligatorisk versionspolicy</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Kräver Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Tillägg</value>
@@ -1876,7 +1876,7 @@
     <value>Installerar Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Förbereder installation av Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Laddar ner ADK installationsprogrammet</value>
@@ -1915,7 +1915,7 @@
     <value>Uppgradera Windows ADK och Windows PE tillägg</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Nedgradera Windows ADK och Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arabiska (Saudiarabien)</value>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ไม่รองรับเวอร์ชัน ADK</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>ติดตั้งรุ่น Windows ADK 24H2 (10.1.26100) ที่รองรับ</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE ส่วนเสริมหายไป</value>
@@ -1852,7 +1852,7 @@
     <value>นโยบายเวอร์ชันที่ต้องการ</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>ต้องใช้ Windows ADK 24H2 (10.1.26100)</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE ส่วนเสริม</value>
@@ -1876,7 +1876,7 @@
     <value>กำลังติดตั้ง Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>กำลังเตรียมการติดตั้ง Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>กำลังดาวน์โหลดตัวติดตั้ง ADK</value>
@@ -1915,7 +1915,7 @@
     <value>อัปเกรด Windows ADK และ Windows PE ส่วนเสริม</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>ดาวน์เกรด Windows ADK และ Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>อาหรับ (ซาอุดีอาระเบีย)</value>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ไม่รองรับเวอร์ชัน ADK</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>อัปเกรด Windows ADK เป็นบิลด์ 10.1.26100 ที่รองรับ</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE ส่วนเสริมหายไป</value>
@@ -1852,7 +1852,7 @@
     <value>นโยบายเวอร์ชันที่ต้องการ</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>ต้องใช้ Windows ADK 10.1.26100.2454+ พร้อมด้วย ADK แพตช์การบริการล่าสุด</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE ส่วนเสริม</value>
@@ -1876,7 +1876,7 @@
     <value>กำลังติดตั้ง Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>กำลังอัพเกรด Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>กำลังดาวน์โหลดตัวติดตั้ง ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>อัปเกรด Windows ADK และ Windows PE ส่วนเสริม</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>อาหรับ (ซาอุดีอาระเบีย)</value>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK sürümü desteklenmiyor</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Desteklenen Windows ADK 24H2 (10.1.26100) sürümünü yükleyin.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Eklenti eksik</value>
@@ -1852,7 +1852,7 @@
     <value>Gerekli sürüm politikası</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Windows ADK 24H2 (10.1.26100) gerektirir.</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Eklenti</value>
@@ -1876,7 +1876,7 @@
     <value>Windows ADK Kurulumu</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Windows ADK 24H2 yüklemesi hazırlanıyor</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>ADK yükleyici indiriliyor</value>
@@ -1915,7 +1915,7 @@
     <value>Windows ADK ve Windows PE Eklentisini Yükseltme</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Windows ADK ve Windows PE Add-on sürümünü düşür</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arapça (Suudi Arabistan)</value>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK sürümü desteklenmiyor</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Windows ADK'yi desteklenen bir 10.1.26100 yapısına yükseltin.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Eklenti eksik</value>
@@ -1852,7 +1852,7 @@
     <value>Gerekli sürüm politikası</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>En son ADK servis yamasını içeren Windows ADK 10.1.26100.2454+ gerektirir.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Eklenti</value>
@@ -1876,7 +1876,7 @@
     <value>Windows ADK Kurulumu</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Windows ADK yükseltiliyor</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>ADK yükleyici indiriliyor</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Windows ADK ve Windows PE Eklentisini Yükseltme</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>Arapça (Suudi Arabistan)</value>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Версія ADK не підтримується</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Оновіть Windows ADK до підтримуваної версії 10.1.26100.</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Доповнення відсутнє</value>
@@ -1852,7 +1852,7 @@
     <value>Необхідна політика версії</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Потрібен Windows ADK 10.1.26100.2454+ з останнім ADK патчем обслуговування.</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Надбудова</value>
@@ -1876,7 +1876,7 @@
     <value>Встановлення Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Оновлення Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Завантаження інсталятора ADK</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>Оновіть доповнення Windows ADK і Windows PE</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>арабська (Саудівська Аравія)</value>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>Версія ADK не підтримується</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>Інсталюйте підтримуваний випуск Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE Доповнення відсутнє</value>
@@ -1852,7 +1852,7 @@
     <value>Необхідна політика версії</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>Потрібен Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE Надбудова</value>
@@ -1876,7 +1876,7 @@
     <value>Встановлення Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>Підготовка інсталяції Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>Завантаження інсталятора ADK</value>
@@ -1915,7 +1915,7 @@
     <value>Оновіть доповнення Windows ADK і Windows PE</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>Повернути Windows ADK і Windows PE Add-on до попередньої версії</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>арабська (Саудівська Аравія)</value>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK版本不受支持</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>安装受支持的 Windows ADK 24H2 (10.1.26100) 版本。</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE 缺少附加组件</value>
@@ -1852,7 +1852,7 @@
     <value>所需版本政策</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>需要 Windows ADK 24H2 (10.1.26100)。</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE 附加组件</value>
@@ -1876,7 +1876,7 @@
     <value>安装Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>正在准备安装 Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>正在下载ADK安装程序</value>
@@ -1915,7 +1915,7 @@
     <value>升级Windows ADK 和Windows PE 附加组件</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>降级 Windows ADK 和 Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>阿拉伯语（沙特阿拉伯）</value>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK版本不受支持</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>将 Windows ADK 升级到受支持的 10.1.26100 版本。</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE 缺少附加组件</value>
@@ -1852,7 +1852,7 @@
     <value>所需版本政策</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>需要Windows ADK 10.1.26100.2454+ 以及最新的ADK 服务补丁。</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE 附加组件</value>
@@ -1876,7 +1876,7 @@
     <value>安装Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>升级Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>正在下载ADK安装程序</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>升级Windows ADK 和Windows PE 附加组件</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>阿拉伯语（沙特阿拉伯）</value>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK版本不受支援</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
+    <value>安裝支援的 Windows ADK 24H2 (10.1.26100) 版本。</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE 缺少附加元件</value>
@@ -1852,7 +1852,7 @@
     <value>所需版本政策</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
+    <value>需要 Windows ADK 24H2 (10.1.26100)。</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE 附加元件</value>
@@ -1876,7 +1876,7 @@
     <value>安裝Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>Preparing Windows ADK 24H2 installation</value>
+    <value>正在準備安裝 Windows ADK 24H2</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>正在下載ADK安裝程序</value>
@@ -1915,7 +1915,7 @@
     <value>升級Windows ADK 和Windows PE 附加元件</value>
   </data>
   <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
-    <value>Downgrade Windows ADK and Windows PE Add-on</value>
+    <value>降級 Windows ADK 和 Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>阿拉伯語（沙烏地阿拉伯）</value>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -1825,7 +1825,7 @@
     <value>ADK版本不受支援</value>
   </data>
   <data name="Adk.Status.IncompatibleDescription" xml:space="preserve">
-    <value>將 Windows ADK 升級至支援的 10.1.26100 版本。</value>
+    <value>Install the supported Windows ADK 24H2 (10.1.26100) release.</value>
   </data>
   <data name="Adk.Status.WinPeMissingTitle" xml:space="preserve">
     <value>Windows PE 缺少附加元件</value>
@@ -1852,7 +1852,7 @@
     <value>所需版本政策</value>
   </data>
   <data name="Adk.Version.RequiredPolicy" xml:space="preserve">
-    <value>需要Windows ADK 10.1.26100.2454+ 以及最新的ADK 服務補丁。</value>
+    <value>Requires Windows ADK 24H2 (10.1.26100).</value>
   </data>
   <data name="Adk.WinPeAddon.Title" xml:space="preserve">
     <value>Windows PE 附加元件</value>
@@ -1876,7 +1876,7 @@
     <value>安裝Windows ADK</value>
   </data>
   <data name="Adk.Operation.UpgradeStarted" xml:space="preserve">
-    <value>升級Windows ADK</value>
+    <value>Preparing Windows ADK 24H2 installation</value>
   </data>
   <data name="Adk.Operation.Downloading" xml:space="preserve">
     <value>正在下載ADK安裝程序</value>
@@ -1913,6 +1913,9 @@
   </data>
   <data name="AdkPage_UpgradeButton.Content" xml:space="preserve">
     <value>升級Windows ADK 和Windows PE 附加元件</value>
+  </data>
+  <data name="AdkPage_DowngradeButton.Content" xml:space="preserve">
+    <value>Downgrade Windows ADK and Windows PE Add-on</value>
   </data>
   <data name="Language.ArabicSaudiArabia" xml:space="preserve">
     <value>阿拉伯語（沙烏地阿拉伯）</value>

--- a/src/Foundry/ViewModels/AdkPageViewModel.cs
+++ b/src/Foundry/ViewModels/AdkPageViewModel.cs
@@ -39,6 +39,9 @@ public sealed partial class AdkPageViewModel : ObservableObject, IDisposable
     public partial string SetupActionDescription { get; set; }
 
     [ObservableProperty]
+    public partial string UpgradeButtonText { get; set; }
+
+    [ObservableProperty]
     public partial string ReadinessDetailsTitle { get; set; }
 
     [ObservableProperty]
@@ -104,6 +107,7 @@ public sealed partial class AdkPageViewModel : ObservableObject, IDisposable
         StatusSeverity = InfoBarSeverity.Informational;
         SetupActionTitle = string.Empty;
         SetupActionDescription = string.Empty;
+        UpgradeButtonText = string.Empty;
         ReadinessDetailsTitle = string.Empty;
         InstalledVersionTitle = string.Empty;
         InstalledVersion = string.Empty;
@@ -211,6 +215,7 @@ public sealed partial class AdkPageViewModel : ObservableObject, IDisposable
         StatusSeverity = GetStatusSeverity(status);
         SetupActionTitle = localizationService.GetString("Adk.SetupAction.Title");
         SetupActionDescription = localizationService.GetString("Adk.SetupAction.Description");
+        UpgradeButtonText = GetUpgradeButtonText(status);
         ReadinessDetailsTitle = localizationService.GetString("Adk.ReadinessDetails.Title");
         InstalledVersionTitle = localizationService.GetString("Adk.Version.InstalledTitle");
         InstalledVersion = status.InstalledVersion ?? localizationService.GetString("Adk.Version.NotDetected");
@@ -286,5 +291,12 @@ public sealed partial class AdkPageViewModel : ObservableObject, IDisposable
         }
 
         return localizationService.GetString("Adk.Status.WinPeMissingDescription");
+    }
+
+    private string GetUpgradeButtonText(AdkInstallationStatus status)
+    {
+        return status.VersionRelation == AdkVersionRelation.AboveSupported
+            ? localizationService.GetString("AdkPage_DowngradeButton.Content")
+            : localizationService.GetString("AdkPage_UpgradeButton.Content");
     }
 }

--- a/src/Foundry/Views/AdkPage.xaml
+++ b/src/Foundry/Views/AdkPage.xaml
@@ -34,8 +34,8 @@
                             Style="{ThemeResource AccentButtonStyle}"
                             Visibility="{x:Bind ViewModel.IsInstallButtonVisible, Mode=OneWay}" />
                     <Button MinWidth="{StaticResource SettingActionControlMinWidth}"
-                            x:Uid="AdkPage_UpgradeButton"
                             Command="{x:Bind ViewModel.UpgradeAdkCommand}"
+                            Content="{x:Bind ViewModel.UpgradeButtonText, Mode=OneWay}"
                             IsEnabled="{x:Bind ViewModel.IsActionEnabled, Mode=OneWay}"
                             Style="{ThemeResource AccentButtonStyle}"
                             Visibility="{x:Bind ViewModel.IsUpgradeButtonVisible, Mode=OneWay}" />


### PR DESCRIPTION
## Summary
- Treat Windows ADK compatibility by `10.1.26100` build line only, ignoring the revision.
- Show a downgrade action label when an installed ADK is newer than the supported 24H2 build line.
- Update ADK page and operation copy to explicitly reference Windows ADK 24H2 / `10.1.26100`.

## Reason
Foundry OSD currently supports the Windows ADK 24H2 build line. Newer ADK builds such as `10.1.28000.x` are unsupported for Foundry media creation and should be presented as a downgrade path instead of an upgrade path.

Closes #227

## Main changes
- Added ADK version relation classification: below supported, supported, above supported, unknown.
- Updated ADK compatibility tests so any `10.1.26100.*` version is accepted.
- Bound the ADK page action button text from the ViewModel so newer unsupported ADKs show a downgrade label.
- Added the downgrade localization key and revised ADK 24H2 wording across resource files.

## Testing
- `dotnet test src\Foundry.Core.Tests\Foundry.Core.Tests.csproj`
- `dotnet test src\Foundry.Localization.Tests\Foundry.Localization.Tests.csproj`
- All test projects under `src\*.Tests`
- `dotnet build src\Foundry\Foundry.csproj -c Debug -p:Platform=x64`
