### PR TITLE
feat(deploy): configure completion reboot behavior

### DIFF
--- a/src/Foundry.Core.Tests/BootMediaTelemetryPropertyBuilderTests.cs
+++ b/src/Foundry.Core.Tests/BootMediaTelemetryPropertyBuilderTests.cs
@@ -573,4 +573,46 @@ public sealed class BootMediaTelemetryPropertyBuilderTests
         Assert.True((bool)result["network_profile_roaming_enabled"]!);
         Assert.True((bool)result["network_private_key_roaming_enabled"]!);
     }
+
+    [Theory]
+    [InlineData(false, 10, "manual", null)]
+    [InlineData(true, 0, "immediate", null)]
+    [InlineData(true, 42, "countdown", 42)]
+    public void Build_ReportsAuthoredDeploymentRebootPolicy(
+        bool automaticRebootEnabled,
+        int automaticRebootDelaySeconds,
+        string expectedMode,
+        int? expectedDelaySeconds)
+    {
+        var document = new FoundryConfigurationDocument
+        {
+            General = new GeneralSettings
+            {
+                AutomaticRebootEnabled = automaticRebootEnabled,
+                AutomaticRebootDelaySeconds = automaticRebootDelaySeconds
+            }
+        };
+
+        IReadOnlyDictionary<string, object?> result = BootMediaTelemetryPropertyBuilder.Build(
+            TelemetryBootMediaTargets.Iso,
+            TelemetryBootMediaUsbOperations.None,
+            new MediaPreflightOptions(),
+            document,
+            success: true,
+            failedStepName: null,
+            duration: TimeSpan.Zero,
+            connectRuntimePayloadSource: TelemetryRuntimePayloadSources.None,
+            deployRuntimePayloadSource: TelemetryRuntimePayloadSources.None);
+
+        Assert.Equal(expectedMode, result["deployment_reboot_mode"]);
+
+        if (expectedDelaySeconds.HasValue)
+        {
+            Assert.Equal(expectedDelaySeconds.Value, result["deployment_reboot_delay_seconds"]);
+        }
+        else
+        {
+            Assert.False(result.ContainsKey("deployment_reboot_delay_seconds"));
+        }
+    }
 }

--- a/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
@@ -24,4 +24,12 @@ public sealed class ConfigurationSchemaVersionsTests
         Assert.False(ConfigurationSchemaVersions.IsBootMediaUpdateRecommended(3, 3));
         Assert.True(ConfigurationSchemaVersions.IsBootMediaUpdateRecommended(2, 3));
     }
+
+    [Fact]
+    public void DeploymentCompletionPolicy_AdvancesAffectedSchemaContracts()
+    {
+        Assert.True(ConfigurationSchemaVersions.FoundryCurrent > 11);
+        Assert.True(ConfigurationSchemaVersions.DeployCurrent > 9);
+        Assert.Equal(2, ConfigurationSchemaVersions.ConnectCurrent);
+    }
 }

--- a/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
@@ -28,8 +28,8 @@ public sealed class ConfigurationSchemaVersionsTests
     [Fact]
     public void DeploymentCompletionPolicy_AdvancesAffectedSchemaContracts()
     {
-        Assert.True(ConfigurationSchemaVersions.FoundryCurrent > 11);
-        Assert.True(ConfigurationSchemaVersions.DeployCurrent > 9);
+        Assert.Equal(12, ConfigurationSchemaVersions.FoundryCurrent);
+        Assert.Equal(10, ConfigurationSchemaVersions.DeployCurrent);
         Assert.Equal(2, ConfigurationSchemaVersions.ConnectCurrent);
     }
 }

