### PR TITLE
refactor(utilities): share WLAN profile parsing

### DIFF
--- a/src/Foundry.Connect.Tests/ProvisionedWifiProfileResolverTests.cs
+++ b/src/Foundry.Connect.Tests/ProvisionedWifiProfileResolverTests.cs
@@ -30,7 +30,7 @@ public sealed class ProvisionedWifiProfileResolverTests
     public void ResolveProfileName_WhenEnterpriseProfileIsUsed_ReadsProfileNameFromXml()
     {
         using var tempDirectory = new TemporaryDirectory();
-        string profilePath = CreateWifiProfile(tempDirectory.Path, "Enterprise WiFi", "WPA3ENT");
+        string profilePath = CreateWifiProfile(tempDirectory.Path, "Enterprise WiFi");
 
         string? profileName = ProvisionedWifiProfileResolver.ResolveProfileName(
             new WifiSettings
@@ -43,18 +43,7 @@ public sealed class ProvisionedWifiProfileResolverTests
         Assert.Equal("Enterprise WiFi", profileName);
     }
 
-    [Fact]
-    public void TryReadProfileAuthentication_WhenXmlContainsAuthentication_ReturnsValue()
-    {
-        using var tempDirectory = new TemporaryDirectory();
-        string profilePath = CreateWifiProfile(tempDirectory.Path, "Enterprise WiFi", "WPA3ENT");
-
-        string? authentication = ProvisionedWifiProfileResolver.TryReadProfileAuthentication(profilePath);
-
-        Assert.Equal("WPA3ENT", authentication);
-    }
-
-    private static string CreateWifiProfile(string directoryPath, string profileName, string authentication)
+    private static string CreateWifiProfile(string directoryPath, string profileName)
     {
         string filePath = Path.Combine(directoryPath, "wifi.xml");
         File.WriteAllText(
@@ -62,13 +51,6 @@ public sealed class ProvisionedWifiProfileResolverTests
             $$"""
               <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
                 <name>{{profileName}}</name>
-                <MSM>
-                  <security>
-                    <authEncryption>
-                      <authentication>{{authentication}}</authentication>
-                    </authEncryption>
-                  </security>
-                </MSM>
               </WLANProfile>
               """);
         return filePath;

--- a/src/Foundry.Connect.Tests/ProvisionedWifiProfileResolverTests.cs
+++ b/src/Foundry.Connect.Tests/ProvisionedWifiProfileResolverTests.cs
@@ -44,23 +44,6 @@ public sealed class ProvisionedWifiProfileResolverTests
     }
 
     [Fact]
-    public void ResolveProfileName_WhenEnterpriseProfileNameContainsXmlEntity_DecodesProfileName()
-    {
-        using var tempDirectory = new TemporaryDirectory();
-        string profilePath = CreateWifiProfile(tempDirectory.Path, "Corp &amp; Guest", "WPA3ENT");
-
-        string? profileName = ProvisionedWifiProfileResolver.ResolveProfileName(
-            new WifiSettings
-            {
-                HasEnterpriseProfile = true,
-                EnterpriseProfileTemplatePath = profilePath
-            },
-            configurationPath: null);
-
-        Assert.Equal("Corp & Guest", profileName);
-    }
-
-    [Fact]
     public void TryReadProfileAuthentication_WhenXmlContainsAuthentication_ReturnsValue()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/src/Foundry.Connect/Services/Configuration/ProvisionedWifiProfileResolver.cs
+++ b/src/Foundry.Connect/Services/Configuration/ProvisionedWifiProfileResolver.cs
@@ -54,31 +54,11 @@ internal static class ProvisionedWifiProfileResolver
         if (wifiSettings.HasEnterpriseProfile)
         {
             string? profilePath = ResolveAssetPath(wifiSettings.EnterpriseProfileTemplatePath, configurationPath);
-            return TryReadProfileName(profilePath);
+            return WlanProfileReader.TryReadName(profilePath);
         }
 
         return string.IsNullOrWhiteSpace(wifiSettings.Ssid)
             ? null
             : wifiSettings.Ssid.Trim();
-    }
-
-    /// <summary>
-    /// Reads the WLAN profile name from a profile XML file.
-    /// </summary>
-    /// <param name="profilePath">Path to the WLAN profile XML file.</param>
-    /// <returns>The profile name, or <see langword="null"/> when it cannot be read.</returns>
-    public static string? TryReadProfileName(string? profilePath)
-    {
-        return WlanProfileReader.TryReadName(profilePath);
-    }
-
-    /// <summary>
-    /// Reads the WLAN authentication mode from a profile XML file.
-    /// </summary>
-    /// <param name="profilePath">Path to the WLAN profile XML file.</param>
-    /// <returns>The authentication value, or <see langword="null"/> when it cannot be read.</returns>
-    public static string? TryReadProfileAuthentication(string? profilePath)
-    {
-        return WlanProfileReader.TryReadAuthentication(profilePath);
     }
 }

