### PR TITLE
feat(deploy): validate Windows 11 prerequisites

### DIFF
--- a/src/Foundry.Deploy.Tests/DeploymentLaunchPreparationServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentLaunchPreparationServiceTests.cs
@@ -6,6 +6,7 @@ using Foundry.Deploy.Models;
 using Foundry.Deploy.Models.Configuration;
 using Foundry.Deploy.Services.ApplicationShell;
 using Foundry.Deploy.Services.Deployment;
+using Foundry.Deploy.Services.Deployment.Preflight;
 using System.Globalization;
 
 namespace Foundry.Deploy.Tests;
@@ -16,7 +17,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
     public void Prepare_WhenDryRunAndTargetDiskMissing_UsesDebugVirtualDisk()
     {
         var shell = new FakeApplicationShellService();
-        var service = new DeploymentLaunchPreparationService(shell);
+        DeploymentLaunchPreparationService service = CreateService(shell);
 
         DeploymentLaunchPreparationResult result = service.Prepare(CreateRequest(selectedTargetDisk: null, isDryRun: true));
 
@@ -30,7 +31,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
     public void Prepare_WhenSelectedDiskIsBlocked_FailsBeforeConfirmation()
     {
         var shell = new FakeApplicationShellService();
-        var service = new DeploymentLaunchPreparationService(shell);
+        DeploymentLaunchPreparationService service = CreateService(shell);
         TargetDiskInfo blockedDisk = CreateDisk(isSelectable: false, selectionWarning: "System disk");
 
         DeploymentLaunchPreparationResult result = service.Prepare(CreateRequest(selectedTargetDisk: blockedDisk));
@@ -44,7 +45,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
     public void Prepare_WhenOemDriverPackSelectionHasNoPackage_FailsValidation()
     {
         var shell = new FakeApplicationShellService();
-        var service = new DeploymentLaunchPreparationService(shell);
+        DeploymentLaunchPreparationService service = CreateService(shell);
 
         DeploymentLaunchPreparationResult result = service.Prepare(
             CreateRequest(
@@ -60,7 +61,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
     public void Prepare_WhenRequestIsValidAndConfirmed_ReturnsDeploymentContext()
     {
         var shell = new FakeApplicationShellService { ConfirmationResult = true };
-        var service = new DeploymentLaunchPreparationService(shell);
+        DeploymentLaunchPreparationService service = CreateService(shell);
         TargetDiskInfo targetDisk = CreateDisk();
         DriverPackCatalogItem driverPack = new()
         {
@@ -127,7 +128,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
     public void Prepare_WhenHardwareHashUploadModeHasNoJsonProfile_ReturnsDeploymentContext()
     {
         var shell = new FakeApplicationShellService { ConfirmationResult = true };
-        var service = new DeploymentLaunchPreparationService(shell);
+        DeploymentLaunchPreparationService service = CreateService(shell);
 
         DeploymentLaunchPreparationResult result = service.Prepare(
             CreateRequest(
@@ -146,7 +147,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
     public void Prepare_WhenInteractiveHardwareHashUploadModeHasNoJsonProfile_ReturnsDeploymentContext()
     {
         var shell = new FakeApplicationShellService { ConfirmationResult = true };
-        var service = new DeploymentLaunchPreparationService(shell);
+        DeploymentLaunchPreparationService service = CreateService(shell);
 
         DeploymentLaunchPreparationResult result = service.Prepare(
             CreateRequest(
@@ -165,7 +166,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
     public void Prepare_WhenLiveHardwareHashUploadModeIsSelected_DoesNotRequireJsonProfile()
     {
         var shell = new FakeApplicationShellService { ConfirmationResult = true };
-        var service = new DeploymentLaunchPreparationService(shell);
+        DeploymentLaunchPreparationService service = CreateService(shell);
         DeployAutopilotHardwareHashUploadSettings hardwareHashUpload = new()
         {
             TenantId = "tenant-id",
@@ -195,7 +196,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
     public void Prepare_WhenJsonProfileModeHasNoProfile_FailsValidation()
     {
         var shell = new FakeApplicationShellService();
-        var service = new DeploymentLaunchPreparationService(shell);
+        DeploymentLaunchPreparationService service = CreateService(shell);
 
         DeploymentLaunchPreparationResult result = service.Prepare(
             CreateRequest(
@@ -220,16 +221,16 @@ public sealed class DeploymentLaunchPreparationServiceTests
         try
         {
             var shell = new FakeApplicationShellService { ConfirmationResult = true };
-            var service = new DeploymentLaunchPreparationService(shell);
+            DeploymentLaunchPreparationService service = CreateService(shell);
 
-            TargetDiskInfo targetDisk = CreateDisk(sizeBytes: 0);
+            TargetDiskInfo targetDisk = CreateDisk();
 
             service.Prepare(CreateRequest(selectedTargetDisk: targetDisk));
 
             Assert.Equal("Confirmer l’effacement du disque", shell.LastConfirmationTitle);
             Assert.Contains("Cela effacera toutes les données du disque sélectionné et installera le système d’exploitation sélectionné.", shell.LastConfirmationMessage);
             Assert.Contains("Disque : 3", shell.LastConfirmationMessage);
-            Assert.Contains("Taille : Taille inconnue", shell.LastConfirmationMessage);
+            Assert.Contains("Taille : 256,0 GiB", shell.LastConfirmationMessage);
             Assert.Contains("Continuer le déploiement ?", shell.LastConfirmationMessage);
         }
         finally
@@ -237,6 +238,41 @@ public sealed class DeploymentLaunchPreparationServiceTests
             CultureInfo.CurrentCulture = originalCulture;
             CultureInfo.CurrentUICulture = originalUiCulture;
         }
+    }
+
+    [Fact]
+    public void Prepare_WhenPreflightHasBlockingFinding_FailsBeforeConfirmation()
+    {
+        var shell = new FakeApplicationShellService();
+        DeploymentLaunchPreparationService service = CreateService(shell);
+        HardwareProfile hardware = CreateReadyHardware() with { FirmwareMode = FirmwareMode.Bios };
+
+        DeploymentLaunchPreparationResult result = service.Prepare(
+            CreateRequest(selectedTargetDisk: CreateDisk(), detectedHardware: hardware));
+
+        Assert.False(result.IsReadyToStart);
+        Assert.Equal(0, shell.ConfirmationCallCount);
+    }
+
+    [Fact]
+    public void Prepare_WhenDiskIsBelowRecommendedSize_IncludesWarningInConfirmation()
+    {
+        var shell = new FakeApplicationShellService { ConfirmationResult = true };
+        DeploymentLaunchPreparationService service = CreateService(shell);
+
+        DeploymentLaunchPreparationResult result = service.Prepare(
+            CreateRequest(selectedTargetDisk: CreateDisk(sizeBytes: 48UL * 1024UL * 1024UL * 1024UL)));
+
+        Assert.True(result.IsReadyToStart);
+        Assert.Equal(1, shell.ConfirmationCallCount);
+        Assert.Contains("64", shell.LastConfirmationMessage);
+        Assert.Contains("GiB", shell.LastConfirmationMessage);
+        Assert.Single(result.Context!.AcknowledgedPreflightWarnings);
+    }
+
+    private static DeploymentLaunchPreparationService CreateService(IApplicationShellService shell)
+    {
+        return new DeploymentLaunchPreparationService(shell, new DeploymentPreflightService());
     }
 
     private static DeploymentLaunchRequest CreateRequest(
@@ -252,7 +288,8 @@ public sealed class DeploymentLaunchPreparationServiceTests
         DeployOobeSettings? oobe = null,
         DeployAppxRemovalSettings? appxRemoval = null,
         DeployAiComponentRemovalSettings? aiComponentRemoval = null,
-        bool isDryRun = false)
+        bool isDryRun = false,
+        HardwareProfile? detectedHardware = null)
     {
         return new DeploymentLaunchRequest
         {
@@ -272,6 +309,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
                 LicenseChannel = "Retail",
                 Build = "26100"
             },
+            DetectedHardware = detectedHardware ?? CreateReadyHardware(),
             DriverPackSelectionKind = driverPackSelectionKind,
             SelectedDriverPack = selectedDriverPack,
             ApplyFirmwareUpdates = false,
@@ -283,6 +321,20 @@ public sealed class DeploymentLaunchPreparationServiceTests
             AppxRemoval = appxRemoval ?? new DeployAppxRemovalSettings(),
             AiComponentRemoval = aiComponentRemoval ?? new DeployAiComponentRemovalSettings(),
             IsDryRun = isDryRun
+        };
+    }
+
+    private static HardwareProfile CreateReadyHardware()
+    {
+        return new HardwareProfile
+        {
+            Architecture = "x64",
+            FirmwareMode = FirmwareMode.Uefi,
+            IsTpmPresent = true,
+            TpmSpecVersion = "2.0",
+            IsTpmEnabled = true,
+            IsTpmActivated = true,
+            SecureBootState = SecureBootState.Enabled
         };
     }
 

--- a/src/Foundry.Deploy.Tests/DeploymentPreflightServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentPreflightServiceTests.cs
@@ -1,0 +1,222 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Deploy.Models;
+using Foundry.Deploy.Services.Deployment.Preflight;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class DeploymentPreflightServiceTests
+{
+    [Fact]
+    public void Evaluate_WhenTargetMeetsRequirements_ReturnsNoFindings()
+    {
+        var service = new DeploymentPreflightService();
+
+        DeploymentPreflightResult result = service.Evaluate(
+            CreateReadyHardware(),
+            CreateDisk(256),
+            CreateOperatingSystem("x64"));
+
+        Assert.Empty(result.Findings);
+        Assert.False(result.HasBlockingFindings);
+        Assert.False(result.HasWarnings);
+    }
+
+    [Fact]
+    public void Evaluate_WhenFirmwareIsNotUefi_ReturnsBlockingFinding()
+    {
+        var service = new DeploymentPreflightService();
+        HardwareProfile hardware = CreateReadyHardware() with { FirmwareMode = FirmwareMode.Bios };
+
+        DeploymentPreflightResult result = service.Evaluate(hardware, CreateDisk(256), CreateOperatingSystem("x64"));
+
+        DeploymentPreflightFinding finding = Assert.Single(result.Findings);
+        Assert.Equal(DeploymentPreflightFindingCodes.FirmwareMode, finding.Code);
+        Assert.Equal(DeploymentPreflightSeverity.Blocking, finding.Severity);
+    }
+
+    [Fact]
+    public void Evaluate_WhenArchitectureDoesNotMatch_ReturnsBlockingFinding()
+    {
+        var service = new DeploymentPreflightService();
+
+        DeploymentPreflightResult result = service.Evaluate(
+            CreateReadyHardware(),
+            CreateDisk(256),
+            CreateOperatingSystem("arm64"));
+
+        DeploymentPreflightFinding finding = Assert.Single(result.Findings);
+        Assert.Equal(DeploymentPreflightFindingCodes.ArchitectureMismatch, finding.Code);
+        Assert.Equal(DeploymentPreflightSeverity.Blocking, finding.Severity);
+        Assert.Equal(["arm64", "x64"], finding.MessageArguments);
+    }
+
+    [Fact]
+    public void Evaluate_WhenTpmIsMissing_ReturnsBlockingFinding()
+    {
+        var service = new DeploymentPreflightService();
+        HardwareProfile hardware = CreateReadyHardware() with { IsTpmPresent = false };
+
+        DeploymentPreflightResult result = service.Evaluate(hardware, CreateDisk(256), CreateOperatingSystem("x64"));
+
+        DeploymentPreflightFinding finding = Assert.Single(result.Findings);
+        Assert.Equal(DeploymentPreflightFindingCodes.TpmMissing, finding.Code);
+        Assert.Equal(DeploymentPreflightSeverity.Blocking, finding.Severity);
+    }
+
+    [Theory]
+    [InlineData("1.2", true, true, DeploymentPreflightFindingCodes.TpmVersion)]
+    [InlineData("2.0", false, true, DeploymentPreflightFindingCodes.TpmDisabled)]
+    [InlineData("2.0", true, false, DeploymentPreflightFindingCodes.TpmDeactivated)]
+    public void Evaluate_WhenTpmIsNotReady_ReturnsBlockingFinding(
+        string version,
+        bool isEnabled,
+        bool isActivated,
+        string expectedCode)
+    {
+        var service = new DeploymentPreflightService();
+        HardwareProfile hardware = CreateReadyHardware() with
+        {
+            TpmSpecVersion = version,
+            IsTpmEnabled = isEnabled,
+            IsTpmActivated = isActivated
+        };
+
+        DeploymentPreflightResult result = service.Evaluate(hardware, CreateDisk(256), CreateOperatingSystem("x64"));
+
+        DeploymentPreflightFinding finding = Assert.Single(result.Findings);
+        Assert.Equal(expectedCode, finding.Code);
+        Assert.Equal(DeploymentPreflightSeverity.Blocking, finding.Severity);
+    }
+
+    [Fact]
+    public void Evaluate_WhenSecureBootIsDisabled_ReturnsWarning()
+    {
+        var service = new DeploymentPreflightService();
+        HardwareProfile hardware = CreateReadyHardware() with { SecureBootState = SecureBootState.Disabled };
+
+        DeploymentPreflightResult result = service.Evaluate(hardware, CreateDisk(256), CreateOperatingSystem("x64"));
+
+        DeploymentPreflightFinding finding = Assert.Single(result.Findings);
+        Assert.Equal(DeploymentPreflightFindingCodes.SecureBootDisabled, finding.Code);
+        Assert.Equal(DeploymentPreflightSeverity.Warning, finding.Severity);
+        Assert.False(result.HasBlockingFindings);
+        Assert.True(result.HasWarnings);
+    }
+
+    [Theory]
+    [InlineData(SecureBootState.Unknown)]
+    [InlineData(SecureBootState.Unsupported)]
+    public void Evaluate_WhenSecureBootCapabilityCannotBeVerified_ReturnsBlockingFinding(SecureBootState state)
+    {
+        var service = new DeploymentPreflightService();
+        HardwareProfile hardware = CreateReadyHardware() with { SecureBootState = state };
+
+        DeploymentPreflightResult result = service.Evaluate(hardware, CreateDisk(256), CreateOperatingSystem("x64"));
+
+        DeploymentPreflightFinding finding = Assert.Single(result.Findings);
+        Assert.Equal(DeploymentPreflightFindingCodes.SecureBootUnavailable, finding.Code);
+        Assert.Equal(DeploymentPreflightSeverity.Blocking, finding.Severity);
+    }
+
+    [Fact]
+    public void Evaluate_WhenDiskIsBelowWindowsRecommendation_ReturnsWarning()
+    {
+        var service = new DeploymentPreflightService();
+
+        DeploymentPreflightResult result = service.Evaluate(
+            CreateReadyHardware(),
+            CreateDisk(48),
+            CreateOperatingSystem("x64"));
+
+        DeploymentPreflightFinding finding = Assert.Single(result.Findings);
+        Assert.Equal(DeploymentPreflightFindingCodes.DiskBelowRecommendedSize, finding.Code);
+        Assert.Equal(DeploymentPreflightSeverity.Warning, finding.Severity);
+        Assert.False(result.HasBlockingFindings);
+    }
+
+    [Fact]
+    public void Evaluate_WhenDiskIsFarBelowWindowsRecommendation_ReturnsWarning()
+    {
+        var service = new DeploymentPreflightService();
+
+        DeploymentPreflightResult result = service.Evaluate(
+            CreateReadyHardware(),
+            CreateDisk(24),
+            CreateOperatingSystem("x64"));
+
+        DeploymentPreflightFinding finding = Assert.Single(result.Findings);
+        Assert.Equal(DeploymentPreflightFindingCodes.DiskBelowRecommendedSize, finding.Code);
+        Assert.Equal(DeploymentPreflightSeverity.Warning, finding.Severity);
+    }
+
+    [Fact]
+    public void GetUnacknowledgedWarnings_WhenExactWarningWasAcknowledged_ReturnsEmpty()
+    {
+        var service = new DeploymentPreflightService();
+        DeploymentPreflightResult result = service.Evaluate(
+            CreateReadyHardware(),
+            CreateDisk(48),
+            CreateOperatingSystem("x64"));
+
+        IReadOnlyList<DeploymentPreflightFinding> unacknowledged =
+            result.GetUnacknowledgedWarnings([result.Findings.Single().AcknowledgementKey]);
+
+        Assert.Empty(unacknowledged);
+    }
+
+    [Fact]
+    public void GetUnacknowledgedWarnings_WhenWarningArgumentsChanged_ReturnsWarning()
+    {
+        var service = new DeploymentPreflightService();
+        DeploymentPreflightResult acknowledged = service.Evaluate(
+            CreateReadyHardware(),
+            CreateDisk(48),
+            CreateOperatingSystem("x64"));
+        DeploymentPreflightResult changed = service.Evaluate(
+            CreateReadyHardware(),
+            CreateDisk(32),
+            CreateOperatingSystem("x64"));
+
+        IReadOnlyList<DeploymentPreflightFinding> unacknowledged =
+            changed.GetUnacknowledgedWarnings([acknowledged.Findings.Single().AcknowledgementKey]);
+
+        Assert.Single(unacknowledged);
+    }
+
+    private static HardwareProfile CreateReadyHardware()
+    {
+        return new HardwareProfile
+        {
+            Architecture = "x64",
+            FirmwareMode = FirmwareMode.Uefi,
+            IsTpmPresent = true,
+            TpmSpecVersion = "2.0, 0, 1.16",
+            IsTpmEnabled = true,
+            IsTpmActivated = true,
+            SecureBootState = SecureBootState.Enabled
+        };
+    }
+
+    private static TargetDiskInfo CreateDisk(ulong sizeGiB)
+    {
+        return new TargetDiskInfo
+        {
+            DiskNumber = 0,
+            FriendlyName = "Test disk",
+            SizeBytes = sizeGiB * 1024UL * 1024UL * 1024UL,
+            IsSelectable = true
+        };
+    }
+
+    private static OperatingSystemCatalogItem CreateOperatingSystem(string architecture)
+    {
+        return new OperatingSystemCatalogItem
+        {
+            WindowsRelease = "11",
+            Architecture = architecture
+        };
+    }
+}

--- a/src/Foundry.Deploy.Tests/DeploymentWizardStateServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentWizardStateServiceTests.cs
@@ -54,6 +54,43 @@ public sealed class DeploymentWizardStateServiceTests
         Assert.False(canStart);
     }
 
+    [Fact]
+    public void CanStartDeployment_WhenPreflightHasBlockingFindings_ReturnsFalse()
+    {
+        var service = new DeploymentWizardStateService();
+
+        bool canStart = service.CanStartDeployment(
+            CreateSnapshot(
+                wizardStepIndex: 3,
+                hasSelectedOperatingSystem: true,
+                hasTargetDiskSelection: true,
+                isTargetComputerNameValid: true,
+                hasValidDriverPackSelection: true,
+                hasValidAutopilotSelection: true,
+                hasBlockingPreflightFindings: true));
+
+        Assert.False(canStart);
+    }
+
+    [Fact]
+    public void CanStartDeployment_WhenDebugSafeModeHasBlockingPreflightFindings_ReturnsTrue()
+    {
+        var service = new DeploymentWizardStateService();
+
+        bool canStart = service.CanStartDeployment(
+            CreateSnapshot(
+                wizardStepIndex: 3,
+                isDebugSafeMode: true,
+                hasSelectedOperatingSystem: true,
+                hasTargetDiskSelection: false,
+                isTargetComputerNameValid: true,
+                hasValidDriverPackSelection: true,
+                hasValidAutopilotSelection: true,
+                hasBlockingPreflightFindings: true));
+
+        Assert.True(canStart);
+    }
+
     private static DeploymentWizardStateSnapshot CreateSnapshot(
         int wizardStepIndex,
         bool isDeploymentRunning = false,
@@ -66,7 +103,8 @@ public sealed class DeploymentWizardStateServiceTests
         bool isSelectedTargetDiskSelectable = true,
         bool hasValidDriverPackSelection = false,
         bool hasValidAutopilotSelection = false,
-        bool isOperatingSystemCatalogReadyForNavigation = true)
+        bool isOperatingSystemCatalogReadyForNavigation = true,
+        bool hasBlockingPreflightFindings = false)
     {
         return new DeploymentWizardStateSnapshot
         {
@@ -81,7 +119,8 @@ public sealed class DeploymentWizardStateServiceTests
             IsSelectedTargetDiskSelectable = isSelectedTargetDiskSelectable,
             HasValidDriverPackSelection = hasValidDriverPackSelection,
             HasValidAutopilotSelection = hasValidAutopilotSelection,
-            IsOperatingSystemCatalogReadyForNavigation = isOperatingSystemCatalogReadyForNavigation
+            IsOperatingSystemCatalogReadyForNavigation = isOperatingSystemCatalogReadyForNavigation,
+            HasBlockingPreflightFindings = hasBlockingPreflightFindings
         };
     }
 }

--- a/src/Foundry.Deploy.Tests/HardwareProfileServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/HardwareProfileServiceTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Deploy.Models;
+using Foundry.Deploy.Services.Hardware;
+using Foundry.Deploy.Services.System;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class HardwareProfileServiceTests
+{
+    [Fact]
+    public async Task GetCurrentAsync_WhenFirmwareSecurityDataIsAvailable_MapsDeploymentPrerequisites()
+    {
+        const string payload = """
+            {
+              "Manufacturer": "Contoso",
+              "Model": "Model 1",
+              "Product": "Product 1",
+              "SerialNumber": "ABC123",
+              "Architecture": "AMD64",
+              "IsOnBattery": false,
+              "IsTpmPresent": true,
+              "TpmSpecVersion": "2.0, 0, 1.16",
+              "IsTpmEnabled": true,
+              "IsTpmActivated": true,
+              "FirmwareMode": "Uefi",
+              "SecureBootState": "Enabled",
+              "SystemFirmwareHardwareId": "",
+              "PnpDevices": []
+            }
+            """;
+        var runner = new StaticProcessRunner(payload);
+        var service = new HardwareProfileService(runner, NullLogger<HardwareProfileService>.Instance);
+
+        HardwareProfile profile = await service.GetCurrentAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(profile.IsTpmPresent);
+        Assert.Equal("2.0, 0, 1.16", profile.TpmSpecVersion);
+        Assert.True(profile.IsTpmEnabled);
+        Assert.True(profile.IsTpmActivated);
+        Assert.Equal(FirmwareMode.Uefi, profile.FirmwareMode);
+        Assert.Equal(SecureBootState.Enabled, profile.SecureBootState);
+    }
+
+    private sealed class StaticProcessRunner(string standardOutput) : IProcessRunner
+    {
+        public Task<ProcessExecutionResult> RunAsync(
+            string fileName,
+            string arguments,
+            string workingDirectory,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new ProcessExecutionResult
+            {
+                ExitCode = 0,
+                StandardOutput = standardOutput
+            });
+        }
+
+        public Task<ProcessExecutionResult> RunAsync(
+            string fileName,
+            IEnumerable<string> arguments,
+            string workingDirectory,
+            CancellationToken cancellationToken = default)
+        {
+            return RunAsync(fileName, string.Join(" ", arguments), workingDirectory, cancellationToken);
+        }
+
+        public Task<ProcessExecutionResult> RunAsync(
+            string fileName,
+            IEnumerable<string> arguments,
+            string workingDirectory,
+            Action<string>? onOutputData,
+            Action<string>? onErrorData,
+            CancellationToken cancellationToken = default)
+        {
+            return RunAsync(fileName, arguments, workingDirectory, cancellationToken);
+        }
+    }
+}

--- a/src/Foundry.Deploy.Tests/LocalizationResourceTests.cs
+++ b/src/Foundry.Deploy.Tests/LocalizationResourceTests.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
+using System.Collections;
 using System.Resources;
+using System.Text.RegularExpressions;
 using Foundry.Deploy.Services.Localization;
 
 namespace Foundry.Deploy.Tests;
@@ -64,5 +66,49 @@ public sealed class LocalizationResourceTests
 
         Assert.NotNull(resourceSet);
         Assert.Equal("Foundry Deploy", resourceSet.GetString("App.Name"));
+    }
+
+    [Theory]
+    [MemberData(nameof(SatelliteCultures))]
+    public void SatelliteResourceSet_HasSameKeysAndFormatArgumentsAsDefaultCulture(string cultureName)
+    {
+        ResourceSet baseline = Assert.IsAssignableFrom<ResourceSet>(
+            LocalizationText.ResourceManager.GetResourceSet(
+                CultureInfo.GetCultureInfo("en-US"),
+                createIfNotExists: true,
+                tryParents: false));
+        ResourceSet localized = Assert.IsAssignableFrom<ResourceSet>(
+            LocalizationText.ResourceManager.GetResourceSet(
+                CultureInfo.GetCultureInfo(cultureName),
+                createIfNotExists: true,
+                tryParents: false));
+        IReadOnlyDictionary<string, string> baselineValues = ReadValues(baseline);
+        IReadOnlyDictionary<string, string> localizedValues = ReadValues(localized);
+
+        Assert.Equal(baselineValues.Keys.Order(), localizedValues.Keys.Order());
+        foreach ((string key, string value) in baselineValues)
+        {
+            Assert.Equal(
+                ReadFormatArgumentIndexes(value),
+                ReadFormatArgumentIndexes(localizedValues[key]));
+        }
+    }
+
+    private static IReadOnlyDictionary<string, string> ReadValues(ResourceSet resourceSet)
+    {
+        return resourceSet
+            .Cast<DictionaryEntry>()
+            .ToDictionary(
+                entry => Assert.IsType<string>(entry.Key),
+                entry => Assert.IsType<string>(entry.Value),
+                StringComparer.Ordinal);
+    }
+
+    private static string[] ReadFormatArgumentIndexes(string value)
+    {
+        return Regex.Matches(value, @"\{(?<index>\d+)(?:[^}]*)\}")
+            .Select(match => match.Groups["index"].Value)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
     }
 }

--- a/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Foundry.Deploy.Services.Cache;
 using Foundry.Deploy.Services.Catalog;
 using Foundry.Deploy.Services.Configuration;
 using Foundry.Deploy.Services.Deployment;
+using Foundry.Deploy.Services.Deployment.Preflight;
 using Foundry.Deploy.Services.Deployment.PreOobe;
 using Foundry.Deploy.Services.Deployment.Steps;
 using Foundry.Deploy.Services.Network;
@@ -79,6 +80,7 @@ public static class ServiceCollectionExtensions
                 logger);
         });
         services.AddSingleton<IDeploymentLaunchPreparationService, DeploymentLaunchPreparationService>();
+        services.AddSingleton<IDeploymentPreflightService, DeploymentPreflightService>();
         services.AddSingleton<IDeploymentExecutionService, DeploymentExecutionService>();
         services.AddSingleton<IProcessRunner, ProcessRunner>();
         services.AddSingleton<IArchiveExtractionService, ArchiveExtractionService>();

--- a/src/Foundry.Deploy/Models/FirmwareMode.cs
+++ b/src/Foundry.Deploy/Models/FirmwareMode.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Deploy.Models;
+
+/// <summary>
+/// Identifies the firmware mode used to start the current Windows PE session.
+/// </summary>
+public enum FirmwareMode
+{
+    Unknown,
+    Bios,
+    Uefi
+}

--- a/src/Foundry.Deploy/Models/HardwareProfile.cs
+++ b/src/Foundry.Deploy/Models/HardwareProfile.cs
@@ -14,6 +14,11 @@ public sealed record HardwareProfile
     public bool IsVirtualMachine { get; init; }
     public bool IsOnBattery { get; init; }
     public bool IsTpmPresent { get; init; }
+    public string TpmSpecVersion { get; init; } = string.Empty;
+    public bool IsTpmEnabled { get; init; }
+    public bool IsTpmActivated { get; init; }
+    public FirmwareMode FirmwareMode { get; init; }
+    public SecureBootState SecureBootState { get; init; }
     public string SystemFirmwareHardwareId { get; init; } = string.Empty;
     public IReadOnlyList<PnpDeviceInfo> PnpDevices { get; init; } = Array.Empty<PnpDeviceInfo>();
 

--- a/src/Foundry.Deploy/Models/SecureBootState.cs
+++ b/src/Foundry.Deploy/Models/SecureBootState.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Deploy.Models;
+
+/// <summary>
+/// Describes the Secure Boot capability and state reported by the current firmware.
+/// </summary>
+public enum SecureBootState
+{
+    Unknown,
+    Unsupported,
+    Disabled,
+    Enabled
+}

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentContext.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentContext.cs
@@ -44,6 +44,11 @@ public sealed record DeploymentContext
     public required OperatingSystemCatalogItem OperatingSystem { get; init; }
 
     /// <summary>
+    /// Gets the exact preflight warnings acknowledged before destructive deployment.
+    /// </summary>
+    public IReadOnlyList<string> AcknowledgedPreflightWarnings { get; init; } = [];
+
+    /// <summary>
     /// Gets the selected driver pack strategy.
     /// </summary>
     public required DriverPackSelectionKind DriverPackSelectionKind { get; init; }

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchPreparationService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchPreparationService.cs
@@ -5,6 +5,7 @@
 using Foundry.Deploy.Models;
 using Foundry.Deploy.Models.Configuration;
 using Foundry.Deploy.Services.ApplicationShell;
+using Foundry.Deploy.Services.Deployment.Preflight;
 using Foundry.Deploy.Services.Localization;
 using Foundry.Deploy.Validation;
 
@@ -16,10 +17,14 @@ namespace Foundry.Deploy.Services.Deployment;
 public sealed class DeploymentLaunchPreparationService : IDeploymentLaunchPreparationService
 {
     private readonly IApplicationShellService _applicationShellService;
+    private readonly IDeploymentPreflightService _deploymentPreflightService;
 
-    public DeploymentLaunchPreparationService(IApplicationShellService applicationShellService)
+    public DeploymentLaunchPreparationService(
+        IApplicationShellService applicationShellService,
+        IDeploymentPreflightService deploymentPreflightService)
     {
         _applicationShellService = applicationShellService;
+        _deploymentPreflightService = deploymentPreflightService;
     }
 
     /// <summary>
@@ -71,7 +76,15 @@ public sealed class DeploymentLaunchPreparationService : IDeploymentLaunchPrepar
             return DeploymentLaunchPreparationResult.Failure(normalizedComputerName);
         }
 
-        if (!request.IsDryRun && !ConfirmDestructiveDeployment(effectiveTargetDisk, request.SelectedOperatingSystem))
+        DeploymentPreflightResult preflight = request.IsDryRun
+            ? new DeploymentPreflightResult { Findings = [] }
+            : _deploymentPreflightService.Evaluate(request.DetectedHardware, effectiveTargetDisk, request.SelectedOperatingSystem);
+        if (preflight.HasBlockingFindings)
+        {
+            return DeploymentLaunchPreparationResult.Failure(normalizedComputerName);
+        }
+
+        if (!request.IsDryRun && !ConfirmDestructiveDeployment(effectiveTargetDisk, request.SelectedOperatingSystem, preflight))
         {
             return DeploymentLaunchPreparationResult.Failure(normalizedComputerName);
         }
@@ -84,6 +97,10 @@ public sealed class DeploymentLaunchPreparationService : IDeploymentLaunchPrepar
             TargetComputerName = normalizedComputerName,
             DefaultTimeZoneId = string.IsNullOrWhiteSpace(request.DefaultTimeZoneId) ? null : request.DefaultTimeZoneId.Trim(),
             OperatingSystem = request.SelectedOperatingSystem,
+            AcknowledgedPreflightWarnings = preflight.Findings
+                .Where(finding => finding.Severity == DeploymentPreflightSeverity.Warning)
+                .Select(finding => finding.AcknowledgementKey)
+                .ToArray(),
             DriverPackSelectionKind = request.DriverPackSelectionKind,
             DriverPack = request.SelectedDriverPack,
             ApplyFirmwareUpdates = request.ApplyFirmwareUpdates,
@@ -109,8 +126,12 @@ public sealed class DeploymentLaunchPreparationService : IDeploymentLaunchPrepar
     /// </summary>
     /// <param name="targetDisk">The disk that will be repartitioned.</param>
     /// <param name="operatingSystem">The operating system image that will be applied.</param>
+    /// <param name="preflight">The readiness result whose warnings require acknowledgement.</param>
     /// <returns><see langword="true"/> when the user confirms the destructive operation.</returns>
-    private bool ConfirmDestructiveDeployment(TargetDiskInfo targetDisk, OperatingSystemCatalogItem operatingSystem)
+    private bool ConfirmDestructiveDeployment(
+        TargetDiskInfo targetDisk,
+        OperatingSystemCatalogItem operatingSystem,
+        DeploymentPreflightResult preflight)
     {
         string sizeGiB = targetDisk.SizeBytes > 0
             ? $"{(targetDisk.SizeBytes / 1024d / 1024d / 1024d):0.0} GiB"
@@ -123,6 +144,16 @@ public sealed class DeploymentLaunchPreparationService : IDeploymentLaunchPrepar
             targetDisk.BusType,
             sizeGiB,
             operatingSystem.DisplayLabel);
+
+        if (preflight.HasWarnings)
+        {
+            string warnings = string.Join(
+                Environment.NewLine,
+                preflight.Findings
+                    .Where(finding => finding.Severity == DeploymentPreflightSeverity.Warning)
+                    .Select(finding => $"• {DeploymentPreflightLocalization.FormatFinding(finding)}"));
+            message = $"{message}{Environment.NewLine}{Environment.NewLine}{LocalizationText.GetString("Preflight.WarningConfirmationIntro")}{Environment.NewLine}{warnings}";
+        }
 
         return _applicationShellService.ConfirmWarning(LocalizationText.GetString("Launch.ConfirmDiskEraseTitle"), message);
     }

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchRequest.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchRequest.cs
@@ -16,6 +16,7 @@ public sealed record DeploymentLaunchRequest
     public string? DefaultTimeZoneId { get; init; }
     public required TargetDiskInfo? SelectedTargetDisk { get; init; }
     public required OperatingSystemCatalogItem? SelectedOperatingSystem { get; init; }
+    public HardwareProfile? DetectedHardware { get; init; }
     public required DriverPackSelectionKind DriverPackSelectionKind { get; init; }
     public required DriverPackCatalogItem? SelectedDriverPack { get; init; }
     public required bool ApplyFirmwareUpdates { get; init; }

--- a/src/Foundry.Deploy/Services/Deployment/Preflight/DeploymentPreflightFinding.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Preflight/DeploymentPreflightFinding.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Deploy.Services.Deployment.Preflight;
+
+/// <summary>
+/// Represents one localized deployment-readiness message and its enforcement severity.
+/// </summary>
+public sealed record DeploymentPreflightFinding
+{
+    public required string Code { get; init; }
+    public required DeploymentPreflightSeverity Severity { get; init; }
+    public required string MessageResourceKey { get; init; }
+    public IReadOnlyList<string> MessageArguments { get; init; } = [];
+
+    /// <summary>
+    /// Gets the stable code and argument signature used to track an acknowledged warning.
+    /// </summary>
+    public string AcknowledgementKey => string.Join(
+        "\u001f",
+        new[] { Code }.Concat(MessageArguments));
+}

--- a/src/Foundry.Deploy/Services/Deployment/Preflight/DeploymentPreflightFindingCodes.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Preflight/DeploymentPreflightFindingCodes.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Deploy.Services.Deployment.Preflight;
+
+/// <summary>
+/// Provides stable identifiers for Windows 11 deployment readiness findings.
+/// </summary>
+public static class DeploymentPreflightFindingCodes
+{
+    public const string FirmwareMode = "firmware_mode";
+    public const string ArchitectureMismatch = "architecture_mismatch";
+    public const string TpmMissing = "tpm_missing";
+    public const string TpmVersion = "tpm_version";
+    public const string TpmDisabled = "tpm_disabled";
+    public const string TpmDeactivated = "tpm_deactivated";
+    public const string SecureBootDisabled = "secure_boot_disabled";
+    public const string SecureBootUnavailable = "secure_boot_unavailable";
+    public const string DiskSizeUnknown = "disk_size_unknown";
+    public const string DiskBelowRecommendedSize = "disk_below_recommended_size";
+}

--- a/src/Foundry.Deploy/Services/Deployment/Preflight/DeploymentPreflightLocalization.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Preflight/DeploymentPreflightLocalization.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Deploy.Services.Localization;
+
+namespace Foundry.Deploy.Services.Deployment.Preflight;
+
+/// <summary>
+/// Resolves localized deployment-readiness messages.
+/// </summary>
+public static class DeploymentPreflightLocalization
+{
+    public static string FormatFinding(DeploymentPreflightFinding finding)
+    {
+        ArgumentNullException.ThrowIfNull(finding);
+
+        return finding.MessageArguments.Count == 0
+            ? LocalizationText.GetString(finding.MessageResourceKey)
+            : LocalizationText.Format(finding.MessageResourceKey, finding.MessageArguments.Cast<object>().ToArray());
+    }
+}

--- a/src/Foundry.Deploy/Services/Deployment/Preflight/DeploymentPreflightResult.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Preflight/DeploymentPreflightResult.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Deploy.Services.Deployment.Preflight;
+
+/// <summary>
+/// Contains the actionable findings produced for one deployment selection.
+/// </summary>
+public sealed record DeploymentPreflightResult
+{
+    public required IReadOnlyList<DeploymentPreflightFinding> Findings { get; init; }
+
+    public bool HasBlockingFindings => Findings.Any(finding => finding.Severity == DeploymentPreflightSeverity.Blocking);
+
+    public bool HasWarnings => Findings.Any(finding => finding.Severity == DeploymentPreflightSeverity.Warning);
+
+    public IReadOnlyList<DeploymentPreflightFinding> GetUnacknowledgedWarnings(
+        IReadOnlyCollection<string> acknowledgedWarnings)
+    {
+        ArgumentNullException.ThrowIfNull(acknowledgedWarnings);
+
+        return Findings
+            .Where(finding =>
+                finding.Severity == DeploymentPreflightSeverity.Warning &&
+                !acknowledgedWarnings.Contains(finding.AcknowledgementKey, StringComparer.Ordinal))
+            .ToArray();
+    }
+}

--- a/src/Foundry.Deploy/Services/Deployment/Preflight/DeploymentPreflightService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Preflight/DeploymentPreflightService.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Deploy.Models;
+
+namespace Foundry.Deploy.Services.Deployment.Preflight;
+
+/// <summary>
+/// Applies the deployment readiness policy for the Windows 11-only workflow.
+/// </summary>
+public sealed class DeploymentPreflightService : IDeploymentPreflightService
+{
+    public const ulong RecommendedDiskSizeBytes = 64UL * 1024UL * 1024UL * 1024UL;
+
+    public DeploymentPreflightResult Evaluate(
+        HardwareProfile? hardware,
+        TargetDiskInfo? targetDisk,
+        OperatingSystemCatalogItem? operatingSystem)
+    {
+        var findings = new List<DeploymentPreflightFinding>();
+
+        EvaluateHardware(hardware, operatingSystem, findings);
+        EvaluateDisk(targetDisk, findings);
+
+        return new DeploymentPreflightResult { Findings = findings };
+    }
+
+    private static void EvaluateHardware(
+        HardwareProfile? hardware,
+        OperatingSystemCatalogItem? operatingSystem,
+        ICollection<DeploymentPreflightFinding> findings)
+    {
+        if (hardware?.FirmwareMode != FirmwareMode.Uefi)
+        {
+            findings.Add(Blocking(DeploymentPreflightFindingCodes.FirmwareMode, "Preflight.FirmwareModeBlocking"));
+        }
+
+        if (hardware is not null &&
+            operatingSystem is not null &&
+            !ArchitecturesMatch(hardware.Architecture, operatingSystem.Architecture))
+        {
+            findings.Add(Blocking(
+                DeploymentPreflightFindingCodes.ArchitectureMismatch,
+                "Preflight.ArchitectureMismatchBlocking",
+                NormalizeArchitecture(operatingSystem.Architecture),
+                NormalizeArchitecture(hardware.Architecture)));
+        }
+
+        if (hardware?.IsTpmPresent != true)
+        {
+            findings.Add(Blocking(DeploymentPreflightFindingCodes.TpmMissing, "Preflight.TpmMissingBlocking"));
+        }
+        else if (!IsTpm2(hardware.TpmSpecVersion))
+        {
+            findings.Add(Blocking(
+                DeploymentPreflightFindingCodes.TpmVersion,
+                "Preflight.TpmVersionBlocking",
+                hardware.TpmSpecVersion));
+        }
+        else if (!hardware.IsTpmEnabled)
+        {
+            findings.Add(Blocking(DeploymentPreflightFindingCodes.TpmDisabled, "Preflight.TpmDisabledBlocking"));
+        }
+        else if (!hardware.IsTpmActivated)
+        {
+            findings.Add(Blocking(DeploymentPreflightFindingCodes.TpmDeactivated, "Preflight.TpmDeactivatedBlocking"));
+        }
+
+        switch (hardware?.SecureBootState)
+        {
+            case SecureBootState.Enabled:
+                break;
+            case SecureBootState.Disabled:
+                findings.Add(Warning(DeploymentPreflightFindingCodes.SecureBootDisabled, "Preflight.SecureBootDisabledWarning"));
+                break;
+            default:
+                findings.Add(Blocking(DeploymentPreflightFindingCodes.SecureBootUnavailable, "Preflight.SecureBootUnavailableBlocking"));
+                break;
+        }
+    }
+
+    private static void EvaluateDisk(
+        TargetDiskInfo? targetDisk,
+        ICollection<DeploymentPreflightFinding> findings)
+    {
+        if (targetDisk is null || targetDisk.SizeBytes == 0)
+        {
+            findings.Add(Blocking(DeploymentPreflightFindingCodes.DiskSizeUnknown, "Preflight.DiskSizeUnknownBlocking"));
+            return;
+        }
+
+        if (targetDisk.SizeBytes < RecommendedDiskSizeBytes)
+        {
+            findings.Add(Warning(
+                DeploymentPreflightFindingCodes.DiskBelowRecommendedSize,
+                "Preflight.DiskBelowRecommendedSizeWarning",
+                FormatGiB(targetDisk.SizeBytes),
+                FormatGiB(RecommendedDiskSizeBytes)));
+        }
+    }
+
+    private static bool ArchitecturesMatch(string hardwareArchitecture, string operatingSystemArchitecture)
+    {
+        string hardware = NormalizeArchitecture(hardwareArchitecture);
+        string operatingSystem = NormalizeArchitecture(operatingSystemArchitecture);
+        return hardware.Length > 0 &&
+               operatingSystem.Length > 0 &&
+               hardware.Equals(operatingSystem, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizeArchitecture(string value)
+    {
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "amd64" => "x64",
+            "aarch64" => "arm64",
+            string normalized => normalized
+        };
+    }
+
+    private static bool IsTpm2(string specVersion)
+    {
+        string primaryVersion = specVersion
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault() ?? string.Empty;
+
+        return Version.TryParse(primaryVersion, out Version? version) && version.Major >= 2;
+    }
+
+    private static string FormatGiB(ulong bytes)
+    {
+        return $"{bytes / 1024d / 1024d / 1024d:0.0}";
+    }
+
+    private static DeploymentPreflightFinding Blocking(string code, string messageResourceKey, params string[] arguments)
+    {
+        return CreateFinding(code, DeploymentPreflightSeverity.Blocking, messageResourceKey, arguments);
+    }
+
+    private static DeploymentPreflightFinding Warning(string code, string messageResourceKey, params string[] arguments)
+    {
+        return CreateFinding(code, DeploymentPreflightSeverity.Warning, messageResourceKey, arguments);
+    }
+
+    private static DeploymentPreflightFinding CreateFinding(
+        string code,
+        DeploymentPreflightSeverity severity,
+        string messageResourceKey,
+        IReadOnlyList<string> arguments)
+    {
+        return new DeploymentPreflightFinding
+        {
+            Code = code,
+            Severity = severity,
+            MessageResourceKey = messageResourceKey,
+            MessageArguments = arguments
+        };
+    }
+}

--- a/src/Foundry.Deploy/Services/Deployment/Preflight/DeploymentPreflightSeverity.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Preflight/DeploymentPreflightSeverity.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Deploy.Services.Deployment.Preflight;
+
+/// <summary>
+/// Determines whether a deployment finding requires acknowledgement or prevents deployment.
+/// </summary>
+public enum DeploymentPreflightSeverity
+{
+    Warning,
+    Blocking
+}

--- a/src/Foundry.Deploy/Services/Deployment/Preflight/IDeploymentPreflightService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Preflight/IDeploymentPreflightService.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Deploy.Models;
+
+namespace Foundry.Deploy.Services.Deployment.Preflight;
+
+/// <summary>
+/// Evaluates Windows 11 firmware, security, architecture, and storage prerequisites.
+/// </summary>
+public interface IDeploymentPreflightService
+{
+    DeploymentPreflightResult Evaluate(
+        HardwareProfile? hardware,
+        TargetDiskInfo? targetDisk,
+        OperatingSystemCatalogItem? operatingSystem);
+}

--- a/src/Foundry.Deploy/Services/Deployment/Steps/ValidateTargetConfigurationStep.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Steps/ValidateTargetConfigurationStep.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Foundry.Deploy.Models;
+using Foundry.Deploy.Services.Deployment.Preflight;
 using Foundry.Deploy.Services.Hardware;
 using Foundry.Deploy.Services.Logging;
 
@@ -11,10 +12,14 @@ namespace Foundry.Deploy.Services.Deployment.Steps;
 public sealed class ValidateTargetConfigurationStep : DeploymentStepBase
 {
     private readonly IHardwareProfileService _hardwareProfileService;
+    private readonly IDeploymentPreflightService _deploymentPreflightService;
 
-    public ValidateTargetConfigurationStep(IHardwareProfileService hardwareProfileService)
+    public ValidateTargetConfigurationStep(
+        IHardwareProfileService hardwareProfileService,
+        IDeploymentPreflightService deploymentPreflightService)
     {
         _hardwareProfileService = hardwareProfileService;
+        _deploymentPreflightService = deploymentPreflightService;
     }
 
     public override int Order => 3;
@@ -27,7 +32,7 @@ public sealed class ValidateTargetConfigurationStep : DeploymentStepBase
             "Validating target configuration...",
             "Revalidating target disk...",
             DeploymentOperationNames.ValidateTargetDisk);
-        (_, DeploymentStepResult? validationFailure) = await context.TryGetValidatedTargetDiskAsync(cancellationToken).ConfigureAwait(false);
+        (TargetDiskInfo? selectedDisk, DeploymentStepResult? validationFailure) = await context.TryGetValidatedTargetDiskAsync(cancellationToken).ConfigureAwait(false);
         if (validationFailure is not null)
         {
             return validationFailure;
@@ -50,6 +55,37 @@ public sealed class ValidateTargetConfigurationStep : DeploymentStepBase
         HardwareProfile hardware = await _hardwareProfileService.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
         context.RuntimeState.HardwareProfile = hardware;
         await context.AppendLogAsync(DeploymentLogLevel.Info, $"Detected hardware: {hardware.DisplayLabel}", cancellationToken).ConfigureAwait(false);
+
+        DeploymentPreflightResult preflight = _deploymentPreflightService.Evaluate(hardware, selectedDisk, context.Request.OperatingSystem);
+        foreach (DeploymentPreflightFinding finding in preflight.Findings)
+        {
+            DeploymentLogLevel level = finding.Severity == DeploymentPreflightSeverity.Blocking
+                ? DeploymentLogLevel.Error
+                : DeploymentLogLevel.Warning;
+            await context.AppendLogAsync(
+                level,
+                $"Deployment preflight [{finding.Code}]: {DeploymentPreflightLocalization.FormatFinding(finding)}",
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        if (preflight.HasBlockingFindings)
+        {
+            string reasons = string.Join(
+                Environment.NewLine,
+                preflight.Findings
+                    .Where(finding => finding.Severity == DeploymentPreflightSeverity.Blocking)
+                    .Select(DeploymentPreflightLocalization.FormatFinding));
+            return DeploymentStepResult.Failed(reasons);
+        }
+
+        IReadOnlyList<DeploymentPreflightFinding> unacknowledgedWarnings =
+            preflight.GetUnacknowledgedWarnings(context.Request.AcknowledgedPreflightWarnings);
+        if (unacknowledgedWarnings.Count > 0)
+        {
+            return DeploymentStepResult.Failed(string.Join(
+                Environment.NewLine,
+                unacknowledgedWarnings.Select(DeploymentPreflightLocalization.FormatFinding)));
+        }
 
         return DeploymentStepResult.Succeeded("Target configuration validated.");
     }

--- a/src/Foundry.Deploy/Services/Hardware/HardwareProfileService.cs
+++ b/src/Foundry.Deploy/Services/Hardware/HardwareProfileService.cs
@@ -41,6 +41,44 @@ function ConvertTo-TrimmedString {
     }
 }
 
+$wpeutil = Get-Command -Name wpeutil.exe -ErrorAction SilentlyContinue
+if ($wpeutil) {
+    & $wpeutil.Source UpdateBootInfo | Out-Null
+}
+
+$firmwareType = (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control' -Name PEFirmwareType -ErrorAction SilentlyContinue).PEFirmwareType
+$firmwareMode = 'Unknown'
+$firmwareMode = switch ($firmwareType) {
+    1 { 'Bios' }
+    2 { 'Uefi' }
+    default { 'Unknown' }
+}
+
+$secureBootState = 'Unknown'
+if ($firmwareMode -eq 'Bios') {
+    $secureBootState = 'Unsupported'
+}
+elseif ($firmwareMode -eq 'Uefi') {
+    $confirmSecureBootCommand = Get-Command -Name Confirm-SecureBootUEFI -ErrorAction SilentlyContinue
+    if ($confirmSecureBootCommand) {
+        try {
+            $secureBootState = if (Confirm-SecureBootUEFI -ErrorAction Stop) { 'Enabled' } else { 'Disabled' }
+        }
+        catch [System.PlatformNotSupportedException] {
+            $secureBootState = 'Unsupported'
+        }
+        catch {
+            $secureBootState = 'Unknown'
+        }
+    }
+    else {
+        $secureBootRegistry = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\SecureBoot\State' -Name UEFISecureBootEnabled -ErrorAction SilentlyContinue
+        if ($null -ne $secureBootRegistry) {
+            $secureBootState = if ([int]$secureBootRegistry.UEFISecureBootEnabled -eq 1) { 'Enabled' } else { 'Disabled' }
+        }
+    }
+}
+
 $computer = Get-CimInstance -ClassName Win32_ComputerSystem
 $product = Get-CimInstance -ClassName Win32_ComputerSystemProduct
 $bios = Get-CimInstance -ClassName Win32_BIOS
@@ -72,6 +110,11 @@ $isOnBattery = @($battery | Where-Object { $_.BatteryStatus -eq 1 }).Count -gt 0
     Architecture = [string]$env:PROCESSOR_ARCHITECTURE
     IsOnBattery = [bool]$isOnBattery
     IsTpmPresent = [bool]($null -ne $tpm)
+    TpmSpecVersion = [string]($tpm.SpecVersion | ConvertTo-TrimmedString)
+    IsTpmEnabled = [bool]($tpm.IsEnabled_InitialValue)
+    IsTpmActivated = [bool]($tpm.IsActivated_InitialValue)
+    FirmwareMode = [string]$firmwareMode
+    SecureBootState = [string]$secureBootState
     SystemFirmwareHardwareId = [string]$systemFirmwareHardwareId
     PnpDevices = $pnpDevices
 } | ConvertTo-Json -Compress -Depth 8
@@ -102,6 +145,11 @@ $isOnBattery = @($battery | Where-Object { $_.BatteryStatus -eq 1 }).Count -gt 0
             bool isVirtualMachine = IsVirtualMachine(manufacturer, model, product);
             bool isOnBattery = ReadBoolProperty(root, "IsOnBattery");
             bool isTpmPresent = ReadBoolProperty(root, "IsTpmPresent");
+            string tpmSpecVersion = ReadProperty(root, "TpmSpecVersion");
+            bool isTpmEnabled = ReadBoolProperty(root, "IsTpmEnabled");
+            bool isTpmActivated = ReadBoolProperty(root, "IsTpmActivated");
+            FirmwareMode firmwareMode = ReadEnumProperty<FirmwareMode>(root, "FirmwareMode");
+            SecureBootState secureBootState = ReadEnumProperty<SecureBootState>(root, "SecureBootState");
             string systemFirmwareHardwareId = ReadProperty(root, "SystemFirmwareHardwareId");
             IReadOnlyList<PnpDeviceInfo> pnpDevices = ReadPnpDevices(root);
 
@@ -115,17 +163,27 @@ $isOnBattery = @($battery | Where-Object { $_.BatteryStatus -eq 1 }).Count -gt 0
                 IsVirtualMachine = isVirtualMachine,
                 IsOnBattery = isOnBattery,
                 IsTpmPresent = isTpmPresent,
+                TpmSpecVersion = tpmSpecVersion,
+                IsTpmEnabled = isTpmEnabled,
+                IsTpmActivated = isTpmActivated,
+                FirmwareMode = firmwareMode,
+                SecureBootState = secureBootState,
                 SystemFirmwareHardwareId = systemFirmwareHardwareId.Trim(),
                 PnpDevices = pnpDevices
             };
 
-            _logger.LogInformation("Hardware profile detected. Manufacturer={Manufacturer}, Model={Model}, Architecture={Architecture}, IsVirtualMachine={IsVirtualMachine}, IsOnBattery={IsOnBattery}, IsTpmPresent={IsTpmPresent}",
+            _logger.LogInformation("Hardware profile detected. Manufacturer={Manufacturer}, Model={Model}, Architecture={Architecture}, FirmwareMode={FirmwareMode}, SecureBootState={SecureBootState}, IsVirtualMachine={IsVirtualMachine}, IsOnBattery={IsOnBattery}, IsTpmPresent={IsTpmPresent}, TpmSpecVersion={TpmSpecVersion}, IsTpmEnabled={IsTpmEnabled}, IsTpmActivated={IsTpmActivated}",
                 profile.Manufacturer,
                 profile.Model,
                 profile.Architecture,
+                profile.FirmwareMode,
+                profile.SecureBootState,
                 profile.IsVirtualMachine,
                 profile.IsOnBattery,
-                profile.IsTpmPresent);
+                profile.IsTpmPresent,
+                profile.TpmSpecVersion,
+                profile.IsTpmEnabled,
+                profile.IsTpmActivated);
             return profile;
         }
         catch (Exception ex)
@@ -169,6 +227,15 @@ $isOnBattery = @($battery | Where-Object { $_.BatteryStatus -eq 1 }).Count -gt 0
 
         return value.ValueKind == JsonValueKind.True ||
                (value.ValueKind == JsonValueKind.String && bool.TryParse(value.GetString(), out bool parsed) && parsed);
+    }
+
+    private static TEnum ReadEnumProperty<TEnum>(JsonElement root, string propertyName)
+        where TEnum : struct, Enum
+    {
+        string value = ReadProperty(root, propertyName);
+        return Enum.TryParse(value, ignoreCase: true, out TEnum parsed)
+            ? parsed
+            : default;
     }
 
     private static IReadOnlyList<PnpDeviceInfo> ReadPnpDevices(JsonElement root)

--- a/src/Foundry.Deploy/Services/Wizard/DeploymentWizardStateService.cs
+++ b/src/Foundry.Deploy/Services/Wizard/DeploymentWizardStateService.cs
@@ -49,6 +49,7 @@ public sealed class DeploymentWizardStateService : IDeploymentWizardStateService
                snapshot.IsTargetComputerNameValid &&
                snapshot.HasSelectedOperatingSystem &&
                hasTargetDisk &&
+               (snapshot.IsDebugSafeMode || !snapshot.HasBlockingPreflightFindings) &&
                snapshot.HasValidDriverPackSelection &&
                snapshot.HasValidAutopilotSelection;
     }

--- a/src/Foundry.Deploy/Services/Wizard/DeploymentWizardStateSnapshot.cs
+++ b/src/Foundry.Deploy/Services/Wizard/DeploymentWizardStateSnapshot.cs
@@ -18,4 +18,5 @@ public sealed record DeploymentWizardStateSnapshot
     public required bool HasValidDriverPackSelection { get; init; }
     public required bool HasValidAutopilotSelection { get; init; }
     public required bool IsOperatingSystemCatalogReadyForNavigation { get; init; }
+    public required bool HasBlockingPreflightFindings { get; init; }
 }

--- a/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
@@ -512,15 +512,11 @@
     <value>تم تجهيز مساعد تسجيل Autopilot التفاعلي (محاكاة).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>جاهزية النشر</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>وضع البرامج الثابتة</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM القديم</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>الهندسة المعمارية</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>التمهيد الآمن</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>سعة القرص</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>محظور</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>تحذير</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>يلبي هذا الجهاز متطلبات نشر Windows 11 الأساسية.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>راجع هذه التحذيرات قبل المتابعة:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>يتطلب نشر Windows 11 UEFI. BIOS/CSM القديم غير مدعوم.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>لا تتطابق بنية Windows المحددة ({0}) مع بنية الجهاز ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
@@ -511,4 +511,27 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>تم تجهيز مساعد تسجيل Autopilot التفاعلي (محاكاة).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>جاهزية النشر</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>وضع البرامج الثابتة</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM القديم</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>الهندسة المعمارية</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>التمهيد الآمن</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>سعة القرص</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>محظور</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>تحذير</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>يلبي هذا الجهاز متطلبات نشر Windows 11 الأساسية.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>راجع هذه التحذيرات قبل المتابعة:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>يتطلب نشر Windows 11 UEFI. BIOS/CSM القديم غير مدعوم.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>لا تتطابق بنية Windows المحددة ({0}) مع بنية الجهاز ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>مطلوب TPM 2.0، ولكن لم يتم اكتشاف TPM.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>مطلوب TPM 2.0. مواصفات TPM التي تم اكتشافها: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 موجود ولكنه معطل في البرامج الثابتة.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 موجود ولكن لم يتم تنشيطه.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>تم تعطيل التمهيد الآمن. يمكنك المتابعة، ولكن Windows 11 مصمم لاستخدام Secure Boot.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>تعذر التحقق من دعم التمهيد الآمن. يتطلب نشر نظام التشغيل Windows 11 وجود برامج ثابتة لـ UEFI مع إمكانية التمهيد الآمن.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>لا يمكن تحديد سعة القرص الهدف.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>سعة القرص المستهدف {0} GiB. يوصي Windows 11 بسعة {1} GiB على الأقل. يمكنك المتابعة إذا كانت الصورة المحددة مناسبة.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
+++ b/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
@@ -511,4 +511,27 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Интерактивният помощник за регистрация на Autopilot е подготвен (симулация).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Готовност за разгръщане</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Режим на фърмуера</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Наследен BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Архитектура</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Сигурно зареждане</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Капацитет на диска</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Блокиран</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Предупреждение</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Това устройство отговаря на предпоставките за внедряване на Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Прегледайте тези предупреждения, преди да продължите:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Внедряването на Windows 11 изисква UEFI. Наследеният BIOS/CSM не се поддържа.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Избраната архитектура на Windows ({0}) не съответства на архитектурата на устройството ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>Изисква се TPM 2.0, но не е открит TPM.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>Изисква се TPM 2.0. Открита TPM спецификация: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 присъства, но е деактивиран във фърмуера.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 е наличен, но не е активиран.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Сигурното зареждане е деактивирано. Можете да продължите, но Windows 11 е проектиран да използва Secure Boot.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Поддръжката на Secure Boot не можа да бъде потвърдена. Внедряването на Windows 11 изисква UEFI фърмуер с възможност за защитено зареждане.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Целевият капацитет на диска не може да бъде определен.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Целевият диск е {0} GiB. Windows 11 препоръчва поне {1} GiB. Можете да продължите, ако избраното изображение пасва.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
+++ b/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
@@ -512,15 +512,11 @@
     <value>Интерактивният помощник за регистрация на Autopilot е подготвен (симулация).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Готовност за разгръщане</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Режим на фърмуера</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Наследен BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Архитектура</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Сигурно зареждане</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Капацитет на диска</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Блокиран</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Предупреждение</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Това устройство отговаря на предпоставките за внедряване на Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Прегледайте тези предупреждения, преди да продължите:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Внедряването на Windows 11 изисква UEFI. Наследеният BIOS/CSM не се поддържа.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Избраната архитектура на Windows ({0}) не съответства на архитектурата на устройството ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
+++ b/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
@@ -512,15 +512,11 @@ Pokračovat v nasazování?</value></data>
     <value>Interaktivní asistent registrace Autopilotu byl připraven (simulace).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Připravenost k nasazení</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Režim firmwaru</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Starší BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architektura</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Secure Boot</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Kapacita disku</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Zablokováno</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Upozornění</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Toto zařízení splňuje předpoklady nasazení Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Než budete pokračovat, přečtěte si tato varování:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Nasazení Windows 11 vyžaduje UEFI. Starší systém BIOS/CSM není podporován.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Vybraná architektura systému Windows ({0}) neodpovídá architektuře zařízení ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
+++ b/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
@@ -511,4 +511,27 @@ Pokračovat v nasazování?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktivní asistent registrace Autopilotu byl připraven (simulace).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Připravenost k nasazení</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Režim firmwaru</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Starší BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architektura</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Secure Boot</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Kapacita disku</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Zablokováno</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Upozornění</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Toto zařízení splňuje předpoklady nasazení Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Než budete pokračovat, přečtěte si tato varování:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Nasazení Windows 11 vyžaduje UEFI. Starší systém BIOS/CSM není podporován.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Vybraná architektura systému Windows ({0}) neodpovídá architektuře zařízení ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>Je vyžadován TPM 2.0, ale nebyl detekován žádný TPM.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>Je vyžadován TPM 2.0. Zjištěná specifikace TPM: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 je přítomen, ale ve firmwaru je zakázán.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 je přítomen, ale není aktivován.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Zabezpečené spouštění je zakázáno. Můžete pokračovat, ale Windows 11 je navržen tak, aby používal zabezpečené spouštění.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Podporu zabezpečeného spouštění nebylo možné ověřit. Nasazení Windows 11 vyžaduje firmware UEFI s funkcí Secure Boot.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Cílovou kapacitu disku nebylo možné určit.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Cílový disk je {0} GiB. Windows 11 doporučuje alespoň {1} GiB. Pokud se vám vybraný obrázek vejde, můžete pokračovat.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/da-DK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/da-DK/Resources.resx
@@ -512,15 +512,11 @@ Vil du fortsætte med implementeringen?</value></data>
     <value>Den interaktive Autopilot-registreringsassistent er klargjort (simulation).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Udrulningsberedskab</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware-tilstand</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Ældre BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arkitektur</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Sikker opstart</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Diskkapacitet</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blokeret</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Advarsel</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Denne enhed opfylder Windows 11-implementeringskravene.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Gennemgå disse advarsler, før du fortsætter:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11-implementering kræver UEFI. Ældre BIOS/CSM understøttes ikke.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Den valgte Windows-arkitektur ({0}) matcher ikke enhedsarkitekturen ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/da-DK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/da-DK/Resources.resx
@@ -511,4 +511,27 @@ Vil du fortsætte med implementeringen?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Den interaktive Autopilot-registreringsassistent er klargjort (simulation).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Udrulningsberedskab</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware-tilstand</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Ældre BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arkitektur</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Sikker opstart</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Diskkapacitet</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blokeret</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Advarsel</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Denne enhed opfylder Windows 11-implementeringskravene.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Gennemgå disse advarsler, før du fortsætter:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11-implementering kræver UEFI. Ældre BIOS/CSM understøttes ikke.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Den valgte Windows-arkitektur ({0}) matcher ikke enhedsarkitekturen ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>TPM 2.0 er påkrævet, men der blev ikke fundet nogen TPM.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>TPM 2.0 er påkrævet. Registreret TPM-specifikation: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 er til stede, men deaktiveret i firmware.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 er til stede, men ikke aktiveret.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Secure Boot er deaktiveret. Du kan fortsætte, men Windows 11 er designet til at bruge Secure Boot.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Secure Boot-understøttelse kunne ikke bekræftes. Windows 11-implementering kræver UEFI-firmware med Secure Boot-funktion.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Måldiskens kapacitet kunne ikke bestemmes.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Måldisken er {0} GiB. Windows 11 anbefaler mindst {1} GiB. Du kan fortsætte, hvis det valgte billede passer.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/de-DE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/de-DE/Resources.resx
@@ -511,4 +511,27 @@ Mit der Bereitstellung fortfahren?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Der interaktive Autopilot-Registrierungsassistent wurde bereitgestellt (Simulation).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Bereitstellungsbereitschaft</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware-Modus</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Legacy-BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architektur</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Sicherer Start</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Festplattenkapazität</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blockiert</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Warnung</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Dieses Gerät erfüllt die Bereitstellungsvoraussetzungen für Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Lesen Sie diese Warnungen, bevor Sie fortfahren:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Für die Bereitstellung von Windows 11 ist UEFI erforderlich. Legacy-BIOS/CSM wird nicht unterstützt.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Die ausgewählte Windows-Architektur ({0}) stimmt nicht mit der Gerätearchitektur ({1}) überein.</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>TPM 2.0 ist erforderlich, es wurde jedoch kein TPM erkannt.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>TPM 2.0 ist erforderlich. Erkannte TPM-Spezifikation: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 ist vorhanden, aber in der Firmware deaktiviert.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 ist vorhanden, aber nicht aktiviert.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Secure Boot ist deaktiviert. Sie können fortfahren, aber Windows 11 ist für die Verwendung von Secure Boot konzipiert.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Die Unterstützung für sicheren Start konnte nicht überprüft werden. Die Bereitstellung von Windows 11 erfordert UEFI-Firmware mit Secure Boot-Funktion.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Die Zielfestplattenkapazität konnte nicht ermittelt werden.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Die Zielfestplatte ist {0} GiB. Windows 11 empfiehlt mindestens {1} GiB. Sie können fortfahren, wenn das ausgewählte Bild passt.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/de-DE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/de-DE/Resources.resx
@@ -512,15 +512,11 @@ Mit der Bereitstellung fortfahren?</value></data>
     <value>Der interaktive Autopilot-Registrierungsassistent wurde bereitgestellt (Simulation).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Bereitstellungsbereitschaft</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware-Modus</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Legacy-BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architektur</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Sicherer Start</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Festplattenkapazität</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blockiert</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Warnung</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Dieses Gerät erfüllt die Bereitstellungsvoraussetzungen für Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Lesen Sie diese Warnungen, bevor Sie fortfahren:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Für die Bereitstellung von Windows 11 ist UEFI erforderlich. Legacy-BIOS/CSM wird nicht unterstützt.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Die ausgewählte Windows-Architektur ({0}) stimmt nicht mit der Gerätearchitektur ({1}) überein.</value></data>

--- a/src/Foundry.Deploy/Strings/el-GR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/el-GR/Resources.resx
@@ -511,4 +511,27 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Ο διαδραστικός βοηθός εγγραφής Autopilot προετοιμάστηκε (προσομοίωση).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Ετοιμότητα ανάπτυξης</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Λειτουργία υλικολογισμικού</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Παλιό BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Αρχιτεκτονική</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Ασφαλής εκκίνηση</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Χωρητικότητα δίσκου</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Αποκλείστηκε</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Προειδοποίηση</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Αυτή η συσκευή πληροί τις προϋποθέσεις ανάπτυξης των Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Διαβάστε αυτές τις προειδοποιήσεις πριν συνεχίσετε:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Η ανάπτυξη των Windows 11 απαιτεί UEFI. Το BIOS/CSM παλαιού τύπου δεν υποστηρίζεται.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Η επιλεγμένη αρχιτεκτονική των Windows ({0}) δεν ταιριάζει με την αρχιτεκτονική της συσκευής ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>Απαιτείται TPM 2.0, αλλά δεν εντοπίστηκε TPM.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>Απαιτείται TPM 2.0. Εντοπίστηκε προδιαγραφή TPM: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>Το TPM 2.0 υπάρχει αλλά είναι απενεργοποιημένο στο υλικολογισμικό.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>Το TPM 2.0 υπάρχει αλλά δεν είναι ενεργοποιημένο.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Η ασφαλής εκκίνηση είναι απενεργοποιημένη. Μπορείτε να συνεχίσετε, αλλά τα Windows 11 έχουν σχεδιαστεί για χρήση Ασφαλούς εκκίνησης.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Δεν ήταν δυνατή η επαλήθευση της υποστήριξης Secure Boot. Η ανάπτυξη των Windows 11 απαιτεί υλικολογισμικό UEFI με δυνατότητα Ασφαλούς εκκίνησης.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Δεν ήταν δυνατός ο προσδιορισμός της χωρητικότητας του δίσκου στόχου.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Ο δίσκος στόχος είναι {0} GiB. Τα Windows 11 συνιστούν τουλάχιστον {1} GiB. Μπορείτε να συνεχίσετε εάν η επιλεγμένη εικόνα ταιριάζει.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/el-GR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/el-GR/Resources.resx
@@ -512,15 +512,11 @@
     <value>Ο διαδραστικός βοηθός εγγραφής Autopilot προετοιμάστηκε (προσομοίωση).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Ετοιμότητα ανάπτυξης</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Λειτουργία υλικολογισμικού</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Παλιό BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Αρχιτεκτονική</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Ασφαλής εκκίνηση</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Χωρητικότητα δίσκου</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Αποκλείστηκε</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Προειδοποίηση</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Αυτή η συσκευή πληροί τις προϋποθέσεις ανάπτυξης των Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Διαβάστε αυτές τις προειδοποιήσεις πριν συνεχίσετε:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Η ανάπτυξη των Windows 11 απαιτεί UEFI. Το BIOS/CSM παλαιού τύπου δεν υποστηρίζεται.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Η επιλεγμένη αρχιτεκτονική των Windows ({0}) δεν ταιριάζει με την αρχιτεκτονική της συσκευής ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/en-GB/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-GB/Resources.resx
@@ -511,4 +511,27 @@ Continue with deployment?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interactive Autopilot registration assistant staged (simulation).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Deployment readiness</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware mode</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Legacy BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architecture</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Secure Boot</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Disk capacity</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blocked</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Warning</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>This device meets the Windows 11 deployment prerequisites.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Review these warnings before continuing:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 deployment requires UEFI. Legacy BIOS/CSM is not supported.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>The selected Windows architecture ({0}) does not match the device architecture ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>TPM 2.0 is required, but no TPM was detected.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>TPM 2.0 is required. Detected TPM specification: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 is present but disabled in firmware.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 is present but not activated.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Secure Boot is disabled. You can continue, but Windows 11 is designed to use Secure Boot.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Secure Boot support could not be verified. Windows 11 deployment requires UEFI firmware with Secure Boot capability.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>The target disk capacity could not be determined.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>The target disk is {0} GiB. Windows 11 recommends at least {1} GiB. You can continue if the selected image fits.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/en-GB/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-GB/Resources.resx
@@ -512,15 +512,11 @@ Continue with deployment?</value></data>
     <value>Interactive Autopilot registration assistant staged (simulation).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Deployment readiness</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware mode</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Legacy BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architecture</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Secure Boot</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Disk capacity</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blocked</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Warning</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>This device meets the Windows 11 deployment prerequisites.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Review these warnings before continuing:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 deployment requires UEFI. Legacy BIOS/CSM is not supported.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>The selected Windows architecture ({0}) does not match the device architecture ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/en-US/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-US/Resources.resx
@@ -511,4 +511,27 @@ Continue with deployment?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interactive Autopilot registration assistant staged (simulation).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Deployment readiness</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware mode</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Legacy BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architecture</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Secure Boot</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Disk capacity</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blocked</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Warning</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>This device meets the Windows 11 deployment prerequisites.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Review these warnings before continuing:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 deployment requires UEFI. Legacy BIOS/CSM is not supported.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>The selected Windows architecture ({0}) does not match the device architecture ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>TPM 2.0 is required, but no TPM was detected.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>TPM 2.0 is required. Detected TPM specification: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 is present but disabled in firmware.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 is present but not activated.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Secure Boot is disabled. You can continue, but Windows 11 is designed to use Secure Boot.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Secure Boot support could not be verified. Windows 11 deployment requires UEFI firmware with Secure Boot capability.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>The target disk capacity could not be determined.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>The target disk is {0} GiB. Windows 11 recommends at least {1} GiB. You can continue if the selected image fits.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/en-US/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-US/Resources.resx
@@ -512,15 +512,11 @@ Continue with deployment?</value></data>
     <value>Interactive Autopilot registration assistant staged (simulation).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Deployment readiness</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware mode</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Legacy BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architecture</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Secure Boot</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Disk capacity</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blocked</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Warning</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>This device meets the Windows 11 deployment prerequisites.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Review these warnings before continuing:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 deployment requires UEFI. Legacy BIOS/CSM is not supported.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>The selected Windows architecture ({0}) does not match the device architecture ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/es-ES/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-ES/Resources.resx
@@ -511,4 +511,27 @@ Sistema operativo: {4}
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Asistente de registro interactivo de Autopilot preparado (simulación).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Preparación para el despliegue</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Modo de firmware</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM heredado</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arquitectura</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Arranque seguro</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Capacidad del disco</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Bloqueado</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Advertencia</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Este dispositivo cumple con los requisitos previos de implementación de Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Revise estas advertencias antes de continuar:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>La implementación de Windows 11 requiere UEFI. No se admite BIOS/CSM heredado.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>La arquitectura de Windows seleccionada ({0}) no coincide con la arquitectura del dispositivo ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>Se requiere TPM 2.0, pero no se detectó ningún TPM.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>Se requiere TPM 2.0. Especificación de TPM detectada: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 está presente pero deshabilitado en el firmware.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 está presente pero no activado.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>El arranque seguro está deshabilitado. Puede continuar, pero Windows 11 está diseñado para utilizar Arranque seguro.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>No se pudo verificar la compatibilidad con el arranque seguro. La implementación de Windows 11 requiere firmware UEFI con capacidad de arranque seguro.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>No se pudo determinar la capacidad del disco de destino.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>El disco de destino es {0} GiB. Windows 11 recomienda al menos {1} GiB. Puedes continuar si la imagen seleccionada encaja.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/es-ES/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-ES/Resources.resx
@@ -512,15 +512,11 @@ Sistema operativo: {4}
     <value>Asistente de registro interactivo de Autopilot preparado (simulación).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Preparación para el despliegue</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Modo de firmware</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM heredado</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arquitectura</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Arranque seguro</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Capacidad del disco</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Bloqueado</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Advertencia</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Este dispositivo cumple con los requisitos previos de implementación de Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Revise estas advertencias antes de continuar:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>La implementación de Windows 11 requiere UEFI. No se admite BIOS/CSM heredado.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>La arquitectura de Windows seleccionada ({0}) no coincide con la arquitectura del dispositivo ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/es-MX/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-MX/Resources.resx
@@ -511,4 +511,27 @@ Sistema operativo: {4}
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Asistente de registro interactivo de Autopilot preparado (simulación).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Preparación para el despliegue</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Modo de firmware</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM heredado</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arquitectura</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Arranque seguro</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Capacidad del disco</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Bloqueado</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Advertencia</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Este dispositivo cumple con los requisitos previos de implementación de Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Revise estas advertencias antes de continuar:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>La implementación de Windows 11 requiere UEFI. No se admite BIOS/CSM heredado.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>La arquitectura de Windows seleccionada ({0}) no coincide con la arquitectura del dispositivo ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>Se requiere TPM 2.0, pero no se detectó ningún TPM.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>Se requiere TPM 2.0. Especificación de TPM detectada: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 está presente pero deshabilitado en el firmware.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 está presente pero no activado.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>El arranque seguro está deshabilitado. Puede continuar, pero Windows 11 está diseñado para utilizar Arranque seguro.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>No se pudo verificar la compatibilidad con el arranque seguro. La implementación de Windows 11 requiere firmware UEFI con capacidad de arranque seguro.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>No se pudo determinar la capacidad del disco de destino.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>El disco de destino es {0} GiB. Windows 11 recomienda al menos {1} GiB. Puedes continuar si la imagen seleccionada encaja.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/es-MX/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-MX/Resources.resx
@@ -512,15 +512,11 @@ Sistema operativo: {4}
     <value>Asistente de registro interactivo de Autopilot preparado (simulación).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Preparación para el despliegue</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Modo de firmware</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM heredado</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arquitectura</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Arranque seguro</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Capacidad del disco</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Bloqueado</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Advertencia</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Este dispositivo cumple con los requisitos previos de implementación de Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Revise estas advertencias antes de continuar:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>La implementación de Windows 11 requiere UEFI. No se admite BIOS/CSM heredado.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>La arquitectura de Windows seleccionada ({0}) no coincide con la arquitectura del dispositivo ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/et-EE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/et-EE/Resources.resx
@@ -511,4 +511,27 @@ Kas jätkata juurutamisega?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktiivne Autopiloti registreerimisabiline on ette valmistatud (simulatsioon).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Kasutusvalmidus</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Püsivararežiim</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Pärand BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arhitektuur</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Turvaline alglaadimine</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Ketta maht</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blokeeritud</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Hoiatus</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>See seade vastab Windows 11 juurutamise eeltingimustele.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Enne jätkamist vaadake need hoiatused üle:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 juurutamine nõuab UEFI-t. Pärand-BIOS/CSM ei ole toetatud.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Valitud Windowsi arhitektuur ({0}) ei ühti seadme arhitektuuriga ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>TPM 2.0 on nõutav, kuid TPM-i ei tuvastatud.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>Nõutav on TPM 2.0. Tuvastatud TPM-i spetsifikatsioon: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 on olemas, kuid püsivara on keelatud.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 on olemas, kuid pole aktiveeritud.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Turvaline alglaadimine on keelatud. Võite jätkata, kuid Windows 11 on loodud kasutama turvalist alglaadimist.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Turvalist alglaadimise tuge ei saanud kontrollida. Windows 11 juurutamiseks on vaja turvalise alglaadimise võimalusega UEFI püsivara.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Sihtketta mahtu ei õnnestunud määrata.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Sihtketas on {0} GiB. Windows 11 soovitab vähemalt {1} GiB. Saate jätkata, kui valitud pilt sobib.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/et-EE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/et-EE/Resources.resx
@@ -512,15 +512,11 @@ Kas jätkata juurutamisega?</value></data>
     <value>Interaktiivne Autopiloti registreerimisabiline on ette valmistatud (simulatsioon).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Kasutusvalmidus</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Püsivararežiim</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Pärand BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arhitektuur</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Turvaline alglaadimine</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Ketta maht</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blokeeritud</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Hoiatus</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>See seade vastab Windows 11 juurutamise eeltingimustele.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Enne jätkamist vaadake need hoiatused üle:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 juurutamine nõuab UEFI-t. Pärand-BIOS/CSM ei ole toetatud.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Valitud Windowsi arhitektuur ({0}) ei ühti seadme arhitektuuriga ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
@@ -512,15 +512,11 @@ Jatketaanko käyttöönottoa?</value></data>
     <value>Vuorovaikutteinen Autopilot-rekisteröintiavustaja on valmisteltu (simulointi).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Käyttöönottovalmius</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Laiteohjelmistotila</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Vanha BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arkkitehtuuri</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Secure Boot</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Levyn kapasiteetti</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Estetty</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Varoitus</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Tämä laite täyttää Windows 11:n käyttöönoton edellytykset.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Tarkista nämä varoitukset ennen kuin jatkat:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11:n käyttöönotto vaatii UEFI:n. Vanhaa BIOS/CSM:ää ei tueta.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Valittu Windows-arkkitehtuuri ({0}) ei vastaa laitteen arkkitehtuuria ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
@@ -511,4 +511,27 @@ Jatketaanko käyttöönottoa?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Vuorovaikutteinen Autopilot-rekisteröintiavustaja on valmisteltu (simulointi).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Käyttöönottovalmius</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Laiteohjelmistotila</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Vanha BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arkkitehtuuri</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Secure Boot</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Levyn kapasiteetti</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Estetty</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Varoitus</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Tämä laite täyttää Windows 11:n käyttöönoton edellytykset.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Tarkista nämä varoitukset ennen kuin jatkat:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11:n käyttöönotto vaatii UEFI:n. Vanhaa BIOS/CSM:ää ei tueta.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Valittu Windows-arkkitehtuuri ({0}) ei vastaa laitteen arkkitehtuuria ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>TPM 2.0 vaaditaan, mutta TPM:ää ei havaittu.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>TPM 2.0 vaaditaan. Havaittu TPM-määritys: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 on olemassa, mutta se ei ole käytössä laiteohjelmistossa.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 on olemassa, mutta ei aktivoitu.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Suojattu käynnistys on poistettu käytöstä. Voit jatkaa, mutta Windows 11 on suunniteltu käyttämään suojattua käynnistystä.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Secure Boot -tukea ei voitu vahvistaa. Windows 11:n käyttöönotto vaatii UEFI-laiteohjelmiston, jossa on Secure Boot -ominaisuus.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Kohdelevyn kapasiteettia ei voitu määrittää.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Kohdelevy on {0} GiB. Windows 11 suosittelee vähintään {1} GiB:tä. Voit jatkaa, jos valittu kuva sopii.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
@@ -511,4 +511,27 @@ Continuer le déploiement?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Assistant d&apos;enregistrement Autopilot interactif préparé (simulation).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Préparation au déploiement</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Mode micrologiciel</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM hérités</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architecture</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Démarrage sécurisé</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Capacité du disque</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Bloqué</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Avertissement</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Cet appareil répond aux prérequis de déploiement de Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Lisez ces avertissements avant de continuer :</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Le déploiement de Windows 11 nécessite UEFI. Le BIOS/CSM hérité n&apos;est pas pris en charge.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>L&apos;architecture Windows sélectionnée ({0}) ne correspond pas à l&apos;architecture de l&apos;appareil ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>TPM 2.0 est requis, mais aucun TPM n&apos;a été détecté.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>Le TPM 2.0 est requis. Spécification TPM détectée : {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 est présent mais désactivé dans le firmware.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>Le TPM 2.0 est présent mais non activé.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Le démarrage sécurisé est désactivé. Vous pouvez continuer, mais Windows 11 est conçu pour utiliser Secure Boot.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>La prise en charge du démarrage sécurisé n&apos;a pas pu être vérifiée. Le déploiement de Windows 11 nécessite un micrologiciel UEFI avec fonctionnalité de démarrage sécurisé.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>La capacité du disque cible n&apos;a pas pu être déterminée.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Le disque cible fait {0} GiB. Windows 11 recommande au moins {1} GiB. Vous pouvez continuer si l’image sélectionnée tient sur le disque.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
@@ -512,15 +512,11 @@ Continuer le déploiement?</value></data>
     <value>Assistant d&apos;enregistrement Autopilot interactif préparé (simulation).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Préparation au déploiement</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Mode micrologiciel</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM hérités</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architecture</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Démarrage sécurisé</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Capacité du disque</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Bloqué</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Avertissement</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Cet appareil répond aux prérequis de déploiement de Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Lisez ces avertissements avant de continuer :</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Le déploiement de Windows 11 nécessite UEFI. Le BIOS/CSM hérité n&apos;est pas pris en charge.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>L&apos;architecture Windows sélectionnée ({0}) ne correspond pas à l&apos;architecture de l&apos;appareil ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
@@ -511,4 +511,27 @@ Continuer le déploiement ?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Assistant d&apos;enregistrement Autopilot interactif préparé (simulation).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Préparation au déploiement</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Mode micrologiciel</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM hérités</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architecture</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Démarrage sécurisé</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Capacité du disque</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Bloqué</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Avertissement</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Cet appareil répond aux prérequis de déploiement de Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Lisez ces avertissements avant de continuer :</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Le déploiement de Windows 11 nécessite UEFI. Le BIOS/CSM hérité n&apos;est pas pris en charge.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>L&apos;architecture Windows sélectionnée ({0}) ne correspond pas à l&apos;architecture de l&apos;appareil ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>TPM 2.0 est requis, mais aucun TPM n&apos;a été détecté.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>Le TPM 2.0 est requis. Spécification TPM détectée : {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 est présent mais désactivé dans le firmware.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>Le TPM 2.0 est présent mais non activé.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Le démarrage sécurisé est désactivé. Vous pouvez continuer, mais Windows 11 est conçu pour utiliser Secure Boot.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>La prise en charge du démarrage sécurisé n&apos;a pas pu être vérifiée. Le déploiement de Windows 11 nécessite un micrologiciel UEFI avec fonctionnalité de démarrage sécurisé.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>La capacité du disque cible n&apos;a pas pu être déterminée.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Le disque cible fait {0} GiB. Windows 11 recommande au moins {1} GiB. Vous pouvez continuer si l’image sélectionnée tient sur le disque.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
@@ -512,15 +512,11 @@ Continuer le déploiement ?</value></data>
     <value>Assistant d&apos;enregistrement Autopilot interactif préparé (simulation).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Préparation au déploiement</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Mode micrologiciel</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM hérités</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architecture</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Démarrage sécurisé</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Capacité du disque</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Bloqué</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Avertissement</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Cet appareil répond aux prérequis de déploiement de Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Lisez ces avertissements avant de continuer :</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Le déploiement de Windows 11 nécessite UEFI. Le BIOS/CSM hérité n&apos;est pas pris en charge.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>L&apos;architecture Windows sélectionnée ({0}) ne correspond pas à l&apos;architecture de l&apos;appareil ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/he-IL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/he-IL/Resources.resx
@@ -512,15 +512,11 @@ ErrorCode=0x80070005
     <value>מסייע הרישום האינטראקטיבי של Autopilot הוכן (סימולציה).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>מוכנות לפריסה</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>מצב קושחה</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM מדור קודם</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>אדריכלות</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>אתחול מאובטח</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>קיבולת דיסק</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>חסום</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>אזהרה</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>מכשיר זה עומד בדרישות הפריסה של Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>עיין באזהרות אלה לפני שתמשיך:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>פריסת Windows 11 דורשת UEFI. BIOS/CSM מדור קודם אינו נתמך.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>ארכיטקטורת Windows שנבחרה ({0}) אינה תואמת לארכיטקטורת המכשיר ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/he-IL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/he-IL/Resources.resx
@@ -511,4 +511,27 @@ ErrorCode=0x80070005
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>מסייע הרישום האינטראקטיבי של Autopilot הוכן (סימולציה).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>מוכנות לפריסה</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>מצב קושחה</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM מדור קודם</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>אדריכלות</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>אתחול מאובטח</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>קיבולת דיסק</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>חסום</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>אזהרה</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>מכשיר זה עומד בדרישות הפריסה של Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>עיין באזהרות אלה לפני שתמשיך:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>פריסת Windows 11 דורשת UEFI. BIOS/CSM מדור קודם אינו נתמך.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>ארכיטקטורת Windows שנבחרה ({0}) אינה תואמת לארכיטקטורת המכשיר ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>נדרש TPM 2.0, אך לא זוהה TPM.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>נדרש TPM 2.0. מפרט TPM שזוהה: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 קיים אך מושבת בקושחה.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 קיים אך אינו מופעל.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>אתחול מאובטח מושבת. אתה יכול להמשיך, אבל Windows 11 נועד להשתמש באתחול מאובטח.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>לא ניתן היה לאמת את התמיכה באתחול מאובטח. פריסת Windows 11 דורשת קושחת UEFI עם יכולת אתחול מאובטח.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>לא ניתן היה לקבוע את קיבולת הדיסק היעד.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>דיסק היעד הוא {0} GiB. Windows 11 ממליץ על לפחות {1} GiB. תוכל להמשיך אם התמונה שנבחרה מתאימה.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
@@ -512,15 +512,11 @@ Nastaviti s implementacijom?</value></data>
     <value>Interaktivni pomoćnik za registraciju Autopilota je pripremljen (simulacija).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Spremnost za raspoređivanje</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware mod</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Naslijeđeni BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arhitektura</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Sigurno pokretanje</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Kapacitet diska</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blokirano</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Upozorenje</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Ovaj uređaj ispunjava preduvjete za implementaciju sustava Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Prije nastavka pregledajte ova upozorenja:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Za implementaciju sustava Windows 11 potreban je UEFI. Naslijeđeni BIOS/CSM nije podržan.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Odabrana Windows arhitektura ({0}) ne odgovara arhitekturi uređaja ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
@@ -511,4 +511,27 @@ Nastaviti s implementacijom?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktivni pomoćnik za registraciju Autopilota je pripremljen (simulacija).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Spremnost za raspoređivanje</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware mod</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Naslijeđeni BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arhitektura</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Sigurno pokretanje</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Kapacitet diska</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blokirano</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Upozorenje</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Ovaj uređaj ispunjava preduvjete za implementaciju sustava Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Prije nastavka pregledajte ova upozorenja:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Za implementaciju sustava Windows 11 potreban je UEFI. Naslijeđeni BIOS/CSM nije podržan.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Odabrana Windows arhitektura ({0}) ne odgovara arhitekturi uređaja ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>Potreban je TPM 2.0, ali TPM nije otkriven.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>Potreban je TPM 2.0. Otkrivena TPM specifikacija: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 je prisutan, ali je onemogućen u firmveru.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 je prisutan, ali nije aktiviran.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Sigurno pokretanje je onemogućeno. Možete nastaviti, ali Windows 11 je dizajniran za korištenje sigurnog pokretanja.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Podršku za sigurno pokretanje nije moguće provjeriti. Za implementaciju sustava Windows 11 potreban je UEFI firmware s mogućnošću Secure Boot.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Nije moguće odrediti ciljni kapacitet diska.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Ciljni disk je {0} GiB. Windows 11 preporučuje najmanje {1} GiB. Možete nastaviti ako odabrana slika odgovara.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
@@ -512,15 +512,11 @@ Folytatja a telepítést?</value></data>
     <value>Az interaktív Autopilot regisztrációs segéd előkészítve (szimuláció).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Bevetési készenlét</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware mód</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Örökös BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Építészet</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Biztonságos rendszerindítás</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Lemezkapacitás</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Letiltva</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Figyelmeztetés</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Ez az eszköz megfelel a Windows 11 központi telepítési előfeltételeinek.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>A folytatás előtt tekintse át ezeket a figyelmeztetéseket:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>A Windows 11 telepítéséhez UEFI szükséges. A régi BIOS/CSM nem támogatott.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>A kiválasztott Windows architektúra ({0}) nem egyezik az eszköz architektúrával ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
@@ -511,4 +511,27 @@ Folytatja a telepítést?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Az interaktív Autopilot regisztrációs segéd előkészítve (szimuláció).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Bevetési készenlét</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware mód</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Örökös BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Építészet</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Biztonságos rendszerindítás</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Lemezkapacitás</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Letiltva</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Figyelmeztetés</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Ez az eszköz megfelel a Windows 11 központi telepítési előfeltételeinek.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>A folytatás előtt tekintse át ezeket a figyelmeztetéseket:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>A Windows 11 telepítéséhez UEFI szükséges. A régi BIOS/CSM nem támogatott.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>A kiválasztott Windows architektúra ({0}) nem egyezik az eszköz architektúrával ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>TPM 2.0 szükséges, de a rendszer nem észlelt TPM-et.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>TPM 2.0 szükséges. Észlelt TPM-specifikáció: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>A TPM 2.0 jelen van, de a firmware-ben le van tiltva.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>A TPM 2.0 jelen van, de nincs aktiválva.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>A biztonságos rendszerindítás le van tiltva. Folytathatja, de a Windows 11 biztonságos rendszerindításra készült.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>A biztonságos rendszerindítás támogatása nem ellenőrizhető. A Windows 11 üzembe helyezéséhez biztonságos rendszerindítási képességgel rendelkező UEFI firmware szükséges.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>A céllemez kapacitása nem határozható meg.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>A céllemez {0} GiB. A Windows 11 legalább {1} GiB-ot ajánl. Folytathatja, ha a kiválasztott kép megfelel.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/it-IT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/it-IT/Resources.resx
@@ -511,4 +511,27 @@ Continuare con la distribuzione?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Assistente di registrazione interattiva di Autopilot preparato (simulazione).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Prontezza per la distribuzione</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Modalità firmware</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM legacy</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architettura</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Avvio sicuro</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Capacità del disco</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Bloccato</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Attenzione</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Questo dispositivo soddisfa i prerequisiti di distribuzione di Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Rivedere questi avvisi prima di continuare:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>La distribuzione di Windows 11 richiede UEFI. Il BIOS/CSM legacy non è supportato.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>L&apos;architettura Windows selezionata ({0}) non corrisponde all&apos;architettura del dispositivo ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>È richiesto TPM 2.0, ma non è stato rilevato alcun TPM.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>È richiesto il TPM 2.0. Specifica TPM rilevata: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 è presente ma disabilitato nel firmware.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 è presente ma non attivato.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>L&apos;avvio sicuro è disabilitato. Puoi continuare, ma Windows 11 è progettato per utilizzare l&apos;avvio protetto.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Impossibile verificare il supporto di avvio sicuro. La distribuzione di Windows 11 richiede un firmware UEFI con funzionalità di avvio sicuro.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Impossibile determinare la capacità del disco di destinazione.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Il disco di destinazione è {0} GiB. Windows 11 consiglia almeno {1} GiB. Puoi continuare se l&apos;immagine selezionata si adatta.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/it-IT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/it-IT/Resources.resx
@@ -512,15 +512,11 @@ Continuare con la distribuzione?</value></data>
     <value>Assistente di registrazione interattiva di Autopilot preparato (simulazione).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Prontezza per la distribuzione</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Modalità firmware</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM legacy</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architettura</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Avvio sicuro</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Capacità del disco</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Bloccato</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Attenzione</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Questo dispositivo soddisfa i prerequisiti di distribuzione di Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Rivedere questi avvisi prima di continuare:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>La distribuzione di Windows 11 richiede UEFI. Il BIOS/CSM legacy non è supportato.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>L&apos;architettura Windows selezionata ({0}) non corrisponde all&apos;architettura del dispositivo ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
@@ -512,15 +512,11 @@
     <value>対話型 Autopilot 登録アシスタントをステージングしました (シミュレーション)。</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>導入の準備</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>ファームウェア モード</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>レガシー BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>アーキテクチャ</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>セキュア ブート</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>ディスク容量</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>ブロックされました</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>警告</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>このデバイスは、Windows 11 展開の前提条件を満たしています。</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>続行する前に、次の警告を確認してください:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 の展開には UEFI が必要です。レガシー BIOS/CSM はサポートされていません。</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>選択した Windows アーキテクチャ ({0}) はデバイス アーキテクチャ ({1}) と一致しません。</value></data>

--- a/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
@@ -511,4 +511,27 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>対話型 Autopilot 登録アシスタントをステージングしました (シミュレーション)。</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>導入の準備</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>ファームウェア モード</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>レガシー BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>アーキテクチャ</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>セキュア ブート</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>ディスク容量</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>ブロックされました</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>警告</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>このデバイスは、Windows 11 展開の前提条件を満たしています。</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>続行する前に、次の警告を確認してください:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 の展開には UEFI が必要です。レガシー BIOS/CSM はサポートされていません。</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>選択した Windows アーキテクチャ ({0}) はデバイス アーキテクチャ ({1}) と一致しません。</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>TPM 2.0 が必要ですが、TPM が検出されませんでした。</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>TPM 2.0が必要です。検出された TPM 仕様: {0}。</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 は存在しますが、ファームウェアで無効になっています。</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 は存在しますが、アクティブ化されていません。</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>セキュアブートが無効になっています。続行できますが、Windows 11 はセキュア ブートを使用するように設計されています。</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>セキュア ブートのサポートを確認できませんでした。 Windows 11 の展開には、セキュア ブート機能を備えた UEFI ファームウェアが必要です。</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>ターゲットのディスク容量を決定できませんでした。</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>ターゲット ディスクは {0} GiB です。 Windows 11 では、少なくとも {1} GiB を推奨します。選択した画像が適合する場合は続行できます。</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
@@ -511,4 +511,27 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>대화형 Autopilot 등록 도우미가 준비되었습니다(시뮬레이션).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>배포 준비 상태</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>펌웨어 모드</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>레거시 BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>건축</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>보안 부팅</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>디스크 용량</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>차단됨</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>경고</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>이 장치는 Windows 11 배포 전제 조건을 충족합니다.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>계속하기 전에 다음 경고를 검토하세요.</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 배포에는 UEFI가 필요합니다. 레거시 BIOS/CSM은 지원되지 않습니다.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>선택한 Windows 아키텍처({0})가 장치 아키텍처({1})와 일치하지 않습니다.</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>TPM 2.0이 필요하지만 TPM이 감지되지 않았습니다.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>TPM 2.0이 필요합니다. 감지된 TPM 사양: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0이 있지만 펌웨어에서는 비활성화되어 있습니다.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0이 있지만 활성화되지 않았습니다.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>보안 부팅이 비활성화되었습니다. 계속할 수 있지만 Windows 11은 보안 부팅을 사용하도록 설계되었습니다.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>보안 부팅 지원을 확인할 수 없습니다. Windows 11 배포에는 보안 부팅 기능이 있는 UEFI 펌웨어가 필요합니다.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>대상 디스크 용량을 확인할 수 없습니다.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>대상 디스크는 {0}GiB입니다. Windows 11에서는 최소 {1}GiB를 권장합니다. 선택한 이미지가 맞으면 계속할 수 있습니다.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
@@ -512,15 +512,11 @@
     <value>대화형 Autopilot 등록 도우미가 준비되었습니다(시뮬레이션).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>배포 준비 상태</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>펌웨어 모드</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>레거시 BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>건축</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>보안 부팅</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>디스크 용량</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>차단됨</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>경고</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>이 장치는 Windows 11 배포 전제 조건을 충족합니다.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>계속하기 전에 다음 경고를 검토하세요.</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 배포에는 UEFI가 필요합니다. 레거시 BIOS/CSM은 지원되지 않습니다.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>선택한 Windows 아키텍처({0})가 장치 아키텍처({1})와 일치하지 않습니다.</value></data>

--- a/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
@@ -511,4 +511,27 @@ Tęsti diegimą?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktyvus Autopilot registracijos pagalbininkas paruoštas (modeliavimas).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Parengtis dislokuoti</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware režimas</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Pasenęs BIOS / CSM (Legacy BIOS/CSM)</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architektūra</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Saugus įkrovimas</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Disko talpa</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Užblokuotas</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Įspėjimas</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Šis įrenginys atitinka būtinas „Windows 11“ diegimo sąlygas.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Prieš tęsdami peržiūrėkite šiuos įspėjimus:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 diegimui būtinas UEFI. Senasis BIOS/CSM nepalaikomas.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Pasirinkta „Windows“ architektūra ({0}) neatitinka įrenginio architektūros ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>Reikalingas TPM 2.0, bet TPM neaptikta.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>Reikalingas TPM 2.0. Aptikta TPM specifikacija: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 yra, bet išjungta programinėje įrangoje.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 yra, bet neaktyvuotas.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Saugus įkrovimas išjungtas. Galite tęsti, bet „Windows 11“ sukurta naudoti saugią įkrovą.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Nepavyko patikrinti saugaus įkrovos palaikymo. „Windows 11“ diegimui reikalinga UEFI programinė įranga su saugaus įkrovimo galimybe.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Nepavyko nustatyti tikslinio disko talpos.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Tikslinis diskas yra {0} GiB. „Windows 11“ rekomenduoja bent {1} GiB. Galite tęsti, jei tinka pasirinktas vaizdas.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
@@ -512,15 +512,11 @@ Tęsti diegimą?</value></data>
     <value>Interaktyvus Autopilot registracijos pagalbininkas paruoštas (modeliavimas).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Parengtis dislokuoti</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware režimas</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Pasenęs BIOS / CSM (Legacy BIOS/CSM)</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architektūra</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Saugus įkrovimas</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Disko talpa</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Užblokuotas</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Įspėjimas</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Šis įrenginys atitinka būtinas „Windows 11“ diegimo sąlygas.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Prieš tęsdami peržiūrėkite šiuos įspėjimus:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 diegimui būtinas UEFI. Senasis BIOS/CSM nepalaikomas.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Pasirinkta „Windows“ architektūra ({0}) neatitinka įrenginio architektūros ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
@@ -512,15 +512,11 @@ Vai turpināt izvietošanu?</value></data>
     <value>Interaktīvais Autopilot reģistrācijas palīgs ir sagatavots (simulācija).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Izvēršanas gatavība</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Programmaparatūras režīms</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Mantotais BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arhitektūra</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Droša sāknēšana</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Diska ietilpība</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Bloķēts</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Brīdinājums</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Šī ierīce atbilst Windows 11 izvietošanas priekšnosacījumiem.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Pirms turpināt, pārskatiet šos brīdinājumus:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 izvietošanai nepieciešams UEFI. Mantotais BIOS/CSM netiek atbalstīts.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Atlasītā Windows arhitektūra ({0}) neatbilst ierīces arhitektūrai ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
@@ -511,4 +511,27 @@ Vai turpināt izvietošanu?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktīvais Autopilot reģistrācijas palīgs ir sagatavots (simulācija).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Izvēršanas gatavība</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Programmaparatūras režīms</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Mantotais BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arhitektūra</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Droša sāknēšana</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Diska ietilpība</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Bloķēts</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Brīdinājums</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Šī ierīce atbilst Windows 11 izvietošanas priekšnosacījumiem.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Pirms turpināt, pārskatiet šos brīdinājumus:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 izvietošanai nepieciešams UEFI. Mantotais BIOS/CSM netiek atbalstīts.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Atlasītā Windows arhitektūra ({0}) neatbilst ierīces arhitektūrai ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>Nepieciešams TPM 2.0, taču TPM netika atklāts.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>Nepieciešams TPM 2.0. Konstatētā TPM specifikācija: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 ir pieejams, taču programmaparatūrā tas ir atspējots.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 ir pieejams, bet nav aktivizēts.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Drošā sāknēšana ir atspējota. Varat turpināt, taču operētājsistēmā Windows 11 ir paredzēts izmantot drošo sāknēšanu.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Drošas sāknēšanas atbalstu nevarēja pārbaudīt. Windows 11 izvietošanai nepieciešama UEFI programmaparatūra ar drošās sāknēšanas iespēju.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Mērķa diska ietilpību nevarēja noteikt.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Mērķa disks ir {0} GiB. Windows 11 iesaka vismaz {1} GiB. Varat turpināt, ja atlasītais attēls ietilpst.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
@@ -512,15 +512,11 @@ Vil du fortsette med distribusjonen?</value></data>
     <value>Den interaktive Autopilot-registreringsassistenten er klargjort (simulering).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Utplasseringsberedskap</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Fastvaremodus</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Eldre BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arkitektur</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Sikker oppstart</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Diskkapasitet</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blokkert</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Advarsel</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Denne enheten oppfyller Windows 11-distribusjonskravene.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Les disse advarslene før du fortsetter:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11-distribusjon krever UEFI. Eldre BIOS/CSM støttes ikke.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Den valgte Windows-arkitekturen ({0}) samsvarer ikke med enhetsarkitekturen ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
@@ -511,4 +511,27 @@ Vil du fortsette med distribusjonen?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Den interaktive Autopilot-registreringsassistenten er klargjort (simulering).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Utplasseringsberedskap</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Fastvaremodus</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Eldre BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arkitektur</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Sikker oppstart</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Diskkapasitet</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blokkert</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Advarsel</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Denne enheten oppfyller Windows 11-distribusjonskravene.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Les disse advarslene før du fortsetter:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11-distribusjon krever UEFI. Eldre BIOS/CSM støttes ikke.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Den valgte Windows-arkitekturen ({0}) samsvarer ikke med enhetsarkitekturen ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>TPM 2.0 er påkrevd, men ingen TPM ble oppdaget.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>TPM 2.0 kreves. Oppdaget TPM-spesifikasjon: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 er til stede, men deaktivert i fastvaren.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 er til stede, men ikke aktivert.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Sikker oppstart er deaktivert. Du kan fortsette, men Windows 11 er laget for å bruke sikker oppstart.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Støtte for sikker oppstart kunne ikke bekreftes. Windows 11-distribusjon krever UEFI-fastvare med Secure Boot-funksjonalitet.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Måldiskkapasiteten kunne ikke bestemmes.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Måldisken er {0} GiB. Windows 11 anbefaler minst {1} GiB. Du kan fortsette hvis det valgte bildet passer.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
@@ -512,15 +512,11 @@ Doorgaan met de implementatie?</value></data>
     <value>Interactieve Autopilot-registratieassistent voorbereid (simulatie).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Gereed voor implementatie</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware-modus</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Verouderd BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architectuur</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Veilig opstarten</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Schijfcapaciteit</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Geblokkeerd</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Waarschuwing</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Dit apparaat voldoet aan de implementatievereisten voor Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Lees deze waarschuwingen voordat u doorgaat:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Voor de implementatie van Windows 11 is UEFI vereist. Legacy BIOS/CSM wordt niet ondersteund.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>De geselecteerde Windows-architectuur ({0}) komt niet overeen met de apparaatarchitectuur ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
@@ -511,4 +511,27 @@ Doorgaan met de implementatie?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interactieve Autopilot-registratieassistent voorbereid (simulatie).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Gereed voor implementatie</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware-modus</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Verouderd BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architectuur</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Veilig opstarten</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Schijfcapaciteit</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Geblokkeerd</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Waarschuwing</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Dit apparaat voldoet aan de implementatievereisten voor Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Lees deze waarschuwingen voordat u doorgaat:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Voor de implementatie van Windows 11 is UEFI vereist. Legacy BIOS/CSM wordt niet ondersteund.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>De geselecteerde Windows-architectuur ({0}) komt niet overeen met de apparaatarchitectuur ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>TPM 2.0 is vereist, maar er is geen TPM gedetecteerd.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>TPM 2.0 is vereist. Gedetecteerde TPM-specificatie: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 is aanwezig maar uitgeschakeld in de firmware.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 is aanwezig maar niet geactiveerd.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Veilig opstarten is uitgeschakeld. U kunt doorgaan, maar Windows 11 is ontworpen om Secure Boot te gebruiken.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Ondersteuning voor Secure Boot kan niet worden geverifieerd. Voor de implementatie van Windows 11 is UEFI-firmware met Secure Boot-mogelijkheid vereist.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>De doelschijfcapaciteit kon niet worden bepaald.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>De doelschijf is {0} GiB. Windows 11 raadt minimaal {1} ​​GiB aan. U kunt doorgaan als de geselecteerde afbeelding past.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
@@ -511,4 +511,27 @@ Kontynuować wdrażanie?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktywny asystent rejestracji Autopilot został przygotowany (symulacja).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Gotowość do wdrożenia</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Tryb oprogramowania</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Starszy BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architektura</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Bezpieczny rozruch</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Pojemność dysku</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Zablokowano</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Uwaga</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>To urządzenie spełnia wymagania wstępne dotyczące wdrożenia systemu Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Zanim przejdziesz dalej, przejrzyj te ostrzeżenia:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Wdrożenie systemu Windows 11 wymaga UEFI. Starsze wersje systemu BIOS/CSM nie są obsługiwane.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Wybrana architektura systemu Windows ({0}) nie jest zgodna z architekturą urządzenia ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>Wymagany jest moduł TPM 2.0, ale nie wykryto modułu TPM.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>Wymagany jest moduł TPM 2.0. Wykryta specyfikacja modułu TPM: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>Moduł TPM 2.0 jest obecny, ale wyłączony w oprogramowaniu sprzętowym.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>Moduł TPM 2.0 jest obecny, ale nie jest aktywowany.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Bezpieczny rozruch jest wyłączony. Możesz kontynuować, ale system Windows 11 został zaprojektowany do korzystania z bezpiecznego rozruchu.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Nie można zweryfikować obsługi bezpiecznego rozruchu. Wdrożenie systemu Windows 11 wymaga oprogramowania sprzętowego UEFI z funkcją bezpiecznego rozruchu.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Nie można określić docelowej pojemności dysku.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Dysk docelowy to {0} GiB. System Windows 11 zaleca co najmniej {1} GiB. Możesz kontynuować, jeśli wybrany obraz pasuje.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
@@ -512,15 +512,11 @@ Kontynuować wdrażanie?</value></data>
     <value>Interaktywny asystent rejestracji Autopilot został przygotowany (symulacja).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Gotowość do wdrożenia</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Tryb oprogramowania</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Starszy BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architektura</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Bezpieczny rozruch</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Pojemność dysku</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Zablokowano</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Uwaga</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>To urządzenie spełnia wymagania wstępne dotyczące wdrożenia systemu Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Zanim przejdziesz dalej, przejrzyj te ostrzeżenia:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Wdrożenie systemu Windows 11 wymaga UEFI. Starsze wersje systemu BIOS/CSM nie są obsługiwane.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Wybrana architektura systemu Windows ({0}) nie jest zgodna z architekturą urządzenia ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
@@ -512,15 +512,11 @@ Continuar com a implantação?</value></data>
     <value>Assistente de registro interativo do Autopilot preparado (simulação).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Preparação para implantação</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Modo de firmware</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM legado</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arquitetura</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Inicialização segura</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Capacidade do disco</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Bloqueado</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Aviso</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Este dispositivo atende aos pré-requisitos de implantação do Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Revise estes avisos antes de continuar:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>A implantação do Windows 11 requer UEFI. BIOS/CSM legado não é compatível.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>A arquitetura do Windows selecionada ({0}) não corresponde à arquitetura do dispositivo ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
@@ -511,4 +511,27 @@ Continuar com a implantação?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Assistente de registro interativo do Autopilot preparado (simulação).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Preparação para implantação</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Modo de firmware</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM legado</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arquitetura</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Inicialização segura</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Capacidade do disco</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Bloqueado</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Aviso</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Este dispositivo atende aos pré-requisitos de implantação do Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Revise estes avisos antes de continuar:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>A implantação do Windows 11 requer UEFI. BIOS/CSM legado não é compatível.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>A arquitetura do Windows selecionada ({0}) não corresponde à arquitetura do dispositivo ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>O TPM 2.0 é necessário, mas nenhum TPM foi detectado.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>O TPM 2.0 é necessário. Especificação TPM detectada: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>O TPM 2.0 está presente, mas desabilitado no firmware.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>O TPM 2.0 está presente, mas não ativado.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>A inicialização segura está desativada. Você pode continuar, mas o Windows 11 foi projetado para usar inicialização segura.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>O suporte de inicialização segura não pôde ser verificado. A implantação do Windows 11 requer firmware UEFI com capacidade de inicialização segura.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>A capacidade do disco de destino não pôde ser determinada.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>O disco de destino tem {0} GiB. O Windows 11 recomenda pelo menos {1} GiB. Você pode continuar se a imagem selecionada couber.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
@@ -512,15 +512,11 @@ Continuar com a implantação?</value></data>
     <value>Assistente de registo interativo do Autopilot preparado (simulação).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Preparação para implantação</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Modo de firmware</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM legado</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arquitetura</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Inicialização segura</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Capacidade do disco</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Bloqueado</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Aviso</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Este dispositivo atende aos pré-requisitos de implantação do Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Revise estes avisos antes de continuar:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>A implantação do Windows 11 requer UEFI. BIOS/CSM legado não é compatível.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>A arquitetura do Windows selecionada ({0}) não corresponde à arquitetura do dispositivo ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
@@ -511,4 +511,27 @@ Continuar com a implantação?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Assistente de registo interativo do Autopilot preparado (simulação).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Preparação para implantação</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Modo de firmware</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM legado</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arquitetura</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Inicialização segura</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Capacidade do disco</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Bloqueado</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Aviso</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Este dispositivo atende aos pré-requisitos de implantação do Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Revise estes avisos antes de continuar:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>A implantação do Windows 11 requer UEFI. BIOS/CSM legado não é compatível.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>A arquitetura do Windows selecionada ({0}) não corresponde à arquitetura do dispositivo ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>O TPM 2.0 é necessário, mas nenhum TPM foi detectado.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>O TPM 2.0 é necessário. Especificação TPM detectada: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>O TPM 2.0 está presente, mas desabilitado no firmware.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>O TPM 2.0 está presente, mas não ativado.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>A inicialização segura está desativada. Você pode continuar, mas o Windows 11 foi projetado para usar inicialização segura.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>O suporte de inicialização segura não pôde ser verificado. A implantação do Windows 11 requer firmware UEFI com capacidade de inicialização segura.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>A capacidade do disco de destino não pôde ser determinada.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>O disco de destino tem {0} GiB. O Windows 11 recomenda pelo menos {1} GiB. Você pode continuar se a imagem selecionada couber.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
@@ -511,4 +511,27 @@ Continuați cu implementarea?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Asistentul de înregistrare interactivă Autopilot a fost pregătit (simulare).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Pregătirea pentru implementare</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Modul firmware</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM vechi</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arhitectura</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Pornire sigură</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Capacitatea discului</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blocat</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Avertisment</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Acest dispozitiv îndeplinește cerințele prealabile de implementare Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Consultați aceste avertismente înainte de a continua:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Implementarea Windows 11 necesită UEFI. BIOS/CSM vechi nu este acceptat.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Arhitectura Windows selectată ({0}) nu se potrivește cu arhitectura dispozitivului ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>Este necesar TPM 2.0, dar nu a fost detectat niciun TPM.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>Este necesar TPM 2.0. Specificație TPM detectată: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 este prezent, dar este dezactivat în firmware.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 este prezent, dar nu este activat.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Secure Boot este dezactivată. Puteți continua, dar Windows 11 este conceput pentru a utiliza Secure Boot.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Asistența pentru pornire securizată nu a putut fi verificată. Implementarea Windows 11 necesită firmware UEFI cu capacitate Secure Boot.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Capacitatea discului țintă nu a putut fi determinată.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Discul țintă este de {0} GiB. Windows 11 recomandă cel puțin {1} GiB. Puteți continua dacă imaginea selectată se potrivește.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
@@ -512,15 +512,11 @@ Continuați cu implementarea?</value></data>
     <value>Asistentul de înregistrare interactivă Autopilot a fost pregătit (simulare).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Pregătirea pentru implementare</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Modul firmware</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM vechi</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arhitectura</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Pornire sigură</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Capacitatea discului</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blocat</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Avertisment</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Acest dispozitiv îndeplinește cerințele prealabile de implementare Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Consultați aceste avertismente înainte de a continua:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Implementarea Windows 11 necesită UEFI. BIOS/CSM vechi nu este acceptat.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Arhitectura Windows selectată ({0}) nu se potrivește cu arhitectura dispozitivului ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
@@ -511,4 +511,27 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Интерактивный помощник регистрации Autopilot подготовлен (симуляция).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Готовность к развертыванию</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Режим прошивки</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Устаревший BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Архитектура</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Безопасная загрузка</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Емкость диска</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Заблокировано</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Предупреждение</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Это устройство соответствует предварительным требованиям для развертывания Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Прежде чем продолжить, прочтите эти предупреждения:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Для развертывания Windows 11 требуется UEFI. Устаревший BIOS/CSM не поддерживается.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Выбранная архитектура Windows ({0}) не соответствует архитектуре устройства ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>Требуется TPM 2.0, но TPM не обнаружен.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>Требуется TPM 2.0. Обнаружена спецификация TPM: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 присутствует, но отключен в микропрограмме.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 присутствует, но не активирован.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Безопасная загрузка отключена. Вы можете продолжить, но Windows 11 предназначена для использования безопасной загрузки.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Не удалось проверить поддержку безопасной загрузки. Для развертывания Windows 11 требуется встроенное ПО UEFI с возможностью безопасной загрузки.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Не удалось определить емкость целевого диска.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Емкость целевого диска — {0} GiB. Windows 11 рекомендует не менее {1} GiB. Можно продолжить, если выбранный образ помещается.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
@@ -512,15 +512,11 @@
     <value>Интерактивный помощник регистрации Autopilot подготовлен (симуляция).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Готовность к развертыванию</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Режим прошивки</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Устаревший BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Архитектура</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Безопасная загрузка</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Емкость диска</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Заблокировано</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Предупреждение</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Это устройство соответствует предварительным требованиям для развертывания Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Прежде чем продолжить, прочтите эти предупреждения:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Для развертывания Windows 11 требуется UEFI. Устаревший BIOS/CSM не поддерживается.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Выбранная архитектура Windows ({0}) не соответствует архитектуре устройства ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
@@ -511,4 +511,27 @@ Pokračovať v nasadzovaní?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktívny asistent registrácie Autopilotu bol pripravený (simulácia).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Pripravenosť na nasadenie</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Režim firmvéru</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Starší systém BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architektúra</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Secure Boot</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Kapacita disku</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Zablokované</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Upozornenie</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Toto zariadenie spĺňa predpoklady na nasadenie Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Pred pokračovaním si prečítajte tieto upozornenia:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Nasadenie Windows 11 vyžaduje UEFI. Starší BIOS/CSM nie je podporovaný.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Vybratá architektúra systému Windows ({0}) sa nezhoduje s architektúrou zariadenia ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>Vyžaduje sa modul TPM 2.0, ale nebol zistený žiadny modul TPM.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>Vyžaduje sa TPM 2.0. Zistená špecifikácia TPM: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 je prítomný, ale vo firmvéri je zakázaný.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 je prítomný, ale nie je aktivovaný.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Zabezpečené spustenie je vypnuté. Môžete pokračovať, ale Windows 11 je navrhnutý tak, aby používal Secure Boot.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Podporu Secure Boot nebolo možné overiť. Nasadenie systému Windows 11 vyžaduje firmvér UEFI s funkciou Secure Boot.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Cieľovú kapacitu disku nebolo možné určiť.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Cieľový disk je {0} GiB. Windows 11 odporúča aspoň {1} GiB. Môžete pokračovať, ak sa vám vybraný obrázok zmestí.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
@@ -512,15 +512,11 @@ Pokračovať v nasadzovaní?</value></data>
     <value>Interaktívny asistent registrácie Autopilotu bol pripravený (simulácia).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Pripravenosť na nasadenie</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Režim firmvéru</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Starší systém BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Architektúra</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Secure Boot</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Kapacita disku</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Zablokované</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Upozornenie</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Toto zariadenie spĺňa predpoklady na nasadenie Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Pred pokračovaním si prečítajte tieto upozornenia:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Nasadenie Windows 11 vyžaduje UEFI. Starší BIOS/CSM nie je podporovaný.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Vybratá architektúra systému Windows ({0}) sa nezhoduje s architektúrou zariadenia ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
@@ -511,4 +511,27 @@ Ali želite nadaljevati z uvajanjem?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktivni pomočnik za registracijo Autopilot je pripravljen (simulacija).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Pripravljenost na razporeditev</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Način vdelane programske opreme</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Podedovani BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arhitektura</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Varen zagon</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Kapaciteta diska</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blokirano</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Opozorilo</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Ta naprava izpolnjuje predpogoje za uvedbo sistema Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Preden nadaljujete, preglejte ta opozorila:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Za namestitev sistema Windows 11 je potreben UEFI. Podedovani BIOS/CSM ni podprt.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Izbrana arhitektura sistema Windows ({0}) se ne ujema z arhitekturo naprave ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>Potreben je TPM 2.0, vendar TPM ni bil zaznan.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>Potreben je TPM 2.0. Zaznana specifikacija TPM: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 je prisoten, vendar je onemogočen v vdelani programski opremi.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 je prisoten, vendar ni aktiviran.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Varni zagon je onemogočen. Lahko nadaljujete, vendar je Windows 11 zasnovan za uporabo varnega zagona.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Podpore za varen zagon ni bilo mogoče preveriti. Za namestitev sistema Windows 11 je potrebna vdelana programska oprema UEFI z možnostjo varnega zagona.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Ciljne zmogljivosti diska ni bilo mogoče določiti.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Ciljni disk je {0} GiB. Windows 11 priporoča vsaj {1} GiB. Če izbrana slika ustreza, lahko nadaljujete.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
@@ -512,15 +512,11 @@ Ali želite nadaljevati z uvajanjem?</value></data>
     <value>Interaktivni pomočnik za registracijo Autopilot je pripravljen (simulacija).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Pripravljenost na razporeditev</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Način vdelane programske opreme</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Podedovani BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arhitektura</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Varen zagon</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Kapaciteta diska</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blokirano</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Opozorilo</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Ta naprava izpolnjuje predpogoje za uvedbo sistema Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Preden nadaljujete, preglejte ta opozorila:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Za namestitev sistema Windows 11 je potreben UEFI. Podedovani BIOS/CSM ni podprt.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Izbrana arhitektura sistema Windows ({0}) se ne ujema z arhitekturo naprave ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
@@ -512,15 +512,11 @@ Operativni sistem: {4}
     <value>Interaktivni pomoćnik za registraciju Autopilota je pripremljen (simulacija).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Spremnost za primenu</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Režim firmvera</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Zastareli BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arhitektura</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Bezbedno pokretanje</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Kapacitet diska</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blokirano</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Upozorenje</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Ovaj uređaj ispunjava preduslove za primenu sistema Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Pregledajte ova upozorenja pre nego što nastavite:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Primena sistema Windows 11 zahteva UEFI. Zastareli BIOS/CSM nije podržan.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Izabrana Windows arhitektura ({0}) ne odgovara arhitekturi uređaja ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
@@ -511,4 +511,27 @@ Operativni sistem: {4}
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktivni pomoćnik za registraciju Autopilota je pripremljen (simulacija).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Spremnost za primenu</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Režim firmvera</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Zastareli BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arhitektura</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Bezbedno pokretanje</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Kapacitet diska</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blokirano</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Upozorenje</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Ovaj uređaj ispunjava preduslove za primenu sistema Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Pregledajte ova upozorenja pre nego što nastavite:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Primena sistema Windows 11 zahteva UEFI. Zastareli BIOS/CSM nije podržan.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Izabrana Windows arhitektura ({0}) ne odgovara arhitekturi uređaja ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>TPM 2.0 je obavezan, ali TPM nije otkriven.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>TPM 2.0 je obavezan. Otkrivena TPM specifikacija: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 je prisutan, ali onemogućen u firmveru.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 je prisutan, ali nije aktiviran.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Bezbedno pokretanje je onemogućeno. Možete nastaviti, ali Windows 11 je dizajniran da ga koristi.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Podrška za Bezbedno pokretanje nije mogla biti potvrđena. Windows 11 zahteva UEFI firmver sa Secure Boot mogućnošću.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Kapacitet ciljnog diska nije moguće utvrditi.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Ciljni disk ima {0} GiB. Windows 11 preporučuje najmanje {1} GiB. Možete nastaviti ako izabrana slika stane.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
@@ -512,15 +512,11 @@ Fortsätt med implementeringen?</value></data>
     <value>Den interaktiva Autopilot-registreringsassistenten har förberetts (simulering).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Utplaceringsberedskap</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware-läge</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Äldre BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arkitektur</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Säker start</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Diskkapacitet</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blockerad</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Varning</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Den här enheten uppfyller installationskraven för Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Granska dessa varningar innan du fortsätter:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11-distribution kräver UEFI. Äldre BIOS/CSM stöds inte.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Den valda Windows-arkitekturen ({0}) matchar inte enhetsarkitekturen ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
@@ -511,4 +511,27 @@ Fortsätt med implementeringen?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Den interaktiva Autopilot-registreringsassistenten har förberetts (simulering).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Utplaceringsberedskap</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Firmware-läge</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Äldre BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Arkitektur</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Säker start</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Diskkapacitet</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Blockerad</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Varning</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Den här enheten uppfyller installationskraven för Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Granska dessa varningar innan du fortsätter:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11-distribution kräver UEFI. Äldre BIOS/CSM stöds inte.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Den valda Windows-arkitekturen ({0}) matchar inte enhetsarkitekturen ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>TPM 2.0 krävs, men ingen TPM upptäcktes.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>TPM 2.0 krävs. Upptäckt TPM-specifikation: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 finns men inaktiverad i firmware.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 finns men är inte aktiverad.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Säker start är inaktiverad. Du kan fortsätta, men Windows 11 är utformad för att använda Secure Boot.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Support för säker start kunde inte verifieras. Windows 11-distribution kräver UEFI-firmware med Secure Boot-kapacitet.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Måldiskens kapacitet kunde inte fastställas.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Måldisken är {0} GiB. Windows 11 rekommenderar minst {1} GiB. Du kan fortsätta om den valda bilden passar.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/th-TH/Resources.resx
+++ b/src/Foundry.Deploy/Strings/th-TH/Resources.resx
@@ -512,15 +512,11 @@
     <value>จัดเตรียมผู้ช่วยลงทะเบียน Autopilot แบบโต้ตอบแล้ว (การจำลอง)</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>ความพร้อมในการใช้งาน</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>โหมดเฟิร์มแวร์</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM รุ่นเก่า</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>สถาปัตยกรรม</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>บูตอย่างปลอดภัย</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>ความจุของดิสก์</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>ถูกบล็อก</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>คำเตือน</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>อุปกรณ์นี้ตรงตามข้อกำหนดเบื้องต้นในการปรับใช้ Windows 11</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>ตรวจสอบคำเตือนเหล่านี้ก่อนดำเนินการต่อ:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>การปรับใช้ Windows 11 ต้องใช้ UEFI ไม่รองรับ BIOS/CSM รุ่นเก่า</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>สถาปัตยกรรม Windows ที่เลือก ({0}) ไม่ตรงกับสถาปัตยกรรมอุปกรณ์ ({1})</value></data>

--- a/src/Foundry.Deploy/Strings/th-TH/Resources.resx
+++ b/src/Foundry.Deploy/Strings/th-TH/Resources.resx
@@ -511,4 +511,27 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>จัดเตรียมผู้ช่วยลงทะเบียน Autopilot แบบโต้ตอบแล้ว (การจำลอง)</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>ความพร้อมในการใช้งาน</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>โหมดเฟิร์มแวร์</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>BIOS/CSM รุ่นเก่า</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>สถาปัตยกรรม</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>บูตอย่างปลอดภัย</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>ความจุของดิสก์</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>ถูกบล็อก</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>คำเตือน</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>อุปกรณ์นี้ตรงตามข้อกำหนดเบื้องต้นในการปรับใช้ Windows 11</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>ตรวจสอบคำเตือนเหล่านี้ก่อนดำเนินการต่อ:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>การปรับใช้ Windows 11 ต้องใช้ UEFI ไม่รองรับ BIOS/CSM รุ่นเก่า</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>สถาปัตยกรรม Windows ที่เลือก ({0}) ไม่ตรงกับสถาปัตยกรรมอุปกรณ์ ({1})</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>จำเป็นต้องมี TPM 2.0 แต่ตรวจไม่พบ TPM</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>จำเป็นต้องมี TPM 2.0 ข้อมูลจำเพาะ TPM ที่ตรวจพบ: {0}</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>มี TPM 2.0 แต่ปิดใช้งานในเฟิร์มแวร์</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>มี TPM 2.0 แต่ไม่ได้เปิดใช้งาน</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Secure Boot ถูกปิดใช้งาน คุณสามารถดำเนินการต่อได้ แต่ Windows 11 ได้รับการออกแบบให้ใช้ Secure Boot</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>ไม่สามารถตรวจสอบการสนับสนุน Secure Boot ได้ การใช้งาน Windows 11 ต้องใช้เฟิร์มแวร์ UEFI ที่มีความสามารถ Secure Boot</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>ไม่สามารถกำหนดความจุของดิสก์เป้าหมายได้</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>ดิสก์เป้าหมายคือ {0} GiB Windows 11 แนะนำอย่างน้อย {1} GiB คุณสามารถดำเนินการต่อได้หากรูปภาพที่เลือกพอดี</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
@@ -512,15 +512,11 @@ Dağıtıma devam edilsin mi?</value></data>
     <value>Etkileşimli Autopilot kayıt yardımcısı hazırlandı (simülasyon).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Dağıtıma hazırlık</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Donanım yazılımı modu</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Eski BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Mimarlık</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Güvenli Önyükleme</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Disk kapasitesi</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Engellendi</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Uyarı</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Bu cihaz Windows 11 dağıtım ön koşullarını karşılamaktadır.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Devam etmeden önce bu uyarıları inceleyin:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 dağıtımı UEFI gerektirir. Eski BIOS/CSM desteklenmez.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Seçilen Windows mimarisi ({0}), cihaz mimarisiyle ({1}) eşleşmiyor.</value></data>

--- a/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
@@ -511,4 +511,27 @@ Dağıtıma devam edilsin mi?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Etkileşimli Autopilot kayıt yardımcısı hazırlandı (simülasyon).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Dağıtıma hazırlık</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Donanım yazılımı modu</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Eski BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Mimarlık</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Güvenli Önyükleme</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Disk kapasitesi</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Engellendi</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Uyarı</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Bu cihaz Windows 11 dağıtım ön koşullarını karşılamaktadır.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Devam etmeden önce bu uyarıları inceleyin:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 dağıtımı UEFI gerektirir. Eski BIOS/CSM desteklenmez.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Seçilen Windows mimarisi ({0}), cihaz mimarisiyle ({1}) eşleşmiyor.</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>TPM 2.0 gerekli ancak TPM algılanmadı.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>TPM 2.0 gereklidir. Algılanan TPM spesifikasyonu: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 mevcut ancak ürün yazılımında devre dışı.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 mevcut ancak etkinleştirilmedi.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Güvenli Önyükleme devre dışı. Devam edebilirsiniz ancak Windows 11, Güvenli Önyüklemeyi kullanacak şekilde tasarlanmıştır.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Güvenli Önyükleme desteği doğrulanamadı. Windows 11 dağıtımı, Güvenli Önyükleme özelliğine sahip UEFI ürün yazılımını gerektirir.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Hedef disk kapasitesi belirlenemedi.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Hedef disk {0} GiB&apos;dir. Windows 11 en az {1} GiB önerir. Seçilen görsel uyuyorsa devam edebilirsiniz.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
@@ -511,4 +511,27 @@ ErrorCode=0x80070005
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Інтерактивний помічник реєстрації Autopilot підготовлено (симуляція).</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>Готовність до розгортання</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Режим прошивки</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Застарілий BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Архітектура</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Безпечне завантаження</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Ємність диска</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Заблоковано</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>Попередження</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Цей пристрій відповідає вимогам для розгортання Windows 11.</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Перегляньте ці попередження, перш ніж продовжити:</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Для розгортання Windows 11 потрібен UEFI. Застарілий BIOS/CSM не підтримується.</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Вибрана архітектура Windows ({0}) не відповідає архітектурі пристрою ({1}).</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>Потрібен TPM 2.0, але TPM не виявлено.</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>Потрібен TPM 2.0. Виявлена ​​специфікація TPM: {0}.</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 присутній, але вимкнений у мікропрограмі.</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 наявний, але не активований.</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>Безпечне завантаження вимкнено. Ви можете продовжити, але Windows 11 розроблено для використання безпечного завантаження.</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>Не вдалося перевірити підтримку безпечного завантаження. Для розгортання Windows 11 потрібна мікропрограма UEFI з можливістю безпечного завантаження.</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>Не вдалося визначити цільову ємність диска.</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>Місткість цільового диска — {0} GiB. Windows 11 рекомендує принаймні {1} GiB. Можна продовжити, якщо вибраний образ уміщується.</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
@@ -512,15 +512,11 @@ ErrorCode=0x80070005
     <value>Інтерактивний помічник реєстрації Autopilot підготовлено (симуляція).</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>Готовність до розгортання</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>Режим прошивки</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>Застарілий BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>Архітектура</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>Безпечне завантаження</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>Ємність диска</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>Заблоковано</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>Попередження</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>Цей пристрій відповідає вимогам для розгортання Windows 11.</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>Перегляньте ці попередження, перш ніж продовжити:</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Для розгортання Windows 11 потрібен UEFI. Застарілий BIOS/CSM не підтримується.</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>Вибрана архітектура Windows ({0}) не відповідає архітектурі пристрою ({1}).</value></data>

--- a/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
@@ -512,15 +512,11 @@
     <value>交互式 Autopilot 注册助手已暂存（模拟）。</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>部署准备</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>固件模式</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>传统 BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>体系结构</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>安全启动</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>磁盘容量</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>被阻止</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>警告</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>此设备满足 Windows 11 部署先决条件。</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>在继续之前查看这些警告：</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 部署需要 UEFI。不支持旧版 BIOS/CSM。</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>所选的 Windows 体系结构 ({0}) 与设备体系结构 ({1}) 不匹配。</value></data>

--- a/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
@@ -511,4 +511,27 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>交互式 Autopilot 注册助手已暂存（模拟）。</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>部署准备</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>固件模式</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>传统 BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>体系结构</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>安全启动</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>磁盘容量</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>被阻止</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>警告</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>此设备满足 Windows 11 部署先决条件。</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>在继续之前查看这些警告：</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 部署需要 UEFI。不支持旧版 BIOS/CSM。</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>所选的 Windows 体系结构 ({0}) 与设备体系结构 ({1}) 不匹配。</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>需要 TPM 2.0，但未检测到 TPM。</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>需要 TPM 2.0。检测到的 TPM 规范：{0}。</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 存在，但在固件中被禁用。</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 存在但未激活。</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>安全启动已禁用。您可以继续，但 Windows 11 设计为使用安全启动。</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>无法验证安全启动支持。 Windows 11 部署需要具有安全启动功能的 UEFI 固件。</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>无法确定目标磁盘容量。</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>目标磁盘为 {0} GiB。 Windows 11 建议至少 {1} GiB。如果所选图像适合，您可以继续。</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
@@ -512,15 +512,11 @@
     <value>互動式 Autopilot 註冊助理已暫存 (模擬)。</value>
   </data>
   <data name="Preflight.SectionTitle" xml:space="preserve"><value>部署準備</value></data>
-  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>韌體模式</value></data>
   <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>傳統 BIOS/CSM</value></data>
-  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>架構</value></data>
   <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
   <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>安全啟動</value></data>
-  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>磁碟容量</value></data>
   <data name="Preflight.StatusBlocked" xml:space="preserve"><value>被阻止</value></data>
   <data name="Preflight.StatusWarning" xml:space="preserve"><value>警告</value></data>
-  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>此設備滿足 Windows 11 部署先決條件。</value></data>
   <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>在繼續之前先查看這些警告：</value></data>
   <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 部署需要 UEFI。不支援舊版 BIOS/CSM。</value></data>
   <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>所選的 Windows 體系結構 ({0}) 與裝置體系結構 ({1}) 不符。</value></data>

--- a/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
@@ -511,4 +511,27 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>互動式 Autopilot 註冊助理已暫存 (模擬)。</value>
   </data>
+  <data name="Preflight.SectionTitle" xml:space="preserve"><value>部署準備</value></data>
+  <data name="Preflight.FirmwareModeLabel" xml:space="preserve"><value>韌體模式</value></data>
+  <data name="Preflight.FirmwareModeLegacy" xml:space="preserve"><value>傳統 BIOS/CSM</value></data>
+  <data name="Preflight.ArchitectureLabel" xml:space="preserve"><value>架構</value></data>
+  <data name="Preflight.TpmLabel" xml:space="preserve"><value>TPM 2.0</value></data>
+  <data name="Preflight.SecureBootLabel" xml:space="preserve"><value>安全啟動</value></data>
+  <data name="Preflight.DiskCapacityLabel" xml:space="preserve"><value>磁碟容量</value></data>
+  <data name="Preflight.StatusBlocked" xml:space="preserve"><value>被阻止</value></data>
+  <data name="Preflight.StatusWarning" xml:space="preserve"><value>警告</value></data>
+  <data name="Preflight.ReadyDetails" xml:space="preserve"><value>此設備滿足 Windows 11 部署先決條件。</value></data>
+  <data name="Preflight.WarningConfirmationIntro" xml:space="preserve"><value>在繼續之前先查看這些警告：</value></data>
+  <data name="Preflight.FirmwareModeBlocking" xml:space="preserve"><value>Windows 11 部署需要 UEFI。不支援舊版 BIOS/CSM。</value></data>
+  <data name="Preflight.ArchitectureMismatchBlocking" xml:space="preserve"><value>所選的 Windows 體系結構 ({0}) 與裝置體系結構 ({1}) 不符。</value></data>
+  <data name="Preflight.TpmMissingBlocking" xml:space="preserve"><value>需要 TPM 2.0，但未偵測到 TPM。</value></data>
+  <data name="Preflight.TpmVersionBlocking" xml:space="preserve"><value>需要 TPM 2.0。偵測到的 TPM 規格：{0}。</value></data>
+  <data name="Preflight.TpmDisabledBlocking" xml:space="preserve"><value>TPM 2.0 存在，但在韌體中被停用。</value></data>
+  <data name="Preflight.TpmDeactivatedBlocking" xml:space="preserve"><value>TPM 2.0 存在但未啟動。</value></data>
+  <data name="Preflight.SecureBootDisabledWarning" xml:space="preserve"><value>安全啟動已停用。您可以繼續，但 Windows 11 設計為使用安全啟動。</value></data>
+  <data name="Preflight.SecureBootUnavailableBlocking" xml:space="preserve"><value>無法驗證安全啟動支援。 Windows 11 部署需要具有安全啟動功能的 UEFI 韌體。</value></data>
+  <data name="Preflight.DiskSizeUnknownBlocking" xml:space="preserve"><value>無法確定目標磁碟容量。</value></data>
+  <data name="Preflight.DiskBelowRecommendedSizeWarning" xml:space="preserve"><value>目標磁碟為 {0} GiB。 Windows 11 建議至少 {1} GiB。如果所選圖像適合，您可以繼續。</value></data>
+  <data name="Preflight.ArchitectureValueFormat" xml:space="preserve"><value>{0} (Windows 11: {1})</value></data>
+  <data name="Preflight.TpmValueFormat" xml:space="preserve"><value>{0} ({1})</value></data>
 </root>

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -14,6 +14,7 @@ using Foundry.Deploy;
 using Foundry.Deploy.Models;
 using Foundry.Deploy.Models.Configuration;
 using Foundry.Deploy.Services.Deployment;
+using Foundry.Deploy.Services.Deployment.Preflight;
 using Foundry.Deploy.Services.Operations;
 using Foundry.Deploy.Services.Runtime;
 using Foundry.Deploy.Services.Startup;
@@ -36,6 +37,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     private readonly IDeploymentLaunchPreparationService _deploymentLaunchPreparationService;
     private readonly IDeploymentExecutionService _deploymentExecutionService;
     private readonly IDeploymentWizardStateService _deploymentWizardStateService;
+    private readonly IDeploymentPreflightService _deploymentPreflightService;
     private readonly IDeploymentOrchestrator _deploymentOrchestrator;
     private readonly IApplicationShellService _applicationShellService;
     private readonly ILogger<MainWindowViewModel> _logger;
@@ -95,6 +97,37 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     public string SummaryAutopilotModeText => Preparation.AutopilotModeText;
     public string SummaryAutopilotProfileText => Preparation.SelectedAutopilotProfile?.DisplayName ?? GetString("Common.None");
     public string SummaryAutopilotGroupTagText => Preparation.EffectiveHardwareHashGroupTagText;
+    public string SummaryFirmwareModeText => Preparation.DetectedHardware?.FirmwareMode switch
+    {
+        FirmwareMode.Uefi => "UEFI",
+        FirmwareMode.Bios => GetString("Preflight.FirmwareModeLegacy"),
+        _ => GetString("Common.Unknown")
+    };
+    public string SummaryArchitectureText => Format(
+        "Preflight.ArchitectureValueFormat",
+        Preparation.DetectedHardware?.Architecture ?? GetString("Common.Unknown"),
+        SelectedOperatingSystem?.Architecture ?? GetString("Common.Unknown"));
+    public string SummaryTpmText => Preparation.DetectedHardware is { IsTpmPresent: true } hardware
+        ? Format("Preflight.TpmValueFormat", hardware.TpmSpecVersion, hardware.IsTpmEnabled && hardware.IsTpmActivated ? GetString("Common.Enabled") : GetString("Common.Disabled"))
+        : GetString("Common.Unavailable");
+    public string SummarySecureBootText => Preparation.DetectedHardware?.SecureBootState switch
+    {
+        SecureBootState.Enabled => GetString("Common.Enabled"),
+        SecureBootState.Disabled => GetString("Common.Disabled"),
+        SecureBootState.Unsupported => GetString("Common.Unavailable"),
+        _ => GetString("Common.Unknown")
+    };
+    public string SummaryDiskCapacityText => Preparation.SelectedTargetDisk is { SizeBytes: > 0 } disk
+        ? $"{disk.SizeBytes / 1024d / 1024d / 1024d:0.0} GiB"
+        : GetString("Disk.UnknownSize");
+    public string SummaryPreflightStatusText => CurrentPreflight.HasBlockingFindings
+        ? GetString("Preflight.StatusBlocked")
+        : CurrentPreflight.HasWarnings
+            ? GetString("Preflight.StatusWarning")
+            : GetString("Common.Ready");
+    public string SummaryPreflightDetailsText => CurrentPreflight.Findings.Count == 0
+        ? GetString("Preflight.ReadyDetails")
+        : string.Join(Environment.NewLine, CurrentPreflight.Findings.Select(DeploymentPreflightLocalization.FormatFinding));
     public bool IsDebugAutopilotNoneMode => IsDebugAutopilotMode(DebugAutopilotMode.None);
     public bool IsDebugAutopilotJsonProfileMode => IsDebugAutopilotMode(DebugAutopilotMode.JsonProfile);
     public bool IsDebugAutopilotHardwareHashUploadValidCertificateMode => IsDebugAutopilotMode(DebugAutopilotMode.HardwareHashUploadValidCertificate);
@@ -111,6 +144,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         IDeploymentLaunchPreparationService deploymentLaunchPreparationService,
         IDeploymentExecutionService deploymentExecutionService,
         IDeploymentWizardStateService deploymentWizardStateService,
+        IDeploymentPreflightService deploymentPreflightService,
         IDeploymentOrchestrator deploymentOrchestrator,
         IApplicationShellService applicationShellService,
         IDeploymentWizardContextFactory deploymentWizardContextFactory,
@@ -123,6 +157,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         _deploymentLaunchPreparationService = deploymentLaunchPreparationService;
         _deploymentExecutionService = deploymentExecutionService;
         _deploymentWizardStateService = deploymentWizardStateService;
+        _deploymentPreflightService = deploymentPreflightService;
         _deploymentOrchestrator = deploymentOrchestrator;
         _applicationShellService = applicationShellService;
         _logger = logger;
@@ -272,6 +307,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
                 DefaultTimeZoneId = _wizardContext.DefaultTimeZoneId,
                 SelectedTargetDisk = Preparation.SelectedTargetDisk,
                 SelectedOperatingSystem = OperatingSystemCatalog.SelectedOperatingSystem,
+                DetectedHardware = Preparation.DetectedHardware,
                 DriverPackSelectionKind = effectiveDriverPackKind,
                 SelectedDriverPack = effectiveDriverPack,
                 ApplyFirmwareUpdates = Preparation.ApplyFirmwareUpdates,
@@ -365,6 +401,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         OnPropertyChanged(nameof(SummaryAutopilotModeText));
         OnPropertyChanged(nameof(SummaryAutopilotProfileText));
         OnPropertyChanged(nameof(SummaryAutopilotGroupTagText));
+        RaisePreflightPropertiesChanged();
         NextWizardStepCommand.NotifyCanExecuteChanged();
         StartDeploymentCommand.NotifyCanExecuteChanged();
     }
@@ -450,7 +487,8 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
                 Preparation.AutopilotProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload ||
                 Preparation.AutopilotProvisioningMode == AutopilotProvisioningMode.InteractiveHardwareHashUpload ||
                 Preparation.SelectedAutopilotProfile is not null,
-            IsOperatingSystemCatalogReadyForNavigation = !IsCatalogLoading && OperatingSystemCatalog.IsReadyForNavigation()
+            IsOperatingSystemCatalogReadyForNavigation = !IsCatalogLoading && OperatingSystemCatalog.IsReadyForNavigation(),
+            HasBlockingPreflightFindings = CurrentPreflight.HasBlockingFindings
         };
     }
 
