### PR TITLE
feat(config): centralize schema versions

### DIFF
--- a/src/Foundry.Connect.Tests/ConnectConfigurationServiceTests.cs
+++ b/src/Foundry.Connect.Tests/ConnectConfigurationServiceTests.cs
@@ -58,7 +58,6 @@ public sealed class ConnectConfigurationServiceTests
 
         Assert.True(service.IsLoadedFromDisk);
         Assert.Equal(System.IO.Path.GetFullPath(configurationPath), service.ConfigurationPath);
-        Assert.True(service.IsBootMediaUpdateRecommended);
         Assert.Equal(FoundryConnectConfiguration.CurrentSchemaVersion, configuration.SchemaVersion);
         Assert.Equal(30, configuration.InternetProbe.TimeoutSeconds);
         Assert.Equal(

--- a/src/Foundry.Connect.Tests/ConnectConfigurationServiceTests.cs
+++ b/src/Foundry.Connect.Tests/ConnectConfigurationServiceTests.cs
@@ -4,6 +4,7 @@ using Foundry.Connect.Models.Configuration;
 using Foundry.Connect.Services.Configuration;
 using Foundry.Core.Services.Configuration;
 using Foundry.Telemetry;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using CoreConfiguration = Foundry.Core.Models.Configuration;
 
@@ -63,6 +64,57 @@ public sealed class ConnectConfigurationServiceTests
         Assert.Equal(
             ["https://example.com/health", "http://contoso.test/connect"],
             configuration.InternetProbe.ProbeUris);
+    }
+
+    [Fact]
+    public void Load_WhenSchemaIsOlderThanMinimumRecommended_RecommendsBootMediaUpdate()
+    {
+        using var environmentScope = new EnvironmentVariableScope("FOUNDRY_CONNECT_CONFIG", null);
+        using var tempDirectory = new TemporaryDirectory();
+        string configurationPath = CreateJsonFile(
+            tempDirectory.Path,
+            "older-than-minimum.json",
+            $$"""
+            {
+              "schemaVersion": {{CoreConfiguration.ConfigurationSchemaVersions.ConnectMinimumRecommended - 1}}
+            }
+            """);
+
+        var logger = new RecordingLogger<ConnectConfigurationService>();
+        var service = new ConnectConfigurationService(["--config", configurationPath], logger);
+
+        service.Load();
+
+        Assert.True(service.IsBootMediaUpdateRecommended);
+        Assert.Contains(
+            logger.Entries,
+            entry =>
+                entry.LogLevel == LogLevel.Warning &&
+                entry.Message.Contains("minimum recommended schema version", StringComparison.Ordinal) &&
+                entry.Message.Contains(CoreConfiguration.ConfigurationSchemaVersions.ConnectMinimumRecommended.ToString(), StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Load_WhenSchemaMatchesMinimumRecommended_DoesNotRecommendBootMediaUpdate()
+    {
+        using var environmentScope = new EnvironmentVariableScope("FOUNDRY_CONNECT_CONFIG", null);
+        using var tempDirectory = new TemporaryDirectory();
+        string configurationPath = CreateJsonFile(
+            tempDirectory.Path,
+            "minimum-recommended.json",
+            $$"""
+            {
+              "schemaVersion": {{CoreConfiguration.ConfigurationSchemaVersions.ConnectMinimumRecommended}}
+            }
+            """);
+
+        var logger = new RecordingLogger<ConnectConfigurationService>();
+        var service = new ConnectConfigurationService(["--config", configurationPath], logger);
+
+        service.Load();
+
+        Assert.False(service.IsBootMediaUpdateRecommended);
+        Assert.DoesNotContain(logger.Entries, entry => entry.LogLevel == LogLevel.Warning);
     }
 
     [Fact]
@@ -470,4 +522,32 @@ public sealed class ConnectConfigurationServiceTests
             }
         }
     }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new LogEntry(logLevel, formatter(state, exception)));
+        }
+    }
+
+    private sealed record LogEntry(LogLevel LogLevel, string Message);
 }