--- a/src/Foundry.Connect/Services/Configuration/ProvisionedWifiProfileResolver.cs
+++ b/src/Foundry.Connect/Services/Configuration/ProvisionedWifiProfileResolver.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
-using System.Xml.Linq;
 using Foundry.Connect.Models.Configuration;
+using Foundry.Utilities.Networking;
 
 namespace Foundry.Connect.Services.Configuration;
 
@@ -13,8 +13,6 @@ namespace Foundry.Connect.Services.Configuration;
 /// </summary>
 internal static class ProvisionedWifiProfileResolver
 {
-    private static readonly XNamespace WlanProfileNamespace = "http://www.microsoft.com/networking/WLAN/profile/v1";
-
     /// <summary>
     /// Resolves a configured asset path relative to the configuration file directory.
     /// When no configuration file path is available, relative assets are resolved from the application base directory.
@@ -71,23 +69,7 @@ internal static class ProvisionedWifiProfileResolver
     /// <returns>The profile name, or <see langword="null"/> when it cannot be read.</returns>
     public static string? TryReadProfileName(string? profilePath)
     {
-        if (string.IsNullOrWhiteSpace(profilePath) || !File.Exists(profilePath))
-        {
-            return null;
-        }
-
-        try
-        {
-            XDocument document = XDocument.Load(profilePath);
-            return document
-                .Descendants(WlanProfileNamespace + "name")
-                .Select(static element => element.Value?.Trim())
-                .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
-        }
-        catch
-        {
-            return null;
-        }
+        return WlanProfileReader.TryReadName(profilePath);
     }
 
     /// <summary>
@@ -97,22 +79,6 @@ internal static class ProvisionedWifiProfileResolver
     /// <returns>The authentication value, or <see langword="null"/> when it cannot be read.</returns>
     public static string? TryReadProfileAuthentication(string? profilePath)
     {
-        if (string.IsNullOrWhiteSpace(profilePath) || !File.Exists(profilePath))
-        {
-            return null;
-        }
-
-        try
-        {
-            XDocument document = XDocument.Load(profilePath);
-            return document
-                .Descendants(WlanProfileNamespace + "authentication")
-                .Select(static element => element.Value?.Trim())
-                .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
-        }
-        catch
-        {
-            return null;
-        }
+        return WlanProfileReader.TryReadAuthentication(profilePath);
     }
 }

--- a/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
@@ -20,6 +20,7 @@ using Foundry.Connect.Services.Network;
 using Foundry.Connect.Services.Theme;
 using Foundry.Localization;
 using Foundry.Telemetry;
+using Foundry.Utilities.Networking;
 using Microsoft.Extensions.Logging;
 using ConnectThemeMode = Foundry.Connect.Services.Theme.ThemeMode;
 
@@ -1479,7 +1480,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
             string? profilePath = ProvisionedWifiProfileResolver.ResolveAssetPath(
                 _configuration.Wifi.EnterpriseProfileTemplatePath,
                 _configurationService.ConfigurationPath);
-            string? profileAuthentication = ProvisionedWifiProfileResolver.TryReadProfileAuthentication(profilePath);
+            string? profileAuthentication = WlanProfileReader.TryReadAuthentication(profilePath);
             return ResolveProvisionedEnterpriseSecurityDisplayText(
                 profileAuthentication ?? _configuration.Wifi.SecurityType,
                 _configuration.Wifi.EnterpriseAuthenticationMode);

--- a/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidator.cs
+++ b/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidator.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
-using System.Xml.Linq;
 using Foundry.Core.Models.Configuration;
