### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,170 @@
+root = true
+
+[*]
+end_of_line = crlf
+indent_style = space
+indent_size = 4
+tab_width = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+file_header_template = Copyright (c) 2026 Foundry Project. Licensed under the MIT License.\nSee the LICENSE file in the project root for more information.
+
+[*{_AssemblyInfo.cs,.g.cs,.g.i.cs,.designer.cs,.Designer.cs}]
+generated_code = true
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[*.{csproj,props,targets,xml,resx,resw,slnx,appxmanifest,manifest}]
+indent_size = 2
+
+[*.xaml]
+indent_size = 4
+
+[*.md]
+indent_size = 2
+trim_trailing_whitespace = false
+
+[*.ps1]
+indent_size = 4
+
+[*.cs]
+csharp_using_directive_placement = outside_namespace:silent
+csharp_style_namespace_declarations = file_scoped:suggestion
+dotnet_code_quality_unused_parameters = all:suggestion
+
+dotnet_style_qualification_for_event = false:silent
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_collection_expression = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_readonly_field = true:suggestion
+
+csharp_style_var_for_built_in_types = false:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = false:silent
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_collection_expression = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_throw_expression = true:suggestion
+
+csharp_style_expression_bodied_accessors = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_indexers = false:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = false:silent
+
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_pattern_matching = true:suggestion
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_braces = true:suggestion
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async
+
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels = no_change
+csharp_indent_switch_labels = true
+
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+dotnet_naming_symbols.interface_types.applicable_kinds = interface
+dotnet_naming_style.interface_prefix.capitalization = pascal_case
+dotnet_naming_style.interface_prefix.required_prefix = I
+dotnet_naming_rule.interface_types_should_be_prefixed.symbols = interface_types
+dotnet_naming_rule.interface_types_should_be_prefixed.style = interface_prefix
+dotnet_naming_rule.interface_types_should_be_prefixed.severity = suggestion
+
+dotnet_naming_symbols.async_methods.applicable_kinds = method
+dotnet_naming_symbols.async_methods.applicable_accessibilities = *
+dotnet_naming_symbols.async_methods.required_modifiers = async
+dotnet_naming_style.async_suffix.capitalization = pascal_case
+dotnet_naming_style.async_suffix.required_suffix = Async
+dotnet_naming_rule.async_methods_should_end_in_async.symbols = async_methods
+dotnet_naming_rule.async_methods_should_end_in_async.style = async_suffix
+dotnet_naming_rule.async_methods_should_end_in_async.severity = suggestion
+
+dotnet_naming_symbols.constant_fields.applicable_kinds = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_fields.required_modifiers =
+dotnet_naming_style.private_field_prefix.capitalization = camel_case
+dotnet_naming_style.private_field_prefix.required_prefix = _
+dotnet_naming_rule.private_fields_should_be_prefixed.symbols = private_fields
+dotnet_naming_rule.private_fields_should_be_prefixed.style = private_field_prefix
+dotnet_naming_rule.private_fields_should_be_prefixed.severity = suggestion

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+* text=auto
+
+*.cs text eol=crlf
+*.xaml text eol=crlf
+*.csproj text eol=crlf
+*.props text eol=crlf
+*.targets text eol=crlf
+*.slnx text eol=crlf
+*.xml text eol=crlf
+*.resx text eol=crlf
+*.resw text eol=crlf
+*.json text eol=crlf
+*.yml text eol=crlf
+*.yaml text eol=crlf
+*.md text eol=crlf
+*.ps1 text eol=crlf
+*.txt text eol=crlf
+*.ini text eol=crlf
+*.reg text eol=crlf
+
+*.png binary
+*.ico binary
+*.exe binary
+*.dll binary
+*.wim binary
+*.zip binary
+*.7z binary

--- a/src/Foundry.Connect/Services/Network/NativeWifiApi.cs
+++ b/src/Foundry.Connect/Services/Network/NativeWifiApi.cs
@@ -53,15 +53,15 @@ internal static class NativeWifiApi
             List<Guid> interfaceIds = ReadInterfaceIds(interfaceListPointer);
             Dictionary<string, WifiNetworkSummary> networks = new(StringComparer.OrdinalIgnoreCase);
 
