### PR TITLE
feat(settings): add page documentation headers

### DIFF
--- a/src/Foundry.Localization.Tests/ResourceKeyParityTests.cs
+++ b/src/Foundry.Localization.Tests/ResourceKeyParityTests.cs
@@ -79,6 +79,25 @@ public sealed class ResourceKeyParityTests
         { "Foundry.Deploy", ".resx" }
     };
 
+    [Fact]
+    public void FoundryResources_IncludePageHeaderDescriptions()
+    {
+        string sourceRoot = FindSourceRoot();
+        string enUsPath = Path.Combine(sourceRoot, "Foundry", "Strings", "en-US", "Resources.resw");
+        SortedSet<string> enUsKeys = ReadResourceKeys(enUsPath);
+
+        string[] expectedKeys =
+        [
+            "Adk.PageDescription",
+            "Customization.PageDescription",
+            "GeneralConfiguration.PageDescription",
+            "Network.PageDescription",
+            "StartMedia.PageDescription"
+        ];
+
+        Assert.Empty(expectedKeys.Except(enUsKeys, StringComparer.Ordinal));
+    }
+
     [Theory]
     [MemberData(nameof(ResourceSets))]
     public void AdkResourceFiles_MatchEnUsKeys(string projectName, string extension)

--- a/src/Foundry/Controls/PageHeader.cs
+++ b/src/Foundry/Controls/PageHeader.cs
@@ -1,0 +1,107 @@
+using Microsoft.UI.Xaml.Media;
+
+namespace Foundry.Controls;
+
+public sealed partial class PageHeader : UserControl
+{
+    public static readonly DependencyProperty TitleProperty = DependencyProperty.Register(
+        nameof(Title),
+        typeof(string),
+        typeof(PageHeader),
+        new PropertyMetadata(string.Empty, OnHeaderPropertyChanged));
+
+    public static readonly DependencyProperty DescriptionProperty = DependencyProperty.Register(
+        nameof(Description),
+        typeof(string),
+        typeof(PageHeader),
+        new PropertyMetadata(string.Empty, OnHeaderPropertyChanged));
+
+    public static readonly DependencyProperty DocumentationUrlProperty = DependencyProperty.Register(
+        nameof(DocumentationUrl),
+        typeof(string),
+        typeof(PageHeader),
+        new PropertyMetadata(string.Empty, OnHeaderPropertyChanged));
+
+    private readonly TextBlock titleTextBlock = new();
+    private readonly TextBlock descriptionTextBlock = new();
+    private readonly DocumentationButton documentationButton = new();
+
+    public PageHeader()
+    {
+        Content = CreateLayout();
+        UpdateContent();
+    }
+
+    public string Title
+    {
+        get => (string)GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
+    }
+
+    public string Description
+    {
+        get => (string)GetValue(DescriptionProperty);
+        set => SetValue(DescriptionProperty, value);
+    }
+
+    public string DocumentationUrl
+    {
+        get => (string)GetValue(DocumentationUrlProperty);
+        set => SetValue(DocumentationUrlProperty, value);
+    }
+
+    private static void OnHeaderPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+    {
+        ((PageHeader)dependencyObject).UpdateContent();
+    }
+
+    private Grid CreateLayout()
+    {
+        Grid layout = new()
+        {
+            Margin = (Thickness)Application.Current.Resources["FoundryPageHeaderMargin"],
+            ColumnSpacing = (double)Application.Current.Resources["FoundryInlineControlSpacing"]
+        };
+
+        layout.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        layout.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        StackPanel textPanel = new()
+        {
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            Spacing = (double)Application.Current.Resources["FoundryTextGroupSpacing"]
+        };
+
+        titleTextBlock.HorizontalAlignment = HorizontalAlignment.Left;
+        titleTextBlock.Style = (Style)Application.Current.Resources["FoundryPageTitleTextBlockStyle"];
+
+        descriptionTextBlock.MaxWidth = (double)Application.Current.Resources["FoundrySummaryTextMaxWidth"];
+        descriptionTextBlock.HorizontalAlignment = HorizontalAlignment.Left;
+        descriptionTextBlock.Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"];
+        descriptionTextBlock.TextAlignment = TextAlignment.Left;
+        descriptionTextBlock.TextWrapping = TextWrapping.WrapWholeWords;
+        descriptionTextBlock.Style = (Style)Application.Current.Resources["FoundryBodyTextBlockStyle"];
+
+        textPanel.Children.Add(titleTextBlock);
+        textPanel.Children.Add(descriptionTextBlock);
+
+        Grid.SetColumn(documentationButton, 1);
+        documentationButton.HorizontalAlignment = HorizontalAlignment.Right;
+        documentationButton.VerticalAlignment = VerticalAlignment.Center;
+
+        layout.Children.Add(textPanel);
+        layout.Children.Add(documentationButton);
+        return layout;
+    }
+
+    private void UpdateContent()
+    {
+        titleTextBlock.Text = Title;
+        descriptionTextBlock.Text = Description;
+        documentationButton.DocumentationUrl = DocumentationUrl;
+        documentationButton.Visibility = string.IsNullOrWhiteSpace(DocumentationUrl)
+            ? Visibility.Collapsed
+            : Visibility.Visible;
+    }
+}

--- a/src/Foundry/FoundryApplicationInfo.cs
+++ b/src/Foundry/FoundryApplicationInfo.cs
@@ -15,9 +15,34 @@ public static class FoundryApplicationInfo
     public const string DocumentationUrl = "https://foundry-osd.github.io/docs/start";
 
     /// <summary>
+    /// Gets the ADK documentation URL.
+    /// </summary>
+    public const string AdkDocumentationUrl = "https://foundry-osd.github.io/docs/start/requirements";
+
+    /// <summary>
     /// Gets the Autopilot documentation URL.
     /// </summary>