--- a/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
@@ -14,6 +14,25 @@ namespace Foundry.Core.Tests.Configuration;
 public sealed class DeployConfigurationGeneratorTests
 {
     [Fact]
+    public void Generate_MapsDeploymentCompletionSettings()
+    {
+        var generator = new DeployConfigurationGenerator();
+        var document = new FoundryConfigurationDocument
+        {
+            General = new GeneralSettings
+            {
+                AutomaticRebootEnabled = false,
+                AutomaticRebootDelaySeconds = 42
+            }
+        };
+
+        FoundryDeployConfigurationDocument result = generator.Generate(document);
+
+        Assert.False(result.Completion.AutomaticRebootEnabled);
+        Assert.Equal(42, result.Completion.AutomaticRebootDelaySeconds);
+    }
+
+    [Fact]
     public void Generate_WhenMachineNamingIsDisabled_ClearsPrefixAndKeepsManualSuffixEditable()
     {
         var generator = new DeployConfigurationGenerator();

--- a/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
@@ -32,6 +32,25 @@ public sealed class DeployConfigurationGeneratorTests
         Assert.Equal(42, result.Completion.AutomaticRebootDelaySeconds);
     }
 
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(3601)]
+    public void Generate_WhenDeploymentRebootDelayIsInvalid_UsesDefault(int configuredDelaySeconds)
+    {
+        var generator = new DeployConfigurationGenerator();
+        var document = new FoundryConfigurationDocument
+        {
+            General = new GeneralSettings
+            {
+                AutomaticRebootDelaySeconds = configuredDelaySeconds
+            }
+        };
+
+        FoundryDeployConfigurationDocument result = generator.Generate(document);
+
+        Assert.Equal(DeploymentRebootDelay.DefaultSeconds, result.Completion.AutomaticRebootDelaySeconds);
+    }
+
     [Fact]
     public void Generate_WhenMachineNamingIsDisabled_ClearsPrefixAndKeepsManualSuffixEditable()
     {

--- a/src/Foundry.Core.Tests/Configuration/DeploymentRebootDelayTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/DeploymentRebootDelayTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Core.Tests.Configuration;
+
+public sealed class DeploymentRebootDelayTests
+{
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(0.1, 1)]
+    [InlineData(10.1, 11)]
+    [InlineData(-1, 0)]
+    [InlineData(3601, 3600)]
+    public void NormalizeAuthoring_ProducesSafeWholeSeconds(double value, int expected)
+    {
+        Assert.Equal(expected, DeploymentRebootDelay.NormalizeAuthoring(value));
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void NormalizeAuthoring_WhenValueIsNotFinite_UsesDefault(double value)
+    {
+        Assert.Equal(DeploymentRebootDelay.DefaultSeconds, DeploymentRebootDelay.NormalizeAuthoring(value));
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(42, 42)]
+    [InlineData(3600, 3600)]
+    [InlineData(-1, 10)]
+    [InlineData(3601, 10)]
+    public void NormalizeRuntime_UsesDefaultOnlyForInvalidValues(int value, int expected)
+    {
+        Assert.Equal(expected, DeploymentRebootDelay.NormalizeRuntime(value));
+    }
+}

--- a/src/Foundry.Core.Tests/DeploymentRebootTelemetryValueResolverTests.cs
+++ b/src/Foundry.Core.Tests/DeploymentRebootTelemetryValueResolverTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Core.Services.Telemetry;
+
+namespace Foundry.Core.Tests;
+
+public sealed class DeploymentRebootTelemetryValueResolverTests
+{
+    [Theory]
+    [InlineData(false, 10, "manual", null)]
+    [InlineData(true, 0, "immediate", null)]
+    [InlineData(true, 42, "countdown", 42)]
+    [InlineData(true, -1, "countdown", 10)]
+    [InlineData(true, 3601, "countdown", 10)]
+    public void Resolve_MapsAuthoredRebootPolicyToStableTelemetryValues(
+        bool automaticRebootEnabled,
+        int delaySeconds,
+        string expectedMode,
+        int? expectedDelaySeconds)
+    {
+        DeploymentRebootTelemetryValue result = DeploymentRebootTelemetryValueResolver.Resolve(
+            automaticRebootEnabled,
+            delaySeconds);
+
+        Assert.Equal(expectedMode, result.Mode);
+        Assert.Equal(expectedDelaySeconds, result.DelaySeconds);
+    }
+}

--- a/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
+++ b/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
@@ -6,11 +6,11 @@ namespace Foundry.Core.Models.Configuration;
 
 public static class ConfigurationSchemaVersions
 {
-    public const int FoundryCurrent = 11;
+    public const int FoundryCurrent = 12;
 
     public const int ConnectCurrent = 2;
 
-    public const int DeployCurrent = 9;
+    public const int DeployCurrent = 10;
 
     public static bool IsBootMediaUpdateRecommended(int schemaVersion, int currentSchemaVersion)
     {

--- a/src/Foundry.Core/Models/Configuration/Deploy/DeployCompletionSettings.cs
+++ b/src/Foundry.Core/Models/Configuration/Deploy/DeployCompletionSettings.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Core.Models.Configuration.Deploy;
+
+/// <summary>
+/// Defines Foundry.Deploy behavior after a successful deployment.
+/// </summary>
+public sealed record DeployCompletionSettings
+{
+    /// <summary>
+    /// Gets a value indicating whether the device reboots automatically.
+    /// </summary>
+    public bool AutomaticRebootEnabled { get; init; } = true;
+
+    /// <summary>
+    /// Gets the configured automatic reboot delay in seconds.
+    /// </summary>
+    public int AutomaticRebootDelaySeconds { get; init; } = 10;
+}

--- a/src/Foundry.Core/Models/Configuration/Deploy/DeployCompletionSettings.cs
+++ b/src/Foundry.Core/Models/Configuration/Deploy/DeployCompletionSettings.cs
@@ -17,5 +17,5 @@ public sealed record DeployCompletionSettings
     /// <summary>
     /// Gets the configured automatic reboot delay in seconds.
     /// </summary>
-    public int AutomaticRebootDelaySeconds { get; init; } = 10;
+    public int AutomaticRebootDelaySeconds { get; init; } = DeploymentRebootDelay.DefaultSeconds;
 }

--- a/src/Foundry.Core/Models/Configuration/Deploy/FoundryDeployConfigurationDocument.cs
+++ b/src/Foundry.Core/Models/Configuration/Deploy/FoundryDeployConfigurationDocument.cs
@@ -23,6 +23,11 @@ public sealed record FoundryDeployConfigurationDocument
     public int SchemaVersion { get; init; } = CurrentSchemaVersion;
 
     /// <summary>
+    /// Gets successful deployment completion behavior.
+    /// </summary>
+    public DeployCompletionSettings Completion { get; init; } = new();
+
+    /// <summary>
     /// Gets Windows catalog selection settings used during apply image selection.
     /// </summary>
     public DeployOperatingSystemSelectionSettings OperatingSystemSelection { get; init; } = new();

--- a/src/Foundry.Core/Models/Configuration/DeploymentRebootDelay.cs
+++ b/src/Foundry.Core/Models/Configuration/DeploymentRebootDelay.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Core.Models.Configuration;
+
+/// <summary>
+/// Defines and normalizes the supported post-deployment reboot delay.
+/// </summary>
+public static class DeploymentRebootDelay
+{
+    public const int DefaultSeconds = 10;
+
+    public const int MaximumSeconds = 3600;
+
+    public static int NormalizeAuthoring(double seconds)
+    {
+        if (!double.IsFinite(seconds))
+        {
+            return DefaultSeconds;
+        }
+
+        return (int)Math.Clamp(Math.Ceiling(seconds), 0, MaximumSeconds);
+    }
+
+    public static int NormalizeRuntime(int seconds)
+    {
+        return seconds is >= 0 and <= MaximumSeconds ? seconds : DefaultSeconds;
+    }
+}

--- a/src/Foundry.Core/Models/Configuration/GeneralSettings.cs
+++ b/src/Foundry.Core/Models/Configuration/GeneralSettings.cs
@@ -42,6 +42,16 @@ public sealed record GeneralSettings
     public UsbFormatMode UsbFormatMode { get; init; } = UsbFormatMode.Quick;
 
     /// <summary>
+    /// Gets a value indicating whether Foundry.Deploy automatically reboots after a successful deployment.
+    /// </summary>
+    public bool AutomaticRebootEnabled { get; init; } = true;
+
+    /// <summary>
+    /// Gets the delay, in seconds, before an automatic post-deployment reboot.
+    /// </summary>
+    public int AutomaticRebootDelaySeconds { get; init; } = 10;
+
+    /// <summary>
     /// Gets a value indicating whether Dell WinPE drivers are included.
     /// </summary>
     public bool IncludeDellDrivers { get; init; }

--- a/src/Foundry.Core/Models/Configuration/GeneralSettings.cs
+++ b/src/Foundry.Core/Models/Configuration/GeneralSettings.cs
@@ -49,7 +49,7 @@ public sealed record GeneralSettings
     /// <summary>
     /// Gets the delay, in seconds, before an automatic post-deployment reboot.
     /// </summary>
-    public int AutomaticRebootDelaySeconds { get; init; } = 10;
+    public int AutomaticRebootDelaySeconds { get; init; } = DeploymentRebootDelay.DefaultSeconds;
 
     /// <summary>
     /// Gets a value indicating whether Dell WinPE drivers are included.

--- a/src/Foundry.Core/Services/Configuration/DeployConfigurationGenerator.cs
+++ b/src/Foundry.Core/Services/Configuration/DeployConfigurationGenerator.cs
@@ -37,7 +37,7 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
             Completion = new DeployCompletionSettings
             {
                 AutomaticRebootEnabled = document.General.AutomaticRebootEnabled,
-                AutomaticRebootDelaySeconds = document.General.AutomaticRebootDelaySeconds
+                AutomaticRebootDelaySeconds = DeploymentRebootDelay.NormalizeRuntime(document.General.AutomaticRebootDelaySeconds)
             },
             OperatingSystemSelection = OperatingSystemSelectionSettingsNormalizer.ToDeploySettings(document.OperatingSystemSelection),
             Localization = new DeployLocalizationSettings

--- a/src/Foundry.Core/Services/Configuration/DeployConfigurationGenerator.cs
+++ b/src/Foundry.Core/Services/Configuration/DeployConfigurationGenerator.cs
@@ -34,6 +34,11 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
 
         return new FoundryDeployConfigurationDocument
         {
+            Completion = new DeployCompletionSettings
+            {
+                AutomaticRebootEnabled = document.General.AutomaticRebootEnabled,
+                AutomaticRebootDelaySeconds = document.General.AutomaticRebootDelaySeconds
+            },
             OperatingSystemSelection = OperatingSystemSelectionSettingsNormalizer.ToDeploySettings(document.OperatingSystemSelection),
             Localization = new DeployLocalizationSettings
             {

--- a/src/Foundry.Core/Services/Telemetry/BootMediaTelemetryPropertyBuilder.cs
+++ b/src/Foundry.Core/Services/Telemetry/BootMediaTelemetryPropertyBuilder.cs
@@ -43,6 +43,10 @@ public static class BootMediaTelemetryPropertyBuilder
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(document);
 
+        DeploymentRebootTelemetryValue rebootPolicy = DeploymentRebootTelemetryValueResolver.Resolve(
+            document.General.AutomaticRebootEnabled,
+            document.General.AutomaticRebootDelaySeconds);
+
         var properties = new Dictionary<string, object?>
         {
             ["boot_media_target"] = bootMediaTarget,
@@ -68,8 +72,14 @@ public static class BootMediaTelemetryPropertyBuilder
             ["boot_media_connect_runtime_payload_source"] = connectRuntimePayloadSource,
             ["boot_media_deploy_runtime_payload_source"] = deployRuntimePayloadSource,
             ["autopilot_enabled"] = options.IsAutopilotEnabled,
-            ["autopilot_provisioning_mode"] = ResolveAutopilotProvisioningMode(options)
+            ["autopilot_provisioning_mode"] = ResolveAutopilotProvisioningMode(options),
+            ["deployment_reboot_mode"] = rebootPolicy.Mode
         };
+
+        if (rebootPolicy.DelaySeconds.HasValue)
+        {
+            properties["deployment_reboot_delay_seconds"] = rebootPolicy.DelaySeconds.Value;
+        }
 
         AddCustomizationTelemetryProperties(properties, document.Customization);
         AddOperatingSystemSelectionTelemetryProperties(properties, document.OperatingSystemSelection);

--- a/src/Foundry.Core/Services/Telemetry/DeploymentRebootTelemetryValueResolver.cs
+++ b/src/Foundry.Core/Services/Telemetry/DeploymentRebootTelemetryValueResolver.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Core.Services.Telemetry;
+
+/// <summary>
+/// Resolves authored deployment reboot settings into stable telemetry values.
+/// </summary>
+public static class DeploymentRebootTelemetryValueResolver
+{
+    /// <summary>
+    /// Maps an authored reboot policy to a stable mode and optional countdown delay.
+    /// </summary>
+    public static DeploymentRebootTelemetryValue Resolve(bool automaticRebootEnabled, int delaySeconds)
+    {
+        int normalizedDelaySeconds = DeploymentRebootDelay.NormalizeRuntime(delaySeconds);
+
+        if (!automaticRebootEnabled)
+        {
+            return new DeploymentRebootTelemetryValue("manual", null);
+        }
+
+        return normalizedDelaySeconds == 0
+            ? new DeploymentRebootTelemetryValue("immediate", null)
+            : new DeploymentRebootTelemetryValue("countdown", normalizedDelaySeconds);
+    }
+}
+
+/// <summary>
+/// Represents the telemetry-safe form of an authored deployment reboot policy.
+/// </summary>
+public sealed record DeploymentRebootTelemetryValue(string Mode, int? DelaySeconds);

--- a/src/Foundry.Deploy.Tests/DeployConfigurationServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeployConfigurationServiceTests.cs
@@ -64,6 +64,30 @@ public sealed class DeployConfigurationServiceTests
     }
 
     [Fact]
+    public void LoadOptional_WhenCompletionSettingsAreMissing_UsesAutomaticTenSecondReboot()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        string configurationPath = CreateJsonFile(
+            tempDirectory.Path,
+            "foundry.deploy.config.json",
+            $$"""
+            {
+              "schemaVersion": {{FoundryDeployConfigurationDocument.CurrentSchemaVersion}}
+            }
+            """);
+
+        var service = new DeployConfigurationService(
+            NullLogger<DeployConfigurationService>.Instance,
+            configurationPath);
+
+        DeployConfigurationLoadResult result = service.LoadOptional();
+
+        Assert.NotNull(result.Document);
+        Assert.True(result.Document.Completion.AutomaticRebootEnabled);
+        Assert.Equal(10, result.Document.Completion.AutomaticRebootDelaySeconds);
+    }
+
+    [Fact]
     public void LoadOptional_WhenConfigurationContainsNetworkProfileRoaming_PreservesOptIn()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/src/Foundry.Deploy.Tests/DeploymentLaunchPreparationServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentLaunchPreparationServiceTests.cs
@@ -124,6 +124,28 @@ public sealed class DeploymentLaunchPreparationServiceTests
     }
 
     [Fact]
+    public void Prepare_WhenCompletionRebootIsDisabled_RetainsConfiguredDelay()
+    {
+        var shell = new FakeApplicationShellService();
+        var service = new DeploymentLaunchPreparationService(shell);
+        DeployCompletionSettings completion = new()
+        {
+            AutomaticRebootEnabled = false,
+            AutomaticRebootDelaySeconds = 42
+        };
+
+        DeploymentLaunchPreparationResult result = service.Prepare(
+            CreateRequest(
+                selectedTargetDisk: CreateDisk(),
+                completion: completion,
+                isDryRun: true));
+
+        Assert.True(result.IsReadyToStart);
+        Assert.False(result.Context!.Completion.AutomaticRebootEnabled);
+        Assert.Equal(42, result.Context.Completion.AutomaticRebootDelaySeconds);
+    }
+
+    [Fact]
     public void Prepare_WhenHardwareHashUploadModeHasNoJsonProfile_ReturnsDeploymentContext()
     {
         var shell = new FakeApplicationShellService { ConfirmationResult = true };
@@ -252,6 +274,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
         DeployOobeSettings? oobe = null,
         DeployAppxRemovalSettings? appxRemoval = null,
         DeployAiComponentRemovalSettings? aiComponentRemoval = null,
+        DeployCompletionSettings? completion = null,
         bool isDryRun = false)
     {
         return new DeploymentLaunchRequest
@@ -282,6 +305,7 @@ public sealed class DeploymentLaunchPreparationServiceTests
             Oobe = oobe ?? new DeployOobeSettings(),
             AppxRemoval = appxRemoval ?? new DeployAppxRemovalSettings(),
             AiComponentRemoval = aiComponentRemoval ?? new DeployAiComponentRemovalSettings(),
+            Completion = completion ?? new DeployCompletionSettings(),
             IsDryRun = isDryRun
         };
     }

