### PR TITLE
fix(deploy): validate target boot layout

### DIFF
--- a/src/Foundry.Deploy.Tests/LocalizationResourceTests.cs
+++ b/src/Foundry.Deploy.Tests/LocalizationResourceTests.cs
@@ -65,4 +65,35 @@ public sealed class LocalizationResourceTests
         Assert.NotNull(resourceSet);
         Assert.Equal("Foundry Deploy", resourceSet.GetString("App.Name"));
     }
+
+    [Theory]
+    [MemberData(nameof(SatelliteCultures))]
+    public void SatelliteResourceSet_ContainsDeploymentValidationMessages(string cultureName)
+    {
+        ResourceSet resourceSet = Assert.IsAssignableFrom<ResourceSet>(
+            LocalizationText.ResourceManager.GetResourceSet(
+                CultureInfo.GetCultureInfo(cultureName),
+                createIfNotExists: true,
+                tryParents: false));
+        string[] keys =
+        [
+            "Deployment.DiskPartFailureFormat",
+            "Deployment.LayoutValidationProcessFailureFormat",
+            "Deployment.LayoutValidationInvalidDataFormat",
+            "Deployment.LayoutNotGptFormat",
+            "Deployment.LayoutInvalidEfiFormat",
+            "Deployment.LayoutInvalidWindowsFormat",
+            "Deployment.LayoutInvalidRecoveryFormat",
+            "Deployment.BcdBootMissingFormat",
+            "Deployment.BcdTemplateMissingFormat",
+            "Deployment.EfiUnavailableFormat",
+            "Deployment.EfiNotWritableFormat",
+            "Deployment.BcdBootFailure"
+        ];
+
+        foreach (string key in keys)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(resourceSet.GetString(key)));
+        }
+    }
 }

--- a/src/Foundry.Deploy.Tests/WindowsDeploymentServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/WindowsDeploymentServiceTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Xml.Linq;
+using System.Text;
 using Foundry.Deploy.Models.Configuration;
 using Foundry.Deploy.Services.Deployment;
 using Foundry.Deploy.Services.System;
@@ -24,7 +25,7 @@ public sealed class WindowsDeploymentServiceTests
 
         string scriptPath = Path.Combine(workingDirectory, "diskpart-os-target.txt");
         string[] scriptLines = await File.ReadAllLinesAsync(scriptPath, TestContext.Current.CancellationToken);
-        int efiIndex = Array.IndexOf(scriptLines, "create partition efi size=260");
+        int efiIndex = Array.IndexOf(scriptLines, "create partition efi size=300");
         int msrIndex = Array.IndexOf(scriptLines, "create partition msr size=16");
         int recoveryIndex = Array.IndexOf(scriptLines, "create partition primary size=5120");
         int windowsIndex = Array.IndexOf(scriptLines, "create partition primary");
@@ -38,6 +39,82 @@ public sealed class WindowsDeploymentServiceTests
         Assert.True(recoveryFormatIndex > recoveryIndex);
         Assert.True(windowsFormatIndex > recoveryFormatIndex);
         Assert.DoesNotContain(scriptLines, line => line.StartsWith("shrink ", StringComparison.OrdinalIgnoreCase));