-    public const string AutopilotDocumentationUrl = "https://foundry-osd.github.io/docs/autopilot";
+    public const string AutopilotDocumentationUrl = "https://foundry-osd.github.io/docs/autopilot/overview";
+
+    /// <summary>
+    /// Gets the customization documentation URL.
+    /// </summary>
+    public const string CustomizationDocumentationUrl = "https://foundry-osd.github.io/docs/configure/customization";
+
+    /// <summary>
+    /// Gets the general configuration documentation URL.
+    /// </summary>
+    public const string GeneralConfigurationDocumentationUrl = "https://foundry-osd.github.io/docs/configure/general";
+
+    /// <summary>
+    /// Gets the network configuration documentation URL.
+    /// </summary>
+    public const string NetworkDocumentationUrl = "https://foundry-osd.github.io/docs/configure/network";
+
+    /// <summary>
+    /// Gets the media creation documentation URL.
+    /// </summary>
+    public const string StartDocumentationUrl = "https://foundry-osd.github.io/docs/build-media/media-creation";
 
     public const string RepositoryUrl = Constants.RepositoryUrl;
 

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>ينسخ شهادات عميل PFX المكوّنة إلى Windows ويستوردها إلى مخزن الشهادات الشخصي LocalMachine قبل OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>راجع جاهزية Windows ADK والملحق Windows PE قبل إنشاء وسائط النشر.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>كوّن تسمية الأجهزة وتحديد نظام التشغيل وسلوك OOBE وإزالة مكونات AI وإزالة حزم AppX المجهزة.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>كوّن أساس الوسائط ولغة WinPE وتوقيع التمهيد وبرامج التشغيل والمنطقة الزمنية للنشر.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>كوّن 802.1X السلكي وتجهيز Wi-Fi وتجوال ملفات التعريف لوسائط النشر.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>راجع الجاهزية واختر إخراج ISO أو USB ثم ابدأ إنشاء الوسائط.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Копира конфигурираните PFX клиентски сертификати в Windows и ги импортира в личното хранилище LocalMachine преди OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Прегледайте готовността на Windows ADK и добавката Windows PE, преди да създадете носител за разполагане.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Конфигурирайте именуване на машини, избор на операционна система, поведение на OOBE, премахване на AI компоненти и премахване на подготвени AppX пакети.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Конфигурирайте базовите настройки на носителя, езика WinPE, подписа за стартиране, драйверите и часовата зона за разполагане.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Конфигурирайте кабелен 802.1X, подготвяне на Wi-Fi и роуминг на профили за носителя за разполагане.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Прегледайте готовността, изберете ISO или USB изход и стартирайте създаването на носител.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Zkopíruje nakonfigurované klientské certifikáty PFX do Windows a před OOBE je importuje do osobního úložiště LocalMachine.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Před vytvořením nasazovacího média zkontrolujte připravenost Windows ADK a doplňku Windows PE.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Nakonfigurujte pojmenování počítačů, výběr operačního systému, chování OOBE, odebrání komponent AI a odebrání zřízených balíčků AppX.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Nakonfigurujte základ média, jazyk WinPE, spouštěcí podpis, ovladače a časové pásmo nasazení.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Nakonfigurujte kabelové 802.1X, zřizování Wi-Fi a roaming profilů pro nasazovací média.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Zkontrolujte připravenost, vyberte výstup ISO nebo USB a spusťte vytvoření média.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Kopierer konfigurerede PFX-klientcertifikater til Windows og importerer dem til det personlige LocalMachine-certifikatlager før OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Gennemgå klarheden for Windows ADK og Windows PE-tilføjelsesprogrammet, før du opretter installationsmedier.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Konfigurer computernavngivning, valg af operativsystem, OOBE-funktionalitet, fjernelse af AI-komponenter og fjernelse af klargjorte AppX-pakker.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Konfigurer mediegrundlaget, WinPE-sprog, startsignatur, drivere og tidszone for installation.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Konfigurer kablet 802.1X, Wi-Fi-klargøring og profilroaming for installationsmedier.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Gennemgå klarheden, vælg ISO- eller USB-output, og start medieoprettelsen.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Kopiert konfigurierte PFX-Clientzertifikate nach Windows und importiert sie vor OOBE in den persönlichen LocalMachine-Zertifikatspeicher.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Prüfen Sie die Bereitschaft von Windows ADK und Windows PE-Add-On, bevor Sie Bereitstellungsmedien erstellen.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Konfigurieren Sie Computernamen, Betriebssystemauswahl, OOBE-Verhalten, Entfernung von AI-Komponenten und Entfernung bereitgestellter AppX-Pakete.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Konfigurieren Sie Medienbasis, WinPE-Sprache, Startsignatur, Treiber und Bereitstellungszeitzone.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Konfigurieren Sie kabelgebundenes 802.1X, Wi-Fi-Bereitstellung und Profilroaming für Bereitstellungsmedien.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Prüfen Sie die Bereitschaft, wählen Sie eine ISO- oder USB-Ausgabe aus, und starten Sie die Medienerstellung.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Αντιγράφει τα διαμορφωμένα πιστοποιητικά πελάτη PFX στα Windows και τα εισάγει στον προσωπικό χώρο αποθήκευσης πιστοποιητικών LocalMachine πριν από το OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Ελέγξτε την ετοιμότητα του Windows ADK και του πρόσθετου Windows PE πριν δημιουργήσετε μέσα ανάπτυξης.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Ρυθμίστε την ονομασία υπολογιστών, την επιλογή λειτουργικού συστήματος, τη συμπεριφορά OOBE, την κατάργηση στοιχείων AI και την κατάργηση προεγκατεστημένων πακέτων AppX.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Ρυθμίστε τη βάση μέσου, τη γλώσσα WinPE, την υπογραφή εκκίνησης, τα προγράμματα οδήγησης και τη ζώνη ώρας ανάπτυξης.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Ρυθμίστε ενσύρματο 802.1X, προετοιμασία Wi-Fi και περιαγωγή προφίλ για μέσα ανάπτυξης.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Ελέγξτε την ετοιμότητα, επιλέξτε έξοδο ISO ή USB και ξεκινήστε τη δημιουργία μέσου.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Copies configured PFX client certificates to Windows and imports them into the LocalMachine personal certificate store before OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Review Windows ADK and Windows PE Add-on readiness before creating deployment media.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Configure machine naming, operating system selection, OOBE behaviour, AI component removal, and provisioned AppX removal.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Configure the media baseline, WinPE language, boot signature, drivers, and deployment time zone.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Configure wired 802.1X, Wi-Fi provisioning, and profile roaming for deployment media.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Review readiness, choose ISO or USB output, and start media creation.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Customization.OperatingSystemDefaultEditionDescription" xml:space="preserve">
     <value>Automatic keeps the catalog default edition.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Review Windows ADK and Windows PE Add-on readiness before creating deployment media.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Configure machine naming, operating system selection, OOBE behavior, AI component removal, and provisioned AppX removal.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Configure the media baseline, WinPE language, boot signature, drivers, and deployment time zone.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Configure wired 802.1X, Wi-Fi provisioning, and profile roaming for deployment media.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Review readiness, choose ISO or USB output, and start media creation.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Copia los certificados de cliente PFX configurados en Windows y los importa en el almacén personal de certificados LocalMachine antes de OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Revise la preparación de Windows ADK y del complemento Windows PE antes de crear medios de implementación.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Configure el nombre de equipo, la selección del sistema operativo, el comportamiento de OOBE, la eliminación de componentes AI y la eliminación de AppX aprovisionadas.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Configure la línea base del medio, el idioma de WinPE, la firma de arranque, los controladores y la zona horaria de implementación.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Configure 802.1X cableado, aprovisionamiento Wi-Fi e itinerancia de perfiles para medios de implementación.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Revise la preparación, elija una salida ISO o USB e inicie la creación del medio.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Copia los certificados de cliente PFX configurados en Windows y los importa en el almacén personal de certificados LocalMachine antes de OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Revise la preparación de Windows ADK y del complemento Windows PE antes de crear medios de implementación.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Configure el nombre del equipo, la selección del sistema operativo, el comportamiento de OOBE, la eliminación de componentes AI y la eliminación de AppX aprovisionadas.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Configure la línea base del medio, el idioma de WinPE, la firma de arranque, los controladores y la zona horaria de implementación.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Configure 802.1X cableado, aprovisionamiento Wi-Fi e itinerancia de perfiles para medios de implementación.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Revise la preparación, elija una salida ISO o USB e inicie la creación del medio.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Kopeerib konfigureeritud PFX-kliendisertifikaadid Windowsisse ja impordib need enne OOBE-d LocalMachine isiklikku sertifikaadihoidlasse.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Enne juurutusmeediumi loomist kontrollige Windows ADK ja Windows PE lisandmooduli valmisolekut.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Konfigureerige arvutinimede määramine, operatsioonisüsteemi valik, OOBE käitumine, AI komponentide eemaldamine ja ettevalmistatud AppX-pakettide eemaldamine.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Konfigureerige meediumi baas, WinPE keel, algkäivituse allkiri, draiverid ja juurutuse ajavöönd.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Konfigureerige juhtmega 802.1X, Wi-Fi ettevalmistus ja profiilide rändlus juurutusmeediumi jaoks.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Kontrollige valmisolekut, valige ISO või USB väljund ja alustage meediumi loomist.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Kopioi määritetyt PFX-asiakasvarmenteet Windowsiin ja tuo ne LocalMachine-henkilökohtaiseen varmennevarastoon ennen OOBE-vaihetta.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Tarkista Windows ADK:n ja Windows PE -lisäosan valmius ennen käyttöönoton median luontia.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Määritä tietokoneiden nimeäminen, käyttöjärjestelmän valinta, OOBE-toiminta, AI-osien poisto ja valmisteltujen AppX-pakettien poisto.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Määritä median perustaso, WinPE-kieli, käynnistyksen allekirjoitus, ohjaimet ja käyttöönoton aikavyöhyke.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Määritä langallinen 802.1X, Wi-Fi-valmistelu ja profiilien verkkovierailu käyttöönoton mediaa varten.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Tarkista valmius, valitse ISO- tai USB-tuloste ja käynnistä median luonti.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Copie les certificats clients PFX configurés vers Windows et les importe dans le magasin de certificats personnel LocalMachine avant l’OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Vérifiez l’état de Windows ADK et du module complémentaire Windows PE avant de créer le support de déploiement.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Configurez le nommage des machines, la sélection du système d’exploitation, le comportement OOBE, la suppression des composants AI et la suppression des AppX provisionnées.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Configurez la base du support, la langue WinPE, la signature de démarrage, les pilotes et le fuseau horaire de déploiement.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Configurez le 802.1X câblé, le provisionnement Wi-Fi et l’itinérance des profils pour le support de déploiement.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Vérifiez l’état, choisissez une sortie ISO ou USB, puis lancez la création du support.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Customization.OperatingSystemDefaultEditionDescription" xml:space="preserve">
     <value>Automatique conserve l'édition par défaut du catalogue.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Vérifiez la disponibilité de Windows ADK et du module complémentaire Windows PE avant de créer le média de déploiement.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Configurez le nommage des machines, la sélection du système d’exploitation, le comportement OOBE, la suppression des composants AI et la suppression des AppX provisionnées.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Configurez la base du média, la langue WinPE, la signature de démarrage, les pilotes et le fuseau horaire de déploiement.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Configurez le 802.1X filaire, le provisionnement Wi-Fi et l’itinérance des profils pour le média de déploiement.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Vérifiez la disponibilité, choisissez une sortie ISO ou USB, puis démarrez la création du média.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>מעתיק אישורי לקוח PFX מוגדרים אל Windows ומייבא אותם אל מאגר האישורים האישי LocalMachine לפני OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>בדוק את המוכנות של Windows ADK ושל התוספת Windows PE לפני יצירת מדיית פריסה.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>הגדר מתן שמות למחשבים, בחירת מערכת הפעלה, התנהגות OOBE, הסרת רכיבי AI והסרת חבילות AppX שסופקו.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>הגדר את בסיס המדיה, שפת WinPE, חתימת האתחול, מנהלי ההתקנים ואזור הזמן של הפריסה.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>הגדר 802.1X קווי, הקצאת Wi-Fi ונדידת פרופילים עבור מדיית הפריסה.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>בדוק מוכנות, בחר פלט ISO או USB והתחל ביצירת המדיה.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Kopira konfigurirane PFX klijentske certifikate u Windows i uvozi ih u osobnu pohranu certifikata LocalMachine prije OOBE-a.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Pregledajte spremnost Windows ADK-a i dodatka Windows PE prije stvaranja implementacijskog medija.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Konfigurirajte imenovanje računala, odabir operacijskog sustava, ponašanje OOBE, uklanjanje komponenti AI i uklanjanje pripremljenih paketa AppX.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Konfigurirajte osnovu medija, WinPE jezik, potpis pokretanja, upravljačke programe i vremensku zonu implementacije.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Konfigurirajte žičani 802.1X, pripremu Wi-Fi i roaming profila za implementacijski medij.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Pregledajte spremnost, odaberite ISO ili USB izlaz i pokrenite stvaranje medija.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Átmásolja a konfigurált PFX ügyféltanúsítványokat a Windowsba, és az OOBE előtt importálja őket a LocalMachine személyes tanúsítványtárába.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Tekintse át a Windows ADK és a Windows PE bővítmény készenlétét az üzembe helyezési adathordozó létrehozása előtt.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Konfigurálja a gépnévadást, az operációsrendszer-választást, az OOBE viselkedését, az AI-összetevők eltávolítását és a kiépített AppX-csomagok eltávolítását.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Konfigurálja az adathordozó alapját, a WinPE nyelvét, a rendszerindítási aláírást, az illesztőprogramokat és az üzembe helyezési időzónát.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Konfigurálja a vezetékes 802.1X-et, a Wi-Fi kiépítést és a profilroamingot az üzembe helyezési adathordozóhoz.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Tekintse át a készenlétet, válasszon ISO vagy USB kimenetet, majd indítsa el az adathordozó létrehozását.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Copia i certificati client PFX configurati in Windows e li importa nell’archivio certificati personale LocalMachine prima di OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Verifica la preparazione di Windows ADK e del componente aggiuntivo Windows PE prima di creare i supporti di distribuzione.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Configura denominazione dei computer, selezione del sistema operativo, comportamento OOBE, rimozione dei componenti AI e rimozione delle AppX con provisioning.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Configura la base del supporto, la lingua WinPE, la firma di avvio, i driver e il fuso orario di distribuzione.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Configura 802.1X cablato, provisioning Wi-Fi e roaming dei profili per i supporti di distribuzione.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Verifica la preparazione, scegli un output ISO o USB e avvia la creazione del supporto.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>構成済みの PFX クライアント証明書を Windows にコピーし、OOBE 前に LocalMachine の個人証明書ストアへインポートします。</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>展開メディアを作成する前に、Windows ADK と Windows PE アドオンの準備状況を確認します。</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>コンピューター名、オペレーティング システムの選択、OOBE の動作、AI コンポーネントの削除、プロビジョニング済み AppX の削除を構成します。</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>メディアの基準、WinPE 言語、ブート署名、ドライバー、展開タイム ゾーンを構成します。</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>展開メディア用に有線 802.1X、Wi-Fi プロビジョニング、プロファイル ローミングを構成します。</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>準備状況を確認し、ISO または USB 出力を選択して、メディアの作成を開始します。</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>구성된 PFX 클라이언트 인증서를 Windows로 복사하고 OOBE 전에 LocalMachine 개인 인증서 저장소로 가져옵니다.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>배포 미디어를 만들기 전에 Windows ADK 및 Windows PE 추가 기능 준비 상태를 검토합니다.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>컴퓨터 이름 지정, 운영 체제 선택, OOBE 동작, AI 구성 요소 제거 및 프로비전된 AppX 제거를 구성합니다.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>미디어 기준, WinPE 언어, 부팅 서명, 드라이버 및 배포 표준 시간대를 구성합니다.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>배포 미디어용 유선 802.1X, Wi-Fi 프로비저닝 및 프로필 로밍을 구성합니다.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>준비 상태를 검토하고 ISO 또는 USB 출력을 선택한 다음 미디어 만들기를 시작합니다.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Nukopijuoja sukonfigūruotus PFX kliento sertifikatus į Windows ir prieš OOBE importuoja juos į LocalMachine asmeninę sertifikatų saugyklą.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Prieš kurdami diegimo laikmeną peržiūrėkite Windows ADK ir Windows PE priedo parengtį.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Konfigūruokite kompiuterių vardus, operacinės sistemos pasirinkimą, OOBE veikimą, AI komponentų šalinimą ir parengtų AppX paketų šalinimą.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Konfigūruokite laikmenos pagrindą, WinPE kalbą, paleidimo parašą, tvarkykles ir diegimo laiko juostą.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Konfigūruokite laidinį 802.1X, Wi-Fi parengimą ir profilių tarptinklinį naudojimą diegimo laikmenai.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Peržiūrėkite parengtį, pasirinkite ISO arba USB išvestį ir pradėkite laikmenos kūrimą.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Kopē konfigurētos PFX klienta sertifikātus uz Windows un pirms OOBE importē tos LocalMachine personīgajā sertifikātu krātuvē.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Pirms izvietošanas datu nesēja izveides pārskatiet Windows ADK un Windows PE papildinājuma gatavību.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Konfigurējiet datoru nosaukšanu, operētājsistēmas atlasi, OOBE darbību, AI komponentu noņemšanu un sagatavoto AppX pakotņu noņemšanu.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Konfigurējiet datu nesēja bāzi, WinPE valodu, sāknēšanas parakstu, draiverus un izvietošanas laika joslu.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Konfigurējiet vadu 802.1X, Wi-Fi sagatavošanu un profilu viesabonēšanu izvietošanas datu nesējam.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Pārskatiet gatavību, izvēlieties ISO vai USB izvadi un sāciet datu nesēja izveidi.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Kopierer konfigurerte PFX-klientsertifikater til Windows og importerer dem til det personlige LocalMachine-sertifikatlageret før OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Kontroller beredskapen for Windows ADK og Windows PE-tillegget før du oppretter distribusjonsmedier.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Konfigurer maskinnavn, valg av operativsystem, OOBE-atferd, fjerning av AI-komponenter og fjerning av klargjorte AppX-pakker.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Konfigurer mediegrunnlaget, WinPE-språk, oppstartssignatur, drivere og distribusjonstidssone.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Konfigurer kablet 802.1X, Wi-Fi-klargjøring og profilroaming for distribusjonsmedier.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Kontroller beredskapen, velg ISO- eller USB-utdata, og start medieopprettingen.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Kopieert geconfigureerde PFX-clientcertificaten naar Windows en importeert ze vóór OOBE in het persoonlijke LocalMachine-certificaatarchief.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Controleer de gereedheid van Windows ADK en de Windows PE-invoegtoepassing voordat u implementatiemedia maakt.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Configureer computernamen, besturingssysteemselectie, OOBE-gedrag, verwijdering van AI-onderdelen en verwijdering van ingerichte AppX-pakketten.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Configureer de mediabasis, WinPE-taal, opstartsignatuur, stuurprogramma’s en implementatietijdzone.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Configureer bekabelde 802.1X, Wi-Fi-inrichting en profielroaming voor implementatiemedia.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Controleer de gereedheid, kies ISO- of USB-uitvoer en start het maken van media.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Kopiuje skonfigurowane certyfikaty klienta PFX do Windows i importuje je do osobistego magazynu certyfikatów LocalMachine przed OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Sprawdź gotowość Windows ADK i dodatku Windows PE przed utworzeniem nośnika wdrożeniowego.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Skonfiguruj nazewnictwo komputerów, wybór systemu operacyjnego, zachowanie OOBE, usuwanie składników AI i usuwanie aprowizowanych pakietów AppX.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Skonfiguruj bazę nośnika, język WinPE, podpis rozruchu, sterowniki i strefę czasową wdrożenia.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Skonfiguruj przewodowe 802.1X, aprowizowanie Wi-Fi i roaming profili dla nośnika wdrożeniowego.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Sprawdź gotowość, wybierz wyjście ISO lub USB i rozpocznij tworzenie nośnika.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Copia os certificados de cliente PFX configurados para o Windows e os importa para o repositório pessoal de certificados LocalMachine antes do OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Revise a prontidão do Windows ADK e do complemento Windows PE antes de criar mídias de implantação.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Configure a nomenclatura dos computadores, a seleção do sistema operacional, o comportamento OOBE, a remoção de componentes AI e a remoção de AppX provisionados.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Configure a base da mídia, o idioma WinPE, a assinatura de inicialização, os drivers e o fuso horário de implantação.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Configure 802.1X cabeado, provisionamento Wi-Fi e roaming de perfis para mídias de implantação.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Revise a prontidão, escolha uma saída ISO ou USB e inicie a criação da mídia.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Copia os certificados de cliente PFX configurados para o Windows e importa-os para o arquivo pessoal de certificados LocalMachine antes do OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Reveja a preparação do Windows ADK e do suplemento Windows PE antes de criar suportes de implementação.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Configure a nomenclatura dos computadores, a seleção do sistema operativo, o comportamento OOBE, a remoção de componentes AI e a remoção de AppX aprovisionadas.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Configure a base do suporte, o idioma WinPE, a assinatura de arranque, os controladores e o fuso horário de implementação.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Configure 802.1X com fios, aprovisionamento Wi-Fi e roaming de perfis para suportes de implementação.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Reveja a preparação, escolha uma saída ISO ou USB e inicie a criação do suporte.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Copiază certificatele client PFX configurate în Windows și le importă în depozitul personal de certificate LocalMachine înainte de OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Revizuiți starea Windows ADK și a suplimentului Windows PE înainte de a crea suportul de implementare.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Configurați denumirea computerelor, selecția sistemului de operare, comportamentul OOBE, eliminarea componentelor AI și eliminarea pachetelor AppX aprovizionate.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Configurați baza suportului, limba WinPE, semnătura de pornire, driverele și fusul orar de implementare.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Configurați 802.1X cu fir, aprovizionarea Wi-Fi și roamingul profilurilor pentru suportul de implementare.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Revizuiți starea, alegeți ieșirea ISO sau USB și porniți crearea suportului.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Копирует настроенные клиентские сертификаты PFX в Windows и импортирует их в личное хранилище сертификатов LocalMachine до OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Проверьте готовность Windows ADK и надстройки Windows PE перед созданием носителя развертывания.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Настройте именование компьютеров, выбор операционной системы, поведение OOBE, удаление компонентов AI и удаление подготовленных пакетов AppX.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Настройте базовые параметры носителя, язык WinPE, подпись загрузки, драйверы и часовой пояс развертывания.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Настройте проводной 802.1X, подготовку Wi-Fi и перемещение профилей для носителя развертывания.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Проверьте готовность, выберите вывод ISO или USB и запустите создание носителя.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Skopíruje nakonfigurované klientské certifikáty PFX do Windows a pred OOBE ich importuje do osobného úložiska certifikátov LocalMachine.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Pred vytvorením nasadzovacieho média skontrolujte pripravenosť Windows ADK a doplnku Windows PE.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Nakonfigurujte pomenovanie počítačov, výber operačného systému, správanie OOBE, odstránenie komponentov AI a odstránenie zriadených balíkov AppX.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Nakonfigurujte základ média, jazyk WinPE, podpis spustenia, ovládače a časové pásmo nasadenia.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Nakonfigurujte káblové 802.1X, zriaďovanie Wi-Fi a roaming profilov pre nasadzovacie médiá.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Skontrolujte pripravenosť, vyberte výstup ISO alebo USB a spustite vytvorenie média.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Kopira konfigurirana odjemalska potrdila PFX v Windows in jih pred OOBE uvozi v osebno shrambo potrdil LocalMachine.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Pred ustvarjanjem namestitvenega medija preverite pripravljenost Windows ADK in dodatka Windows PE.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Konfigurirajte poimenovanje računalnikov, izbiro operacijskega sistema, vedenje OOBE, odstranjevanje komponent AI in odstranjevanje omogočenih paketov AppX.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Konfigurirajte osnovo medija, jezik WinPE, zagonski podpis, gonilnike in časovni pas namestitve.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Konfigurirajte žični 802.1X, omogočanje Wi-Fi in gostovanje profilov za namestitveni medij.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Preverite pripravljenost, izberite izhod ISO ali USB in začnite ustvarjanje medija.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Kopira konfigurisane PFX klijentske sertifikate u Windows i uvozi ih u lično skladište sertifikata LocalMachine pre OOBE-a.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Pregledajte spremnost za Windows ADK i dodatak Windows PE pre kreiranja medija za primenu.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Konfigurišite imenovanje računara, izbor operativnog sistema, ponašanje OOBE, uklanjanje AI komponenti i uklanjanje obezbeđenih AppX paketa.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Konfigurišite osnovu medija, WinPE jezik, potpis pokretanja, upravljačke programe i vremensku zonu primene.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Konfigurišite žični 802.1X, obezbeđivanje Wi-Fi i roming profila za medij za primenu.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Pregledajte spremnost, izaberite ISO ili USB izlaz i pokrenite kreiranje medija.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Kopierar konfigurerade PFX-klientcertifikat till Windows och importerar dem till LocalMachine personliga certifikatarkiv före OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Granska beredskapen för Windows ADK och Windows PE-tillägget innan du skapar distributionsmedia.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Konfigurera datornamn, val av operativsystem, OOBE-beteende, borttagning av AI-komponenter och borttagning av provisionerade AppX-paket.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Konfigurera mediebaslinje, WinPE-språk, startsignatur, drivrutiner och distributionstidszon.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Konfigurera trådbunden 802.1X, Wi-Fi-provisionering och profilroaming för distributionsmedia.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Granska beredskapen, välj ISO- eller USB-utdata och starta medieskapandet.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>คัดลอกใบรับรองไคลเอ็นต์ PFX ที่กำหนดค่าไว้ไปยัง Windows และนำเข้าไปยังที่เก็บใบรับรองส่วนบุคคล LocalMachine ก่อน OOBE</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>ตรวจสอบความพร้อมของ Windows ADK และส่วนเสริม Windows PE ก่อนสร้างสื่อการปรับใช้</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>กำหนดค่าการตั้งชื่อเครื่อง การเลือกระบบปฏิบัติการ ลักษณะการทำงานของ OOBE การลบคอมโพเนนต์ AI และการลบ AppX ที่จัดเตรียมไว้</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>กำหนดค่าพื้นฐานของสื่อ ภาษา WinPE ลายเซ็นการเริ่มระบบ ไดรเวอร์ และโซนเวลาการปรับใช้</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>กำหนดค่า 802.1X แบบใช้สาย การจัดเตรียม Wi-Fi และการโรมมิ่งโปรไฟล์สำหรับสื่อการปรับใช้</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>ตรวจสอบความพร้อม เลือกเอาต์พุต ISO หรือ USB แล้วเริ่มสร้างสื่อ</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Yapılandırılmış PFX istemci sertifikalarını Windows’a kopyalar ve OOBE öncesinde LocalMachine kişisel sertifika deposuna içe aktarır.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Dağıtım medyası oluşturmadan önce Windows ADK ve Windows PE eklentisinin hazır olup olmadığını gözden geçirin.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Makine adlandırmayı, işletim sistemi seçimini, OOBE davranışını, AI bileşen kaldırmayı ve sağlanan AppX kaldırmayı yapılandırın.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Medya temelini, WinPE dilini, önyükleme imzasını, sürücüleri ve dağıtım saat dilimini yapılandırın.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Dağıtım medyası için kablolu 802.1X, Wi-Fi sağlama ve profil dolaşımını yapılandırın.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Hazırlığı gözden geçirin, ISO veya USB çıktısını seçin ve medya oluşturmayı başlatın.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>Копіює налаштовані клієнтські сертифікати PFX до Windows і імпортує їх до особистого сховища сертифікатів LocalMachine перед OOBE.</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>Перевірте готовність Windows ADK і додатка Windows PE перед створенням носія розгортання.</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>Налаштуйте іменування комп’ютерів, вибір операційної системи, поведінку OOBE, видалення компонентів AI і видалення підготовлених пакетів AppX.</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>Налаштуйте базові параметри носія, мову WinPE, підпис завантаження, драйвери та часовий пояс розгортання.</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>Налаштуйте дротовий 802.1X, підготовку Wi-Fi і роумінг профілів для носія розгортання.</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>Перевірте готовність, виберіть вихід ISO або USB і запустіть створення носія.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>将配置的 PFX 客户端证书复制到 Windows，并在 OOBE 前导入 LocalMachine 个人证书存储区。</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>创建部署媒体之前，请检查 Windows ADK 和 Windows PE 加载项的就绪情况。</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>配置计算机命名、操作系统选择、OOBE 行为、AI 组件移除以及已预配 AppX 移除。</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>配置媒体基线、WinPE 语言、启动签名、驱动程序和部署时区。</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>为部署媒体配置有线 802.1X、Wi-Fi 预配和配置文件漫游。</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>检查就绪情况，选择 ISO 或 USB 输出，然后开始创建媒体。</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -2112,4 +2112,19 @@
   <data name="Network.RoamPrivateKeyMaterialHelperText" xml:space="preserve">
     <value>將已設定的 PFX 用戶端憑證複製到 Windows，並在 OOBE 前匯入 LocalMachine 個人憑證存放區。</value>
   </data>
