### PR TITLE
refactor(utilities): share Windows system inspection

### DIFF
--- a/src/Foundry.Connect.Tests/NetworkBootstrapServiceTests.cs
+++ b/src/Foundry.Connect.Tests/NetworkBootstrapServiceTests.cs
@@ -5,12 +5,30 @@
 using Foundry.Connect.Models.Configuration;
 using Foundry.Connect.Services.Configuration;
 using Foundry.Connect.Services.Network;
+using Foundry.Utilities.Networking;
+using System.Net.NetworkInformation;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Foundry.Connect.Tests;
 
 public sealed class NetworkBootstrapServiceTests
 {
+    [Fact]
+    public void SelectEthernetInterfaceName_UsesFirstNamedEthernetRegardlessOfStatus()
+    {
+        NetworkAdapterSnapshot[] adapters =
+        [
+            CreateAdapter("Wi-Fi", NetworkInterfaceType.Wireless80211, OperationalStatus.Up),
+            CreateAdapter("", NetworkInterfaceType.Ethernet, OperationalStatus.Up),
+            CreateAdapter("Wired 1", NetworkInterfaceType.Ethernet, OperationalStatus.Down),
+            CreateAdapter("Wired 2", NetworkInterfaceType.GigabitEthernet, OperationalStatus.Up)
+        ];
+
+        string? interfaceName = NetworkBootstrapService.SelectEthernetInterfaceName(adapters);
+
+        Assert.Equal("Wired 1", interfaceName);
+    }
+
     [Fact]
     public async Task ApplyProvisionedSettingsAsync_WhenProvisionedWifiHasNoWinPeAdapter_StillCapturesProfileForRoaming()
     {
@@ -91,6 +109,23 @@ public sealed class NetworkBootstrapServiceTests
             WiredCaptureRequest = request;
             return Task.CompletedTask;
         }
+    }
+
+    private static NetworkAdapterSnapshot CreateAdapter(
+        string name,
+        NetworkInterfaceType interfaceType,
+        OperationalStatus operationalStatus)
+    {
+        return new NetworkAdapterSnapshot(
+            name,
+            name,
+            interfaceType,
+            operationalStatus,
+            string.Empty,
+            [],
+            [],
+            [],
+            false);
     }
 
     private sealed class FakeConnectConfigurationService(FoundryConnectConfiguration configuration) : IConnectConfigurationService

--- a/src/Foundry.Connect.Tests/NetworkStatusServiceTests.cs
+++ b/src/Foundry.Connect.Tests/NetworkStatusServiceTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.NetworkInformation;
+using Foundry.Connect.Models.Configuration;
+using Foundry.Connect.Models.Network;
+using Foundry.Connect.Services.Localization;
+using Foundry.Connect.Services.Network;
+using Foundry.Utilities.Networking;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Connect.Tests;
+
+public sealed class NetworkStatusServiceTests
+{
+    [Fact]
+    public async Task GetSnapshotAsync_SelectsFirstConnectedEthernetAdapter()
+    {
+        NetworkAdapterSnapshot[] adapters =
+        [
+            CreateAdapter("Loopback", NetworkInterfaceType.Loopback, OperationalStatus.Up, "127.0.0.1"),
+            CreateAdapter("Disconnected", NetworkInterfaceType.Ethernet, OperationalStatus.Down, "192.0.2.5"),
+            CreateAdapter(
+                "Connected",
+                NetworkInterfaceType.GigabitEthernet,
+                OperationalStatus.Up,
+                "192.0.2.10",
+                gateway: "192.0.2.1",
+                isDhcpEnabled: true),
+            CreateAdapter("Wi-Fi", NetworkInterfaceType.Wireless80211, OperationalStatus.Down)
+        ];
+        NetworkStatusService service = CreateService(new StubNetworkAdapterSnapshotProvider(adapters));
+
+        NetworkStatusSnapshot snapshot = await service.GetSnapshotAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(snapshot.HasEthernetAdapter);
+        Assert.True(snapshot.IsEthernetConnected);
+        Assert.True(snapshot.HasDhcpLease);
+        Assert.True(snapshot.HasEthernetIpv4);
+        Assert.True(snapshot.HasWirelessAdapter);
+        Assert.False(snapshot.IsWifiRuntimeAvailable);
+        Assert.False(snapshot.HasInternetAccess);
+        Assert.Equal("Connected", snapshot.EthernetAdapterName);
+        Assert.Equal("192.0.2.10", snapshot.EthernetIpAddress);
+        Assert.Equal("192.0.2.1", snapshot.EthernetGateway);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_WhenEthernetIsDisconnected_UsesFirstAdapterForDisplay()
+    {
+        NetworkStatusService service = CreateService(new StubNetworkAdapterSnapshotProvider(
+        [
+            CreateAdapter("First", NetworkInterfaceType.Ethernet, OperationalStatus.Down, "198.51.100.5"),
+            CreateAdapter("Second", NetworkInterfaceType.Ethernet, OperationalStatus.Down, "198.51.100.6")
+        ]));
+
+        NetworkStatusSnapshot snapshot = await service.GetSnapshotAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(snapshot.IsEthernetConnected);
+        Assert.False(snapshot.HasDhcpLease);
+        Assert.Equal("First", snapshot.EthernetAdapterName);
+        Assert.Equal("198.51.100.5", snapshot.EthernetIpAddress);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_WhenProviderFails_PropagatesFailure()
+    {
+        NetworkStatusService service = CreateService(new StubNetworkAdapterSnapshotProvider(
+            () => throw new NetworkInformationException()));
+
+        await Assert.ThrowsAsync<NetworkInformationException>(
+            () => service.GetSnapshotAsync(TestContext.Current.CancellationToken));
+    }
+
+    private static NetworkStatusService CreateService(INetworkAdapterSnapshotProvider provider)
+    {
+        var configuration = new FoundryConnectConfiguration
+        {
+            InternetProbe = new InternetProbeOptions { ProbeUris = [] }
+        };
+
+        return new NetworkStatusService(
+            configuration,
+            new LocalizationService(),
+            NullLogger<NetworkStatusService>.Instance,
+            provider);
+    }
+
+    private static NetworkAdapterSnapshot CreateAdapter(
+        string name,
+        NetworkInterfaceType interfaceType,
+        OperationalStatus operationalStatus,
+        string? ipv4Address = null,
+        string? gateway = null,
+        bool isDhcpEnabled = false)
+    {
+        return new NetworkAdapterSnapshot(
+            name,
+            name,
+            interfaceType,
+            operationalStatus,
+            string.Empty,
+            ipv4Address is null ? [] : [new NetworkIpv4AddressSnapshot(ipv4Address, "255.255.255.0")],
+            gateway is null ? [] : [gateway],
+            [],
+            isDhcpEnabled);
+    }
+
+    private sealed class StubNetworkAdapterSnapshotProvider : INetworkAdapterSnapshotProvider
+    {
+        private readonly Func<IReadOnlyList<NetworkAdapterSnapshot>> _getAdapters;
+
+        public StubNetworkAdapterSnapshotProvider(IReadOnlyList<NetworkAdapterSnapshot> adapters)
+            : this(() => adapters)
+        {
+        }
+
+        public StubNetworkAdapterSnapshotProvider(Func<IReadOnlyList<NetworkAdapterSnapshot>> getAdapters)
+        {
+            _getAdapters = getAdapters;
+        }
+
+        public IReadOnlyList<NetworkAdapterSnapshot> GetAdapters() => _getAdapters();
+    }
+}

--- a/src/Foundry.Connect/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Connect/DependencyInjection/ServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ using Foundry.Connect.Services.Runtime;
 using Foundry.Connect.Services.Theme;
 using Foundry.Connect.ViewModels;
 using Foundry.Telemetry;
+using Foundry.Utilities.Networking;
 using Foundry.Utilities.Runtime;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -63,6 +64,7 @@ public static class ServiceCollectionExtensions
                 logger);
         });
         services.AddSingleton<ILocalizationService, LocalizationService>();
+        services.AddSingleton<INetworkAdapterSnapshotProvider, WindowsNetworkAdapterSnapshotProvider>();
         services.AddSingleton<INetworkProfileRoamingService, NetworkProfileRoamingService>();
         services.AddSingleton<INetworkBootstrapService, NetworkBootstrapService>();
         services.AddSingleton<INetworkStatusService, NetworkStatusService>();

--- a/src/Foundry.Connect/Services/Network/NetworkBootstrapService.cs
+++ b/src/Foundry.Connect/Services/Network/NetworkBootstrapService.cs
@@ -12,6 +12,7 @@ using Foundry.Connect.Services.Configuration;
 using Foundry.Connect.Services.Runtime;
 using Foundry.Connect.Services.System;
 using Foundry.Core.Services.Configuration;
+using Foundry.Utilities.Networking;
 using Foundry.Utilities.Processes;
 using Microsoft.Extensions.Logging;
 
@@ -33,6 +34,7 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
     private readonly ILogger<NetworkBootstrapService> _logger;
     private readonly ConnectProcessExecutor _processExecutor;
     private readonly Func<IReadOnlyList<Guid>> _getWifiInterfaceIds;
+    private readonly INetworkAdapterSnapshotProvider _networkAdapterSnapshotProvider;
 
     /// <summary>
     /// Initializes a network bootstrap service.
@@ -41,12 +43,20 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
     /// <param name="configurationService">The configuration service used to resolve relative asset paths.</param>
     /// <param name="networkProfileRoamingService">The service used to capture eligible profiles for Windows import.</param>
     /// <param name="logger">The logger used for network command diagnostics.</param>
+    /// <param name="networkAdapterSnapshotProvider">The provider used to enumerate wired adapters.</param>
     public NetworkBootstrapService(
         FoundryConnectConfiguration configuration,
         IConnectConfigurationService configurationService,
         INetworkProfileRoamingService networkProfileRoamingService,
-        ILogger<NetworkBootstrapService> logger)
-        : this(configuration, configurationService, networkProfileRoamingService, logger, NativeWifiApi.GetInterfaceIds)
+        ILogger<NetworkBootstrapService> logger,
+        INetworkAdapterSnapshotProvider? networkAdapterSnapshotProvider = null)
+        : this(
+            configuration,
+            configurationService,
+            networkProfileRoamingService,
+            logger,
+            NativeWifiApi.GetInterfaceIds,
+            networkAdapterSnapshotProvider)
     {
     }
 
@@ -55,7 +65,8 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
         IConnectConfigurationService configurationService,
         INetworkProfileRoamingService networkProfileRoamingService,
         ILogger<NetworkBootstrapService> logger,
-        Func<IReadOnlyList<Guid>> getWifiInterfaceIds)
+        Func<IReadOnlyList<Guid>> getWifiInterfaceIds,
+        INetworkAdapterSnapshotProvider? networkAdapterSnapshotProvider = null)
     {
         _configuration = configuration;
         _configurationService = configurationService;
@@ -63,6 +74,7 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
         _logger = logger;
         _processExecutor = new ConnectProcessExecutor(logger);
         _getWifiInterfaceIds = getWifiInterfaceIds;
+        _networkAdapterSnapshotProvider = networkAdapterSnapshotProvider ?? new WindowsNetworkAdapterSnapshotProvider();
     }
 
     /// <inheritdoc />
@@ -501,8 +513,14 @@ public sealed class NetworkBootstrapService : INetworkBootstrapService
 
     private string? GetEthernetInterfaceName()
     {
-        return NetworkInterface.GetAllNetworkInterfaces()
-            .Where(static adapter => adapter.NetworkInterfaceType is NetworkInterfaceType.Ethernet
+        return SelectEthernetInterfaceName(_networkAdapterSnapshotProvider.GetAdapters());
+    }
+
+    internal static string? SelectEthernetInterfaceName(
+        IReadOnlyList<NetworkAdapterSnapshot> adapters)
+    {
+        return adapters
+            .Where(static adapter => adapter.InterfaceType is NetworkInterfaceType.Ethernet
                 or NetworkInterfaceType.GigabitEthernet
                 or NetworkInterfaceType.FastEthernetFx
                 or NetworkInterfaceType.FastEthernetT

--- a/src/Foundry.Connect/Services/Network/NetworkStatusService.cs
+++ b/src/Foundry.Connect/Services/Network/NetworkStatusService.cs
@@ -4,12 +4,12 @@
 
 using System.Net.Http;
 using System.Net.NetworkInformation;
-using System.Net.Sockets;
 using System.Diagnostics;
 using Foundry.Connect.Models;
 using Foundry.Connect.Models.Configuration;
 using Foundry.Connect.Services.Localization;
 using Foundry.Connect.Models.Network;
+using Foundry.Utilities.Networking;
 using Microsoft.Extensions.Logging;
 
 namespace Foundry.Connect.Services.Network;
@@ -27,6 +27,7 @@ public sealed class NetworkStatusService : INetworkStatusService
 
     private readonly FoundryConnectConfiguration _configuration;
     private readonly ILocalizationService _localizationService;
+    private readonly INetworkAdapterSnapshotProvider _networkAdapterSnapshotProvider;
     private readonly ILogger<NetworkStatusService> _logger;
     private IReadOnlyList<WifiNetworkSummary> _lastStableWifiNetworks = Array.Empty<WifiNetworkSummary>();
     private DateTimeOffset? _lastStableWifiNetworksAt;
@@ -34,25 +35,27 @@ public sealed class NetworkStatusService : INetworkStatusService
     public NetworkStatusService(
         FoundryConnectConfiguration configuration,
         ILocalizationService localizationService,
-        ILogger<NetworkStatusService> logger)
+        ILogger<NetworkStatusService> logger,
+        INetworkAdapterSnapshotProvider? networkAdapterSnapshotProvider = null)
     {
         _configuration = configuration;
         _localizationService = localizationService;
         _logger = logger;
+        _networkAdapterSnapshotProvider = networkAdapterSnapshotProvider ?? new WindowsNetworkAdapterSnapshotProvider();
     }
 
     public async Task<NetworkStatusSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
     {
         bool isDebugWifiEnabled = Debugger.IsAttached;
-        NetworkInterface[] adapters = NetworkInterface.GetAllNetworkInterfaces()
-            .Where(static adapter => adapter.NetworkInterfaceType is not NetworkInterfaceType.Loopback and not NetworkInterfaceType.Tunnel)
+        NetworkAdapterSnapshot[] adapters = _networkAdapterSnapshotProvider.GetAdapters()
+            .Where(static adapter => adapter.InterfaceType is not NetworkInterfaceType.Loopback and not NetworkInterfaceType.Tunnel)
             .ToArray();
 
-        NetworkInterface[] ethernetAdapters = adapters.Where(IsEthernetAdapter).ToArray();
-        NetworkInterface[] wirelessAdapters = adapters.Where(static adapter => adapter.NetworkInterfaceType == NetworkInterfaceType.Wireless80211).ToArray();
+        NetworkAdapterSnapshot[] ethernetAdapters = adapters.Where(IsEthernetAdapter).ToArray();
+        NetworkAdapterSnapshot[] wirelessAdapters = adapters.Where(static adapter => adapter.InterfaceType == NetworkInterfaceType.Wireless80211).ToArray();
 
-        NetworkInterface? connectedEthernetAdapter = ethernetAdapters.FirstOrDefault(static adapter => adapter.OperationalStatus == OperationalStatus.Up);
-        NetworkInterface? ethernetDisplayAdapter = connectedEthernetAdapter ?? ethernetAdapters.FirstOrDefault();
+        NetworkAdapterSnapshot? connectedEthernetAdapter = ethernetAdapters.FirstOrDefault(static adapter => adapter.OperationalStatus == OperationalStatus.Up);
+        NetworkAdapterSnapshot? ethernetDisplayAdapter = connectedEthernetAdapter ?? ethernetAdapters.FirstOrDefault();
 
         bool hasEthernetAdapter = ethernetAdapters.Length > 0;
         bool isEthernetConnected = ethernetAdapters.Any(static adapter => adapter.OperationalStatus == OperationalStatus.Up);
@@ -63,17 +66,11 @@ public sealed class NetworkStatusService : INetworkStatusService
         IReadOnlyList<WifiNetworkSummary> wifiNetworks = isWifiRuntimeAvailable
             ? await DiscoverWifiNetworksAsync(cancellationToken).ConfigureAwait(false)
             : Array.Empty<WifiNetworkSummary>();
-        bool hasDhcpLease = HasDhcpLease(connectedEthernetAdapter);
+        bool hasDhcpLease = connectedEthernetAdapter?.IsDhcpEnabled == true;
         bool hasInternetAccess = await ProbeInternetAsync(cancellationToken).ConfigureAwait(false);
 
-        UnicastIPAddressInformation? ethernetIpv4Information = ethernetDisplayAdapter?
-            .GetIPProperties()
-            .UnicastAddresses
-            .FirstOrDefault(static address => address.Address.AddressFamily == AddressFamily.InterNetwork);
-        GatewayIPAddressInformation? ethernetGatewayInformation = connectedEthernetAdapter?
-            .GetIPProperties()
-            .GatewayAddresses
-            .FirstOrDefault(static gateway => gateway.Address.AddressFamily == AddressFamily.InterNetwork);
+        NetworkIpv4AddressSnapshot? ethernetIpv4Information = ethernetDisplayAdapter?.Ipv4Addresses.FirstOrDefault();
+        string? ethernetGateway = connectedEthernetAdapter?.Gateways.FirstOrDefault();
         bool hasEthernetIpv4 = ethernetIpv4Information is not null;
 
         return new NetworkStatusSnapshot
@@ -89,8 +86,8 @@ public sealed class NetworkStatusService : INetworkStatusService
             EthernetStatusText = BuildEthernetStatusText(hasEthernetAdapter, isEthernetConnected, hasEthernetIpv4),
             EthernetSecondaryStatusText = BuildEthernetSecondaryStatusText(hasEthernetAdapter, isEthernetConnected, hasEthernetIpv4, hasDhcpLease),
             EthernetAdapterName = ethernetDisplayAdapter?.Name ?? GetString("Common.Unavailable"),
-            EthernetIpAddress = ethernetIpv4Information?.Address.ToString() ?? GetString("Common.Unavailable"),
-            EthernetGateway = ethernetGatewayInformation?.Address.ToString() ?? GetString("Common.Unavailable"),
+            EthernetIpAddress = ethernetIpv4Information?.Address ?? GetString("Common.Unavailable"),
+            EthernetGateway = ethernetGateway ?? GetString("Common.Unavailable"),
             ConnectedWifiSsid = connectedWifiSsid,
             WifiNetworks = wifiNetworks
         };
@@ -177,25 +174,13 @@ public sealed class NetworkStatusService : INetworkStatusService
         }
     }
 
-    private static bool IsEthernetAdapter(NetworkInterface adapter)
+    private static bool IsEthernetAdapter(NetworkAdapterSnapshot adapter)
     {
-        return adapter.NetworkInterfaceType is NetworkInterfaceType.Ethernet
+        return adapter.InterfaceType is NetworkInterfaceType.Ethernet
             or NetworkInterfaceType.GigabitEthernet
             or NetworkInterfaceType.FastEthernetFx
             or NetworkInterfaceType.FastEthernetT
             or NetworkInterfaceType.Ethernet3Megabit;
-    }
-
-    private static bool HasDhcpLease(NetworkInterface? adapter)
-    {
-        try
-        {
-            return adapter?.GetIPProperties().GetIPv4Properties()?.IsDhcpEnabled == true;
-        }
-        catch
-        {
-            return false;
-        }
     }
 
     private string BuildEthernetStatusText(bool hasEthernetAdapter, bool isEthernetConnected, bool hasEthernetIpv4)

--- a/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeUsbMediaService.cs
@@ -2,8 +2,9 @@
 // Licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
-using System.Text;
 using System.Text.Json;
+using Foundry.Utilities.Processes;
+using Foundry.Utilities.Serialization;
 
 namespace Foundry.Core.Services.WinPe;
 
@@ -670,8 +671,7 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
             formatMode);
 
         Directory.CreateDirectory(workingDirectoryPath);
