### PR TITLE
chore(deps): update .NET dependencies

### DIFF
--- a/src/Foundry.Connect.Tests/Foundry.Connect.Tests.csproj
+++ b/src/Foundry.Connect.Tests/Foundry.Connect.Tests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Foundry.Connect/Foundry.Connect.csproj
+++ b/src/Foundry.Connect/Foundry.Connect.csproj
@@ -11,9 +11,9 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
-    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/src/Foundry.Core.Tests/Foundry.Core.Tests.csproj
+++ b/src/Foundry.Core.Tests/Foundry.Core.Tests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Foundry.Deploy.Tests/Foundry.Deploy.Tests.csproj
+++ b/src/Foundry.Deploy.Tests/Foundry.Deploy.Tests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Foundry.Deploy/Foundry.Deploy.csproj
+++ b/src/Foundry.Deploy/Foundry.Deploy.csproj
@@ -12,9 +12,9 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
-    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/src/Foundry.Localization.Tests/Foundry.Localization.Tests.csproj
+++ b/src/Foundry.Localization.Tests/Foundry.Localization.Tests.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Foundry.Telemetry.Tests/Foundry.Telemetry.Tests.csproj
+++ b/src/Foundry.Telemetry.Tests/Foundry.Telemetry.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Foundry.Telemetry/Foundry.Telemetry.csproj
+++ b/src/Foundry.Telemetry/Foundry.Telemetry.csproj
@@ -16,7 +16,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -55,15 +55,15 @@
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.251219" />
-    <PackageReference Include="DevWinUI" Version="10.0.0" />
+    <PackageReference Include="DevWinUI" Version="10.1.0" />
     <PackageReference Include="DevWinUI.ContextMenu" Version="10.0.0" />
-    <PackageReference Include="DevWinUI.SourceGenerator" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="DevWinUI.SourceGenerator" Version="10.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
-    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2270" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.3.1" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Velopack" Version="1.2.0" />


### PR DESCRIPTION
## Summary

Update the .NET dependency set across Foundry, Foundry.Connect, Foundry.Deploy, telemetry, and test projects.

## Reason

Keep the solution on current servicing releases while verifying API, runtime, source-generator, test-platform, and packaging compatibility before adoption.

## Main changes

- Update Microsoft.Extensions.DependencyInjection, Hosting, and Logging.Abstractions from 10.0.9 to 10.0.10.
- Update Microsoft.NET.Test.Sdk from 18.7.0 to 18.8.1.
- Update Serilog from 4.3.1 to 4.4.0.
- Update DevWinUI and DevWinUI.SourceGenerator from 10.0.0 to 10.1.0.
- Update Microsoft.Windows.SDK.BuildTools from 10.0.28000.1839 to 10.0.28000.2270.
- Update Microsoft.WindowsAppSDK from 2.2.0 to 2.3.1.

## Compatibility audit

- Microsoft.Extensions 10.0.10 contains no relevant DI, hosting, or logging API breaks for Foundry's usage.
- VSTest 18.8 removes its transitive Newtonsoft.Json dependency. Foundry does not consume that leaked dependency or custom VSTest protocol APIs; 18.8.1 also includes the System.Text.Json protocol negotiation fix.
- Serilog 4.4.0 changes are additive diagnostics/metrics and fixes; current logger configuration, enrichers, sinks, and lifecycle calls remain compatible.
- Windows App SDK 2.3.1 changes `DISABLE_XAML_GENERATED_MAIN` to rename the generated entry point. Foundry's explicit `Program.Main` remains the effective entry point and builds/publishes successfully.
- DevWinUI 10.1.0 and its source generator restore and compile with the existing DevWinUI.ContextMenu 10.0.0 package; ContextMenu has no dependency on the core DevWinUI package.
- No vulnerable direct or transitive packages were reported.

Primary references:

- [.NET 10.0.10](https://github.com/dotnet/runtime/releases/tag/v10.0.10)
- [VSTest 18.8.0](https://github.com/microsoft/vstest/releases/tag/v18.8.0) and [18.8.1](https://github.com/microsoft/vstest/releases/tag/v18.8.1)
- [Serilog 4.4.0](https://github.com/serilog/serilog/releases/tag/v4.4.0)
- [Windows App SDK 2.3.1](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/release-notes/windows-app-sdk-2-0#version-231)
- [DevWinUI 10.1.0](https://github.com/ghost1372/DevWinUI/releases/tag/v10.1.0)

## Testing notes

- Foundry formatting script: passed; 44/44 XAML files passed.
- Release build x64: passed.
- Release build ARM64: passed.
- Release tests x64: 778 passed, 0 failed, 0 skipped.
- Release publish x64: produced Foundry.exe, Foundry.Connect.exe, and Foundry.Deploy.exe.
- NuGet vulnerability scan including transitive packages: no vulnerabilities.
- Independent code review: ready to merge; no Critical, Important, or Minor findings.

A manual installed-app smoke test on a clean Windows machine remains recommended for startup and shell context-menu integration.

## Merge strategy

Preserve the commit history. Do not squash this PR.
