### PR TITLE
fix(updates): persist background check timestamp

### DIFF
--- a/src/Foundry/Services/Settings/JsonAppSettingsService.cs
+++ b/src/Foundry/Services/Settings/JsonAppSettingsService.cs
@@ -19,6 +19,7 @@ namespace Foundry.Services.Settings;
 internal sealed partial class JsonAppSettingsService : IAppSettingsService
 {
     private readonly ILogger logger;
+    private readonly object saveLock = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="JsonAppSettingsService"/> class.
@@ -46,16 +47,19 @@ internal sealed partial class JsonAppSettingsService : IAppSettingsService
     /// <inheritdoc />
     public void Save()
     {
-        try
+        lock (saveLock)
         {
-            Directory.CreateDirectory(Constants.SettingsDirectoryPath);
-            string json = JsonSerializer.Serialize(Current, FoundryAppSettingsJsonContext.Default.FoundryAppSettings);
-            File.WriteAllText(Constants.AppSettingsPath, json);
-        }
-        catch (Exception ex)
-        {
-            logger.Error(ex, "Failed to save app settings. SettingsPath={SettingsPath}", Constants.AppSettingsPath);
-            throw;
+            try
+            {
+                Directory.CreateDirectory(Constants.SettingsDirectoryPath);
+                string json = JsonSerializer.Serialize(Current, FoundryAppSettingsJsonContext.Default.FoundryAppSettings);
+                File.WriteAllText(Constants.AppSettingsPath, json);
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, "Failed to save app settings. SettingsPath={SettingsPath}", Constants.AppSettingsPath);
+                throw;
+            }
         }
     }
 

--- a/src/Foundry/Services/Updates/ApplicationUpdateService.cs
+++ b/src/Foundry/Services/Updates/ApplicationUpdateService.cs
@@ -316,6 +316,9 @@ internal sealed class ApplicationUpdateService(
 
     private ApplicationUpdateCheckResult PublishCheckResult(ApplicationUpdateCheckResult result)
     {
+        appSettingsService.Current.Updates.LastCheckedAt = DateTimeOffset.Now;
+        appSettingsService.Save();
+
         updateStateService.Publish(result);
         return result;
     }

--- a/src/Foundry/ViewModels/Settings/AppUpdateSettingViewModel.cs
+++ b/src/Foundry/ViewModels/Settings/AppUpdateSettingViewModel.cs
@@ -131,11 +131,6 @@ namespace Foundry.ViewModels
             try
             {
                 ApplicationUpdateCheckResult result = await applicationUpdateService.CheckForUpdatesAsync();
-                DateTimeOffset checkedAt = DateTimeOffset.Now;
-                appSettingsService.Current.Updates.LastCheckedAt = checkedAt;
-                appSettingsService.Save();
-
-                LastUpdateCheck = FormatLastUpdateCheck(checkedAt);
                 ApplyCurrentUpdateState(result);
             }
             finally
@@ -242,6 +237,7 @@ namespace Foundry.ViewModels
         private void ApplyCurrentUpdateState(ApplicationUpdateCheckResult? result)
         {
             currentCheckResult = result;
+            LastUpdateCheck = FormatLastUpdateCheck(appSettingsService.Current.Updates.LastCheckedAt);
 
             if (result is null)
             {


### PR DESCRIPTION
## Summary
- Persist the application update check timestamp from `ApplicationUpdateService` for both startup and manual checks.
- Refresh the Updates page last-check display from persisted settings whenever update state is applied.
- Serialize app settings saves to avoid overlapping writes from the background startup check and UI settings changes.

## Reason
The startup update check published in-memory update state, but only the manual Updates page check wrote `Updates.LastCheckedAt`. This made the Updates page show that no check had run after a background startup check completed.

## Main changes
- Move `LastCheckedAt` persistence into the update service publish path.
- Remove the duplicate manual timestamp write from the update settings view model.
- Add a narrow lock around JSON settings saves.

## Testing notes
- `dotnet restore .\Foundry.slnx -p:Platform=x64`
- `dotnet test .\Foundry.slnx --configuration Debug --no-restore -p:Platform=x64`
- `dotnet build .\Foundry\Foundry.csproj --configuration Debug --no-restore -p:Platform=x64`
- `git diff --check`