--- a/src/Foundry.Deploy.Tests/DeploymentOrchestratorTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentOrchestratorTests.cs
@@ -132,6 +132,55 @@ public sealed class DeploymentOrchestratorTests
         Assert.False(telemetryEvent.Properties.ContainsKey("autopilot_enabled"));
     }
 
+    [Theory]
+    [InlineData(false, 42, "manual", null)]
+    [InlineData(true, 0, "immediate", null)]
+    [InlineData(true, 42, "countdown", 42)]
+    public async Task RunAsync_TracksConfiguredCompletionRebootTelemetry(
+        bool automaticRebootEnabled,
+        int delaySeconds,
+        string expectedMode,
+        int? expectedDelaySeconds)
+    {
+        using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
+        var telemetryService = new RecordingTelemetryService();
+        var orchestrator = new DeploymentOrchestrator(
+            new FakeOperationProgressService(),
+            new FakeDeploymentLogService(),
+            new FakeTargetDiskService(),
+            CreateSteps(Path.Combine(workspace.RootPath, "TargetWindows")),
+            telemetryService,
+            NullLogger<DeploymentOrchestrator>.Instance);
+
+        await orchestrator.RunAsync(new DeploymentContext
+        {
+            Mode = DeploymentMode.Iso,
+            IsDryRun = false,
+            CacheRootPath = workspace.RootPath,
+            TargetDiskNumber = 1,
+            TargetComputerName = "LAB01",
+            OperatingSystem = new OperatingSystemCatalogItem(),
+            DriverPackSelectionKind = DriverPackSelectionKind.None,
+            Completion = new DeployCompletionSettings
+            {
+                AutomaticRebootEnabled = automaticRebootEnabled,
+                AutomaticRebootDelaySeconds = delaySeconds
+            }
+        });
+
+        TelemetryEvent telemetryEvent = Assert.Single(telemetryService.Events);
+
+        Assert.Equal(expectedMode, telemetryEvent.Properties["deploy_completion_reboot_mode"]);
+        if (expectedDelaySeconds is null)
+        {
+            Assert.False(telemetryEvent.Properties.ContainsKey("deploy_completion_reboot_delay_seconds"));
+        }
+        else
+        {
+            Assert.Equal(expectedDelaySeconds, telemetryEvent.Properties["deploy_completion_reboot_delay_seconds"]);
+        }
+    }
+
     private static IDeploymentStep[] CreateSteps(string targetWindowsRoot)
     {
         return DeploymentStepNames.All

--- a/src/Foundry.Deploy.Tests/DeploymentRebootPolicyTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentRebootPolicyTests.cs
@@ -10,16 +10,15 @@ namespace Foundry.Deploy.Tests;
 public sealed class DeploymentRebootPolicyTests
 {
     [Theory]
-    [InlineData(true, 10, true, false, 10)]
-    [InlineData(true, 0, false, true, 0)]
-    [InlineData(false, 10, false, false, 10)]
-    [InlineData(true, -1, true, false, 10)]
-    [InlineData(true, 3601, true, false, 10)]
+    [InlineData(true, 10, DeploymentRebootAction.StartCountdown, 10)]
+    [InlineData(true, 0, DeploymentRebootAction.RebootImmediately, 0)]
+    [InlineData(false, 10, DeploymentRebootAction.WaitForManualReboot, 10)]
+    [InlineData(true, -1, DeploymentRebootAction.StartCountdown, 10)]
+    [InlineData(true, 3601, DeploymentRebootAction.StartCountdown, 10)]
     public void Create_ResolvesExpectedBehavior(
         bool automaticRebootEnabled,
         int configuredDelaySeconds,
-        bool shouldStartCountdown,
-        bool shouldRebootImmediately,
+        DeploymentRebootAction expectedAction,
         int expectedDelaySeconds)
     {
         DeploymentRebootPolicy policy = DeploymentRebootPolicy.Create(
@@ -31,8 +30,7 @@ public sealed class DeploymentRebootPolicyTests
 
         Assert.Equal(automaticRebootEnabled, policy.AutomaticRebootEnabled);
         Assert.Equal(expectedDelaySeconds, policy.DelaySeconds);
-        Assert.Equal(shouldStartCountdown, policy.ShouldStartCountdown);
-        Assert.Equal(shouldRebootImmediately, policy.ShouldRebootImmediately);
+        Assert.Equal(expectedAction, policy.Action);
     }
 
     [Theory]

--- a/src/Foundry.Deploy.Tests/DeploymentRebootPolicyTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentRebootPolicyTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Deploy.Models.Configuration;
+using Foundry.Deploy.Services.Deployment;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class DeploymentRebootPolicyTests
+{
+    [Theory]
+    [InlineData(true, 10, true, false, 10)]
+    [InlineData(true, 0, false, true, 0)]
+    [InlineData(false, 10, false, false, 10)]
+    [InlineData(true, -1, true, false, 10)]
+    [InlineData(true, 3601, true, false, 10)]
+    public void Create_ResolvesExpectedBehavior(
+        bool automaticRebootEnabled,
+        int configuredDelaySeconds,
+        bool shouldStartCountdown,
+        bool shouldRebootImmediately,
+        int expectedDelaySeconds)
+    {
+        DeploymentRebootPolicy policy = DeploymentRebootPolicy.Create(
+            new DeployCompletionSettings
+            {
+                AutomaticRebootEnabled = automaticRebootEnabled,
+                AutomaticRebootDelaySeconds = configuredDelaySeconds
+            });
+
+        Assert.Equal(automaticRebootEnabled, policy.AutomaticRebootEnabled);
+        Assert.Equal(expectedDelaySeconds, policy.DelaySeconds);
+        Assert.Equal(shouldStartCountdown, policy.ShouldStartCountdown);
+        Assert.Equal(shouldRebootImmediately, policy.ShouldRebootImmediately);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(3600)]
+    public void Create_PreservesValidDelayBoundaries(int configuredDelaySeconds)
+    {
+        DeploymentRebootPolicy policy = DeploymentRebootPolicy.Create(
+            new DeployCompletionSettings { AutomaticRebootDelaySeconds = configuredDelaySeconds });
+
+        Assert.Equal(configuredDelaySeconds, policy.DelaySeconds);
+    }
+}

--- a/src/Foundry.Deploy/Models/Configuration/DeployCompletionSettings.cs
+++ b/src/Foundry.Deploy/Models/Configuration/DeployCompletionSettings.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
+using Foundry.Core.Models.Configuration;
+
 namespace Foundry.Deploy.Models.Configuration;
 
 /// <summary>
@@ -17,5 +19,5 @@ public sealed record DeployCompletionSettings
     /// <summary>
     /// Gets the configured automatic reboot delay in seconds.
     /// </summary>
-    public int AutomaticRebootDelaySeconds { get; init; } = 10;
+    public int AutomaticRebootDelaySeconds { get; init; } = DeploymentRebootDelay.DefaultSeconds;
 }

--- a/src/Foundry.Deploy/Models/Configuration/DeployCompletionSettings.cs
+++ b/src/Foundry.Deploy/Models/Configuration/DeployCompletionSettings.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Deploy.Models.Configuration;
+
+/// <summary>
+/// Defines Foundry.Deploy behavior after a successful deployment.
+/// </summary>
+public sealed record DeployCompletionSettings
+{
+    /// <summary>
+    /// Gets a value indicating whether the device reboots automatically.
+    /// </summary>
+    public bool AutomaticRebootEnabled { get; init; } = true;
+
+    /// <summary>
+    /// Gets the configured automatic reboot delay in seconds.
+    /// </summary>
+    public int AutomaticRebootDelaySeconds { get; init; } = 10;
+}

--- a/src/Foundry.Deploy/Models/Configuration/FoundryDeployConfigurationDocument.cs
+++ b/src/Foundry.Deploy/Models/Configuration/FoundryDeployConfigurationDocument.cs
@@ -24,6 +24,11 @@ public sealed record FoundryDeployConfigurationDocument
     public int SchemaVersion { get; init; } = CurrentSchemaVersion;
 
     /// <summary>
+    /// Gets successful deployment completion behavior.
+    /// </summary>
+    public DeployCompletionSettings Completion { get; init; } = new();
+
+    /// <summary>
     /// Gets Windows catalog selection settings used during apply image selection.
     /// </summary>
     public DeployOperatingSystemSelectionSettings OperatingSystemSelection { get; init; } = new();

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentContext.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentContext.cs
@@ -99,6 +99,11 @@ public sealed record DeploymentContext
     public DeployAiComponentRemovalSettings AiComponentRemoval { get; init; } = new();
 
     /// <summary>
+    /// Gets the completion settings used after deployment finishes.
+    /// </summary>
+    public DeployCompletionSettings Completion { get; init; } = new();
+
+    /// <summary>
     /// Gets a value indicating whether deployment runs against a temporary workspace instead of mutating a target disk.
     /// </summary>
     public bool IsDryRun { get; init; }

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchPreparationService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchPreparationService.cs
@@ -95,6 +95,7 @@ public sealed class DeploymentLaunchPreparationService : IDeploymentLaunchPrepar
             Oobe = request.Oobe,
             AppxRemoval = request.AppxRemoval,
             AiComponentRemoval = request.AiComponentRemoval,
+            Completion = request.Completion,
             IsDryRun = request.IsDryRun
         };
 

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchRequest.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentLaunchRequest.cs
@@ -27,5 +27,6 @@ public sealed record DeploymentLaunchRequest
     public DeployOobeSettings Oobe { get; init; } = new();
     public DeployAppxRemovalSettings AppxRemoval { get; init; } = new();
     public DeployAiComponentRemovalSettings AiComponentRemoval { get; init; } = new();
+    public DeployCompletionSettings Completion { get; init; } = new();
     public required bool IsDryRun { get; init; }
 }

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentOrchestrator.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentOrchestrator.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using Foundry.Core.Services.Telemetry;
 using Foundry.Deploy.Models;
 using Foundry.Deploy.Models.Configuration;
 using Foundry.Deploy.Services.Hardware;