+using Foundry.Utilities.Networking;
 
 namespace Foundry.Core.Services.Configuration;
 
@@ -307,7 +307,9 @@ public static class NetworkConfigurationValidator
 
         if (RequiresExplicitEnterpriseTemplateAuthentication(enterpriseSecurityType))
         {
-            string? templateSecurityType = TryReadEnterpriseTemplateSecurityType(fullTemplatePath);
+            // WPA3 enterprise profiles must match the explicit authentication mode selected in the UI.
+            string? templateSecurityType = NormalizeEnterpriseSecurityType(
+                WlanProfileReader.TryReadAuthentication(fullTemplatePath));
             if (templateSecurityType is null)
             {
                 return NetworkConfigurationValidationResult.Failure(NetworkConfigurationValidationCode.WifiEnterpriseAuthenticationUnsupported);
@@ -347,23 +349,4 @@ public static class NetworkConfigurationValidator
                string.Equals(securityType, WifiSecurityEnterpriseWpa3192, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string? TryReadEnterpriseTemplateSecurityType(string profileTemplatePath)
-    {
-        try
-        {
-            // WPA3 enterprise profiles must match the explicit authentication mode selected in the UI.
-            XDocument document = XDocument.Load(Path.GetFullPath(profileTemplatePath));
-            XNamespace wlanProfile = "http://www.microsoft.com/networking/WLAN/profile/v1";
-            string? authentication = document
-                .Descendants(wlanProfile + "authentication")
-                .Select(static element => element.Value?.Trim())
-                .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
-
-            return NormalizeEnterpriseSecurityType(authentication);
-        }
-        catch
-        {
-            return null;
-        }
-    }
 }

--- a/src/Foundry.Utilities.Tests/Networking/WlanProfileReaderTests.cs
+++ b/src/Foundry.Utilities.Tests/Networking/WlanProfileReaderTests.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Utilities.Networking;
+
+namespace Foundry.Utilities.Tests.Networking;
+
+public sealed class WlanProfileReaderTests
+{
+    [Fact]
+    public void TryReadName_WhenProfileContainsEntity_ReturnsTrimmedDecodedValue()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        string profilePath = temporaryDirectory.CreateProfile(
+            """
+            <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
+              <name>  Corp &amp; Guest  </name>
+            </WLANProfile>
+            """);
+
+        string? name = WlanProfileReader.TryReadName(profilePath);
+
+        Assert.Equal("Corp & Guest", name);
+    }
+
+    [Fact]
+    public void TryReadAuthentication_WhenFirstValueIsBlank_ReturnsFirstNonBlankValue()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        string profilePath = temporaryDirectory.CreateProfile(
+            """
+            <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
+              <authentication>  </authentication>
+              <MSM>
+                <security>
+                  <authEncryption>
+                    <authentication>  WPA3ENT  </authentication>
+                  </authEncryption>
+                </security>
+              </MSM>
+            </WLANProfile>
+            """);
+
+        string? authentication = WlanProfileReader.TryReadAuthentication(profilePath);
+
+        Assert.Equal("WPA3ENT", authentication);
+    }
+
+    [Fact]
+    public void TryReadName_WhenElementIsMissing_ReturnsNull()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        string profilePath = temporaryDirectory.CreateProfile(
+            """
+            <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1" />
+            """);
+
+        string? name = WlanProfileReader.TryReadName(profilePath);
+
+        Assert.Null(name);
+    }
+
+    [Fact]
+    public void TryReadName_WhenPathIsBlank_ReturnsNull()
+    {
+        Assert.Null(WlanProfileReader.TryReadName("  "));
+    }
+
+    [Fact]
+    public void TryReadAuthentication_WhenFileIsMissing_ReturnsNull()
+    {
+        string profilePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.xml");
+
+        string? authentication = WlanProfileReader.TryReadAuthentication(profilePath);
+
+        Assert.Null(authentication);
+    }
+
+    [Fact]
+    public void TryReadAuthentication_WhenXmlIsMalformed_ReturnsNull()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        string profilePath = temporaryDirectory.CreateProfile("<WLANProfile>");
+
+        string? authentication = WlanProfileReader.TryReadAuthentication(profilePath);
+
+        Assert.Null(authentication);
+    }
+
+    [Fact]
+    public void TryReadName_WhenNamespaceDoesNotMatch_ReturnsNull()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        string profilePath = temporaryDirectory.CreateProfile(
+            """
+            <WLANProfile>
+              <name>Corp WiFi</name>
+            </WLANProfile>
+            """);
+
+        string? name = WlanProfileReader.TryReadName(profilePath);
+
+        Assert.Null(name);
+    }
+
+    [Fact]
+    public void TryReadName_WhenDocumentContainsDtd_ReturnsNull()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        string profilePath = temporaryDirectory.CreateProfile(
+            """
+            <!DOCTYPE WLANProfile [<!ENTITY profileName "Corp WiFi">]>
+            <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
+              <name>&profileName;</name>
+            </WLANProfile>
+            """);
+
+        string? name = WlanProfileReader.TryReadName(profilePath);
+
+        Assert.Null(name);
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "Foundry.Utilities.Tests",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public string CreateProfile(string xml)
+        {
+            string profilePath = System.IO.Path.Combine(Path, "wifi.xml");
+            File.WriteAllText(profilePath, xml);
+            return profilePath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}