--- a/src/Foundry.Connect.Tests/ConnectConfigurationServiceTests.cs
+++ b/src/Foundry.Connect.Tests/ConnectConfigurationServiceTests.cs
@@ -66,16 +66,16 @@ public sealed class ConnectConfigurationServiceTests
     }
 
     [Fact]
-    public void Load_WhenSchemaIsOlderThanMinimumRecommended_RecommendsBootMediaUpdate()
+    public void Load_WhenSchemaIsOlderThanCurrent_RecommendsBootMediaUpdate()
     {
         using var environmentScope = new EnvironmentVariableScope("FOUNDRY_CONNECT_CONFIG", null);
         using var tempDirectory = new TemporaryDirectory();
         string configurationPath = CreateJsonFile(
             tempDirectory.Path,
-            "older-than-minimum.json",
+            "older-than-current.json",
             $$"""
             {
-              "schemaVersion": {{CoreConfiguration.ConfigurationSchemaVersions.ConnectMinimumRecommended - 1}}
+              "schemaVersion": {{CoreConfiguration.ConfigurationSchemaVersions.ConnectCurrent - 1}}
             }
             """);
 
@@ -89,21 +89,21 @@ public sealed class ConnectConfigurationServiceTests
             logger.Entries,
             entry =>
                 entry.LogLevel == LogLevel.Warning &&
-                entry.Message.Contains("minimum recommended schema version", StringComparison.Ordinal) &&
-                entry.Message.Contains(CoreConfiguration.ConfigurationSchemaVersions.ConnectMinimumRecommended.ToString(), StringComparison.Ordinal));
+                entry.Message.Contains("current schema version", StringComparison.Ordinal) &&
+                entry.Message.Contains(CoreConfiguration.ConfigurationSchemaVersions.ConnectCurrent.ToString(), StringComparison.Ordinal));
     }
 
     [Fact]
-    public void Load_WhenSchemaMatchesMinimumRecommended_DoesNotRecommendBootMediaUpdate()
+    public void Load_WhenSchemaMatchesCurrent_DoesNotRecommendBootMediaUpdate()
     {
         using var environmentScope = new EnvironmentVariableScope("FOUNDRY_CONNECT_CONFIG", null);
         using var tempDirectory = new TemporaryDirectory();
         string configurationPath = CreateJsonFile(
             tempDirectory.Path,
-            "minimum-recommended.json",
+            "current.json",
             $$"""
             {
-              "schemaVersion": {{CoreConfiguration.ConfigurationSchemaVersions.ConnectMinimumRecommended}}
+              "schemaVersion": {{CoreConfiguration.ConfigurationSchemaVersions.ConnectCurrent}}
             }
             """);
 

--- a/src/Foundry.Connect/Models/Configuration/FoundryConnectConfiguration.cs
+++ b/src/Foundry.Connect/Models/Configuration/FoundryConnectConfiguration.cs
@@ -1,3 +1,4 @@
+using Foundry.Core.Models.Configuration;
 using Foundry.Telemetry;
 using CoreConnectNetworkSettings = Foundry.Core.Models.Configuration.ConnectNetworkSettings;
 
@@ -11,7 +12,7 @@ public sealed class FoundryConnectConfiguration
     /// <summary>
     /// Gets the current configuration schema version.
     /// </summary>
-    public const int CurrentSchemaVersion = 2;
+    public const int CurrentSchemaVersion = ConfigurationSchemaVersions.ConnectCurrent;
 
     /// <summary>
     /// Gets the schema version of this configuration.

--- a/src/Foundry.Connect/Services/Configuration/ConnectConfigurationService.cs
+++ b/src/Foundry.Connect/Services/Configuration/ConnectConfigurationService.cs
@@ -109,13 +109,13 @@ public sealed class ConnectConfigurationService : IConnectConfigurationService
     {
         IsBootMediaUpdateRecommended = ConfigurationSchemaVersions.IsBootMediaUpdateRecommended(
             schemaVersion,
-            ConfigurationSchemaVersions.ConnectMinimumRecommended);
+            ConfigurationSchemaVersions.ConnectCurrent);
         if (IsBootMediaUpdateRecommended)
         {
             _logger.LogWarning(
-                "Foundry.Connect configuration uses schema version {SchemaVersion}, older than minimum recommended schema version {MinimumRecommendedSchemaVersion}. Boot media update is recommended.",
+                "Foundry.Connect configuration uses schema version {SchemaVersion}, older than current schema version {CurrentSchemaVersion}. Boot media update is recommended.",
                 schemaVersion,
-                ConfigurationSchemaVersions.ConnectMinimumRecommended);
+                ConfigurationSchemaVersions.ConnectCurrent);
         }
     }
 

