### PR TITLE
refactor(deploy): make Windows edition selection metadata-driven

### DIFF
--- a/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
@@ -368,6 +368,55 @@ public sealed class DeployConfigurationGeneratorTests
         Assert.Equal("Enterprise", result.OperatingSystemSelection.DefaultEdition);
     }
 
+    [Theory]
+    [InlineData("Home", "VOL", "RET")]
+    [InlineData("Home China", "VOL", "RET")]
+    [InlineData("Enterprise", "RET", "VOL")]
+    public void Generate_WhenEditionAndLicenseChannelConflict_PreservesEditionAndForcesCompatibleChannel(
+        string edition,
+        string configuredChannel,
+        string expectedChannel)
+    {
+        var generator = new DeployConfigurationGenerator();
+        var document = new FoundryConfigurationDocument
+        {
+            OperatingSystemSelection = new OperatingSystemSelectionSettings
+            {
+                IsEnabled = true,
+                AllowedLicenseChannels = [configuredChannel],
+                AllowedEditions = [edition]
+            }
+        };
+
+        var result = generator.Generate(document);
+
+        Assert.Equal([edition], result.OperatingSystemSelection.AllowedEditions);
+        Assert.Equal([expectedChannel], result.OperatingSystemSelection.AllowedLicenseChannels);
+        Assert.Equal(expectedChannel, result.OperatingSystemSelection.DefaultLicenseChannel);
+    }
+
+    [Fact]
+    public void Generate_WhenDefaultEditionConflictsWithChannelOnlyPolicy_DropsTheDefaultEdition()
+    {
+        var generator = new DeployConfigurationGenerator();
+        var document = new FoundryConfigurationDocument
+        {
+            OperatingSystemSelection = new OperatingSystemSelectionSettings
+            {
+                IsEnabled = true,
+                AllowedLicenseChannels = ["VOL"],
+                DefaultLicenseChannel = "VOL",
+                DefaultEdition = "Home"
+            }
+        };
+
+        var result = generator.Generate(document);
+
+        Assert.Equal(["VOL"], result.OperatingSystemSelection.AllowedLicenseChannels);
+        Assert.Equal("VOL", result.OperatingSystemSelection.DefaultLicenseChannel);
+        Assert.Null(result.OperatingSystemSelection.DefaultEdition);
+    }
+
     [Fact]
     public void Generate_WhenOperatingSystemSelectionIsDisabled_DoesNotPropagatePolicy()
     {

--- a/src/Foundry.Core.Tests/Configuration/WindowsEditionCatalogTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/WindowsEditionCatalogTests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Core.Tests.Configuration;
+
+using Foundry.Core.Models.Configuration;
+
+public sealed class WindowsEditionCatalogTests
+{
+    [Theory]
+    [InlineData("Home", "RET")]
+    [InlineData("Enterprise", "VOL")]
+    [InlineData("Pro", "RET", "VOL")]
+    public void GetCompatibleLicenseChannels_ReturnsChannelsSupportedBySelectedEditions(
+        string edition,
+        params string[] expectedChannels)
+    {
+        IReadOnlyList<string> channels = WindowsEditionCatalog.GetCompatibleLicenseChannels([edition]);
+
+        Assert.Equal(expectedChannels, channels);
+    }
+
+    [Fact]
+    public void GetCompatibleLicenseChannels_WhenHomeAndEnterpriseAreSelected_ReturnsBothChannels()
+    {
+        IReadOnlyList<string> channels = WindowsEditionCatalog.GetCompatibleLicenseChannels(["Home", "Enterprise"]);
+
+        Assert.Equal(["RET", "VOL"], channels);
+    }
+
+    [Theory]
+    [InlineData(new[] { "Home" }, new[] { "RET" })]
+    [InlineData(new[] { "Enterprise" }, new[] { "VOL" })]
+    [InlineData(new[] { "Pro" }, new string[0])]
+    [InlineData(new[] { "Home", "Enterprise" }, new[] { "RET", "VOL" })]
+    public void GetRequiredLicenseChannels_ReturnsChannelsRequiredBySelectedEditions(
+        string[] editions,
+        string[] expectedChannels)
+    {
+        IReadOnlyList<string> channels = WindowsEditionCatalog.GetRequiredLicenseChannels(editions);
+
+        Assert.Equal(expectedChannels, channels);
+    }
+}

--- a/src/Foundry.Core/Models/Configuration/OperatingSystemSelectionCatalog.cs
+++ b/src/Foundry.Core/Models/Configuration/OperatingSystemSelectionCatalog.cs
@@ -46,16 +46,5 @@ public static class OperatingSystemSelectionCatalog
     /// <summary>
     /// Gets the supported target editions shown in the deployment catalog.
     /// </summary>
-    public static IReadOnlyList<string> SupportedEditions { get; } =
-    [
-        "Home",
-        "Home N",
-        "Home Single Language",
-        "Education",
-        "Education N",
-        "Pro",
-        "Pro N",
-        "Enterprise",
-        "Enterprise N"
-    ];
+    public static IReadOnlyList<string> SupportedEditions => WindowsEditionCatalog.SupportedEditions;
 }

--- a/src/Foundry.Core/Models/Configuration/OperatingSystemSelectionCatalog.cs
+++ b/src/Foundry.Core/Models/Configuration/OperatingSystemSelectionCatalog.cs
@@ -37,11 +37,7 @@ public static class OperatingSystemSelectionCatalog
     /// <summary>
     /// Gets the supported catalog license channel tokens.
     /// </summary>
-    public static IReadOnlyList<string> SupportedLicenseChannels { get; } =
-    [
-        "RET",
-        "VOL"
-    ];
+    public static IReadOnlyList<string> SupportedLicenseChannels => WindowsEditionCatalog.SupportedLicenseChannels;
 
     /// <summary>
     /// Gets the supported target editions shown in the deployment catalog.