@@ -518,7 +556,26 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
             OnPropertyChanged(nameof(SummaryAutopilotModeText));
             OnPropertyChanged(nameof(SummaryAutopilotProfileText));
             OnPropertyChanged(nameof(SummaryAutopilotGroupTagText));
+            RaisePreflightPropertiesChanged();
         });
+    }
+
+    private DeploymentPreflightResult CurrentPreflight => IsDebugSafeMode
+        ? new DeploymentPreflightResult { Findings = [] }
+        : _deploymentPreflightService.Evaluate(
+            Preparation.DetectedHardware,
+            Preparation.SelectedTargetDisk,
+            SelectedOperatingSystem);
+
+    private void RaisePreflightPropertiesChanged()
+    {
+        OnPropertyChanged(nameof(SummaryFirmwareModeText));
+        OnPropertyChanged(nameof(SummaryArchitectureText));
+        OnPropertyChanged(nameof(SummaryTpmText));
+        OnPropertyChanged(nameof(SummarySecureBootText));
+        OnPropertyChanged(nameof(SummaryDiskCapacityText));
+        OnPropertyChanged(nameof(SummaryPreflightStatusText));
+        OnPropertyChanged(nameof(SummaryPreflightDetailsText));
     }
 
     private string GetString(string key)

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -97,27 +97,27 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     public string SummaryAutopilotModeText => Preparation.AutopilotModeText;
     public string SummaryAutopilotProfileText => Preparation.SelectedAutopilotProfile?.DisplayName ?? GetString("Common.None");
     public string SummaryAutopilotGroupTagText => Preparation.EffectiveHardwareHashGroupTagText;