--- a/src/Foundry.Connect/Services/Configuration/ConnectConfigurationService.cs
+++ b/src/Foundry.Connect/Services/Configuration/ConnectConfigurationService.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Text.Json;
 using Foundry.Connect.Models.Configuration;
+using ConfigurationSchemaVersions = Foundry.Core.Models.Configuration.ConfigurationSchemaVersions;
 using CoreConnectNetworkSettings = Foundry.Core.Models.Configuration.ConnectNetworkSettings;
 using Foundry.Connect.Services.Runtime;
 using Microsoft.Extensions.Logging;
@@ -106,13 +107,15 @@ public sealed class ConnectConfigurationService : IConnectConfigurationService
 
     private void ApplySchemaCompatibilityState(int schemaVersion)
     {
-        IsBootMediaUpdateRecommended = schemaVersion < FoundryConnectConfiguration.CurrentSchemaVersion;
+        IsBootMediaUpdateRecommended = ConfigurationSchemaVersions.IsBootMediaUpdateRecommended(
+            schemaVersion,
+            ConfigurationSchemaVersions.ConnectMinimumRecommended);
         if (IsBootMediaUpdateRecommended)
         {
             _logger.LogWarning(
-                "Foundry.Connect configuration uses schema version {SchemaVersion}, older than current schema version {CurrentSchemaVersion}. Boot media update is recommended.",
+                "Foundry.Connect configuration uses schema version {SchemaVersion}, older than minimum recommended schema version {MinimumRecommendedSchemaVersion}. Boot media update is recommended.",
                 schemaVersion,
-                FoundryConnectConfiguration.CurrentSchemaVersion);
+                ConfigurationSchemaVersions.ConnectMinimumRecommended);
         }
     }
 

--- a/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using Foundry.Core.Models.Configuration;
 using Foundry.Core.Models.Configuration.Deploy;
 
@@ -15,22 +14,7 @@ public sealed class ConfigurationSchemaVersionsTests
     }
 
     [Fact]
-    public void MinimumRecommendedVersions_OnlyExistForRuntimeContracts()
-    {
-        Assert.Equal(ConfigurationSchemaVersions.ConnectCurrent, ConfigurationSchemaVersions.ConnectMinimumRecommended);
-        Assert.Equal(ConfigurationSchemaVersions.DeployCurrent, ConfigurationSchemaVersions.DeployMinimumRecommended);
-        FieldInfo[] authoringMinimumFields = typeof(ConfigurationSchemaVersions)
-            .GetFields(BindingFlags.Public | BindingFlags.Static)
-            .Where(static field =>
-                field.Name.StartsWith("Foundry", StringComparison.Ordinal) &&
-                field.Name.Contains("MinimumRecommended", StringComparison.Ordinal))
-            .ToArray();
-
-        Assert.Empty(authoringMinimumFields);
-    }
-
-    [Fact]
-    public void IsBootMediaUpdateRecommended_UsesMinimumRecommendedSchemaVersion()
+    public void IsBootMediaUpdateRecommended_UsesCurrentSchemaVersion()
     {
         Assert.False(ConfigurationSchemaVersions.IsBootMediaUpdateRecommended(4, 3));
         Assert.False(ConfigurationSchemaVersions.IsBootMediaUpdateRecommended(3, 3));

--- a/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Foundry.Core.Models.Configuration;
 using Foundry.Core.Models.Configuration.Deploy;
 
@@ -30,10 +31,31 @@ public sealed class ConfigurationSchemaVersionsTests
     }
 
     [Fact]