-        foreach (Guid interfaceId in interfaceIds)
-        {
-            IReadOnlyList<WifiNetworkSummary> interfaceNetworks = ReadAvailableNetworks(clientHandle, interfaceId);
-            TryStartScan(clientHandle, interfaceId);
-
-            foreach (WifiNetworkSummary network in interfaceNetworks)
+            foreach (Guid interfaceId in interfaceIds)
             {
-                if (networks.TryGetValue(network.Ssid, out WifiNetworkSummary? existing) &&
-                    existing.SignalStrengthPercent >= network.SignalStrengthPercent)
+                IReadOnlyList<WifiNetworkSummary> interfaceNetworks = ReadAvailableNetworks(clientHandle, interfaceId);
+                TryStartScan(clientHandle, interfaceId);
+
+                foreach (WifiNetworkSummary network in interfaceNetworks)
+                {
+                    if (networks.TryGetValue(network.Ssid, out WifiNetworkSummary? existing) &&
+                        existing.SignalStrengthPercent >= network.SignalStrengthPercent)
                     {
                         continue;
                     }

--- a/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
@@ -601,16 +601,16 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         string wifiSecurity = ResolveWifiSecurity(snapshot, connectionType);
         string wifiSource = ResolveWifiSource(snapshot, connectionType);
         var properties = new Dictionary<string, object?>
-            {
-                ["connect_network_connection_type"] = connectionType,
-                ["connect_network_layout_mode"] = NetworkTelemetryClassifier.ClassifyLayout(snapshot.LayoutMode),
-                ["connect_ethernet_available"] = snapshot.HasEthernetAdapter,
-                ["connect_wifi_available"] = snapshot.HasWirelessAdapter && snapshot.IsWifiRuntimeAvailable,
-                ["connect_wifi_security_type"] = wifiSecurity,
-                ["connect_wifi_source"] = wifiSource,
-                ["connect_wired_dot1x_enabled"] = _configuration.Dot1x.IsEnabled,
-                ["connect_wifi_provisioned"] = HasProvisionedWifiProfile
-            };
+        {
+            ["connect_network_connection_type"] = connectionType,
+            ["connect_network_layout_mode"] = NetworkTelemetryClassifier.ClassifyLayout(snapshot.LayoutMode),
+            ["connect_ethernet_available"] = snapshot.HasEthernetAdapter,
+            ["connect_wifi_available"] = snapshot.HasWirelessAdapter && snapshot.IsWifiRuntimeAvailable,
+            ["connect_wifi_security_type"] = wifiSecurity,
+            ["connect_wifi_source"] = wifiSource,
+            ["connect_wired_dot1x_enabled"] = _configuration.Dot1x.IsEnabled,
+            ["connect_wifi_provisioned"] = HasProvisionedWifiProfile
+        };
 
         _logger.LogDebug(
             "Tracking Connect session-ready telemetry event. ConnectionType={ConnectionType}, LayoutMode={LayoutMode}, WifiSecurity={WifiSecurity}, WifiSource={WifiSource}, WiredDot1xEnabled={WiredDot1xEnabled}, WifiProvisioned={WifiProvisioned}.",

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentOrchestrator.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentOrchestrator.cs
@@ -271,31 +271,31 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
     {
         HardwareProfile? hardware = runtimeState?.HardwareProfile;
         var properties = new Dictionary<string, object?>
-            {
-                ["deploy_session_success"] = success,
-                ["deploy_session_cancelled"] = cancelled,
-                ["deploy_session_duration_seconds"] = Math.Round(duration.TotalSeconds, 2),
-                ["deploy_session_completed_step_count"] = runtimeState?.CompletedSteps.Count ?? 0,
-                ["deploy_session_failed_step_name"] = failedStepName,
-                ["deploy_session_mode"] = context.Mode.ToString().ToLowerInvariant(),
-                ["deploy_session_dry_run_enabled"] = context.IsDryRun,
-                ["deploy_hardware_vendor"] = NormalizeTelemetryString(hardware?.Manufacturer),
-                ["deploy_hardware_model"] = NormalizeTelemetryString(hardware?.Model),
-                ["deploy_hardware_virtual_machine"] = hardware?.IsVirtualMachine ?? false,
-                ["deploy_os_product"] = ResolveOperatingSystemProduct(context.OperatingSystem),
-                ["deploy_os_version"] = NormalizeTelemetryString(context.OperatingSystem.ReleaseId),
-                ["deploy_os_build"] = NormalizeTelemetryString(context.OperatingSystem.Build),
-                ["deploy_os_architecture"] = NormalizeTelemetryString(context.OperatingSystem.Architecture),
-                ["deploy_os_language"] = NormalizeTelemetryString(context.OperatingSystem.LanguageCode),
-                ["deploy_driver_pack_selection_kind"] = context.DriverPackSelectionKind.ToString().ToLowerInvariant(),
-                ["deploy_driver_pack_vendor"] = NormalizeTelemetryString(context.DriverPack?.Manufacturer, "none"),
-                ["deploy_driver_pack_model"] = ResolveDriverPackCatalogModel(context.DriverPack),
-                ["deploy_firmware_updates_enabled"] = context.ApplyFirmwareUpdates,
-                ["deploy_autopilot_enabled"] = context.IsAutopilotEnabled,
-                ["deploy_autopilot_provisioning_mode"] = NormalizeTelemetryString(ResolveAutopilotProvisioningMode(context)),
-                ["deploy_autopilot_hash_upload_state"] = NormalizeTelemetryString(runtimeState?.AutopilotHardwareHashUploadState.ToString()),
-                ["deploy_autopilot_hash_group_tag_selected"] = !string.IsNullOrWhiteSpace(runtimeState?.AutopilotHardwareHashGroupTag)
-            };
+        {
+            ["deploy_session_success"] = success,
+            ["deploy_session_cancelled"] = cancelled,
+            ["deploy_session_duration_seconds"] = Math.Round(duration.TotalSeconds, 2),
+            ["deploy_session_completed_step_count"] = runtimeState?.CompletedSteps.Count ?? 0,
+            ["deploy_session_failed_step_name"] = failedStepName,
+            ["deploy_session_mode"] = context.Mode.ToString().ToLowerInvariant(),
+            ["deploy_session_dry_run_enabled"] = context.IsDryRun,
+            ["deploy_hardware_vendor"] = NormalizeTelemetryString(hardware?.Manufacturer),
+            ["deploy_hardware_model"] = NormalizeTelemetryString(hardware?.Model),
+            ["deploy_hardware_virtual_machine"] = hardware?.IsVirtualMachine ?? false,
+            ["deploy_os_product"] = ResolveOperatingSystemProduct(context.OperatingSystem),
+            ["deploy_os_version"] = NormalizeTelemetryString(context.OperatingSystem.ReleaseId),
+            ["deploy_os_build"] = NormalizeTelemetryString(context.OperatingSystem.Build),
+            ["deploy_os_architecture"] = NormalizeTelemetryString(context.OperatingSystem.Architecture),
+            ["deploy_os_language"] = NormalizeTelemetryString(context.OperatingSystem.LanguageCode),
+            ["deploy_driver_pack_selection_kind"] = context.DriverPackSelectionKind.ToString().ToLowerInvariant(),
+            ["deploy_driver_pack_vendor"] = NormalizeTelemetryString(context.DriverPack?.Manufacturer, "none"),
+            ["deploy_driver_pack_model"] = ResolveDriverPackCatalogModel(context.DriverPack),
+            ["deploy_firmware_updates_enabled"] = context.ApplyFirmwareUpdates,
+            ["deploy_autopilot_enabled"] = context.IsAutopilotEnabled,
+            ["deploy_autopilot_provisioning_mode"] = NormalizeTelemetryString(ResolveAutopilotProvisioningMode(context)),
+            ["deploy_autopilot_hash_upload_state"] = NormalizeTelemetryString(runtimeState?.AutopilotHardwareHashUploadState.ToString()),
+            ["deploy_autopilot_hash_group_tag_selected"] = !string.IsNullOrWhiteSpace(runtimeState?.AutopilotHardwareHashGroupTag)
+        };
 
         _logger.LogDebug(
             "Tracking deployment telemetry event. Success={Success}, Cancelled={Cancelled}, DurationSeconds={DurationSeconds}, CompletedStepCount={CompletedStepCount}, FailedStepName={FailedStepName}, Mode={Mode}, IsDryRun={IsDryRun}, HardwareVendor={HardwareVendor}, HardwareModel={HardwareModel}, OsProduct={OsProduct}, OsVersion={OsVersion}, DriverPackSelectionKind={DriverPackSelectionKind}, DriverPackVendor={DriverPackVendor}, DriverPackModel={DriverPackModel}.",


### PR DESCRIPTION
## Summary
- Add a root `.editorconfig` with Foundry-specific editor, formatting, C# style, and naming conventions.
- Add `.gitattributes` so Git and editors agree on text normalization, CRLF working-tree line endings, and binary assets.
- Apply formatter-only indentation updates required by the new whitespace policy.

## Reason
Foundry did not have committed editor or Git attribute configuration, so contributors could get inconsistent whitespace, line endings, and C# style guidance. The CommunityToolkit/Windows config was useful as a reference, but it includes project-specific ownership headers, StyleCop suppressions, and analyzer history that do not belong in Foundry.

## Main changes
- Set repository-wide CRLF, space indentation, trailing-whitespace trimming, and final-newline defaults.
- Define per-file indentation for C#, XAML, PowerShell, JSON/YAML, MSBuild/XML/resource files, Markdown, and manifests.
- Define a Foundry-owned MIT header template for new files instead of the `.NET Foundation` header.
- Add modern C# style guidance for namespaces, braces, expression preferences, `var`, pattern matching, modifier order, and naming.
- Keep rules at suggestion/silent severity where broad enforcement would create unrelated analyzer churn.
- Normalize indentation in three existing C# files so whitespace verification passes with the new policy.

## Testing
- `dotnet format whitespace .\src\Foundry.slnx --verify-no-changes --no-restore --verbosity minimal`
- `dotnet build .\src\Foundry.slnx -c Release -p:Platform=x64 -p:ContinuousIntegrationBuild=true --no-restore --nologo`
- `dotnet test .\src\Foundry.slnx -c Release -p:Platform=x64 --no-build --nologo`

Note: full `dotnet format .\src\Foundry.slnx --verify-no-changes --no-restore --verbosity minimal` still exits non-zero on pre-existing xUnit analyzer warnings (`xUnit1051`) in test projects. That warning cleanup is separate from editor configuration.