+  <data name="Adk.PageDescription" xml:space="preserve">
+    <value>建立部署媒體之前，請檢閱 Windows ADK 和 Windows PE 附加元件的就緒狀態。</value>
+  </data>
+  <data name="Customization.PageDescription" xml:space="preserve">
+    <value>設定電腦命名、作業系統選擇、OOBE 行為、AI 元件移除，以及已佈建 AppX 移除。</value>
+  </data>
+  <data name="GeneralConfiguration.PageDescription" xml:space="preserve">
+    <value>設定媒體基準、WinPE 語言、開機簽章、驅動程式和部署時區。</value>
+  </data>
+  <data name="Network.PageDescription" xml:space="preserve">
+    <value>為部署媒體設定有線 802.1X、Wi-Fi 佈建和設定檔漫遊。</value>
+  </data>
+  <data name="StartMedia.PageDescription" xml:space="preserve">
+    <value>檢閱就緒狀態，選擇 ISO 或 USB 輸出，然後開始建立媒體。</value>
+  </data>
 </root>

--- a/src/Foundry/ViewModels/AdkPageViewModel.cs
+++ b/src/Foundry/ViewModels/AdkPageViewModel.cs
@@ -24,6 +24,9 @@ public sealed partial class AdkPageViewModel : ObservableObject, IDisposable
     public partial string PageTitle { get; set; }
 
     [ObservableProperty]