+    public void MinimumRecommendedVersions_AreDeclaredIndependentlyFromCurrentVersions()
+    {
+        string source = File.ReadAllText(GetConfigurationSchemaVersionsSourcePath());
+
+        Assert.DoesNotContain("ConnectMinimumRecommended = ConnectCurrent", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("DeployMinimumRecommended = DeployCurrent", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void IsBootMediaUpdateRecommended_UsesMinimumRecommendedSchemaVersion()
     {
         Assert.False(ConfigurationSchemaVersions.IsBootMediaUpdateRecommended(4, 3));
         Assert.False(ConfigurationSchemaVersions.IsBootMediaUpdateRecommended(3, 3));
         Assert.True(ConfigurationSchemaVersions.IsBootMediaUpdateRecommended(2, 3));
+    }
+
+    private static string GetConfigurationSchemaVersionsSourcePath([CallerFilePath] string testFilePath = "")
+    {
+        return Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(testFilePath)!,
+            "..",
+            "..",
+            "Foundry.Core",
+            "Models",
+            "Configuration",
+            "ConfigurationSchemaVersions.cs"));
     }
 }

--- a/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using Foundry.Core.Models.Configuration;
 using Foundry.Core.Models.Configuration.Deploy;
 
@@ -31,31 +30,10 @@ public sealed class ConfigurationSchemaVersionsTests
     }
 
     [Fact]
-    public void MinimumRecommendedVersions_AreDeclaredIndependentlyFromCurrentVersions()
-    {
-        string source = File.ReadAllText(GetConfigurationSchemaVersionsSourcePath());
-
-        Assert.DoesNotContain("ConnectMinimumRecommended = ConnectCurrent", source, StringComparison.Ordinal);
-        Assert.DoesNotContain("DeployMinimumRecommended = DeployCurrent", source, StringComparison.Ordinal);
-    }
-
-    [Fact]
     public void IsBootMediaUpdateRecommended_UsesMinimumRecommendedSchemaVersion()
     {
         Assert.False(ConfigurationSchemaVersions.IsBootMediaUpdateRecommended(4, 3));
         Assert.False(ConfigurationSchemaVersions.IsBootMediaUpdateRecommended(3, 3));
         Assert.True(ConfigurationSchemaVersions.IsBootMediaUpdateRecommended(2, 3));
-    }
-
-    private static string GetConfigurationSchemaVersionsSourcePath([CallerFilePath] string testFilePath = "")
-    {
-        return Path.GetFullPath(Path.Combine(
-            Path.GetDirectoryName(testFilePath)!,
-            "..",
-            "..",
-            "Foundry.Core",
-            "Models",
-            "Configuration",
-            "ConfigurationSchemaVersions.cs"));
     }
 }