--- a/src/Foundry.Core/Models/Configuration/WindowsEditionCatalog.cs
+++ b/src/Foundry.Core/Models/Configuration/WindowsEditionCatalog.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Core.Models.Configuration;
+
+/// <summary>
+/// Describes a selectable Windows edition and its invariant deployment metadata.
+/// </summary>
+public sealed record WindowsEditionDefinition(
+    string Name,
+    string EditionId,
+    IReadOnlyList<string> LicenseChannels,
+    IReadOnlyList<string> Architectures);
+
+/// <summary>
+/// Provides the supported Windows edition, DISM edition ID, media channel, and architecture mappings.
+/// </summary>
+public static class WindowsEditionCatalog
+{
+    private static readonly WindowsEditionDefinition[] Definitions =
+    [
+        new("Home", "Core", ["RET"], ["x64", "arm64"]),
+        new("Home N", "CoreN", ["RET"], ["x64", "arm64"]),
+        new("Home Single Language", "CoreSingleLanguage", ["RET"], ["x64", "arm64"]),
+        new("Home China", "CoreCountrySpecific", ["RET"], ["x64"]),
+        new("Education", "Education", ["RET", "VOL"], ["x64", "arm64"]),
+        new("Education N", "EducationN", ["RET", "VOL"], ["x64", "arm64"]),
+        new("Pro", "Professional", ["RET", "VOL"], ["x64", "arm64"]),
+        new("Pro N", "ProfessionalN", ["RET", "VOL"], ["x64", "arm64"]),
+        new("Enterprise", "Enterprise", ["VOL"], ["x64", "arm64"]),
+        new("Enterprise N", "EnterpriseN", ["VOL"], ["x64", "arm64"])
+    ];
+
+    /// <summary>
+    /// Gets all supported edition definitions in display order.
+    /// </summary>
+    public static IReadOnlyList<WindowsEditionDefinition> SupportedDefinitions => Definitions;
+
+    /// <summary>
+    /// Gets all supported friendly edition names in display order.
+    /// </summary>
+    public static IReadOnlyList<string> SupportedEditions { get; } = Definitions.Select(definition => definition.Name).ToArray();
+
+    /// <summary>
+    /// Finds a supported edition by its friendly name.
+    /// </summary>
+    public static WindowsEditionDefinition? Find(string? edition)
+    {
+        if (string.IsNullOrWhiteSpace(edition))
+        {
+            return null;
+        }
+
+        return Definitions.FirstOrDefault(definition =>
+            definition.Name.Equals(edition.Trim(), StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Determines whether an edition is supported by a media channel and processor architecture.
+    /// </summary>
+    public static bool IsSupported(string edition, string licenseChannel, string architecture)
+    {
+        WindowsEditionDefinition? definition = Find(edition);
+        return definition is not null &&
+               definition.LicenseChannels.Contains(licenseChannel, StringComparer.OrdinalIgnoreCase) &&
+               definition.Architectures.Contains(architecture, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/Foundry.Core/Models/Configuration/WindowsEditionCatalog.cs
+++ b/src/Foundry.Core/Models/Configuration/WindowsEditionCatalog.cs
@@ -38,6 +38,14 @@ public static class WindowsEditionCatalog
     public static IReadOnlyList<WindowsEditionDefinition> SupportedDefinitions => Definitions;
 
     /// <summary>
+    /// Gets all supported license channels in display order.
+    /// </summary>
+    public static IReadOnlyList<string> SupportedLicenseChannels { get; } = Definitions
+        .SelectMany(definition => definition.LicenseChannels)
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+    /// <summary>
     /// Gets all supported friendly edition names in display order.
     /// </summary>
     public static IReadOnlyList<string> SupportedEditions { get; } = Definitions.Select(definition => definition.Name).ToArray();
@@ -54,6 +62,38 @@ public static class WindowsEditionCatalog
 
         return Definitions.FirstOrDefault(definition =>
             definition.Name.Equals(edition.Trim(), StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Gets the license channels supported by at least one selected edition.
+    /// </summary>
+    public static IReadOnlyList<string> GetCompatibleLicenseChannels(IEnumerable<string> editions)
+    {
+        HashSet<string> channels = editions
+            .Select(Find)
+            .Where(definition => definition is not null)
+            .SelectMany(definition => definition!.LicenseChannels)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return SupportedLicenseChannels
+            .Where(channels.Contains)
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Gets the license channels required by selected editions that only exist in one channel.
+    /// </summary>
+    public static IReadOnlyList<string> GetRequiredLicenseChannels(IEnumerable<string> editions)
+    {
+        HashSet<string> channels = editions
+            .Select(Find)
+            .Where(definition => definition?.LicenseChannels.Count == 1)
+            .Select(definition => definition!.LicenseChannels[0])
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return SupportedLicenseChannels
+            .Where(channels.Contains)
+            .ToArray();
     }
 
     /// <summary>

--- a/src/Foundry.Core/Services/Configuration/OperatingSystemSelectionSettingsNormalizer.cs
+++ b/src/Foundry.Core/Services/Configuration/OperatingSystemSelectionSettingsNormalizer.cs
@@ -35,16 +35,10 @@ public static class OperatingSystemSelectionSettingsNormalizer
                 OperatingSystemSelectionCatalog.SupportedReleaseIds,
                 static value => value.Trim()),
             allowedReleaseIds);
-        string[] allowedLicenseChannels = CanonicalizeKnownValues(
+        string[] configuredLicenseChannels = CanonicalizeKnownValues(
             settings.AllowedLicenseChannels,
             OperatingSystemSelectionCatalog.SupportedLicenseChannels,
             NormalizeLicenseChannel);
-        string? defaultLicenseChannel = NormalizeDefault(
-            CanonicalizeKnownValue(
-                settings.DefaultLicenseChannel,
-                OperatingSystemSelectionCatalog.SupportedLicenseChannels,
-                NormalizeLicenseChannel),
-            allowedLicenseChannels);
         string[] allowedEditions = CanonicalizeKnownValues(
             settings.AllowedEditions,
             OperatingSystemSelectionCatalog.SupportedEditions,
@@ -55,6 +49,12 @@ public static class OperatingSystemSelectionSettingsNormalizer
                 OperatingSystemSelectionCatalog.SupportedEditions,
                 static value => value.Trim()),
             allowedEditions);
+        string[] allowedLicenseChannels = EnsureCompatibleLicenseChannels(configuredLicenseChannels, allowedEditions);
+        defaultEdition = EnsureCompatibleDefaultEdition(defaultEdition, allowedEditions, allowedLicenseChannels);
+        string? defaultLicenseChannel = ResolveDefaultLicenseChannel(
+            settings.DefaultLicenseChannel,
+            allowedLicenseChannels,
+            defaultEdition);
 
         return new OperatingSystemSelectionSettings
         {
@@ -113,6 +113,77 @@ public static class OperatingSystemSelectionSettingsNormalizer
             "VOLUME" => "VOL",
             _ => normalized
         };
+    }
+
+    private static string[] EnsureCompatibleLicenseChannels(
+        IReadOnlyList<string> configuredChannels,
+        IReadOnlyList<string> allowedEditions)
+    {
+        if (configuredChannels.Count == 0 || allowedEditions.Count == 0)
+        {
+            return configuredChannels.ToArray();
+        }
+
+        HashSet<string> compatibleChannels = allowedEditions
+            .Select(WindowsEditionCatalog.Find)
+            .Where(definition => definition is not null)
+            .SelectMany(definition => definition!.LicenseChannels)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        HashSet<string> requiredChannels = allowedEditions
+            .Select(WindowsEditionCatalog.Find)
+            .Where(definition => definition?.LicenseChannels.Count == 1)
+            .Select(definition => definition!.LicenseChannels[0])
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return OperatingSystemSelectionCatalog.SupportedLicenseChannels
+            .Where(channel =>
+                requiredChannels.Contains(channel) ||
+                (compatibleChannels.Contains(channel) && configuredChannels.Contains(channel, StringComparer.OrdinalIgnoreCase)))
+            .ToArray();
+    }
+
+    private static string? ResolveDefaultLicenseChannel(
+        string? configuredDefault,
+        IReadOnlyList<string> allowedChannels,
+        string? defaultEdition)
+    {
+        string? canonicalDefault = CanonicalizeKnownValue(
+            configuredDefault,
+            OperatingSystemSelectionCatalog.SupportedLicenseChannels,
+            NormalizeLicenseChannel);
+        WindowsEditionDefinition? edition = WindowsEditionCatalog.Find(defaultEdition);
+
+        if (edition is not null)
+        {
+            string[] compatibleAllowedChannels = edition.LicenseChannels
+                .Where(channel => allowedChannels.Count == 0 || allowedChannels.Contains(channel, StringComparer.OrdinalIgnoreCase))
+                .ToArray();
+            if (canonicalDefault is not null && compatibleAllowedChannels.Contains(canonicalDefault, StringComparer.OrdinalIgnoreCase))
+            {
+                return canonicalDefault;
+            }
+
+            return compatibleAllowedChannels.FirstOrDefault() ?? edition.LicenseChannels[0];
+        }
+
+        return NormalizeDefault(canonicalDefault, allowedChannels);
+    }
+
+    private static string? EnsureCompatibleDefaultEdition(
+        string? defaultEdition,
+        IReadOnlyList<string> allowedEditions,
+        IReadOnlyList<string> allowedChannels)
+    {
+        if (defaultEdition is null || allowedEditions.Count > 0 || allowedChannels.Count == 0)
+        {
+            return defaultEdition;
+        }
+
+        WindowsEditionDefinition? definition = WindowsEditionCatalog.Find(defaultEdition);
+        return definition is not null &&
+               definition.LicenseChannels.Any(channel => allowedChannels.Contains(channel, StringComparer.OrdinalIgnoreCase))
+            ? defaultEdition
+            : null;
     }
 
     private static string[] CanonicalizeLanguageCodes(IEnumerable<string> languageCodes)

--- a/src/Foundry.Core/Services/Configuration/OperatingSystemSelectionSettingsNormalizer.cs
+++ b/src/Foundry.Core/Services/Configuration/OperatingSystemSelectionSettingsNormalizer.cs
@@ -124,16 +124,8 @@ public static class OperatingSystemSelectionSettingsNormalizer
             return configuredChannels.ToArray();
         }
 
-        HashSet<string> compatibleChannels = allowedEditions
-            .Select(WindowsEditionCatalog.Find)
-            .Where(definition => definition is not null)
-            .SelectMany(definition => definition!.LicenseChannels)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        HashSet<string> requiredChannels = allowedEditions
-            .Select(WindowsEditionCatalog.Find)
-            .Where(definition => definition?.LicenseChannels.Count == 1)
-            .Select(definition => definition!.LicenseChannels[0])
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        IReadOnlyList<string> compatibleChannels = WindowsEditionCatalog.GetCompatibleLicenseChannels(allowedEditions);
+        IReadOnlyList<string> requiredChannels = WindowsEditionCatalog.GetRequiredLicenseChannels(allowedEditions);
 
         return OperatingSystemSelectionCatalog.SupportedLicenseChannels
             .Where(channel =>

--- a/src/Foundry.Deploy.Tests/OperatingSystemCatalogViewModelTests.cs
+++ b/src/Foundry.Deploy.Tests/OperatingSystemCatalogViewModelTests.cs
@@ -43,6 +43,110 @@ public sealed class OperatingSystemCatalogViewModelTests
         Assert.Contains("Enterprise N", viewModel.EditionFilters);
     }
 
+    [Theory]
+    [InlineData("Home", "RET")]
+    [InlineData("Home N", "RET")]
+    [InlineData("Home Single Language", "RET")]
+    [InlineData("Enterprise", "VOL")]
+    [InlineData("Enterprise N", "VOL")]
+    public void SelectingChannelSpecificEdition_ForcesItsLicenseChannel(string edition, string expectedChannel)
+    {
+        var viewModel = new OperatingSystemCatalogViewModel(NullLogger.Instance, "x64");
+        viewModel.ApplyCatalog(
+        [
+            CreateOperatingSystem("en-US", licenseChannel: "RET", sourceId: "media"),
+            CreateOperatingSystem("en-US", licenseChannel: "VOL", sourceId: "media")
+        ]);
+
+        viewModel.SelectedEdition = edition;
+
+        Assert.Equal([expectedChannel], viewModel.LicenseChannelFilters);
+        Assert.Equal(expectedChannel, viewModel.SelectedLicenseChannel);
+        Assert.False(viewModel.IsLicenseChannelSelectionEnabled);
+        Assert.Equal(edition, viewModel.SelectedOperatingSystem?.Edition);
+    }
+
+    [Theory]
+    [InlineData("Pro")]
+    [InlineData("Pro N")]
+    [InlineData("Education")]
+    [InlineData("Education N")]
+    public void SelectingDualChannelEdition_OffersRetailAndVolume(string edition)
+    {
+        var viewModel = new OperatingSystemCatalogViewModel(NullLogger.Instance, "x64");
+        viewModel.ApplyCatalog(
+        [
+            CreateOperatingSystem("en-US", licenseChannel: "RET", sourceId: "media"),
+            CreateOperatingSystem("en-US", licenseChannel: "VOL", sourceId: "media")
+        ]);
+
+        viewModel.SelectedEdition = edition;
+
+        Assert.Equal(["RET", "VOL"], viewModel.LicenseChannelFilters);
+        Assert.True(viewModel.IsLicenseChannelSelectionEnabled);
+    }
+
+    [Fact]
+    public void SelectingHomeChina_SelectsOnlyCountrySpecificMedia()
+    {
+        var viewModel = new OperatingSystemCatalogViewModel(NullLogger.Instance, "x64");
+        viewModel.ApplyCatalog(
+        [
+            CreateOperatingSystem("zh-CN", licenseChannel: "RET", catalogEdition: "UltimateN", sourceSuffix: "consumer"),
+            CreateOperatingSystem("zh-CN", licenseChannel: "RET", catalogEdition: "CoreCountrySpecific", sourceSuffix: "china")
+        ]);
+
+        Assert.Contains("Home China", viewModel.EditionFilters);
+
+        viewModel.SelectedEdition = "Home China";
+
+        Assert.Contains("china", viewModel.SelectedOperatingSystem?.Url, StringComparison.Ordinal);
+        Assert.Equal("Home China", viewModel.SelectedOperatingSystem?.Edition);
+    }
+
+    [Fact]
+    public void ApplyCatalog_ForArm64_OffersOnlyAvailableArm64Editions()
+    {
+        var viewModel = new OperatingSystemCatalogViewModel(NullLogger.Instance, "arm64");
+        viewModel.ApplyCatalog(
+        [
+            CreateOperatingSystem("en-US", licenseChannel: "RET", architecture: "arm64", sourceId: "media"),
+            CreateOperatingSystem("en-US", licenseChannel: "VOL", architecture: "arm64", sourceId: "media")
+        ]);
+
+        Assert.Equal(
+            ["Education", "Education N", "Enterprise", "Enterprise N", "Home", "Home N", "Home Single Language", "Pro", "Pro N"],
+            viewModel.EditionFilters);
+
+        viewModel.SelectedEdition = "Enterprise";
+
+        Assert.Equal(["VOL"], viewModel.LicenseChannelFilters);
+        Assert.Equal("VOL", viewModel.SelectedLicenseChannel);
+    }
+
+    [Fact]
+    public void ApplyOperatingSystemSelection_WithVolumeOnlyPolicy_DoesNotOfferRetailOnlyEditions()
+    {
+        var viewModel = new OperatingSystemCatalogViewModel(NullLogger.Instance, "x64");
+        viewModel.ApplyCatalog(
+        [
+            CreateOperatingSystem("en-US", licenseChannel: "RET", sourceId: "media"),
+            CreateOperatingSystem("en-US", licenseChannel: "VOL", sourceId: "media")
+        ]);
+
+        viewModel.ApplyOperatingSystemSelection(new DeployOperatingSystemSelectionSettings
+        {
+            IsEnabled = true,
+            AllowedLicenseChannels = ["VOL"]
+        });
+
+        Assert.DoesNotContain("Home", viewModel.EditionFilters);
+        Assert.DoesNotContain("Home N", viewModel.EditionFilters);
+        Assert.DoesNotContain("Home Single Language", viewModel.EditionFilters);
+        Assert.Contains("Enterprise", viewModel.EditionFilters);
+        Assert.Equal(["VOL"], viewModel.LicenseChannelFilters);
+    }
+
     [Fact]
     public void ApplyOperatingSystemSelection_UsesCanonicalLanguageCodesForFiltersAndSelection()
     {
@@ -121,7 +225,7 @@ public sealed class OperatingSystemCatalogViewModelTests
         Assert.Equal(["25H2"], viewModel.ReleaseIdFilters);
         Assert.True(viewModel.IsReleaseIdSelectionEnabled);
         Assert.Equal(["RET"], viewModel.LicenseChannelFilters);
-        Assert.True(viewModel.IsLicenseChannelSelectionEnabled);
+        Assert.False(viewModel.IsLicenseChannelSelectionEnabled);
         Assert.Contains("Pro", viewModel.EditionFilters);
         Assert.True(viewModel.IsEditionSelectionEnabled);
     }
@@ -154,7 +258,7 @@ public sealed class OperatingSystemCatalogViewModelTests
         Assert.Equal(["en-US"], viewModel.LanguageFilters);
         Assert.True(viewModel.IsLanguageSelectionEnabled);
         Assert.Equal(["RET"], viewModel.LicenseChannelFilters);
-        Assert.True(viewModel.IsLicenseChannelSelectionEnabled);
+        Assert.False(viewModel.IsLicenseChannelSelectionEnabled);
         Assert.Contains("Pro", viewModel.EditionFilters);
         Assert.True(viewModel.IsEditionSelectionEnabled);
     }
@@ -258,20 +362,25 @@ public sealed class OperatingSystemCatalogViewModelTests
         string? sourceId = null,
         DateOnly? mediaDate = null,
         string build = "26200.8873",
-        string architecture = "x64")
+        string architecture = "x64",
+        string catalogEdition = "Pro",
+        string? sourceSuffix = null)
     {
         return new OperatingSystemCatalogItem
         {
             SourceId = sourceId ?? $"{releaseId}-{licenseChannel}",
+            ClientType = licenseChannel.Equals("VOL", StringComparison.OrdinalIgnoreCase)
+                ? "CLIENTBUSINESS"
+                : "CLIENTCONSUMER",
             WindowsRelease = "11",
             ReleaseId = releaseId,
             Architecture = architecture,
             LanguageCode = languageCode,
-            Edition = "Pro",
+            Edition = catalogEdition,
             LicenseChannel = licenseChannel,
             Build = build,
             MediaDate = mediaDate ?? new DateOnly(2026, 7, 10),
-            Url = $"https://example.test/windows-{sourceId ?? releaseId}-{licenseChannel}-{languageCode}.iso"
+            Url = $"https://example.test/windows-{sourceId ?? releaseId}-{licenseChannel}-{languageCode}{sourceSuffix}.iso"
         };
     }
 }

--- a/src/Foundry.Deploy.Tests/OperatingSystemCatalogViewModelTests.cs
+++ b/src/Foundry.Deploy.Tests/OperatingSystemCatalogViewModelTests.cs
@@ -12,6 +12,37 @@ namespace Foundry.Deploy.Tests;
 
 public sealed class OperatingSystemCatalogViewModelTests
 {
+    [Theory]
+    [InlineData("x64")]
+    [InlineData("arm64")]
+    public void ApplyCatalog_ForRetailMedia_DoesNotOfferEnterprise(string architecture)
+    {
+        var viewModel = new OperatingSystemCatalogViewModel(NullLogger.Instance, architecture);
+
+        viewModel.ApplyCatalog(
+        [
+            CreateOperatingSystem("en-US", licenseChannel: "RET", architecture: architecture)
+        ]);
+
+        Assert.Contains("Pro", viewModel.EditionFilters);
+        Assert.DoesNotContain("Enterprise", viewModel.EditionFilters);
+        Assert.DoesNotContain("Enterprise N", viewModel.EditionFilters);
+    }
+
+    [Fact]
+    public void ApplyCatalog_ForVolumeMedia_OffersEnterprise()
+    {
+        var viewModel = new OperatingSystemCatalogViewModel(NullLogger.Instance, "x64");
+
+        viewModel.ApplyCatalog(
+        [
+            CreateOperatingSystem("en-US", licenseChannel: "VOL")
+        ]);
+
+        Assert.Contains("Enterprise", viewModel.EditionFilters);
+        Assert.Contains("Enterprise N", viewModel.EditionFilters);
+    }
+
     [Fact]
     public void ApplyOperatingSystemSelection_UsesCanonicalLanguageCodesForFiltersAndSelection()
     {
@@ -226,14 +257,15 @@ public sealed class OperatingSystemCatalogViewModelTests
         string licenseChannel = "RET",
         string? sourceId = null,
         DateOnly? mediaDate = null,
-        string build = "26200.8873")
+        string build = "26200.8873",
+        string architecture = "x64")
     {
         return new OperatingSystemCatalogItem
         {
             SourceId = sourceId ?? $"{releaseId}-{licenseChannel}",
             WindowsRelease = "11",
             ReleaseId = releaseId,
-            Architecture = "x64",
+            Architecture = architecture,
             LanguageCode = languageCode,
             Edition = "Pro",
             LicenseChannel = licenseChannel,

--- a/src/Foundry.Deploy.Tests/WindowsDeploymentServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/WindowsDeploymentServiceTests.cs
@@ -20,10 +20,14 @@ public sealed class WindowsDeploymentServiceTests
         await File.WriteAllTextAsync(imagePath, string.Empty, TestContext.Current.CancellationToken);
         var processRunner = new RecordingProcessRunner
         {
-            Result = new ProcessExecutionResult
-            {
-                ExitCode = 0,
-                StandardOutput = """
+            ResultFactory = arguments => arguments.Contains("/Index:4", StringComparison.OrdinalIgnoreCase)
+                ? new ProcessExecutionResult { ExitCode = 0, StandardOutput = "Index : 4\nEdition : Core" }
+                : arguments.Contains("/Index:9", StringComparison.OrdinalIgnoreCase)
+                    ? new ProcessExecutionResult { ExitCode = 0, StandardOutput = "Index : 9\nEdition : Professional" }
+                    : new ProcessExecutionResult
+                    {
+                        ExitCode = 0,
+                        StandardOutput = """
                     Index : 1
                     Name : Windows Setup Media
 
@@ -33,7 +37,7 @@ public sealed class WindowsDeploymentServiceTests
                     Index : 9
                     Name : Windows 11 Pro
                     """
-            }
+                    }
         };
         var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
 
@@ -45,8 +49,8 @@ public sealed class WindowsDeploymentServiceTests
                 TestContext.Current.CancellationToken));
 
         Assert.Contains("Enterprise", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("Windows 11 Home", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("Windows 11 Pro", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("4: Core", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("9: Professional", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -84,17 +88,21 @@ public sealed class WindowsDeploymentServiceTests
         await File.WriteAllTextAsync(imagePath, string.Empty, TestContext.Current.CancellationToken);
         var processRunner = new RecordingProcessRunner
         {
-            Result = new ProcessExecutionResult
-            {
-                ExitCode = 0,
-                StandardOutput = """
+            ResultFactory = arguments => arguments.Contains("/Index:5", StringComparison.OrdinalIgnoreCase)
+                ? new ProcessExecutionResult { ExitCode = 0, StandardOutput = "Index : 5\nEdition : ProfessionalN" }
+                : arguments.Contains("/Index:9", StringComparison.OrdinalIgnoreCase)
+                    ? new ProcessExecutionResult { ExitCode = 0, StandardOutput = "Index : 9\nEdition : Professional" }
+                    : new ProcessExecutionResult
+                    {
+                        ExitCode = 0,
+                        StandardOutput = """
                     Index : 5
                     Name : Windows 11 Pro N
 
                     Index : 9
                     Name : Windows 11 Pro
                     """
-            }
+                    }
         };
         var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
 
@@ -108,57 +116,56 @@ public sealed class WindowsDeploymentServiceTests
     }
 
     [Theory]
-    [InlineData("Home", 4)]
-    [InlineData("Home N", 5)]
-    [InlineData("Home Single Language", 6)]
-    [InlineData("Education", 7)]
-    [InlineData("Education N", 8)]
-    [InlineData("Pro", 9)]
-    [InlineData("Pro N", 10)]
-    [InlineData("Enterprise", 11)]
-    [InlineData("Enterprise N", 12)]
-    public async Task ResolveImageIndexAsync_ResolvesEachSupportedEdition(string edition, int expectedIndex)
+    [InlineData("Home", "Core", 4)]
+    [InlineData("Home N", "CoreN", 5)]
+    [InlineData("Home Single Language", "CoreSingleLanguage", 6)]
+    [InlineData("Home China", "CoreCountrySpecific", 7)]
+    [InlineData("Education", "Education", 8)]
+    [InlineData("Education N", "EducationN", 9)]
+    [InlineData("Pro", "Professional", 10)]
+    [InlineData("Pro N", "ProfessionalN", 11)]
+    [InlineData("Enterprise", "Enterprise", 12)]
+    [InlineData("Enterprise N", "EnterpriseN", 13)]
+    public async Task ResolveImageIndexAsync_ResolvesExactEditionIdFromDetailedImageMetadata(
+        string edition,
+        string editionId,
+        int expectedIndex)
     {
         using var workspace = new TemporaryWorkspace();
         string imagePath = Path.Combine(workspace.RootPath, "windows.esd");
         await File.WriteAllTextAsync(imagePath, string.Empty, TestContext.Current.CancellationToken);
         var processRunner = new RecordingProcessRunner
         {
-            Result = new ProcessExecutionResult
-            {
-                ExitCode = 0,
-                StandardOutput = """
-                    Index : 1
-                    Name : Windows Setup Media
+            ResultFactory = arguments => arguments.Contains($"/Index:{expectedIndex}", StringComparison.OrdinalIgnoreCase)
+                ? new ProcessExecutionResult
+                {
+                    ExitCode = 0,
+                    StandardOutput = $"""
+                        Index : {expectedIndex}
+                        Name : Nom Windows localise arbitraire
+                        Edition : {editionId}
+                        """
+                }
+                : arguments.Contains("/Index:", StringComparison.OrdinalIgnoreCase)
+                    ? new ProcessExecutionResult
+                    {
+                        ExitCode = 0,
+                        StandardOutput = """
+                            Index : 1
+                            Name : Windows Setup Media
+                            """
+                    }
+                    : new ProcessExecutionResult
+                    {
+                        ExitCode = 0,
+                        StandardOutput = $"""
+                        Index : 1
+                        Name : Windows Setup Media
 
-                    Index : 4
-                    Name : Windows 11 Home
-
-                    Index : 5
-                    Name : Windows 11 Home N
-
-                    Index : 6
-                    Name : Windows 11 Home Single Language
-
-                    Index : 7
-                    Name : Windows 11 Education
-
-                    Index : 8
-                    Name : Windows 11 Education N
-
-                    Index : 9
-                    Name : Windows 11 Pro
-
-                    Index : 10
-                    Name : Windows 11 Pro N
-
-                    Index : 11
-                    Name : Windows 11 Enterprise
-
-                    Index : 12
-                    Name : Windows 11 Enterprise N
-                    """
-            }
+                        Index : {expectedIndex}
+                        Name : Nom Windows localise arbitraire
+                        """
+                    }
         };
         var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
 
@@ -169,6 +176,31 @@ public sealed class WindowsDeploymentServiceTests
             TestContext.Current.CancellationToken);
 
         Assert.Equal(expectedIndex, imageIndex);
+        Assert.Contains(processRunner.Calls, call => call.Contains($"/Index:{expectedIndex}", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ResolveImageIndexAsync_WhenEditionIdOccursMoreThanOnce_ThrowsWithoutFallback()
+    {
+        using var workspace = new TemporaryWorkspace();
+        string imagePath = Path.Combine(workspace.RootPath, "windows.esd");
+        await File.WriteAllTextAsync(imagePath, string.Empty, TestContext.Current.CancellationToken);
+        var processRunner = new RecordingProcessRunner
+        {
+            ResultFactory = arguments => arguments.Contains("/Index:", StringComparison.OrdinalIgnoreCase)
+                ? new ProcessExecutionResult { ExitCode = 0, StandardOutput = $"Index : {ParseRequestedIndex(arguments)}\nEdition : Professional" }
+                : new ProcessExecutionResult { ExitCode = 0, StandardOutput = "Index : 8\nName : Pro first\n\nIndex : 9\nName : Pro second" }
+        };
+        var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.ResolveImageIndexAsync(
+                imagePath,
+                "Pro",
+                workspace.RootPath,
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("found 2", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -464,6 +496,12 @@ public sealed class WindowsDeploymentServiceTests
         return windowsRoot;
     }
 
+    private static int ParseRequestedIndex(string arguments)
+    {
+        string value = arguments[(arguments.LastIndexOf("/Index:", StringComparison.OrdinalIgnoreCase) + 7)..];
+        return int.Parse(value);
+    }
+
     private sealed class TemporaryWorkspace : IDisposable
     {
         public TemporaryWorkspace()
@@ -522,6 +560,7 @@ public sealed class WindowsDeploymentServiceTests
         public string? LastArguments { get; private set; }
         public string? LastWorkingDirectory { get; private set; }
         public ProcessExecutionResult Result { get; init; } = new() { ExitCode = 0 };
+        public Func<string, ProcessExecutionResult>? ResultFactory { get; init; }
 
         public Task<ProcessExecutionResult> RunAsync(
             string fileName,
@@ -533,7 +572,7 @@ public sealed class WindowsDeploymentServiceTests
             LastFileName = fileName;
             LastArguments = arguments;
             LastWorkingDirectory = workingDirectory;
-            return Task.FromResult(Result);
+            return Task.FromResult(ResultFactory?.Invoke(arguments) ?? Result);
         }
 
         public Task<ProcessExecutionResult> RunAsync(

--- a/src/Foundry.Deploy.Tests/WindowsDeploymentServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/WindowsDeploymentServiceTests.cs
@@ -13,6 +13,165 @@ namespace Foundry.Deploy.Tests;
 public sealed class WindowsDeploymentServiceTests
 {
     [Fact]
+    public async Task ResolveImageIndexAsync_WhenRequestedEditionIsMissing_ThrowsBeforeImageApplication()
+    {
+        using var workspace = new TemporaryWorkspace();
+        string imagePath = Path.Combine(workspace.RootPath, "consumer.esd");
+        await File.WriteAllTextAsync(imagePath, string.Empty, TestContext.Current.CancellationToken);
+        var processRunner = new RecordingProcessRunner
+        {
+            Result = new ProcessExecutionResult
+            {
+                ExitCode = 0,
+                StandardOutput = """
+                    Index : 1
+                    Name : Windows Setup Media
+
+                    Index : 4
+                    Name : Windows 11 Home
+
+                    Index : 9
+                    Name : Windows 11 Pro
+                    """
+            }
+        };
+        var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.ResolveImageIndexAsync(
+                imagePath,
+                "Enterprise",
+                workspace.RootPath,
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("Enterprise", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Windows 11 Home", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Windows 11 Pro", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ResolveImageIndexAsync_WhenSingleImageDoesNotMatchRequestedEdition_Throws()
+    {
+        using var workspace = new TemporaryWorkspace();
+        string imagePath = Path.Combine(workspace.RootPath, "setup-media.esd");
+        await File.WriteAllTextAsync(imagePath, string.Empty, TestContext.Current.CancellationToken);
+        var processRunner = new RecordingProcessRunner
+        {
+            Result = new ProcessExecutionResult
+            {
+                ExitCode = 0,
+                StandardOutput = """
+                    Index : 1
+                    Name : Windows Setup Media
+                    """
+            }
+        };
+        var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.ResolveImageIndexAsync(
+                imagePath,
+                "Enterprise",
+                workspace.RootPath,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ResolveImageIndexAsync_DoesNotSelectNVariantForNonNEdition()
+    {
+        using var workspace = new TemporaryWorkspace();
+        string imagePath = Path.Combine(workspace.RootPath, "consumer.esd");
+        await File.WriteAllTextAsync(imagePath, string.Empty, TestContext.Current.CancellationToken);
+        var processRunner = new RecordingProcessRunner
+        {
+            Result = new ProcessExecutionResult
+            {
+                ExitCode = 0,
+                StandardOutput = """
+                    Index : 5
+                    Name : Windows 11 Pro N
+
+                    Index : 9
+                    Name : Windows 11 Pro
+                    """
+            }
+        };
+        var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
+
+        int imageIndex = await service.ResolveImageIndexAsync(
+            imagePath,
+            "Pro",
+            workspace.RootPath,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(9, imageIndex);
+    }
+
+    [Theory]
+    [InlineData("Home", 4)]
+    [InlineData("Home N", 5)]
+    [InlineData("Home Single Language", 6)]
+    [InlineData("Education", 7)]
+    [InlineData("Education N", 8)]
+    [InlineData("Pro", 9)]
+    [InlineData("Pro N", 10)]
+    [InlineData("Enterprise", 11)]
+    [InlineData("Enterprise N", 12)]
+    public async Task ResolveImageIndexAsync_ResolvesEachSupportedEdition(string edition, int expectedIndex)
+    {
+        using var workspace = new TemporaryWorkspace();
+        string imagePath = Path.Combine(workspace.RootPath, "windows.esd");
+        await File.WriteAllTextAsync(imagePath, string.Empty, TestContext.Current.CancellationToken);
+        var processRunner = new RecordingProcessRunner
+        {
+            Result = new ProcessExecutionResult
+            {
+                ExitCode = 0,
+                StandardOutput = """
+                    Index : 1
+                    Name : Windows Setup Media
+
+                    Index : 4
+                    Name : Windows 11 Home
+
+                    Index : 5
+                    Name : Windows 11 Home N
+
+                    Index : 6
+                    Name : Windows 11 Home Single Language
+
+                    Index : 7
+                    Name : Windows 11 Education
+
+                    Index : 8
+                    Name : Windows 11 Education N
+
+                    Index : 9
+                    Name : Windows 11 Pro
+
+                    Index : 10
+                    Name : Windows 11 Pro N
+
+                    Index : 11
+                    Name : Windows 11 Enterprise
+
+                    Index : 12
+                    Name : Windows 11 Enterprise N
+                    """
+            }
+        };
+        var service = new WindowsDeploymentService(processRunner, NullLogger<WindowsDeploymentService>.Instance);
+
+        int imageIndex = await service.ResolveImageIndexAsync(
+            imagePath,
+            edition,
+            workspace.RootPath,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(expectedIndex, imageIndex);
+    }
+
+    [Fact]
     public async Task PrepareTargetDiskAsync_CreatesPartitionsInExpectedOrder_Efi_Msr_Recovery_Windows()
     {
         using var workspace = new TemporaryWorkspace();

--- a/src/Foundry.Deploy/Models/OperatingSystemSupportMatrix.cs
+++ b/src/Foundry.Deploy/Models/OperatingSystemSupportMatrix.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using Foundry.Core.Models.Configuration;
 
 namespace Foundry.Deploy.Models;
 
@@ -28,24 +29,11 @@ internal static class OperatingSystemSupportMatrix
         "VOL"
     ];
 
-    private static readonly string[] SupportedEditionOrder =
-    [
-        "Home",
-        "Home N",
-        "Home Single Language",
-        "Education",
-        "Education N",
-        "Pro",
-        "Pro N",
-        "Enterprise",
-        "Enterprise N"
-    ];
-
     public static IReadOnlyList<string> ReleaseSearchOrder => SupportedReleaseIdOrder;
 
     public static IReadOnlyList<string> LicenseChannelOrder => SupportedLicenseChannelOrder;
 
-    public static IReadOnlyList<string> EditionOrder => SupportedEditionOrder;
+    public static IReadOnlyList<string> EditionOrder => WindowsEditionCatalog.SupportedEditions;
 
     public static bool IsSupported(OperatingSystemCatalogItem item)
     {

--- a/src/Foundry.Deploy/Services/Deployment/Steps/ApplyOperatingSystemImageStep.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Steps/ApplyOperatingSystemImageStep.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using Foundry.Core.Models.Configuration;
 using Foundry.Deploy.Services.Logging;
 
 namespace Foundry.Deploy.Services.Deployment.Steps;
@@ -92,13 +93,15 @@ public sealed class ApplyOperatingSystemImageStep : DeploymentStepBase
 
             if (!string.IsNullOrWhiteSpace(appliedEdition))
             {
-                DeploymentLogLevel editionLogLevel = EditionsMatch(context.Request.OperatingSystem.Edition, appliedEdition)
+                WindowsEditionDefinition? requestedEdition = WindowsEditionCatalog.Find(context.Request.OperatingSystem.Edition);
+                DeploymentLogLevel editionLogLevel = requestedEdition is not null &&
+                    requestedEdition.EditionId.Equals(appliedEdition, StringComparison.OrdinalIgnoreCase)
                     ? DeploymentLogLevel.Info
                     : DeploymentLogLevel.Warning;
 
                 string message = editionLogLevel == DeploymentLogLevel.Info
                     ? $"Applied Windows edition verified: {appliedEdition}."
-                    : $"Applied Windows edition '{appliedEdition}' does not closely match requested edition '{context.Request.OperatingSystem.Edition}'.";
+                    : $"Applied Windows edition ID '{appliedEdition}' does not match requested edition '{context.Request.OperatingSystem.Edition}'.";
 
                 await context.AppendLogAsync(editionLogLevel, message, cancellationToken).ConfigureAwait(false);
             }
@@ -144,32 +147,4 @@ public sealed class ApplyOperatingSystemImageStep : DeploymentStepBase
         return DeploymentStepResult.Succeeded("Operating system image applied (simulation).");
     }
 
-    private static bool EditionsMatch(string requestedEdition, string appliedEdition)
-    {
-        string requested = NormalizeEditionToken(requestedEdition);
-        string applied = NormalizeEditionToken(appliedEdition);
-
-        if (requested.Length == 0 || applied.Length == 0)
-        {
-            return false;
-        }
-
-        return requested.Contains(applied, StringComparison.OrdinalIgnoreCase) ||
-               applied.Contains(requested, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static string NormalizeEditionToken(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return string.Empty;
-        }
-
-        char[] filtered = value
-            .ToLowerInvariant()
-            .Where(char.IsLetterOrDigit)
-            .ToArray();
-
-        return new string(filtered);
-    }
 }

--- a/src/Foundry.Deploy/Services/Deployment/WindowsDeploymentService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/WindowsDeploymentService.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using Foundry.Core.Models.Configuration;
 using Foundry.Deploy.Models.Configuration;
 using Foundry.Deploy.Services.System;
 using Foundry.Deploy.Services.Deployment.Unattend;
@@ -146,34 +147,60 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
                 execution.ExitCode);
         }
 
-        IReadOnlyList<ImageIndexDescriptor> descriptors = ParseImageDescriptors(execution.StandardOutput);
-        if (descriptors.Count == 0)
+        IReadOnlyList<int> imageIndexes = ParseImageIndexes(execution.StandardOutput);
+        if (imageIndexes.Count == 0)
         {
             throw new InvalidOperationException($"The operating system image does not expose any image indexes: '{imagePath}'.");
         }
 
-        string requested = NormalizeToken(requestedEdition);
-        if (requested.Length == 0)
+        WindowsEditionDefinition? requestedDefinition = WindowsEditionCatalog.Find(requestedEdition);
+        if (requestedDefinition is null)
         {
-            return descriptors[0].Index;
+            throw new InvalidOperationException($"Windows edition '{requestedEdition}' is not supported.");
         }
 
-        ImageIndexDescriptor? bestMatch = descriptors.FirstOrDefault(item =>
-            MatchesEdition(item.Name, requested) ||
-            MatchesEdition(item.Edition, requested) ||
-            MatchesEdition(item.EditionId, requested));
-
-        if (bestMatch is null)
+        var imageMetadata = new List<ImageIndexMetadata>(imageIndexes.Count);
+        foreach (int imageIndex in imageIndexes)
         {
-            string availableImages = string.Join(
+            ProcessExecutionResult detailedExecution = await _processRunner
+                .RunAsync(
+                    "dism.exe",
+                    $"/English /Get-ImageInfo /ImageFile:\"{imagePath}\" /Index:{imageIndex}",
+                    workingDirectory,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!detailedExecution.IsSuccess)
+            {
+                _logger.LogError(
+                    "Failed to inspect OS image index {ImageIndex} for {ImagePath}. Diagnostic={Diagnostic}",
+                    imageIndex,
+                    imagePath,
+                    ToDiagnostic(detailedExecution));
+                throw new DeploymentProcessException(
+                    $"Unable to inspect image index {imageIndex} in '{imagePath}'.{Environment.NewLine}{ToDiagnostic(detailedExecution)}",
+                    detailedExecution.ExitCode);
+            }
+
+            imageMetadata.Add(new ImageIndexMetadata(imageIndex, ParseEditionId(detailedExecution.StandardOutput)));
+        }
+
+        ImageIndexMetadata[] matches = imageMetadata
+            .Where(item => item.EditionId.Equals(requestedDefinition.EditionId, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        if (matches.Length != 1)
+        {
+            string availableEditionIds = string.Join(
                 ", ",
-                descriptors.Select(item => $"{item.Index}: {GetImageDescriptorDisplayName(item)}"));
+                imageMetadata.Select(item => $"{item.Index}: {item.EditionId}"));
 
             throw new InvalidOperationException(
-                $"Windows edition '{requestedEdition}' was not found in '{imagePath}'. Available images: {availableImages}.");
+                $"Expected exactly one '{requestedDefinition.EditionId}' image for Windows edition '{requestedDefinition.Name}' in '{imagePath}', " +
+                $"but found {matches.Length}. Available edition IDs: {availableEditionIds}.");
         }
 
-        int resolvedIndex = bestMatch.Index;
+        int resolvedIndex = matches[0].Index;
         _logger.LogInformation("Resolved OS image index {ImageIndex} for ImagePath={ImagePath}", resolvedIndex, imagePath);
         return resolvedIndex;
     }
@@ -1019,132 +1046,34 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
         parent.Element(elementNamespace + elementName)?.Remove();
     }
 
-    private static IReadOnlyList<ImageIndexDescriptor> ParseImageDescriptors(string output)
+    private static IReadOnlyList<int> ParseImageIndexes(string output)
     {
         if (string.IsNullOrWhiteSpace(output))
         {
             return [];
         }
 
-        var descriptors = new List<ImageIndexDescriptor>();
-        ImageIndexDescriptor? current = null;
-
-        foreach (string line in output.Split(["\r\n", "\n"], StringSplitOptions.None))
-        {
-            Match indexMatch = Regex.Match(line, @"^\s*Index\s*:\s*(\d+)\s*$", RegexOptions.IgnoreCase);
-            if (indexMatch.Success)
-            {
-                if (current is not null)
-                {
-                    descriptors.Add(current);
-                }
-
-                current = new ImageIndexDescriptor
-                {
-                    Index = int.Parse(indexMatch.Groups[1].Value),
-                    Name = string.Empty,
-                    Edition = string.Empty,
-                    EditionId = string.Empty
-                };
-
-                continue;
-            }
-
-            if (current is null)
-            {
-                continue;
-            }
-
-            Match nameMatch = Regex.Match(line, @"^\s*Name\s*:\s*(.+)\s*$", RegexOptions.IgnoreCase);
-            if (nameMatch.Success)
-            {
-                current = current with { Name = nameMatch.Groups[1].Value.Trim() };
-                continue;
-            }
-
-            Match editionMatch = Regex.Match(line, @"^\s*Edition\s*:\s*(.+)\s*$", RegexOptions.IgnoreCase);
-            if (editionMatch.Success)
-            {
-                current = current with { Edition = editionMatch.Groups[1].Value.Trim() };
-                continue;
-            }
-
-            Match editionIdMatch = Regex.Match(line, @"^\s*Edition\s+ID\s*:\s*(.+)\s*$", RegexOptions.IgnoreCase);
-            if (editionIdMatch.Success)
-            {
-                current = current with { EditionId = editionIdMatch.Groups[1].Value.Trim() };
-            }
-        }
-
-        if (current is not null)
-        {
-            descriptors.Add(current);
-        }
-
-        return descriptors;
-    }
-
-    private static bool MatchesEdition(string source, string expected)
-    {
-        string normalizedSource = NormalizeEditionToken(source);
-        string normalizedExpected = NormalizeEditionToken(expected);
-        if (normalizedSource.Length == 0 || normalizedExpected.Length == 0)
-        {
-            return false;
-        }
-
-        return normalizedSource.Equals(normalizedExpected, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static string NormalizeEditionToken(string value)
-    {
-        string normalized = NormalizeToken(value);
-        normalized = Regex.Replace(normalized, @"^(?:microsoft)?windows\d+", string.Empty, RegexOptions.IgnoreCase);
-
-        return normalized switch
-        {
-            "core" => "home",
-            "coren" => "homen",
-            "coresinglelanguage" => "homesinglelanguage",
-            "professional" => "pro",
-            "professionaln" => "pron",
-            _ => normalized
-        };
-    }
-
-    private static string GetImageDescriptorDisplayName(ImageIndexDescriptor descriptor)
-    {
-        if (!string.IsNullOrWhiteSpace(descriptor.Name))
-        {
-            return descriptor.Name;
-        }
-
-        if (!string.IsNullOrWhiteSpace(descriptor.Edition))
-        {
-            return descriptor.Edition;
-        }
-
-        if (!string.IsNullOrWhiteSpace(descriptor.EditionId))
-        {
-            return descriptor.EditionId;
-        }
-
-        return "Unnamed image";
-    }
-
-    private static string NormalizeToken(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return string.Empty;
-        }
-
-        char[] filtered = value
-            .ToLowerInvariant()
-            .Where(char.IsLetterOrDigit)
+        return Regex.Matches(output, @"^\s*Index\s*:\s*(\d+)\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline)
+            .Select(match => int.Parse(match.Groups[1].Value))
+            .Distinct()
             .ToArray();
+    }
 
-        return new string(filtered);
+    private static string ParseEditionId(string output)
+    {
+        string editionId = ParseImageProperty(output, "Edition ID");
+        return !string.IsNullOrWhiteSpace(editionId)
+            ? editionId
+            : ParseImageProperty(output, "Edition");
+    }
+
+    private static string ParseImageProperty(string output, string propertyName)
+    {
+        Match match = Regex.Match(
+            output,
+            $@"^\s*{Regex.Escape(propertyName)}\s*:\s*(.+)\s*$",
+            RegexOptions.IgnoreCase | RegexOptions.Multiline);
+        return match.Success ? match.Groups[1].Value.Trim() : string.Empty;
     }
 
     private static string ToDiagnostic(ProcessExecutionResult execution)
@@ -1154,11 +1083,5 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
                $"StdErr:{Environment.NewLine}{execution.StandardError}";
     }
 
-    private sealed record ImageIndexDescriptor
-    {
-        public required int Index { get; init; }
-        public required string Name { get; init; }
-        public required string Edition { get; init; }
-        public required string EditionId { get; init; }
-    }
+    private sealed record ImageIndexMetadata(int Index, string EditionId);
 }

--- a/src/Foundry.Deploy/Services/Deployment/WindowsDeploymentService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/WindowsDeploymentService.cs
@@ -149,12 +149,7 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
         IReadOnlyList<ImageIndexDescriptor> descriptors = ParseImageDescriptors(execution.StandardOutput);
         if (descriptors.Count == 0)
         {
-            return 1;
-        }
-
-        if (descriptors.Count == 1)
-        {
-            return descriptors[0].Index;
+            throw new InvalidOperationException($"The operating system image does not expose any image indexes: '{imagePath}'.");
         }
 
         string requested = NormalizeToken(requestedEdition);
@@ -164,11 +159,21 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
         }
 
         ImageIndexDescriptor? bestMatch = descriptors.FirstOrDefault(item =>
-            ContainsNormalized(item.Name, requested) ||
-            ContainsNormalized(item.Edition, requested) ||
-            ContainsNormalized(item.EditionId, requested));
+            MatchesEdition(item.Name, requested) ||
+            MatchesEdition(item.Edition, requested) ||
+            MatchesEdition(item.EditionId, requested));
 
-        int resolvedIndex = bestMatch?.Index ?? descriptors[0].Index;
+        if (bestMatch is null)
+        {
+            string availableImages = string.Join(
+                ", ",
+                descriptors.Select(item => $"{item.Index}: {GetImageDescriptorDisplayName(item)}"));
+
+            throw new InvalidOperationException(
+                $"Windows edition '{requestedEdition}' was not found in '{imagePath}'. Available images: {availableImages}.");
+        }
+
+        int resolvedIndex = bestMatch.Index;
         _logger.LogInformation("Resolved OS image index {ImageIndex} for ImagePath={ImagePath}", resolvedIndex, imagePath);
         return resolvedIndex;
     }
@@ -1079,16 +1084,52 @@ public sealed class WindowsDeploymentService : IWindowsDeploymentService
         return descriptors;
     }
 
-    private static bool ContainsNormalized(string source, string expected)
+    private static bool MatchesEdition(string source, string expected)
     {
-        string normalized = NormalizeToken(source);
-        if (normalized.Length == 0 || expected.Length == 0)
+        string normalizedSource = NormalizeEditionToken(source);
+        string normalizedExpected = NormalizeEditionToken(expected);
+        if (normalizedSource.Length == 0 || normalizedExpected.Length == 0)
         {
             return false;
         }
 
-        return normalized.Contains(expected, StringComparison.OrdinalIgnoreCase) ||
-               expected.Contains(normalized, StringComparison.OrdinalIgnoreCase);
+        return normalizedSource.Equals(normalizedExpected, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizeEditionToken(string value)
+    {
+        string normalized = NormalizeToken(value);
+        normalized = Regex.Replace(normalized, @"^(?:microsoft)?windows\d+", string.Empty, RegexOptions.IgnoreCase);
+
+        return normalized switch
+        {
+            "core" => "home",
+            "coren" => "homen",
+            "coresinglelanguage" => "homesinglelanguage",
+            "professional" => "pro",
+            "professionaln" => "pron",
+            _ => normalized
+        };
+    }
+
+    private static string GetImageDescriptorDisplayName(ImageIndexDescriptor descriptor)
+    {
+        if (!string.IsNullOrWhiteSpace(descriptor.Name))
+        {
+            return descriptor.Name;
+        }
+
+        if (!string.IsNullOrWhiteSpace(descriptor.Edition))
+        {
+            return descriptor.Edition;
+        }
+
+        if (!string.IsNullOrWhiteSpace(descriptor.EditionId))
+        {
+            return descriptor.EditionId;
+        }
+
+        return "Unnamed image";
     }
 
     private static string NormalizeToken(string value)

--- a/src/Foundry.Deploy/ViewModels/OperatingSystemCatalogViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/OperatingSystemCatalogViewModel.cs
@@ -28,9 +28,7 @@ public sealed partial class OperatingSystemCatalogViewModel : ObservableObject
         "Education",
         "Education N",
         "Pro",
-        "Pro N",
-        "Enterprise",
-        "Enterprise N"
+        "Pro N"
     ];
     private static readonly string[] VolumeEditionOptions =
     [
@@ -44,8 +42,7 @@ public sealed partial class OperatingSystemCatalogViewModel : ObservableObject
     private static readonly string[] Arm64RetailEditionOptions =
     [
         "Home",
-        "Pro",
-        "Enterprise"
+        "Pro"
     ];
     private static readonly string[] Arm64VolumeEditionOptions =
     [

--- a/src/Foundry.Deploy/ViewModels/OperatingSystemCatalogViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/OperatingSystemCatalogViewModel.cs
@@ -5,6 +5,7 @@
 using System.Collections.ObjectModel;
 using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Foundry.Core.Models.Configuration;
 using Foundry.Deploy.Models;
 using Foundry.Deploy.Models.Configuration;
 using Foundry.Deploy.Services.Catalog;
@@ -20,36 +21,6 @@ public sealed partial class OperatingSystemCatalogViewModel : ObservableObject
     private const string DefaultEdition = OperatingSystemSupportMatrix.DefaultEdition;
     private const string FallbackLanguageCode = "en-US";
     private static readonly string DefaultLanguageCode = ResolveDefaultLanguageCode();
-    private static readonly string[] RetailEditionOptions =
-    [
-        "Home",
-        "Home N",
-        "Home Single Language",
-        "Education",
-        "Education N",
-        "Pro",
-        "Pro N"
-    ];
-    private static readonly string[] VolumeEditionOptions =
-    [
-        "Education",
-        "Education N",
-        "Pro",
-        "Pro N",
-        "Enterprise",
-        "Enterprise N"
-    ];
-    private static readonly string[] Arm64RetailEditionOptions =
-    [
-        "Home",
-        "Pro"
-    ];
-    private static readonly string[] Arm64VolumeEditionOptions =
-    [
-        "Pro",
-        "Enterprise"
-    ];
-
     private readonly ILogger _logger;
     private readonly HashSet<string> _configuredAllowedLanguageCodes = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<string> _configuredAllowedReleaseIds = new(StringComparer.OrdinalIgnoreCase);
@@ -314,7 +285,27 @@ public sealed partial class OperatingSystemCatalogViewModel : ObservableObject
                 _configuredDefaultLanguageCode);
             LogUnavailableDefaultLanguage();
 
-            IEnumerable<OperatingSystemCatalogItem> licenseScope = ApplyLanguageFilter(languageScope);
+            IEnumerable<OperatingSystemCatalogItem> editionScope = ApplyLanguageFilter(languageScope);
+            IEnumerable<string> availableEditions = BuildAvailableEditionOptions(editionScope);
+            IEnumerable<string> effectiveEditionValues = BuildEffectiveFilterValues(
+                availableEditions,
+                _configuredAllowedEditions,
+                "editions",
+                ref _hasLoggedUnavailableConfiguredEditions,
+                out _isEditionRestrictedToSingleOption);
+            SelectedEdition = UpdateFilterSelection(
+                EditionFilters,
+                effectiveEditionValues,
+                previousEdition,
+                _configuredDefaultEdition ?? DefaultEdition,
+                selectFirstWhenNoMatch: true);
+            LogUnavailableDefault(
+                _configuredDefaultEdition,
+                EditionFilters,
+                "edition",
+                ref _hasLoggedUnavailableDefaultEdition);
+
+            IEnumerable<OperatingSystemCatalogItem> licenseScope = ApplyEditionMediaFilter(editionScope);
             IEnumerable<string> effectiveLicenseChannelValues = BuildEffectiveFilterValues(
                 licenseScope.Select(item => item.LicenseChannel),
                 _configuredAllowedLicenseChannels,
@@ -332,26 +323,7 @@ public sealed partial class OperatingSystemCatalogViewModel : ObservableObject
                 LicenseChannelFilters,
                 "license channel",
                 ref _hasLoggedUnavailableDefaultLicenseChannel);
-
-            IEnumerable<OperatingSystemCatalogItem> editionScope = ApplyLicenseChannelFilter(licenseScope);
-            IEnumerable<string> recommendedEditions = BuildRecommendedEditionOptions(editionScope);
-            IEnumerable<string> effectiveEditionValues = BuildEffectiveFilterValues(
-                recommendedEditions,
-                _configuredAllowedEditions,
-                "editions",
-                ref _hasLoggedUnavailableConfiguredEditions,
-                out _isEditionRestrictedToSingleOption);
-            SelectedEdition = UpdateFilterSelection(
-                EditionFilters,
-                effectiveEditionValues,
-                previousEdition,
-                _configuredDefaultEdition ?? DefaultEdition,
-                selectFirstWhenNoMatch: true);
-            LogUnavailableDefault(
-                _configuredDefaultEdition,
-                EditionFilters,
-                "edition",
-                ref _hasLoggedUnavailableDefaultEdition);
+            _isLicenseChannelRestrictedToSingleOption = LicenseChannelFilters.Count == 1;
         }
         finally
         {
@@ -576,37 +548,19 @@ public sealed partial class OperatingSystemCatalogViewModel : ObservableObject
             : source.Where(item => item.LicenseChannel.Equals(SelectedLicenseChannel, StringComparison.OrdinalIgnoreCase));
     }
 
-    private IEnumerable<string> BuildRecommendedEditionOptions(IEnumerable<OperatingSystemCatalogItem> scope)
+    private IEnumerable<string> BuildAvailableEditionOptions(IEnumerable<OperatingSystemCatalogItem> scope)
     {
         string architecture = NormalizeArchitecture(EffectiveOsArchitecture);
-        bool hasRetail = scope.Any(item => item.LicenseChannel.Equals("RET", StringComparison.OrdinalIgnoreCase));
-        bool hasVolume = scope.Any(item => item.LicenseChannel.Equals("VOL", StringComparison.OrdinalIgnoreCase));
+        OperatingSystemCatalogItem[] availableMedia = scope.ToArray();
 
-        List<string> recommended = [];
-
-        if (IsFilterUnset(SelectedLicenseChannel))
-        {
-            if (hasRetail)
-            {
-                recommended.AddRange(GetEditionOptionsForChannel("RET", architecture));
-            }
-
-            if (hasVolume)
-            {
-                recommended.AddRange(GetEditionOptionsForChannel("VOL", architecture));
-            }
-        }
-        else
-        {
-            recommended.AddRange(GetEditionOptionsForChannel(SelectedLicenseChannel, architecture));
-        }
-
-        if (recommended.Count == 0)
-        {
-            recommended.AddRange(scope.Select(item => item.Edition));
-        }
-
-        return recommended;
+        return WindowsEditionCatalog.SupportedDefinitions
+            .Where(definition => definition.Architectures.Contains(architecture, StringComparer.OrdinalIgnoreCase))
+            .Where(definition =>
+                _configuredAllowedEditions.Count > 0 ||
+                _configuredAllowedLicenseChannels.Count == 0 ||
+                definition.LicenseChannels.Any(_configuredAllowedLicenseChannels.Contains))
+            .Where(definition => availableMedia.Any(item => CatalogItemContainsEdition(item, definition)))
+            .Select(definition => definition.Name);
     }
 
     private OperatingSystemCatalogItem[] BuildFilteredOperatingSystems()
@@ -615,6 +569,7 @@ public sealed partial class OperatingSystemCatalogViewModel : ObservableObject
         query = ApplyReleaseIdFilter(query);
         query = ApplyMediaFilter(query);
         query = ApplyLanguageFilter(query);
+        query = ApplyEditionMediaFilter(query);
         query = ApplyLicenseChannelFilter(query);
 
         return query
@@ -640,21 +595,34 @@ public sealed partial class OperatingSystemCatalogViewModel : ObservableObject
         return item with { Edition = SelectedEdition };
     }
 
-    private static IEnumerable<string> GetEditionOptionsForChannel(string licenseChannel, string architecture)
+    private IEnumerable<OperatingSystemCatalogItem> ApplyEditionMediaFilter(IEnumerable<OperatingSystemCatalogItem> source)
     {
-        bool isArm64 = architecture.Equals("arm64", StringComparison.OrdinalIgnoreCase);
-
-        if (licenseChannel.Equals("VOL", StringComparison.OrdinalIgnoreCase))
+        WindowsEditionDefinition? definition = WindowsEditionCatalog.Find(SelectedEdition);
+        if (definition is null)
         {
-            return isArm64 ? Arm64VolumeEditionOptions : VolumeEditionOptions;
+            return [];
         }
 
-        if (licenseChannel.Equals("RET", StringComparison.OrdinalIgnoreCase))
+        return source.Where(item => CatalogItemContainsEdition(item, definition));
+    }
+
+    private static bool CatalogItemContainsEdition(
+        OperatingSystemCatalogItem item,
+        WindowsEditionDefinition definition)
+    {
+        bool isCountrySpecificMedia = item.Edition.Equals("CoreCountrySpecific", StringComparison.OrdinalIgnoreCase);
+        bool isCountrySpecificEdition = definition.EditionId.Equals("CoreCountrySpecific", StringComparison.OrdinalIgnoreCase);
+        if (isCountrySpecificMedia || isCountrySpecificEdition)
         {
-            return isArm64 ? Arm64RetailEditionOptions : RetailEditionOptions;
+            return isCountrySpecificMedia && isCountrySpecificEdition;
         }
 
-        return [];
+        string expectedClientType = item.LicenseChannel.Equals("RET", StringComparison.OrdinalIgnoreCase)
+            ? "CLIENTCONSUMER"
+            : "CLIENTBUSINESS";
+
+        return item.ClientType.Equals(expectedClientType, StringComparison.OrdinalIgnoreCase) &&
+               definition.LicenseChannels.Contains(item.LicenseChannel, StringComparer.OrdinalIgnoreCase);
     }
 
     private void ResetOperatingSystemSelectionPolicy(DeployOperatingSystemSelectionSettings settings)

--- a/src/Foundry.Deploy/Views/Wizard/OperatingSystemCatalogStepView.xaml
+++ b/src/Foundry.Deploy/Views/Wizard/OperatingSystemCatalogStepView.xaml
@@ -60,6 +60,16 @@
                         <TextBlock
                             Margin="0,20,0,0"
                             Style="{StaticResource BodyTextBlockStyle}"
+                            Text="{Binding Strings[Catalog.EditionTarget]}" />
+                        <ComboBox
+                            Margin="0,8,0,0"
+                            IsEnabled="{Binding OperatingSystemCatalog.IsEditionSelectionEnabled}"
+                            ItemsSource="{Binding OperatingSystemCatalog.EditionFilters}"
+                            SelectedItem="{Binding OperatingSystemCatalog.SelectedEdition}" />
+
+                        <TextBlock
+                            Margin="0,20,0,0"
+                            Style="{StaticResource BodyTextBlockStyle}"
                             Text="{Binding Strings[Catalog.LicenseChannel]}" />
                         <ComboBox
                             Margin="0,8,0,0"
@@ -72,16 +82,6 @@
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>
-
-                        <TextBlock
-                            Margin="0,20,0,0"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            Text="{Binding Strings[Catalog.EditionTarget]}" />
-                        <ComboBox
-                            Margin="0,8,0,0"
-                            IsEnabled="{Binding OperatingSystemCatalog.IsEditionSelectionEnabled}"
-                            ItemsSource="{Binding OperatingSystemCatalog.EditionFilters}"
-                            SelectedItem="{Binding OperatingSystemCatalog.SelectedEdition}" />
                     </StackPanel>
                 </Border>
             </Grid>

--- a/src/Foundry/ViewModels/CustomizationConfigurationViewModel.OperatingSystemSelection.cs
+++ b/src/Foundry/ViewModels/CustomizationConfigurationViewModel.OperatingSystemSelection.cs
@@ -29,7 +29,7 @@ public sealed partial class CustomizationConfigurationViewModel
     public bool IsOperatingSystemSelectionOptionsEnabled => IsOperatingSystemSelectionEnabled;
     public bool IsDefaultOperatingSystemLanguageSelectionEnabled => IsOperatingSystemSelectionOptionsEnabled && !HasSingleSelectedOption(OperatingSystemLanguageOptions);
     public bool IsDefaultOperatingSystemReleaseSelectionEnabled => IsOperatingSystemSelectionOptionsEnabled && !HasSingleSelectedOption(OperatingSystemReleaseOptions);
-    public bool IsDefaultOperatingSystemLicenseChannelSelectionEnabled => IsOperatingSystemSelectionOptionsEnabled && !HasSingleSelectedOption(OperatingSystemLicenseChannelOptions);
+    public bool IsDefaultOperatingSystemLicenseChannelSelectionEnabled => IsOperatingSystemSelectionOptionsEnabled && DefaultOperatingSystemLicenseChannelOptions.Count > 1;
     public bool IsDefaultOperatingSystemEditionSelectionEnabled => IsOperatingSystemSelectionOptionsEnabled && !HasSingleSelectedOption(OperatingSystemEditionOptions);
 
     [ObservableProperty]
@@ -167,7 +167,6 @@ public sealed partial class CustomizationConfigurationViewModel
             return;
         }
 
-        RefreshOperatingSystemDefaultOptions(BuildOperatingSystemSelectionSettings());
         SaveState();
     }
 
@@ -178,7 +177,7 @@ public sealed partial class CustomizationConfigurationViewModel
             return;
         }
 
-        RefreshOperatingSystemDefaultOptions(BuildOperatingSystemSelectionSettings());
+        RefreshOperatingSystemDefaultLicenseChannelOptions(BuildOperatingSystemSelectionSettings());
         SaveState();
     }
 
@@ -220,6 +219,7 @@ public sealed partial class CustomizationConfigurationViewModel
         SetSelectedOptions(OperatingSystemReleaseOptions, settings.AllowedReleaseIds);
         SetSelectedOptions(OperatingSystemLicenseChannelOptions, settings.AllowedLicenseChannels);
         SetSelectedOptions(OperatingSystemEditionOptions, settings.AllowedEditions);
+        RefreshOperatingSystemLicenseChannelAvailability();
 
         RefreshOperatingSystemMediaOffsetOptions(settings.DefaultMediaOffset);
         RefreshOperatingSystemDefaultOptions(settings);
@@ -310,8 +310,7 @@ public sealed partial class CustomizationConfigurationViewModel
             RefreshDefaultOptions(DefaultOperatingSystemReleaseOptions, OperatingSystemReleaseOptions);
             SelectedDefaultOperatingSystemRelease = SelectStringOption(DefaultOperatingSystemReleaseOptions, settings.DefaultReleaseId) ?? DefaultOperatingSystemReleaseOptions[0];
 
-            RefreshDefaultOptions(DefaultOperatingSystemLicenseChannelOptions, OperatingSystemLicenseChannelOptions);
-            SelectedDefaultOperatingSystemLicenseChannel = SelectStringOption(DefaultOperatingSystemLicenseChannelOptions, settings.DefaultLicenseChannel) ?? DefaultOperatingSystemLicenseChannelOptions[0];
+            RefreshOperatingSystemDefaultLicenseChannelOptions(settings);
 
             RefreshDefaultOptions(DefaultOperatingSystemEditionOptions, OperatingSystemEditionOptions);
             SelectedDefaultOperatingSystemEdition = SelectStringOption(DefaultOperatingSystemEditionOptions, settings.DefaultEdition) ?? DefaultOperatingSystemEditionOptions[0];
@@ -341,6 +340,7 @@ public sealed partial class CustomizationConfigurationViewModel
         try
         {
             SetSelectedOptions(OperatingSystemLicenseChannelOptions, normalized.AllowedLicenseChannels);
+            RefreshOperatingSystemLicenseChannelAvailability();
         }
         finally
         {
@@ -349,6 +349,43 @@ public sealed partial class CustomizationConfigurationViewModel
 
         RefreshOperatingSystemDefaultOptions(normalized);
         SaveState();
+    }
+
+    private void RefreshOperatingSystemDefaultLicenseChannelOptions(OperatingSystemSelectionSettings settings)
+    {
+        WindowsEditionDefinition? defaultEdition = WindowsEditionCatalog.Find(settings.DefaultEdition);
+        IEnumerable<SelectableStringOptionViewModel> compatibleOptions = defaultEdition is null
+            ? OperatingSystemLicenseChannelOptions
+            : OperatingSystemLicenseChannelOptions.Where(option =>
+                defaultEdition.LicenseChannels.Contains(option.Value, StringComparer.OrdinalIgnoreCase));
+
+        RefreshDefaultOptions(DefaultOperatingSystemLicenseChannelOptions, compatibleOptions);
+        SelectedDefaultOperatingSystemLicenseChannel =
+            SelectStringOption(DefaultOperatingSystemLicenseChannelOptions, settings.DefaultLicenseChannel) ??
+            DefaultOperatingSystemLicenseChannelOptions[0];
+        OnPropertyChanged(nameof(IsDefaultOperatingSystemLicenseChannelSelectionEnabled));
+    }
+
+    private void RefreshOperatingSystemLicenseChannelAvailability()
+    {
+        string[] selectedEditions = GetSelectedOptionValues(OperatingSystemEditionOptions);
+        if (selectedEditions.Length == 0)
+        {
+            foreach (SelectableStringOptionViewModel option in OperatingSystemLicenseChannelOptions)
+            {
+                option.IsEnabled = true;
+            }
+
+            return;
+        }
+
+        IReadOnlyList<string> compatibleChannels = WindowsEditionCatalog.GetCompatibleLicenseChannels(selectedEditions);
+        IReadOnlyList<string> requiredChannels = WindowsEditionCatalog.GetRequiredLicenseChannels(selectedEditions);
+        foreach (SelectableStringOptionViewModel option in OperatingSystemLicenseChannelOptions)
+        {
+            option.IsEnabled = compatibleChannels.Contains(option.Value, StringComparer.OrdinalIgnoreCase) &&
+                               !requiredChannels.Contains(option.Value, StringComparer.OrdinalIgnoreCase);
+        }
     }
 
     private void AddOperatingSystemSelectionOptions(

--- a/src/Foundry/ViewModels/CustomizationConfigurationViewModel.OperatingSystemSelection.cs
+++ b/src/Foundry/ViewModels/CustomizationConfigurationViewModel.OperatingSystemSelection.cs
@@ -162,11 +162,23 @@ public sealed partial class CustomizationConfigurationViewModel
 
     partial void OnSelectedDefaultOperatingSystemLicenseChannelChanged(SelectionOption<string>? value)
     {
+        if (isRefreshingOperatingSystemSelectionOptions)
+        {
+            return;
+        }
+
+        RefreshOperatingSystemDefaultOptions(BuildOperatingSystemSelectionSettings());
         SaveState();
     }
 
     partial void OnSelectedDefaultOperatingSystemEditionChanged(SelectionOption<string>? value)
     {
+        if (isRefreshingOperatingSystemSelectionOptions)
+        {
+            return;
+        }
+
+        RefreshOperatingSystemDefaultOptions(BuildOperatingSystemSelectionSettings());
         SaveState();
     }
 
@@ -318,12 +330,24 @@ public sealed partial class CustomizationConfigurationViewModel
     private void OnOperatingSystemSelectionOptionPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (isApplyingState ||
+            isRefreshingOperatingSystemSelectionOptions ||
             !string.Equals(e.PropertyName, nameof(SelectableStringOptionViewModel.IsSelected), StringComparison.Ordinal))
         {
             return;
         }
 
-        RefreshOperatingSystemDefaultOptions(BuildOperatingSystemSelectionSettings());
+        OperatingSystemSelectionSettings normalized = BuildOperatingSystemSelectionSettings();
+        isRefreshingOperatingSystemSelectionOptions = true;
+        try
+        {
+            SetSelectedOptions(OperatingSystemLicenseChannelOptions, normalized.AllowedLicenseChannels);
+        }
+        finally
+        {
+            isRefreshingOperatingSystemSelectionOptions = false;
+        }
+
+        RefreshOperatingSystemDefaultOptions(normalized);
         SaveState();
     }
 

--- a/src/Foundry/ViewModels/SelectableStringOptionViewModel.cs
+++ b/src/Foundry/ViewModels/SelectableStringOptionViewModel.cs
@@ -34,4 +34,7 @@ public sealed partial class SelectableStringOptionViewModel : ObservableObject
 
     [ObservableProperty]
     public partial bool IsSelected { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsEnabled { get; set; } = true;
 }

--- a/src/Foundry/Views/CustomizationPage.xaml
+++ b/src/Foundry/Views/CustomizationPage.xaml
@@ -223,7 +223,8 @@
                                             <DataTemplate x:DataType="viewModels:SelectableStringOptionViewModel">
                                                 <CheckBox
                                                     Content="{x:Bind DisplayName, Mode=OneWay}"
-                                                    IsChecked="{x:Bind IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                                    IsChecked="{x:Bind IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                    IsEnabled="{x:Bind IsEnabled, Mode=OneWay}" />
                                             </DataTemplate>
                                         </ItemsRepeater.ItemTemplate>
                                     </ItemsRepeater>


### PR DESCRIPTION
## Summary

- Resolve Windows image indexes from exact DISM edition metadata instead of localized image names or static positions.
- Make the deployment wizard edition-first and derive compatible Retail or Volume media from the selected edition.
- Keep Foundry OSD preselection policies coherent across edition and license-channel defaults.

## Reason

Consumer and business ESD files place setup and WinPE images before deployable Windows editions, and their index positions vary by media family. Selecting Enterprise with consumer Retail media could therefore apply the wrong image and later report that `bcdboot.exe` was missing.

## Main changes

- Add one shared edition catalog for friendly names, invariant `EditionId` values, supported channels, and x64/ARM64 availability.
- Enumerate every ESD index with DISM, inspect each index in detail, and require exactly one matching `EditionId`; there is no index fallback.
- Support Home, N variants, Home Single Language, Education, Pro, Enterprise, and `CoreCountrySpecific` China media.
- Select standard consumer or business media by catalog family and reserve China media for Home China.
- Show edition before license channel; force Retail for Home variants and Volume for Enterprise variants while preserving both choices for Education and Pro.
- Normalize Foundry OSD policies so explicit edition restrictions force compatible channels and channel-only restrictions hide incompatible editions.
- Remove the obsolete localized-name matching and loose post-apply edition comparison.

## Testing

- `scripts/Test-FoundryFormat.ps1`
- Release solution build: x64 (0 errors)
- Release solution build: ARM64 (0 errors)
- Full x64 solution test suite: 835 passed, 0 failed
- Real ESD DISM inspection still requires an elevated shell; the non-elevated attempt returned Windows error 740.