@@ -290,6 +291,9 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
         CancellationToken cancellationToken)
     {
         HardwareProfile? hardware = runtimeState?.HardwareProfile;
+        DeploymentRebootTelemetryValue rebootPolicy = DeploymentRebootTelemetryValueResolver.Resolve(
+            context.Completion.AutomaticRebootEnabled,
+            context.Completion.AutomaticRebootDelaySeconds);
         var properties = new Dictionary<string, object?>
         {
             ["deploy_session_success"] = success,
@@ -320,8 +324,14 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
             ["deploy_autopilot_enabled"] = context.IsAutopilotEnabled,
             ["deploy_autopilot_provisioning_mode"] = NormalizeTelemetryString(ResolveAutopilotProvisioningMode(context)),
             ["deploy_autopilot_hash_upload_state"] = NormalizeTelemetryString(runtimeState?.AutopilotHardwareHashUploadState.ToString()),
-            ["deploy_autopilot_hash_group_tag_selected"] = !string.IsNullOrWhiteSpace(runtimeState?.AutopilotHardwareHashGroupTag)
+            ["deploy_autopilot_hash_group_tag_selected"] = !string.IsNullOrWhiteSpace(runtimeState?.AutopilotHardwareHashGroupTag),
+            ["deploy_completion_reboot_mode"] = rebootPolicy.Mode
         };
+
+        if (rebootPolicy.DelaySeconds is not null)
+        {
+            properties["deploy_completion_reboot_delay_seconds"] = rebootPolicy.DelaySeconds.Value;
+        }
 
         if (failure is not null)
         {

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentRebootPolicy.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentRebootPolicy.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Deploy.Models.Configuration;
+
+namespace Foundry.Deploy.Services.Deployment;
+
+/// <summary>
+/// Resolves configured deployment completion settings into safe runtime reboot behavior.
+/// </summary>
+public sealed record DeploymentRebootPolicy(bool AutomaticRebootEnabled, int DelaySeconds)
+{
+    public const int DefaultDelaySeconds = 10;
+
+    public const int MaximumDelaySeconds = 3600;
+
+    public bool ShouldRebootImmediately => AutomaticRebootEnabled && DelaySeconds == 0;
+
+    public bool ShouldStartCountdown => AutomaticRebootEnabled && DelaySeconds > 0;
+
+    public static DeploymentRebootPolicy Create(DeployCompletionSettings? settings)
+    {
+        settings ??= new DeployCompletionSettings();
+        int delaySeconds = settings.AutomaticRebootDelaySeconds is >= 0 and <= MaximumDelaySeconds
+            ? settings.AutomaticRebootDelaySeconds
+            : DefaultDelaySeconds;
+
+        return new DeploymentRebootPolicy(settings.AutomaticRebootEnabled, delaySeconds);
+    }
+}

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentRebootPolicy.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentRebootPolicy.cs
@@ -2,29 +2,33 @@
 // Licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
+using Foundry.Core.Models.Configuration;
 using Foundry.Deploy.Models.Configuration;
 
 namespace Foundry.Deploy.Services.Deployment;
+
+public enum DeploymentRebootAction
+{
+    WaitForManualReboot,
+    StartCountdown,
+    RebootImmediately
+}
 
 /// <summary>
 /// Resolves configured deployment completion settings into safe runtime reboot behavior.
 /// </summary>
 public sealed record DeploymentRebootPolicy(bool AutomaticRebootEnabled, int DelaySeconds)
 {
-    public const int DefaultDelaySeconds = 10;
-
-    public const int MaximumDelaySeconds = 3600;
-
-    public bool ShouldRebootImmediately => AutomaticRebootEnabled && DelaySeconds == 0;
-
-    public bool ShouldStartCountdown => AutomaticRebootEnabled && DelaySeconds > 0;
+    public DeploymentRebootAction Action => !AutomaticRebootEnabled
+        ? DeploymentRebootAction.WaitForManualReboot
+        : DelaySeconds == 0
+            ? DeploymentRebootAction.RebootImmediately
+            : DeploymentRebootAction.StartCountdown;
 
     public static DeploymentRebootPolicy Create(DeployCompletionSettings? settings)
     {
         settings ??= new DeployCompletionSettings();
-        int delaySeconds = settings.AutomaticRebootDelaySeconds is >= 0 and <= MaximumDelaySeconds
-            ? settings.AutomaticRebootDelaySeconds
-            : DefaultDelaySeconds;
+        int delaySeconds = DeploymentRebootDelay.NormalizeRuntime(settings.AutomaticRebootDelaySeconds);
 
         return new DeploymentRebootPolicy(settings.AutomaticRebootEnabled, delaySeconds);
     }

--- a/src/Foundry.Deploy/Services/Wizard/DeploymentWizardContext.cs
+++ b/src/Foundry.Deploy/Services/Wizard/DeploymentWizardContext.cs
@@ -35,6 +35,7 @@ public sealed class DeploymentWizardContext : IDisposable
     public OperatingSystemCatalogViewModel OperatingSystemCatalog { get; }
     public DriverPackSelectionViewModel DriverPackSelection { get; }
     public string? DefaultTimeZoneId { get; private set; }
+    public DeployCompletionSettings Completion { get; private set; } = new();
     public CoreDeployNetworkSettings Network { get; private set; } = new();
     public DeployOobeSettings Oobe { get; private set; } = new();
     public DeployAppxRemovalSettings AppxRemoval { get; private set; } = new();
@@ -105,6 +106,7 @@ public sealed class DeploymentWizardContext : IDisposable
         string seedComputerName,
         IReadOnlyList<AutopilotProfileCatalogItem> autopilotProfiles)
     {
+        Completion = document.Completion ?? new DeployCompletionSettings();
         OperatingSystemCatalog.ApplyOperatingSystemSelection(document.OperatingSystemSelection);
         DefaultTimeZoneId = string.IsNullOrWhiteSpace(document.Localization.DefaultTimeZoneId)
             ? null

--- a/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
@@ -511,4 +511,5 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>تم تجهيز مساعد تسجيل Autopilot التفاعلي (محاكاة).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>أزل وسائط التمهيد، ثم حدد إعادة التشغيل.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
+++ b/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
@@ -511,4 +511,5 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Интерактивният помощник за регистрация на Autopilot е подготвен (симулация).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Премахнете носителя за стартиране, след което изберете „Рестартиране“.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
+++ b/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
@@ -511,4 +511,5 @@ Pokračovat v nasazování?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktivní asistent registrace Autopilotu byl připraven (simulace).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Odeberte spouštěcí médium a potom vyberte Restartovat.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/da-DK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/da-DK/Resources.resx
@@ -511,4 +511,5 @@ Vil du fortsætte med implementeringen?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Den interaktive Autopilot-registreringsassistent er klargjort (simulation).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Fjern startmediet, og vælg derefter Genstart.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/de-DE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/de-DE/Resources.resx
@@ -511,4 +511,5 @@ Mit der Bereitstellung fortfahren?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Der interaktive Autopilot-Registrierungsassistent wurde bereitgestellt (Simulation).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Entfernen Sie das Startmedium, und wählen Sie dann „Neu starten“.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/el-GR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/el-GR/Resources.resx
@@ -511,4 +511,5 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Ο διαδραστικός βοηθός εγγραφής Autopilot προετοιμάστηκε (προσομοίωση).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Αφαιρέστε το μέσο εκκίνησης και, στη συνέχεια, επιλέξτε Επανεκκίνηση.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/en-GB/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-GB/Resources.resx
@@ -511,4 +511,5 @@ Continue with deployment?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interactive Autopilot registration assistant staged (simulation).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Remove the boot media, then select Reboot.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/en-US/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-US/Resources.resx
@@ -145,6 +145,7 @@ Action: Verify disk attributes and retry deployment.</value></data>
   <data name="Progress.ElapsedTime" xml:space="preserve"><value>Elapsed time</value></data>
   <data name="Success.Completed" xml:space="preserve"><value>Deployment completed successfully.</value></data>
   <data name="Success.RebootCountdownFormat" xml:space="preserve"><value>This computer will restart in {0}s.</value></data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Remove the boot media, then select Reboot.</value></data>
   <data name="Success.RebootNow" xml:space="preserve"><value>Reboot</value></data>
   <data name="Error.Title" xml:space="preserve"><value>Deployment failed</value></data>
   <data name="Error.FailedStep" xml:space="preserve"><value>Failed step</value></data>

--- a/src/Foundry.Deploy/Strings/es-ES/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-ES/Resources.resx
@@ -511,4 +511,5 @@ Sistema operativo: {4}
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Asistente de registro interactivo de Autopilot preparado (simulación).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Retire el medio de arranque y seleccione Reiniciar.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/es-MX/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-MX/Resources.resx
@@ -511,4 +511,5 @@ Sistema operativo: {4}
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Asistente de registro interactivo de Autopilot preparado (simulación).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Retire el medio de arranque y seleccione Reiniciar.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/et-EE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/et-EE/Resources.resx
@@ -511,4 +511,5 @@ Kas jätkata juurutamisega?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktiivne Autopiloti registreerimisabiline on ette valmistatud (simulatsioon).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Eemaldage algkäivitusmeedium ja valige Taaskäivita.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
@@ -511,4 +511,5 @@ Jatketaanko käyttöönottoa?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Vuorovaikutteinen Autopilot-rekisteröintiavustaja on valmisteltu (simulointi).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Poista käynnistysmedia ja valitse sitten Käynnistä uudelleen.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
@@ -511,4 +511,5 @@ Continuer le déploiement?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Assistant d&apos;enregistrement Autopilot interactif préparé (simulation).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Retirez le support de démarrage, puis sélectionnez Redémarrer.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
@@ -511,4 +511,5 @@ Continuer le déploiement ?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Assistant d&apos;enregistrement Autopilot interactif préparé (simulation).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Retirez le support de démarrage, puis sélectionnez Redémarrer.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/he-IL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/he-IL/Resources.resx
@@ -511,4 +511,5 @@ ErrorCode=0x80070005
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>מסייע הרישום האינטראקטיבי של Autopilot הוכן (סימולציה).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>הסר את מדיית האתחול ולאחר מכן בחר הפעל מחדש.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
@@ -511,4 +511,5 @@ Nastaviti s implementacijom?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktivni pomoćnik za registraciju Autopilota je pripremljen (simulacija).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Uklonite medij za pokretanje, a zatim odaberite Ponovno pokreni.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
@@ -511,4 +511,5 @@ Folytatja a telepítést?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Az interaktív Autopilot regisztrációs segéd előkészítve (szimuláció).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Távolítsa el a rendszerindító adathordozót, majd válassza az Újraindítás lehetőséget.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/it-IT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/it-IT/Resources.resx
@@ -511,4 +511,5 @@ Continuare con la distribuzione?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Assistente di registrazione interattiva di Autopilot preparato (simulazione).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Rimuovere il supporto di avvio, quindi selezionare Riavvia.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
@@ -511,4 +511,5 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>対話型 Autopilot 登録アシスタントをステージングしました (シミュレーション)。</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>ブート メディアを取り外してから、[再起動] を選択してください。</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
@@ -511,4 +511,5 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>대화형 Autopilot 등록 도우미가 준비되었습니다(시뮬레이션).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>부팅 미디어를 제거한 다음 다시 시작을 선택하세요.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
@@ -511,4 +511,5 @@ Tęsti diegimą?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktyvus Autopilot registracijos pagalbininkas paruoštas (modeliavimas).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Pašalinkite paleidimo laikmeną, tada pasirinkite Paleisti iš naujo.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
@@ -511,4 +511,5 @@ Vai turpināt izvietošanu?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktīvais Autopilot reģistrācijas palīgs ir sagatavots (simulācija).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Izņemiet sāknēšanas datu nesēju un pēc tam atlasiet Restartēt.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
@@ -511,4 +511,5 @@ Vil du fortsette med distribusjonen?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Den interaktive Autopilot-registreringsassistenten er klargjort (simulering).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Fjern oppstartsmediet, og velg deretter Start på nytt.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
@@ -511,4 +511,5 @@ Doorgaan met de implementatie?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interactieve Autopilot-registratieassistent voorbereid (simulatie).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Verwijder het opstartmedium en selecteer vervolgens Opnieuw opstarten.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
@@ -511,4 +511,5 @@ Kontynuować wdrażanie?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktywny asystent rejestracji Autopilot został przygotowany (symulacja).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Usuń nośnik rozruchowy, a następnie wybierz Uruchom ponownie.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
@@ -511,4 +511,5 @@ Continuar com a implantação?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Assistente de registro interativo do Autopilot preparado (simulação).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Remova a mídia de inicialização e selecione Reiniciar.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
@@ -511,4 +511,5 @@ Continuar com a implantação?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Assistente de registo interativo do Autopilot preparado (simulação).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Remova o suporte de arranque e selecione Reiniciar.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
@@ -511,4 +511,5 @@ Continuați cu implementarea?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Asistentul de înregistrare interactivă Autopilot a fost pregătit (simulare).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Scoateți suportul de pornire, apoi selectați Repornire.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
@@ -511,4 +511,5 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Интерактивный помощник регистрации Autopilot подготовлен (симуляция).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Извлеките загрузочный носитель, затем выберите «Перезапустить».</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
@@ -511,4 +511,5 @@ Pokračovať v nasadzovaní?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktívny asistent registrácie Autopilotu bol pripravený (simulácia).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Odstráňte zavádzacie médium a potom vyberte položku Reštartovať.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
@@ -511,4 +511,5 @@ Ali želite nadaljevati z uvajanjem?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktivni pomočnik za registracijo Autopilot je pripravljen (simulacija).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Odstranite zagonski medij in nato izberite Ponovni zagon.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
@@ -511,4 +511,5 @@ Operativni sistem: {4}
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Interaktivni pomoćnik za registraciju Autopilota je pripremljen (simulacija).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Uklonite medijum za pokretanje, a zatim izaberite Ponovo pokreni.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
@@ -511,4 +511,5 @@ Fortsätt med implementeringen?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Den interaktiva Autopilot-registreringsassistenten har förberetts (simulering).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Ta bort startmediet och välj sedan Starta om.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/th-TH/Resources.resx
+++ b/src/Foundry.Deploy/Strings/th-TH/Resources.resx
@@ -511,4 +511,5 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>จัดเตรียมผู้ช่วยลงทะเบียน Autopilot แบบโต้ตอบแล้ว (การจำลอง)</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>นำสื่อสำหรับบูตออก แล้วเลือก รีสตาร์ต</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
@@ -511,4 +511,5 @@ Dağıtıma devam edilsin mi?</value></data>
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Etkileşimli Autopilot kayıt yardımcısı hazırlandı (simülasyon).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Önyükleme medyasını çıkarın ve ardından Yeniden Başlat'ı seçin.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
@@ -511,4 +511,5 @@ ErrorCode=0x80070005
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>Інтерактивний помічник реєстрації Autopilot підготовлено (симуляція).</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>Вийміть завантажувальний носій, а потім виберіть «Перезавантажити».</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
@@ -511,4 +511,5 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>交互式 Autopilot 注册助手已暂存（模拟）。</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>移除启动介质，然后选择“重启”。</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
@@ -511,4 +511,5 @@
   <data name="StepResult.InteractiveAutopilotRegistrationAssistantStagedSimulation" xml:space="preserve">
     <value>互動式 Autopilot 註冊助理已暫存 (模擬)。</value>
   </data>
+  <data name="Success.ManualRebootInstruction" xml:space="preserve"><value>移除開機媒體，然後選取「重新啟動」。</value></data>
 </root>

--- a/src/Foundry.Deploy/ViewModels/DeploymentSessionViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentSessionViewModel.cs
@@ -9,6 +9,7 @@ using System.Net.NetworkInformation;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Foundry.Core.Models.Configuration;
 using Foundry.Deploy.Services.Deployment;
 using Foundry.Deploy.Services.Localization;
 using Foundry.Deploy.Services.Logging;
@@ -120,7 +121,7 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RebootNowCommand))]
     [NotifyPropertyChangedFor(nameof(CompletionInstructionText))]
