### PR TITLE
feat(about): improve licenses page

### DIFF
--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -46,13 +46,10 @@
     <value>الترخيص</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>{0} الصفحة الرئيسية</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>التراخيص</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>مفتوح</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>الملف الشخصي</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>مستودع</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD يتضمن أدوات 7-Zip Extra لدعم إنشاء الوسائط.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-الرمز البريدي اضافية</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows تأليف وسائط النشر</value>

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>الترخيص</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} الصفحة الرئيسية</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>الموقع الإلكتروني</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>التراخيص</value>

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>الترخيص</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>التراخيص</value>
   </data>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Лиценз</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Лицензи</value>
   </data>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -46,13 +46,10 @@
     <value>Лиценз</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Начална страница на {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Лицензи</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Отворете</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Профил</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Хранилище</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD включва допълнителни инструменти 7-Zip за поддръжка на създаване на мултимедия.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows създаване на медия за внедряване</value>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Лиценз</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Начална страница на {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Уебсайт</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Лицензи</value>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licence</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Domovská stránka {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Web</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>licence</value>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licence</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Domovská stránka {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>licence</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Otevřít</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Úložiště</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD obsahuje nástroje 7-Zip Extra pro podporu vytváření médií.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-zip navíc</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows vytváření médií pro nasazení</value>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licence</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>licence</value>
   </data>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licens</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>{0}-hjemmeside</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenser</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Åbn</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Depot</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD inkluderer 7-Zip Ekstra værktøj til medieoprettelse.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Ekstra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows udrulning af medier</value>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licens</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenser</value>
   </data>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licens</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0}-hjemmeside</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Websted</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenser</value>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Lizenz</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Lizenzen</value>
   </data>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Lizenz</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0}-Homepage</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Website</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Lizenzen</value>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -46,13 +46,10 @@
     <value>Lizenz</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>{0}-Homepage</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Lizenzen</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Offen</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Repository</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD enthält 7-Zip Extra-Tools zur Unterstützung der Medienerstellung.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip-Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows Erstellung von Bereitstellungsmedien</value>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Άδεια</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Αρχική σελίδα {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Ιστότοπος</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Άδειες</value>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -46,13 +46,10 @@
     <value>Άδεια</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Αρχική σελίδα {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Άδειες</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Ανοίξτε</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Προφίλ</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Αποθετήριο</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Το Foundry OSD περιλαμβάνει εργαλείο 7-Zip Extra για υποστήριξη δημιουργίας πολυμέσων.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows ανάπτυξη μέσων συγγραφής</value>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Άδεια</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Άδειες</value>
   </data>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -51,9 +51,6 @@
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenses</value>
   </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Open</value>
-  </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profile</value>
   </data>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Repository</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD includes 7-Zip Extra tooling for media creation support.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows deployment media authoring</value>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>License</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenses</value>
   </data>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>License</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Website</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenses</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -51,9 +51,6 @@
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenses</value>
   </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Open</value>
-  </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profile</value>
   </data>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Repository</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD includes 7-Zip Extra tooling for media creation support.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows deployment media authoring</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>License</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenses</value>
   </data>
@@ -82,10 +85,10 @@
     <value>Support</value>
   </data>
   <data name="AboutDialog.ThirdPartyLicenseDescription" xml:space="preserve">
-    <value>Third-party package licenses are tracked through the project repository and dependency manifests.</value>
+    <value>Foundry OSD uses the following libraries and tools. Their licenses and project pages are listed below.</value>
   </data>
   <data name="AboutDialog.ThirdPartyLicenseTitle" xml:space="preserve">
-    <value>Third-party dependencies</value>
+    <value>Third-party licenses</value>
   </data>
   <data name="AboutDialog.Title" xml:space="preserve">
     <value>About Foundry OSD</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>License</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Website</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenses</value>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licencia</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Página principal de {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencias</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Abierto</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Perfil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Repositorio</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD incluye herramientas 7-Zip Extra para soporte de creación de medios.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7 cremalleras adicionales</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows creación de medios de implementación</value>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licencia</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Página principal de {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Sitio web</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencias</value>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licencia</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencias</value>
   </data>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licencia</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Página principal de {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencias</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Abierto</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Perfil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Repositorio</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD incluye herramientas 7-Zip Extra para soporte de creación de medios.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7 cremalleras adicionales</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows creación de medios de implementación</value>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licencia</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Página principal de {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Sitio web</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencias</value>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licencia</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencias</value>
   </data>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -46,13 +46,10 @@
     <value>Litsents</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>{0} avaleht</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Litsentsid</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Avatud</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profiil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Hoidla</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD sisaldab 7-Zip Extra tööriistu meedia loomise toeks.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows juurutusmeedia loomine</value>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Litsents</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Litsentsid</value>
   </data>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Litsents</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} avaleht</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Veebisait</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Litsentsid</value>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Lisenssi</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Lisenssit</value>
   </data>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Lisenssi</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0}-kotisivu</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Verkkosivusto</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Lisenssit</value>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -46,13 +46,10 @@
     <value>Lisenssi</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>{0}-kotisivu</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Lisenssit</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Avaa</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profiili</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Arkisto</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD sisältää 7-Zip Extra -työkalut median luomiseen.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows käyttöönottomedian luonti</value>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licence</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Page d’accueil de {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Site web</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licences</value>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licence</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Page d’accueil de {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licences</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Ouvert</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Référentiel</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD inclut les outils 7-Zip Extra pour la prise en charge de la création multimédia.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7 fermetures éclair supplémentaires</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows création de supports de déploiement</value>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licence</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licences</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licence</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Page d’accueil de {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Site web</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licences</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licence</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Page d’accueil de {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licences</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Ouvrir</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Dépôt</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD inclut les outils 7-Zip Extra pour la création de médias.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Création de médias de déploiement Windows</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licence</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licences</value>
   </data>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>רישיון</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>רישיונות</value>
   </data>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>רישיון</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>דף הבית של {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>אתר</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>רישיונות</value>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -46,13 +46,10 @@
     <value>רישיון</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>דף הבית של {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>רישיונות</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>פתוח</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>פרופיל</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>מאגר</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD כולל כלי 7-Zip Extra לתמיכה ביצירת מדיה.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows עריכת מדיה לפריסה</value>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licenca</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licence</value>
   </data>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licenca</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Početna stranica za {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licence</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Otvoriti</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Spremište</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD uključuje 7-Zip Extra alate za podršku stvaranja medija.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows autorstvo medija za implementaciju</value>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licenca</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Početna stranica za {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Web-mjesto</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licence</value>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licenc</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencek</value>
   </data>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licenc</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} kezdőlapja</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Webhely</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencek</value>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licenc</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>{0} kezdőlapja</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencek</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Nyissa meg</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Adattár</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Az Foundry OSD 7-Zip Extra eszközöket tartalmaz a médiakészítés támogatásához.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-cipzáros extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows telepítési adathordozó készítése</value>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licenza</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenze</value>
   </data>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licenza</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Homepage di {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Sito web</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenze</value>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licenza</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Homepage di {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenze</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Aperto</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profilo</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Deposito</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD include gli strumenti 7-Zip Extra per il supporto della creazione di contenuti multimediali.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7 zip extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows creazione di supporti di distribuzione</value>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -46,13 +46,10 @@
     <value>ライセンス</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>{0} のホームページ</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>ライセンス</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>開く</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>プロフィール</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>リポジトリ</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD には、メディア作成をサポートする 7-Zip Extra ツールが含まれています。</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip エクストラ</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows 導入メディア オーサリング</value>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>ライセンス</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>ライセンス</value>
   </data>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>ライセンス</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} のホームページ</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Web サイト</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>ライセンス</value>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>라이센스</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} 홈페이지</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>웹사이트</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>라이센스</value>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -46,13 +46,10 @@
     <value>라이센스</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>{0} 홈페이지</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>라이센스</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>열기</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>프로필</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>저장소</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD에는 미디어 생성 지원을 위한 7-Zip Extra 도구가 포함되어 있습니다.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip 추가</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows 배포 미디어 제작</value>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>라이센스</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>라이센스</value>
   </data>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licencija</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} pagrindinis puslapis</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Svetainė</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencijos</value>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licencija</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencijos</value>
   </data>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licencija</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>{0} pagrindinis puslapis</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencijos</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Atidaryti</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profilis</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Saugykla</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD apima 7-Zip Extra įrankį, skirtą medijos kūrimo palaikymui.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows diegimo laikmenos kūrimas</value>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licence</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>{0} sākumlapa</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licences</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Atvērt</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profils</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Repozitorijs</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD ietver 7-Zip Extra rīkus multivides izveides atbalstam.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows izvietošanas datu nesēja autorēšana</value>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licence</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licences</value>
   </data>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licence</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} sākumlapa</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Tīmekļa vietne</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licences</value>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Lisens</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0}-hjemmeside</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Nettsted</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Lisenser</value>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -46,13 +46,10 @@
     <value>Lisens</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>{0}-hjemmeside</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Lisenser</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Åpne</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Depot</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD inkluderer 7-zip-ekstraverktøy for støtte for medieskaping.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-zip ekstra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows redigering av distribusjonsmedier</value>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Lisens</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Lisenser</value>
   </data>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licentie</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0}-startpagina</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Website</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenties</value>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licentie</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>{0}-startpagina</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenties</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Openen</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profiel</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Bewaarplaats</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD bevat 7-Zip Extra tooling voor ondersteuning bij het maken van media.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>Extra rits met 7 ritsen</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows creatie van media voor implementatie</value>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licentie</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenties</value>
   </data>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licencja</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencje</value>
   </data>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licencja</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Strona główna {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencje</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Otwórz</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Repozytorium</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD zawiera narzędzia 7-Zip Extra do obsługi tworzenia multimediów.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows tworzenie nośników wdrożeniowych</value>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licencja</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Strona główna {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Witryna</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencje</value>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licença</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Página inicial de {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenças</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Abrir</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Perfil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Repositório</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD inclui ferramentas 7-Zip Extra para suporte à criação de mídia.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows criação de mídia de implantação</value>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licença</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenças</value>
   </data>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licença</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Página inicial de {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Site</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenças</value>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licença</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Página inicial de {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenças</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Abrir</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Perfil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Repositório</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD inclui ferramentas 7-Zip Extra para suporte à criação de mídia.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows criação de mídia de implantação</value>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licença</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenças</value>
   </data>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licença</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Página inicial de {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Site</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenças</value>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licență</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Pagina principală {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licențe</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Deschide</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Depozitul</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD include instrumente 7-Zip Extra pentru suport pentru crearea media.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows crearea media de implementare</value>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licență</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Pagina principală {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Site web</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licențe</value>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licență</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licențe</value>
   </data>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -46,13 +46,10 @@
     <value>Лицензия</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Домашняя страница {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Лицензии</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Открыть</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Профиль</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Репозиторий</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD включает дополнительные инструменты 7-Zip для поддержки создания мультимедиа.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Экстра</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows создание носителя для развертывания</value>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Лицензия</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Домашняя страница {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Веб-сайт</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Лицензии</value>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Лицензия</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Лицензии</value>
   </data>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licencia</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Domovská stránka {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencie</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Otvorte</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Úložisko</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD obsahuje 7-Zip Extra nástroje na podporu tvorby médií.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows vytváranie médií nasadenia</value>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licencia</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Domovská stránka {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Webová lokalita</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencie</value>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licencia</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licencie</value>
   </data>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licenca</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licence</value>
   </data>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licenca</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Domača stran {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licence</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Odpri</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Repozitorij</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD vključuje dodatno orodje 7-Zip Extra za podporo pri ustvarjanju medijev.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows avtorstvo medijev za uvajanje</value>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licenca</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Domača stran {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Spletno mesto</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licence</value>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licenca</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licence</value>
   </data>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licenca</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Početna stranica za {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Veb-sajt</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licence</value>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licenca</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Početna stranica za {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licence</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Otvori</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Repozitorijum</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD uključuje 7-Zip Ektra alate za podršku kreiranju medija.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Ektra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows Autorstvo medija za primenu</value>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licens</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0}-hemsida</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Webbplats</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenser</value>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -46,13 +46,10 @@
     <value>Licens</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>{0}-hemsida</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenser</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Öppna</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Förvar</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD inkluderar 7-Zip Extra verktyg för att skapa media.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows redigering av distributionsmedier</value>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Licens</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Licenser</value>
   </data>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>ใบอนุญาต</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>หน้าแรกของ {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>เว็บไซต์</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>ใบอนุญาต</value>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -46,13 +46,10 @@
     <value>ใบอนุญาต</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>หน้าแรกของ {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>ใบอนุญาต</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>เปิด</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>โปรไฟล์</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>พื้นที่เก็บข้อมูล</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD รวมถึงเครื่องมือ 7-Zip Extra สำหรับการสนับสนุนการสร้างสื่อ</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip พิเศษ</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows การเขียนสื่อการปรับใช้งาน</value>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>ใบอนุญาต</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>ใบอนุญาต</value>
   </data>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -46,13 +46,10 @@
     <value>Lisans</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>{0} ana sayfası</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Lisanslar</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>Açık</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Profil</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Depo</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD, medya oluşturma desteği için 7-Zip Ekstra araç içerir.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Ekstra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows dağıtım ortamı yazma</value>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Lisans</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Lisanslar</value>
   </data>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Lisans</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} ana sayfası</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Web sitesi</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Lisanslar</value>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -46,13 +46,10 @@
     <value>Ліцензія</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>Домашня сторінка {0}</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Ліцензії</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>відкритий</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>Профіль</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>Репозиторій</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD містить додаткові інструменти 7-Zip Extra для підтримки створення медіа.</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7-Zip Extra</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows створення носіїв для розгортання</value>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Ліцензія</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>Домашня сторінка {0}</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>Веб-сайт</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Ліцензії</value>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>Ліцензія</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>Ліцензії</value>
   </data>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>许可证</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>许可证</value>
   </data>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -46,13 +46,10 @@
     <value>许可证</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>{0} 主页</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>许可证</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>打开</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>公司简介</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>存储库</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD 包括用于媒体创建支持的 7-Zip Extra 工具。</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7 拉链额外</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows 部署媒体创作</value>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>许可证</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} 主页</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>网站</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>许可证</value>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -45,8 +45,8 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>許可證</value>
   </data>
-  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} 首頁</value>
+  <data name="AboutDialog.HomepageLink" xml:space="preserve">
+    <value>網站</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>許可證</value>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -45,6 +45,9 @@
   <data name="AboutDialog.LicenseLink" xml:space="preserve">
     <value>許可證</value>
   </data>
+  <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
+    <value>{0} homepage</value>
+  </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>許可證</value>
   </data>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -46,13 +46,10 @@
     <value>許可證</value>
   </data>
   <data name="AboutDialog.HomepageLinkFormat" xml:space="preserve">
-    <value>{0} homepage</value>
+    <value>{0} 首頁</value>
   </data>
   <data name="AboutDialog.LicensesSection" xml:space="preserve">
     <value>許可證</value>
-  </data>
-  <data name="AboutDialog.OpenLink" xml:space="preserve">
-    <value>打開</value>
   </data>
   <data name="AboutDialog.OpenProfile" xml:space="preserve">
     <value>公司簡介</value>
@@ -71,12 +68,6 @@
   </data>
   <data name="AboutDialog.RepositoryLink" xml:space="preserve">
     <value>儲存庫</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseDescription" xml:space="preserve">
-    <value>Foundry OSD 包括用於媒體創建支援的 7-Zip Extra 工具。</value>
-  </data>
-  <data name="AboutDialog.SevenZipLicenseTitle" xml:space="preserve">
-    <value>7 拉鍊額外</value>
   </data>
   <data name="AboutDialog.Subtitle" xml:space="preserve">
     <value>Windows 部署媒體創作</value>

--- a/src/Foundry/ViewModels/Settings/AboutUsSettingViewModel.cs
+++ b/src/Foundry/ViewModels/Settings/AboutUsSettingViewModel.cs
@@ -81,7 +81,19 @@ namespace Foundry.ViewModels
                 "https://github.com/microsoft/WindowsAppSDK",
                 true),
             CreateThirdPartyLicenseItem(
-                "DevWinUI",
+                "Microsoft.Windows.CsWinRT",
+                "MIT",
+                "https://github.com/microsoft/CsWinRT/blob/master/LICENSE",
+                "https://github.com/microsoft/CsWinRT",
+                false),
+            CreateThirdPartyLicenseItem(
+                "Microsoft Windows SDK Build Tools",
+                "Microsoft Software License Terms",
+                "https://aka.ms/WindowSDKLicenseTerms",
+                "https://developer.microsoft.com/windows/downloads/windows-sdk/",
+                true),
+            CreateThirdPartyLicenseItem(
+                "DevWinUI controls and tooling",
                 "MIT",
                 "https://github.com/Ghost1372/DevWinUI/blob/main/LICENSE",
                 "https://github.com/Ghost1372/DevWinUI",
@@ -93,7 +105,7 @@ namespace Foundry.ViewModels
                 "https://github.com/CommunityToolkit/dotnet",
                 true),
             CreateThirdPartyLicenseItem(
-                "CommunityToolkit.WinUI",
+                "CommunityToolkit.WinUI SettingsControls",
                 "MIT",
                 "https://github.com/CommunityToolkit/Windows/blob/main/License.md",
                 "https://github.com/CommunityToolkit/Windows",
@@ -105,10 +117,22 @@ namespace Foundry.ViewModels
                 "https://learn.microsoft.com/dotnet/core/extensions/generic-host",
                 true),
             CreateThirdPartyLicenseItem(
-                "Serilog",
+                "Microsoft.Extensions.Logging.Abstractions",
+                "MIT",
+                "https://github.com/dotnet/runtime/blob/main/LICENSE.TXT",
+                "https://learn.microsoft.com/dotnet/core/extensions/logging",
+                false),
+            CreateThirdPartyLicenseItem(
+                "Serilog core and sinks",
                 "Apache-2.0",
                 "https://github.com/serilog/serilog/blob/dev/LICENSE",
                 "https://serilog.net/",
+                true),
+            CreateThirdPartyLicenseItem(
+                "Serilog.Extensions.Logging",
+                "Apache-2.0",
+                "https://github.com/serilog/serilog-extensions-logging/blob/dev/LICENSE",
+                "https://github.com/serilog/serilog-extensions-logging",
                 false),
             CreateThirdPartyLicenseItem(
                 "Velopack",
@@ -135,11 +159,17 @@ namespace Foundry.ViewModels
                 "https://github.com/w-ahmad/WinUI.TableView",
                 false),
             CreateThirdPartyLicenseItem(
+                "Windows ADK / Windows PE",
+                "Microsoft Software License Terms",
+                "https://learn.microsoft.com/windows-hardware/get-started/adk-install",
+                "https://learn.microsoft.com/windows-hardware/get-started/adk-install",
+                true),
+            CreateThirdPartyLicenseItem(
                 "7-Zip Extra",
                 "LGPL / BSD",
                 "https://www.7-zip.org/license.txt",
                 "https://www.7-zip.org/",
-                true)
+                false)
         };
 
         public ObservableCollection<ContributorItemViewModel> ContributorItems { get; } = [];

--- a/src/Foundry/ViewModels/Settings/AboutUsSettingViewModel.cs
+++ b/src/Foundry/ViewModels/Settings/AboutUsSettingViewModel.cs
@@ -69,34 +69,22 @@ namespace Foundry.ViewModels
         public IReadOnlyList<ThirdPartyLicenseItemViewModel> ThirdPartyLicenseItems => new[]
         {
             CreateThirdPartyLicenseItem(
+                "7-Zip Extra",
+                "LGPL / BSD",
+                "https://www.7-zip.org/license.txt",
+                "https://www.7-zip.org/",
+                false),
+            CreateThirdPartyLicenseItem(
                 ".NET",
                 "MIT",
                 "https://github.com/dotnet/runtime/blob/main/LICENSE.TXT",
                 "https://dotnet.microsoft.com/",
-                false),
-            CreateThirdPartyLicenseItem(
-                "Windows App SDK / WinUI 3",
-                "MIT",
-                "https://github.com/microsoft/WindowsAppSDK/blob/main/LICENSE",
-                "https://github.com/microsoft/WindowsAppSDK",
                 true),
             CreateThirdPartyLicenseItem(
-                "Microsoft.Windows.CsWinRT",
+                "Azure.Identity",
                 "MIT",
-                "https://github.com/microsoft/CsWinRT/blob/master/LICENSE",
-                "https://github.com/microsoft/CsWinRT",
-                false),
-            CreateThirdPartyLicenseItem(
-                "Microsoft Windows SDK Build Tools",
-                "Microsoft Software License Terms",
-                "https://aka.ms/WindowSDKLicenseTerms",
-                "https://developer.microsoft.com/windows/downloads/windows-sdk/",
-                true),
-            CreateThirdPartyLicenseItem(
-                "DevWinUI controls and tooling",
-                "MIT",
-                "https://github.com/Ghost1372/DevWinUI/blob/main/LICENSE",
-                "https://github.com/Ghost1372/DevWinUI",
+                "https://github.com/Azure/azure-sdk-for-net/blob/main/LICENSE.txt",
+                "https://github.com/Azure/azure-sdk-for-net",
                 false),
             CreateThirdPartyLicenseItem(
                 "CommunityToolkit.Mvvm",
@@ -111,16 +99,40 @@ namespace Foundry.ViewModels
                 "https://github.com/CommunityToolkit/Windows",
                 false),
             CreateThirdPartyLicenseItem(
+                "DevWinUI controls and tooling",
+                "MIT",
+                "https://github.com/Ghost1372/DevWinUI/blob/main/LICENSE",
+                "https://github.com/Ghost1372/DevWinUI",
+                true),
+            CreateThirdPartyLicenseItem(
+                "HtmlAgilityPack",
+                "MIT",
+                "https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE",
+                "https://html-agility-pack.net/",
+                false),
+            CreateThirdPartyLicenseItem(
+                "Microsoft Windows SDK Build Tools",
+                "Microsoft",
+                "https://aka.ms/WindowSDKLicenseTerms",
+                "https://developer.microsoft.com/windows/downloads/windows-sdk/",
+                true),
+            CreateThirdPartyLicenseItem(
                 "Microsoft.Extensions.Hosting / DependencyInjection",
                 "MIT",
                 "https://github.com/dotnet/runtime/blob/main/LICENSE.TXT",
                 "https://learn.microsoft.com/dotnet/core/extensions/generic-host",
-                true),
+                false),
             CreateThirdPartyLicenseItem(
                 "Microsoft.Extensions.Logging.Abstractions",
                 "MIT",
                 "https://github.com/dotnet/runtime/blob/main/LICENSE.TXT",
                 "https://learn.microsoft.com/dotnet/core/extensions/logging",
+                true),
+            CreateThirdPartyLicenseItem(
+                "Microsoft.Windows.CsWinRT",
+                "MIT",
+                "https://github.com/microsoft/CsWinRT/blob/master/LICENSE",
+                "https://github.com/microsoft/CsWinRT",
                 false),
             CreateThirdPartyLicenseItem(
                 "Serilog core and sinks",
@@ -141,34 +153,22 @@ namespace Foundry.ViewModels
                 "https://velopack.io/",
                 true),
             CreateThirdPartyLicenseItem(
-                "Azure.Identity",
-                "MIT",
-                "https://github.com/Azure/azure-sdk-for-net/blob/main/LICENSE.txt",
-                "https://github.com/Azure/azure-sdk-for-net",
+                "Windows ADK / Windows PE",
+                "Microsoft",
+                "https://learn.microsoft.com/windows-hardware/get-started/adk-install",
+                "https://learn.microsoft.com/windows-hardware/get-started/adk-install",
                 false),
             CreateThirdPartyLicenseItem(
-                "HtmlAgilityPack",
+                "Windows App SDK / WinUI 3",
                 "MIT",
-                "https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE",
-                "https://html-agility-pack.net/",
+                "https://github.com/microsoft/WindowsAppSDK/blob/main/LICENSE",
+                "https://github.com/microsoft/WindowsAppSDK",
                 true),
             CreateThirdPartyLicenseItem(
                 "WinUI.TableView",
                 "MIT",
                 "https://github.com/w-ahmad/WinUI.TableView/blob/master/LICENSE.md",
                 "https://github.com/w-ahmad/WinUI.TableView",
-                false),
-            CreateThirdPartyLicenseItem(
-                "Windows ADK / Windows PE",
-                "Microsoft Software License Terms",
-                "https://learn.microsoft.com/windows-hardware/get-started/adk-install",
-                "https://learn.microsoft.com/windows-hardware/get-started/adk-install",
-                true),
-            CreateThirdPartyLicenseItem(
-                "7-Zip Extra",
-                "LGPL / BSD",
-                "https://www.7-zip.org/license.txt",
-                "https://www.7-zip.org/",
                 false)
         };
 
@@ -259,7 +259,7 @@ namespace Foundry.ViewModels
                 name,
                 license,
                 new Uri(licenseUrl),
-                localizationService.FormatString("AboutDialog.HomepageLinkFormat", name),
+                localizationService.GetString("AboutDialog.HomepageLink"),
                 new Uri(homepageUrl),
                 isAlternate);
         }

--- a/src/Foundry/ViewModels/Settings/AboutUsSettingViewModel.cs
+++ b/src/Foundry/ViewModels/Settings/AboutUsSettingViewModel.cs
@@ -50,6 +50,10 @@ namespace Foundry.ViewModels
         public string AuthorsText => localizationService.GetString("AboutDialog.AuthorsText");
         public string FooterText => localizationService.GetString("AboutDialog.Footer");
         public string UsefulLinksText => localizationService.GetString("AboutDialog.UsefulLinks");
+        public string FoundryLicenseTitle => localizationService.GetString("AboutDialog.FoundryLicenseTitle");
+        public string FoundryLicenseDescription => localizationService.GetString("AboutDialog.FoundryLicenseDescription");
+        public string ThirdPartyLicenseTitle => localizationService.GetString("AboutDialog.ThirdPartyLicenseTitle");
+        public string ThirdPartyLicenseDescription => localizationService.GetString("AboutDialog.ThirdPartyLicenseDescription");
         public string CloseText => localizationService.GetString("Common.Close");
         public string ReleaseNotesLoadingText => localizationService.GetString("AboutDialog.ReleaseNotesLoading");
         public string ReleaseNotesErrorText => localizationService.GetString("AboutDialog.ReleaseNotesError");
@@ -62,26 +66,80 @@ namespace Foundry.ViewModels
         public Uri SupportUri { get; } = new(FoundryApplicationInfo.SupportUrl);
         public Uri LicenseUri { get; } = new(FoundryApplicationInfo.LicenseUrl);
 
-        public IReadOnlyList<AboutLinkItemViewModel> LicenseItems => new[]
+        public IReadOnlyList<ThirdPartyLicenseItemViewModel> ThirdPartyLicenseItems => new[]
         {
-            new AboutLinkItemViewModel(
-                localizationService.GetString("AboutDialog.FoundryLicenseTitle"),
-                localizationService.GetString("AboutDialog.FoundryLicenseDescription"),
-                localizationService.GetString("AboutDialog.OpenLink"),
-                LicenseUri,
+            CreateThirdPartyLicenseItem(
+                ".NET",
+                "MIT",
+                "https://github.com/dotnet/runtime/blob/main/LICENSE.TXT",
+                "https://dotnet.microsoft.com/",
                 false),
-            new AboutLinkItemViewModel(
-                localizationService.GetString("AboutDialog.SevenZipLicenseTitle"),
-                localizationService.GetString("AboutDialog.SevenZipLicenseDescription"),
-                localizationService.GetString("AboutDialog.OpenLink"),
-                new Uri("https://www.7-zip.org/license.txt"),
+            CreateThirdPartyLicenseItem(
+                "Windows App SDK / WinUI 3",
+                "MIT",
+                "https://github.com/microsoft/WindowsAppSDK/blob/main/LICENSE",
+                "https://github.com/microsoft/WindowsAppSDK",
                 true),
-            new AboutLinkItemViewModel(
-                localizationService.GetString("AboutDialog.ThirdPartyLicenseTitle"),
-                localizationService.GetString("AboutDialog.ThirdPartyLicenseDescription"),
-                localizationService.GetString("AboutDialog.OpenLink"),
-                RepositoryUri,
-                false)
+            CreateThirdPartyLicenseItem(
+                "DevWinUI",
+                "MIT",
+                "https://github.com/Ghost1372/DevWinUI/blob/main/LICENSE",
+                "https://github.com/Ghost1372/DevWinUI",
+                false),
+            CreateThirdPartyLicenseItem(
+                "CommunityToolkit.Mvvm",
+                "MIT",
+                "https://github.com/CommunityToolkit/dotnet/blob/main/License.md",
+                "https://github.com/CommunityToolkit/dotnet",
+                true),
+            CreateThirdPartyLicenseItem(
+                "CommunityToolkit.WinUI",
+                "MIT",
+                "https://github.com/CommunityToolkit/Windows/blob/main/License.md",
+                "https://github.com/CommunityToolkit/Windows",
+                false),
+            CreateThirdPartyLicenseItem(
+                "Microsoft.Extensions.Hosting / DependencyInjection",
+                "MIT",
+                "https://github.com/dotnet/runtime/blob/main/LICENSE.TXT",
+                "https://learn.microsoft.com/dotnet/core/extensions/generic-host",
+                true),
+            CreateThirdPartyLicenseItem(
+                "Serilog",
+                "Apache-2.0",
+                "https://github.com/serilog/serilog/blob/dev/LICENSE",
+                "https://serilog.net/",
+                false),
+            CreateThirdPartyLicenseItem(
+                "Velopack",
+                "MIT",
+                "https://github.com/velopack/velopack/blob/develop/LICENSE",
+                "https://velopack.io/",
+                true),
+            CreateThirdPartyLicenseItem(
+                "Azure.Identity",
+                "MIT",
+                "https://github.com/Azure/azure-sdk-for-net/blob/main/LICENSE.txt",
+                "https://github.com/Azure/azure-sdk-for-net",
+                false),
+            CreateThirdPartyLicenseItem(
+                "HtmlAgilityPack",
+                "MIT",
+                "https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE",
+                "https://html-agility-pack.net/",
+                true),
+            CreateThirdPartyLicenseItem(
+                "WinUI.TableView",
+                "MIT",
+                "https://github.com/w-ahmad/WinUI.TableView/blob/master/LICENSE.md",
+                "https://github.com/w-ahmad/WinUI.TableView",
+                false),
+            CreateThirdPartyLicenseItem(
+                "7-Zip Extra",
+                "LGPL / BSD",
+                "https://www.7-zip.org/license.txt",
+                "https://www.7-zip.org/",
+                true)
         };
 
         public ObservableCollection<ContributorItemViewModel> ContributorItems { get; } = [];
@@ -160,6 +218,22 @@ namespace Foundry.ViewModels
                 : $"{contributor.DisplayName} (@{contributor.Login})";
         }
 
+        private ThirdPartyLicenseItemViewModel CreateThirdPartyLicenseItem(
+            string name,
+            string license,
+            string licenseUrl,
+            string homepageUrl,
+            bool isAlternate)
+        {
+            return new ThirdPartyLicenseItemViewModel(
+                name,
+                license,
+                new Uri(licenseUrl),
+                localizationService.FormatString("AboutDialog.HomepageLinkFormat", name),
+                new Uri(homepageUrl),
+                isAlternate);
+        }
+
         [RelayCommand]
         private async Task OpenUriAsync(Uri uri)
         {
@@ -167,7 +241,13 @@ namespace Foundry.ViewModels
         }
     }
 
-    public sealed record AboutLinkItemViewModel(string Title, string Description, string LinkText, Uri Uri, bool IsAlternate);
+    public sealed record ThirdPartyLicenseItemViewModel(
+        string Name,
+        string License,
+        Uri LicenseUri,
+        string HomepageText,
+        Uri HomepageUri,
+        bool IsAlternate);
 
     public sealed record ContributorItemViewModel(
         string Name,

--- a/src/Foundry/Views/AboutLicensesDialogPage.xaml
+++ b/src/Foundry/Views/AboutLicensesDialogPage.xaml
@@ -9,8 +9,8 @@
       mc:Ignorable="d">
     <Page.Resources>
         <converters:BooleanToBrushConverter x:Key="LicenseRowBackgroundConverter"
-                                            FalseBrush="{ThemeResource ControlFillColorDefaultBrush}"
-                                            TrueBrush="{ThemeResource ControlFillColorSecondaryBrush}" />
+                                            FalseBrush="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                            TrueBrush="{ThemeResource CardBackgroundFillColorSecondaryBrush}" />
     </Page.Resources>
 
     <ScrollView Margin="{ThemeResource FoundryDialogPageMargin}"
@@ -39,10 +39,11 @@
                     <DataTemplate>
                         <Border Background="{Binding IsAlternate, Converter={StaticResource LicenseRowBackgroundConverter}}"
                                 BorderBrush="{ThemeResource FoundrySurfaceBorderBrush}"
-                                BorderThickness="0,0,0,1">
-                            <Grid MinHeight="72"
-                                  Padding="{ThemeResource FoundryDefaultContentPadding}"
-                                  ColumnSpacing="{ThemeResource FoundrySpace16}">
+                                BorderThickness="0,0,0,1"
+                                Padding="0">
+                            <Grid MinHeight="54"
+                                  Padding="14,8"
+                                  ColumnSpacing="{ThemeResource FoundrySpace12}">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="Auto" />
@@ -55,11 +56,22 @@
                                            TextWrapping="WrapWholeWords" />
 
                                 <HyperlinkButton Grid.Column="1"
+                                                 Padding="0"
                                                  VerticalAlignment="Center"
-                                                 Content="{Binding License}"
-                                                 NavigateUri="{Binding LicenseUri}" />
+                                                 NavigateUri="{Binding LicenseUri}">
+                                    <Border MinWidth="48"
+                                            Padding="10,4"
+                                            Background="{ThemeResource ControlFillColorTertiaryBrush}"
+                                            CornerRadius="4">
+                                        <TextBlock HorizontalAlignment="Center"
+                                                   FontSize="12"
+                                                   FontWeight="SemiBold"
+                                                   Text="{Binding License}" />
+                                    </Border>
+                                </HyperlinkButton>
 
                                 <HyperlinkButton Grid.Column="2"
+                                                 Padding="0"
                                                  VerticalAlignment="Center"
                                                  Content="{Binding HomepageText}"
                                                  NavigateUri="{Binding HomepageUri}" />

--- a/src/Foundry/Views/AboutLicensesDialogPage.xaml
+++ b/src/Foundry/Views/AboutLicensesDialogPage.xaml
@@ -16,6 +16,7 @@
     <ScrollView Margin="{ThemeResource FoundryDialogPageMargin}"
                 VerticalScrollBarVisibility="Auto">
         <StackPanel x:Name="ContentRoot"
+                    Margin="0,0,16,0"
                     Spacing="{ThemeResource FoundrySpace16}">
             <Grid ColumnSpacing="{ThemeResource FoundrySpace16}">
                 <Grid.ColumnDefinitions>

--- a/src/Foundry/Views/AboutLicensesDialogPage.xaml
+++ b/src/Foundry/Views/AboutLicensesDialogPage.xaml
@@ -11,7 +11,6 @@
         <converters:BooleanToBrushConverter x:Key="LicenseRowBackgroundConverter"
                                             FalseBrush="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                                             TrueBrush="{ThemeResource CardBackgroundFillColorSecondaryBrush}" />
-        <Thickness x:Key="LicenseActionButtonPadding">10,4</Thickness>
         <Thickness x:Key="LicenseRowPadding">14,8</Thickness>
         <Thickness x:Key="LicenseScrollContentMargin">0,0,16,0</Thickness>
     </Page.Resources>
@@ -71,14 +70,14 @@
                                            TextWrapping="WrapWholeWords" />
 
                                 <Button Grid.Column="1"
-                                        Padding="{StaticResource LicenseActionButtonPadding}"
+                                        Padding="10,4"
                                         VerticalAlignment="Center"
                                         Command="{Binding DataContext.OpenUriCommand, ElementName=ContentRoot}"
                                         CommandParameter="{Binding LicenseUri}"
                                         Content="{Binding License}" />
 
                                 <Button Grid.Column="2"
-                                        Padding="{StaticResource LicenseActionButtonPadding}"
+                                        Padding="10,4"
                                         VerticalAlignment="Center"
                                         Command="{Binding DataContext.OpenUriCommand, ElementName=ContentRoot}"
                                         CommandParameter="{Binding HomepageUri}"

--- a/src/Foundry/Views/AboutLicensesDialogPage.xaml
+++ b/src/Foundry/Views/AboutLicensesDialogPage.xaml
@@ -11,12 +11,15 @@
         <converters:BooleanToBrushConverter x:Key="LicenseRowBackgroundConverter"
                                             FalseBrush="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                                             TrueBrush="{ThemeResource CardBackgroundFillColorSecondaryBrush}" />
+        <Thickness x:Key="LicenseActionButtonPadding">10,4</Thickness>
+        <Thickness x:Key="LicenseRowPadding">14,8</Thickness>
+        <Thickness x:Key="LicenseScrollContentMargin">0,0,16,0</Thickness>
     </Page.Resources>
 
     <ScrollView Margin="{ThemeResource FoundryDialogPageMargin}"
                 VerticalScrollBarVisibility="Auto">
         <StackPanel x:Name="ContentRoot"
-                    Margin="0,0,16,0"
+                    Margin="{StaticResource LicenseScrollContentMargin}"
                     Spacing="{ThemeResource FoundrySpace16}">
             <Grid ColumnSpacing="{ThemeResource FoundrySpace16}">
                 <Grid.ColumnDefinitions>
@@ -33,7 +36,6 @@
                 </StackPanel>
 
                 <Button Grid.Column="1"
-                        MinWidth="84"
                         VerticalAlignment="Center"
                         Command="{Binding OpenUriCommand}"
                         CommandParameter="{Binding LicenseUri}"
@@ -53,10 +55,9 @@
                     <DataTemplate>
                         <Border Background="{Binding IsAlternate, Converter={StaticResource LicenseRowBackgroundConverter}}"
                                 BorderBrush="{ThemeResource FoundrySurfaceBorderBrush}"
-                                BorderThickness="0,0,0,1"
-                                Padding="0">
+                                BorderThickness="0,0,0,1">
                             <Grid MinHeight="54"
-                                  Padding="14,8"
+                                  Padding="{StaticResource LicenseRowPadding}"
                                   ColumnSpacing="{ThemeResource FoundrySpace12}">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
@@ -70,24 +71,18 @@
                                            TextWrapping="WrapWholeWords" />
 
                                 <Button Grid.Column="1"
-                                        MinWidth="64"
-                                        Padding="10,4"
+                                        Padding="{StaticResource LicenseActionButtonPadding}"
                                         VerticalAlignment="Center"
                                         Command="{Binding DataContext.OpenUriCommand, ElementName=ContentRoot}"
                                         CommandParameter="{Binding LicenseUri}"
-                                        Content="{Binding License}"
-                                        FontSize="12"
-                                        FontWeight="SemiBold" />
+                                        Content="{Binding License}" />
 
                                 <Button Grid.Column="2"
-                                        MinWidth="72"
-                                        Padding="10,4"
+                                        Padding="{StaticResource LicenseActionButtonPadding}"
                                         VerticalAlignment="Center"
                                         Command="{Binding DataContext.OpenUriCommand, ElementName=ContentRoot}"
                                         CommandParameter="{Binding HomepageUri}"
-                                        Content="{Binding HomepageText}"
-                                        FontSize="12"
-                                        FontWeight="SemiBold" />
+                                        Content="{Binding HomepageText}" />
                             </Grid>
                         </Border>
                     </DataTemplate>

--- a/src/Foundry/Views/AboutLicensesDialogPage.xaml
+++ b/src/Foundry/Views/AboutLicensesDialogPage.xaml
@@ -15,16 +15,29 @@
 
     <ScrollView Margin="{ThemeResource FoundryDialogPageMargin}"
                 VerticalScrollBarVisibility="Auto">
-        <StackPanel Spacing="{ThemeResource FoundrySpace16}">
-            <StackPanel Spacing="{ThemeResource FoundrySpace4}">
-                <TextBlock Style="{ThemeResource FoundryPageTitleTextBlockStyle}"
-                           Text="{Binding FoundryLicenseTitle}" />
-                <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                           Text="{Binding FoundryLicenseDescription}"
-                           TextWrapping="WrapWholeWords" />
-                <HyperlinkButton Content="{Binding LicenseText}"
-                                 NavigateUri="{Binding LicenseUri}" />
-            </StackPanel>
+        <StackPanel x:Name="ContentRoot"
+                    Spacing="{ThemeResource FoundrySpace16}">
+            <Grid ColumnSpacing="{ThemeResource FoundrySpace16}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Spacing="{ThemeResource FoundrySpace4}">
+                    <TextBlock Style="{ThemeResource FoundryPageTitleTextBlockStyle}"
+                               Text="{Binding FoundryLicenseTitle}" />
+                    <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               Text="{Binding FoundryLicenseDescription}"
+                               TextWrapping="WrapWholeWords" />
+                </StackPanel>
+
+                <Button Grid.Column="1"
+                        MinWidth="84"
+                        VerticalAlignment="Center"
+                        Command="{Binding OpenUriCommand}"
+                        CommandParameter="{Binding LicenseUri}"
+                        Content="{Binding LicenseText}" />
+            </Grid>
 
             <StackPanel Spacing="{ThemeResource FoundrySpace4}">
                 <TextBlock Style="{ThemeResource FoundryPageTitleTextBlockStyle}"
@@ -55,26 +68,25 @@
                                            Text="{Binding Name}"
                                            TextWrapping="WrapWholeWords" />
 
-                                <HyperlinkButton Grid.Column="1"
-                                                 Padding="0"
-                                                 VerticalAlignment="Center"
-                                                 NavigateUri="{Binding LicenseUri}">
-                                    <Border MinWidth="48"
-                                            Padding="10,4"
-                                            Background="{ThemeResource ControlFillColorTertiaryBrush}"
-                                            CornerRadius="4">
-                                        <TextBlock HorizontalAlignment="Center"
-                                                   FontSize="12"
-                                                   FontWeight="SemiBold"
-                                                   Text="{Binding License}" />
-                                    </Border>
-                                </HyperlinkButton>
+                                <Button Grid.Column="1"
+                                        MinWidth="64"
+                                        Padding="10,4"
+                                        VerticalAlignment="Center"
+                                        Command="{Binding DataContext.OpenUriCommand, ElementName=ContentRoot}"
+                                        CommandParameter="{Binding LicenseUri}"
+                                        Content="{Binding License}"
+                                        FontSize="12"
+                                        FontWeight="SemiBold" />
 
-                                <HyperlinkButton Grid.Column="2"
-                                                 Padding="0"
-                                                 VerticalAlignment="Center"
-                                                 Content="{Binding HomepageText}"
-                                                 NavigateUri="{Binding HomepageUri}" />
+                                <Button Grid.Column="2"
+                                        MinWidth="72"
+                                        Padding="10,4"
+                                        VerticalAlignment="Center"
+                                        Command="{Binding DataContext.OpenUriCommand, ElementName=ContentRoot}"
+                                        CommandParameter="{Binding HomepageUri}"
+                                        Content="{Binding HomepageText}"
+                                        FontSize="12"
+                                        FontWeight="SemiBold" />
                             </Grid>
                         </Border>
                     </DataTemplate>

--- a/src/Foundry/Views/AboutLicensesDialogPage.xaml
+++ b/src/Foundry/Views/AboutLicensesDialogPage.xaml
@@ -16,9 +16,25 @@
     <ScrollView Margin="{ThemeResource FoundryDialogPageMargin}"
                 VerticalScrollBarVisibility="Auto">
         <StackPanel Spacing="{ThemeResource FoundrySpace16}">
-            <TextBlock Style="{ThemeResource FoundryPageTitleTextBlockStyle}"
-                       Text="{Binding LicensesSectionText}" />
-            <ItemsControl ItemsSource="{Binding LicenseItems}">
+            <StackPanel Spacing="{ThemeResource FoundrySpace4}">
+                <TextBlock Style="{ThemeResource FoundryPageTitleTextBlockStyle}"
+                           Text="{Binding FoundryLicenseTitle}" />
+                <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           Text="{Binding FoundryLicenseDescription}"
+                           TextWrapping="WrapWholeWords" />
+                <HyperlinkButton Content="{Binding LicenseText}"
+                                 NavigateUri="{Binding LicenseUri}" />
+            </StackPanel>
+
+            <StackPanel Spacing="{ThemeResource FoundrySpace4}">
+                <TextBlock Style="{ThemeResource FoundryPageTitleTextBlockStyle}"
+                           Text="{Binding ThirdPartyLicenseTitle}" />
+                <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           Text="{Binding ThirdPartyLicenseDescription}"
+                           TextWrapping="WrapWholeWords" />
+            </StackPanel>
+
+            <ItemsControl ItemsSource="{Binding ThirdPartyLicenseItems}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <Border Background="{Binding IsAlternate, Converter={StaticResource LicenseRowBackgroundConverter}}"
@@ -26,26 +42,27 @@
                                 BorderThickness="0,0,0,1">
                             <Grid MinHeight="72"
                                   Padding="{ThemeResource FoundryDefaultContentPadding}"
-                                  ColumnSpacing="{ThemeResource FoundryContentGroupSpacing}">
+                                  ColumnSpacing="{ThemeResource FoundrySpace16}">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
 
-                                <StackPanel VerticalAlignment="Center"
-                                            Spacing="{ThemeResource FoundryTextGroupSpacing}">
-                                    <TextBlock FontWeight="SemiBold"
-                                               Text="{Binding Title}"
-                                               TextWrapping="WrapWholeWords" />
-                                    <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                               Text="{Binding Description}"
-                                               TextWrapping="WrapWholeWords" />
-                                </StackPanel>
+                                <TextBlock VerticalAlignment="Center"
+                                           FontWeight="SemiBold"
+                                           Text="{Binding Name}"
+                                           TextWrapping="WrapWholeWords" />
 
                                 <HyperlinkButton Grid.Column="1"
                                                  VerticalAlignment="Center"
-                                                 Content="{Binding LinkText}"
-                                                 NavigateUri="{Binding Uri}" />
+                                                 Content="{Binding License}"
+                                                 NavigateUri="{Binding LicenseUri}" />
+
+                                <HyperlinkButton Grid.Column="2"
+                                                 VerticalAlignment="Center"
+                                                 Content="{Binding HomepageText}"
+                                                 NavigateUri="{Binding HomepageUri}" />
                             </Grid>
                         </Border>
                     </DataTemplate>


### PR DESCRIPTION
## Summary
- Reworks the About Licenses page into a Foundry license section plus a compact third-party license list.
- Adds a curated catalog of the frameworks, libraries, tooling, and bundled components used by Foundry OSD with license and homepage links.
- Localizes the new homepage link label across all Foundry resource cultures.

## Reason
The previous Licenses page only showed a few generic links. This makes the page more useful and closer to UniGetUI's component/license/homepage presentation while staying scoped to the existing About dialog.

## Main changes
- Replaced the old flat `LicenseItems` rows with `ThirdPartyLicenseItems` containing component name, license link, and homepage link.
- Updated the Licenses page XAML to render the Foundry MIT license block and third-party license rows.
- Included .NET, Windows App SDK / WinUI 3, Microsoft.Windows.CsWinRT, Microsoft Windows SDK Build Tools, DevWinUI, CommunityToolkit, Microsoft.Extensions, Serilog, Velopack, Azure.Identity, HtmlAgilityPack, WinUI.TableView, Windows ADK / Windows PE, and 7-Zip Extra.
- Removed obsolete About license resource keys that are no longer used.

## Testing notes
- `dotnet test src/Foundry.Localization.Tests/Foundry.Localization.Tests.csproj --no-restore`
- `dotnet build src/Foundry/Foundry.csproj --no-restore -p:Platform=x64`

Closes #222