+    public partial string PageDescription { get; set; }
+
+    [ObservableProperty]
     public partial string StatusTitle { get; set; }
 
     [ObservableProperty]
@@ -83,6 +86,8 @@ public sealed partial class AdkPageViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     public partial bool IsActionEnabled { get; set; }
 
+    public string DocumentationUrl => FoundryApplicationInfo.AdkDocumentationUrl;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="AdkPageViewModel"/> class.
     /// </summary>
@@ -102,6 +107,7 @@ public sealed partial class AdkPageViewModel : ObservableObject, IDisposable
         this.logger = logger.ForContext<AdkPageViewModel>();
 
         PageTitle = localizationService.GetString("Adk.PageTitle");
+        PageDescription = localizationService.GetString("Adk.PageDescription");
         StatusTitle = string.Empty;
         StatusDescription = string.Empty;
         StatusSeverity = InfoBarSeverity.Informational;
@@ -197,6 +203,7 @@ public sealed partial class AdkPageViewModel : ObservableObject, IDisposable
         if (!appDispatcher.TryEnqueue(() =>
         {
             PageTitle = localizationService.GetString("Adk.PageTitle");
+            PageDescription = localizationService.GetString("Adk.PageDescription");
             ApplyStatus(adkService.CurrentStatus);
             ApplyOperationState(operationProgressService.State);
         }))