--- a/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Models.Configuration.Deploy;
+
+namespace Foundry.Core.Tests.Configuration;
+
+public sealed class ConfigurationSchemaVersionsTests
+{
+    [Fact]
+    public void CurrentVersions_MatchConfigurationDocumentContracts()
+    {
+        Assert.Equal(FoundryConfigurationDocument.CurrentSchemaVersion, ConfigurationSchemaVersions.FoundryCurrent);
+        Assert.Equal(FoundryConnectConfigurationDocument.CurrentSchemaVersion, ConfigurationSchemaVersions.ConnectCurrent);
+        Assert.Equal(FoundryDeployConfigurationDocument.CurrentSchemaVersion, ConfigurationSchemaVersions.DeployCurrent);
+    }
+
+    [Fact]
+    public void MinimumRecommendedVersions_OnlyExistForRuntimeContracts()
+    {
+        Assert.Equal(ConfigurationSchemaVersions.ConnectCurrent, ConfigurationSchemaVersions.ConnectMinimumRecommended);
+        Assert.Equal(ConfigurationSchemaVersions.DeployCurrent, ConfigurationSchemaVersions.DeployMinimumRecommended);
+        FieldInfo[] authoringMinimumFields = typeof(ConfigurationSchemaVersions)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(static field =>
+                field.Name.StartsWith("Foundry", StringComparison.Ordinal) &&
+                field.Name.Contains("MinimumRecommended", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Empty(authoringMinimumFields);
+    }
+
+    [Fact]
+    public void IsBootMediaUpdateRecommended_UsesMinimumRecommendedSchemaVersion()
+    {
+        Assert.False(ConfigurationSchemaVersions.IsBootMediaUpdateRecommended(4, 3));
+        Assert.False(ConfigurationSchemaVersions.IsBootMediaUpdateRecommended(3, 3));
+        Assert.True(ConfigurationSchemaVersions.IsBootMediaUpdateRecommended(2, 3));
+    }
+}

--- a/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
+++ b/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
@@ -1,0 +1,19 @@
+namespace Foundry.Core.Models.Configuration;
+
+public static class ConfigurationSchemaVersions
+{
+    public const int FoundryCurrent = 10;
+
+    public const int ConnectCurrent = 2;
+
+    public const int ConnectMinimumRecommended = ConnectCurrent;
+
+    public const int DeployCurrent = 8;
+
+    public const int DeployMinimumRecommended = DeployCurrent;
+
+    public static bool IsBootMediaUpdateRecommended(int schemaVersion, int minimumRecommendedSchemaVersion)
+    {
+        return schemaVersion < minimumRecommendedSchemaVersion;
+    }
+}

--- a/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
+++ b/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
@@ -6,11 +6,11 @@ public static class ConfigurationSchemaVersions
 
     public const int ConnectCurrent = 2;
 
-    public const int ConnectMinimumRecommended = ConnectCurrent;
+    public const int ConnectMinimumRecommended = 2;
 
     public const int DeployCurrent = 8;
 
-    public const int DeployMinimumRecommended = DeployCurrent;
+    public const int DeployMinimumRecommended = 8;
 
     public static bool IsBootMediaUpdateRecommended(int schemaVersion, int minimumRecommendedSchemaVersion)
     {

--- a/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
+++ b/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
@@ -6,14 +6,10 @@ public static class ConfigurationSchemaVersions
 
     public const int ConnectCurrent = 2;
 
-    public const int ConnectMinimumRecommended = 2;
-
     public const int DeployCurrent = 8;
 
-    public const int DeployMinimumRecommended = 8;
-
-    public static bool IsBootMediaUpdateRecommended(int schemaVersion, int minimumRecommendedSchemaVersion)
+    public static bool IsBootMediaUpdateRecommended(int schemaVersion, int currentSchemaVersion)
     {
-        return schemaVersion < minimumRecommendedSchemaVersion;
+        return schemaVersion < currentSchemaVersion;
     }
 }

--- a/src/Foundry.Core/Models/Configuration/Deploy/FoundryDeployConfigurationDocument.cs
+++ b/src/Foundry.Core/Models/Configuration/Deploy/FoundryDeployConfigurationDocument.cs
@@ -1,3 +1,4 @@
+using Foundry.Core.Models.Configuration;
 using Foundry.Telemetry;
 
 namespace Foundry.Core.Models.Configuration.Deploy;
@@ -10,7 +11,7 @@ public sealed record FoundryDeployConfigurationDocument
     /// <summary>
     /// Gets the current schema version for Foundry.Deploy configuration documents.
     /// </summary>
-    public const int CurrentSchemaVersion = 8;
+    public const int CurrentSchemaVersion = ConfigurationSchemaVersions.DeployCurrent;
 
     /// <summary>
     /// Gets the schema version of this deployment configuration document.

--- a/src/Foundry.Core/Models/Configuration/FoundryConfigurationDocument.cs
+++ b/src/Foundry.Core/Models/Configuration/FoundryConfigurationDocument.cs
@@ -10,7 +10,7 @@ public sealed record FoundryConfigurationDocument
     /// <summary>
     /// Gets the current schema version for Foundry configuration documents.
     /// </summary>
-    public const int CurrentSchemaVersion = 10;
+    public const int CurrentSchemaVersion = ConfigurationSchemaVersions.FoundryCurrent;
 
     /// <summary>
     /// Gets the schema version of this configuration document.

--- a/src/Foundry.Core/Models/Configuration/FoundryConnectConfigurationDocument.cs
+++ b/src/Foundry.Core/Models/Configuration/FoundryConnectConfigurationDocument.cs
@@ -10,7 +10,7 @@ public sealed record FoundryConnectConfigurationDocument
     /// <summary>
     /// Gets the current schema version for Foundry.Connect configuration documents.
     /// </summary>
-    public const int CurrentSchemaVersion = 2;
+    public const int CurrentSchemaVersion = ConfigurationSchemaVersions.ConnectCurrent;
 
     /// <summary>
     /// Gets the schema version of this configuration document.

--- a/src/Foundry.Deploy.Tests/DeployConfigurationServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeployConfigurationServiceTests.cs
@@ -8,7 +8,7 @@ namespace Foundry.Deploy.Tests;
 public sealed class DeployConfigurationServiceTests
 {
     [Fact]
-    public void LoadOptional_WhenSchemaIsOlderThanMinimumRecommended_RecommendsBootMediaUpdate()
+    public void LoadOptional_WhenSchemaIsOlderThanCurrent_RecommendsBootMediaUpdate()
     {
         using var tempDirectory = new TemporaryDirectory();
         string configurationPath = CreateJsonFile(
@@ -16,7 +16,7 @@ public sealed class DeployConfigurationServiceTests
             "foundry.deploy.config.json",
             $$"""
             {
-              "schemaVersion": {{Foundry.Core.Models.Configuration.ConfigurationSchemaVersions.DeployMinimumRecommended - 1}}
+              "schemaVersion": {{Foundry.Core.Models.Configuration.ConfigurationSchemaVersions.DeployCurrent - 1}}
             }
             """);
 
@@ -30,30 +30,8 @@ public sealed class DeployConfigurationServiceTests
             logger.Entries,
             entry =>
                 entry.LogLevel == LogLevel.Warning &&
-                entry.Message.Contains("minimum recommended schema version", StringComparison.Ordinal) &&
-                entry.Message.Contains(Foundry.Core.Models.Configuration.ConfigurationSchemaVersions.DeployMinimumRecommended.ToString(), StringComparison.Ordinal));
-    }
-
-    [Fact]
-    public void LoadOptional_WhenSchemaMatchesMinimumRecommended_DoesNotRecommendBootMediaUpdate()
-    {
-        using var tempDirectory = new TemporaryDirectory();
-        string configurationPath = CreateJsonFile(
-            tempDirectory.Path,
-            "foundry.deploy.config.json",
-            $$"""
-            {
-              "schemaVersion": {{Foundry.Core.Models.Configuration.ConfigurationSchemaVersions.DeployMinimumRecommended}}
-            }
-            """);
-
-        var logger = new RecordingLogger<DeployConfigurationService>();
-        var service = new DeployConfigurationService(logger, configurationPath);
-
-        DeployConfigurationLoadResult result = service.LoadOptional();
-
-        Assert.False(result.IsBootMediaUpdateRecommended);
-        Assert.DoesNotContain(logger.Entries, entry => entry.LogLevel == LogLevel.Warning);
+                entry.Message.Contains("current schema version", StringComparison.Ordinal) &&
+                entry.Message.Contains(Foundry.Core.Models.Configuration.ConfigurationSchemaVersions.DeployCurrent.ToString(), StringComparison.Ordinal));
     }
 
     [Fact]

--- a/src/Foundry.Deploy.Tests/DeployConfigurationServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeployConfigurationServiceTests.cs
@@ -1,5 +1,6 @@
 using Foundry.Deploy.Models.Configuration;
 using Foundry.Deploy.Services.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Foundry.Deploy.Tests;
@@ -7,7 +8,7 @@ namespace Foundry.Deploy.Tests;
 public sealed class DeployConfigurationServiceTests
 {
     [Fact]
-    public void LoadOptional_WhenSchemaIsOlderThanCurrent_RecommendsBootMediaUpdate()
+    public void LoadOptional_WhenSchemaIsOlderThanMinimumRecommended_RecommendsBootMediaUpdate()
     {
         using var tempDirectory = new TemporaryDirectory();
         string configurationPath = CreateJsonFile(
@@ -15,20 +16,44 @@ public sealed class DeployConfigurationServiceTests
             "foundry.deploy.config.json",
             $$"""
             {
-              "schemaVersion": {{FoundryDeployConfigurationDocument.CurrentSchemaVersion - 1}}
+              "schemaVersion": {{Foundry.Core.Models.Configuration.ConfigurationSchemaVersions.DeployMinimumRecommended - 1}}
             }
             """);
 
-        var service = new DeployConfigurationService(
-            NullLogger<DeployConfigurationService>.Instance,
-            configurationPath);
+        var logger = new RecordingLogger<DeployConfigurationService>();
+        var service = new DeployConfigurationService(logger, configurationPath);
 
         DeployConfigurationLoadResult result = service.LoadOptional();
 
-        Assert.True(result.Exists);
-        Assert.NotNull(result.Document);
-        Assert.Equal(FoundryDeployConfigurationDocument.CurrentSchemaVersion - 1, result.Document.SchemaVersion);
         Assert.True(result.IsBootMediaUpdateRecommended);
+        Assert.Contains(
+            logger.Entries,
+            entry =>
+                entry.LogLevel == LogLevel.Warning &&
+                entry.Message.Contains("minimum recommended schema version", StringComparison.Ordinal) &&
+                entry.Message.Contains(Foundry.Core.Models.Configuration.ConfigurationSchemaVersions.DeployMinimumRecommended.ToString(), StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void LoadOptional_WhenSchemaMatchesMinimumRecommended_DoesNotRecommendBootMediaUpdate()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        string configurationPath = CreateJsonFile(
+            tempDirectory.Path,
+            "foundry.deploy.config.json",
+            $$"""
+            {
+              "schemaVersion": {{Foundry.Core.Models.Configuration.ConfigurationSchemaVersions.DeployMinimumRecommended}}
+            }
+            """);
+
+        var logger = new RecordingLogger<DeployConfigurationService>();
+        var service = new DeployConfigurationService(logger, configurationPath);
+
+        DeployConfigurationLoadResult result = service.LoadOptional();
+
+        Assert.False(result.IsBootMediaUpdateRecommended);
+        Assert.DoesNotContain(logger.Entries, entry => entry.LogLevel == LogLevel.Warning);
     }
 
     [Fact]
@@ -111,4 +136,32 @@ public sealed class DeployConfigurationServiceTests
             }
         }
     }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new LogEntry(logLevel, formatter(state, exception)));