-    private int rebootCountdownSeconds = DeploymentRebootPolicy.DefaultDelaySeconds;
+    private int rebootCountdownSeconds = DeploymentRebootDelay.DefaultSeconds;
 
     [ObservableProperty]
     private string failedStepName = string.Empty;
@@ -475,15 +476,22 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
     {
         StopRebootCountdown(resetSeconds: false);
         RebootCountdownSeconds = _rebootPolicy.DelaySeconds;
-        if (_isDebugSafeMode || !_rebootPolicy.AutomaticRebootEnabled)
+        if (_isDebugSafeMode)
         {
             return;
         }
 
-        if (_rebootPolicy.ShouldRebootImmediately)
+        switch (_rebootPolicy.Action)
         {
-            _ = ExecuteRebootAsync();
-            return;
+            case DeploymentRebootAction.WaitForManualReboot:
+                return;
+            case DeploymentRebootAction.RebootImmediately:
+                _ = ExecuteRebootAsync();
+                return;
+            case DeploymentRebootAction.StartCountdown:
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported reboot action: {_rebootPolicy.Action}.");
         }
 
         _rebootCountdownTimer = new DispatcherTimer(DispatcherPriority.Background, _dispatcher)

--- a/src/Foundry.Deploy/ViewModels/DeploymentSessionViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentSessionViewModel.cs
@@ -39,6 +39,7 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
     private bool _isDeploymentInProgress;
     private bool _isRebootInProgress;
     private bool _isDisposed;
+    private DeploymentRebootPolicy _rebootPolicy = DeploymentRebootPolicy.Create(settings: null);
 
     public DeploymentSessionViewModel(
         Dispatcher dispatcher,
@@ -118,8 +119,8 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RebootNowCommand))]
-    [NotifyPropertyChangedFor(nameof(RebootCountdownText))]
-    private int rebootCountdownSeconds = 10;
+    [NotifyPropertyChangedFor(nameof(CompletionInstructionText))]
+    private int rebootCountdownSeconds = DeploymentRebootPolicy.DefaultDelaySeconds;
 
     [ObservableProperty]
     private string failedStepName = string.Empty;
@@ -134,7 +135,17 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
     public bool IsStartupReady => !IsStartupInitializing;
 
     public int PlannedStepCount => _deploymentOrchestrator.PlannedSteps.Count;