--- a/src/Foundry/ViewModels/CustomizationConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/CustomizationConfigurationViewModel.cs
@@ -58,8 +58,13 @@ public sealed partial class CustomizationConfigurationViewModel : ObservableObje
         ? Visibility.Visible
         : Visibility.Collapsed;
 
+    public string DocumentationUrl => FoundryApplicationInfo.CustomizationDocumentationUrl;
+
     [ObservableProperty]
     public partial string PageTitle { get; set; }
+
+    [ObservableProperty]
+    public partial string PageDescription { get; set; }
 
     [ObservableProperty]
     public partial string MachineNamingHeader { get; set; }
@@ -231,6 +236,7 @@ public sealed partial class CustomizationConfigurationViewModel : ObservableObje
     private void RefreshLocalizedText()
     {
         PageTitle = localizationService.GetString("CustomizationPage_Title.Text");
+        PageDescription = localizationService.GetString("Customization.PageDescription");
         MachineNamingHeader = localizationService.GetString("Customization.MachineNamingHeader");
         MachineNamingDescription = localizationService.GetString("Customization.MachineNamingDescription");
         MachineNamingEnableText = localizationService.GetString("Customization.MachineNamingEnableLabel");

--- a/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
@@ -58,6 +58,7 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
         IncludeHpDrivers = general.IncludeHpDrivers;
         CustomDriverDirectoryPath = general.CustomDriverDirectoryPath ?? string.Empty;
         WinPeLanguageUnavailableDescription = string.Empty;
+        RefreshLocalizedText();
         RefreshTimeZones();
         ApplyLocalizationState(configurationStateService.Current.Localization);
 
@@ -79,6 +80,12 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
     /// Gets the Windows time-zone options available for generated deployment media.
     /// </summary>
     public ObservableCollection<SelectionOption<string>> TimeZoneOptions { get; } = [];
+
+    [ObservableProperty]
+    public partial string PageTitle { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string PageDescription { get; set; } = string.Empty;
 
     [ObservableProperty]
     public partial SelectionOption<WinPeArchitecture>? SelectedArchitecture { get; set; }
@@ -116,6 +123,8 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
     /// </summary>
     public Visibility WinPeLanguageUnavailableVisibility => HasWinPeLanguages ? Visibility.Collapsed : Visibility.Visible;
 
+    public string DocumentationUrl => FoundryApplicationInfo.GeneralConfigurationDocumentationUrl;
+
     /// <inheritdoc />
     public void Dispose()
     {
@@ -140,6 +149,12 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
     public void RefreshAdkState()
     {
         CanCreateMedia = adkService.CurrentStatus.CanCreateMedia;
+    }
+
+    public void RefreshLocalizedText()
+    {
+        PageTitle = localizationService.GetString("GeneralConfigurationPage_Title.Text");
+        PageDescription = localizationService.GetString("GeneralConfiguration.PageDescription");
     }
 
     /// <summary>

--- a/src/Foundry/ViewModels/NetworkConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/NetworkConfigurationViewModel.cs
@@ -53,6 +53,9 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
     public partial string PageTitle { get; set; }
 
     [ObservableProperty]
+    public partial string PageDescription { get; set; }
+
+    [ObservableProperty]
     public partial string EthernetHeader { get; set; }
 
     [ObservableProperty]
@@ -278,6 +281,8 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
     public string WifiValidationMessage => FormatValidationMessage(NetworkConfigurationValidator.Validate(BuildWifiOnlySettings()), dot1xOnly: false);
     public Visibility WifiValidationVisibility => HasWifiValidationError ? Visibility.Visible : Visibility.Collapsed;
     public bool HasValidationError => HasDot1xValidationError || HasWifiValidationError;
+
+    public string DocumentationUrl => FoundryApplicationInfo.NetworkDocumentationUrl;
     public string ValidationMessage => HasDot1xValidationError ? Dot1xValidationMessage : WifiValidationMessage;
     public Visibility Dot1xSettingsVisibility => IsDot1xEnabled ? Visibility.Visible : Visibility.Collapsed;
     public Visibility Dot1xCertificatePathVisibility => IsDot1xCertificatePathEnabled ? Visibility.Visible : Visibility.Collapsed;
@@ -637,6 +642,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
     private void RefreshLocalizedText()
     {
         PageTitle = localizationService.GetString("NetworkPage_Title.Text");
+        PageDescription = localizationService.GetString("Network.PageDescription");
         EthernetHeader = localizationService.GetString("Network.EthernetSectionTitle");
         EthernetDescription = localizationService.GetString("Network.EthernetHelperText");
         Dot1xEnableText = localizationService.GetString("Dot1x.EnableLabel");

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -151,6 +151,9 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     public partial string PageTitle { get; set; } = string.Empty;
 
     [ObservableProperty]
+    public partial string PageDescription { get; set; } = string.Empty;
+
+    [ObservableProperty]
     public partial string IsoOutputPath { get; set; }
 
     [ObservableProperty]
@@ -224,6 +227,8 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     [ObservableProperty]
     public partial bool IsFoundryConfigurationReadinessExpanded { get; set; }
+
+    public string DocumentationUrl => FoundryApplicationInfo.StartDocumentationUrl;
 
     /// <inheritdoc />
     public void Dispose()
@@ -1249,6 +1254,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     private void ApplyLocalizedText()
     {
         PageTitle = localizationService.GetString("StartPage_Title.Text");
+        PageDescription = localizationService.GetString("StartMedia.PageDescription");
         RebuildFormatModes();
         RebuildUsbCandidateDisplayNames();
     }

--- a/src/Foundry/Views/AdkPage.xaml
+++ b/src/Foundry/Views/AdkPage.xaml
@@ -2,6 +2,7 @@
 <Page x:Class="Foundry.Views.AdkPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:controls="using:Foundry.Controls"
       xmlns:dev="using:DevWinUI"
       xmlns:wct="using:CommunityToolkit.WinUI.Controls">
     <ScrollView Margin="{ThemeResource ContentPageMargin}"
@@ -9,8 +10,9 @@
                 VerticalScrollBarVisibility="Auto">
         <StackPanel dev:PanelAttach.ChildrenTransitions="Default"
                     Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
-            <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
-                       Style="{ThemeResource FoundryPageTitleTextBlockStyle}" />
+            <controls:PageHeader Title="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
+                                 Description="{x:Bind ViewModel.PageDescription, Mode=OneWay}"
+                                 DocumentationUrl="{x:Bind ViewModel.DocumentationUrl, Mode=OneWay}" />
 
             <InfoBar IsClosable="False"
                      IsIconVisible="True"

--- a/src/Foundry/Views/AutopilotPage.xaml
+++ b/src/Foundry/Views/AutopilotPage.xaml
@@ -13,40 +13,9 @@
                 Padding="{ThemeResource ContentPagePadding}"
                 VerticalScrollBarVisibility="Auto">
         <StackPanel>
-            <Grid Margin="{ThemeResource FoundryPageHeaderMargin}"
-                  ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-
-                <Grid HorizontalAlignment="Left"
-                      VerticalAlignment="Center"
-                      RowSpacing="{ThemeResource FoundryTextGroupSpacing}">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
-
-                    <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
-                               HorizontalAlignment="Left"
-                               Style="{ThemeResource FoundryPageTitleTextBlockStyle}" />
-
-                    <TextBlock Grid.Row="1"
-                               MaxWidth="{ThemeResource FoundrySummaryTextMaxWidth}"
-                               HorizontalAlignment="Left"
-                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                               Text="{x:Bind ViewModel.PageDescription, Mode=OneWay}"
-                               TextAlignment="Left"
-                               TextWrapping="WrapWholeWords"
-                               Style="{ThemeResource FoundryBodyTextBlockStyle}" />
-                </Grid>
-
-                <controls:DocumentationButton Grid.Column="1"
-                                              HorizontalAlignment="Right"
-                                              VerticalAlignment="Center"
-                                              DocumentationUrl="{x:Bind ViewModel.DocumentationUrl, Mode=OneWay}" />
-            </Grid>
+            <controls:PageHeader Title="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
+                                 Description="{x:Bind ViewModel.PageDescription, Mode=OneWay}"
+                                 DocumentationUrl="{x:Bind ViewModel.DocumentationUrl, Mode=OneWay}" />
 
             <StackPanel Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
                 <wct:SettingsCard Header="{x:Bind ViewModel.AutopilotHeader, Mode=OneWay}"

--- a/src/Foundry/Views/CustomizationPage.xaml
+++ b/src/Foundry/Views/CustomizationPage.xaml
@@ -3,6 +3,7 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:behaviors="using:Foundry.Behaviors"
+      xmlns:controls="using:Foundry.Controls"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:viewModels="using:Foundry.ViewModels"
@@ -12,8 +13,9 @@
                 Padding="{ThemeResource ContentPagePadding}"
                 VerticalScrollBarVisibility="Auto">
         <StackPanel Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
-            <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
-                       Style="{ThemeResource FoundryPageTitleTextBlockStyle}" />
+            <controls:PageHeader Title="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
+                                 Description="{x:Bind ViewModel.PageDescription, Mode=OneWay}"
+                                 DocumentationUrl="{x:Bind ViewModel.DocumentationUrl, Mode=OneWay}" />
 
             <wct:SettingsExpander Header="{x:Bind ViewModel.MachineNamingHeader, Mode=OneWay}"
                                   Description="{x:Bind ViewModel.MachineNamingDescription, Mode=OneWay}"

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml
@@ -2,6 +2,7 @@
 <Page x:Class="Foundry.Views.GeneralConfigurationPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:controls="using:Foundry.Controls"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:dev="using:DevWinUI"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -12,8 +13,9 @@
                 VerticalScrollBarVisibility="Auto">
         <StackPanel dev:PanelAttach.ChildrenTransitions="Default"
                     Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
-            <TextBlock x:Uid="GeneralConfigurationPage_Title"
-                       Style="{ThemeResource FoundryPageTitleTextBlockStyle}" />
+            <controls:PageHeader Title="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
+                                 Description="{x:Bind ViewModel.PageDescription, Mode=OneWay}"
+                                 DocumentationUrl="{x:Bind ViewModel.DocumentationUrl, Mode=OneWay}" />
 
             <wct:SettingsCard x:Name="ArchitectureCard">
                 <wct:SettingsCard.HeaderIcon>

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
@@ -64,6 +64,8 @@ public sealed partial class GeneralConfigurationPage : Page
 
     private void ApplyLocalizedText()
     {
+        ViewModel.RefreshLocalizedText();
+
         ArchitectureCard.Header = localizationService.GetString("StartMedia.Architecture.Header");
         ArchitectureCard.Description = localizationService.GetString("StartMedia.Architecture.Description");
         Ca2023Toggle.OnContent = localizationService.GetString("StartMedia.Signature.Ca2023");

--- a/src/Foundry/Views/NetworkPage.xaml
+++ b/src/Foundry/Views/NetworkPage.xaml
@@ -3,6 +3,7 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:behaviors="using:Foundry.Behaviors"
+      xmlns:controls="using:Foundry.Controls"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:wct="using:CommunityToolkit.WinUI.Controls"
@@ -11,8 +12,9 @@
                 Padding="{ThemeResource ContentPagePadding}"
                 VerticalScrollBarVisibility="Auto">
         <StackPanel Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
-            <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
-                       Style="{ThemeResource FoundryPageTitleTextBlockStyle}" />
+            <controls:PageHeader Title="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
+                                 Description="{x:Bind ViewModel.PageDescription, Mode=OneWay}"
+                                 DocumentationUrl="{x:Bind ViewModel.DocumentationUrl, Mode=OneWay}" />
 
             <wct:SettingsExpander Header="{x:Bind ViewModel.EthernetHeader, Mode=OneWay}"
                                   Description="{x:Bind ViewModel.EthernetDescription, Mode=OneWay}"

--- a/src/Foundry/Views/StartPage.xaml
+++ b/src/Foundry/Views/StartPage.xaml
@@ -2,6 +2,7 @@
 <Page x:Class="Foundry.Views.StartPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:controls="using:Foundry.Controls"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:viewModels="using:Foundry.ViewModels"
@@ -60,8 +61,9 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <TextBlock Text="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
-                       Style="{ThemeResource FoundryPageTitleTextBlockStyle}" />
+            <controls:PageHeader Title="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
+                                 Description="{x:Bind ViewModel.PageDescription, Mode=OneWay}"
+                                 DocumentationUrl="{x:Bind ViewModel.DocumentationUrl, Mode=OneWay}" />
 
             <InfoBar Grid.Row="1"
                      IsClosable="False"


### PR DESCRIPTION
## Summary
Add the Autopilot-style page header pattern to ADK, General, Start, Network, and Customization settings pages.

## Reason
These settings pages should expose the same localized description and Documentation action pattern already used by Autopilot.

## Main changes
- Added a reusable `PageHeader` control that combines title, description, and documentation button layout.
- Replaced duplicated Autopilot header markup with the shared control.
- Added page descriptions and documentation URLs for ADK, General, Start, Network, and Customization.
- Added translated page-description resources for all Foundry UI cultures from the `en-US` source strings.
- Added localization coverage for the new page-description resource keys.

## Testing
- `dotnet test src\Foundry.Localization.Tests\Foundry.Localization.Tests.csproj --logger "console;verbosity=normal"`
- `dotnet build src\Foundry\Foundry.csproj`

## Merge note
Do not squash this PR.