### PR TITLE
chore(deps): update DevWinUI to 10.0.0

### DIFF
--- a/src/Foundry/App.xaml
+++ b/src/Foundry/App.xaml
@@ -7,7 +7,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-                <ResourceDictionary Source="ms-appx:///DevWinUI.Controls/Themes/Generic.xaml" />
+                <ResourceDictionary Source="ms-appx:///DevWinUI/Themes/Generic.xaml" />
                 <ResourceDictionary Source="Themes/Styles.xaml" />
 
                 <ResourceDictionary Source="Themes/ThemeResources.xaml" />

--- a/src/Foundry/App.xaml.cs
+++ b/src/Foundry/App.xaml.cs
@@ -113,11 +113,11 @@ namespace Foundry
 
         private static async Task InitializeAppAsync()
         {
-            ContextMenuService menuService = GetService<ContextMenuService>();
             if (RuntimeHelper.IsPackaged())
             {
                 try
                 {
+                    ContextMenuService menuService = GetService<ContextMenuService>();
                     ContextMenuItem menu = new()
                     {
                         Title = "Open Foundry Here",
@@ -172,7 +172,7 @@ namespace Foundry
             BackdropType backdropType = ParseEnum(settingsService.Current.Appearance.BackdropType, BackdropType.Mica);
 
             ThemeService
-                .ConfigureAutoSave(false, Constants.AppSettingsPath)
+                .ConfigureAutoSave(false)
                 .ConfigureElementTheme(elementTheme)
                 .ConfigureBackdrop(backdropType)
                 .Initialize(MainWindow);

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -122,7 +122,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IFilePickerService, WinUiFilePickerService>();
 
         services.AddTransient<MainViewModel>();
-        services.AddSingleton<ContextMenuService>();
+        services.AddSingleton(_ => new ContextMenuService(Windows.Storage.ApplicationData.Current.LocalFolder));
         services.AddTransient<GeneralConfigurationViewModel>();
         services.AddTransient<NetworkConfigurationViewModel>();
         services.AddTransient<AutopilotConfigurationViewModel>();

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -55,10 +55,9 @@
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.251219" />
-    <PackageReference Include="DevWinUI" Version="9.9.4" />
-    <PackageReference Include="DevWinUI.ContextMenu" Version="9.9.1" />
-    <PackageReference Include="DevWinUI.Controls" Version="9.9.4" />
-    <PackageReference Include="DevWinUI.SourceGenerator" Version="9.9.0" />
+    <PackageReference Include="DevWinUI" Version="10.0.0" />
+    <PackageReference Include="DevWinUI.ContextMenu" Version="10.0.0" />
+    <PackageReference Include="DevWinUI.SourceGenerator" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />


### PR DESCRIPTION
## Summary
- Updates Foundry's DevWinUI packages to 10.0.0.
- Migrates the DevWinUI resource dictionary path and ThemeService auto-save call to the v10 API.
- Fixes ContextMenuService startup activation for the v10 constructor contract.

## Reason
DevWinUI 10.0.0 renamed the controls package into the main DevWinUI package and changed runtime APIs used during app startup.

## Main changes
- Removed the obsolete DevWinUI.Controls package reference.
- Updated App.xaml to load ms-appx:///DevWinUI/Themes/Generic.xaml.
- Updated ThemeService.ConfigureAutoSave usage for the v10 overload.
- Registered ContextMenuService with ApplicationData.Current.LocalFolder and resolve it only for packaged startup.

## Testing notes
- dotnet test src\Foundry.slnx --no-restore
- Debug startup smoke test: no WinUI launch failure or StorageFolder DI error in the new log segment.
- Generated and manually validated x64 Velopack MSI: artifacts\velopack\release-assets\FoundrySetup-x64.msi