-    public string RebootCountdownText => Format("Success.RebootCountdownFormat", RebootCountdownSeconds);
+    public string CompletionInstructionText => _rebootPolicy.AutomaticRebootEnabled && !_isDebugSafeMode
+        ? Format("Success.RebootCountdownFormat", RebootCountdownSeconds)
+        : GetString("Success.ManualRebootInstruction");
+
+    public void ConfigureRebootPolicy(DeploymentRebootPolicy rebootPolicy)
+    {
+        ArgumentNullException.ThrowIfNull(rebootPolicy);
+        _rebootPolicy = rebootPolicy;
+        RebootCountdownSeconds = rebootPolicy.DelaySeconds;
+        OnPropertyChanged(nameof(CompletionInstructionText));
+    }
 
     public void SetComputerName(string computerName)
     {
@@ -357,7 +368,7 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
     {
         if (value == DeploymentPage.Success)
         {
-            StartRebootCountdown();
+            StartConfiguredReboot();
         }
         else
         {
@@ -460,10 +471,21 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
         return startTime.ToLocalTime().ToString("G", CultureInfo.CurrentCulture);
     }
 
-    private void StartRebootCountdown()
+    private void StartConfiguredReboot()
     {
         StopRebootCountdown(resetSeconds: false);
-        RebootCountdownSeconds = 10;
+        RebootCountdownSeconds = _rebootPolicy.DelaySeconds;
+        if (_isDebugSafeMode || !_rebootPolicy.AutomaticRebootEnabled)
+        {
+            return;
+        }
+
+        if (_rebootPolicy.ShouldRebootImmediately)
+        {
+            _ = ExecuteRebootAsync();
+            return;
+        }
+
         _rebootCountdownTimer = new DispatcherTimer(DispatcherPriority.Background, _dispatcher)
         {
             Interval = TimeSpan.FromSeconds(1)
@@ -483,7 +505,7 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
 
         if (resetSeconds)
         {
-            RebootCountdownSeconds = 10;
+            RebootCountdownSeconds = _rebootPolicy.DelaySeconds;
         }
     }
 
@@ -688,7 +710,7 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
                 ? string.Empty
                 : DeploymentUiTextLocalizer.LocalizeMessage(_rawFailedStepErrorMessage);
             StepCounterText = BuildStepCounterText(_activeStepIndex);
-            OnPropertyChanged(nameof(RebootCountdownText));
+            OnPropertyChanged(nameof(CompletionInstructionText));
             CaptureNetworkSnapshot();
         });
     }

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -283,6 +283,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
                 Oobe = _wizardContext.Oobe,
                 AppxRemoval = _wizardContext.AppxRemoval,
                 AiComponentRemoval = _wizardContext.AiComponentRemoval,
+                Completion = _wizardContext.Completion,
                 IsDryRun = IsDebugSafeMode
             });
 

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -468,6 +468,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
 
         _wizardContext.ApplyStartupSnapshot(startupSnapshot);
         IsBootMediaUpdateRecommended = startupSnapshot.IsBootMediaUpdateRecommended;
+        Session.ConfigureRebootPolicy(DeploymentRebootPolicy.Create(_wizardContext.Completion));
         Session.SetComputerName(Preparation.TargetComputerName);
         Session.CompleteStartupInitialization();
     }

--- a/src/Foundry.Deploy/Views/SuccessView.xaml
+++ b/src/Foundry.Deploy/Views/SuccessView.xaml
@@ -36,7 +36,7 @@
                     HorizontalAlignment="Center"
                     Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                     Style="{StaticResource BodyTextBlockStyle}"
-                    Text="{Binding RebootCountdownText}"
+                    Text="{Binding CompletionInstructionText}"
                     TextAlignment="Center" />
                 <Button
                     Width="140"

--- a/src/Foundry.Telemetry.Tests/TelemetryEventPropertyPolicyTests.cs
+++ b/src/Foundry.Telemetry.Tests/TelemetryEventPropertyPolicyTests.cs
@@ -304,4 +304,22 @@ public sealed class TelemetryEventPropertyPolicyTests
         Assert.False(TelemetryEventPropertyPolicy.IsKnownEvent("deployment_completed"));
         Assert.False(TelemetryEventPropertyPolicy.IsKnownEvent("unknown_event"));
     }
+
+    [Fact]
+    public void Sanitize_ForBootMediaFinished_RetainsOnlyApprovedRebootPolicyProperties()
+    {
+        Dictionary<string, object?> input = new()
+        {
+            ["deployment_reboot_mode"] = "countdown",
+            ["deployment_reboot_delay_seconds"] = 42,
+            ["automatic_reboot_enabled"] = true
+        };
+
+        IReadOnlyDictionary<string, object?> result = TelemetryEventPropertyPolicy.Sanitize(TelemetryEvents.OsdBootMediaFinished, input);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("countdown", result["deployment_reboot_mode"]);
+        Assert.Equal(42, result["deployment_reboot_delay_seconds"]);
+        Assert.False(result.ContainsKey("automatic_reboot_enabled"));
+    }
 }

--- a/src/Foundry.Telemetry.Tests/TelemetryEventPropertyPolicyTests.cs
+++ b/src/Foundry.Telemetry.Tests/TelemetryEventPropertyPolicyTests.cs
@@ -322,4 +322,19 @@ public sealed class TelemetryEventPropertyPolicyTests
         Assert.Equal(42, result["deployment_reboot_delay_seconds"]);
         Assert.False(result.ContainsKey("automatic_reboot_enabled"));
     }
+
+    [Fact]
+    public void Sanitize_ForDeploySessionFinished_RetainsCompletionRebootTelemetryProperties()
+    {
+        Dictionary<string, object?> input = new()
+        {
+            ["deploy_completion_reboot_mode"] = "countdown",
+            ["deploy_completion_reboot_delay_seconds"] = 42
+        };
+
+        IReadOnlyDictionary<string, object?> result = TelemetryEventPropertyPolicy.Sanitize(TelemetryEvents.DeploySessionFinished, input);
+
+        Assert.Equal("countdown", result["deploy_completion_reboot_mode"]);
+        Assert.Equal(42, result["deploy_completion_reboot_delay_seconds"]);
+    }
 }

--- a/src/Foundry.Telemetry/TelemetryEventPropertyPolicy.cs
+++ b/src/Foundry.Telemetry/TelemetryEventPropertyPolicy.cs
@@ -166,7 +166,9 @@ public static class TelemetryEventPropertyPolicy
                 "deploy_autopilot_enabled",
                 "deploy_autopilot_provisioning_mode",
                 "deploy_autopilot_hash_upload_state",
-                "deploy_autopilot_hash_group_tag_selected"
+                "deploy_autopilot_hash_group_tag_selected",
+                "deploy_completion_reboot_mode",
+                "deploy_completion_reboot_delay_seconds"
             }
         };
 

--- a/src/Foundry.Telemetry/TelemetryEventPropertyPolicy.cs
+++ b/src/Foundry.Telemetry/TelemetryEventPropertyPolicy.cs
@@ -67,6 +67,8 @@ public static class TelemetryEventPropertyPolicy
                 "boot_media_deploy_runtime_payload_source",
                 "autopilot_enabled",
                 "autopilot_provisioning_mode",
