### PR TITLE
fix(deps): target latest .NET 10 runtime patch

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -38,6 +38,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <TargetFramework>net10.0-windows</TargetFramework>
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

Configure all .NET projects to resolve the latest patched .NET 10 runtime.

## Reason

Dependabot reports 40 alerts for vulnerable Microsoft.NETCore.App.Runtime 10.0.9 packages. The first patched runtime is 10.0.10.

## Main changes

- Set TargetLatestRuntimePatch to true in src/Directory.Build.props.
- Keep the net10.0 target framework while ensuring self-contained publications use the latest .NET 10 security patch.
- Resolve win-x64 and win-arm64 runtime packs to 10.0.10 with the current SDK.

## Testing

- dotnet restore src/Foundry.slnx --force-evaluate
- dotnet list src/Foundry.slnx package --vulnerable --include-transitive
- dotnet build src/Foundry.slnx --no-restore --configuration Release
- dotnet test src/Foundry.slnx --no-build --no-restore --configuration Release: 778 passed
- Self-contained win-x64 publish confirmed Microsoft.NETCore.App.Runtime 10.0.10 resolution