### PR TITLE
feat(deploy): use VM-friendly target partition order

### DIFF
--- a/src/Foundry.Deploy.Tests/WindowsDeploymentServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/WindowsDeploymentServiceTests.cs
@@ -9,6 +9,34 @@ namespace Foundry.Deploy.Tests;
 public sealed class WindowsDeploymentServiceTests
 {
     [Fact]
+    public async Task PrepareTargetDiskAsync_CreatesPartitionsInExpectedOrder_Efi_Msr_Recovery_Windows()
+    {
+        using var workspace = new TemporaryWorkspace();
+        string workingDirectory = Path.Combine(workspace.RootPath, "Work");
+        var processRunner = new RecordingProcessRunner();
+        var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
+
+        await service.PrepareTargetDiskAsync(1, workingDirectory, TestContext.Current.CancellationToken);
+
+        string scriptPath = Path.Combine(workingDirectory, "diskpart-os-target.txt");
+        string[] scriptLines = await File.ReadAllLinesAsync(scriptPath, TestContext.Current.CancellationToken);
+        int efiIndex = Array.IndexOf(scriptLines, "create partition efi size=260");
+        int msrIndex = Array.IndexOf(scriptLines, "create partition msr size=16");
+        int recoveryIndex = Array.IndexOf(scriptLines, "create partition primary size=5120");
+        int windowsIndex = Array.IndexOf(scriptLines, "create partition primary");
+        int recoveryFormatIndex = Array.IndexOf(scriptLines, "format quick fs=ntfs label=Recovery");
+        int windowsFormatIndex = Array.IndexOf(scriptLines, "format quick fs=ntfs label=Windows");
+
+        Assert.True(efiIndex >= 0);
+        Assert.True(msrIndex > efiIndex);
+        Assert.True(recoveryIndex > msrIndex);
+        Assert.True(windowsIndex > recoveryIndex);
+        Assert.True(recoveryFormatIndex > recoveryIndex);
+        Assert.True(windowsFormatIndex > recoveryFormatIndex);
+        Assert.DoesNotContain(scriptLines, line => line.StartsWith("shrink ", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task ConfigureOfflineComputerNameAsync_WhenDefaultTimeZoneIdIsProvided_WritesUnattendTimeZone()
     {
         using var workspace = new TemporaryWorkspace();

--- a/src/Foundry.Deploy/Services/Deployment/WindowsDeploymentService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/WindowsDeploymentService.cs
@@ -72,16 +72,14 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
             "format quick fs=fat32 label=System",
             $"assign letter={systemLetter}",
             $"create partition msr size={MsrPartitionSizeMb}",
-            "create partition primary",
-            "format quick fs=ntfs label=Windows",
-            $"assign letter={windowsLetter}",
-            $"select volume {windowsLetter}",
-            $"shrink desired={RecoveryPartitionSizeMb} minimum={RecoveryPartitionSizeMb}",
             $"create partition primary size={RecoveryPartitionSizeMb}",
             $"set id=\"{RecoveryPartitionGuid}\"",
             $"gpt attributes={RecoveryPartitionAttributes}",
             $"format quick fs=ntfs label={RecoveryPartitionLabel}",
-            $"assign letter={recoveryLetter}"
+            $"assign letter={recoveryLetter}",
+            "create partition primary",
+            "format quick fs=ntfs label=Windows",
+            $"assign letter={windowsLetter}"
         ];
 
         string scriptPath = Path.Combine(workingDirectory, "diskpart-os-target.txt");


### PR DESCRIPTION
## Summary
- Change Foundry Deploy target disk layout to `EFI -> MSR -> Recovery -> Windows`.
- Remove the obsolete shrink-based Recovery creation flow.
- Keep the Windows partition last so expanded virtual disks can extend the system volume directly.

## Reason
The previous layout placed Recovery after Windows. On virtual machines, increasing the virtual disk then leaves unallocated space after Recovery, which blocks a straightforward Windows partition extension.

## Main changes
- Create the Recovery partition before the Windows partition in the DiskPart deployment script.
- Keep Recovery GUID, GPT attributes, NTFS format, and temporary drive-letter assignment unchanged.
- Add a regression test for the expected partition and format command order.

## Testing notes
- `dotnet test src\Foundry.Deploy.Tests\Foundry.Deploy.Tests.csproj --no-restore --verbosity minimal`
- Result: 313 passed, 0 failed.
- Manual VM validation confirmed partition order: `System -> MSR -> Recovery -> Windows`.
- Manual `reagentc /info` validation confirmed WinRE is enabled and points to `harddisk0\partition3\Recovery\WindowsRE`.

## Merge note
Do not squash this PR.