+        }
+    }
+
+    private sealed record LogEntry(LogLevel LogLevel, string Message);
 }

--- a/src/Foundry.Deploy/Models/Configuration/FoundryDeployConfigurationDocument.cs
+++ b/src/Foundry.Deploy/Models/Configuration/FoundryDeployConfigurationDocument.cs
@@ -1,3 +1,4 @@
+using Foundry.Core.Models.Configuration;
 using Foundry.Telemetry;
 using CoreDeployNetworkSettings = Foundry.Core.Models.Configuration.Deploy.DeployNetworkSettings;
 
@@ -11,7 +12,7 @@ public sealed record FoundryDeployConfigurationDocument
     /// <summary>
     /// Gets the current configuration schema version.
     /// </summary>
-    public const int CurrentSchemaVersion = 8;
+    public const int CurrentSchemaVersion = ConfigurationSchemaVersions.DeployCurrent;
 
     /// <summary>
     /// Gets the schema version of this configuration.

--- a/src/Foundry.Deploy/Services/Configuration/DeployConfigurationService.cs
+++ b/src/Foundry.Deploy/Services/Configuration/DeployConfigurationService.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Text.Json;
 using Foundry.Deploy.Models.Configuration;
+using ConfigurationSchemaVersions = Foundry.Core.Models.Configuration.ConfigurationSchemaVersions;
 using Microsoft.Extensions.Logging;
 
 namespace Foundry.Deploy.Services.Configuration;