-        string encodedScript = Convert.ToBase64String(Encoding.Unicode.GetBytes(script));
-        string arguments = $"-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand {encodedScript}";
+        string arguments = CreatePowerShellArguments(script);
         var provisioningOutput = new UsbProvisioningOutputForwarder(progress);
         WinPeProcessExecution execution = _processRunner is IWinPeProcessOutputRunner outputRunner
             ? await outputRunner.RunWithOutputAsync(
@@ -840,8 +840,7 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
             formatMode);
 
         Directory.CreateDirectory(workingDirectoryPath);
-        string encodedScript = Convert.ToBase64String(Encoding.Unicode.GetBytes(script));
-        string arguments = $"-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand {encodedScript}";
+        string arguments = CreatePowerShellArguments(script);
         var provisioningOutput = new UsbProvisioningOutputForwarder(progress);
         WinPeProcessExecution execution = _processRunner is IWinPeProcessOutputRunner outputRunner
             ? await outputRunner.RunWithOutputAsync(
@@ -1065,10 +1064,9 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
         string workingDirectoryPath,
         CancellationToken cancellationToken)
     {
-        string encodedScript = Convert.ToBase64String(Encoding.Unicode.GetBytes(script));
         WinPeProcessExecution execution = await _processRunner.RunAsync(
             tools.PowerShellPath,
-            $"-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand {encodedScript}",
+            CreatePowerShellArguments(script),
             workingDirectoryPath,
             cancellationToken).ConfigureAwait(false);
 
@@ -1094,23 +1092,10 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
 
     private static IReadOnlyList<WinPeUsbDiskCandidate> ParseUsbCandidates(string json)
     {
-        using JsonDocument document = JsonDocument.Parse(json);
         var candidates = new List<WinPeUsbDiskCandidate>();
-
-        if (document.RootElement.ValueKind == JsonValueKind.Array)
+        foreach (JsonElement element in JsonObjectSequence.Parse(json))
         {
-            foreach (JsonElement element in document.RootElement.EnumerateArray())
-            {
-                WinPeUsbDiskCandidate? candidate = ParseUsbCandidate(element);
-                if (candidate is not null)
-                {
-                    candidates.Add(candidate);
-                }
-            }
-        }
-        else if (document.RootElement.ValueKind == JsonValueKind.Object)
-        {
-            WinPeUsbDiskCandidate? candidate = ParseUsbCandidate(document.RootElement);
+            WinPeUsbDiskCandidate? candidate = ParseUsbCandidate(element);
             if (candidate is not null)
             {
                 candidates.Add(candidate);
@@ -1118,6 +1103,19 @@ public sealed class WinPeUsbMediaService : IWinPeUsbMediaService
         }
 
         return candidates;
+    }
+
+    private static string CreatePowerShellArguments(string script)
+    {
+        return string.Join(
+            ' ',
+            [
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy",
+                "Bypass",
+                .. PowerShellCommand.CreateEncodedArguments(script)
+            ]);
     }
 
     private static WinPeUsbDiskCandidate? ParseUsbCandidate(JsonElement element)

--- a/src/Foundry.Deploy.Tests/CacheLocatorServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/CacheLocatorServiceTests.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using Foundry.Deploy.Models;
 using Foundry.Deploy.Services.Cache;
+using Foundry.Utilities.Storage;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Foundry.Deploy.Tests;
@@ -13,9 +15,11 @@ public sealed class CacheLocatorServiceTests
     [Fact]
     public async Task ResolveAsync_WhenIsoModeAndPreferredPathMissing_UsesIsoPolicyRoot()
     {
-        var service = new CacheLocatorService(NullLogger<CacheLocatorService>.Instance);
+        var service = CreateService();
 
-        CacheResolution result = await service.ResolveAsync(DeploymentMode.Iso);
+        CacheResolution result = await service.ResolveAsync(
+            DeploymentMode.Iso,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(@"X:\Foundry\Runtime", result.RootPath);
         Assert.Equal("ISO policy root", result.Source);
@@ -24,11 +28,40 @@ public sealed class CacheLocatorServiceTests
     [Fact]
     public async Task ResolveAsync_WhenUsbModeAndPreferredPathIsExplicit_UsesPreferredPath()
     {
-        var service = new CacheLocatorService(NullLogger<CacheLocatorService>.Instance);
+        var service = CreateService();
 
-        CacheResolution result = await service.ResolveAsync(DeploymentMode.Usb, @" C:\CacheRoot ");
+        CacheResolution result = await service.ResolveAsync(
+            DeploymentMode.Usb,
+            @" C:\CacheRoot ",
+            TestContext.Current.CancellationToken);
 
         Assert.Equal(@"C:\CacheRoot", result.RootPath);
         Assert.Equal("Preferred path", result.Source);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WhenUsbModeUsesTransientPlaceholder_FindsCacheLabelIgnoringCase()
+    {
+        var service = CreateService(new VolumeInfo(@"F:\", "fOuNdRy CaChE", DriveType.Removable, true, 100));
+
+        CacheResolution result = await service.ResolveAsync(
+            DeploymentMode.Usb,
+            @"X:\Foundry\Runtime",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(@"F:\Runtime", result.RootPath);
+        Assert.Equal("Detected USB cache partition", result.Source);
+    }
+
+    private static CacheLocatorService CreateService(params VolumeInfo[] volumes)
+    {
+        return new CacheLocatorService(
+            NullLogger<CacheLocatorService>.Instance,
+            new StubVolumeDiscovery(volumes));
+    }
+
+    private sealed class StubVolumeDiscovery(IReadOnlyList<VolumeInfo> volumes) : IVolumeDiscovery
+    {
+        public IReadOnlyList<VolumeInfo> GetVolumes() => volumes;
     }
 }

--- a/src/Foundry.Deploy.Tests/DeploymentRuntimeContextServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentRuntimeContextServiceTests.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using Foundry.Deploy.Models;
+using Foundry.Deploy.Services.Runtime;
+using Foundry.Utilities.Storage;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class DeploymentRuntimeContextServiceTests
+{
+    [Fact]
+    public void Resolve_WhenEnvironmentForcesIso_IgnoresDetectedUsbVolume()
+    {
+        var service = CreateService("iso", CreateVolume(@"F:\", "Foundry Cache"));
+
+        DeploymentRuntimeContext result = service.Resolve();
+
+        Assert.Equal(DeploymentMode.Iso, result.Mode);
+        Assert.Null(result.UsbCacheRuntimeRoot);
+    }
+
+    [Fact]
+    public void Resolve_WhenEnvironmentForcesUsb_UsesDetectedRuntimeRoot()
+    {
+        var service = CreateService(" USB ", CreateVolume(@"F:\", "fOuNdRy CaChE"));
+
+        DeploymentRuntimeContext result = service.Resolve();
+
+        Assert.Equal(DeploymentMode.Usb, result.Mode);
+        Assert.Equal(@"F:\Runtime", result.UsbCacheRuntimeRoot);
+    }
+
+    [Fact]
+    public void Resolve_WhenEnvironmentIsMissingAndCacheVolumeExists_DetectsUsbMode()
+    {
+        var service = CreateService(null, CreateVolume(@"G:\", "Foundry Cache"));
+
+        DeploymentRuntimeContext result = service.Resolve();
+
+        Assert.Equal(DeploymentMode.Usb, result.Mode);
+        Assert.Equal(@"G:\Runtime", result.UsbCacheRuntimeRoot);
+    }
+
+    [Fact]
+    public void Resolve_WhenEnvironmentIsMissingAndCacheVolumeDoesNotExist_FallsBackToIsoMode()
+    {
+        var service = CreateService(null, CreateVolume(@"C:\", "Windows"));
+
+        DeploymentRuntimeContext result = service.Resolve();
+
+        Assert.Equal(DeploymentMode.Iso, result.Mode);
+        Assert.Null(result.UsbCacheRuntimeRoot);
+    }
+
+    private static DeploymentRuntimeContextService CreateService(string? deploymentMode, params VolumeInfo[] volumes)
+    {
+        return new DeploymentRuntimeContextService(
+            new StubVolumeDiscovery(volumes),
+            variableName => variableName == "FOUNDRY_DEPLOYMENT_MODE" ? deploymentMode : null);
+    }
+
+    private static VolumeInfo CreateVolume(string rootPath, string label)
+    {
+        return new VolumeInfo(rootPath, label, DriveType.Fixed, true, 100);
+    }
+
+    private sealed class StubVolumeDiscovery(IReadOnlyList<VolumeInfo> volumes) : IVolumeDiscovery
+    {
+        public IReadOnlyList<VolumeInfo> GetVolumes() => volumes;
+    }
+}

--- a/src/Foundry.Deploy.Tests/DeploymentSessionNetworkSnapshotTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentSessionNetworkSnapshotTests.cs
@@ -41,6 +41,29 @@ public sealed class DeploymentSessionNetworkSnapshotTests
         Assert.Null(adapter);
     }
 
+    [Fact]
+    public void CreateNetworkSnapshot_MapsFirstAddressMaskGatewayAndMac()
+    {
+        NetworkAdapterSnapshot adapter = new(
+            "ethernet-id",
+            "Ethernet",
+            NetworkInterfaceType.Ethernet,
+            OperationalStatus.Up,
+            "00-11-AA-BB-CC-DD",
+            [new NetworkIpv4AddressSnapshot("192.0.2.10", "255.255.255.0")],
+            ["192.0.2.1"],
+            [],
+            true);
+
+        var snapshot = DeploymentSessionViewModel.CreateNetworkSnapshot([adapter]);
+
+        Assert.NotNull(snapshot);
+        Assert.Equal("192.0.2.10", snapshot.Value.IpAddress);
+        Assert.Equal("255.255.255.0", snapshot.Value.SubnetMask);
+        Assert.Equal("192.0.2.1", snapshot.Value.GatewayAddress);
+        Assert.Equal("00-11-AA-BB-CC-DD", snapshot.Value.MacAddress);
+    }
+
     private static NetworkAdapterSnapshot CreateAdapter(
         string name,
         NetworkInterfaceType interfaceType,

--- a/src/Foundry.Deploy.Tests/DeploymentSessionNetworkSnapshotTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentSessionNetworkSnapshotTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.NetworkInformation;
+using Foundry.Deploy.ViewModels;
+using Foundry.Utilities.Networking;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class DeploymentSessionNetworkSnapshotTests
+{
+    [Fact]
+    public void SelectNetworkAdapter_UsesFirstConnectedNonVirtualAdapterWithIpv4()
+    {
+        NetworkAdapterSnapshot[] adapters =
+        [
+            CreateAdapter("Loopback", NetworkInterfaceType.Loopback, OperationalStatus.Up, hasIpv4: true),
+            CreateAdapter("Down", NetworkInterfaceType.Ethernet, OperationalStatus.Down, hasIpv4: true),
+            CreateAdapter("No address", NetworkInterfaceType.Ethernet, OperationalStatus.Up, hasIpv4: false),
+            CreateAdapter("Selected", NetworkInterfaceType.Ethernet, OperationalStatus.Up, hasIpv4: true),
+            CreateAdapter("Later", NetworkInterfaceType.Ethernet, OperationalStatus.Up, hasIpv4: true)
+        ];
+
+        NetworkAdapterSnapshot? adapter = DeploymentSessionViewModel.SelectNetworkAdapter(adapters);
+
+        Assert.Equal("Selected", adapter?.Name);
+    }
+
+    [Fact]
+    public void SelectNetworkAdapter_WhenNoAdapterMatches_ReturnsNull()
+    {
+        NetworkAdapterSnapshot[] adapters =
+        [
+            CreateAdapter("Tunnel", NetworkInterfaceType.Tunnel, OperationalStatus.Up, hasIpv4: true),
+            CreateAdapter("Down", NetworkInterfaceType.Ethernet, OperationalStatus.Down, hasIpv4: true)
+        ];
+
+        NetworkAdapterSnapshot? adapter = DeploymentSessionViewModel.SelectNetworkAdapter(adapters);
+
+        Assert.Null(adapter);
+    }
+
+    private static NetworkAdapterSnapshot CreateAdapter(
+        string name,
+        NetworkInterfaceType interfaceType,
+        OperationalStatus operationalStatus,
+        bool hasIpv4)
+    {
+        return new NetworkAdapterSnapshot(
+            name,
+            name,
+            interfaceType,
+            operationalStatus,
+            "00-11-22-33-44-55",
+            hasIpv4 ? [new NetworkIpv4AddressSnapshot("192.0.2.10", "255.255.255.0")] : [],
+            ["192.0.2.1"],
+            [],
+            true);
+    }
+}

--- a/src/Foundry.Deploy.Tests/HardwareProfileServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/HardwareProfileServiceTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Deploy.Models;
+using Foundry.Deploy.Services.Hardware;
+using Foundry.Utilities.Hardware;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class HardwareProfileServiceTests
+{
+    [Fact]
+    public async Task GetCurrentAsync_MapsSnapshotAndAppliesDeployPresentationPolicy()
+    {
+        var snapshot = new HardwareSnapshot(
+            "Hewlett-Packard",
+            " ",
+            "EliteBook",
+            "SERIAL",
+            "x64",
+            false,
+            true,
+            true,
+            "UEFI\\RES_{FIRMWARE}",
+            [new PnpDeviceSnapshot("Device", "PCI\\VEN_1234", ["PCI\\VEN_1234"], "{CLASS}", "Vendor", "Net")]);
+        var service = CreateService(_ => Task.FromResult(snapshot));
+
+        HardwareProfile profile = await service.GetCurrentAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal("HP", profile.Manufacturer);
+        Assert.Equal("Unknown", profile.Model);
+        Assert.Equal("EliteBook", profile.Product);
+        Assert.Equal("SERIAL", profile.SerialNumber);
+        Assert.Equal("x64", profile.Architecture);
+        Assert.False(profile.IsVirtualMachine);
+        Assert.True(profile.IsOnBattery);
+        Assert.True(profile.IsTpmPresent);
+        Assert.Equal("UEFI\\RES_{FIRMWARE}", profile.SystemFirmwareHardwareId);
+        Assert.Equal("HP | Unknown | EliteBook | x64", profile.DisplayLabel);
+
+        PnpDeviceInfo device = Assert.Single(profile.PnpDevices);
+        Assert.Equal("Device", device.Name);
+        Assert.Equal("PCI\\VEN_1234", device.DeviceId);
+        Assert.Equal(["PCI\\VEN_1234"], device.HardwareIds);
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_WhenInspectionDataIsUnavailable_UsesFallbackProfile()
+    {
+        var service = CreateService(_ => Task.FromException<HardwareSnapshot>(new InvalidDataException()));
+
+        HardwareProfile profile = await service.GetCurrentAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal("Unknown", profile.Manufacturer);
+        Assert.Equal("Unknown", profile.Model);
+        Assert.Equal("Unknown", profile.Product);
+        Assert.Equal("Unknown", profile.SerialNumber);
+        Assert.False(profile.IsVirtualMachine);
+        Assert.Empty(profile.PnpDevices);
+    }
+
+    [Theory]
+    [InlineData(typeof(InvalidOperationException))]
+    [InlineData(typeof(ApplicationException))]
+    public async Task GetCurrentAsync_WhenInspectionFailsUnexpectedly_PropagatesFailure(Type exceptionType)
+    {
+        Exception exception = (Exception)Activator.CreateInstance(exceptionType)!;
+        var service = CreateService(_ => Task.FromException<HardwareSnapshot>(exception));
+
+        Exception thrown = await Assert.ThrowsAnyAsync<Exception>(
+            () => service.GetCurrentAsync(TestContext.Current.CancellationToken));
+
+        Assert.IsType(exceptionType, thrown);
+    }
+
+    private static HardwareProfileService CreateService(
+        Func<CancellationToken, Task<HardwareSnapshot>> getCurrent)
+    {
+        return new HardwareProfileService(
+            new StubHardwareInspector(getCurrent),
+            NullLogger<HardwareProfileService>.Instance);
+    }
+
+    private sealed class StubHardwareInspector(
+        Func<CancellationToken, Task<HardwareSnapshot>> getCurrent) : IHardwareInspector
+    {
+        public Task<HardwareSnapshot> GetCurrentAsync(CancellationToken cancellationToken = default)
+            => getCurrent(cancellationToken);
+    }
+}

--- a/src/Foundry.Deploy.Tests/TargetDiskServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/TargetDiskServiceTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Deploy.Models;
+using Foundry.Deploy.Services.Hardware;
+using Foundry.Deploy.Services.Localization;
+using Foundry.Utilities.Storage;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class TargetDiskServiceTests
+{
+    [Fact]
+    public async Task GetDisksAsync_MapsFactsAndAppliesTargetSelectionPolicy()
+    {
+        DiskInfo[] snapshots =
+        [
+            new(0, "System", "", "NVMe", "GPT", 1024, true, false, false, false, false),
+            new(2, "USB media", "USB-2", "USB", "GPT", 2048, false, false, false, false, true),
+            new(1, "Target", "SERIAL-1", "SATA", "GPT", 4096, false, false, false, false, false),
+            new(3, "Removable target", "SERIAL-3", "SD", "GPT", 8192, false, false, false, false, true)
+        ];
+        var service = CreateService(getDisks: _ => Task.FromResult<IReadOnlyList<DiskInfo>>(snapshots));
+
+        IReadOnlyList<TargetDiskInfo> disks = await service.GetDisksAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal([1, 3, 0], disks.Select(static disk => disk.DiskNumber));
+        Assert.True(disks[0].IsSelectable);
+        Assert.Equal("Target", disks[0].FriendlyName);
+        Assert.Equal("SERIAL-1", disks[0].SerialNumber);
+        Assert.True(disks[1].IsSelectable);
+        Assert.True(disks[1].IsRemovable);
+        Assert.False(disks[2].IsSelectable);
+        Assert.Equal(LocalizationText.GetString("Disk.BlockedSystemDisk"), disks[2].SelectionWarning);
+        Assert.Equal(LocalizationText.GetString("Common.Unknown"), disks[2].SerialNumber);
+    }
+
+    [Fact]
+    public async Task GetDisksAsync_WhenInspectionDataIsInvalid_ReturnsEmptyList()
+    {
+        var service = CreateService(getDisks: _ => Task.FromException<IReadOnlyList<DiskInfo>>(
+            new InvalidDataException()));
+
+        IReadOnlyList<TargetDiskInfo> disks = await service.GetDisksAsync(TestContext.Current.CancellationToken);
+
+        Assert.Empty(disks);
+    }
+
+    [Fact]
+    public async Task GetDisksAsync_WhenInspectionFailsUnexpectedly_PropagatesFailure()
+    {
+        var service = CreateService(getDisks: _ => Task.FromException<IReadOnlyList<DiskInfo>>(
+            new ApplicationException("Unexpected failure.")));
+
+        await Assert.ThrowsAsync<ApplicationException>(
+            () => service.GetDisksAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task GetDisksAsync_WhenInspectionIsCanceled_PropagatesCancellation()
+    {
+        using var cancellationSource = new CancellationTokenSource();
+        cancellationSource.Cancel();
+        var service = CreateService(getDisks: cancellationToken =>
+            Task.FromCanceled<IReadOnlyList<DiskInfo>>(cancellationToken));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => service.GetDisksAsync(cancellationSource.Token));
+    }
+
+    [Fact]
+    public async Task GetDiskNumberForPathAsync_DelegatesToInspector()
+    {
+        string? capturedPath = null;
+        var service = CreateService(resolveDisk: (path, _) =>
+        {
+            capturedPath = path;
+            return Task.FromResult<int?>(3);
+        });
+
+        int? diskNumber = await service.GetDiskNumberForPathAsync(
+            "X:\\Foundry",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, diskNumber);
+        Assert.Equal("X:\\Foundry", capturedPath);
+    }
+
+    [Fact]
+    public async Task GetDiskNumberForPathAsync_WhenInspectionDataIsInvalid_ReturnsNull()
+    {
+        var service = CreateService(resolveDisk: (_, _) => Task.FromException<int?>(new InvalidDataException()));
+
+        int? diskNumber = await service.GetDiskNumberForPathAsync(
+            "X:\\Foundry",
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(diskNumber);
+    }
+
+    private static TargetDiskService CreateService(
+        Func<CancellationToken, Task<IReadOnlyList<DiskInfo>>>? getDisks = null,
+        Func<string, CancellationToken, Task<int?>>? resolveDisk = null)
+    {
+        return new TargetDiskService(
+            new StubDiskInspector(
+                getDisks ?? (_ => Task.FromResult<IReadOnlyList<DiskInfo>>([])),
+                resolveDisk ?? ((_, _) => Task.FromResult<int?>(null))),
+            NullLogger<TargetDiskService>.Instance);
+    }
+
+    private sealed class StubDiskInspector(
+        Func<CancellationToken, Task<IReadOnlyList<DiskInfo>>> getDisks,
+        Func<string, CancellationToken, Task<int?>> resolveDisk) : IWindowsDiskInspector
+    {
+        public Task<IReadOnlyList<DiskInfo>> GetDisksAsync(CancellationToken cancellationToken = default)
+            => getDisks(cancellationToken);
+
+        public Task<int?> ResolveDiskNumberForPathAsync(
+            string path,
+            CancellationToken cancellationToken = default)
+            => resolveDisk(path, cancellationToken);
+    }
+}

--- a/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ using Foundry.Deploy.Services.Theme;
 using Foundry.Deploy.Services.Wizard;
 using Foundry.Deploy.ViewModels;
 using Foundry.Telemetry;
+using Foundry.Utilities.Hardware;
 using Foundry.Utilities.Runtime;
 using Foundry.Utilities.Storage;
 using Microsoft.Extensions.DependencyInjection;
@@ -89,6 +90,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IArchiveExtractionService, ArchiveExtractionService>();
         services.AddSingleton<ICacheLocatorService, CacheLocatorService>();
         services.AddSingleton<IDeploymentLogService, DeploymentLogService>();
+        services.AddSingleton<IHardwareInspector, WindowsHardwareInspector>();
         services.AddSingleton<IHardwareProfileService, HardwareProfileService>();
         services.AddSingleton<IOfflineWindowsComputerNameService, OfflineWindowsComputerNameService>();
         services.AddSingleton<ITargetDiskService, TargetDiskService>();

--- a/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ using Foundry.Deploy.Services.Wizard;
 using Foundry.Deploy.ViewModels;
 using Foundry.Telemetry;
 using Foundry.Utilities.Hardware;
+using Foundry.Utilities.Networking;
 using Foundry.Utilities.Runtime;
 using Foundry.Utilities.Storage;
 using Microsoft.Extensions.DependencyInjection;
@@ -92,6 +93,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IDeploymentLogService, DeploymentLogService>();
         services.AddSingleton<IHardwareInspector, WindowsHardwareInspector>();
         services.AddSingleton<IHardwareProfileService, HardwareProfileService>();
+        services.AddSingleton<INetworkAdapterSnapshotProvider, WindowsNetworkAdapterSnapshotProvider>();
         services.AddSingleton<IOfflineWindowsComputerNameService, OfflineWindowsComputerNameService>();
         services.AddSingleton<IWindowsDiskInspector, WindowsDiskInspector>();
         services.AddSingleton<ITargetDiskService, TargetDiskService>();

--- a/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ using Foundry.Deploy.Services.Wizard;
 using Foundry.Deploy.ViewModels;
 using Foundry.Telemetry;
 using Foundry.Utilities.Runtime;
+using Foundry.Utilities.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using UtilityProcessRunner = Foundry.Utilities.Processes.ProcessRunner;
@@ -52,6 +53,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IDeploymentWizardContextFactory, DeploymentWizardContextFactory>();
         services.AddSingleton<IDeploymentStartupCoordinator, DeploymentStartupCoordinator>();
         services.AddSingleton<IOperationProgressService, OperationProgressService>();
+        services.AddSingleton<IVolumeDiscovery, WindowsVolumeDiscovery>();
         services.AddSingleton<IDeploymentRuntimeContextService, DeploymentRuntimeContextService>();
         services.AddSingleton<IDeployConfigurationService, DeployConfigurationService>();
         services.AddSingleton(CreateTelemetryOptions);

--- a/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
@@ -93,6 +93,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IHardwareInspector, WindowsHardwareInspector>();
         services.AddSingleton<IHardwareProfileService, HardwareProfileService>();
         services.AddSingleton<IOfflineWindowsComputerNameService, OfflineWindowsComputerNameService>();
+        services.AddSingleton<IWindowsDiskInspector, WindowsDiskInspector>();
         services.AddSingleton<ITargetDiskService, TargetDiskService>();
         services.AddSingleton<IOperatingSystemCatalogService, OperatingSystemCatalogService>();
         services.AddSingleton<IDriverPackCatalogService, DriverPackCatalogService>();

--- a/src/Foundry.Deploy/Services/Cache/CacheLocatorService.cs
+++ b/src/Foundry.Deploy/Services/Cache/CacheLocatorService.cs
@@ -2,8 +2,9 @@
 // Licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
-using Foundry.Deploy.Models;
 using System.IO;
+using Foundry.Deploy.Models;
+using Foundry.Utilities.Storage;
 using Microsoft.Extensions.Logging;
 
 namespace Foundry.Deploy.Services.Cache;
@@ -15,10 +16,19 @@ public sealed class CacheLocatorService : ICacheLocatorService
     private const string CacheVolumeLabel = "Foundry Cache";
     private const string RuntimeFolderName = "Runtime";
     private readonly ILogger<CacheLocatorService> _logger;
+    private readonly IVolumeDiscovery _volumeDiscovery;
 
     public CacheLocatorService(ILogger<CacheLocatorService> logger)
+        : this(logger, new WindowsVolumeDiscovery())
+    {
+    }
+
+    public CacheLocatorService(
+        ILogger<CacheLocatorService> logger,
+        IVolumeDiscovery volumeDiscovery)
     {
         _logger = logger;
+        _volumeDiscovery = volumeDiscovery;
     }
 
     public Task<CacheResolution> ResolveAsync(
@@ -50,7 +60,7 @@ public sealed class CacheLocatorService : ICacheLocatorService
             hasPreferred ? "Preferred path" : "ISO policy root");
     }
 
-    private static CacheResolution ResolveUsb(string preferredRoot)
+    private CacheResolution ResolveUsb(string preferredRoot)
     {
         // USB mode:
         // 1) honor explicit preferred path when it is not the WinPE transient placeholder
@@ -87,27 +97,19 @@ public sealed class CacheLocatorService : ICacheLocatorService
         };
     }
 
-    private static string? FindUsbCacheRuntimeRoot()
+    private string? FindUsbCacheRuntimeRoot()
     {
-        foreach (DriveInfo drive in DriveInfo.GetDrives())
+        foreach (VolumeInfo volume in _volumeDiscovery.GetVolumes())
         {
-            if (!drive.IsReady)
+            if (!volume.IsReady)
             {
                 continue;
             }
 
-            try
+            if (string.Equals(volume.VolumeLabel, CacheVolumeLabel, StringComparison.OrdinalIgnoreCase))
             {
-                if (string.Equals(drive.VolumeLabel, CacheVolumeLabel, StringComparison.OrdinalIgnoreCase))
-                {
-                    return Path.Combine(drive.RootDirectory.FullName, RuntimeFolderName);
-                }
+                return Path.Combine(volume.RootPath, RuntimeFolderName);
             }
-            catch
-            {
-                // Ignore drives that cannot expose label.
-            }
-
         }
 
         return null;

--- a/src/Foundry.Deploy/Services/Hardware/HardwareProfileService.cs
+++ b/src/Foundry.Deploy/Services/Hardware/HardwareProfileService.cs
@@ -2,126 +2,47 @@
 // Licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
-using System.Text.Json;
 using System.IO;
 using Foundry.Deploy.Models;
-using Foundry.Deploy.Services.System;
-using Foundry.Utilities.Processes;
+using Foundry.Utilities.Hardware;
 using Microsoft.Extensions.Logging;
 
 namespace Foundry.Deploy.Services.Hardware;
 
 public sealed class HardwareProfileService : IHardwareProfileService
 {
-    private readonly IProcessRunner _processRunner;
+    private readonly IHardwareInspector _hardwareInspector;
     private readonly ILogger<HardwareProfileService> _logger;
 
-    public HardwareProfileService(IProcessRunner processRunner, ILogger<HardwareProfileService> logger)
+    public HardwareProfileService(
+        IHardwareInspector hardwareInspector,
+        ILogger<HardwareProfileService> logger)
     {
-        _processRunner = processRunner;
+        _hardwareInspector = hardwareInspector;
         _logger = logger;
     }
 
     public async Task<HardwareProfile> GetCurrentAsync(CancellationToken cancellationToken = default)
     {
         _logger.LogInformation("Detecting current hardware profile.");
-        string script = @"
-function ConvertTo-TrimmedString {
-    param (
-        [Parameter(ValueFromPipeline = $true)]
-        $Value
-    )
-
-    process {
-        if ($null -eq $Value) {
-            return ''
-        }
-
-        return $Value.ToString().Trim()
-    }
-}
-
-$computer = Get-CimInstance -ClassName Win32_ComputerSystem
-$product = Get-CimInstance -ClassName Win32_ComputerSystemProduct
-$bios = Get-CimInstance -ClassName Win32_BIOS
-$tpm = Get-CimInstance -Namespace 'ROOT\cimv2\Security\MicrosoftTpm' -ClassName Win32_Tpm -ErrorAction SilentlyContinue
-$battery = Get-CimInstance -ClassName Win32_Battery -ErrorAction SilentlyContinue
-$pnpDevices = @(Get-CimInstance -ClassName Win32_PnpEntity -Property Name,DeviceID,HardwareID,ClassGuid,Manufacturer,PNPClass -ErrorAction SilentlyContinue | ForEach-Object {
-    $hardwareIds = @($_.HardwareID | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | ForEach-Object { $_.ToString().Trim() })
-    [pscustomobject]@{
-        Name = [string]($_.Name | ConvertTo-TrimmedString)
-        DeviceId = [string]($_.DeviceID | ConvertTo-TrimmedString)
-        HardwareIds = $hardwareIds
-        ClassGuid = [string]($_.ClassGuid | ConvertTo-TrimmedString)
-        Manufacturer = [string]($_.Manufacturer | ConvertTo-TrimmedString)
-        PnpClass = [string]($_.PNPClass | ConvertTo-TrimmedString)
-    }
-})
-$firmwareDevice = $pnpDevices | Where-Object { $_.ClassGuid -eq '{f2e7dd72-6468-4e36-b6f1-6488f42c1b52}' } | Select-Object -First 1
-$systemFirmwareHardwareId = ''
-if ($firmwareDevice -and $firmwareDevice.DeviceId -match '\{?(([0-9a-f]){8}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){12})\}?') {
-    $systemFirmwareHardwareId = $Matches[1]
-}
-$isOnBattery = @($battery | Where-Object { $_.BatteryStatus -eq 1 }).Count -gt 0
-
-[pscustomobject]@{
-    Manufacturer = [string]$computer.Manufacturer
-    Model = [string]$computer.Model
-    Product = [string]$product.Version
-    SerialNumber = [string]$bios.SerialNumber
-    Architecture = [string]$env:PROCESSOR_ARCHITECTURE
-    IsOnBattery = [bool]$isOnBattery
-    IsTpmPresent = [bool]($null -ne $tpm)
-    SystemFirmwareHardwareId = [string]$systemFirmwareHardwareId
-    PnpDevices = $pnpDevices
-} | ConvertTo-Json -Compress -Depth 8
-";
-
-        IReadOnlyList<string> arguments =
-        [
-            "-NoProfile",
-            "-ExecutionPolicy",
-            "Bypass",
-            .. PowerShellCommand.CreateEncodedArguments(script)
-        ];
-        ProcessExecutionResult execution = await _processRunner
-            .RunAsync("powershell.exe", arguments, Path.GetTempPath(), cancellationToken)
-            .ConfigureAwait(false);
-
-        if (!execution.IsSuccess || string.IsNullOrWhiteSpace(execution.StandardOutput))
-        {
-            _logger.LogWarning("Hardware profile detection returned no data. Using fallback profile. ExitCode={ExitCode}", execution.ExitCode);
-            return BuildFallbackProfile();
-        }
-
         try
         {
-            using JsonDocument document = JsonDocument.Parse(execution.StandardOutput);
-            JsonElement root = document.RootElement;
-
-            string manufacturer = ReadProperty(root, "Manufacturer");
-            string model = ReadProperty(root, "Model");
-            string product = ReadProperty(root, "Product");
-            string serial = ReadProperty(root, "SerialNumber");
-            string architecture = NormalizeArchitecture(ReadProperty(root, "Architecture"));
-            bool isVirtualMachine = IsVirtualMachine(manufacturer, model, product);
-            bool isOnBattery = ReadBoolProperty(root, "IsOnBattery");
-            bool isTpmPresent = ReadBoolProperty(root, "IsTpmPresent");
-            string systemFirmwareHardwareId = ReadProperty(root, "SystemFirmwareHardwareId");
-            IReadOnlyList<PnpDeviceInfo> pnpDevices = ReadPnpDevices(root);
+            HardwareSnapshot snapshot = await _hardwareInspector
+                .GetCurrentAsync(cancellationToken)
+                .ConfigureAwait(false);
 
             HardwareProfile profile = new()
             {
-                Manufacturer = NormalizeManufacturer(manufacturer),
-                Model = NormalizeValue(model),
-                Product = NormalizeValue(product),
-                SerialNumber = NormalizeValue(serial),
-                Architecture = architecture,
-                IsVirtualMachine = isVirtualMachine,
-                IsOnBattery = isOnBattery,
-                IsTpmPresent = isTpmPresent,
-                SystemFirmwareHardwareId = systemFirmwareHardwareId.Trim(),
-                PnpDevices = pnpDevices
+                Manufacturer = NormalizeManufacturer(snapshot.Manufacturer),
+                Model = NormalizeValue(snapshot.Model),
+                Product = NormalizeValue(snapshot.Product),
+                SerialNumber = NormalizeValue(snapshot.SerialNumber),
+                Architecture = snapshot.Architecture,
+                IsVirtualMachine = snapshot.IsVirtualMachine,
+                IsOnBattery = snapshot.IsOnBattery,
+                IsTpmPresent = snapshot.IsTpmPresent,
+                SystemFirmwareHardwareId = snapshot.SystemFirmwareHardwareId.Trim(),
+                PnpDevices = snapshot.PnpDevices.Select(MapPnpDevice).ToArray()
             };
 
             _logger.LogInformation("Hardware profile detected. Manufacturer={Manufacturer}, Model={Model}, Architecture={Architecture}, IsVirtualMachine={IsVirtualMachine}, IsOnBattery={IsOnBattery}, IsTpmPresent={IsTpmPresent}",
@@ -133,11 +54,24 @@ $isOnBattery = @($battery | Where-Object { $_.BatteryStatus -eq 1 }).Count -gt 0
                 profile.IsTpmPresent);
             return profile;
         }
-        catch (Exception ex)
+        catch (InvalidDataException ex)
         {
-            _logger.LogError(ex, "Failed to parse hardware profile payload. Falling back to default profile.");
+            _logger.LogWarning(ex, "Hardware profile detection returned no data. Using fallback profile.");
             return BuildFallbackProfile();
         }
+    }
+
+    private static PnpDeviceInfo MapPnpDevice(PnpDeviceSnapshot device)
+    {
+        return new PnpDeviceInfo
+        {
+            Name = device.Name,
+            DeviceId = device.DeviceId,
+            HardwareIds = device.HardwareIds,
+            ClassGuid = device.ClassGuid,
+            Manufacturer = device.Manufacturer,
+            PnpClass = device.PnpClass
+        };
     }
 
     private static HardwareProfile BuildFallbackProfile()
@@ -156,102 +90,6 @@ $isOnBattery = @($battery | Where-Object { $_.BatteryStatus -eq 1 }).Count -gt 0
             SystemFirmwareHardwareId = string.Empty,
             PnpDevices = Array.Empty<PnpDeviceInfo>()
         };
-    }
-
-    private static string ReadProperty(JsonElement root, string propertyName)
-    {
-        return root.TryGetProperty(propertyName, out JsonElement value)
-            ? value.GetString() ?? string.Empty
-            : string.Empty;
-    }
-
-    private static bool ReadBoolProperty(JsonElement root, string propertyName)
-    {
-        if (!root.TryGetProperty(propertyName, out JsonElement value))
-        {
-            return false;
-        }
-
-        return value.ValueKind == JsonValueKind.True ||
-               (value.ValueKind == JsonValueKind.String && bool.TryParse(value.GetString(), out bool parsed) && parsed);
-    }
-
-    private static IReadOnlyList<PnpDeviceInfo> ReadPnpDevices(JsonElement root)
-    {
-        if (!root.TryGetProperty("PnpDevices", out JsonElement devicesElement) ||
-            devicesElement.ValueKind != JsonValueKind.Array)
-        {
-            return Array.Empty<PnpDeviceInfo>();
-        }
-
-        var devices = new List<PnpDeviceInfo>();
-        foreach (JsonElement deviceElement in devicesElement.EnumerateArray())
-        {
-            if (deviceElement.ValueKind != JsonValueKind.Object)
-            {
-                continue;
-            }
-
-            devices.Add(new PnpDeviceInfo
-            {
-                Name = ReadProperty(deviceElement, "Name"),
-                DeviceId = ReadProperty(deviceElement, "DeviceId"),
-                HardwareIds = ReadStringArrayProperty(deviceElement, "HardwareIds"),
-                ClassGuid = ReadProperty(deviceElement, "ClassGuid"),
-                Manufacturer = ReadProperty(deviceElement, "Manufacturer"),
-                PnpClass = ReadProperty(deviceElement, "PnpClass")
-            });
-        }
-
-        return devices;
-    }
-
-    private static IReadOnlyList<string> ReadStringArrayProperty(JsonElement root, string propertyName)
-    {
-        if (!root.TryGetProperty(propertyName, out JsonElement value))
-        {
-            return Array.Empty<string>();
-        }
-
-        if (value.ValueKind == JsonValueKind.Array)
-        {
-            return value
-                .EnumerateArray()
-                .Select(item => item.ValueKind == JsonValueKind.String ? item.GetString() ?? string.Empty : string.Empty)
-                .Where(item => !string.IsNullOrWhiteSpace(item))
-                .Select(item => item.Trim())
-                .ToArray();
-        }
-
-        if (value.ValueKind == JsonValueKind.String)
-        {
-            string? stringValue = value.GetString();
-            return string.IsNullOrWhiteSpace(stringValue)
-                ? Array.Empty<string>()
-                : [stringValue.Trim()];
-        }
-
-        return Array.Empty<string>();
-    }
-
-    private static bool IsVirtualMachine(string manufacturer, string model, string product)
-    {
-        string combined = string.Join(" | ", manufacturer, model, product).ToLowerInvariant();
-
-        if (combined.Contains("vmware") ||
-            combined.Contains("virtualbox") ||
-            combined.Contains("virtual machine") ||
-            combined.Contains("kvm") ||
-            combined.Contains("qemu") ||
-            combined.Contains("xen") ||
-            combined.Contains("hvm domu") ||
-            combined.Contains("parallels") ||
-            combined.Contains("bhyve"))
-        {
-            return true;
-        }
-
-        return combined.Contains("microsoft corporation") && combined.Contains("virtual");
     }
 
     private static string NormalizeManufacturer(string value)

--- a/src/Foundry.Deploy/Services/Hardware/HardwareProfileService.cs
+++ b/src/Foundry.Deploy/Services/Hardware/HardwareProfileService.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Text.Json;
-using System.Text;
 using System.IO;
 using Foundry.Deploy.Models;
 using Foundry.Deploy.Services.System;
@@ -78,10 +77,15 @@ $isOnBattery = @($battery | Where-Object { $_.BatteryStatus -eq 1 }).Count -gt 0
 } | ConvertTo-Json -Compress -Depth 8
 ";
 
-        string encoded = Convert.ToBase64String(Encoding.Unicode.GetBytes(script));
-        string args = $"-NoProfile -ExecutionPolicy Bypass -EncodedCommand {encoded}";
+        IReadOnlyList<string> arguments =
+        [
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            .. PowerShellCommand.CreateEncodedArguments(script)
+        ];
         ProcessExecutionResult execution = await _processRunner
-            .RunAsync("powershell.exe", args, Path.GetTempPath(), cancellationToken)
+            .RunAsync("powershell.exe", arguments, Path.GetTempPath(), cancellationToken)
             .ConfigureAwait(false);
 
         if (!execution.IsSuccess || string.IsNullOrWhiteSpace(execution.StandardOutput))

--- a/src/Foundry.Deploy/Services/Hardware/TargetDiskService.cs
+++ b/src/Foundry.Deploy/Services/Hardware/TargetDiskService.cs
@@ -3,214 +3,119 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
-using System.Text.Json;
 using Foundry.Deploy.Models;
 using Foundry.Deploy.Services.Localization;
-using Foundry.Deploy.Services.System;
-using Foundry.Utilities.Processes;
-using Foundry.Utilities.Serialization;
+using Foundry.Utilities.Storage;
 using Microsoft.Extensions.Logging;
 
 namespace Foundry.Deploy.Services.Hardware;
 
 public sealed class TargetDiskService : ITargetDiskService
 {
-    private readonly IProcessRunner _processRunner;
+    private readonly IWindowsDiskInspector _diskInspector;
     private readonly ILogger<TargetDiskService> _logger;
 
-    public TargetDiskService(IProcessRunner processRunner, ILogger<TargetDiskService> logger)
+    public TargetDiskService(
+        IWindowsDiskInspector diskInspector,
+        ILogger<TargetDiskService> logger)
     {
-        _processRunner = processRunner;
+        _diskInspector = diskInspector;
         _logger = logger;
     }
 
-    public async Task<IReadOnlyList<TargetDiskInfo>> GetDisksAsync(CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<TargetDiskInfo>> GetDisksAsync(
+        CancellationToken cancellationToken = default)
     {
         _logger.LogInformation("Querying target disks.");
-        string script = @"
-$disks = Get-Disk | Sort-Object -Property Number
-$result = foreach ($disk in $disks) {
-    [pscustomobject]@{
-        Number = [int]$disk.Number
-        FriendlyName = [string]$disk.FriendlyName
-        SerialNumber = [string]$disk.SerialNumber
-        BusType = [string]$disk.BusType
-        PartitionStyle = [string]$disk.PartitionStyle
-        Size = [uint64]$disk.Size
-        IsSystem = [bool]$disk.IsSystem
-        IsBoot = [bool]$disk.IsBoot
-        IsReadOnly = [bool]$disk.IsReadOnly
-        IsOffline = [bool]$disk.IsOffline
-        IsRemovable = [bool]$disk.IsRemovable
-    }
-}
-$result | ConvertTo-Json -Compress
-";
-
-        IReadOnlyList<string> arguments = CreatePowerShellArguments(script);
-
-        ProcessExecutionResult execution = await _processRunner
-            .RunAsync("powershell.exe", arguments, Path.GetTempPath(), cancellationToken)
-            .ConfigureAwait(false);
-
-        if (!execution.IsSuccess || string.IsNullOrWhiteSpace(execution.StandardOutput))
-        {
-            _logger.LogWarning("Target disk query returned no data. ExitCode={ExitCode}", execution.ExitCode);
-            return [];
-        }
 
         try
         {
+            IReadOnlyList<DiskInfo> snapshots = await _diskInspector
+                .GetDisksAsync(cancellationToken)
+                .ConfigureAwait(false);
             var disks = new List<TargetDiskInfo>();
-            foreach (JsonElement diskElement in JsonObjectSequence.Parse(execution.StandardOutput))
+
+            foreach (DiskInfo snapshot in snapshots)
             {
-                TargetDiskInfo info = ParseDisk(diskElement);
-                if (ShouldExcludeFromTargets(info))
+                TargetDiskInfo disk = MapDisk(snapshot);
+                if (ShouldExcludeFromTargets(disk))
                 {
                     _logger.LogInformation(
                         "Skipping disk {DiskNumber} from target selection because it is attached over USB. FriendlyName={FriendlyName}",
-                        info.DiskNumber,
-                        info.FriendlyName);
+                        disk.DiskNumber,
+                        disk.FriendlyName);
                     continue;
                 }
 
-                disks.Add(info);
+                disks.Add(disk);
             }
 
             TargetDiskInfo[] orderedDisks = disks
-                .OrderByDescending(disk => disk.IsSelectable)
-                .ThenBy(disk => disk.DiskNumber)
+                .OrderByDescending(static disk => disk.IsSelectable)
+                .ThenBy(static disk => disk.DiskNumber)
                 .ToArray();
 
-            _logger.LogInformation("Resolved {DiskCount} target disks ({SelectableCount} selectable).",
+            _logger.LogInformation(
+                "Resolved {DiskCount} target disks ({SelectableCount} selectable).",
                 orderedDisks.Length,
-                orderedDisks.Count(disk => disk.IsSelectable));
+                orderedDisks.Count(static disk => disk.IsSelectable));
             return orderedDisks;
         }
-        catch (Exception ex)
+        catch (InvalidDataException exception)
         {
-            _logger.LogError(ex, "Failed to parse target disk query output.");
+            _logger.LogError(exception, "Failed to inspect target disks.");
             return [];
         }
     }
 
-    public async Task<int?> GetDiskNumberForPathAsync(string path, CancellationToken cancellationToken = default)
+    public async Task<int?> GetDiskNumberForPathAsync(
+        string path,
+        CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return null;
-        }
-
-        string? root = Path.GetPathRoot(path);
-        if (string.IsNullOrWhiteSpace(root))
-        {
-            return null;
-        }
-
-        string driveLetter = root.TrimEnd('\\').TrimEnd(':');
-        if (driveLetter.Length == 0)
-        {
-            return null;
-        }
-
-        string script = $@"
-$partition = Get-Partition -DriveLetter '{EscapeForSingleQuote(driveLetter)}' -ErrorAction SilentlyContinue
-if ($null -eq $partition) {{
-    return
-}}
-
-[pscustomobject]@{{
-    DiskNumber = [int]$partition.DiskNumber
-}} | ConvertTo-Json -Compress
-";
-
-        IReadOnlyList<string> arguments = CreatePowerShellArguments(script);
-
-        ProcessExecutionResult execution = await _processRunner
-            .RunAsync("powershell.exe", arguments, Path.GetTempPath(), cancellationToken)
-            .ConfigureAwait(false);
-
-        if (!execution.IsSuccess || string.IsNullOrWhiteSpace(execution.StandardOutput))
-        {
-            _logger.LogDebug("Disk number lookup for path {Path} returned no data. ExitCode={ExitCode}", path, execution.ExitCode);
-            return null;
-        }
-
         try
         {
-            using JsonDocument document = JsonDocument.Parse(execution.StandardOutput);
-            JsonElement rootElement = document.RootElement;
-            if (!rootElement.TryGetProperty("DiskNumber", out JsonElement diskNumberElement))
-            {
-                return null;
-            }
-
-            if (diskNumberElement.ValueKind == JsonValueKind.Number && diskNumberElement.TryGetInt32(out int numericValue))
-            {
-                return numericValue;
-            }
-
-            if (diskNumberElement.ValueKind == JsonValueKind.String &&
-                int.TryParse(diskNumberElement.GetString(), out int parsedValue))
-            {
-                return parsedValue;
-            }
+            return await _diskInspector
+                .ResolveDiskNumberForPathAsync(path, cancellationToken)
+                .ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (InvalidDataException exception)
         {
-            _logger.LogError(ex, "Failed to parse disk number for path {Path}.", path);
+            _logger.LogError(exception, "Failed to resolve the disk number for path {Path}.", path);
             return null;
         }
-
-        return null;
     }
 
-    private static TargetDiskInfo ParseDisk(JsonElement element)
+    private static TargetDiskInfo MapDisk(DiskInfo snapshot)
     {
-        int diskNumber = ReadInt(element, "Number");
-        string friendlyName = NormalizeValue(ReadString(element, "FriendlyName"), fallback: LocalizationText.GetString("Common.Unknown"));
-        string serial = NormalizeValue(ReadString(element, "SerialNumber"), fallback: LocalizationText.GetString("Common.Unknown"));
-        string busType = NormalizeValue(ReadString(element, "BusType"), fallback: LocalizationText.GetString("Common.Unknown"));
-        string partitionStyle = NormalizeValue(ReadString(element, "PartitionStyle"), fallback: LocalizationText.GetString("Common.Unknown"));
-        ulong sizeBytes = ReadUInt64(element, "Size");
-        bool isSystem = ReadBool(element, "IsSystem");
-        bool isBoot = ReadBool(element, "IsBoot");
-        bool isReadOnly = ReadBool(element, "IsReadOnly");
-        bool isOffline = ReadBool(element, "IsOffline");
-        bool isRemovable = ReadBool(element, "IsRemovable");
-
-        string warning = BuildSelectionWarning(isSystem, isBoot, isReadOnly, isOffline);
+        string warning = BuildSelectionWarning(
+            snapshot.IsSystem,
+            snapshot.IsBoot,
+            snapshot.IsReadOnly,
+            snapshot.IsOffline);
 
         return new TargetDiskInfo
         {
-            DiskNumber = diskNumber,
-            FriendlyName = friendlyName,
-            SerialNumber = serial,
-            BusType = busType,
-            PartitionStyle = partitionStyle,
-            SizeBytes = sizeBytes,
-            IsSystem = isSystem,
-            IsBoot = isBoot,
-            IsReadOnly = isReadOnly,
-            IsOffline = isOffline,
-            IsRemovable = isRemovable,
+            DiskNumber = snapshot.Number,
+            FriendlyName = NormalizeValue(snapshot.FriendlyName),
+            SerialNumber = NormalizeValue(snapshot.SerialNumber),
+            BusType = NormalizeValue(snapshot.BusType),
+            PartitionStyle = NormalizeValue(snapshot.PartitionStyle),
+            SizeBytes = snapshot.SizeBytes,
+            IsSystem = snapshot.IsSystem,
+            IsBoot = snapshot.IsBoot,
+            IsReadOnly = snapshot.IsReadOnly,
+            IsOffline = snapshot.IsOffline,
+            IsRemovable = snapshot.IsRemovable,
             IsSelectable = string.IsNullOrWhiteSpace(warning),
             SelectionWarning = warning
         };
     }
 
-    private static IReadOnlyList<string> CreatePowerShellArguments(string script)
-    {
-        return
-        [
-            "-NoProfile",
-            "-ExecutionPolicy",
-            "Bypass",
-            .. PowerShellCommand.CreateEncodedArguments(script)
-        ];
-    }
-
-    private static string BuildSelectionWarning(bool isSystem, bool isBoot, bool isReadOnly, bool isOffline)
+    private static string BuildSelectionWarning(
+        bool isSystem,
+        bool isBoot,
+        bool isReadOnly,
+        bool isOffline)
     {
         if (isSystem)
         {
@@ -238,91 +143,11 @@ if ($null -eq $partition) {{
     private static bool ShouldExcludeFromTargets(TargetDiskInfo disk)
         => string.Equals(disk.BusType, "USB", StringComparison.OrdinalIgnoreCase);
 
-    private static string ReadString(JsonElement root, string propertyName)
-    {
-        if (!root.TryGetProperty(propertyName, out JsonElement property))
-        {
-            return string.Empty;
-        }
-
-        return property.ValueKind == JsonValueKind.String
-            ? property.GetString() ?? string.Empty
-            : property.ToString();
-    }
-
-    private static int ReadInt(JsonElement root, string propertyName)
-    {
-        if (!root.TryGetProperty(propertyName, out JsonElement property))
-        {
-            return -1;
-        }
-
-        if (property.ValueKind == JsonValueKind.Number && property.TryGetInt32(out int value))
-        {
-            return value;
-        }
-
-        if (property.ValueKind == JsonValueKind.String && int.TryParse(property.GetString(), out int parsed))
-        {
-            return parsed;
-        }
-
-        return -1;
-    }
-
-    private static ulong ReadUInt64(JsonElement root, string propertyName)
-    {
-        if (!root.TryGetProperty(propertyName, out JsonElement property))
-        {
-            return 0;
-        }
-
-        if (property.ValueKind == JsonValueKind.Number && property.TryGetUInt64(out ulong value))
-        {
-            return value;
-        }
-
-        if (property.ValueKind == JsonValueKind.String && ulong.TryParse(property.GetString(), out ulong parsed))
-        {
-            return parsed;
-        }
-
-        return 0;
-    }
-
-    private static bool ReadBool(JsonElement root, string propertyName)
-    {
-        if (!root.TryGetProperty(propertyName, out JsonElement property))
-        {
-            return false;
-        }
-
-        if (property.ValueKind == JsonValueKind.True)
-        {
-            return true;
-        }
-
-        if (property.ValueKind == JsonValueKind.False)
-        {
-            return false;
-        }
-
-        if (property.ValueKind == JsonValueKind.String && bool.TryParse(property.GetString(), out bool parsed))
-        {
-            return parsed;
-        }
-
-        return false;
-    }
-
-    private static string NormalizeValue(string value, string fallback)
+    private static string NormalizeValue(string value)
     {
         string normalized = value.Trim();
-        return string.IsNullOrWhiteSpace(normalized) ? fallback : normalized;
-    }
-
-    private static string EscapeForSingleQuote(string value)
-    {
-        return value.Replace("'", "''", StringComparison.Ordinal);
+        return string.IsNullOrWhiteSpace(normalized)
+            ? LocalizationText.GetString("Common.Unknown")
+            : normalized;
     }
 }

--- a/src/Foundry.Deploy/Services/Hardware/TargetDiskService.cs
+++ b/src/Foundry.Deploy/Services/Hardware/TargetDiskService.cs
@@ -3,12 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
-using System.Text;
 using System.Text.Json;
 using Foundry.Deploy.Models;
 using Foundry.Deploy.Services.Localization;
 using Foundry.Deploy.Services.System;
 using Foundry.Utilities.Processes;
+using Foundry.Utilities.Serialization;
 using Microsoft.Extensions.Logging;
 
 namespace Foundry.Deploy.Services.Hardware;
@@ -47,11 +47,10 @@ $result = foreach ($disk in $disks) {
 $result | ConvertTo-Json -Compress
 ";
 
-        string encoded = Convert.ToBase64String(Encoding.Unicode.GetBytes(script));
-        string args = $"-NoProfile -ExecutionPolicy Bypass -EncodedCommand {encoded}";
+        IReadOnlyList<string> arguments = CreatePowerShellArguments(script);
 
         ProcessExecutionResult execution = await _processRunner
-            .RunAsync("powershell.exe", args, Path.GetTempPath(), cancellationToken)
+            .RunAsync("powershell.exe", arguments, Path.GetTempPath(), cancellationToken)
             .ConfigureAwait(false);
 
         if (!execution.IsSuccess || string.IsNullOrWhiteSpace(execution.StandardOutput))
@@ -62,34 +61,20 @@ $result | ConvertTo-Json -Compress
 
         try
         {
-            using JsonDocument document = JsonDocument.Parse(execution.StandardOutput);
-            JsonElement root = document.RootElement;
-
             var disks = new List<TargetDiskInfo>();
-            if (root.ValueKind == JsonValueKind.Array)
+            foreach (JsonElement diskElement in JsonObjectSequence.Parse(execution.StandardOutput))
             {
-                foreach (JsonElement diskElement in root.EnumerateArray())
+                TargetDiskInfo info = ParseDisk(diskElement);
+                if (ShouldExcludeFromTargets(info))
                 {
-                    TargetDiskInfo info = ParseDisk(diskElement);
-                    if (ShouldExcludeFromTargets(info))
-                    {
-                        _logger.LogInformation(
-                            "Skipping disk {DiskNumber} from target selection because it is attached over USB. FriendlyName={FriendlyName}",
-                            info.DiskNumber,
-                            info.FriendlyName);
-                        continue;
-                    }
+                    _logger.LogInformation(
+                        "Skipping disk {DiskNumber} from target selection because it is attached over USB. FriendlyName={FriendlyName}",
+                        info.DiskNumber,
+                        info.FriendlyName);
+                    continue;
+                }
 
-                    disks.Add(info);
-                }
-            }
-            else if (root.ValueKind == JsonValueKind.Object)
-            {
-                TargetDiskInfo info = ParseDisk(root);
-                if (!ShouldExcludeFromTargets(info))
-                {
-                    disks.Add(info);
-                }
+                disks.Add(info);
             }
 
             TargetDiskInfo[] orderedDisks = disks
@@ -139,11 +124,10 @@ if ($null -eq $partition) {{
 }} | ConvertTo-Json -Compress
 ";
 
-        string encoded = Convert.ToBase64String(Encoding.Unicode.GetBytes(script));
-        string args = $"-NoProfile -ExecutionPolicy Bypass -EncodedCommand {encoded}";
+        IReadOnlyList<string> arguments = CreatePowerShellArguments(script);
 
         ProcessExecutionResult execution = await _processRunner
-            .RunAsync("powershell.exe", args, Path.GetTempPath(), cancellationToken)
+            .RunAsync("powershell.exe", arguments, Path.GetTempPath(), cancellationToken)
             .ConfigureAwait(false);
 
         if (!execution.IsSuccess || string.IsNullOrWhiteSpace(execution.StandardOutput))
@@ -213,6 +197,17 @@ if ($null -eq $partition) {{
             IsSelectable = string.IsNullOrWhiteSpace(warning),
             SelectionWarning = warning
         };
+    }
+
+    private static IReadOnlyList<string> CreatePowerShellArguments(string script)
+    {
+        return
+        [
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            .. PowerShellCommand.CreateEncodedArguments(script)
+        ];
     }
 
     private static string BuildSelectionWarning(bool isSystem, bool isBoot, bool isReadOnly, bool isOffline)

--- a/src/Foundry.Deploy/Services/Runtime/DeploymentRuntimeContextService.cs
+++ b/src/Foundry.Deploy/Services/Runtime/DeploymentRuntimeContextService.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using Foundry.Deploy.Models;
+using Foundry.Utilities.Storage;
 
 namespace Foundry.Deploy.Services.Runtime;
 
@@ -12,6 +13,26 @@ public sealed class DeploymentRuntimeContextService : IDeploymentRuntimeContextS
     private const string DeploymentModeEnvironmentVariable = "FOUNDRY_DEPLOYMENT_MODE";
     private const string CacheVolumeLabel = "Foundry Cache";
     private const string RuntimeFolderName = "Runtime";
+    private readonly IVolumeDiscovery _volumeDiscovery;
+    private readonly Func<string, string?> _environmentVariableReader;
+
+    public DeploymentRuntimeContextService()
+        : this(new WindowsVolumeDiscovery())
+    {
+    }
+
+    public DeploymentRuntimeContextService(IVolumeDiscovery volumeDiscovery)
+        : this(volumeDiscovery, Environment.GetEnvironmentVariable)
+    {
+    }
+
+    internal DeploymentRuntimeContextService(
+        IVolumeDiscovery volumeDiscovery,
+        Func<string, string?> environmentVariableReader)
+    {
+        _volumeDiscovery = volumeDiscovery;
+        _environmentVariableReader = environmentVariableReader;
+    }
 
     public DeploymentRuntimeContext Resolve()
     {
@@ -29,9 +50,9 @@ public sealed class DeploymentRuntimeContextService : IDeploymentRuntimeContextS
             : new DeploymentRuntimeContext(DeploymentMode.Usb, detectedUsbRoot);
     }
 
-    private static bool TryResolveDeploymentModeFromEnvironment(out DeploymentMode mode)
+    private bool TryResolveDeploymentModeFromEnvironment(out DeploymentMode mode)
     {
-        string? raw = Environment.GetEnvironmentVariable(DeploymentModeEnvironmentVariable);
+        string? raw = _environmentVariableReader(DeploymentModeEnvironmentVariable);
         if (string.IsNullOrWhiteSpace(raw))
         {
             mode = default;
@@ -49,27 +70,19 @@ public sealed class DeploymentRuntimeContextService : IDeploymentRuntimeContextS
         return normalized is "usb" or "iso";
     }
 
-    private static string? TryGetUsbCacheRuntimeRoot()
+    private string? TryGetUsbCacheRuntimeRoot()
     {
-        foreach (DriveInfo drive in DriveInfo.GetDrives())
+        foreach (VolumeInfo volume in _volumeDiscovery.GetVolumes())
         {
-            if (!drive.IsReady)
+            if (!volume.IsReady)
             {
                 continue;
             }
 
-            try
+            if (string.Equals(volume.VolumeLabel, CacheVolumeLabel, StringComparison.OrdinalIgnoreCase))
             {
-                if (string.Equals(drive.VolumeLabel, CacheVolumeLabel, StringComparison.OrdinalIgnoreCase))
-                {
-                    return Path.Combine(drive.RootDirectory.FullName, RuntimeFolderName);
-                }
+                return Path.Combine(volume.RootPath, RuntimeFolderName);
             }
-            catch
-            {
-                // Ignore drives that cannot expose a label.
-            }
-
         }
 
         return null;

--- a/src/Foundry.Deploy/ViewModels/DeploymentSessionViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentSessionViewModel.cs
@@ -627,22 +627,21 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
 
         try
         {
-            NetworkAdapterSnapshot? adapter = SelectNetworkAdapter(
+            var snapshot = CreateNetworkSnapshot(
                 _networkAdapterSnapshotProvider.GetAdapters());
-            if (adapter is null)
+            if (snapshot is null)
             {
                 return;
             }
 
-            NetworkIpv4AddressSnapshot ipv4AddressInfo = adapter.Ipv4Addresses[0];
-            IpAddress = ipv4AddressInfo.Address;
-            SubnetMask = string.IsNullOrWhiteSpace(ipv4AddressInfo.SubnetMask)
+            IpAddress = snapshot.Value.IpAddress;
+            SubnetMask = string.IsNullOrWhiteSpace(snapshot.Value.SubnetMask)
                 ? notAvailable
-                : ipv4AddressInfo.SubnetMask;
-            GatewayAddress = adapter.Gateways.FirstOrDefault() ?? notAvailable;
-            MacAddress = string.IsNullOrWhiteSpace(adapter.MacAddress)
+                : snapshot.Value.SubnetMask;
+            GatewayAddress = snapshot.Value.GatewayAddress ?? notAvailable;
+            MacAddress = string.IsNullOrWhiteSpace(snapshot.Value.MacAddress)
                 ? notAvailable
-                : adapter.MacAddress;
+                : snapshot.Value.MacAddress;
         }
         catch (Exception ex)
         {
@@ -657,6 +656,23 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
             adapter.OperationalStatus == OperationalStatus.Up &&
             adapter.InterfaceType is not NetworkInterfaceType.Loopback and not NetworkInterfaceType.Tunnel &&
             adapter.Ipv4Addresses.Count > 0);
+    }
+
+    internal static (string IpAddress, string? SubnetMask, string? GatewayAddress, string MacAddress)?
+        CreateNetworkSnapshot(IReadOnlyList<NetworkAdapterSnapshot> adapters)
+    {
+        NetworkAdapterSnapshot? adapter = SelectNetworkAdapter(adapters);
+        if (adapter is null)
+        {
+            return null;
+        }
+
+        NetworkIpv4AddressSnapshot address = adapter.Ipv4Addresses[0];
+        return (
+            address.Address,
+            address.SubnetMask,
+            adapter.Gateways.FirstOrDefault(),
+            adapter.MacAddress);
     }
 
     private string BuildStepCounterText(int currentStep)

--- a/src/Foundry.Deploy/ViewModels/DeploymentSessionViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DeploymentSessionViewModel.cs
@@ -10,6 +10,7 @@ using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Foundry.Core.Models.Configuration;
+using Foundry.Utilities.Networking;
 using Foundry.Deploy.Services.Deployment;
 using Foundry.Deploy.Services.Localization;
 using Foundry.Utilities.Processes;
@@ -27,6 +28,7 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
     private readonly IOperationProgressService _operationProgressService;
     private readonly IDeploymentOrchestrator _deploymentOrchestrator;
     private readonly IProcessRunner _processRunner;
+    private readonly INetworkAdapterSnapshotProvider _networkAdapterSnapshotProvider;
     private readonly bool _isDebugSafeMode;
     private string _rawCurrentStepName = "Waiting for deployment...";
     private string _rawCurrentStepProgressText = "Waiting for progress...";
@@ -50,7 +52,8 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
         IDeploymentOrchestrator deploymentOrchestrator,
         IProcessRunner processRunner,
         ILocalizationService localizationService,
-        bool isDebugSafeMode)
+        bool isDebugSafeMode,
+        INetworkAdapterSnapshotProvider? networkAdapterSnapshotProvider = null)
         : base(localizationService)
     {
         _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
@@ -58,6 +61,7 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
         _operationProgressService = operationProgressService ?? throw new ArgumentNullException(nameof(operationProgressService));
         _deploymentOrchestrator = deploymentOrchestrator ?? throw new ArgumentNullException(nameof(deploymentOrchestrator));
         _processRunner = processRunner ?? throw new ArgumentNullException(nameof(processRunner));
+        _networkAdapterSnapshotProvider = networkAdapterSnapshotProvider ?? new WindowsNetworkAdapterSnapshotProvider();
         _isDebugSafeMode = isDebugSafeMode;
 
         _operationProgressService.ProgressChanged += OnOperationProgressChanged;
@@ -623,43 +627,36 @@ public sealed partial class DeploymentSessionViewModel : LocalizedViewModelBase
 
         try
         {
-            foreach (NetworkInterface networkInterface in NetworkInterface.GetAllNetworkInterfaces())
+            NetworkAdapterSnapshot? adapter = SelectNetworkAdapter(
+                _networkAdapterSnapshotProvider.GetAdapters());
+            if (adapter is null)
             {
-                if (networkInterface.OperationalStatus != OperationalStatus.Up)
-                {
-                    continue;
-                }
-
-                if (networkInterface.NetworkInterfaceType is NetworkInterfaceType.Loopback or NetworkInterfaceType.Tunnel)
-                {
-                    continue;
-                }
-
-                IPInterfaceProperties ipProperties = networkInterface.GetIPProperties();
-                UnicastIPAddressInformation? ipv4AddressInfo = ipProperties.UnicastAddresses
-                    .FirstOrDefault(item => item.Address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork);
-                if (ipv4AddressInfo is null)
-                {
-                    continue;
-                }
-
-                GatewayIPAddressInformation? gatewayInfo = ipProperties.GatewayAddresses
-                    .FirstOrDefault(item => item.Address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork);
-                byte[] macBytes = networkInterface.GetPhysicalAddress().GetAddressBytes();
-
-                IpAddress = ipv4AddressInfo.Address.ToString();
-                SubnetMask = ipv4AddressInfo.IPv4Mask?.ToString() ?? notAvailable;
-                GatewayAddress = gatewayInfo?.Address.ToString() ?? notAvailable;
-                MacAddress = macBytes.Length == 0
-                    ? notAvailable
-                    : string.Join("-", macBytes.Select(value => value.ToString("X2", CultureInfo.InvariantCulture)));
                 return;
             }
+
+            NetworkIpv4AddressSnapshot ipv4AddressInfo = adapter.Ipv4Addresses[0];
+            IpAddress = ipv4AddressInfo.Address;
+            SubnetMask = string.IsNullOrWhiteSpace(ipv4AddressInfo.SubnetMask)
+                ? notAvailable
+                : ipv4AddressInfo.SubnetMask;
+            GatewayAddress = adapter.Gateways.FirstOrDefault() ?? notAvailable;
+            MacAddress = string.IsNullOrWhiteSpace(adapter.MacAddress)
+                ? notAvailable
+                : adapter.MacAddress;
         }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Unable to resolve network snapshot for deployment session.");
         }
+    }
+
+    internal static NetworkAdapterSnapshot? SelectNetworkAdapter(
+        IReadOnlyList<NetworkAdapterSnapshot> adapters)
+    {
+        return adapters.FirstOrDefault(static adapter =>
+            adapter.OperationalStatus == OperationalStatus.Up &&
+            adapter.InterfaceType is not NetworkInterfaceType.Loopback and not NetworkInterfaceType.Tunnel &&
+            adapter.Ipv4Addresses.Count > 0);
     }
 
     private string BuildStepCounterText(int currentStep)

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -20,6 +20,7 @@ using Foundry.Deploy.Services.Startup;
 using Foundry.Deploy.Services.ApplicationShell;
 using Foundry.Deploy.Services.Localization;
 using Foundry.Deploy.Services.System;
+using Foundry.Utilities.Networking;
 using Foundry.Deploy.Services.Theme;
 using Foundry.Deploy.Services.Wizard;
 using Foundry.Localization;
@@ -115,7 +116,8 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         IApplicationShellService applicationShellService,
         IDeploymentWizardContextFactory deploymentWizardContextFactory,
         IProcessRunner processRunner,
-        ILogger<MainWindowViewModel> logger)
+        ILogger<MainWindowViewModel> logger,
+        INetworkAdapterSnapshotProvider? networkAdapterSnapshotProvider = null)
         : base(localizationService)
     {
         _themeService = themeService;
@@ -140,7 +142,8 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
             _deploymentOrchestrator,
             processRunner,
             localizationService,
-            IsDebugSafeMode);
+            IsDebugSafeMode,
+            networkAdapterSnapshotProvider);
         Session.PropertyChanged += OnSessionPropertyChanged;
         LocalizationService.LanguageChanged += OnLocalizationLanguageChanged;
         RefreshSupportedCultures();

--- a/src/Foundry.Utilities.Tests/Hardware/WindowsHardwareInspectorTests.cs
+++ b/src/Foundry.Utilities.Tests/Hardware/WindowsHardwareInspectorTests.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Utilities.Hardware;
+using Foundry.Utilities.Processes;
+
+namespace Foundry.Utilities.Tests.Hardware;
+
+public sealed class WindowsHardwareInspectorTests
+{
+    [Fact]
+    public async Task GetCurrentAsync_ParsesHardwareAndPnpFacts()
+    {
+        ProcessExecutionRequest? capturedRequest = null;
+        var inspector = new WindowsHardwareInspector((request, _) =>
+        {
+            capturedRequest = request;
+            return Task.FromResult(CreateSuccessResult(
+                """
+                {
+                  "Manufacturer":" VMware, Inc. ",
+                  "Model":" Virtual Machine ",
+                  "Product":" Workstation ",
+                  "SerialNumber":" SERIAL-1 ",
+                  "Architecture":"AMD64",
+                  "IsOnBattery":true,
+                  "IsTpmPresent":"true",
+                  "SystemFirmwareHardwareId":" UEFI\\RES_{FIRMWARE} ",
+                  "PnpDevices":{
+                    "Name":" Network Adapter ",
+                    "DeviceId":" PCI\\VEN_1234 ",
+                    "HardwareIds":[" PCI\\VEN_1234 "," "],
+                    "ClassGuid":" {CLASS} ",
+                    "Manufacturer":" Vendor ",
+                    "PnpClass":" Net "
+                  }
+                }
+                """));
+        });
+
+        HardwareSnapshot snapshot = await inspector.GetCurrentAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal("VMware, Inc.", snapshot.Manufacturer);
+        Assert.Equal("Virtual Machine", snapshot.Model);
+        Assert.Equal("Workstation", snapshot.Product);
+        Assert.Equal("SERIAL-1", snapshot.SerialNumber);
+        Assert.Equal("x64", snapshot.Architecture);
+        Assert.True(snapshot.IsVirtualMachine);
+        Assert.True(snapshot.IsOnBattery);
+        Assert.True(snapshot.IsTpmPresent);
+        Assert.Equal("UEFI\\RES_{FIRMWARE}", snapshot.SystemFirmwareHardwareId);
+
+        PnpDeviceSnapshot device = Assert.Single(snapshot.PnpDevices);
+        Assert.Equal("Network Adapter", device.Name);
+        Assert.Equal("PCI\\VEN_1234", device.DeviceId);
+        Assert.Equal(["PCI\\VEN_1234"], device.HardwareIds);
+        Assert.Equal("{CLASS}", device.ClassGuid);
+        Assert.Equal("Vendor", device.Manufacturer);
+        Assert.Equal("Net", device.PnpClass);
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal("powershell.exe", capturedRequest.FileName);
+        Assert.Equal("-NoProfile", capturedRequest.ArgumentList?[0]);
+        Assert.Contains("-EncodedCommand", capturedRequest.ArgumentList!);
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_WhenRootIsSingleItemArray_ParsesSnapshot()
+    {
+        var inspector = CreateInspector("""[{"Manufacturer":"Dell","Architecture":"ARM64"}]""");
+
+        HardwareSnapshot snapshot = await inspector.GetCurrentAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal("Dell", snapshot.Manufacturer);
+        Assert.Equal("arm64", snapshot.Architecture);
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_WhenFieldsAreMissing_ReturnsNeutralFacts()
+    {
+        var inspector = CreateInspector("{}");
+
+        HardwareSnapshot snapshot = await inspector.GetCurrentAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(string.Empty, snapshot.Manufacturer);
+        Assert.Equal(string.Empty, snapshot.Model);
+        Assert.Equal(string.Empty, snapshot.Product);
+        Assert.Equal(string.Empty, snapshot.SerialNumber);
+        Assert.Equal(string.Empty, snapshot.Architecture);
+        Assert.False(snapshot.IsVirtualMachine);
+        Assert.False(snapshot.IsOnBattery);
+        Assert.False(snapshot.IsTpmPresent);
+        Assert.Equal(string.Empty, snapshot.SystemFirmwareHardwareId);
+        Assert.Empty(snapshot.PnpDevices);
+    }
+
+    [Theory]
+    [InlineData("AMD64", "x64")]
+    [InlineData("x64", "x64")]
+    [InlineData("ARM64", "arm64")]
+    [InlineData("aarch64", "arm64")]
+    [InlineData("custom", "custom")]
+    public async Task GetCurrentAsync_NormalizesArchitecture(string architecture, string expected)
+    {
+        var inspector = CreateInspector($$"""{"Architecture":"{{architecture}}"}""");
+
+        HardwareSnapshot snapshot = await inspector.GetCurrentAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(expected, snapshot.Architecture);
+    }
+
+    [Theory]
+    [InlineData("VMware, Inc.", "Physical", "Product", true)]
+    [InlineData("Microsoft Corporation", "Virtual Machine", "Product", true)]
+    [InlineData("Dell Inc.", "Latitude", "Laptop", false)]
+    public async Task GetCurrentAsync_DetectsVirtualMachines(
+        string manufacturer,
+        string model,
+        string product,
+        bool expected)
+    {
+        var inspector = CreateInspector(
+            $$"""{"Manufacturer":"{{manufacturer}}","Model":"{{model}}","Product":"{{product}}"}""");
+
+        HardwareSnapshot snapshot = await inspector.GetCurrentAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(expected, snapshot.IsVirtualMachine);
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_WhenProcessReturnsNoData_ThrowsInvalidDataException()
+    {
+        var inspector = new WindowsHardwareInspector((_, _) => Task.FromResult(
+            new ProcessExecutionResult { ExitCode = 1, StandardError = "CIM failed" }));
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => inspector.GetCurrentAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_WhenPayloadIsMalformed_ThrowsInvalidDataException()
+    {
+        var inspector = CreateInspector("{");
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => inspector.GetCurrentAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_WhenExecutionIsCanceled_PropagatesCancellation()
+    {
+        using var cancellationSource = new CancellationTokenSource();
+        cancellationSource.Cancel();
+        var inspector = new WindowsHardwareInspector(
+            (_, cancellationToken) => Task.FromCanceled<ProcessExecutionResult>(cancellationToken));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => inspector.GetCurrentAsync(cancellationSource.Token));
+    }
+
+    private static WindowsHardwareInspector CreateInspector(string json)
+    {
+        return new WindowsHardwareInspector((_, _) => Task.FromResult(CreateSuccessResult(json)));
+    }
+
+    private static ProcessExecutionResult CreateSuccessResult(string json)
+    {
+        return new ProcessExecutionResult
+        {
+            ExitCode = 0,
+            StandardOutput = json
+        };
+    }
+}

--- a/src/Foundry.Utilities.Tests/Networking/WindowsNetworkAdapterSnapshotProviderTests.cs
+++ b/src/Foundry.Utilities.Tests/Networking/WindowsNetworkAdapterSnapshotProviderTests.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.NetworkInformation;
+using Foundry.Utilities.Networking;
+
+namespace Foundry.Utilities.Tests.Networking;
+
+public sealed class WindowsNetworkAdapterSnapshotProviderTests
+{
+    [Fact]
+    public void GetAdapters_MapsFactsAndPreservesSourceOrder()
+    {
+        var ethernet = new StubNetworkAdapterInfo
+        {
+            Id = "ethernet-id",
+            Name = "Ethernet",
+            InterfaceType = NetworkInterfaceType.Ethernet,
+            OperationalStatus = OperationalStatus.Up,
+            PhysicalAddressBytes = [0x00, 0x11, 0xAA, 0xBB, 0xCC, 0xDD],
+            IpFacts = new NetworkAdapterIpFacts(
+                [new NetworkIpv4AddressSnapshot("192.0.2.10", "255.255.255.0")],
+                ["192.0.2.1"],
+                ["192.0.2.53", "2001:db8::53"],
+                true)
+        };
+        var loopback = new StubNetworkAdapterInfo
+        {
+            Id = "loopback-id",
+            Name = "Loopback",
+            InterfaceType = NetworkInterfaceType.Loopback,
+            OperationalStatus = OperationalStatus.Up
+        };
+        var provider = new WindowsNetworkAdapterSnapshotProvider(() => [ethernet, loopback]);
+
+        IReadOnlyList<NetworkAdapterSnapshot> adapters = provider.GetAdapters();
+
+        Assert.Equal(["ethernet-id", "loopback-id"], adapters.Select(static adapter => adapter.Id));
+        NetworkAdapterSnapshot snapshot = adapters[0];
+        Assert.Equal("Ethernet", snapshot.Name);
+        Assert.Equal(NetworkInterfaceType.Ethernet, snapshot.InterfaceType);
+        Assert.Equal(OperationalStatus.Up, snapshot.OperationalStatus);
+        Assert.Equal("00-11-AA-BB-CC-DD", snapshot.MacAddress);
+        NetworkIpv4AddressSnapshot address = Assert.Single(snapshot.Ipv4Addresses);
+        Assert.Equal("192.0.2.10", address.Address);
+        Assert.Equal("255.255.255.0", address.SubnetMask);
+        Assert.Equal(["192.0.2.1"], snapshot.Gateways);
+        Assert.Equal(["192.0.2.53", "2001:db8::53"], snapshot.DnsServers);
+        Assert.True(snapshot.IsDhcpEnabled);
+    }
+
+    [Fact]
+    public void GetAdapters_WhenOptionalFactsFail_RetainsAdapterWithNeutralFacts()
+    {
+        var adapter = new StubNetworkAdapterInfo
+        {
+            Id = "ethernet-id",
+            Name = "Ethernet",
+            InterfaceType = NetworkInterfaceType.Ethernet,
+            OperationalStatus = OperationalStatus.Up,
+            ThrowOnPhysicalAddress = true,
+            ThrowOnIpFacts = true
+        };
+        var provider = new WindowsNetworkAdapterSnapshotProvider(() => [adapter]);
+
+        NetworkAdapterSnapshot snapshot = Assert.Single(provider.GetAdapters());
+
+        Assert.Equal(string.Empty, snapshot.MacAddress);
+        Assert.Empty(snapshot.Ipv4Addresses);
+        Assert.Empty(snapshot.Gateways);
+        Assert.Empty(snapshot.DnsServers);
+        Assert.False(snapshot.IsDhcpEnabled);
+    }
+
+    [Fact]
+    public void GetAdapters_WhenOneAdapterIdentityFails_ContinuesWithOtherAdapters()
+    {
+        var invalid = new StubNetworkAdapterInfo { ThrowOnIdentity = true };
+        var valid = new StubNetworkAdapterInfo
+        {
+            Id = "valid-id",
+            Name = "Ethernet",
+            InterfaceType = NetworkInterfaceType.Ethernet,
+            OperationalStatus = OperationalStatus.Down
+        };
+        var provider = new WindowsNetworkAdapterSnapshotProvider(() => [invalid, valid]);
+
+        NetworkAdapterSnapshot snapshot = Assert.Single(provider.GetAdapters());
+
+        Assert.Equal("valid-id", snapshot.Id);
+    }
+
+    [Fact]
+    public void GetAdapters_WhenEnumerationFails_PropagatesFailure()
+    {
+        var provider = new WindowsNetworkAdapterSnapshotProvider(
+            () => throw new NetworkInformationException());
+
+        Assert.Throws<NetworkInformationException>(() => provider.GetAdapters());
+    }
+
+    private sealed class StubNetworkAdapterInfo : IWindowsNetworkAdapterInfo
+    {
+        private string _id = string.Empty;
+
+        public string Id
+        {
+            get => ThrowOnIdentity ? throw new InvalidOperationException() : _id;
+            init => _id = value;
+        }
+
+        public string Name { get; init; } = string.Empty;
+
+        public NetworkInterfaceType InterfaceType { get; init; }
+
+        public OperationalStatus OperationalStatus { get; init; }
+
+        public byte[] PhysicalAddressBytes { get; init; } = [];
+
+        public NetworkAdapterIpFacts IpFacts { get; init; } = NetworkAdapterIpFacts.Empty;
+
+        public bool ThrowOnIdentity { get; init; }
+
+        public bool ThrowOnPhysicalAddress { get; init; }
+
+        public bool ThrowOnIpFacts { get; init; }
+
+        public byte[] GetPhysicalAddressBytes()
+            => ThrowOnPhysicalAddress ? throw new InvalidOperationException() : PhysicalAddressBytes;
+
+        public NetworkAdapterIpFacts GetIpFacts()
+            => ThrowOnIpFacts ? throw new InvalidOperationException() : IpFacts;
+    }
+}

--- a/src/Foundry.Utilities.Tests/Networking/WindowsNetworkAdapterSnapshotProviderTests.cs
+++ b/src/Foundry.Utilities.Tests/Networking/WindowsNetworkAdapterSnapshotProviderTests.cs
@@ -3,12 +3,38 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Net.NetworkInformation;
+using System.Net;
 using Foundry.Utilities.Networking;
 
 namespace Foundry.Utilities.Tests.Networking;
 
 public sealed class WindowsNetworkAdapterSnapshotProviderTests
 {
+    [Fact]
+    public void CreateIpFacts_MapsIpv4AddressesAndGatewaysWhilePreservingDualStackDns()
+    {
+        NetworkAdapterIpFacts facts = WindowsNetworkAdapterInfo.CreateIpFacts(
+            [
+                new NetworkAddressFacts(
+                    IPAddress.Parse("192.0.2.10"),
+                    IPAddress.Parse("255.255.255.0")),
+                new NetworkAddressFacts(IPAddress.Parse("2001:db8::10"), null),
+                new NetworkAddressFacts(IPAddress.Parse("198.51.100.10"), null)
+            ],
+            [IPAddress.Parse("192.0.2.1"), IPAddress.Parse("2001:db8::1")],
+            [IPAddress.Parse("192.0.2.53"), IPAddress.Parse("2001:db8::53")],
+            isDhcpEnabled: true);
+
+        Assert.Equal(2, facts.Ipv4Addresses.Count);
+        Assert.Equal("192.0.2.10", facts.Ipv4Addresses[0].Address);
+        Assert.Equal("255.255.255.0", facts.Ipv4Addresses[0].SubnetMask);
+        Assert.Equal("198.51.100.10", facts.Ipv4Addresses[1].Address);
+        Assert.Null(facts.Ipv4Addresses[1].SubnetMask);
+        Assert.Equal(["192.0.2.1"], facts.Gateways);
+        Assert.Equal(["192.0.2.53", "2001:db8::53"], facts.DnsServers);
+        Assert.True(facts.IsDhcpEnabled);
+    }
+
     [Fact]
     public void GetAdapters_MapsFactsAndPreservesSourceOrder()
     {

--- a/src/Foundry.Utilities.Tests/Processes/PowerShellCommandTests.cs
+++ b/src/Foundry.Utilities.Tests/Processes/PowerShellCommandTests.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Utilities.Processes;
+
+namespace Foundry.Utilities.Tests.Processes;
+
+public sealed class PowerShellCommandTests
+{
+    [Fact]
+    public void CreateEncodedArguments_ReturnsIndependentTokensWithUtf16LittleEndianPayload()
+    {
+        IReadOnlyList<string> arguments = PowerShellCommand.CreateEncodedArguments("Write-Output 'café'");
+
+        Assert.Equal(
+            [
+                "-EncodedCommand",
+                "VwByAGkAdABlAC0ATwB1AHQAcAB1AHQAIAAnAGMAYQBmAOkAJwA="
+            ],
+            arguments);
+    }
+}

--- a/src/Foundry.Utilities.Tests/Serialization/JsonObjectSequenceTests.cs
+++ b/src/Foundry.Utilities.Tests/Serialization/JsonObjectSequenceTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using Foundry.Utilities.Serialization;
+
+namespace Foundry.Utilities.Tests.Serialization;
+
+public sealed class JsonObjectSequenceTests
+{
+    [Fact]
+    public void Parse_WhenInputIsNull_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => JsonObjectSequence.Parse(null!));
+    }
+
+    [Fact]
+    public void Parse_WhenInputIsBlank_ReturnsEmptySequence()
+    {
+        IReadOnlyList<JsonElement> elements = JsonObjectSequence.Parse("  ");
+
+        Assert.Empty(elements);
+    }
+
+    [Fact]
+    public void Parse_WhenRootIsObject_ReturnsIndependentObject()
+    {
+        IReadOnlyList<JsonElement> elements = JsonObjectSequence.Parse("""{"Name":"Disk"}""");
+
+        JsonElement element = Assert.Single(elements);
+        Assert.Equal("Disk", element.GetProperty("Name").GetString());
+    }
+
+    [Fact]
+    public void Parse_WhenRootIsArray_ReturnsIndependentObjectsInOrder()
+    {
+        IReadOnlyList<JsonElement> elements = JsonObjectSequence.Parse(
+            """[{"Number":1},{"Number":2}]""");
+
+        Assert.Collection(
+            elements,
+            element => Assert.Equal(1, element.GetProperty("Number").GetInt32()),
+            element => Assert.Equal(2, element.GetProperty("Number").GetInt32()));
+    }
+
+    [Fact]
+    public void Parse_WhenJsonIsMalformed_ThrowsJsonException()
+    {
+        Assert.ThrowsAny<JsonException>(() => JsonObjectSequence.Parse("{"));
+    }
+
+    [Theory]
+    [InlineData("42")]
+    [InlineData("[{} , 42]")]
+    public void Parse_WhenPayloadDoesNotContainOnlyObjects_ThrowsJsonException(string json)
+    {
+        Assert.Throws<JsonException>(() => JsonObjectSequence.Parse(json));
+    }
+}

--- a/src/Foundry.Utilities.Tests/Storage/WindowsDiskInspectorTests.cs
+++ b/src/Foundry.Utilities.Tests/Storage/WindowsDiskInspectorTests.cs
@@ -1,0 +1,243 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+using Foundry.Utilities.Processes;
+using Foundry.Utilities.Storage;
+
+namespace Foundry.Utilities.Tests.Storage;
+
+public sealed class WindowsDiskInspectorTests
+{
+    [Fact]
+    public async Task GetDisksAsync_ParsesRawDiskFacts()
+    {
+        ProcessExecutionRequest? capturedRequest = null;
+        var inspector = new WindowsDiskInspector((request, _) =>
+        {
+            capturedRequest = request;
+            return Task.FromResult(CreateSuccessResult(
+                """
+                {
+                  "Number":"2",
+                  "FriendlyName":" NVMe Disk ",
+                  "SerialNumber":" SERIAL-2 ",
+                  "BusType":" NVMe ",
+                  "PartitionStyle":" GPT ",
+                  "Size":"1073741824",
+                  "IsSystem":"true",
+                  "IsBoot":false,
+                  "IsReadOnly":true,
+                  "IsOffline":"false",
+                  "IsRemovable":false
+                }
+                """));
+        });
+
+        DiskInfo disk = Assert.Single(
+            await inspector.GetDisksAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal(2, disk.Number);
+        Assert.Equal("NVMe Disk", disk.FriendlyName);
+        Assert.Equal("SERIAL-2", disk.SerialNumber);
+        Assert.Equal("NVMe", disk.BusType);
+        Assert.Equal("GPT", disk.PartitionStyle);
+        Assert.Equal(1073741824UL, disk.SizeBytes);
+        Assert.True(disk.IsSystem);
+        Assert.False(disk.IsBoot);
+        Assert.True(disk.IsReadOnly);
+        Assert.False(disk.IsOffline);
+        Assert.False(disk.IsRemovable);
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal("powershell.exe", capturedRequest.FileName);
+        Assert.Equal("-NoProfile", capturedRequest.ArgumentList?[0]);
+        IReadOnlyList<string> arguments = Assert.IsAssignableFrom<IReadOnlyList<string>>(
+            capturedRequest.ArgumentList);
+        int encodedCommandIndex = arguments.ToList().IndexOf("-EncodedCommand");
+        Assert.True(encodedCommandIndex >= 0);
+        string script = Encoding.Unicode.GetString(
+            Convert.FromBase64String(arguments[encodedCommandIndex + 1]));
+        Assert.Contains("Get-Disk", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetDisksAsync_WhenPayloadIsArray_PreservesSourceOrder()
+    {
+        var inspector = CreateInspector(
+            """
+            [
+              {"Number":3,"IsSystem":false,"IsBoot":false,"IsReadOnly":false,"IsOffline":false},
+              {"Number":1,"IsSystem":false,"IsBoot":false,"IsReadOnly":false,"IsOffline":false}
+            ]
+            """);
+
+        IReadOnlyList<DiskInfo> disks = await inspector.GetDisksAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal([3, 1], disks.Select(static disk => disk.Number));
+    }
+
+    [Fact]
+    public async Task GetDisksAsync_WhenPayloadIsEmptyArray_ReturnsEmptyList()
+    {
+        var inspector = CreateInspector("[]");
+
+        IReadOnlyList<DiskInfo> disks = await inspector.GetDisksAsync(TestContext.Current.CancellationToken);
+
+        Assert.Empty(disks);
+    }
+
+    [Theory]
+    [InlineData(0, "")]
+    [InlineData(1, "query failed")]
+    public async Task GetDisksAsync_WhenQueryReturnsNoUsableData_ThrowsInvalidDataException(
+        int exitCode,
+        string standardOutput)
+    {
+        var inspector = new WindowsDiskInspector((_, _) => Task.FromResult(
+            new ProcessExecutionResult { ExitCode = exitCode, StandardOutput = standardOutput }));
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => inspector.GetDisksAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task GetDisksAsync_WhenPayloadIsMalformed_ThrowsInvalidDataException()
+    {
+        var inspector = CreateInspector("{");
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => inspector.GetDisksAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Theory]
+    [InlineData("{\"Number\":-1,\"IsSystem\":false,\"IsBoot\":false,\"IsReadOnly\":false,\"IsOffline\":false}")]
+    [InlineData("{\"Number\":1,\"IsBoot\":false,\"IsReadOnly\":false,\"IsOffline\":false}")]
+    [InlineData("{\"Number\":1,\"IsSystem\":\"invalid\",\"IsBoot\":false,\"IsReadOnly\":false,\"IsOffline\":false}")]
+    public async Task GetDisksAsync_WhenSafetyFactsAreInvalid_ThrowsInvalidDataException(string json)
+    {
+        var inspector = CreateInspector(json);
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => inspector.GetDisksAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ResolveDiskNumberForPathAsync_ParsesNumericString()
+    {
+        ProcessExecutionRequest? capturedRequest = null;
+        var inspector = new WindowsDiskInspector((request, _) =>
+        {
+            capturedRequest = request;
+            return Task.FromResult(CreateSuccessResult("""{"DiskNumber":"4"}"""));
+        });
+
+        int? diskNumber = await inspector.ResolveDiskNumberForPathAsync(
+            "X:\\Foundry\\Runtime",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(4, diskNumber);
+        Assert.NotNull(capturedRequest);
+        IReadOnlyList<string> arguments = Assert.IsAssignableFrom<IReadOnlyList<string>>(
+            capturedRequest.ArgumentList);
+        int encodedCommandIndex = arguments.ToList().IndexOf("-EncodedCommand");
+        string script = Encoding.Unicode.GetString(
+            Convert.FromBase64String(arguments[encodedCommandIndex + 1]));
+        Assert.Contains("Get-Partition -DriveLetter 'X'", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ResolveDiskNumberForPathAsync_WhenPartitionIsNotFound_ReturnsNull()
+    {
+        var inspector = CreateInspector("{}");
+
+        int? diskNumber = await inspector.ResolveDiskNumberForPathAsync(
+            "X:\\Foundry",
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(diskNumber);
+    }
+
+    [Fact]
+    public async Task ResolveDiskNumberForPathAsync_WhenQueryReturnsBlankOutput_ReturnsNull()
+    {
+        var inspector = CreateInspector(string.Empty);
+
+        int? diskNumber = await inspector.ResolveDiskNumberForPathAsync(
+            "X:\\Foundry",
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(diskNumber);
+    }
+
+    [Fact]
+    public async Task ResolveDiskNumberForPathAsync_WhenPayloadIsMalformed_ThrowsInvalidDataException()
+    {
+        var inspector = CreateInspector("{");
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => inspector.ResolveDiskNumberForPathAsync(
+                "X:\\Foundry",
+                TestContext.Current.CancellationToken));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("relative\\path")]
+    [InlineData("x:relative")]
+    [InlineData("\\\\server\\share\\folder")]
+    [InlineData("\\\\?\\Volume{00000000-0000-0000-0000-000000000000}\\folder")]
+    public async Task ResolveDiskNumberForPathAsync_WhenPathHasNoDrive_ReturnsNullWithoutExecution(string path)
+    {
+        bool executed = false;
+        var inspector = new WindowsDiskInspector((_, _) =>
+        {
+            executed = true;
+            return Task.FromResult(CreateSuccessResult("""{"DiskNumber":1}"""));
+        });
+
+        int? diskNumber = await inspector.ResolveDiskNumberForPathAsync(
+            path,
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(diskNumber);
+        Assert.False(executed);
+    }
+
+    [Fact]
+    public async Task GetDisksAsync_WhenExecutionFailsUnexpectedly_PropagatesFailure()
+    {
+        var inspector = new WindowsDiskInspector((_, _) => Task.FromException<ProcessExecutionResult>(
+            new ApplicationException("Unexpected failure.")));
+
+        await Assert.ThrowsAsync<ApplicationException>(
+            () => inspector.GetDisksAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task GetDisksAsync_WhenExecutionIsCanceled_PropagatesCancellation()
+    {
+        using var cancellationSource = new CancellationTokenSource();
+        cancellationSource.Cancel();
+        var inspector = new WindowsDiskInspector(
+            (_, cancellationToken) => Task.FromCanceled<ProcessExecutionResult>(cancellationToken));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => inspector.GetDisksAsync(cancellationSource.Token));
+    }
+
+    private static WindowsDiskInspector CreateInspector(string json)
+    {
+        return new WindowsDiskInspector((_, _) => Task.FromResult(CreateSuccessResult(json)));
+    }
+
+    private static ProcessExecutionResult CreateSuccessResult(string json)
+    {
+        return new ProcessExecutionResult
+        {
+            ExitCode = 0,
+            StandardOutput = json
+        };
+    }
+}

--- a/src/Foundry.Utilities.Tests/Storage/WindowsVolumeDiscoveryTests.cs
+++ b/src/Foundry.Utilities.Tests/Storage/WindowsVolumeDiscoveryTests.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using Foundry.Utilities.Storage;
+
+namespace Foundry.Utilities.Tests.Storage;
+
+public sealed class WindowsVolumeDiscoveryTests
+{
+    [Fact]
+    public void GetVolumes_WhenDriveIsReady_ReturnsAllAvailableFacts()
+    {
+        var discovery = new WindowsVolumeDiscovery(() =>
+        [
+            new FakeDriveInfo
+            {
+                RootPath = @"D:\",
+                VolumeLabel = "Data",
+                DriveType = DriveType.Fixed,
+                IsReady = true,
+                AvailableFreeSpace = 42
+            }
+        ]);
+
+        VolumeInfo volume = Assert.Single(discovery.GetVolumes());
+
+        Assert.Equal(@"D:\", volume.RootPath);
+        Assert.Equal("Data", volume.VolumeLabel);
+        Assert.Equal(DriveType.Fixed, volume.DriveType);
+        Assert.True(volume.IsReady);
+        Assert.Equal(42, volume.AvailableFreeSpace);
+    }
+
+    [Fact]
+    public void GetVolumes_WhenDriveIsNotReady_ReturnsOnlySafeFacts()
+    {
+        var drive = new FakeDriveInfo
+        {
+            RootPath = @"E:\",
+            DriveType = DriveType.CDRom,
+            IsReady = false,
+            ThrowWhenReadyOnlyFactsAreRead = true
+        };
+        var discovery = new WindowsVolumeDiscovery(() => [drive]);
+
+        VolumeInfo volume = Assert.Single(discovery.GetVolumes());
+
+        Assert.Equal(@"E:\", volume.RootPath);
+        Assert.Equal(string.Empty, volume.VolumeLabel);
+        Assert.Equal(DriveType.CDRom, volume.DriveType);
+        Assert.False(volume.IsReady);
+        Assert.Equal(0, volume.AvailableFreeSpace);
+    }
+
+    [Fact]
+    public void GetVolumes_WhenReadyOnlyFactsAreInaccessible_ReturnsSafeFallbacks()
+    {
+        var inaccessibleDrive = new FakeDriveInfo
+        {
+            RootPath = @"E:\",
+            DriveType = DriveType.Removable,
+            IsReady = true,
+            ThrowWhenReadyOnlyFactsAreRead = true
+        };
+        var discovery = new WindowsVolumeDiscovery(() => [inaccessibleDrive]);
+
+        VolumeInfo volume = Assert.Single(discovery.GetVolumes());
+
+        Assert.Equal(@"E:\", volume.RootPath);
+        Assert.Equal(string.Empty, volume.VolumeLabel);
+        Assert.Equal(DriveType.Removable, volume.DriveType);
+        Assert.True(volume.IsReady);
+        Assert.Equal(0, volume.AvailableFreeSpace);
+    }
+
+    [Fact]
+    public void GetVolumes_WhenDriveEnumerationFailsUnexpectedly_PropagatesFailure()
+    {
+        var discovery = new WindowsVolumeDiscovery(
+            () => throw new InvalidOperationException("Unexpected failure."));
+
+        Assert.Throws<InvalidOperationException>(() => discovery.GetVolumes());
+    }
+
+    [Fact]
+    public void GetVolumes_WhenDrivePropertyFailsUnexpectedly_PropagatesFailure()
+    {
+        var drive = new FakeDriveInfo
+        {
+            RootPath = @"E:\",
+            DriveType = DriveType.Removable,
+            IsReady = true,
+            ReadyOnlyFactsException = new InvalidOperationException("Unexpected failure.")
+        };
+        var discovery = new WindowsVolumeDiscovery(() => [drive]);
+
+        Assert.Throws<InvalidOperationException>(() => discovery.GetVolumes());
+    }
+
+    private sealed class FakeDriveInfo : IWindowsDriveInfo
+    {
+        private string _volumeLabel = string.Empty;
+        private long _availableFreeSpace;
+
+        public required string RootPath { get; init; }
+
+        public string VolumeLabel
+        {
+            get => ReadyOnlyFactsException is not null
+                ? throw ReadyOnlyFactsException
+                : _volumeLabel;
+            init => _volumeLabel = value;
+        }
+
+        public DriveType DriveType { get; init; }
+
+        public bool IsReady { get; init; }
+
+        public long AvailableFreeSpace
+        {
+            get => ReadyOnlyFactsException is not null
+                ? throw ReadyOnlyFactsException
+                : _availableFreeSpace;
+            init => _availableFreeSpace = value;
+        }
+
+        public bool ThrowWhenReadyOnlyFactsAreRead
+        {
+            init => ReadyOnlyFactsException = value
+                ? new IOException("The drive is inaccessible.")
+                : null;
+        }
+
+        public Exception? ReadyOnlyFactsException { get; init; }
+    }
+}

--- a/src/Foundry.Utilities/Hardware/HardwareSnapshot.cs
+++ b/src/Foundry.Utilities/Hardware/HardwareSnapshot.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Utilities.Hardware;
+
+/// <summary>
+/// Describes hardware facts for the current machine.
+/// </summary>
+public sealed record HardwareSnapshot(
+    string Manufacturer,
+    string Model,
+    string Product,
+    string SerialNumber,
+    string Architecture,
+    bool IsVirtualMachine,
+    bool IsOnBattery,
+    bool IsTpmPresent,
+    string SystemFirmwareHardwareId,
+    IReadOnlyList<PnpDeviceSnapshot> PnpDevices);

--- a/src/Foundry.Utilities/Hardware/IHardwareInspector.cs
+++ b/src/Foundry.Utilities/Hardware/IHardwareInspector.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Utilities.Hardware;
+
+/// <summary>
+/// Inspects hardware facts for the current machine.
+/// </summary>
+public interface IHardwareInspector
+{
+    /// <summary>
+    /// Gets the current hardware snapshot.
+    /// </summary>
+    Task<HardwareSnapshot> GetCurrentAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Foundry.Utilities/Hardware/PnpDeviceSnapshot.cs
+++ b/src/Foundry.Utilities/Hardware/PnpDeviceSnapshot.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Utilities.Hardware;
+
+/// <summary>
+/// Describes raw Plug and Play device facts.
+/// </summary>
+public sealed record PnpDeviceSnapshot(
+    string Name,
+    string DeviceId,
+    IReadOnlyList<string> HardwareIds,
+    string ClassGuid,
+    string Manufacturer,
+    string PnpClass);

--- a/src/Foundry.Utilities/Hardware/WindowsHardwareInspector.cs
+++ b/src/Foundry.Utilities/Hardware/WindowsHardwareInspector.cs
@@ -1,0 +1,257 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Text.Json;
+using Foundry.Utilities.Processes;
+using Foundry.Utilities.Serialization;
+
+namespace Foundry.Utilities.Hardware;
+
+/// <summary>
+/// Inspects Windows hardware through CIM and PowerShell.
+/// </summary>
+public sealed class WindowsHardwareInspector : IHardwareInspector
+{
+    private const string InspectionScript = """
+        function ConvertTo-TrimmedString {
+            param (
+                [Parameter(ValueFromPipeline = $true)]
+                $Value
+            )
+
+            process {
+                if ($null -eq $Value) {
+                    return ''
+                }
+
+                return $Value.ToString().Trim()
+            }
+        }
+
+        $computer = Get-CimInstance -ClassName Win32_ComputerSystem
+        $product = Get-CimInstance -ClassName Win32_ComputerSystemProduct
+        $bios = Get-CimInstance -ClassName Win32_BIOS
+        $tpm = Get-CimInstance -Namespace 'ROOT\cimv2\Security\MicrosoftTpm' -ClassName Win32_Tpm -ErrorAction SilentlyContinue
+        $battery = Get-CimInstance -ClassName Win32_Battery -ErrorAction SilentlyContinue
+        $pnpDevices = @(Get-CimInstance -ClassName Win32_PnpEntity -Property Name,DeviceID,HardwareID,ClassGuid,Manufacturer,PNPClass -ErrorAction SilentlyContinue | ForEach-Object {
+            $hardwareIds = @($_.HardwareID | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | ForEach-Object { $_.ToString().Trim() })
+            [pscustomobject]@{
+                Name = [string]($_.Name | ConvertTo-TrimmedString)
+                DeviceId = [string]($_.DeviceID | ConvertTo-TrimmedString)
+                HardwareIds = $hardwareIds
+                ClassGuid = [string]($_.ClassGuid | ConvertTo-TrimmedString)
+                Manufacturer = [string]($_.Manufacturer | ConvertTo-TrimmedString)
+                PnpClass = [string]($_.PNPClass | ConvertTo-TrimmedString)
+            }
+        })
+        $firmwareDevice = $pnpDevices | Where-Object { $_.ClassGuid -eq '{f2e7dd72-6468-4e36-b6f1-6488f42c1b52}' } | Select-Object -First 1
+        $systemFirmwareHardwareId = ''
+        if ($firmwareDevice -and $firmwareDevice.DeviceId -match '\{?(([0-9a-f]){8}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){12})\}?') {
+            $systemFirmwareHardwareId = $Matches[1]
+        }
+        $isOnBattery = @($battery | Where-Object { $_.BatteryStatus -eq 1 }).Count -gt 0
+
+        [pscustomobject]@{
+            Manufacturer = [string]$computer.Manufacturer
+            Model = [string]$computer.Model
+            Product = [string]$product.Version
+            SerialNumber = [string]$bios.SerialNumber
+            Architecture = [string]$env:PROCESSOR_ARCHITECTURE
+            IsOnBattery = [bool]$isOnBattery
+            IsTpmPresent = [bool]($null -ne $tpm)
+            SystemFirmwareHardwareId = [string]$systemFirmwareHardwareId
+            PnpDevices = $pnpDevices
+        } | ConvertTo-Json -Compress -Depth 8
+        """;
+
+    private readonly Func<ProcessExecutionRequest, CancellationToken, Task<ProcessExecutionResult>> _executeProcess;
+
+    /// <summary>
+    /// Initializes a new inspector using the shared process runner.
+    /// </summary>
+    public WindowsHardwareInspector(ProcessRunner processRunner)
+        : this(processRunner.RunAsync)
+    {
+    }
+
+    internal WindowsHardwareInspector(
+        Func<ProcessExecutionRequest, CancellationToken, Task<ProcessExecutionResult>> executeProcess)
+    {
+        ArgumentNullException.ThrowIfNull(executeProcess);
+        _executeProcess = executeProcess;
+    }
+
+    /// <inheritdoc />
+    public async Task<HardwareSnapshot> GetCurrentAsync(CancellationToken cancellationToken = default)
+    {
+        var request = new ProcessExecutionRequest(
+            "powershell.exe",
+            [
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                .. PowerShellCommand.CreateEncodedArguments(InspectionScript)
+            ],
+            Path.GetTempPath());
+
+        ProcessExecutionResult execution = await _executeProcess(request, cancellationToken).ConfigureAwait(false);
+        if (!execution.IsSuccess || string.IsNullOrWhiteSpace(execution.StandardOutput))
+        {
+            throw new InvalidDataException(
+                $"Hardware inspection returned no data. ExitCode={execution.ExitCode}.");
+        }
+
+        try
+        {
+            IReadOnlyList<JsonElement> roots = JsonObjectSequence.Parse(execution.StandardOutput);
+            if (roots.Count != 1)
+            {
+                throw new JsonException("Hardware inspection must return exactly one object.");
+            }
+
+            return ParseSnapshot(roots[0]);
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidDataException("Failed to parse the hardware inspection payload.", exception);
+        }
+    }
+
+    private static HardwareSnapshot ParseSnapshot(JsonElement root)
+    {
+        string manufacturer = ReadString(root, "Manufacturer");
+        string model = ReadString(root, "Model");
+        string product = ReadString(root, "Product");
+
+        return new HardwareSnapshot(
+            manufacturer,
+            model,
+            product,
+            ReadString(root, "SerialNumber"),
+            NormalizeArchitecture(ReadString(root, "Architecture")),
+            IsVirtualMachine(manufacturer, model, product),
+            ReadBool(root, "IsOnBattery"),
+            ReadBool(root, "IsTpmPresent"),
+            ReadString(root, "SystemFirmwareHardwareId"),
+            ReadPnpDevices(root));
+    }
+
+    private static IReadOnlyList<PnpDeviceSnapshot> ReadPnpDevices(JsonElement root)
+    {
+        if (!root.TryGetProperty("PnpDevices", out JsonElement devicesElement))
+        {
+            return [];
+        }
+
+        if (devicesElement.ValueKind == JsonValueKind.Object)
+        {
+            return [ParsePnpDevice(devicesElement)];
+        }
+
+        if (devicesElement.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return devicesElement
+            .EnumerateArray()
+            .Where(static element => element.ValueKind == JsonValueKind.Object)
+            .Select(ParsePnpDevice)
+            .ToArray();
+    }
+
+    private static PnpDeviceSnapshot ParsePnpDevice(JsonElement element)
+    {
+        return new PnpDeviceSnapshot(
+            ReadString(element, "Name"),
+            ReadString(element, "DeviceId"),
+            ReadStringArray(element, "HardwareIds"),
+            ReadString(element, "ClassGuid"),
+            ReadString(element, "Manufacturer"),
+            ReadString(element, "PnpClass"));
+    }
+
+    private static IReadOnlyList<string> ReadStringArray(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out JsonElement value))
+        {
+            return [];
+        }
+
+        if (value.ValueKind == JsonValueKind.String)
+        {
+            string item = value.GetString()?.Trim() ?? string.Empty;
+            return string.IsNullOrWhiteSpace(item) ? [] : [item];
+        }
+
+        if (value.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return value
+            .EnumerateArray()
+            .Where(static item => item.ValueKind == JsonValueKind.String)
+            .Select(static item => item.GetString()?.Trim() ?? string.Empty)
+            .Where(static item => !string.IsNullOrWhiteSpace(item))
+            .ToArray();
+    }
+
+    private static string ReadString(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out JsonElement value) ||
+            value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+        {
+            return string.Empty;
+        }
+
+        return value.ValueKind == JsonValueKind.String
+            ? value.GetString()?.Trim() ?? string.Empty
+            : value.ToString().Trim();
+    }
+
+    private static bool ReadBool(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out JsonElement value))
+        {
+            return false;
+        }
+
+        return value.ValueKind == JsonValueKind.True ||
+               (value.ValueKind == JsonValueKind.String &&
+                bool.TryParse(value.GetString(), out bool parsed) &&
+                parsed);
+    }
+
+    private static string NormalizeArchitecture(string value)
+    {
+        string normalized = value.Trim().ToLowerInvariant();
+        return normalized switch
+        {
+            "amd64" or "x64" => "x64",
+            "arm64" or "aarch64" => "arm64",
+            _ => normalized
+        };
+    }
+
+    private static bool IsVirtualMachine(string manufacturer, string model, string product)
+    {
+        string combined = string.Join(" | ", manufacturer, model, product).ToLowerInvariant();
+        if (combined.Contains("vmware") ||
+            combined.Contains("virtualbox") ||
+            combined.Contains("virtual machine") ||
+            combined.Contains("kvm") ||
+            combined.Contains("qemu") ||
+            combined.Contains("xen") ||
+            combined.Contains("hvm domu") ||
+            combined.Contains("parallels") ||
+            combined.Contains("bhyve"))
+        {
+            return true;
+        }
+
+        return combined.Contains("microsoft corporation") && combined.Contains("virtual");
+    }
+}

--- a/src/Foundry.Utilities/Networking/INetworkAdapterSnapshotProvider.cs
+++ b/src/Foundry.Utilities/Networking/INetworkAdapterSnapshotProvider.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Utilities.Networking;
+
+/// <summary>
+/// Provides raw network adapter snapshots.
+/// </summary>
+public interface INetworkAdapterSnapshotProvider
+{
+    /// <summary>
+    /// Gets the current network adapters in platform enumeration order.
+    /// </summary>
+    IReadOnlyList<NetworkAdapterSnapshot> GetAdapters();
+}

--- a/src/Foundry.Utilities/Networking/NetworkAdapterSnapshot.cs
+++ b/src/Foundry.Utilities/Networking/NetworkAdapterSnapshot.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.NetworkInformation;
+
+namespace Foundry.Utilities.Networking;
+
+/// <summary>
+/// Describes raw Windows network adapter facts.
+/// </summary>
+public sealed record NetworkAdapterSnapshot(
+    string Id,
+    string Name,
+    NetworkInterfaceType InterfaceType,
+    OperationalStatus OperationalStatus,
+    string MacAddress,
+    IReadOnlyList<NetworkIpv4AddressSnapshot> Ipv4Addresses,
+    IReadOnlyList<string> Gateways,
+    IReadOnlyList<string> DnsServers,
+    bool IsDhcpEnabled);

--- a/src/Foundry.Utilities/Networking/NetworkIpv4AddressSnapshot.cs
+++ b/src/Foundry.Utilities/Networking/NetworkIpv4AddressSnapshot.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Utilities.Networking;
+
+/// <summary>
+/// Describes an IPv4 address and its subnet mask.
+/// </summary>
+public sealed record NetworkIpv4AddressSnapshot(string Address, string? SubnetMask);

--- a/src/Foundry.Utilities/Networking/WindowsNetworkAdapterSnapshotProvider.cs
+++ b/src/Foundry.Utilities/Networking/WindowsNetworkAdapterSnapshotProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
+using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 
@@ -147,19 +148,15 @@ internal sealed class WindowsNetworkAdapterInfo(NetworkInterface adapter) : IWin
     public NetworkAdapterIpFacts GetIpFacts()
     {
         IPInterfaceProperties properties = adapter.GetIPProperties();
-        NetworkIpv4AddressSnapshot[] ipv4Addresses = properties.UnicastAddresses
-            .Where(static address => address.Address.AddressFamily == AddressFamily.InterNetwork)
-            .Select(static address => new NetworkIpv4AddressSnapshot(
-                address.Address.ToString(),
-                address.IPv4Mask?.ToString()))
+        NetworkAddressFacts[] addresses = properties.UnicastAddresses
+            .Select(static address => new NetworkAddressFacts(
+                address.Address,
+                address.Address.AddressFamily == AddressFamily.InterNetwork ? address.IPv4Mask : null))
             .ToArray();
-        string[] gateways = properties.GatewayAddresses
-            .Where(static gateway => gateway.Address.AddressFamily == AddressFamily.InterNetwork)
-            .Select(static gateway => gateway.Address.ToString())
+        IPAddress[] gateways = properties.GatewayAddresses
+            .Select(static gateway => gateway.Address)
             .ToArray();
-        string[] dnsServers = properties.DnsAddresses
-            .Select(static address => address.ToString())
-            .ToArray();
+        IPAddress[] dnsServers = [.. properties.DnsAddresses];
 
         bool isDhcpEnabled;
         try
@@ -173,6 +170,35 @@ internal sealed class WindowsNetworkAdapterInfo(NetworkInterface adapter) : IWin
             isDhcpEnabled = false;
         }
 
-        return new NetworkAdapterIpFacts(ipv4Addresses, gateways, dnsServers, isDhcpEnabled);
+        return CreateIpFacts(addresses, gateways, dnsServers, isDhcpEnabled);
+    }
+
+    internal static NetworkAdapterIpFacts CreateIpFacts(
+        IEnumerable<NetworkAddressFacts> addresses,
+        IEnumerable<IPAddress> gateways,
+        IEnumerable<IPAddress> dnsServers,
+        bool isDhcpEnabled)
+    {
+        NetworkIpv4AddressSnapshot[] ipv4Addresses = addresses
+            .Where(static address => address.Address.AddressFamily == AddressFamily.InterNetwork)
+            .Select(static address => new NetworkIpv4AddressSnapshot(
+                address.Address.ToString(),
+                address.SubnetMask?.ToString()))
+            .ToArray();
+        string[] ipv4Gateways = gateways
+            .Where(static gateway => gateway.AddressFamily == AddressFamily.InterNetwork)
+            .Select(static gateway => gateway.ToString())
+            .ToArray();
+        string[] mappedDnsServers = dnsServers
+            .Select(static address => address.ToString())
+            .ToArray();
+
+        return new NetworkAdapterIpFacts(
+            ipv4Addresses,
+            ipv4Gateways,
+            mappedDnsServers,
+            isDhcpEnabled);
     }
 }
+
+internal sealed record NetworkAddressFacts(IPAddress Address, IPAddress? SubnetMask);

--- a/src/Foundry.Utilities/Networking/WindowsNetworkAdapterSnapshotProvider.cs
+++ b/src/Foundry.Utilities/Networking/WindowsNetworkAdapterSnapshotProvider.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+
+namespace Foundry.Utilities.Networking;
+
+/// <summary>
+/// Reads network adapter facts from Windows.
+/// </summary>
+public sealed class WindowsNetworkAdapterSnapshotProvider : INetworkAdapterSnapshotProvider
+{
+    private readonly Func<IEnumerable<IWindowsNetworkAdapterInfo>> _enumerateAdapters;
+
+    /// <summary>
+    /// Initializes a provider backed by <see cref="NetworkInterface"/>.
+    /// </summary>
+    public WindowsNetworkAdapterSnapshotProvider()
+        : this(EnumerateWindowsAdapters)
+    {
+    }
+
+    internal WindowsNetworkAdapterSnapshotProvider(
+        Func<IEnumerable<IWindowsNetworkAdapterInfo>> enumerateAdapters)
+    {
+        ArgumentNullException.ThrowIfNull(enumerateAdapters);
+        _enumerateAdapters = enumerateAdapters;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<NetworkAdapterSnapshot> GetAdapters()
+    {
+        var snapshots = new List<NetworkAdapterSnapshot>();
+        foreach (IWindowsNetworkAdapterInfo adapter in _enumerateAdapters())
+        {
+            string id;
+            string name;
+            NetworkInterfaceType interfaceType;
+            OperationalStatus operationalStatus;
+
+            try
+            {
+                id = adapter.Id;
+                name = adapter.Name;
+                interfaceType = adapter.InterfaceType;
+                operationalStatus = adapter.OperationalStatus;
+            }
+            catch (Exception exception) when (IsAdapterAccessException(exception))
+            {
+                continue;
+            }
+
+            string macAddress = string.Empty;
+            try
+            {
+                macAddress = FormatMacAddress(adapter.GetPhysicalAddressBytes());
+            }
+            catch (Exception exception) when (IsAdapterAccessException(exception))
+            {
+            }
+
+            NetworkAdapterIpFacts ipFacts = NetworkAdapterIpFacts.Empty;
+            try
+            {
+                ipFacts = adapter.GetIpFacts();
+            }
+            catch (Exception exception) when (IsAdapterAccessException(exception))
+            {
+            }
+
+            snapshots.Add(new NetworkAdapterSnapshot(
+                id,
+                name,
+                interfaceType,
+                operationalStatus,
+                macAddress,
+                ipFacts.Ipv4Addresses,
+                ipFacts.Gateways,
+                ipFacts.DnsServers,
+                ipFacts.IsDhcpEnabled));
+        }
+
+        return snapshots;
+    }
+
+    private static IEnumerable<IWindowsNetworkAdapterInfo> EnumerateWindowsAdapters()
+    {
+        return NetworkInterface.GetAllNetworkInterfaces()
+            .Select(static adapter => (IWindowsNetworkAdapterInfo)new WindowsNetworkAdapterInfo(adapter));
+    }
+
+    private static string FormatMacAddress(byte[] addressBytes)
+    {
+        return addressBytes.Length == 0
+            ? string.Empty
+            : string.Join("-", addressBytes.Select(static value => value.ToString("X2", CultureInfo.InvariantCulture)));
+    }
+
+    private static bool IsAdapterAccessException(Exception exception)
+    {
+        return exception is NetworkInformationException
+            or InvalidOperationException
+            or ObjectDisposedException
+            or PlatformNotSupportedException;
+    }
+}
+
+internal interface IWindowsNetworkAdapterInfo
+{
+    string Id { get; }
+
+    string Name { get; }
+
+    NetworkInterfaceType InterfaceType { get; }
+
+    OperationalStatus OperationalStatus { get; }
+
+    byte[] GetPhysicalAddressBytes();
+
+    NetworkAdapterIpFacts GetIpFacts();
+}
+
+internal sealed record NetworkAdapterIpFacts(
+    IReadOnlyList<NetworkIpv4AddressSnapshot> Ipv4Addresses,
+    IReadOnlyList<string> Gateways,
+    IReadOnlyList<string> DnsServers,
+    bool IsDhcpEnabled)
+{
+    public static NetworkAdapterIpFacts Empty { get; } = new([], [], [], false);
+}
+
+internal sealed class WindowsNetworkAdapterInfo(NetworkInterface adapter) : IWindowsNetworkAdapterInfo
+{
+    public string Id => adapter.Id;
+
+    public string Name => adapter.Name;
+
+    public NetworkInterfaceType InterfaceType => adapter.NetworkInterfaceType;
+
+    public OperationalStatus OperationalStatus => adapter.OperationalStatus;
+
+    public byte[] GetPhysicalAddressBytes() => adapter.GetPhysicalAddress().GetAddressBytes();
+
+    public NetworkAdapterIpFacts GetIpFacts()
+    {
+        IPInterfaceProperties properties = adapter.GetIPProperties();
+        NetworkIpv4AddressSnapshot[] ipv4Addresses = properties.UnicastAddresses
+            .Where(static address => address.Address.AddressFamily == AddressFamily.InterNetwork)
+            .Select(static address => new NetworkIpv4AddressSnapshot(
+                address.Address.ToString(),
+                address.IPv4Mask?.ToString()))
+            .ToArray();
+        string[] gateways = properties.GatewayAddresses
+            .Where(static gateway => gateway.Address.AddressFamily == AddressFamily.InterNetwork)
+            .Select(static gateway => gateway.Address.ToString())
+            .ToArray();
+        string[] dnsServers = properties.DnsAddresses
+            .Select(static address => address.ToString())
+            .ToArray();
+
+        bool isDhcpEnabled;
+        try
+        {
+            isDhcpEnabled = properties.GetIPv4Properties()?.IsDhcpEnabled == true;
+        }
+        catch (Exception exception) when (exception is NetworkInformationException
+                                              or InvalidOperationException
+                                              or PlatformNotSupportedException)
+        {
+            isDhcpEnabled = false;
+        }
+
+        return new NetworkAdapterIpFacts(ipv4Addresses, gateways, dnsServers, isDhcpEnabled);
+    }
+}

--- a/src/Foundry.Utilities/Processes/PowerShellCommand.cs
+++ b/src/Foundry.Utilities/Processes/PowerShellCommand.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace Foundry.Utilities.Processes;
+
+/// <summary>
+/// Creates command-line arguments for encoded PowerShell scripts.
+/// </summary>
+public static class PowerShellCommand
+{
+    /// <summary>
+    /// Encodes a script as UTF-16LE Base64 and returns independent PowerShell argument tokens.
+    /// </summary>
+    /// <param name="script">The PowerShell script to execute.</param>
+    public static IReadOnlyList<string> CreateEncodedArguments(string script)
+    {
+        ArgumentNullException.ThrowIfNull(script);
+
+        string encodedScript = Convert.ToBase64String(Encoding.Unicode.GetBytes(script));
+        return
+        [
+            "-EncodedCommand",
+            encodedScript
+        ];
+    }
+}

--- a/src/Foundry.Utilities/Serialization/JsonObjectSequence.cs
+++ b/src/Foundry.Utilities/Serialization/JsonObjectSequence.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+
+namespace Foundry.Utilities.Serialization;
+
+/// <summary>
+/// Reads a JSON object or an array of JSON objects as an independent sequence.
+/// </summary>
+public static class JsonObjectSequence
+{
+    /// <summary>
+    /// Parses a JSON object or array of objects and clones each returned element.
+    /// </summary>
+    /// <param name="json">The JSON payload.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="json"/> is null.</exception>
+    /// <exception cref="JsonException">The payload is malformed or does not contain only objects.</exception>
+    public static IReadOnlyList<JsonElement> Parse(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return [];
+        }
+
+        using JsonDocument document = JsonDocument.Parse(json);
+        JsonElement root = document.RootElement;
+        if (root.ValueKind == JsonValueKind.Object)
+        {
+            return [root.Clone()];
+        }
+
+        if (root.ValueKind != JsonValueKind.Array)
+        {
+            throw new JsonException("The JSON root must be an object or an array of objects.");
+        }
+
+        var elements = new List<JsonElement>();
+        foreach (JsonElement element in root.EnumerateArray())
+        {
+            if (element.ValueKind != JsonValueKind.Object)
+            {
+                throw new JsonException("The JSON array must contain only objects.");
+            }
+
+            elements.Add(element.Clone());
+        }
+
+        return elements;
+    }
+}

--- a/src/Foundry.Utilities/Storage/DiskInfo.cs
+++ b/src/Foundry.Utilities/Storage/DiskInfo.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Utilities.Storage;
+
+/// <summary>
+/// Describes raw Windows disk facts.
+/// </summary>
+public sealed record DiskInfo(
+    int Number,
+    string FriendlyName,
+    string SerialNumber,
+    string BusType,
+    string PartitionStyle,
+    ulong SizeBytes,
+    bool IsSystem,
+    bool IsBoot,
+    bool IsReadOnly,
+    bool IsOffline,
+    bool IsRemovable);

--- a/src/Foundry.Utilities/Storage/IVolumeDiscovery.cs
+++ b/src/Foundry.Utilities/Storage/IVolumeDiscovery.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Utilities.Storage;
+
+/// <summary>
+/// Discovers file-system volumes visible to the current process.
+/// </summary>
+public interface IVolumeDiscovery
+{
+    /// <summary>
+    /// Returns the currently visible volumes.
+    /// </summary>
+    IReadOnlyList<VolumeInfo> GetVolumes();
+}

--- a/src/Foundry.Utilities/Storage/IWindowsDiskInspector.cs
+++ b/src/Foundry.Utilities/Storage/IWindowsDiskInspector.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Utilities.Storage;
+
+/// <summary>
+/// Provides raw Windows disk inspection.
+/// </summary>
+public interface IWindowsDiskInspector
+{
+    /// <summary>
+    /// Gets the disks reported by Windows.
+    /// </summary>
+    Task<IReadOnlyList<DiskInfo>> GetDisksAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves the physical disk number that contains a path.
+    /// </summary>
+    Task<int?> ResolveDiskNumberForPathAsync(
+        string path,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Foundry.Utilities/Storage/VolumeInfo.cs
+++ b/src/Foundry.Utilities/Storage/VolumeInfo.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+
+namespace Foundry.Utilities.Storage;
+
+/// <summary>
+/// Describes the observable facts for a file-system volume.
+/// </summary>
+public sealed record VolumeInfo(
+    string RootPath,
+    string VolumeLabel,
+    DriveType DriveType,
+    bool IsReady,
+    long AvailableFreeSpace);

--- a/src/Foundry.Utilities/Storage/WindowsDiskInspector.cs
+++ b/src/Foundry.Utilities/Storage/WindowsDiskInspector.cs
@@ -1,0 +1,278 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+using Foundry.Utilities.Processes;
+using Foundry.Utilities.Serialization;
+
+namespace Foundry.Utilities.Storage;
+
+/// <summary>
+/// Inspects Windows disks through PowerShell storage cmdlets.
+/// </summary>
+public sealed class WindowsDiskInspector : IWindowsDiskInspector
+{
+    private const string DiskQueryScript = """
+        $disks = Get-Disk | Sort-Object -Property Number
+        $result = foreach ($disk in $disks) {
+            [pscustomobject]@{
+                Number = [int]$disk.Number
+                FriendlyName = [string]$disk.FriendlyName
+                SerialNumber = [string]$disk.SerialNumber
+                BusType = [string]$disk.BusType
+                PartitionStyle = [string]$disk.PartitionStyle
+                Size = [uint64]$disk.Size
+                IsSystem = [bool]$disk.IsSystem
+                IsBoot = [bool]$disk.IsBoot
+                IsReadOnly = [bool]$disk.IsReadOnly
+                IsOffline = [bool]$disk.IsOffline
+                IsRemovable = [bool]$disk.IsRemovable
+            }
+        }
+        $result | ConvertTo-Json -Compress
+        """;
+
+    private readonly Func<ProcessExecutionRequest, CancellationToken, Task<ProcessExecutionResult>> _executeProcess;
+
+    /// <summary>
+    /// Initializes a new inspector using the shared process runner.
+    /// </summary>
+    public WindowsDiskInspector(ProcessRunner processRunner)
+        : this(processRunner.RunAsync)
+    {
+    }
+
+    internal WindowsDiskInspector(
+        Func<ProcessExecutionRequest, CancellationToken, Task<ProcessExecutionResult>> executeProcess)
+    {
+        ArgumentNullException.ThrowIfNull(executeProcess);
+        _executeProcess = executeProcess;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<DiskInfo>> GetDisksAsync(
+        CancellationToken cancellationToken = default)
+    {
+        ProcessExecutionResult execution = await ExecuteScriptAsync(DiskQueryScript, cancellationToken)
+            .ConfigureAwait(false);
+        EnsureSuccessfulOutput(execution, "Disk query");
+
+        try
+        {
+            return JsonObjectSequence.Parse(execution.StandardOutput)
+                .Select(ParseDisk)
+                .ToArray();
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidDataException("Failed to parse the disk query payload.", exception);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<int?> ResolveDiskNumberForPathAsync(
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        string? root = Path.GetPathRoot(path);
+        if (string.IsNullOrWhiteSpace(root) ||
+            !Path.IsPathFullyQualified(path) ||
+            root.Length < 2 ||
+            root[1] != ':' ||
+            !char.IsAsciiLetter(root[0]) ||
+            root.AsSpan(2).ContainsAnyExcept('\\', '/'))
+        {
+            return null;
+        }
+
+        string driveLetter = char.ToUpperInvariant(root[0]).ToString(CultureInfo.InvariantCulture);
+
+        string script = $@"
+$partition = Get-Partition -DriveLetter '{EscapeForSingleQuote(driveLetter)}' -ErrorAction SilentlyContinue
+if ($null -eq $partition) {{
+    return
+}}
+
+[pscustomobject]@{{
+    DiskNumber = [int]$partition.DiskNumber
+}} | ConvertTo-Json -Compress
+";
+
+        ProcessExecutionResult execution = await ExecuteScriptAsync(script, cancellationToken).ConfigureAwait(false);
+        if (!execution.IsSuccess)
+        {
+            throw new InvalidDataException(
+                $"Disk number lookup failed. ExitCode={execution.ExitCode}.");
+        }
+
+        if (string.IsNullOrWhiteSpace(execution.StandardOutput))
+        {
+            return null;
+        }
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(execution.StandardOutput);
+            JsonElement rootElement = document.RootElement;
+            if (rootElement.ValueKind != JsonValueKind.Object ||
+                !rootElement.TryGetProperty("DiskNumber", out JsonElement diskNumberElement))
+            {
+                return null;
+            }
+
+            int? diskNumber = ReadNullableInt(diskNumberElement);
+            return diskNumber >= 0 ? diskNumber : null;
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidDataException("Failed to parse the disk number lookup payload.", exception);
+        }
+    }
+
+    private async Task<ProcessExecutionResult> ExecuteScriptAsync(
+        string script,
+        CancellationToken cancellationToken)
+    {
+        var request = new ProcessExecutionRequest(
+            "powershell.exe",
+            [
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                .. PowerShellCommand.CreateEncodedArguments(script)
+            ],
+            Path.GetTempPath());
+
+        return await _executeProcess(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static DiskInfo ParseDisk(JsonElement element)
+    {
+        return new DiskInfo(
+            ReadRequiredNonNegativeInt(element, "Number"),
+            ReadString(element, "FriendlyName"),
+            ReadString(element, "SerialNumber"),
+            ReadString(element, "BusType"),
+            ReadString(element, "PartitionStyle"),
+            ReadUInt64(element, "Size"),
+            ReadRequiredBool(element, "IsSystem"),
+            ReadRequiredBool(element, "IsBoot"),
+            ReadRequiredBool(element, "IsReadOnly"),
+            ReadRequiredBool(element, "IsOffline"),
+            ReadBool(element, "IsRemovable"));
+    }
+
+    private static string ReadString(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out JsonElement property) ||
+            property.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+        {
+            return string.Empty;
+        }
+
+        return property.ValueKind == JsonValueKind.String
+            ? property.GetString()?.Trim() ?? string.Empty
+            : property.ToString().Trim();
+    }
+
+    private static int ReadRequiredNonNegativeInt(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out JsonElement property) ||
+            ReadNullableInt(property) is not int value ||
+            value < 0)
+        {
+            throw new JsonException($"Disk property '{propertyName}' must be a non-negative integer.");
+        }
+
+        return value;
+    }
+
+    private static int? ReadNullableInt(JsonElement property)
+    {
+        if (property.ValueKind == JsonValueKind.Number && property.TryGetInt32(out int value))
+        {
+            return value;
+        }
+
+        return property.ValueKind == JsonValueKind.String &&
+               int.TryParse(property.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed)
+            ? parsed
+            : null;
+    }
+
+    private static ulong ReadUInt64(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out JsonElement property))
+        {
+            return 0;
+        }
+
+        if (property.ValueKind == JsonValueKind.Number && property.TryGetUInt64(out ulong value))
+        {
+            return value;
+        }
+
+        return property.ValueKind == JsonValueKind.String &&
+               ulong.TryParse(property.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out ulong parsed)
+            ? parsed
+            : 0;
+    }
+
+    private static bool ReadBool(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out JsonElement property))
+        {
+            return false;
+        }
+
+        return property.ValueKind == JsonValueKind.True ||
+               (property.ValueKind == JsonValueKind.String &&
+                bool.TryParse(property.GetString(), out bool parsed) &&
+                parsed);
+    }
+
+    private static bool ReadRequiredBool(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out JsonElement property))
+        {
+            throw new JsonException($"Disk property '{propertyName}' is required.");
+        }
+
+        if (property.ValueKind == JsonValueKind.True)
+        {
+            return true;
+        }
+
+        if (property.ValueKind == JsonValueKind.False)
+        {
+            return false;
+        }
+
+        if (property.ValueKind == JsonValueKind.String &&
+            bool.TryParse(property.GetString(), out bool parsed))
+        {
+            return parsed;
+        }
+
+        throw new JsonException($"Disk property '{propertyName}' must be a Boolean.");
+    }
+
+    private static void EnsureSuccessfulOutput(ProcessExecutionResult execution, string operation)
+    {
+        if (!execution.IsSuccess || string.IsNullOrWhiteSpace(execution.StandardOutput))
+        {
+            throw new InvalidDataException($"{operation} returned no data. ExitCode={execution.ExitCode}.");
+        }
+    }
+
+    private static string EscapeForSingleQuote(string value)
+        => value.Replace("'", "''", StringComparison.Ordinal);
+}

--- a/src/Foundry.Utilities/Storage/WindowsVolumeDiscovery.cs
+++ b/src/Foundry.Utilities/Storage/WindowsVolumeDiscovery.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Security;
+
+namespace Foundry.Utilities.Storage;
+
+/// <summary>
+/// Discovers volumes through the Windows drive information APIs.
+/// </summary>
+public sealed class WindowsVolumeDiscovery : IVolumeDiscovery
+{
+    private readonly Func<IEnumerable<IWindowsDriveInfo>> _driveSource;
+
+    /// <summary>
+    /// Initializes a new instance that reads the drives visible to the current process.
+    /// </summary>
+    public WindowsVolumeDiscovery()
+        : this(GetWindowsDrives)
+    {
+    }
+
+    internal WindowsVolumeDiscovery(Func<IEnumerable<IWindowsDriveInfo>> driveSource)
+    {
+        ArgumentNullException.ThrowIfNull(driveSource);
+        _driveSource = driveSource;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<VolumeInfo> GetVolumes()
+    {
+        var volumes = new List<VolumeInfo>();
+        foreach (IWindowsDriveInfo drive in _driveSource())
+        {
+            if (TryReadVolume(drive, out VolumeInfo? volume))
+            {
+                volumes.Add(volume);
+            }
+        }
+
+        return volumes;
+    }
+
+    private static bool TryReadVolume(
+        IWindowsDriveInfo drive,
+        [NotNullWhen(true)] out VolumeInfo? volume)
+    {
+        string rootPath;
+        try
+        {
+            rootPath = drive.RootPath;
+        }
+        catch (Exception exception) when (IsDriveAccessException(exception))
+        {
+            volume = null;
+            return false;
+        }
+
+        DriveType driveType = ReadOrDefault(() => drive.DriveType, DriveType.Unknown);
+        bool isReady = drive.IsReady;
+        string volumeLabel = isReady
+            ? ReadOrDefault(() => drive.VolumeLabel, string.Empty)
+            : string.Empty;
+        long availableFreeSpace = isReady
+            ? ReadOrDefault(() => drive.AvailableFreeSpace, 0L)
+            : 0L;
+
+        volume = new VolumeInfo(rootPath, volumeLabel, driveType, isReady, availableFreeSpace);
+        return true;
+    }
+
+    private static T ReadOrDefault<T>(Func<T> readValue, T defaultValue)
+    {
+        try
+        {
+            return readValue();
+        }
+        catch (Exception exception) when (IsDriveAccessException(exception))
+        {
+            return defaultValue;
+        }
+    }
+
+    private static bool IsDriveAccessException(Exception exception)
+    {
+        return exception is IOException or UnauthorizedAccessException or SecurityException;
+    }
+
+    private static IEnumerable<IWindowsDriveInfo> GetWindowsDrives()
+    {
+        return DriveInfo.GetDrives().Select(static drive => new WindowsDriveInfo(drive));
+    }
+
+    private sealed class WindowsDriveInfo(DriveInfo drive) : IWindowsDriveInfo
+    {
+        public string RootPath => drive.RootDirectory.FullName;
+
+        public string VolumeLabel => drive.VolumeLabel;
+
+        public DriveType DriveType => drive.DriveType;
+
+        public bool IsReady => drive.IsReady;
+
+        public long AvailableFreeSpace => drive.AvailableFreeSpace;
+    }
+}
+
+internal interface IWindowsDriveInfo
+{
+    string RootPath { get; }
+
+    string VolumeLabel { get; }
+
+    DriveType DriveType { get; }
+
+    bool IsReady { get; }
+
+    long AvailableFreeSpace { get; }
+}


### PR DESCRIPTION
## Summary

Extracts shared Windows system inspection primitives into `Foundry.Utilities` and migrates the current Core, Deploy, and Connect consumers.

## Reason

Windows volume, PowerShell JSON, hardware, disk, and network inspection logic had overlapping implementations and mixed low-level mechanics with application policy. Centralizing the reusable mechanisms reduces duplication while keeping product-specific decisions in their owning applications.

## Main changes

- add shared Windows volume discovery
- add reusable PowerShell encoded-command and JSON object-sequence helpers
- add hardware and disk inspectors with raw snapshot contracts
- add network adapter snapshot inspection, including paired IPv4 address and subnet-mask data
- migrate Core, Deploy, and Connect consumers while preserving application-owned policy and fallback behavior
- add focused Utilities and consumer regression tests

## Testing

- Full x64 solution test suite: 1,049 tests passed
- Connect x64 self-contained single-file publish: passed
- Deploy x64 self-contained single-file publish: passed
- ARM64 was not run per project instruction
- CI was not awaited

## Dependency

This is a stacked PR targeting `refactor/foundry-utilities` and depends on #268.