-    public string SummaryFirmwareModeText => Preparation.DetectedHardware?.FirmwareMode switch
+    private string SummaryFirmwareModeText => Preparation.DetectedHardware?.FirmwareMode switch
     {
         FirmwareMode.Uefi => "UEFI",
         FirmwareMode.Bios => GetString("Preflight.FirmwareModeLegacy"),
         _ => GetString("Common.Unknown")
     };
-    public string SummaryArchitectureText => Format(
+    private string SummaryArchitectureText => Format(
         "Preflight.ArchitectureValueFormat",
         Preparation.DetectedHardware?.Architecture ?? GetString("Common.Unknown"),
         SelectedOperatingSystem?.Architecture ?? GetString("Common.Unknown"));
-    public string SummaryTpmText => Preparation.DetectedHardware is { IsTpmPresent: true } hardware
+    private string SummaryTpmText => Preparation.DetectedHardware is { IsTpmPresent: true } hardware
         ? Format("Preflight.TpmValueFormat", hardware.TpmSpecVersion, hardware.IsTpmEnabled && hardware.IsTpmActivated ? GetString("Common.Enabled") : GetString("Common.Disabled"))
         : GetString("Common.Unavailable");
-    public string SummarySecureBootText => Preparation.DetectedHardware?.SecureBootState switch
+    private string SummarySecureBootText => Preparation.DetectedHardware?.SecureBootState switch
     {
         SecureBootState.Enabled => GetString("Common.Enabled"),
         SecureBootState.Disabled => GetString("Common.Disabled"),
         SecureBootState.Unsupported => GetString("Common.Unavailable"),
         _ => GetString("Common.Unknown")
     };
-    public string SummaryDiskCapacityText => Preparation.SelectedTargetDisk is { SizeBytes: > 0 } disk
+    private string SummaryDiskCapacityText => Preparation.SelectedTargetDisk is { SizeBytes: > 0 } disk
         ? $"{disk.SizeBytes / 1024d / 1024d / 1024d:0.0} GiB"
         : GetString("Disk.UnknownSize");
     public string SummaryPreflightStatusText => CurrentPreflight.HasBlockingFindings
@@ -125,9 +125,28 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         : CurrentPreflight.HasWarnings
             ? GetString("Preflight.StatusWarning")
             : GetString("Common.Ready");
-    public string SummaryPreflightDetailsText => CurrentPreflight.Findings.Count == 0
-        ? GetString("Preflight.ReadyDetails")
-        : string.Join(Environment.NewLine, CurrentPreflight.Findings.Select(DeploymentPreflightLocalization.FormatFinding));
+    public string SummaryPreflightSeparatorText => CurrentPreflight.Findings.Count > 0
+        ? Environment.NewLine
+        : " · ";
+    public string SummaryPreflightDisplayText
+    {
+        get
+        {
+            DeploymentPreflightResult preflight = CurrentPreflight;
+            if (preflight.Findings.Count > 0)
+            {
+                return string.Join(Environment.NewLine, preflight.Findings.Select(DeploymentPreflightLocalization.FormatFinding));
+            }
+
+            return string.Join(
+                " · ",
+                SummaryFirmwareModeText,
+                SummaryArchitectureText,
+                $"{GetString("Preflight.TpmLabel")}: {SummaryTpmText}",
+                $"{GetString("Preflight.SecureBootLabel")}: {SummarySecureBootText}",
+                SummaryDiskCapacityText);
+        }
+    }
     public bool IsDebugAutopilotNoneMode => IsDebugAutopilotMode(DebugAutopilotMode.None);
     public bool IsDebugAutopilotJsonProfileMode => IsDebugAutopilotMode(DebugAutopilotMode.JsonProfile);
     public bool IsDebugAutopilotHardwareHashUploadValidCertificateMode => IsDebugAutopilotMode(DebugAutopilotMode.HardwareHashUploadValidCertificate);
@@ -569,13 +588,9 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
 
     private void RaisePreflightPropertiesChanged()
     {
-        OnPropertyChanged(nameof(SummaryFirmwareModeText));
-        OnPropertyChanged(nameof(SummaryArchitectureText));
-        OnPropertyChanged(nameof(SummaryTpmText));
-        OnPropertyChanged(nameof(SummarySecureBootText));
-        OnPropertyChanged(nameof(SummaryDiskCapacityText));
         OnPropertyChanged(nameof(SummaryPreflightStatusText));
-        OnPropertyChanged(nameof(SummaryPreflightDetailsText));
+        OnPropertyChanged(nameof(SummaryPreflightSeparatorText));
+        OnPropertyChanged(nameof(SummaryPreflightDisplayText));
     }
 
     private string GetString(string key)

--- a/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Foundry.Deploy.Views.Wizard.SummaryStepView"
+<UserControl x:Class="Foundry.Deploy.Views.Wizard.SummaryStepView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -69,86 +69,13 @@
                             Style="{StaticResource SubtitleTextBlockStyle}"
                             Text="{Binding Strings[Preflight.SectionTitle]}" />
 
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="8" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="8" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="8" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="8" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="8" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="8" />
-                                <RowDefinition Height="Auto" />
-                            </Grid.RowDefinitions>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="220" />
-                                <ColumnDefinition Width="24" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-
-                            <TextBlock
-                                Style="{StaticResource BodyStrongTextBlockStyle}"
-                                Text="{Binding Strings[Preflight.FirmwareModeLabel]}" />
-                            <TextBlock
-                                Grid.Column="2"
-                                Text="{Binding SummaryFirmwareModeText}"
-                                TextWrapping="Wrap" />
-
-                            <TextBlock
-                                Grid.Row="2"
-                                Style="{StaticResource BodyStrongTextBlockStyle}"
-                                Text="{Binding Strings[Preflight.ArchitectureLabel]}" />
-                            <TextBlock
-                                Grid.Row="2"
-                                Grid.Column="2"
-                                Text="{Binding SummaryArchitectureText}"
-                                TextWrapping="Wrap" />
-
-                            <TextBlock
-                                Grid.Row="4"
-                                Style="{StaticResource BodyStrongTextBlockStyle}"
-                                Text="{Binding Strings[Preflight.TpmLabel]}" />
-                            <TextBlock
-                                Grid.Row="4"
-                                Grid.Column="2"
-                                Text="{Binding SummaryTpmText}"
-                                TextWrapping="Wrap" />
-
-                            <TextBlock
-                                Grid.Row="6"
-                                Style="{StaticResource BodyStrongTextBlockStyle}"
-                                Text="{Binding Strings[Preflight.SecureBootLabel]}" />
-                            <TextBlock
-                                Grid.Row="6"
-                                Grid.Column="2"
-                                Text="{Binding SummarySecureBootText}"
-                                TextWrapping="Wrap" />
-
-                            <TextBlock
-                                Grid.Row="8"
-                                Style="{StaticResource BodyStrongTextBlockStyle}"
-                                Text="{Binding Strings[Preflight.DiskCapacityLabel]}" />
-                            <TextBlock
-                                Grid.Row="8"
-                                Grid.Column="2"
-                                Text="{Binding SummaryDiskCapacityText}"
-                                TextWrapping="Wrap" />
-
-                            <TextBlock
-                                Grid.Row="10"
-                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                        <TextBlock TextWrapping="Wrap">
+                            <Run
+                                FontWeight="SemiBold"
                                 Text="{Binding SummaryPreflightStatusText}" />
-                            <TextBlock
-                                Grid.Row="12"
-                                Grid.ColumnSpan="3"
-                                Text="{Binding SummaryPreflightDetailsText}"
-                                TextWrapping="Wrap" />
-                        </Grid>
+                            <Run Text="{Binding SummaryPreflightSeparatorText}" />
+                            <Run Text="{Binding SummaryPreflightDisplayText}" />
+                        </TextBlock>
 
                         <Separator Margin="0,8,0,8" />
 

--- a/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="Foundry.Deploy.Views.Wizard.SummaryStepView"
+﻿<UserControl x:Class="Foundry.Deploy.Views.Wizard.SummaryStepView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -72,9 +72,9 @@
                         <TextBlock TextWrapping="Wrap">
                             <Run
                                 FontWeight="SemiBold"
-                                Text="{Binding SummaryPreflightStatusText}" />
-                            <Run Text="{Binding SummaryPreflightSeparatorText}" />
-                            <Run Text="{Binding SummaryPreflightDisplayText}" />
+                                Text="{Binding SummaryPreflightStatusText, Mode=OneWay}" />
+                            <Run Text="{Binding SummaryPreflightSeparatorText, Mode=OneWay}" />
+                            <Run Text="{Binding SummaryPreflightDisplayText, Mode=OneWay}" />
                         </TextBlock>
 
                         <Separator Margin="0,8,0,8" />

--- a/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/SummaryStepView.xaml
@@ -67,6 +67,94 @@
                         <TextBlock
                             Margin="0,0,0,8"
                             Style="{StaticResource SubtitleTextBlockStyle}"
+                            Text="{Binding Strings[Preflight.SectionTitle]}" />
+
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="8" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="8" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="8" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="8" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="8" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="8" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="220" />
+                                <ColumnDefinition Width="24" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+
+                            <TextBlock
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="{Binding Strings[Preflight.FirmwareModeLabel]}" />
+                            <TextBlock
+                                Grid.Column="2"
+                                Text="{Binding SummaryFirmwareModeText}"
+                                TextWrapping="Wrap" />
+
+                            <TextBlock
+                                Grid.Row="2"
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="{Binding Strings[Preflight.ArchitectureLabel]}" />
+                            <TextBlock
+                                Grid.Row="2"
+                                Grid.Column="2"
+                                Text="{Binding SummaryArchitectureText}"
+                                TextWrapping="Wrap" />
+
+                            <TextBlock
+                                Grid.Row="4"
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="{Binding Strings[Preflight.TpmLabel]}" />
+                            <TextBlock
+                                Grid.Row="4"
+                                Grid.Column="2"
+                                Text="{Binding SummaryTpmText}"
+                                TextWrapping="Wrap" />
+
+                            <TextBlock
+                                Grid.Row="6"
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="{Binding Strings[Preflight.SecureBootLabel]}" />
+                            <TextBlock
+                                Grid.Row="6"
+                                Grid.Column="2"
+                                Text="{Binding SummarySecureBootText}"
+                                TextWrapping="Wrap" />
+
+                            <TextBlock
+                                Grid.Row="8"
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="{Binding Strings[Preflight.DiskCapacityLabel]}" />
+                            <TextBlock
+                                Grid.Row="8"
+                                Grid.Column="2"
+                                Text="{Binding SummaryDiskCapacityText}"
+                                TextWrapping="Wrap" />
+
+                            <TextBlock
+                                Grid.Row="10"
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="{Binding SummaryPreflightStatusText}" />
+                            <TextBlock
+                                Grid.Row="12"
+                                Grid.ColumnSpan="3"
+                                Text="{Binding SummaryPreflightDetailsText}"
+                                TextWrapping="Wrap" />
+                        </Grid>
+
+                        <Separator Margin="0,8,0,8" />
+
+                        <TextBlock
+                            Margin="0,0,0,8"
+                            Style="{StaticResource SubtitleTextBlockStyle}"
                             Text="{Binding Strings[Summary.SectionSystem]}" />
 
                         <Grid>


### PR DESCRIPTION
## Summary
Add a localized Windows 11 readiness preflight to Foundry Deploy.

## Reason
Deployment previously proceeded without clearly validating UEFI boot mode, architecture compatibility, TPM 2.0, Secure Boot, or the Windows 11 storage recommendation.

## Main changes
- detect firmware mode, TPM readiness, and Secure Boot state in WinPE
- block Legacy/CSM, architecture mismatch, missing or unusable TPM 2.0, and unverifiable Secure Boot capability
- warn with confirmation when Secure Boot is disabled or the selected disk is below 64 GiB
- show readiness details in the deployment summary
- repeat validation before destructive disk preparation and reject changed, unacknowledged warnings
- localize all new user-facing text in all 38 supported cultures
- enforce localization key and format-placeholder parity

## Testing
- x64 Foundry.Deploy.Tests: 393 passed
- ARM64 Foundry.Deploy build: passed
- repository format verification: passed