@@ -63,23 +64,25 @@ public sealed class DeployConfigurationService : IDeployConfigurationService
                 };
             }
 
-            if (document.SchemaVersion > FoundryDeployConfigurationDocument.CurrentSchemaVersion)
+            if (document.SchemaVersion > ConfigurationSchemaVersions.DeployCurrent)
             {
                 _logger.LogWarning(
                     "Deploy configuration at '{ConfigurationPath}' uses schema version {SchemaVersion}, newer than supported schema version {SupportedSchemaVersion}. Unknown properties will be ignored.",
                     _configurationPath,
                     document.SchemaVersion,
-                    FoundryDeployConfigurationDocument.CurrentSchemaVersion);
+                    ConfigurationSchemaVersions.DeployCurrent);
             }
 
-            bool isBootMediaUpdateRecommended = document.SchemaVersion < FoundryDeployConfigurationDocument.CurrentSchemaVersion;
+            bool isBootMediaUpdateRecommended = ConfigurationSchemaVersions.IsBootMediaUpdateRecommended(
+                document.SchemaVersion,
+                ConfigurationSchemaVersions.DeployMinimumRecommended);
             if (isBootMediaUpdateRecommended)
             {
                 _logger.LogWarning(
-                    "Deploy configuration at '{ConfigurationPath}' uses schema version {SchemaVersion}, older than current schema version {CurrentSchemaVersion}. Boot media update is recommended.",
+                    "Deploy configuration at '{ConfigurationPath}' uses schema version {SchemaVersion}, older than minimum recommended schema version {MinimumRecommendedSchemaVersion}. Boot media update is recommended.",
                     _configurationPath,
                     document.SchemaVersion,
-                    FoundryDeployConfigurationDocument.CurrentSchemaVersion);
+                    ConfigurationSchemaVersions.DeployMinimumRecommended);
             }
 
             _logger.LogInformation(

--- a/src/Foundry.Deploy/Services/Configuration/DeployConfigurationService.cs
+++ b/src/Foundry.Deploy/Services/Configuration/DeployConfigurationService.cs
@@ -75,14 +75,14 @@ public sealed class DeployConfigurationService : IDeployConfigurationService
 
             bool isBootMediaUpdateRecommended = ConfigurationSchemaVersions.IsBootMediaUpdateRecommended(
                 document.SchemaVersion,
-                ConfigurationSchemaVersions.DeployMinimumRecommended);
+                ConfigurationSchemaVersions.DeployCurrent);
             if (isBootMediaUpdateRecommended)
             {
                 _logger.LogWarning(
-                    "Deploy configuration at '{ConfigurationPath}' uses schema version {SchemaVersion}, older than minimum recommended schema version {MinimumRecommendedSchemaVersion}. Boot media update is recommended.",
+                    "Deploy configuration at '{ConfigurationPath}' uses schema version {SchemaVersion}, older than current schema version {CurrentSchemaVersion}. Boot media update is recommended.",
                     _configurationPath,
                     document.SchemaVersion,
-                    ConfigurationSchemaVersions.DeployMinimumRecommended);
+                    ConfigurationSchemaVersions.DeployCurrent);
             }
 
             _logger.LogInformation(


### PR DESCRIPTION
## Summary
Centralizes Foundry schema version values in a single Core catalog while keeping existing model constants as compatibility aliases.

## Reason
Schema versions were duplicated across Core, Connect, and Deploy runtime models. Centralizing them makes version bumps easier and allows Connect and Deploy to use explicit minimum recommended schema thresholds for boot media warnings.

## Main changes
- Added `ConfigurationSchemaVersions` in Core.
- Aliased existing authoring, Connect, and Deploy `CurrentSchemaVersion` constants to the catalog.
- Updated Connect and Deploy warning checks to use centralized minimum recommended thresholds.
- Added tests for catalog values, absence of an authoring minimum warning threshold, and runtime warning log behavior.

## Testing
- `dotnet test src\Foundry.Core.Tests\Foundry.Core.Tests.csproj --no-restore -v:minimal -m:1`
- `dotnet test src\Foundry.Connect.Tests\Foundry.Connect.Tests.csproj --no-restore -v:minimal -m:1`
- `dotnet test src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --no-restore -v:minimal -m:1`
