### PR TITLE
chore(deps): update selected NuGet packages

### DIFF
--- a/scripts/Publish-FoundryVelopack.ps1
+++ b/scripts/Publish-FoundryVelopack.ps1
@@ -9,7 +9,7 @@ param(
     [ValidateSet('Release', 'Debug')]
     [string]$Configuration = 'Release',
 
-    [string]$VpkVersion = '1.0.1',
+    [string]$VpkVersion = '1.2.0',
 
     [string]$VelopackFeedUrl = 'https://github.com/foundry-osd/foundry',
 

--- a/src/Foundry.Connect.Tests/Foundry.Connect.Tests.csproj
+++ b/src/Foundry.Connect.Tests/Foundry.Connect.Tests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Foundry.Connect/Foundry.Connect.csproj
+++ b/src/Foundry.Connect/Foundry.Connect.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />

--- a/src/Foundry.Core.Tests/Foundry.Core.Tests.csproj
+++ b/src/Foundry.Core.Tests/Foundry.Core.Tests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Foundry.Deploy.Tests/Foundry.Deploy.Tests.csproj
+++ b/src/Foundry.Deploy.Tests/Foundry.Deploy.Tests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Foundry.Deploy/Foundry.Deploy.csproj
+++ b/src/Foundry.Deploy/Foundry.Deploy.csproj
@@ -12,8 +12,8 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />

--- a/src/Foundry.Localization.Tests/Foundry.Localization.Tests.csproj
+++ b/src/Foundry.Localization.Tests/Foundry.Localization.Tests.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Foundry.Telemetry.Tests/Foundry.Telemetry.Tests.csproj
+++ b/src/Foundry.Telemetry.Tests/Foundry.Telemetry.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Foundry.Telemetry/Foundry.Telemetry.csproj
+++ b/src/Foundry.Telemetry/Foundry.Telemetry.csproj
@@ -16,7 +16,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -59,15 +59,15 @@
     <PackageReference Include="DevWinUI.ContextMenu" Version="9.9.1" />
     <PackageReference Include="DevWinUI.Controls" Version="9.9.4" />
     <PackageReference Include="DevWinUI.SourceGenerator" Version="9.9.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="Velopack" Version="1.0.1" />
+    <PackageReference Include="Velopack" Version="1.2.0" />
     <PackageReference Include="WinUI.TableView" Version="1.4.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Updates selected NuGet packages across the Foundry solution.
- Aligns the Velopack `vpk` CLI version used by the publish script with the updated Velopack package version.

## Reason
- Keep selected dependencies current while preserving the existing project structure and package scope.
- Avoid a Velopack library/CLI version mismatch during release packaging.

## Main changes
- Updates `Microsoft.NET.Test.Sdk` from `18.6.0` to `18.7.0` in test projects.
- Updates `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Hosting`, and `Microsoft.Extensions.Logging.Abstractions` from `10.0.8` to `10.0.9` where referenced.
- Updates `Microsoft.WindowsAppSDK` from `2.1.3` to `2.2.0`.
- Updates `Velopack` from `1.0.1` to `1.2.0` and sets the publish script default `vpk` tool version to `1.2.0`.

## Testing notes
- `dotnet build .\src\Foundry.slnx --no-restore`
- `dotnet test .\src\Foundry.slnx --no-build`
- `dotnet test .\src\Foundry.slnx --no-restore`
- `powershell -ExecutionPolicy Bypass -File .\scripts\Publish-FoundryVelopack.ps1 -RuntimeIdentifier win-x64 -PackVersion 26.6.24-build.1 -SkipPreviousReleaseDownload`
- `powershell -ExecutionPolicy Bypass -File .\scripts\Publish-FoundryVelopack.ps1 -RuntimeIdentifier win-arm64 -PackVersion 26.6.24-build.1 -SkipPreviousReleaseDownload`
