### PR TITLE
fix(deploy): use applied Windows BCDBoot

### DIFF
--- a/src/Foundry.Deploy.Tests/WindowsDeploymentServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/WindowsDeploymentServiceTests.cs
@@ -62,6 +62,93 @@ public sealed class WindowsDeploymentServiceTests
         Assert.DoesNotContain(scriptLines, line => line.StartsWith("shrink ", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Theory]
+    [InlineData(26199, "/v")]
+    [InlineData(26200, "/bootex")]
+    public async Task ConfigureBootAsync_UsesAppliedWindowsBcdBootWithExpectedArguments(
+        int operatingSystemBuildMajor,
+        string expectedFinalSwitch)
+    {
+        using var workspace = new TemporaryWorkspace();
+        string windowsRoot = Path.Combine(workspace.RootPath, "Target Windows");
+        string windowsPath = Path.Combine(windowsRoot, "Windows");
+        string bcdBootPath = Path.Combine(windowsPath, "System32", "bcdboot.exe");
+        string workingDirectory = Path.Combine(workspace.RootPath, "Work");
+        const string systemRoot = @"S:\";
+        Directory.CreateDirectory(Path.GetDirectoryName(bcdBootPath)!);
+        await File.WriteAllTextAsync(bcdBootPath, string.Empty, TestContext.Current.CancellationToken);
+        var processRunner = new RecordingProcessRunner();
+        var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
+
+        await service.ConfigureBootAsync(
+            windowsRoot,
+            systemRoot,
+            operatingSystemBuildMajor,
+            workingDirectory,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(bcdBootPath, processRunner.LastFileName);
+        Assert.Equal(
+            $"\"{windowsPath}\" /s \"{systemRoot}\" /f UEFI /c {expectedFinalSwitch}",
+            processRunner.LastArguments);
+        Assert.Equal(workingDirectory, processRunner.LastWorkingDirectory);
+    }
+
+    [Fact]
+    public async Task ConfigureBootAsync_WhenAppliedBcdBootIsMissing_ThrowsFileNotFoundException()
+    {
+        using var workspace = new TemporaryWorkspace();
+        string windowsRoot = Path.Combine(workspace.RootPath, "WindowsRoot");
+        string expectedBcdBootPath = Path.Combine(windowsRoot, "Windows", "System32", "bcdboot.exe");
+        var processRunner = new RecordingProcessRunner();
+        var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
+
+        FileNotFoundException exception = await Assert.ThrowsAsync<FileNotFoundException>(() =>
+            service.ConfigureBootAsync(
+                windowsRoot,
+                @"S:\",
+                26200,
+                Path.Combine(workspace.RootPath, "Work"),
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(expectedBcdBootPath, exception.FileName);
+        Assert.Null(processRunner.LastFileName);
+    }
+
+    [Fact]
+    public async Task ConfigureBootAsync_WhenAppliedBcdBootFails_PropagatesDiagnostic()
+    {
+        using var workspace = new TemporaryWorkspace();
+        string windowsRoot = Path.Combine(workspace.RootPath, "WindowsRoot");
+        string bcdBootPath = Path.Combine(windowsRoot, "Windows", "System32", "bcdboot.exe");
+        Directory.CreateDirectory(Path.GetDirectoryName(bcdBootPath)!);
+        await File.WriteAllTextAsync(bcdBootPath, string.Empty, TestContext.Current.CancellationToken);
+        var processRunner = new RecordingProcessRunner
+        {
+            Result = new ProcessExecutionResult
+            {
+                ExitCode = 193,
+                StandardOutput = "Failure when attempting to copy boot files.",
+                StandardError = "diagnostic"
+            }
+        };
+        var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.ConfigureBootAsync(
+                windowsRoot,
+                @"S:\",
+                26200,
+                Path.Combine(workspace.RootPath, "Work"),
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(bcdBootPath, processRunner.LastFileName);
+        Assert.Contains("BCDBoot configuration failed", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("ExitCode=193", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Failure when attempting to copy boot files.", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("diagnostic", exception.Message, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task ConfigureOfflineComputerNameAsync_WhenDefaultTimeZoneIdIsProvided_WritesUnattendTimeZone()
     {
@@ -293,6 +380,10 @@ public sealed class WindowsDeploymentServiceTests
     private sealed class RecordingProcessRunner : IProcessRunner
     {
         public List<string> Calls { get; } = [];
+        public string? LastFileName { get; private set; }
+        public string? LastArguments { get; private set; }
+        public string? LastWorkingDirectory { get; private set; }
+        public ProcessExecutionResult Result { get; init; } = new() { ExitCode = 0 };
 
         public Task<ProcessExecutionResult> RunAsync(
             string fileName,
@@ -301,7 +392,10 @@ public sealed class WindowsDeploymentServiceTests
             CancellationToken cancellationToken = default)
         {
             Calls.Add($"{fileName} {arguments}");
-            return Task.FromResult(new ProcessExecutionResult { ExitCode = 0 });
+            LastFileName = fileName;
+            LastArguments = arguments;
+            LastWorkingDirectory = workingDirectory;
+            return Task.FromResult(Result);
         }
 
         public Task<ProcessExecutionResult> RunAsync(

--- a/src/Foundry.Deploy.Tests/WindowsDeploymentServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/WindowsDeploymentServiceTests.cs
@@ -12,28 +12,6 @@ namespace Foundry.Deploy.Tests;
 
 public sealed class WindowsDeploymentServiceTests
 {
-    [Theory]
-    [InlineData(26199, "/c /v")]
-    [InlineData(26200, "/c /bootex /v")]
-    public async Task ConfigureBootAsync_UsesExpectedDiagnosticArguments(
-        int build,
-        string expectedArguments)
-    {
-        using var workspace = new TemporaryWorkspace();
-        var processRunner = new RecordingProcessRunner();
-        var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
-
-        await service.ConfigureBootAsync(
-            @"W:\",
-            @"S:\",
-            build,
-            workspace.RootPath,
-            TestContext.Current.CancellationToken);
-
-        string call = Assert.Single(processRunner.Calls);
-        Assert.Contains(expectedArguments, call, StringComparison.Ordinal);
-    }
-
     [Fact]
     public async Task PrepareTargetDiskAsync_CreatesPartitionsInExpectedOrder_Efi_Msr_Recovery_Windows()
     {
@@ -63,11 +41,11 @@ public sealed class WindowsDeploymentServiceTests
     }
 
     [Theory]
-    [InlineData(26199, "/v")]
-    [InlineData(26200, "/bootex")]
+    [InlineData(26199, "/c /v")]
+    [InlineData(26200, "/c /bootex /v")]
     public async Task ConfigureBootAsync_UsesAppliedWindowsBcdBootWithExpectedArguments(
         int operatingSystemBuildMajor,
-        string expectedFinalSwitch)
+        string expectedArguments)
     {
         using var workspace = new TemporaryWorkspace();
         string windowsRoot = Path.Combine(workspace.RootPath, "Target Windows");
@@ -89,7 +67,7 @@ public sealed class WindowsDeploymentServiceTests
 
         Assert.Equal(bcdBootPath, processRunner.LastFileName);
         Assert.Equal(
-            $"\"{windowsPath}\" /s \"{systemRoot}\" /f UEFI /c {expectedFinalSwitch}",
+            $"\"{windowsPath}\" /s \"{systemRoot}\" /f UEFI {expectedArguments}",
             processRunner.LastArguments);
         Assert.Equal(workingDirectory, processRunner.LastWorkingDirectory);
     }
@@ -134,7 +112,7 @@ public sealed class WindowsDeploymentServiceTests
         };
         var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
 
-        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        DeploymentProcessException exception = await Assert.ThrowsAsync<DeploymentProcessException>(() =>
             service.ConfigureBootAsync(
                 windowsRoot,
                 @"S:\",
@@ -142,6 +120,7 @@ public sealed class WindowsDeploymentServiceTests
                 Path.Combine(workspace.RootPath, "Work"),
                 TestContext.Current.CancellationToken));
 
+        Assert.IsAssignableFrom<InvalidOperationException>(exception);
         Assert.Equal(bcdBootPath, processRunner.LastFileName);
         Assert.Contains("BCDBoot configuration failed", exception.Message, StringComparison.Ordinal);
         Assert.Contains("ExitCode=193", exception.Message, StringComparison.Ordinal);

--- a/src/Foundry.Deploy/Services/Deployment/WindowsDeploymentService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/WindowsDeploymentService.cs
@@ -827,6 +827,14 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
         CancellationToken cancellationToken = default)
     {
         string windowsPath = Path.Combine(windowsPartitionRoot, "Windows");
+        string bcdBootPath = Path.Combine(windowsPath, "System32", "bcdboot.exe");
+        if (!File.Exists(bcdBootPath))
+        {
+            throw new FileNotFoundException(
+                "The applied Windows image does not contain bcdboot.exe.",
+                bcdBootPath);
+        }
+
         _logger.LogInformation("Configuring boot files. WindowsPath={WindowsPath}, SystemPartitionRoot={SystemPartitionRoot}", windowsPath, systemPartitionRoot);
 
         string arguments = operatingSystemBuildMajor >= 26200
@@ -834,7 +842,7 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
             : $"\"{windowsPath}\" /s \"{systemPartitionRoot}\" /f UEFI /c /v";
 
         await RunRequiredProcessAsync(
-            "bcdboot.exe",
+            bcdBootPath,
             arguments,
             workingDirectory,
             "BCDBoot configuration failed",


### PR DESCRIPTION
## Summary

Use BCDBoot from the applied Windows image instead of the WinPE environment.

## Reason

The deployed Windows BCDBoot binary matches the target operating system and avoids WinPE/target-version compatibility failures such as exit code 193.

## Main changes

- Resolve `System32\bcdboot.exe` from the applied Windows directory.
- Fail clearly when that executable is missing.
- Preserve structured deployment process failure details introduced by #257.
- Keep `/c /v` for older builds and `/c /bootex /v` from build 26200 onward.
- Consolidate BCDBoot path, argument, missing-file, and failure-contract coverage.

## Testing notes

- `Foundry.Deploy.Tests`: 337 passed.
- Repository format check: passed, including 44/44 XAML files.