+                "deployment_reboot_mode",
+                "deployment_reboot_delay_seconds",
                 "customization_any_enabled",
                 "customization_machine_naming_enabled",
                 "customization_machine_naming_mode",

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>اختر المنطقة الزمنية المطبقة أثناء النشر.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>بعد النشر الناجح</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>اختر ما إذا كان الجهاز سيُعاد تشغيله بعد النشر وموعد ذلك.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>إعادة التشغيل تلقائيًا</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>التأخير قبل إعادة التشغيل</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>أدخل مهلة من 0 إلى 3600 ثانية. استخدم 0 لإعادة التشغيل فورًا.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>التمهيد الآمن</value>
   </data>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Изберете часовата зона, прилагана по време на разполагане.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>След успешно разполагане</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Изберете дали и кога устройството да се рестартира след разполагането.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Автоматично рестартиране</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Забавяне преди рестартиране</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Въведете забавяне от 0 до 3600 секунди. Използвайте 0 за незабавно рестартиране.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Защитено стартиране</value>
   </data>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Vyberte časové pásmo použité během nasazení.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Po úspěšném nasazení</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Zvolte, zda a kdy se má zařízení po nasazení restartovat.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Restartovat automaticky</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Prodleva před restartováním</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Zadejte prodlevu od 0 do 3600 sekund. Hodnota 0 znamená okamžité restartování.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Zabezpečené spouštění</value>
   </data>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Vælg den tidszone, der anvendes under udrulningen.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Efter fuldført installation</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Vælg, om og hvornår enheden skal genstarte efter installationen.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Genstart automatisk</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Forsinkelse før genstart</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Angiv en forsinkelse på 0 til 3600 sekunder. Brug 0 for at genstarte med det samme.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Sikker start</value>
   </data>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Wählen Sie die Zeitzone aus, die während der Bereitstellung angewendet wird.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Nach erfolgreicher Bereitstellung</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Wählen Sie aus, ob und wann das Gerät nach der Bereitstellung neu gestartet wird.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Automatisch neu starten</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Verzögerung vor dem Neustart</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Geben Sie eine Verzögerung von 0 bis 3600 Sekunden ein. Mit 0 wird sofort neu gestartet.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Sicherer Start</value>
   </data>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Επιλέξτε τη ζώνη ώρας που εφαρμόζεται κατά την ανάπτυξη.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Μετά την επιτυχή ανάπτυξη</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Επιλέξτε αν και πότε θα γίνει επανεκκίνηση της συσκευής μετά την ανάπτυξη.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Αυτόματη επανεκκίνηση</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Καθυστέρηση πριν από την επανεκκίνηση</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Εισαγάγετε καθυστέρηση από 0 έως 3600 δευτερόλεπτα. Χρησιμοποιήστε το 0 για άμεση επανεκκίνηση.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Ασφαλής εκκίνηση</value>
   </data>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Choose the time zone applied during deployment.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>After successful deployment</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Choose whether and when the device restarts after deployment.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Restart automatically</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Delay before restart</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Enter a delay from 0 to 3600 seconds. Use 0 to restart immediately.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Secure Boot</value>
   </data>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Choose the time zone applied during deployment.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>After successful deployment</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Choose whether and when the device restarts after deployment.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Restart automatically</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Delay before restart</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Enter a delay from 0 to 3600 seconds. Use 0 to restart immediately.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Secure Boot</value>
   </data>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Elige la zona horaria aplicada durante la implementación.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Después de una implementación correcta</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Elija si el dispositivo se reinicia después de la implementación y cuándo.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Reiniciar automáticamente</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Retraso antes del reinicio</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Especifique un retraso de 0 a 3600 segundos. Use 0 para reiniciar inmediatamente.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Arranque seguro</value>
   </data>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Elige la zona horaria aplicada durante la implementación.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Después de una implementación correcta</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Elija si el dispositivo se reinicia después de la implementación y cuándo.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Reiniciar automáticamente</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Retraso antes del reinicio</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Ingrese un retraso de 0 a 3600 segundos. Use 0 para reiniciar inmediatamente.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Arranque seguro</value>
   </data>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Valige juurutamise ajal rakendatav ajavöönd.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Pärast edukat juurutamist</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Valige, kas ja millal seade pärast juurutamist taaskäivitatakse.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Taaskäivita automaatselt</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Viivitus enne taaskäivitamist</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Sisestage viivitus 0 kuni 3600 sekundit. Kohe taaskäivitamiseks kasutage väärtust 0.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Turvaline algkäivitus</value>
   </data>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Valitse käyttöönoton aikana käytettävä aikavyöhyke.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Onnistuneen käyttöönoton jälkeen</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Valitse, käynnistetäänkö laite uudelleen käyttöönoton jälkeen ja milloin.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Käynnistä automaattisesti uudelleen</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Viive ennen uudelleenkäynnistystä</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Anna viive väliltä 0–3600 sekuntia. Arvo 0 käynnistää uudelleen heti.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Suojattu käynnistys</value>
   </data>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Choisissez le fuseau horaire appliqué pendant le déploiement.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Après un déploiement réussi</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Choisissez si et quand l’appareil redémarre après le déploiement.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Redémarrer automatiquement</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Délai avant le redémarrage</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Entrez un délai de 0 à 3 600 secondes. Utilisez 0 pour redémarrer immédiatement.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Démarrage sécurisé</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Choisissez le fuseau horaire appliqué pendant le déploiement.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Après un déploiement réussi</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Choisissez si et quand l’appareil redémarre après le déploiement.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Redémarrer automatiquement</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Délai avant le redémarrage</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Saisissez un délai de 0 à 3 600 secondes. Utilisez 0 pour redémarrer immédiatement.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Démarrage sécurisé</value>
   </data>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>בחר את אזור הזמן שיוחל במהלך הפריסה.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>לאחר פריסה מוצלחת</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>בחר אם ומתי המכשיר יופעל מחדש לאחר הפריסה.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>הפעל מחדש באופן אוטומטי</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>השהיה לפני הפעלה מחדש</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>הזן השהיה של 0 עד 3600 שניות. השתמש ב-0 להפעלה מחדש מיידית.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>אתחול מאובטח</value>
   </data>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Odaberite vremensku zonu koja se primjenjuje tijekom implementacije.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Nakon uspješne implementacije</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Odaberite hoće li se i kada uređaj ponovno pokrenuti nakon implementacije.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Automatski ponovno pokreni</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Odgoda prije ponovnog pokretanja</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Unesite odgodu od 0 do 3600 sekundi. Upotrijebite 0 za trenutačno ponovno pokretanje.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Sigurno pokretanje</value>
   </data>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Válassza ki a telepítés során alkalmazott időzónát.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Sikeres üzembe helyezés után</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Válassza ki, hogy az eszköz újrainduljon-e az üzembe helyezés után, és mikor.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Automatikus újraindítás</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Késleltetés újraindítás előtt</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Adjon meg 0 és 3600 másodperc közötti késleltetést. A 0 azonnali újraindítást jelent.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Biztonságos rendszerindítás</value>
   </data>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Scegli il fuso orario applicato durante la distribuzione.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Dopo la distribuzione completata</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Scegliere se e quando riavviare il dispositivo dopo la distribuzione.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Riavvia automaticamente</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Ritardo prima del riavvio</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Immettere un ritardo da 0 a 3600 secondi. Usare 0 per riavviare immediatamente.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Avvio protetto</value>
   </data>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>展開中に適用するタイム ゾーンを選択します。</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>展開が正常に完了した後</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>展開後にデバイスを再起動するかどうかと、そのタイミングを選択します。</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>自動的に再起動する</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>再起動までの待機時間</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>0～3600 秒の待機時間を入力します。すぐに再起動するには 0 を使用します。</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>セキュア ブート</value>
   </data>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>배포 중에 적용할 표준 시간대를 선택합니다.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>배포 성공 후</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>배포 후 장치를 다시 시작할지 여부와 시점을 선택합니다.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>자동으로 다시 시작</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>다시 시작 전 지연 시간</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>0~3600초의 지연 시간을 입력합니다. 즉시 다시 시작하려면 0을 사용하세요.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>보안 부팅</value>
   </data>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Pasirinkite diegimo metu taikomą laiko juostą.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Po sėkmingo diegimo</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Pasirinkite, ar ir kada įrenginys bus paleistas iš naujo po diegimo.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Paleisti iš naujo automatiškai</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Delsa prieš paleidžiant iš naujo</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Įveskite delsą nuo 0 iki 3600 sekundžių. Norėdami paleisti iš naujo iš karto, naudokite 0.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Saugioji įkrova</value>
   </data>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Izvēlieties laika joslu, kas tiek lietota izvietošanas laikā.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Pēc sekmīgas izvietošanas</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Izvēlieties, vai un kad ierīce pēc izvietošanas tiek restartēta.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Restartēt automātiski</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Aizkave pirms restartēšanas</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Ievadiet aizkavi no 0 līdz 3600 sekundēm. Izmantojiet 0, lai restartētu nekavējoties.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Drošā sāknēšana</value>
   </data>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Velg tidssonen som brukes under distribusjon.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Etter vellykket distribusjon</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Velg om og når enheten skal starte på nytt etter distribusjonen.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Start på nytt automatisk</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Forsinkelse før omstart</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Angi en forsinkelse fra 0 til 3600 sekunder. Bruk 0 for å starte på nytt umiddelbart.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Sikker oppstart</value>
   </data>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Kies de tijdzone die tijdens de implementatie wordt toegepast.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Na een geslaagde implementatie</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Kies of en wanneer het apparaat na de implementatie opnieuw wordt opgestart.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Automatisch opnieuw opstarten</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Vertraging vóór opnieuw opstarten</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Voer een vertraging van 0 tot 3600 seconden in. Gebruik 0 om onmiddellijk opnieuw op te starten.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Veilig opstarten</value>
   </data>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Wybierz strefę czasową stosowaną podczas wdrażania.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Po pomyślnym wdrożeniu</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Wybierz, czy i kiedy urządzenie ma zostać ponownie uruchomione po wdrożeniu.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Uruchom ponownie automatycznie</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Opóźnienie przed ponownym uruchomieniem</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Wprowadź opóźnienie od 0 do 3600 sekund. Użyj wartości 0, aby uruchomić ponownie natychmiast.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Bezpieczny rozruch</value>
   </data>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Escolha o fuso horário aplicado durante a implantação.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Após a implantação bem-sucedida</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Escolha se e quando o dispositivo será reiniciado após a implantação.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Reiniciar automaticamente</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Atraso antes de reiniciar</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Insira um atraso de 0 a 3600 segundos. Use 0 para reiniciar imediatamente.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Inicialização segura</value>
   </data>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Escolha o fuso horário aplicado durante a implementação.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Após a implementação bem-sucedida</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Escolha se e quando o dispositivo é reiniciado após a implementação.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Reiniciar automaticamente</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Atraso antes do reinício</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Introduza um atraso de 0 a 3600 segundos. Utilize 0 para reiniciar imediatamente.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Arranque seguro</value>
   </data>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Alegeți fusul orar aplicat în timpul implementării.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>După implementarea reușită</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Alegeți dacă și când repornește dispozitivul după implementare.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Repornește automat</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Întârziere înainte de repornire</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Introduceți o întârziere între 0 și 3600 de secunde. Utilizați 0 pentru repornire imediată.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Pornire securizată</value>
   </data>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Выберите часовой пояс, применяемый во время развертывания.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>После успешного развертывания</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Выберите, следует ли и когда перезапускать устройство после развертывания.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Перезапускать автоматически</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Задержка перед перезапуском</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Введите задержку от 0 до 3600 секунд. Значение 0 означает немедленный перезапуск.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Безопасная загрузка</value>
   </data>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Vyberte časové pásmo použité počas nasadenia.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Po úspešnom nasadení</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Vyberte, či a kedy sa má zariadenie po nasadení reštartovať.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Reštartovať automaticky</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Oneskorenie pred reštartovaním</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Zadajte oneskorenie od 0 do 3600 sekúnd. Hodnota 0 znamená okamžité reštartovanie.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Zabezpečené spustenie</value>
   </data>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Izberite časovni pas, uporabljen med uvedbo.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Po uspešni uvedbi</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Izberite, ali in kdaj naj se naprava po uvedbi znova zažene.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Samodejni ponovni zagon</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Zakasnitev pred ponovnim zagonom</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Vnesite zakasnitev od 0 do 3600 sekund. Za takojšnji ponovni zagon uporabite 0.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Varni zagon</value>
   </data>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Izaberite vremensku zonu koja se primenjuje tokom primene.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Nakon uspešne primene</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Odaberite da li će se i kada uređaj ponovo pokrenuti nakon primene.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Automatski ponovo pokreni</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Odlaganje pre ponovnog pokretanja</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Unesite odlaganje od 0 do 3600 sekundi. Koristite 0 za trenutno ponovno pokretanje.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Bezbedno pokretanje</value>
   </data>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Välj tidszonen som används under distributionen.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Efter slutförd distribution</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Välj om och när enheten ska startas om efter distributionen.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Starta om automatiskt</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Fördröjning före omstart</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Ange en fördröjning från 0 till 3600 sekunder. Använd 0 för att starta om direkt.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Säker start</value>
   </data>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>เลือกเขตเวลาที่ใช้ระหว่างการปรับใช้</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>หลังจากการปรับใช้สำเร็จ</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>เลือกว่าจะให้รีสตาร์ตอุปกรณ์หลังการปรับใช้หรือไม่และเมื่อใด</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>รีสตาร์ตโดยอัตโนมัติ</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>ระยะเวลาก่อนรีสตาร์ต</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>ป้อนระยะเวลาตั้งแต่ 0 ถึง 3600 วินาที ใช้ 0 เพื่อรีสตาร์ตทันที</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>การบูตแบบปลอดภัย</value>
   </data>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Dağıtım sırasında uygulanacak saat dilimini seçin.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Başarılı dağıtımdan sonra</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Dağıtımdan sonra cihazın yeniden başlatılıp başlatılmayacağını ve zamanını seçin.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Otomatik olarak yeniden başlat</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Yeniden başlatma öncesi gecikme</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>0 ile 3600 saniye arasında bir gecikme girin. Hemen yeniden başlatmak için 0 kullanın.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Güvenli Önyükleme</value>
   </data>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>Виберіть часовий пояс, який застосовується під час розгортання.</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>Після успішного розгортання</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Виберіть, чи потрібно та коли перезавантажувати пристрій після розгортання.</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>Перезавантажувати автоматично</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>Затримка перед перезавантаженням</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>Введіть затримку від 0 до 3600 секунд. Значення 0 означає негайне перезавантаження.</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Безпечне завантаження</value>
   </data>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>选择部署期间应用的时区。</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>成功部署后</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>选择设备是否以及何时在部署后重启。</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>自动重启</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>重启前延迟</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>输入 0 到 3600 秒的延迟。使用 0 可立即重启。</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>安全启动</value>
   </data>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -810,6 +810,21 @@
   <data name="GeneralConfiguration.TimeZone.Description" xml:space="preserve">
     <value>選擇部署期間套用的時區。</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