--- a/src/Foundry.Utilities/Networking/WlanProfileReader.cs
+++ b/src/Foundry.Utilities/Networking/WlanProfileReader.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Foundry.Utilities.Networking;
+
+/// <summary>
+/// Reads raw values from Windows WLAN profile XML files.
+/// </summary>
+public static class WlanProfileReader
+{
+    private static readonly XNamespace WlanProfileNamespace =
+        "http://www.microsoft.com/networking/WLAN/profile/v1";
+
+    /// <summary>
+    /// Reads the first non-empty profile name from a WLAN profile.
+    /// </summary>
+    /// <param name="profilePath">Path to the WLAN profile XML file.</param>
+    /// <returns>The trimmed profile name, or <see langword="null"/> when it cannot be read.</returns>
+    public static string? TryReadName(string? profilePath)
+    {
+        return TryReadValue(profilePath, "name");
+    }
+
+    /// <summary>
+    /// Reads the first non-empty authentication value from a WLAN profile.
+    /// </summary>
+    /// <param name="profilePath">Path to the WLAN profile XML file.</param>
+    /// <returns>The trimmed authentication value, or <see langword="null"/> when it cannot be read.</returns>
+    public static string? TryReadAuthentication(string? profilePath)
+    {
+        return TryReadValue(profilePath, "authentication");
+    }
+
+    private static string? TryReadValue(string? profilePath, string elementName)
+    {
+        if (string.IsNullOrWhiteSpace(profilePath) || !File.Exists(profilePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            var settings = new XmlReaderSettings
+            {
+                DtdProcessing = DtdProcessing.Prohibit,
+                XmlResolver = null
+            };
+            using XmlReader reader = XmlReader.Create(profilePath, settings);
+            XDocument document = XDocument.Load(reader);
+
+            return document
+                .Descendants(WlanProfileNamespace + elementName)
+                .Select(static element => element.Value.Trim())
+                .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Extracts reusable, read-only Windows WLAN profile XML parsing into `Foundry.Utilities` and migrates the current Core and Connect consumers.

## Reason

Core and Connect independently loaded the same WLAN v1 XML namespace, selected the first non-empty profile value, trimmed it, and converted read failures to `null`. Centralizing that technical mechanism removes duplication while keeping configuration validation, path resolution, security mapping, and UI/runtime behavior in their owning projects.

## Main changes

- add `WlanProfileReader` for raw profile name and authentication values
- prohibit DTD processing and disable XML resolution
- migrate Core enterprise authentication validation
- migrate Connect provisioned-profile display parsing
- remove obsolete Connect forwarding methods and redundant adapter coverage
- add focused parser tests for entities, trimming, missing/malformed input, namespace matching, and DTD rejection

## Testing

- Full x64 solution test suite: 1,055 tests passed
- Repository format/analyzer gate: passed
- XAML format verification: 44/44 passed
- Connect x64 self-contained single-file publish: passed
- Deploy x64 self-contained single-file publish: passed
- ARM64 was not run per project instruction
- CI was not awaited

## Dependency

This is a stacked PR targeting `refactor/foundry-utilities` and depends on #268.