### PR TITLE
feat(configuration): enable PCA2023 by default

### DIFF
--- a/src/Foundry.Core.Tests/Configuration/FoundryConfigurationServiceTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/FoundryConfigurationServiceTests.cs
@@ -20,6 +20,14 @@ public sealed class FoundryConfigurationServiceTests
     }
 
     [Fact]
+    public void DefaultConfiguration_EnablesPca2023Signature()
+    {
+        var document = new FoundryConfigurationDocument();
+
+        Assert.True(document.General.UseCa2023);
+    }
+
+    [Fact]
     public void Serialize_ThenDeserialize_RoundTripsBusinessSettings()
     {
         var service = new FoundryConfigurationService();

--- a/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
+++ b/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
@@ -6,7 +6,7 @@ namespace Foundry.Core.Models.Configuration;
 
 public static class ConfigurationSchemaVersions
 {
-    public const int FoundryCurrent = 11;
+    public const int FoundryCurrent = 10;
 
     public const int ConnectCurrent = 2;
 

--- a/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
+++ b/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
@@ -6,7 +6,7 @@ namespace Foundry.Core.Models.Configuration;
 
 public static class ConfigurationSchemaVersions
 {
-    public const int FoundryCurrent = 10;
+    public const int FoundryCurrent = 11;
 
     public const int ConnectCurrent = 2;
 

--- a/src/Foundry.Core/Models/Configuration/GeneralSettings.cs
+++ b/src/Foundry.Core/Models/Configuration/GeneralSettings.cs
@@ -29,7 +29,7 @@ public sealed record GeneralSettings
     /// <summary>
     /// Gets a value indicating whether generated media should use the CA 2023 boot signature.
     /// </summary>
-    public bool UseCa2023 { get; init; }
+    public bool UseCa2023 { get; init; } = true;
 
     /// <summary>
     /// Gets the partition style used when creating USB media.


### PR DESCRIPTION
## Summary
Enable PCA2023 as the default boot signature for new Foundry OSD authoring configurations.

## Reason
PCA2023 should now be the default media signature mode while still preserving explicit user or migrated legacy settings.

## Main changes
- Default `GeneralSettings.UseCa2023` to `true`.
- Add regression coverage for the default configuration signature setting.

## Testing notes
- `dotnet test src\Foundry.Core.Tests\Foundry.Core.Tests.csproj`
- `scripts\Test-FoundryFormat.ps1`