+    <value>成功部署後</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>選擇裝置是否以及何時在部署後重新啟動。</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
+    <value>自動重新啟動</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
+    <value>重新啟動前的延遲</value>
+  </data>
+  <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
+    <value>輸入 0 到 3600 秒的延遲。使用 0 可立即重新啟動。</value>
+  </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>安全開機</value>
   </data>

--- a/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
@@ -61,7 +61,7 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
         IncludeDellDrivers = general.IncludeDellDrivers;
         IncludeHpDrivers = general.IncludeHpDrivers;
         AutomaticRebootEnabled = general.AutomaticRebootEnabled;
-        AutomaticRebootDelaySeconds = general.AutomaticRebootDelaySeconds;
+        AutomaticRebootDelaySeconds = DeploymentRebootDelay.NormalizeRuntime(general.AutomaticRebootDelaySeconds);
         CustomDriverDirectoryPath = general.CustomDriverDirectoryPath ?? string.Empty;
         WinPeLanguageUnavailableDescription = string.Empty;
         RefreshLocalizedText();
@@ -329,7 +329,13 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
             return;
         }
 
-        int delaySeconds = (int)Math.Clamp(Math.Round(value), 0, 3600);
+        int delaySeconds = DeploymentRebootDelay.NormalizeAuthoring(value);
+        if (value != delaySeconds)
+        {
+            AutomaticRebootDelaySeconds = delaySeconds;
+            return;
+        }
+
         Save(configurationStateService.Current.General with { AutomaticRebootDelaySeconds = delaySeconds });
     }
 

--- a/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
@@ -60,6 +60,8 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
         UseCa2023Signature = general.UseCa2023;
         IncludeDellDrivers = general.IncludeDellDrivers;
         IncludeHpDrivers = general.IncludeHpDrivers;
+        AutomaticRebootEnabled = general.AutomaticRebootEnabled;
+        AutomaticRebootDelaySeconds = general.AutomaticRebootDelaySeconds;
         CustomDriverDirectoryPath = general.CustomDriverDirectoryPath ?? string.Empty;
         WinPeLanguageUnavailableDescription = string.Empty;
         RefreshLocalizedText();
@@ -102,6 +104,12 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
 
     [ObservableProperty]
     public partial bool IncludeHpDrivers { get; set; }
+
+    [ObservableProperty]
+    public partial bool AutomaticRebootEnabled { get; set; }
+
+    [ObservableProperty]
+    public partial double AutomaticRebootDelaySeconds { get; set; }
 
     [ObservableProperty]
     public partial string CustomDriverDirectoryPath { get; set; }
@@ -302,6 +310,27 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
         }
 
         Save(configurationStateService.Current.General with { IncludeHpDrivers = value });
+    }
+
+    partial void OnAutomaticRebootEnabledChanged(bool value)
+    {
+        if (isInitializing)
+        {
+            return;
+        }
+
+        Save(configurationStateService.Current.General with { AutomaticRebootEnabled = value });
+    }
+
+    partial void OnAutomaticRebootDelaySecondsChanged(double value)
+    {
+        if (isInitializing || !double.IsFinite(value))
+        {
+            return;
+        }
+
+        int delaySeconds = (int)Math.Clamp(Math.Round(value), 0, 3600);
+        Save(configurationStateService.Current.General with { AutomaticRebootDelaySeconds = delaySeconds });
     }
 
     partial void OnCustomDriverDirectoryPathChanged(string value)

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml
@@ -76,6 +76,27 @@
                             SelectedItem="{x:Bind ViewModel.SelectedTimeZone, Mode=TwoWay}" />
                     </wct:SettingsCard>
 
+                    <wct:SettingsExpander x:Name="DeploymentCompletionCard">
+                        <wct:SettingsExpander.HeaderIcon>
+                            <FontIcon Glyph="&#xE777;" />
+                        </wct:SettingsExpander.HeaderIcon>
+                        <ToggleSwitch x:Name="AutomaticRebootToggle"
+                            IsOn="{x:Bind ViewModel.AutomaticRebootEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <wct:SettingsExpander.Items>
+                            <wct:SettingsCard x:Name="RebootDelayCard">
+                                <NumberBox
+                                    Width="{ThemeResource SettingActionControlMinWidth}"
+                                    IsEnabled="{x:Bind ViewModel.AutomaticRebootEnabled, Mode=OneWay}"
+                                    Maximum="3600"
+                                    Minimum="0"
+                                    SmallChange="1"
+                                    SpinButtonPlacementMode="Compact"
+                                    ValidationMode="InvalidInputOverwritten"
+                                    Value="{x:Bind ViewModel.AutomaticRebootDelaySeconds, Mode=TwoWay}" />
+                            </wct:SettingsCard>
+                        </wct:SettingsExpander.Items>
+                    </wct:SettingsExpander>
+
                     <wct:SettingsExpander x:Name="DriverOptionsCard">
                         <wct:SettingsExpander.HeaderIcon>
                             <FontIcon Glyph="&#xE90F;" />

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
@@ -81,6 +81,13 @@ public sealed partial class GeneralConfigurationPage : Page
         WinPeLanguageCard.Description = localizationService.GetString("StartMedia.WinPeLanguage.Description");
         TimeZoneCard.Header = localizationService.GetString("GeneralConfiguration.TimeZone.Header");
         TimeZoneCard.Description = localizationService.GetString("GeneralConfiguration.TimeZone.Description");
+        DeploymentCompletionCard.Header = localizationService.GetString("GeneralConfiguration.Completion.Header");
+        DeploymentCompletionCard.Description = localizationService.GetString("GeneralConfiguration.Completion.Description");
+        string automaticRebootText = localizationService.GetString("GeneralConfiguration.Completion.AutomaticReboot");
+        AutomaticRebootToggle.OnContent = automaticRebootText;
+        AutomaticRebootToggle.OffContent = automaticRebootText;
+        RebootDelayCard.Header = localizationService.GetString("GeneralConfiguration.Completion.Delay.Header");
+        RebootDelayCard.Description = localizationService.GetString("GeneralConfiguration.Completion.Delay.Description");
 
         DriverOptionsCard.Header = localizationService.GetString("StartMedia.DriverOptions.Header");
         DriverOptionsCard.Description = localizationService.GetString("StartMedia.DriverOptions.Description");


### PR DESCRIPTION
## Summary
Add configurable post-deployment reboot behavior to generated Foundry media and measure adoption through existing privacy-allowlisted telemetry events.

## Reason
Technicians can otherwise return to a machine that rebooted from still-connected USB media and appears ready to start deployment again. Telemetry helps compare how reboot policies are configured with which policies are actively used.

## Main changes
- Keep automatic reboot enabled by default with a 10-second delay.
- Allow automatic reboot to be disabled, delayed from 1 to 3600 seconds, or performed immediately with a zero-second delay.
- Show a localized manual-reboot instruction when automatic reboot is disabled.
- Normalize authored and hand-edited delay values before media generation and at runtime.
- Update Foundry and Deploy schemas and translate the new UI in all 38 supported locales.
- Enrich `osd:boot_media_finished` with authored reboot mode and countdown delay.
- Enrich `deploy:session_finished` with the active completion reboot mode and countdown delay.
- Reuse the existing telemetry events and privacy allowlist; no new event, interaction tracking, or free-form data.

## Testing notes
- `dotnet test src/Foundry.slnx --nologo` (882 passed)
- `dotnet build src/Foundry/Foundry.csproj --nologo` (passed; 106 existing XAML warnings)
- `dotnet build src/Foundry.Deploy/Foundry.Deploy.csproj --nologo` (passed, no warnings)
- `scripts/Test-FoundryFormat.ps1` (856 C# files clean; 44/44 XAML files passed)
- Independent task reviews and final whole-branch review completed with no findings.