+        string encodedScript = processRunner.LastArguments!.Split(' ', StringSplitOptions.RemoveEmptyEntries).Last();
+        string validationScript = Encoding.Unicode.GetString(Convert.FromBase64String(encodedScript));
+        Assert.Contains("Update-HostStorageCache", validationScript, StringComparison.Ordinal);
+        Assert.Contains("AddSeconds(30)", validationScript, StringComparison.Ordinal);
+        Assert.Contains("Start-Sleep -Milliseconds 500", validationScript, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PrepareTargetDiskAsync_WhenResultingDiskIsNotGpt_ThrowsInvalidOperationException()
+    {
+        using var workspace = new TemporaryWorkspace();
+        var processRunner = new RecordingProcessRunner
+        {
+            LayoutValidationResult = new ProcessExecutionResult
+            {
+                ExitCode = 0,
+                StandardOutput = CreateLayoutValidationJson(partitionStyle: "MBR")
+            }
+        };
+        var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.PrepareTargetDiskAsync(
+                1,
+                Path.Combine(workspace.RootPath, "Work"),
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("GPT", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PrepareTargetDiskAsync_WhenResultingEfiPartitionIsNotFat32_ThrowsInvalidOperationException()
+    {
+        using var workspace = new TemporaryWorkspace();
+        var processRunner = new RecordingProcessRunner
+        {
+            LayoutValidationResult = new ProcessExecutionResult
+            {
+                ExitCode = 0,
+                StandardOutput = CreateLayoutValidationJson().Replace(
+                    "\"SystemFileSystem\": \"FAT32\"",
+                    "\"SystemFileSystem\": \"NTFS\"",
+                    StringComparison.Ordinal)
+            }
+        };
+        var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.PrepareTargetDiskAsync(
+                1,
+                Path.Combine(workspace.RootPath, "Work"),
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("EFI", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("FAT32", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PrepareTargetDiskAsync_WhenLayoutValidationReturnsInvalidJson_ThrowsInvalidOperationException()
+    {
+        using var workspace = new TemporaryWorkspace();
+        var processRunner = new RecordingProcessRunner
+        {
+            LayoutValidationResult = new ProcessExecutionResult
+            {
+                ExitCode = 0,
+                StandardOutput = "not-json"
+            }
+        };
+        var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.PrepareTargetDiskAsync(
+                1,
+                Path.Combine(workspace.RootPath, "Work"),
+                TestContext.Current.CancellationToken));
     }
 
     [Theory]
@@ -51,10 +128,17 @@ public sealed class WindowsDeploymentServiceTests
         string windowsRoot = Path.Combine(workspace.RootPath, "Target Windows");
         string windowsPath = Path.Combine(windowsRoot, "Windows");
         string bcdBootPath = Path.Combine(windowsPath, "System32", "bcdboot.exe");
+        string bcdTemplatePath = Path.Combine(windowsPath, "System32", "Config", "BCD-Template");
         string workingDirectory = Path.Combine(workspace.RootPath, "Work");
-        const string systemRoot = @"S:\";
+        string systemRoot = Path.Combine(workspace.RootPath, "System");
         Directory.CreateDirectory(Path.GetDirectoryName(bcdBootPath)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(bcdTemplatePath)!);
+        Directory.CreateDirectory(systemRoot);
         await File.WriteAllTextAsync(bcdBootPath, string.Empty, TestContext.Current.CancellationToken);
+        await File.WriteAllTextAsync(
+            bcdTemplatePath,
+            string.Empty,
+            TestContext.Current.CancellationToken);
         var processRunner = new RecordingProcessRunner();
         var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
 
@@ -94,13 +178,76 @@ public sealed class WindowsDeploymentServiceTests
     }
 
     [Fact]
+    public async Task ConfigureBootAsync_WhenBcdTemplateIsMissing_ThrowsFileNotFoundException()
+    {
+        using var workspace = new TemporaryWorkspace();
+        string windowsRoot = Path.Combine(workspace.RootPath, "WindowsRoot");
+        string bcdBootPath = Path.Combine(windowsRoot, "Windows", "System32", "bcdboot.exe");
+        string expectedTemplatePath = Path.Combine(windowsRoot, "Windows", "System32", "Config", "BCD-Template");
+        string systemRoot = Path.Combine(workspace.RootPath, "System");
+        Directory.CreateDirectory(Path.GetDirectoryName(bcdBootPath)!);
+        Directory.CreateDirectory(systemRoot);
+        await File.WriteAllTextAsync(bcdBootPath, string.Empty, TestContext.Current.CancellationToken);
+        var processRunner = new RecordingProcessRunner();
+        var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
+
+        FileNotFoundException exception = await Assert.ThrowsAsync<FileNotFoundException>(() =>
+            service.ConfigureBootAsync(
+                windowsRoot,
+                systemRoot,
+                26200,
+                Path.Combine(workspace.RootPath, "Work"),
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(expectedTemplatePath, exception.FileName);
+        Assert.Null(processRunner.LastFileName);
+    }
+
+    [Fact]
+    public async Task ConfigureBootAsync_WhenSystemPartitionIsUnavailable_ThrowsDirectoryNotFoundException()
+    {
+        using var workspace = new TemporaryWorkspace();
+        string windowsRoot = Path.Combine(workspace.RootPath, "WindowsRoot");
+        string windowsPath = Path.Combine(windowsRoot, "Windows");
+        string bcdBootPath = Path.Combine(windowsPath, "System32", "bcdboot.exe");
+        string bcdTemplatePath = Path.Combine(windowsPath, "System32", "Config", "BCD-Template");
+        Directory.CreateDirectory(Path.GetDirectoryName(bcdBootPath)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(bcdTemplatePath)!);
+        await File.WriteAllTextAsync(bcdBootPath, string.Empty, TestContext.Current.CancellationToken);
+        await File.WriteAllTextAsync(
+            bcdTemplatePath,
+            string.Empty,
+            TestContext.Current.CancellationToken);
+        var processRunner = new RecordingProcessRunner();
+        var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
+
+        await Assert.ThrowsAsync<DirectoryNotFoundException>(() =>
+            service.ConfigureBootAsync(
+                windowsRoot,
+                Path.Combine(workspace.RootPath, "MissingSystem"),
+                26200,
+                Path.Combine(workspace.RootPath, "Work"),
+                TestContext.Current.CancellationToken));
+
+        Assert.Null(processRunner.LastFileName);
+    }
+
+    [Fact]
     public async Task ConfigureBootAsync_WhenAppliedBcdBootFails_PropagatesDiagnostic()
     {
         using var workspace = new TemporaryWorkspace();
         string windowsRoot = Path.Combine(workspace.RootPath, "WindowsRoot");
         string bcdBootPath = Path.Combine(windowsRoot, "Windows", "System32", "bcdboot.exe");
+        string bcdTemplatePath = Path.Combine(windowsRoot, "Windows", "System32", "Config", "BCD-Template");
+        string systemRoot = Path.Combine(workspace.RootPath, "System");
         Directory.CreateDirectory(Path.GetDirectoryName(bcdBootPath)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(bcdTemplatePath)!);
+        Directory.CreateDirectory(systemRoot);
         await File.WriteAllTextAsync(bcdBootPath, string.Empty, TestContext.Current.CancellationToken);
+        await File.WriteAllTextAsync(
+            bcdTemplatePath,
+            string.Empty,
+            TestContext.Current.CancellationToken);
         var processRunner = new RecordingProcessRunner
         {
             Result = new ProcessExecutionResult
@@ -115,14 +262,14 @@ public sealed class WindowsDeploymentServiceTests
         DeploymentProcessException exception = await Assert.ThrowsAsync<DeploymentProcessException>(() =>
             service.ConfigureBootAsync(
                 windowsRoot,
-                @"S:\",
+                systemRoot,
                 26200,
                 Path.Combine(workspace.RootPath, "Work"),
                 TestContext.Current.CancellationToken));
 
         Assert.IsAssignableFrom<InvalidOperationException>(exception);
         Assert.Equal(bcdBootPath, processRunner.LastFileName);
-        Assert.Contains("BCDBoot configuration failed", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("BCDBoot", exception.Message, StringComparison.Ordinal);
         Assert.Contains("ExitCode=193", exception.Message, StringComparison.Ordinal);
         Assert.Contains("Failure when attempting to copy boot files.", exception.Message, StringComparison.Ordinal);
         Assert.Contains("diagnostic", exception.Message, StringComparison.Ordinal);
@@ -305,6 +452,25 @@ public sealed class WindowsDeploymentServiceTests
         return windowsRoot;
     }
 
+    private static string CreateLayoutValidationJson(string partitionStyle = "GPT")
+    {
+        return $$"""
+            {
+              "DiskNumber": 1,
+              "PartitionStyle": "{{partitionStyle}}",
+              "SystemDiskNumber": 1,
+              "SystemGptType": "{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}",
+              "SystemSizeBytes": 314572800,
+              "SystemFileSystem": "FAT32",
+              "SystemDriveLetter": "S",
+              "WindowsDiskNumber": 1,
+              "WindowsFileSystem": "NTFS",
+              "RecoveryDiskNumber": 1,
+              "RecoveryFileSystem": "NTFS"
+            }
+            """;
+    }
+
     private sealed class TemporaryWorkspace : IDisposable
     {
         public TemporaryWorkspace()
@@ -363,6 +529,7 @@ public sealed class WindowsDeploymentServiceTests
         public string? LastArguments { get; private set; }
         public string? LastWorkingDirectory { get; private set; }
         public ProcessExecutionResult Result { get; init; } = new() { ExitCode = 0 };
+        public ProcessExecutionResult? LayoutValidationResult { get; init; }
 
         public Task<ProcessExecutionResult> RunAsync(
             string fileName,
@@ -374,6 +541,15 @@ public sealed class WindowsDeploymentServiceTests
             LastFileName = fileName;
             LastArguments = arguments;
             LastWorkingDirectory = workingDirectory;
+            if (fileName.Equals("powershell.exe", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(LayoutValidationResult ?? new ProcessExecutionResult
+                {
+                    ExitCode = 0,
+                    StandardOutput = CreateLayoutValidationJson()
+                });
+            }
+
             return Task.FromResult(Result);
         }
 

--- a/src/Foundry.Deploy/Services/Deployment/WindowsDeploymentService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/WindowsDeploymentService.cs
@@ -3,9 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Foundry.Deploy.Models.Configuration;
+using Foundry.Deploy.Services.Localization;
 using Foundry.Deploy.Services.System;
 using Foundry.Deploy.Services.Deployment.Unattend;
 using Foundry.Deploy.Validation;
@@ -18,11 +21,12 @@ namespace Foundry.Deploy.Services.Deployment;
 /// </summary>
 public sealed class WindowsDeploymentService : IWindowsDeploymentService
 {
-    private const int EfiPartitionSizeMb = 260;
+    private const int EfiPartitionSizeMb = 300;
     private const int MsrPartitionSizeMb = 16;
     private const int RecoveryPartitionSizeMb = 5120;
     private const string RecoveryPartitionLabel = "Recovery";
     private const string RecoveryPartitionGuid = "de94bba4-06d1-4d40-a16a-bfd50179d6ac";
+    private const string EfiPartitionGuid = "c12a7328-f81f-11d2-ba4b-00a0c93ec93b";
     private const string RecoveryPartitionAttributes = "0x8000000000000001";
     private const string WinReImageFileName = "winre.wim";
     private readonly IProcessRunner _processRunner;
@@ -93,12 +97,19 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
             "diskpart.exe",
             $"/s \"{scriptPath}\"",
             workingDirectory,
-            $"Disk partitioning failed for disk {diskNumber}",
+            LocalizationText.Format("Deployment.DiskPartFailureFormat", diskNumber),
             cancellationToken).ConfigureAwait(false);
 
         string systemPartitionRoot = $"{systemLetter}:\\";
         string windowsPartitionRoot = $"{windowsLetter}:\\";
         string recoveryPartitionRoot = $"{recoveryLetter}:\\";
+        await ValidateTargetDiskLayoutAsync(
+            diskNumber,
+            systemLetter,
+            windowsLetter,
+            recoveryLetter,
+            workingDirectory,
+            cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
             "Target disk layout prepared. DiskNumber={DiskNumber}, SystemPartition={SystemPartition}, WindowsPartition={WindowsPartition}, RecoveryPartition={RecoveryPartition}",
@@ -115,6 +126,111 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
             RecoveryPartitionRoot = recoveryPartitionRoot,
             RecoveryPartitionLetter = recoveryLetter
         };
+    }
+
+    private async Task ValidateTargetDiskLayoutAsync(
+        int diskNumber,
+        char systemLetter,
+        char windowsLetter,
+        char recoveryLetter,
+        string workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        string script = $$"""
+            $ErrorActionPreference = 'Stop'
+            Import-Module Storage
+
+            $deadline = (Get-Date).AddSeconds(30)
+            do {
+                Update-HostStorageCache -ErrorAction SilentlyContinue
+                Update-Disk -Number {{diskNumber}} -ErrorAction SilentlyContinue
+                $disk = Get-Disk -Number {{diskNumber}} -ErrorAction SilentlyContinue
+                $systemPartition = Get-Partition -DriveLetter '{{systemLetter}}' -ErrorAction SilentlyContinue
+                $windowsPartition = Get-Partition -DriveLetter '{{windowsLetter}}' -ErrorAction SilentlyContinue
+                $recoveryPartition = Get-Partition -DriveLetter '{{recoveryLetter}}' -ErrorAction SilentlyContinue
+                $systemVolume = $systemPartition | Get-Volume -ErrorAction SilentlyContinue
+                $windowsVolume = $windowsPartition | Get-Volume -ErrorAction SilentlyContinue
+                $recoveryVolume = $recoveryPartition | Get-Volume -ErrorAction SilentlyContinue
+
+                if ($disk -and $systemPartition -and $windowsPartition -and $recoveryPartition -and $systemVolume -and $windowsVolume -and $recoveryVolume) {
+                    break
+                }
+
+                Start-Sleep -Milliseconds 500
+            } while ((Get-Date) -lt $deadline)
+
+            if (-not ($disk -and $systemPartition -and $windowsPartition -and $recoveryPartition -and $systemVolume -and $windowsVolume -and $recoveryVolume)) {
+                throw 'Timed out waiting for the target disk layout to become available.'
+            }
+
+            [pscustomobject]@{
+                DiskNumber = [int]$disk.Number
+                PartitionStyle = [string]$disk.PartitionStyle
+                SystemDiskNumber = [int]$systemPartition.DiskNumber
+                SystemGptType = [string]$systemPartition.GptType
+                SystemSizeBytes = [long]$systemPartition.Size
+                SystemFileSystem = [string]$systemVolume.FileSystem
+                SystemDriveLetter = [string]$systemPartition.DriveLetter
+                WindowsDiskNumber = [int]$windowsPartition.DiskNumber
+                WindowsFileSystem = [string]$windowsVolume.FileSystem
+                RecoveryDiskNumber = [int]$recoveryPartition.DiskNumber
+                RecoveryFileSystem = [string]$recoveryVolume.FileSystem
+            } | ConvertTo-Json -Compress
+            """;
+        string encoded = Convert.ToBase64String(Encoding.Unicode.GetBytes(script));
+        ProcessExecutionResult execution = await RunRequiredProcessAsync(
+            "powershell.exe",
+            $"-NoProfile -ExecutionPolicy Bypass -EncodedCommand {encoded}",
+            workingDirectory,
+            LocalizationText.Format("Deployment.LayoutValidationProcessFailureFormat", diskNumber),
+            cancellationToken).ConfigureAwait(false);
+
+        TargetDiskLayoutValidation? validation;
+        try
+        {
+            validation = JsonSerializer.Deserialize<TargetDiskLayoutValidation>(execution.StandardOutput);
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidOperationException(
+                LocalizationText.Format("Deployment.LayoutValidationInvalidDataFormat", diskNumber),
+                exception);
+        }
+
+        if (validation is null ||
+            validation.DiskNumber != diskNumber ||
+            !validation.PartitionStyle.Equals("GPT", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(LocalizationText.Format("Deployment.LayoutNotGptFormat", diskNumber));
+        }
+
+        ulong minimumEfiBytes = (ulong)EfiPartitionSizeMb * 1024UL * 1024UL;
+        bool isValidEfi =
+            validation.SystemDiskNumber == diskNumber &&
+            NormalizeGuid(validation.SystemGptType).Equals(EfiPartitionGuid, StringComparison.OrdinalIgnoreCase) &&
+            validation.SystemSizeBytes >= minimumEfiBytes &&
+            validation.SystemFileSystem.Equals("FAT32", StringComparison.OrdinalIgnoreCase) &&
+            validation.SystemDriveLetter.Equals(systemLetter.ToString(), StringComparison.OrdinalIgnoreCase);
+        if (!isValidEfi)
+        {
+            throw new InvalidOperationException(LocalizationText.Format(
+                "Deployment.LayoutInvalidEfiFormat",
+                diskNumber,
+                systemLetter,
+                EfiPartitionSizeMb));
+        }
+
+        if (validation.WindowsDiskNumber != diskNumber ||
+            !validation.WindowsFileSystem.Equals("NTFS", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(LocalizationText.Format("Deployment.LayoutInvalidWindowsFormat", diskNumber));
+        }
+
+        if (validation.RecoveryDiskNumber != diskNumber ||
+            !validation.RecoveryFileSystem.Equals("NTFS", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(LocalizationText.Format("Deployment.LayoutInvalidRecoveryFormat", diskNumber));
+        }
     }
 
     /// <inheritdoc />
@@ -828,12 +944,22 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
     {
         string windowsPath = Path.Combine(windowsPartitionRoot, "Windows");
         string bcdBootPath = Path.Combine(windowsPath, "System32", "bcdboot.exe");
+        string bcdTemplatePath = Path.Combine(windowsPath, "System32", "Config", "BCD-Template");
         if (!File.Exists(bcdBootPath))
         {
             throw new FileNotFoundException(
-                "The applied Windows image does not contain bcdboot.exe.",
+                LocalizationText.Format("Deployment.BcdBootMissingFormat", bcdBootPath),
                 bcdBootPath);
         }
+
+        if (!File.Exists(bcdTemplatePath))
+        {
+            throw new FileNotFoundException(
+                LocalizationText.Format("Deployment.BcdTemplateMissingFormat", bcdTemplatePath),
+                bcdTemplatePath);
+        }
+
+        EnsureSystemPartitionIsWritable(systemPartitionRoot);
 
         _logger.LogInformation("Configuring boot files. WindowsPath={WindowsPath}, SystemPartitionRoot={SystemPartitionRoot}", windowsPath, systemPartitionRoot);
 
@@ -845,10 +971,42 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
             bcdBootPath,
             arguments,
             workingDirectory,
-            "BCDBoot configuration failed",
+            LocalizationText.GetString("Deployment.BcdBootFailure"),
             cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation("BCDBoot configuration completed successfully.");
+    }
+
+    private static void EnsureSystemPartitionIsWritable(string systemPartitionRoot)
+    {
+        if (!Directory.Exists(systemPartitionRoot))
+        {
+            throw new DirectoryNotFoundException(
+                LocalizationText.Format("Deployment.EfiUnavailableFormat", systemPartitionRoot));
+        }
+
+        string probePath = Path.Combine(systemPartitionRoot, $".foundry-write-test-{Guid.NewGuid():N}.tmp");
+        try
+        {
+            using FileStream stream = new(
+                probePath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 1,
+                FileOptions.DeleteOnClose);
+            stream.WriteByte(0);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            throw new IOException(
+                LocalizationText.Format("Deployment.EfiNotWritableFormat", systemPartitionRoot),
+                exception);
+        }
+        finally
+        {
+            TryDeleteFile(probePath);
+        }
     }
 
     private async Task<ProcessExecutionResult> RunRequiredProcessAsync(
@@ -975,9 +1133,46 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
         }
     }
 
+    private static void TryDeleteFile(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return;
+        }
+
+        try
+        {
+            File.Delete(path);
+        }
+        catch
+        {
+            // Best effort cleanup for transient validation files.
+        }
+    }
+
+    private static string NormalizeGuid(string value)
+    {
+        return value.Trim().Trim('{', '}');
+    }
+
     private static string GetRecoveryDirectoryPath(string recoveryPartitionRoot)
     {
         return Path.Combine(recoveryPartitionRoot, "Recovery", "WindowsRE");
+    }
+
+    private sealed record TargetDiskLayoutValidation
+    {
+        public int DiskNumber { get; init; }
+        public string PartitionStyle { get; init; } = string.Empty;
+        public int SystemDiskNumber { get; init; }
+        public string SystemGptType { get; init; } = string.Empty;
+        public ulong SystemSizeBytes { get; init; }
+        public string SystemFileSystem { get; init; } = string.Empty;
+        public string SystemDriveLetter { get; init; } = string.Empty;
+        public int WindowsDiskNumber { get; init; }
+        public string WindowsFileSystem { get; init; } = string.Empty;
+        public int RecoveryDiskNumber { get; init; }
+        public string RecoveryFileSystem { get; init; } = string.Empty;
     }
 
     private static string GetRecoveryImagePath(string recoveryPartitionRoot)

--- a/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
@@ -511,4 +511,40 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>تم تجهيز مساعد تسجيل Autopilot التفاعلي (محاكاة).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>فشل التحقق من تخطيط القرص الهدف للقرص {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>أرجع التحقق من تخطيط القرص الهدف بيانات غير صالحة للقرص {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>القرص الهدف {0} ليس قرص GPT صالحًا بعد التقسيم.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>قسم نظام EFI على القرص {0} غير صالح. المتوقع FAT32 ونوع EFI GPT ومحرك الأقراص {1}: وحجم لا يقل عن {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>قسم Windows على القرص {0} ليس وحدة تخزين NTFS يمكن الوصول إليها.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>قسم الاسترداد على القرص {0} ليس وحدة تخزين NTFS يمكن الوصول إليها.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>لا تحتوي صورة Windows المطبقة على BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>لا تحتوي صورة Windows المطبقة على BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>لا يمكن الوصول إلى قسم نظام EFI في {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>قسم نظام EFI غير قابل للكتابة في {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>فشل تقسيم القرص {0} باستخدام DiskPart</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>فشل تكوين BCDBoot</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
+++ b/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
@@ -511,4 +511,40 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Интерактивният помощник за регистрация на Autopilot е подготвен (симулация).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Проверката на оформлението на целевия диск е неуспешна за диск {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Проверката на оформлението на целевия диск върна невалидни данни за диск {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Целевият диск {0} не е валиден GPT диск след разделянето.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>Системният EFI дял на диск {0} е невалиден. Очакват се FAT32, EFI GPT тип, устройство {1}: и поне {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Дялът на Windows на диск {0} не е достъпен NTFS том.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Дялът за възстановяване на диск {0} не е достъпен NTFS том.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Приложеният образ на Windows не съдържа BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Приложеният образ на Windows не съдържа BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>Системният EFI дял не е достъпен на {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>В системния EFI дял не може да се записва на {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Разделянето на диск {0} с DiskPart е неуспешно</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>Конфигурирането на BCDBoot е неуспешно</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
+++ b/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
@@ -511,4 +511,40 @@ Pokračovat v nasazování?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktivní asistent registrace Autopilotu byl připraven (simulace).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Ověření rozložení cílového disku selhalo pro disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Ověření rozložení cílového disku vrátilo neplatná data pro disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Cílový disk {0} není po rozdělení platným diskem GPT.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>Systémový oddíl EFI na disku {0} není platný. Očekává se FAT32, typ EFI GPT, jednotka {1}: a alespoň {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Oddíl Windows na disku {0} není přístupný svazek NTFS.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Oddíl pro obnovení na disku {0} není přístupný svazek NTFS.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Použitá bitová kopie Windows neobsahuje BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Použitá bitová kopie Windows neobsahuje BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>Systémový oddíl EFI není dostupný v umístění {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>Do systémového oddílu EFI nelze zapisovat v umístění {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Rozdělení disku {0} pomocí nástroje DiskPart selhalo</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>Konfigurace BCDBoot selhala</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/da-DK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/da-DK/Resources.resx
@@ -511,4 +511,40 @@ Vil du fortsætte med implementeringen?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Den interaktive Autopilot-registreringsassistent er klargjort (simulation).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Validering af destinationsdiskens layout mislykkedes for disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Validering af destinationsdiskens layout returnerede ugyldige data for disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Destinationsdisken {0} er ikke en gyldig GPT-disk efter partitionering.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>EFI-systempartitionen på disk {0} er ugyldig. Der forventes FAT32, EFI GPT-type, drev {1}: og mindst {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Windows-partitionen på disk {0} er ikke en tilgængelig NTFS-diskenhed.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Genoprettelsespartitionen på disk {0} er ikke en tilgængelig NTFS-diskenhed.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Det anvendte Windows-image indeholder ikke BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Det anvendte Windows-image indeholder ikke BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>EFI-systempartitionen er ikke tilgængelig på {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>Der kan ikke skrives til EFI-systempartitionen på {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Partitionering af disk {0} med DiskPart mislykkedes</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>Konfiguration af BCDBoot mislykkedes</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/de-DE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/de-DE/Resources.resx
@@ -511,4 +511,40 @@ Mit der Bereitstellung fortfahren?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Der interaktive Autopilot-Registrierungsassistent wurde bereitgestellt (Simulation).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Die Überprüfung des Ziellaufwerklayouts ist für Datenträger {0} fehlgeschlagen.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Die Überprüfung des Ziellaufwerklayouts hat ungültige Daten für Datenträger {0} zurückgegeben.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Der Zieldatenträger {0} ist nach der Partitionierung kein gültiger GPT-Datenträger.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>Die EFI-Systempartition auf Datenträger {0} ist ungültig. Erwartet werden FAT32, der EFI-GPT-Typ, Laufwerk {1}: und mindestens {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Die Windows-Partition auf Datenträger {0} ist kein zugängliches NTFS-Volume.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Die Wiederherstellungspartition auf Datenträger {0} ist kein zugängliches NTFS-Volume.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Das angewendete Windows-Abbild enthält BCDBoot nicht: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Das angewendete Windows-Abbild enthält BCD-Template nicht: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>Auf die EFI-Systempartition unter {0} kann nicht zugegriffen werden.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>Die EFI-Systempartition unter {0} ist nicht beschreibbar.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Die Partitionierung von Datenträger {0} mit DiskPart ist fehlgeschlagen</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>Die BCDBoot-Konfiguration ist fehlgeschlagen</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/el-GR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/el-GR/Resources.resx
@@ -511,4 +511,40 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Ο διαδραστικός βοηθός εγγραφής Autopilot προετοιμάστηκε (προσομοίωση).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Η επικύρωση της διάταξης του δίσκου προορισμού απέτυχε για τον δίσκο {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Η επικύρωση της διάταξης του δίσκου προορισμού επέστρεψε μη έγκυρα δεδομένα για τον δίσκο {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Ο δίσκος προορισμού {0} δεν είναι έγκυρος δίσκος GPT μετά τη διαμέριση.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>Το διαμέρισμα συστήματος EFI στον δίσκο {0} δεν είναι έγκυρο. Αναμένονται FAT32, τύπος EFI GPT, μονάδα {1}: και τουλάχιστον {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Το διαμέρισμα Windows στον δίσκο {0} δεν είναι προσβάσιμος τόμος NTFS.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Το διαμέρισμα αποκατάστασης στον δίσκο {0} δεν είναι προσβάσιμος τόμος NTFS.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Το εφαρμοσμένο είδωλο Windows δεν περιέχει το BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Το εφαρμοσμένο είδωλο Windows δεν περιέχει το BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>Το διαμέρισμα συστήματος EFI δεν είναι προσβάσιμο στη θέση {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>Δεν είναι δυνατή η εγγραφή στο διαμέρισμα συστήματος EFI στη θέση {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Η διαμέριση του δίσκου {0} με το DiskPart απέτυχε</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>Η ρύθμιση παραμέτρων του BCDBoot απέτυχε</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/en-GB/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-GB/Resources.resx
@@ -511,4 +511,40 @@ Continue with deployment?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interactive Autopilot registration assistant staged (simulation).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Target disk layout validation failed for disk {0}</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Target disk layout validation returned invalid data for disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Target disk {0} is not a valid GPT disk after partitioning.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>The EFI system partition on disk {0} is invalid. Expected FAT32, EFI GPT type, drive {1}:, and at least {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>The Windows partition on disk {0} is not an accessible NTFS volume.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>The recovery partition on disk {0} is not an accessible NTFS volume.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>The applied Windows image does not contain BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>The applied Windows image does not contain BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>The EFI system partition is not accessible at {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>The EFI system partition is not writable at {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Disk partitioning failed for disk {0}</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>BCDBoot configuration failed</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/en-US/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-US/Resources.resx
@@ -511,4 +511,40 @@ Continue with deployment?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interactive Autopilot registration assistant staged (simulation).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Target disk layout validation failed for disk {0}</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Target disk layout validation returned invalid data for disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Target disk {0} is not a valid GPT disk after partitioning.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>The EFI system partition on disk {0} is invalid. Expected FAT32, EFI GPT type, drive {1}:, and at least {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>The Windows partition on disk {0} is not an accessible NTFS volume.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>The recovery partition on disk {0} is not an accessible NTFS volume.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>The applied Windows image does not contain BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>The applied Windows image does not contain BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>The EFI system partition is not accessible at {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>The EFI system partition is not writable at {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Disk partitioning failed for disk {0}</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>BCDBoot configuration failed</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/es-ES/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-ES/Resources.resx
@@ -511,4 +511,40 @@ Sistema operativo: {4}
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Asistente de registro interactivo de Autopilot preparado (simulación).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>La validación del diseño del disco de destino ha fallado para el disco {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>La validación del diseño del disco de destino devolvió datos no válidos para el disco {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>El disco de destino {0} no es un disco GPT válido después del particionado.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>La partición del sistema EFI del disco {0} no es válida. Se esperaba FAT32, tipo GPT EFI, unidad {1}: y al menos {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>La partición de Windows del disco {0} no es un volumen NTFS accesible.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>La partición de recuperación del disco {0} no es un volumen NTFS accesible.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>La imagen de Windows aplicada no contiene BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>La imagen de Windows aplicada no contiene BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>No se puede acceder a la partición del sistema EFI en {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>No se puede escribir en la partición del sistema EFI en {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>El particionado del disco {0} con DiskPart ha fallado</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>La configuración de BCDBoot ha fallado</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/es-MX/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-MX/Resources.resx
@@ -511,4 +511,40 @@ Sistema operativo: {4}
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Asistente de registro interactivo de Autopilot preparado (simulación).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>La validación del diseño del disco de destino falló para el disco {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>La validación del diseño del disco de destino devolvió datos no válidos para el disco {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>El disco de destino {0} no es un disco GPT válido después de crear las particiones.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>La partición del sistema EFI del disco {0} no es válida. Se esperaba FAT32, tipo GPT EFI, unidad {1}: y al menos {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>La partición de Windows del disco {0} no es un volumen NTFS accesible.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>La partición de recuperación del disco {0} no es un volumen NTFS accesible.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>La imagen de Windows aplicada no contiene BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>La imagen de Windows aplicada no contiene BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>No se puede acceder a la partición del sistema EFI en {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>No se puede escribir en la partición del sistema EFI en {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Error al crear las particiones del disco {0} con DiskPart</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>Error en la configuración de BCDBoot</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/et-EE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/et-EE/Resources.resx
@@ -511,4 +511,40 @@ Kas jätkata juurutamisega?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktiivne Autopiloti registreerimisabiline on ette valmistatud (simulatsioon).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Sihtketta paigutuse valideerimine nurjus kettal {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Sihtketta paigutuse valideerimine tagastas ketta {0} kohta sobimatud andmed.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Sihtketas {0} ei ole pärast partitsioneerimist kehtiv GPT-ketas.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>Ketta {0} EFI-süsteemipartitsioon ei sobi. Eeldatud on FAT32, EFI GPT tüüp, draiv {1}: ja vähemalt {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Ketta {0} Windowsi partitsioon ei ole juurdepääsetav NTFS-köide.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Ketta {0} taastepartitsioon ei ole juurdepääsetav NTFS-köide.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Rakendatud Windowsi tõmmis ei sisalda BCDBooti: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Rakendatud Windowsi tõmmis ei sisalda BCD-Template&apos;i: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>EFI-süsteemipartitsioon pole asukohas {0} juurdepääsetav.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>EFI-süsteemipartitsioon pole asukohas {0} kirjutatav.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Ketta {0} partitsioneerimine DiskPartiga nurjus</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>BCDBooti konfigureerimine nurjus</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
@@ -511,4 +511,40 @@ Jatketaanko käyttöönottoa?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Vuorovaikutteinen Autopilot-rekisteröintiavustaja on valmisteltu (simulointi).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Kohdelevyn asettelun vahvistus epäonnistui levyllä {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Kohdelevyn asettelun vahvistus palautti virheellisiä tietoja levylle {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Kohdelevy {0} ei ole kelvollinen GPT-levy osioinnin jälkeen.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>Levyn {0} EFI-järjestelmäosio on virheellinen. Odotettiin FAT32-muotoa, EFI GPT -tyyppiä, asemaa {1}: ja vähintään {2} MiB:n kokoa.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Levyn {0} Windows-osio ei ole käytettävissä oleva NTFS-taltio.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Levyn {0} palautusosio ei ole käytettävissä oleva NTFS-taltio.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Käytetty Windows-näköistiedosto ei sisällä BCDBootia: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Käytetty Windows-näköistiedosto ei sisällä BCD-Templatea: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>EFI-järjestelmäosio ei ole käytettävissä sijainnissa {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>EFI-järjestelmäosioon ei voi kirjoittaa sijainnissa {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Levyn {0} osiointi DiskPartilla epäonnistui</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>BCDBoot-määritys epäonnistui</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
@@ -511,4 +511,40 @@ Continuer le déploiement?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Assistant d&apos;enregistrement Autopilot interactif préparé (simulation).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>La validation de la disposition du disque cible a échoué pour le disque {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>La validation de la disposition du disque cible a retourné des données non valides pour le disque {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Le disque cible {0} n’est pas un disque GPT valide après le partitionnement.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>La partition système EFI du disque {0} n’est pas valide. Sont attendus : FAT32, le type GPT EFI, le lecteur {1}: et au moins {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>La partition Windows du disque {0} n’est pas un volume NTFS accessible.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>La partition de récupération du disque {0} n’est pas un volume NTFS accessible.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>L’image Windows appliquée ne contient pas BCDBoot : {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>L’image Windows appliquée ne contient pas BCD-Template : {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>La partition système EFI n’est pas accessible à l’emplacement {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>La partition système EFI n’est pas accessible en écriture à l’emplacement {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Le partitionnement du disque {0} avec DiskPart a échoué</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>La configuration de BCDBoot a échoué</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
@@ -511,4 +511,40 @@ Continuer le déploiement ?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Assistant d&apos;enregistrement Autopilot interactif préparé (simulation).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>La validation de la disposition du disque cible a échoué pour le disque {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>La validation de la disposition du disque cible a renvoyé des données non valides pour le disque {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Le disque cible {0} n’est pas un disque GPT valide après le partitionnement.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>La partition système EFI du disque {0} n’est pas valide. Sont attendus : FAT32, le type GPT EFI, le lecteur {1}: et au moins {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>La partition Windows du disque {0} n’est pas un volume NTFS accessible.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>La partition de récupération du disque {0} n’est pas un volume NTFS accessible.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>L’image Windows appliquée ne contient pas BCDBoot : {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>L’image Windows appliquée ne contient pas BCD-Template : {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>La partition système EFI n’est pas accessible à l’emplacement {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>La partition système EFI n’est pas accessible en écriture à l’emplacement {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Le partitionnement du disque {0} avec DiskPart a échoué</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>La configuration de BCDBoot a échoué</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/he-IL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/he-IL/Resources.resx
@@ -511,4 +511,40 @@ ErrorCode=0x80070005
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>מסייע הרישום האינטראקטיבי של Autopilot הוכן (סימולציה).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>אימות פריסת דיסק היעד נכשל עבור דיסק {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>אימות פריסת דיסק היעד החזיר נתונים לא חוקיים עבור דיסק {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>דיסק היעד {0} אינו דיסק GPT חוקי לאחר החלוקה למחיצות.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>מחיצת המערכת EFI בדיסק {0} אינה חוקית. נדרשים FAT32, סוג EFI GPT, כונן {1}: וגודל של לפחות {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>מחיצת Windows בדיסק {0} אינה אמצעי אחסון NTFS נגיש.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>מחיצת השחזור בדיסק {0} אינה אמצעי אחסון NTFS נגיש.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>תמונת Windows שהוחלה אינה מכילה את BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>תמונת Windows שהוחלה אינה מכילה את BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>מחיצת המערכת EFI אינה נגישה ב-{0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>מחיצת המערכת EFI אינה ניתנת לכתיבה ב-{0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>חלוקת דיסק {0} למחיצות באמצעות DiskPart נכשלה</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>קביעת התצורה של BCDBoot נכשלה</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
@@ -511,4 +511,40 @@ Nastaviti s implementacijom?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktivni pomoćnik za registraciju Autopilota je pripremljen (simulacija).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Provjera rasporeda ciljnog diska nije uspjela za disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Provjera rasporeda ciljnog diska vratila je nevaljane podatke za disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Ciljni disk {0} nakon particioniranja nije valjan GPT disk.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>EFI sistemska particija na disku {0} nije valjana. Očekuju se FAT32, EFI GPT vrsta, pogon {1}: i najmanje {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Windows particija na disku {0} nije dostupan NTFS volumen.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Particija za oporavak na disku {0} nije dostupan NTFS volumen.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Primijenjena slika sustava Windows ne sadrži BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Primijenjena slika sustava Windows ne sadrži BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>EFI sistemska particija nije dostupna na lokaciji {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>U EFI sistemsku particiju nije moguće pisati na lokaciji {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Particioniranje diska {0} pomoću alata DiskPart nije uspjelo</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>Konfiguracija BCDBoot nije uspjela</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
@@ -511,4 +511,40 @@ Folytatja a telepítést?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Az interaktív Autopilot regisztrációs segéd előkészítve (szimuláció).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>A céllemez elrendezésének ellenőrzése sikertelen a(z) {0}. lemeznél.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>A céllemez elrendezésének ellenőrzése érvénytelen adatokat adott vissza a(z) {0}. lemezhez.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>A(z) {0}. céllemez a particionálás után nem érvényes GPT-lemez.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>A(z) {0}. lemez EFI rendszerpartíciója érvénytelen. Az elvárt formátum FAT32, EFI GPT-típus, {1}: meghajtó és legalább {2} MiB méret.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>A(z) {0}. lemez Windows-partíciója nem elérhető NTFS-kötet.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>A(z) {0}. lemez helyreállítási partíciója nem elérhető NTFS-kötet.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Az alkalmazott Windows-rendszerkép nem tartalmazza a BCDBoot fájlt: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Az alkalmazott Windows-rendszerkép nem tartalmazza a BCD-Template fájlt: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>Az EFI rendszerpartíció nem érhető el itt: {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>Az EFI rendszerpartíció nem írható itt: {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>A(z) {0}. lemez particionálása a DiskPart használatával sikertelen</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>A BCDBoot konfigurálása sikertelen</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/it-IT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/it-IT/Resources.resx
@@ -511,4 +511,40 @@ Continuare con la distribuzione?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Assistente di registrazione interattiva di Autopilot preparato (simulazione).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>La convalida del layout del disco di destinazione non è riuscita per il disco {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>La convalida del layout del disco di destinazione ha restituito dati non validi per il disco {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Il disco di destinazione {0} non è un disco GPT valido dopo il partizionamento.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>La partizione di sistema EFI sul disco {0} non è valida. Sono previsti FAT32, tipo GPT EFI, unità {1}: e almeno {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>La partizione Windows sul disco {0} non è un volume NTFS accessibile.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>La partizione di ripristino sul disco {0} non è un volume NTFS accessibile.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>L’immagine Windows applicata non contiene BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>L’immagine Windows applicata non contiene BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>La partizione di sistema EFI non è accessibile in {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>La partizione di sistema EFI non è scrivibile in {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Il partizionamento del disco {0} con DiskPart non è riuscito</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>La configurazione di BCDBoot non è riuscita</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
@@ -511,4 +511,40 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>対話型 Autopilot 登録アシスタントをステージングしました (シミュレーション)。</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>ディスク {0} のターゲット ディスク レイアウト検証に失敗しました。</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>ターゲット ディスク レイアウト検証でディスク {0} の無効なデータが返されました。</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>ターゲット ディスク {0} は、パーティション分割後に有効な GPT ディスクではありません。</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>ディスク {0} の EFI システム パーティションが無効です。FAT32、EFI GPT タイプ、ドライブ {1}:、および {2} MiB 以上が必要です。</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>ディスク {0} の Windows パーティションはアクセス可能な NTFS ボリュームではありません。</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>ディスク {0} の回復パーティションはアクセス可能な NTFS ボリュームではありません。</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>適用された Windows イメージに BCDBoot が含まれていません: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>適用された Windows イメージに BCD-Template が含まれていません: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>{0} の EFI システム パーティションにアクセスできません。</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>{0} の EFI システム パーティションに書き込めません。</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>DiskPart によるディスク {0} のパーティション分割に失敗しました</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>BCDBoot の構成に失敗しました</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
@@ -511,4 +511,40 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>대화형 Autopilot 등록 도우미가 준비되었습니다(시뮬레이션).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>디스크 {0}의 대상 디스크 레이아웃 유효성 검사에 실패했습니다.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>대상 디스크 레이아웃 유효성 검사에서 디스크 {0}에 대한 잘못된 데이터를 반환했습니다.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>대상 디스크 {0}은(는) 파티션 구성 후 유효한 GPT 디스크가 아닙니다.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>디스크 {0}의 EFI 시스템 파티션이 잘못되었습니다. FAT32, EFI GPT 유형, 드라이브 {1}: 및 최소 {2}MiB가 필요합니다.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>디스크 {0}의 Windows 파티션이 액세스 가능한 NTFS 볼륨이 아닙니다.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>디스크 {0}의 복구 파티션이 액세스 가능한 NTFS 볼륨이 아닙니다.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>적용된 Windows 이미지에 BCDBoot가 없습니다: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>적용된 Windows 이미지에 BCD-Template이 없습니다: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>{0}에서 EFI 시스템 파티션에 액세스할 수 없습니다.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>{0}에서 EFI 시스템 파티션에 쓸 수 없습니다.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>DiskPart를 사용한 디스크 {0} 파티션 구성에 실패했습니다</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>BCDBoot 구성에 실패했습니다</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
@@ -511,4 +511,40 @@ Tęsti diegimą?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktyvus Autopilot registracijos pagalbininkas paruoštas (modeliavimas).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Tikslinio disko išdėstymo tikrinimas nepavyko diskui {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Tikslinio disko išdėstymo tikrinimas grąžino netinkamus disko {0} duomenis.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Tikslinis diskas {0} po skaidymo nėra tinkamas GPT diskas.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>Disko {0} EFI sistemos skaidinys netinkamas. Tikėtasi FAT32, EFI GPT tipo, {1}: disko ir bent {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Disko {0} „Windows“ skaidinys nėra pasiekiamas NTFS tomas.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Disko {0} atkūrimo skaidinys nėra pasiekiamas NTFS tomas.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Pritaikytame „Windows“ atvaizde nėra BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Pritaikytame „Windows“ atvaizde nėra BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>EFI sistemos skaidinys nepasiekiamas vietoje {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>EFI sistemos skaidinys vietoje {0} nėra įrašomas.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Disko {0} skaidymas naudojant DiskPart nepavyko</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>BCDBoot konfigūravimas nepavyko</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
@@ -511,4 +511,40 @@ Vai turpināt izvietošanu?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktīvais Autopilot reģistrācijas palīgs ir sagatavots (simulācija).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Mērķa diska izkārtojuma validācija neizdevās diskam {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Mērķa diska izkārtojuma validācija atgrieza nederīgus datus diskam {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Mērķa disks {0} pēc sadalīšanas nav derīgs GPT disks.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>Diska {0} EFI sistēmas nodalījums nav derīgs. Paredzēts FAT32, EFI GPT tips, disks {1}: un vismaz {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Diska {0} Windows nodalījums nav pieejams NTFS sējums.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Diska {0} atkopšanas nodalījums nav pieejams NTFS sējums.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Lietotajā Windows attēlā nav BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Lietotajā Windows attēlā nav BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>EFI sistēmas nodalījums nav pieejams vietā {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>EFI sistēmas nodalījums nav rakstāms vietā {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Diska {0} sadalīšana ar DiskPart neizdevās</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>BCDBoot konfigurēšana neizdevās</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
@@ -511,4 +511,40 @@ Vil du fortsette med distribusjonen?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Den interaktive Autopilot-registreringsassistenten er klargjort (simulering).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Validering av måldiskoppsettet mislyktes for disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Validering av måldiskoppsettet returnerte ugyldige data for disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Måldisk {0} er ikke en gyldig GPT-disk etter partisjonering.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>EFI-systempartisjonen på disk {0} er ugyldig. Forventet FAT32, EFI GPT-type, stasjon {1}: og minst {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Windows-partisjonen på disk {0} er ikke et tilgjengelig NTFS-volum.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Gjenopprettingspartisjonen på disk {0} er ikke et tilgjengelig NTFS-volum.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Det anvendte Windows-avbildningen inneholder ikke BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Det anvendte Windows-avbildningen inneholder ikke BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>EFI-systempartisjonen er ikke tilgjengelig på {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>EFI-systempartisjonen er ikke skrivbar på {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Partisjonering av disk {0} med DiskPart mislyktes</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>Konfigurasjon av BCDBoot mislyktes</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
@@ -511,4 +511,40 @@ Doorgaan met de implementatie?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interactieve Autopilot-registratieassistent voorbereid (simulatie).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Validatie van de indeling van de doelschijf is mislukt voor schijf {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Validatie van de indeling van de doelschijf heeft ongeldige gegevens geretourneerd voor schijf {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Doelschijf {0} is na partitionering geen geldige GPT-schijf.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>De EFI-systeempartitie op schijf {0} is ongeldig. Verwacht: FAT32, EFI GPT-type, station {1}: en minimaal {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>De Windows-partitie op schijf {0} is geen toegankelijk NTFS-volume.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>De herstelpartitie op schijf {0} is geen toegankelijk NTFS-volume.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>De toegepaste Windows-installatiekopie bevat geen BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>De toegepaste Windows-installatiekopie bevat geen BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>De EFI-systeempartitie is niet toegankelijk op {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>De EFI-systeempartitie is niet beschrijfbaar op {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Partitionering van schijf {0} met DiskPart is mislukt</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>Configuratie van BCDBoot is mislukt</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
@@ -511,4 +511,40 @@ Kontynuować wdrażanie?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktywny asystent rejestracji Autopilot został przygotowany (symulacja).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Walidacja układu dysku docelowego nie powiodła się dla dysku {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Walidacja układu dysku docelowego zwróciła nieprawidłowe dane dla dysku {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Dysk docelowy {0} nie jest prawidłowym dyskiem GPT po partycjonowaniu.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>Partycja systemowa EFI na dysku {0} jest nieprawidłowa. Oczekiwano FAT32, typu GPT EFI, dysku {1}: i co najmniej {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Partycja Windows na dysku {0} nie jest dostępnym woluminem NTFS.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Partycja odzyskiwania na dysku {0} nie jest dostępnym woluminem NTFS.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Zastosowany obraz systemu Windows nie zawiera programu BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Zastosowany obraz systemu Windows nie zawiera pliku BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>Partycja systemowa EFI nie jest dostępna w lokalizacji {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>Partycja systemowa EFI nie jest zapisywalna w lokalizacji {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Partycjonowanie dysku {0} za pomocą DiskPart nie powiodło się</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>Konfiguracja BCDBoot nie powiodła się</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
@@ -511,4 +511,40 @@ Continuar com a implantação?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Assistente de registro interativo do Autopilot preparado (simulação).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>A validação do layout do disco de destino falhou para o disco {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>A validação do layout do disco de destino retornou dados inválidos para o disco {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>O disco de destino {0} não é um disco GPT válido após o particionamento.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>A partição do sistema EFI no disco {0} é inválida. Esperado: FAT32, tipo GPT EFI, unidade {1}: e pelo menos {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>A partição do Windows no disco {0} não é um volume NTFS acessível.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>A partição de recuperação no disco {0} não é um volume NTFS acessível.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>A imagem do Windows aplicada não contém o BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>A imagem do Windows aplicada não contém o BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>A partição do sistema EFI não está acessível em {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>A partição do sistema EFI não permite gravação em {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>O particionamento do disco {0} com o DiskPart falhou</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>A configuração do BCDBoot falhou</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
@@ -511,4 +511,40 @@ Continuar com a implantação?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Assistente de registo interativo do Autopilot preparado (simulação).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>A validação do esquema do disco de destino falhou para o disco {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>A validação do esquema do disco de destino devolveu dados inválidos para o disco {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>O disco de destino {0} não é um disco GPT válido após o particionamento.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>A partição de sistema EFI no disco {0} é inválida. Esperado: FAT32, tipo GPT EFI, unidade {1}: e pelo menos {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>A partição do Windows no disco {0} não é um volume NTFS acessível.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>A partição de recuperação no disco {0} não é um volume NTFS acessível.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>A imagem do Windows aplicada não contém o BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>A imagem do Windows aplicada não contém o BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>A partição de sistema EFI não está acessível em {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>A partição de sistema EFI não permite escrita em {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>O particionamento do disco {0} com o DiskPart falhou</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>A configuração do BCDBoot falhou</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
@@ -511,4 +511,40 @@ Continuați cu implementarea?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Asistentul de înregistrare interactivă Autopilot a fost pregătit (simulare).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Validarea structurii discului țintă a eșuat pentru discul {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Validarea structurii discului țintă a returnat date nevalide pentru discul {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Discul țintă {0} nu este un disc GPT valid după partiționare.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>Partiția de sistem EFI de pe discul {0} nu este validă. Se așteaptă FAT32, tip GPT EFI, unitatea {1}: și cel puțin {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Partiția Windows de pe discul {0} nu este un volum NTFS accesibil.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Partiția de recuperare de pe discul {0} nu este un volum NTFS accesibil.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Imaginea Windows aplicată nu conține BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Imaginea Windows aplicată nu conține BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>Partiția de sistem EFI nu este accesibilă la {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>Partiția de sistem EFI nu permite scrierea la {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Partiționarea discului {0} cu DiskPart a eșuat</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>Configurarea BCDBoot a eșuat</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
@@ -511,4 +511,40 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Интерактивный помощник регистрации Autopilot подготовлен (симуляция).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Проверка структуры целевого диска завершилась сбоем для диска {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Проверка структуры целевого диска вернула недопустимые данные для диска {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Целевой диск {0} не является допустимым GPT-диском после создания разделов.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>Системный раздел EFI на диске {0} недопустим. Ожидаются FAT32, тип GPT EFI, диск {1}: и размер не менее {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Раздел Windows на диске {0} не является доступным томом NTFS.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Раздел восстановления на диске {0} не является доступным томом NTFS.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Примененный образ Windows не содержит BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Примененный образ Windows не содержит BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>Системный раздел EFI недоступен по адресу {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>Системный раздел EFI недоступен для записи по адресу {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Не удалось разбить диск {0} на разделы с помощью DiskPart</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>Не удалось настроить BCDBoot</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
@@ -511,4 +511,40 @@ Pokračovať v nasadzovaní?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktívny asistent registrácie Autopilotu bol pripravený (simulácia).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Overenie rozloženia cieľového disku zlyhalo pre disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Overenie rozloženia cieľového disku vrátilo neplatné údaje pre disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Cieľový disk {0} nie je po rozdelení platným diskom GPT.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>Systémová oblasť EFI na disku {0} je neplatná. Očakáva sa FAT32, typ EFI GPT, jednotka {1}: a aspoň {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Oblasť Windows na disku {0} nie je dostupný zväzok NTFS.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Oblasť na obnovenie na disku {0} nie je dostupný zväzok NTFS.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Použitý obraz Windows neobsahuje BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Použitý obraz Windows neobsahuje BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>Systémová oblasť EFI nie je dostupná v umiestnení {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>Do systémovej oblasti EFI nemožno zapisovať v umiestnení {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Rozdelenie disku {0} pomocou nástroja DiskPart zlyhalo</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>Konfigurácia BCDBoot zlyhala</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
@@ -511,4 +511,40 @@ Ali želite nadaljevati z uvajanjem?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktivni pomočnik za registracijo Autopilot je pripravljen (simulacija).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Preverjanje postavitve ciljnega diska ni uspelo za disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Preverjanje postavitve ciljnega diska je vrnilo neveljavne podatke za disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Ciljni disk {0} po razdelitvi ni veljaven disk GPT.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>Sistemska particija EFI na disku {0} ni veljavna. Pričakovani so FAT32, vrsta GPT EFI, pogon {1}: in najmanj {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Particija Windows na disku {0} ni dostopen nosilec NTFS.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Obnovitvena particija na disku {0} ni dostopen nosilec NTFS.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Uporabljena slika sistema Windows ne vsebuje BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Uporabljena slika sistema Windows ne vsebuje BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>Sistemska particija EFI ni dostopna na mestu {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>V sistemsko particijo EFI ni mogoče pisati na mestu {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Razdelitev diska {0} z orodjem DiskPart ni uspela</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>Konfiguracija BCDBoot ni uspela</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
@@ -511,4 +511,40 @@ Operativni sistem: {4}
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktivni pomoćnik za registraciju Autopilota je pripremljen (simulacija).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Provera rasporeda ciljnog diska nije uspela za disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Provera rasporeda ciljnog diska vratila je nevažeće podatke za disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Ciljni disk {0} nakon particionisanja nije važeći GPT disk.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>EFI sistemska particija na disku {0} nije važeća. Očekuju se FAT32, EFI GPT tip, disk jedinica {1}: i najmanje {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Windows particija na disku {0} nije dostupna NTFS jedinica.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Particija za oporavak na disku {0} nije dostupna NTFS jedinica.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Primenjena Windows slika ne sadrži BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Primenjena Windows slika ne sadrži BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>EFI sistemska particija nije dostupna na lokaciji {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>Upis na EFI sistemsku particiju nije moguć na lokaciji {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Particionisanje diska {0} pomoću alatke DiskPart nije uspelo</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>Konfigurisanje BCDBoot nije uspelo</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
@@ -511,4 +511,40 @@ Fortsätt med implementeringen?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Den interaktiva Autopilot-registreringsassistenten har förberetts (simulering).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Valideringen av måldiskens layout misslyckades för disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Valideringen av måldiskens layout returnerade ogiltiga data för disk {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Måldisken {0} är inte en giltig GPT-disk efter partitioneringen.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>EFI-systempartitionen på disk {0} är ogiltig. FAT32, EFI GPT-typ, enhet {1}: och minst {2} MiB förväntades.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Windows-partitionen på disk {0} är inte en tillgänglig NTFS-volym.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Återställningspartitionen på disk {0} är inte en tillgänglig NTFS-volym.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Den tillämpade Windows-avbildningen innehåller inte BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Den tillämpade Windows-avbildningen innehåller inte BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>EFI-systempartitionen är inte tillgänglig på {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>EFI-systempartitionen är inte skrivbar på {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Partitioneringen av disk {0} med DiskPart misslyckades</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>Konfigurationen av BCDBoot misslyckades</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/th-TH/Resources.resx
+++ b/src/Foundry.Deploy/Strings/th-TH/Resources.resx
@@ -511,4 +511,40 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>จัดเตรียมผู้ช่วยลงทะเบียน Autopilot แบบโต้ตอบแล้ว (การจำลอง)</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>การตรวจสอบเค้าโครงดิสก์เป้าหมายล้มเหลวสำหรับดิสก์ {0}</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>การตรวจสอบเค้าโครงดิสก์เป้าหมายส่งคืนข้อมูลที่ไม่ถูกต้องสำหรับดิสก์ {0}</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>ดิสก์เป้าหมาย {0} ไม่ใช่ดิสก์ GPT ที่ถูกต้องหลังจากแบ่งพาร์ติชัน</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>พาร์ติชันระบบ EFI บนดิสก์ {0} ไม่ถูกต้อง ต้องเป็น FAT32 ชนิด EFI GPT ไดรฟ์ {1}: และมีขนาดอย่างน้อย {2} MiB</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>พาร์ติชัน Windows บนดิสก์ {0} ไม่ใช่ไดรฟ์ข้อมูล NTFS ที่เข้าถึงได้</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>พาร์ติชันการกู้คืนบนดิสก์ {0} ไม่ใช่ไดรฟ์ข้อมูล NTFS ที่เข้าถึงได้</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>อิมเมจ Windows ที่นำไปใช้ไม่มี BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>อิมเมจ Windows ที่นำไปใช้ไม่มี BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>ไม่สามารถเข้าถึงพาร์ติชันระบบ EFI ที่ {0}</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>ไม่สามารถเขียนไปยังพาร์ติชันระบบ EFI ที่ {0}</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>การแบ่งพาร์ติชันดิสก์ {0} ด้วย DiskPart ล้มเหลว</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>การกำหนดค่า BCDBoot ล้มเหลว</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
@@ -511,4 +511,40 @@ Dağıtıma devam edilsin mi?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Etkileşimli Autopilot kayıt yardımcısı hazırlandı (simülasyon).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Hedef disk düzeni doğrulaması {0} diski için başarısız oldu.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Hedef disk düzeni doğrulaması {0} diski için geçersiz veri döndürdü.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>{0} hedef diski, bölümlendirmeden sonra geçerli bir GPT diski değil.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>{0} diskindeki EFI sistem bölümü geçersiz. FAT32, EFI GPT türü, {1}: sürücüsü ve en az {2} MiB bekleniyor.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>{0} diskindeki Windows bölümü erişilebilir bir NTFS birimi değil.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>{0} diskindeki kurtarma bölümü erişilebilir bir NTFS birimi değil.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Uygulanan Windows görüntüsü BCDBoot içermiyor: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Uygulanan Windows görüntüsü BCD-Template içermiyor: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>EFI sistem bölümüne {0} konumundan erişilemiyor.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>EFI sistem bölümü {0} konumunda yazılabilir değil.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>{0} diskinin DiskPart ile bölümlendirilmesi başarısız oldu</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>BCDBoot yapılandırması başarısız oldu</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
@@ -511,4 +511,40 @@ ErrorCode=0x80070005
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Інтерактивний помічник реєстрації Autopilot підготовлено (симуляція).</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>Не вдалося перевірити структуру цільового диска {0}.</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>Перевірка структури цільового диска повернула неприпустимі дані для диска {0}.</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>Цільовий диск {0} не є припустимим GPT-диском після створення розділів.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>Системний розділ EFI на диску {0} неприпустимий. Очікуються FAT32, тип GPT EFI, диск {1}: і розмір щонайменше {2} MiB.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>Розділ Windows на диску {0} не є доступним томом NTFS.</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>Розділ відновлення на диску {0} не є доступним томом NTFS.</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>Застосований образ Windows не містить BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>Застосований образ Windows не містить BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>Системний розділ EFI недоступний за адресою {0}.</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>Системний розділ EFI недоступний для записування за адресою {0}.</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>Не вдалося розділити диск {0} на розділи за допомогою DiskPart</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>Не вдалося налаштувати BCDBoot</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
@@ -511,4 +511,40 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>交互式 Autopilot 注册助手已暂存（模拟）。</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>磁盘 {0} 的目标磁盘布局验证失败。</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>目标磁盘布局验证为磁盘 {0} 返回了无效数据。</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>目标磁盘 {0} 在分区后不是有效的 GPT 磁盘。</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>磁盘 {0} 上的 EFI 系统分区无效。应为 FAT32、EFI GPT 类型、驱动器 {1}:，且至少为 {2} MiB。</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>磁盘 {0} 上的 Windows 分区不是可访问的 NTFS 卷。</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>磁盘 {0} 上的恢复分区不是可访问的 NTFS 卷。</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>应用的 Windows 映像不包含 BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>应用的 Windows 映像不包含 BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>无法访问 {0} 处的 EFI 系统分区。</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>无法写入 {0} 处的 EFI 系统分区。</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>使用 DiskPart 对磁盘 {0} 进行分区失败</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>BCDBoot 配置失败</value>
+  </data>
 </root>

--- a/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
@@ -511,4 +511,40 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>互動式 Autopilot 註冊助理已暫存 (模擬)。</value>
   </data>
+  <data name="Deployment.LayoutValidationProcessFailureFormat" xml:space="preserve">
+    <value>磁碟 {0} 的目標磁碟配置驗證失敗。</value>
+  </data>
+  <data name="Deployment.LayoutValidationInvalidDataFormat" xml:space="preserve">
+    <value>目標磁碟配置驗證為磁碟 {0} 傳回無效資料。</value>
+  </data>
+  <data name="Deployment.LayoutNotGptFormat" xml:space="preserve">
+    <value>目標磁碟 {0} 在分割後不是有效的 GPT 磁碟。</value>
+  </data>
+  <data name="Deployment.LayoutInvalidEfiFormat" xml:space="preserve">
+    <value>磁碟 {0} 上的 EFI 系統分割區無效。應為 FAT32、EFI GPT 類型、磁碟機 {1}:，且至少為 {2} MiB。</value>
+  </data>
+  <data name="Deployment.LayoutInvalidWindowsFormat" xml:space="preserve">
+    <value>磁碟 {0} 上的 Windows 分割區不是可存取的 NTFS 磁碟區。</value>
+  </data>
+  <data name="Deployment.LayoutInvalidRecoveryFormat" xml:space="preserve">
+    <value>磁碟 {0} 上的復原分割區不是可存取的 NTFS 磁碟區。</value>
+  </data>
+  <data name="Deployment.BcdBootMissingFormat" xml:space="preserve">
+    <value>套用的 Windows 映像不包含 BCDBoot: {0}</value>
+  </data>
+  <data name="Deployment.BcdTemplateMissingFormat" xml:space="preserve">
+    <value>套用的 Windows 映像不包含 BCD-Template: {0}</value>
+  </data>
+  <data name="Deployment.EfiUnavailableFormat" xml:space="preserve">
+    <value>無法存取 {0} 的 EFI 系統分割區。</value>
+  </data>
+  <data name="Deployment.EfiNotWritableFormat" xml:space="preserve">
+    <value>無法寫入 {0} 的 EFI 系統分割區。</value>
+  </data>
+  <data name="Deployment.DiskPartFailureFormat" xml:space="preserve">
+    <value>使用 DiskPart 對磁碟 {0} 進行分割失敗</value>
+  </data>
+  <data name="Deployment.BcdBootFailure" xml:space="preserve">
+    <value>BCDBoot 設定失敗</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
Validate the actual target disk layout after DiskPart and the required inputs immediately before BCDBoot.

## Reason
A successful DiskPart exit code did not prove that the target ESP and Windows volumes were usable, and BCDBoot failures lacked prerequisite-specific diagnostics.

## Main changes
- increase the ESP from 260 MiB to 300 MiB
- refresh and retry WinPE Storage discovery for up to 30 seconds after DiskPart
- verify GPT, same-disk partition ownership, EFI GPT type, FAT32, assigned letter, ESP size, and NTFS Windows/recovery volumes
- verify BCDBoot, BCD-Template, ESP accessibility, and ESP writability before execution
- localize all new validation and failure messages in all 38 supported cultures
- add regression coverage for retry behavior, invalid GPT/ESP/JSON, missing boot prerequisites, and localization presence

## Testing
- x64 Foundry.Deploy.Tests: 379 passed
- ARM64 Foundry.Deploy build: passed
- repository format verification: passed

## Merge order
Merge PR #259 first, then synchronize this branch with main before merging because both PRs extend the localization resources.