### PR TITLE
feat(winui): redesign home landing hero

### DIFF
--- a/src/Foundry/App.xaml
+++ b/src/Foundry/App.xaml
@@ -7,6 +7,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+                <ResourceDictionary Source="Controls/OpacityMaskView.xaml" />
                 <ResourceDictionary Source="Themes/Styles.xaml" />
 
                 <ResourceDictionary Source="Themes/ThemeResources.xaml" />

--- a/src/Foundry/Controls/HomeCardButtonResources.xaml
+++ b/src/Foundry/Controls/HomeCardButtonResources.xaml
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Light">
+            <SolidColorBrush x:Key="ButtonBorderBrush"
+                Color="{ThemeResource ControlStrokeColorDefault}" />
+            <SolidColorBrush x:Key="ButtonBorderBrushPointerOver"
+                Color="{ThemeResource ControlStrokeColorSecondary}" />
+            <SolidColorBrush x:Key="ButtonBorderBrushPressed"
+                Color="{ThemeResource ControlStrokeColorDefault}" />
+            <SolidColorBrush x:Key="ButtonBorderBrushDisabled"
+                Color="{ThemeResource ControlStrokeColorDefault}" />
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="Dark">
+            <SolidColorBrush x:Key="ButtonBorderBrush"
+                Color="{ThemeResource ControlStrokeColorDefault}" />
+            <SolidColorBrush x:Key="ButtonBorderBrushPointerOver"
+                Color="{ThemeResource ControlStrokeColorSecondary}" />
+            <SolidColorBrush x:Key="ButtonBorderBrushPressed"
+                Color="{ThemeResource ControlStrokeColorDefault}" />
+            <SolidColorBrush x:Key="ButtonBorderBrushDisabled"
+                Color="{ThemeResource ControlStrokeColorDefault}" />
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="HighContrast">
+            <SolidColorBrush x:Key="ButtonBorderBrush"
+                Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="ButtonBorderBrushPointerOver"
+                Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="ButtonBorderBrushPressed"
+                Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="ButtonBorderBrushDisabled"
+                Color="{ThemeResource SystemColorButtonTextColor}" />
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+</ResourceDictionary>

--- a/src/Foundry/Controls/HomeLandingHeader.xaml
+++ b/src/Foundry/Controls/HomeLandingHeader.xaml
@@ -1,0 +1,164 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<UserControl x:Class="Foundry.Controls.HomeLandingHeader"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Foundry.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <ImageSource x:Key="HomeHeaderImage">/Assets/Cover/CoverLight.png</ImageSource>
+                    <SolidColorBrush x:Key="HomeHeaderBackgroundBrush"
+                        Color="#F3F3F3" />
+                    <SolidColorBrush x:Key="HomeHeaderForegroundBrush"
+                        Color="White" />
+                    <x:Double x:Key="HomeHeaderImageOpacity">1</x:Double>
+                    <LinearGradientBrush x:Key="HomeHeaderOpacityMask"
+                        StartPoint="0.5,0"
+                        EndPoint="0.5,1">
+                        <GradientStop
+                            Offset="0"
+                            Color="#FFFFFFFF" />
+                        <GradientStop
+                            Offset="0.75"
+                            Color="#FFFFFFFF" />
+                        <GradientStop
+                            Offset="0.85"
+                            Color="#00FFFFFF" />
+                        <GradientStop
+                            Offset="1"
+                            Color="#00FFFFFF" />
+                    </LinearGradientBrush>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <ImageSource x:Key="HomeHeaderImage">/Assets/Cover/CoverDark.png</ImageSource>
+                    <SolidColorBrush x:Key="HomeHeaderBackgroundBrush"
+                        Color="#202020" />
+                    <SolidColorBrush x:Key="HomeHeaderForegroundBrush"
+                        Color="White" />
+                    <x:Double x:Key="HomeHeaderImageOpacity">1</x:Double>
+                    <LinearGradientBrush x:Key="HomeHeaderOpacityMask"
+                        StartPoint="0.5,0"
+                        EndPoint="0.5,1">
+                        <GradientStop
+                            Offset="0"
+                            Color="#FF000000" />
+                        <GradientStop
+                            Offset="0.75"
+                            Color="#FF000000" />
+                        <GradientStop
+                            Offset="0.85"
+                            Color="#00000000" />
+                        <GradientStop
+                            Offset="1"
+                            Color="#00000000" />
+                    </LinearGradientBrush>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="HighContrast">
+                    <ImageSource x:Key="HomeHeaderImage">/Assets/Cover/CoverDark.png</ImageSource>
+                    <SolidColorBrush x:Key="HomeHeaderBackgroundBrush"
+                        Color="Black" />
+                    <SolidColorBrush x:Key="HomeHeaderForegroundBrush"
+                        Color="White" />
+                    <x:Double x:Key="HomeHeaderImageOpacity">0.8</x:Double>
+                    <LinearGradientBrush x:Key="HomeHeaderOpacityMask"
+                        StartPoint="0.5,0"
+                        EndPoint="0.5,1">
+                        <GradientStop
+                            Offset="0"
+                            Color="#FF000000" />
+                        <GradientStop
+                            Offset="0.55"
+                            Color="#FF000000" />
+                        <GradientStop
+                            Offset="0.95"
+                            Color="#00000000" />
+                    </LinearGradientBrush>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid Height="400">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <controls:OpacityMaskView
+            Grid.RowSpan="3"
+            Height="400"
+            VerticalAlignment="Stretch"
+            AutomationProperties.AccessibilityView="Raw">
+            <controls:OpacityMaskView.OpacityMask>
+                <Rectangle Fill="{ThemeResource HomeHeaderOpacityMask}" />
+            </controls:OpacityMaskView.OpacityMask>
+            <Grid
+                Margin="0,-100,0,0"
+                Background="{ThemeResource HomeHeaderBackgroundBrush}">
+                <Image
+                    AutomationProperties.AccessibilityView="Raw"
+                    Opacity="{ThemeResource HomeHeaderImageOpacity}"
+                    Source="{ThemeResource HomeHeaderImage}"
+                    Stretch="UniformToFill" />
+                <Rectangle
+                    AutomationProperties.AccessibilityView="Raw"
+                    Fill="#59000000" />
+            </Grid>
+        </controls:OpacityMaskView>
+
+        <StackPanel
+            Margin="36,48,36,0"
+            VerticalAlignment="Center"
+            Orientation="Vertical">
+            <TextBlock
+                FontSize="18"
+                Foreground="{ThemeResource HomeHeaderForegroundBrush}"
+                Text="{x:Bind ViewModel.HeaderSubtitle, Mode=OneWay}"
+                TextWrapping="Wrap" />
+            <TextBlock
+                AutomationProperties.HeadingLevel="Level1"
+                Foreground="{ThemeResource HomeHeaderForegroundBrush}"
+                Style="{StaticResource TitleLargeTextBlockStyle}"
+                Text="{x:Bind ViewModel.HeaderTitle, Mode=OneWay}"
+                TextWrapping="Wrap" />
+        </StackPanel>
+
+        <controls:HorizontalScrollContainer
+            Grid.Row="2"
+            Margin="0,56,0,0"
+            ScrollBackText="{x:Bind ViewModel.ScrollBackText, Mode=OneWay}"
+            ScrollForwardText="{x:Bind ViewModel.ScrollForwardText, Mode=OneWay}">
+            <controls:HorizontalScrollContainer.Source>
+                <StackPanel
+                    Orientation="Horizontal"
+                    Spacing="12">
+                    <controls:HomeTile
+                        Title="{x:Bind ViewModel.OpenAdkTitle, Mode=OneWay}"
+                        Click="OpenAdkTile_Click"
+                        Description="{x:Bind ViewModel.OpenAdkDescription, Mode=OneWay}"
+                        IconGlyph="&#xEC7A;" />
+                    <controls:HomeTile
+                        Title="{x:Bind ViewModel.ConfigureMediaTitle, Mode=OneWay}"
+                        Click="ConfigureMediaTile_Click"
+                        Description="{x:Bind ViewModel.ConfigureMediaDescription, Mode=OneWay}"
+                        IconGlyph="&#xE713;" />
+                    <controls:HomeTile
+                        Title="{x:Bind ViewModel.ReviewAndStartTitle, Mode=OneWay}"
+                        Click="ReviewAndStartTile_Click"
+                        Description="{x:Bind ViewModel.ReviewAndStartDescription, Mode=OneWay}"
+                        IconGlyph="&#xE768;" />
+                    <controls:HomeTile
+                        Title="{x:Bind ViewModel.OpenDocumentationTitle, Mode=OneWay}"
+                        Click="OpenDocumentationTile_Click"
+                        Description="{x:Bind ViewModel.OpenDocumentationDescription, Mode=OneWay}"
+                        IconGlyph="&#xE8A5;" />
+                </StackPanel>
+            </controls:HorizontalScrollContainer.Source>
+        </controls:HorizontalScrollContainer>
+    </Grid>
+</UserControl>

--- a/src/Foundry/Controls/HomeLandingHeader.xaml
+++ b/src/Foundry/Controls/HomeLandingHeader.xaml
@@ -146,12 +146,14 @@
                         Title="{x:Bind ViewModel.ConfigureMediaTitle, Mode=OneWay}"
                         Click="ConfigureMediaTile_Click"
                         Description="{x:Bind ViewModel.ConfigureMediaDescription, Mode=OneWay}"
-                        IconGlyph="&#xE713;" />
+                        IconGlyph="&#xE713;"
+                        IsEnabled="{x:Bind ViewModel.IsWorkflowNavigationEnabled, Mode=OneWay}" />
                     <controls:HomeTile
                         Title="{x:Bind ViewModel.ReviewAndStartTitle, Mode=OneWay}"
                         Click="ReviewAndStartTile_Click"
                         Description="{x:Bind ViewModel.ReviewAndStartDescription, Mode=OneWay}"
-                        IconGlyph="&#xE768;" />
+                        IconGlyph="&#xE768;"
+                        IsEnabled="{x:Bind ViewModel.IsWorkflowNavigationEnabled, Mode=OneWay}" />
                     <controls:HomeTile
                         Title="{x:Bind ViewModel.OpenDocumentationTitle, Mode=OneWay}"
                         Click="OpenDocumentationTile_Click"

--- a/src/Foundry/Controls/HomeLandingHeader.xaml.cs
+++ b/src/Foundry/Controls/HomeLandingHeader.xaml.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.ViewModels;
+
+namespace Foundry.Controls;
+
+/// <summary>
+/// Presents the Foundry home hero and its primary actions.
+/// </summary>
+public sealed partial class HomeLandingHeader : UserControl
+{
+    public static readonly DependencyProperty ViewModelProperty = DependencyProperty.Register(
+        nameof(ViewModel),
+        typeof(HomeLandingViewModel),
+        typeof(HomeLandingHeader),
+        new PropertyMetadata(null));
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HomeLandingHeader"/> class.
+    /// </summary>
+    public HomeLandingHeader()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// Occurs when the Windows ADK action is activated.
+    /// </summary>
+    public event RoutedEventHandler? OpenAdkRequested;
+
+    /// <summary>
+    /// Occurs when the media configuration action is activated.
+    /// </summary>
+    public event RoutedEventHandler? ConfigureMediaRequested;
+
+    /// <summary>
+    /// Occurs when the review and start action is activated.
+    /// </summary>
+    public event RoutedEventHandler? ReviewAndStartRequested;
+
+    /// <summary>
+    /// Occurs when the documentation action is activated.
+    /// </summary>
+    public event RoutedEventHandler? OpenDocumentationRequested;
+
+    /// <summary>
+    /// Gets or sets the view model that supplies localized home content.
+    /// </summary>
+    public HomeLandingViewModel? ViewModel
+    {
+        get => (HomeLandingViewModel?)GetValue(ViewModelProperty);
+        set => SetValue(ViewModelProperty, value);
+    }
+
+    private void OpenAdkTile_Click(object sender, RoutedEventArgs e)
+    {
+        OpenAdkRequested?.Invoke(this, e);
+    }
+
+    private void ConfigureMediaTile_Click(object sender, RoutedEventArgs e)
+    {
+        ConfigureMediaRequested?.Invoke(this, e);
+    }
+
+    private void ReviewAndStartTile_Click(object sender, RoutedEventArgs e)
+    {
+        ReviewAndStartRequested?.Invoke(this, e);
+    }
+
+    private void OpenDocumentationTile_Click(object sender, RoutedEventArgs e)
+    {
+        OpenDocumentationRequested?.Invoke(this, e);
+    }
+}

--- a/src/Foundry/Controls/HomeStatusCard.xaml
+++ b/src/Foundry/Controls/HomeStatusCard.xaml
@@ -9,42 +9,12 @@
 
     <Grid
         Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
-        BorderBrush="{ThemeResource SurfaceStrokeColorFlyoutBrush}"
         CornerRadius="8">
         <Grid.Resources>
             <ResourceDictionary>
-                <ResourceDictionary.ThemeDictionaries>
-                    <ResourceDictionary x:Key="Light">
-                        <SolidColorBrush x:Key="ButtonBorderBrush"
-                            Color="{ThemeResource ControlStrokeColorDefault}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushPointerOver"
-                            Color="{ThemeResource ControlStrokeColorSecondary}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushPressed"
-                            Color="{ThemeResource ControlStrokeColorDefault}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushDisabled"
-                            Color="{ThemeResource ControlStrokeColorDefault}" />
-                    </ResourceDictionary>
-                    <ResourceDictionary x:Key="Dark">
-                        <SolidColorBrush x:Key="ButtonBorderBrush"
-                            Color="{ThemeResource ControlStrokeColorDefault}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushPointerOver"
-                            Color="{ThemeResource ControlStrokeColorSecondary}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushPressed"
-                            Color="{ThemeResource ControlStrokeColorDefault}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushDisabled"
-                            Color="{ThemeResource ControlStrokeColorDefault}" />
-                    </ResourceDictionary>
-                    <ResourceDictionary x:Key="HighContrast">
-                        <SolidColorBrush x:Key="ButtonBorderBrush"
-                            Color="{ThemeResource SystemColorButtonTextColor}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushPointerOver"
-                            Color="{ThemeResource SystemColorButtonTextColor}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushPressed"
-                            Color="{ThemeResource SystemColorButtonTextColor}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushDisabled"
-                            Color="{ThemeResource SystemColorButtonTextColor}" />
-                    </ResourceDictionary>
-                </ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary.MergedDictionaries>
+                    <ResourceDictionary Source="HomeCardButtonResources.xaml" />
+                </ResourceDictionary.MergedDictionaries>
             </ResourceDictionary>
         </Grid.Resources>
         <Button

--- a/src/Foundry/Controls/HomeStatusCard.xaml
+++ b/src/Foundry/Controls/HomeStatusCard.xaml
@@ -5,7 +5,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     MinWidth="240"
-    MinHeight="172"
     mc:Ignorable="d">
 
     <Grid
@@ -58,8 +57,8 @@
             Click="CardButton_Click"
             CornerRadius="{StaticResource OverlayCornerRadius}">
             <StackPanel
-                Padding="24,20"
-                Spacing="12">
+                Padding="20,16"
+                Spacing="8">
 
                 <Grid>
                     <Grid.ColumnDefinitions>

--- a/src/Foundry/Controls/HomeStatusCard.xaml
+++ b/src/Foundry/Controls/HomeStatusCard.xaml
@@ -1,0 +1,140 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<UserControl x:Class="Foundry.Controls.HomeStatusCard"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    MinWidth="240"
+    mc:Ignorable="d">
+
+    <Grid
+        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+        BorderThickness="1"
+        CornerRadius="{StaticResource FoundryCardCornerRadius}">
+        <Button
+            Padding="-1"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            HorizontalContentAlignment="Stretch"
+            VerticalContentAlignment="Stretch"
+            AutomationProperties.Name="{x:Bind AutomationName, Mode=OneTime}"
+            Click="CardButton_Click"
+            CornerRadius="{StaticResource FoundryCardCornerRadius}">
+            <StackPanel
+                Padding="16"
+                Spacing="12">
+
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <FontIcon
+                        Grid.Column="0"
+                        Margin="0,0,10,0"
+                        VerticalAlignment="Center"
+                        FontSize="{ThemeResource FoundryIconSizeDefault}"
+                        Glyph="{x:Bind IconGlyph, Mode=OneWay}" />
+                    <TextBlock
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{x:Bind Title, Mode=OneWay}" />
+                    <Border
+                        Grid.Column="2"
+                        Padding="8,3"
+                        Background="{x:Bind BadgeBackground, Mode=OneWay}"
+                        CornerRadius="12">
+                        <StackPanel
+                            Orientation="Horizontal"
+                            Spacing="4">
+                            <FontIcon
+                                FontSize="10"
+                                Foreground="{x:Bind BadgeForeground, Mode=OneWay}"
+                                Glyph="{x:Bind BadgeGlyph, Mode=OneWay}" />
+                            <TextBlock
+                                VerticalAlignment="Center"
+                                FontSize="11"
+                                Foreground="{x:Bind BadgeForeground, Mode=OneWay}"
+                                Text="{x:Bind StatusText, Mode=OneWay}" />
+                        </StackPanel>
+                    </Border>
+                </Grid>
+
+                <Rectangle
+                    Height="1"
+                    Fill="{ThemeResource DividerStrokeColorDefaultBrush}"
+                    Opacity="0.5" />
+
+                <Grid
+                    ColumnSpacing="12"
+                    RowSpacing="6">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        Style="{ThemeResource FoundryCaptionTextBlockStyle}"
+                        Text="{x:Bind Line1Label, Mode=OneWay}"
+                        Visibility="{x:Bind Line1Visibility, Mode=OneWay}" />
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        Text="{x:Bind Line1Value, Mode=OneWay}"
+                        TextTrimming="CharacterEllipsis"
+                        Visibility="{x:Bind Line1Visibility, Mode=OneWay}" />
+
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        Style="{ThemeResource FoundryCaptionTextBlockStyle}"
+                        Text="{x:Bind Line2Label, Mode=OneWay}"
+                        Visibility="{x:Bind Line2Visibility, Mode=OneWay}" />
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        Text="{x:Bind Line2Value, Mode=OneWay}"
+                        TextTrimming="CharacterEllipsis"
+                        Visibility="{x:Bind Line2Visibility, Mode=OneWay}" />
+
+                    <TextBlock
+                        Grid.Row="2"
+                        Grid.Column="0"
+                        Style="{ThemeResource FoundryCaptionTextBlockStyle}"
+                        Text="{x:Bind Line3Label, Mode=OneWay}"
+                        Visibility="{x:Bind Line3Visibility, Mode=OneWay}" />
+                    <TextBlock
+                        Grid.Row="2"
+                        Grid.Column="1"
+                        Text="{x:Bind Line3Value, Mode=OneWay}"
+                        TextTrimming="CharacterEllipsis"
+                        Visibility="{x:Bind Line3Visibility, Mode=OneWay}" />
+
+                    <TextBlock
+                        Grid.Row="3"
+                        Grid.Column="0"
+                        Style="{ThemeResource FoundryCaptionTextBlockStyle}"
+                        Text="{x:Bind Line4Label, Mode=OneWay}"
+                        Visibility="{x:Bind Line4Visibility, Mode=OneWay}" />
+                    <TextBlock
+                        Grid.Row="3"
+                        Grid.Column="1"
+                        Text="{x:Bind Line4Value, Mode=OneWay}"
+                        TextTrimming="CharacterEllipsis"
+                        Visibility="{x:Bind Line4Visibility, Mode=OneWay}" />
+                </Grid>
+            </StackPanel>
+        </Button>
+    </Grid>
+</UserControl>

--- a/src/Foundry/Controls/HomeStatusCard.xaml
+++ b/src/Foundry/Controls/HomeStatusCard.xaml
@@ -5,13 +5,49 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     MinWidth="240"
+    MinHeight="172"
     mc:Ignorable="d">
 
     <Grid
-        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-        BorderThickness="1"
-        CornerRadius="{StaticResource FoundryCardCornerRadius}">
+        Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
+        BorderBrush="{ThemeResource SurfaceStrokeColorFlyoutBrush}"
+        CornerRadius="8">
+        <Grid.Resources>
+            <ResourceDictionary>
+                <ResourceDictionary.ThemeDictionaries>
+                    <ResourceDictionary x:Key="Light">
+                        <SolidColorBrush x:Key="ButtonBorderBrush"
+                            Color="{ThemeResource ControlStrokeColorDefault}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushPointerOver"
+                            Color="{ThemeResource ControlStrokeColorSecondary}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushPressed"
+                            Color="{ThemeResource ControlStrokeColorDefault}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushDisabled"
+                            Color="{ThemeResource ControlStrokeColorDefault}" />
+                    </ResourceDictionary>
+                    <ResourceDictionary x:Key="Dark">
+                        <SolidColorBrush x:Key="ButtonBorderBrush"
+                            Color="{ThemeResource ControlStrokeColorDefault}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushPointerOver"
+                            Color="{ThemeResource ControlStrokeColorSecondary}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushPressed"
+                            Color="{ThemeResource ControlStrokeColorDefault}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushDisabled"
+                            Color="{ThemeResource ControlStrokeColorDefault}" />
+                    </ResourceDictionary>
+                    <ResourceDictionary x:Key="HighContrast">
+                        <SolidColorBrush x:Key="ButtonBorderBrush"
+                            Color="{ThemeResource SystemColorButtonTextColor}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushPointerOver"
+                            Color="{ThemeResource SystemColorButtonTextColor}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushPressed"
+                            Color="{ThemeResource SystemColorButtonTextColor}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushDisabled"
+                            Color="{ThemeResource SystemColorButtonTextColor}" />
+                    </ResourceDictionary>
+                </ResourceDictionary.ThemeDictionaries>
+            </ResourceDictionary>
+        </Grid.Resources>
         <Button
             Padding="-1"
             HorizontalAlignment="Stretch"
@@ -20,9 +56,9 @@
             VerticalContentAlignment="Stretch"
             AutomationProperties.Name="{x:Bind AutomationName, Mode=OneTime}"
             Click="CardButton_Click"
-            CornerRadius="{StaticResource FoundryCardCornerRadius}">
+            CornerRadius="{StaticResource OverlayCornerRadius}">
             <StackPanel
-                Padding="16"
+                Padding="24,20"
                 Spacing="12">
 
                 <Grid>
@@ -33,9 +69,9 @@
                     </Grid.ColumnDefinitions>
                     <FontIcon
                         Grid.Column="0"
-                        Margin="0,0,10,0"
+                        Margin="0,0,12,0"
                         VerticalAlignment="Center"
-                        FontSize="{ThemeResource FoundryIconSizeDefault}"
+                        FontSize="24"
                         Glyph="{x:Bind IconGlyph, Mode=OneWay}" />
                     <TextBlock
                         Grid.Column="1"
@@ -66,7 +102,7 @@
                 <Rectangle
                     Height="1"
                     Fill="{ThemeResource DividerStrokeColorDefaultBrush}"
-                    Opacity="0.5" />
+                    Opacity="0.35" />
 
                 <Grid
                     ColumnSpacing="12"
@@ -87,12 +123,13 @@
                         Grid.Column="0"
                         Style="{ThemeResource FoundryCaptionTextBlockStyle}"
                         Text="{x:Bind Line1Label, Mode=OneWay}"
+                        TextWrapping="Wrap"
                         Visibility="{x:Bind Line1Visibility, Mode=OneWay}" />
                     <TextBlock
                         Grid.Row="0"
                         Grid.Column="1"
                         Text="{x:Bind Line1Value, Mode=OneWay}"
-                        TextTrimming="CharacterEllipsis"
+                        TextWrapping="Wrap"
                         Visibility="{x:Bind Line1Visibility, Mode=OneWay}" />
 
                     <TextBlock
@@ -100,12 +137,13 @@
                         Grid.Column="0"
                         Style="{ThemeResource FoundryCaptionTextBlockStyle}"
                         Text="{x:Bind Line2Label, Mode=OneWay}"
+                        TextWrapping="Wrap"
                         Visibility="{x:Bind Line2Visibility, Mode=OneWay}" />
                     <TextBlock
                         Grid.Row="1"
                         Grid.Column="1"
                         Text="{x:Bind Line2Value, Mode=OneWay}"
-                        TextTrimming="CharacterEllipsis"
+                        TextWrapping="Wrap"
                         Visibility="{x:Bind Line2Visibility, Mode=OneWay}" />
 
                     <TextBlock
@@ -113,12 +151,13 @@
                         Grid.Column="0"
                         Style="{ThemeResource FoundryCaptionTextBlockStyle}"
                         Text="{x:Bind Line3Label, Mode=OneWay}"
+                        TextWrapping="Wrap"
                         Visibility="{x:Bind Line3Visibility, Mode=OneWay}" />
                     <TextBlock
                         Grid.Row="2"
                         Grid.Column="1"
                         Text="{x:Bind Line3Value, Mode=OneWay}"
-                        TextTrimming="CharacterEllipsis"
+                        TextWrapping="Wrap"
                         Visibility="{x:Bind Line3Visibility, Mode=OneWay}" />
 
                     <TextBlock
@@ -126,12 +165,13 @@
                         Grid.Column="0"
                         Style="{ThemeResource FoundryCaptionTextBlockStyle}"
                         Text="{x:Bind Line4Label, Mode=OneWay}"
+                        TextWrapping="Wrap"
                         Visibility="{x:Bind Line4Visibility, Mode=OneWay}" />
                     <TextBlock
                         Grid.Row="3"
                         Grid.Column="1"
                         Text="{x:Bind Line4Value, Mode=OneWay}"
-                        TextTrimming="CharacterEllipsis"
+                        TextWrapping="Wrap"
                         Visibility="{x:Bind Line4Visibility, Mode=OneWay}" />
                 </Grid>
             </StackPanel>

--- a/src/Foundry/Controls/HomeStatusCard.xaml.cs
+++ b/src/Foundry/Controls/HomeStatusCard.xaml.cs
@@ -1,0 +1,204 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.UI.Xaml.Media;
+
+namespace Foundry.Controls;
+
+/// <summary>
+/// A compact, clickable card that shows an icon, title, coloured status badge,
+/// and up to four label/value detail rows. Used on the Home landing page.
+/// </summary>
+public sealed partial class HomeStatusCard : UserControl
+{
+    public static readonly DependencyProperty TitleProperty =
+        DependencyProperty.Register(nameof(Title), typeof(string), typeof(HomeStatusCard), new PropertyMetadata(string.Empty, OnContentChanged));
+
+    public static readonly DependencyProperty IconGlyphProperty =
+        DependencyProperty.Register(nameof(IconGlyph), typeof(string), typeof(HomeStatusCard), new PropertyMetadata(string.Empty));
+
+    public static readonly DependencyProperty StatusTextProperty =
+        DependencyProperty.Register(nameof(StatusText), typeof(string), typeof(HomeStatusCard), new PropertyMetadata(string.Empty, OnContentChanged));
+
+    public static readonly DependencyProperty SeverityProperty =
+        DependencyProperty.Register(nameof(Severity), typeof(InfoBarSeverity), typeof(HomeStatusCard), new PropertyMetadata(InfoBarSeverity.Informational, OnSeverityChanged));
+
+    public static readonly DependencyProperty Line1LabelProperty =
+        DependencyProperty.Register(nameof(Line1Label), typeof(string), typeof(HomeStatusCard), new PropertyMetadata(string.Empty, OnContentChanged));
+
+    public static readonly DependencyProperty Line1ValueProperty =
+        DependencyProperty.Register(nameof(Line1Value), typeof(string), typeof(HomeStatusCard), new PropertyMetadata(string.Empty, OnContentChanged));
+
+    public static readonly DependencyProperty Line2LabelProperty =
+        DependencyProperty.Register(nameof(Line2Label), typeof(string), typeof(HomeStatusCard), new PropertyMetadata(string.Empty, OnContentChanged));
+
+    public static readonly DependencyProperty Line2ValueProperty =
+        DependencyProperty.Register(nameof(Line2Value), typeof(string), typeof(HomeStatusCard), new PropertyMetadata(string.Empty, OnContentChanged));
+
+    public static readonly DependencyProperty Line3LabelProperty =
+        DependencyProperty.Register(nameof(Line3Label), typeof(string), typeof(HomeStatusCard), new PropertyMetadata(string.Empty, OnContentChanged));
+
+    public static readonly DependencyProperty Line3ValueProperty =
+        DependencyProperty.Register(nameof(Line3Value), typeof(string), typeof(HomeStatusCard), new PropertyMetadata(string.Empty, OnContentChanged));
+
+    public static readonly DependencyProperty Line4LabelProperty =
+        DependencyProperty.Register(nameof(Line4Label), typeof(string), typeof(HomeStatusCard), new PropertyMetadata(string.Empty, OnContentChanged));
+
+    public static readonly DependencyProperty Line4ValueProperty =
+        DependencyProperty.Register(nameof(Line4Value), typeof(string), typeof(HomeStatusCard), new PropertyMetadata(string.Empty, OnContentChanged));
+
+    /// <summary>Raised when the card is clicked.</summary>
+    public event EventHandler? NavigationRequested;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HomeStatusCard"/> class.
+    /// </summary>
+    public HomeStatusCard()
+    {
+        InitializeComponent();
+    }
+
+    public string Title
+    {
+        get => (string)GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
+    }
+
+    public string IconGlyph
+    {
+        get => (string)GetValue(IconGlyphProperty);
+        set => SetValue(IconGlyphProperty, value);
+    }
+
+    public string StatusText
+    {
+        get => (string)GetValue(StatusTextProperty);
+        set => SetValue(StatusTextProperty, value);
+    }
+
+    public InfoBarSeverity Severity
+    {
+        get => (InfoBarSeverity)GetValue(SeverityProperty);
+        set => SetValue(SeverityProperty, value);
+    }
+
+    public string Line1Label
+    {
+        get => (string)GetValue(Line1LabelProperty);
+        set => SetValue(Line1LabelProperty, value);
+    }
+
+    public string Line1Value
+    {
+        get => (string)GetValue(Line1ValueProperty);
+        set => SetValue(Line1ValueProperty, value);
+    }
+
+    public string Line2Label
+    {
+        get => (string)GetValue(Line2LabelProperty);
+        set => SetValue(Line2LabelProperty, value);
+    }
+
+    public string Line2Value
+    {
+        get => (string)GetValue(Line2ValueProperty);
+        set => SetValue(Line2ValueProperty, value);
+    }
+
+    public string Line3Label
+    {
+        get => (string)GetValue(Line3LabelProperty);
+        set => SetValue(Line3LabelProperty, value);
+    }
+
+    public string Line3Value
+    {
+        get => (string)GetValue(Line3ValueProperty);
+        set => SetValue(Line3ValueProperty, value);
+    }
+
+    public string Line4Label
+    {
+        get => (string)GetValue(Line4LabelProperty);
+        set => SetValue(Line4LabelProperty, value);
+    }
+
+    public string Line4Value
+    {
+        get => (string)GetValue(Line4ValueProperty);
+        set => SetValue(Line4ValueProperty, value);
+    }
+
+    /// <summary>Background brush of the status badge, computed from <see cref="Severity"/>.</summary>
+    public Brush BadgeBackground => Severity switch
+    {
+        InfoBarSeverity.Success => (Brush)Application.Current.Resources["FoundryStatusReadyBrush"],
+        InfoBarSeverity.Warning => (Brush)Application.Current.Resources["FoundryStatusWarningBrush"],
+        _ => (Brush)Application.Current.Resources["FoundryStatusNeutralBrush"],
+    };
+
+    /// <summary>Foreground brush of the status badge, computed from <see cref="Severity"/>.</summary>
+    public Brush BadgeForeground => Severity switch
+    {
+        InfoBarSeverity.Success => (Brush)Application.Current.Resources["FoundryStatusReadyForegroundBrush"],
+        InfoBarSeverity.Warning => (Brush)Application.Current.Resources["FoundryStatusWarningForegroundBrush"],
+        _ => (Brush)Application.Current.Resources["FoundryStatusNeutralForegroundBrush"],
+    };
+
+    /// <summary>Glyph shown in the badge, computed from <see cref="Severity"/>.</summary>
+    public string BadgeGlyph => Severity switch
+    {
+        InfoBarSeverity.Success => "\uE73E",
+        InfoBarSeverity.Warning => "\uE7BA",
+        _ => "\uE9CE",
+    };
+
+    public Visibility Line1Visibility => string.IsNullOrEmpty(Line1Label) ? Visibility.Collapsed : Visibility.Visible;
+    public Visibility Line2Visibility => string.IsNullOrEmpty(Line2Label) ? Visibility.Collapsed : Visibility.Visible;
+    public Visibility Line3Visibility => string.IsNullOrEmpty(Line3Label) ? Visibility.Collapsed : Visibility.Visible;
+    public Visibility Line4Visibility => string.IsNullOrEmpty(Line4Label) ? Visibility.Collapsed : Visibility.Visible;
+
+    public string AutomationName
+    {
+        get
+        {
+            List<string> parts = [Title, StatusText];
+            AddDetail(parts, Line1Label, Line1Value);
+            AddDetail(parts, Line2Label, Line2Value);
+            AddDetail(parts, Line3Label, Line3Value);
+            AddDetail(parts, Line4Label, Line4Value);
+            return string.Join(". ", parts.Where(part => !string.IsNullOrWhiteSpace(part)));
+        }
+    }
+
+    private static void OnSeverityChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is HomeStatusCard card)
+        {
+            card.Bindings.Update();
+        }
+    }
+
+    private static void OnContentChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is HomeStatusCard card)
+        {
+            card.Bindings.Update();
+        }
+    }
+
+    private static void AddDetail(List<string> parts, string label, string value)
+    {
+        if (!string.IsNullOrWhiteSpace(label))
+        {
+            parts.Add($"{label}: {value}");
+        }
+    }
+
+    private void CardButton_Click(object sender, RoutedEventArgs e)
+    {
+        NavigationRequested?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/Foundry/Controls/HomeTile.xaml
+++ b/src/Foundry/Controls/HomeTile.xaml
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<UserControl x:Class="Foundry.Controls.HomeTile"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Width="232"
+    Height="172"
+    mc:Ignorable="d">
+    <Grid
+        Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
+        BorderBrush="{ThemeResource SurfaceStrokeColorFlyoutBrush}"
+        CornerRadius="8">
+        <Grid.Resources>
+            <ResourceDictionary>
+                <ResourceDictionary.ThemeDictionaries>
+                    <ResourceDictionary x:Key="Light">
+                        <SolidColorBrush x:Key="ButtonBorderBrush"
+                            Color="{ThemeResource ControlStrokeColorDefault}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushPointerOver"
+                            Color="{ThemeResource ControlStrokeColorSecondary}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushPressed"
+                            Color="{ThemeResource ControlStrokeColorDefault}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushDisabled"
+                            Color="{ThemeResource ControlStrokeColorDefault}" />
+                    </ResourceDictionary>
+                    <ResourceDictionary x:Key="Dark">
+                        <SolidColorBrush x:Key="ButtonBorderBrush"
+                            Color="{ThemeResource ControlStrokeColorDefault}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushPointerOver"
+                            Color="{ThemeResource ControlStrokeColorSecondary}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushPressed"
+                            Color="{ThemeResource ControlStrokeColorDefault}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushDisabled"
+                            Color="{ThemeResource ControlStrokeColorDefault}" />
+                    </ResourceDictionary>
+                    <ResourceDictionary x:Key="HighContrast">
+                        <SolidColorBrush x:Key="ButtonBorderBrush"
+                            Color="{ThemeResource SystemColorButtonTextColor}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushPointerOver"
+                            Color="{ThemeResource SystemColorButtonTextColor}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushPressed"
+                            Color="{ThemeResource SystemColorButtonTextColor}" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushDisabled"
+                            Color="{ThemeResource SystemColorButtonTextColor}" />
+                    </ResourceDictionary>
+                </ResourceDictionary.ThemeDictionaries>
+            </ResourceDictionary>
+        </Grid.Resources>
+        <Button
+            Padding="-1"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            HorizontalContentAlignment="Stretch"
+            VerticalContentAlignment="Stretch"
+            AutomationProperties.HelpText="{x:Bind Description, Mode=OneWay}"
+            AutomationProperties.Name="{x:Bind Title, Mode=OneWay}"
+            Click="TileButton_Click"
+            CornerRadius="{StaticResource OverlayCornerRadius}">
+            <Grid
+                Padding="24"
+                VerticalAlignment="Stretch"
+                RowSpacing="16">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="36" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <FontIcon
+                    Grid.RowSpan="2"
+                    Margin="-12"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Bottom"
+                    FontSize="14"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Glyph="&#xE8A7;" />
+                <FontIcon
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
+                    FontSize="{ThemeResource FoundryIconSizeHero}"
+                    Glyph="{x:Bind IconGlyph, Mode=OneWay}" />
+                <StackPanel
+                    Grid.Row="1"
+                    Orientation="Vertical"
+                    Spacing="4">
+                    <TextBlock
+                        Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="{x:Bind Title, Mode=OneWay}" />
+                    <TextBlock
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{x:Bind Description, Mode=OneWay}"
+                        TextWrapping="Wrap" />
+                </StackPanel>
+            </Grid>
+        </Button>
+    </Grid>
+</UserControl>

--- a/src/Foundry/Controls/HomeTile.xaml
+++ b/src/Foundry/Controls/HomeTile.xaml
@@ -9,42 +9,12 @@
     mc:Ignorable="d">
     <Grid
         Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
-        BorderBrush="{ThemeResource SurfaceStrokeColorFlyoutBrush}"
         CornerRadius="8">
         <Grid.Resources>
             <ResourceDictionary>
-                <ResourceDictionary.ThemeDictionaries>
-                    <ResourceDictionary x:Key="Light">
-                        <SolidColorBrush x:Key="ButtonBorderBrush"
-                            Color="{ThemeResource ControlStrokeColorDefault}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushPointerOver"
-                            Color="{ThemeResource ControlStrokeColorSecondary}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushPressed"
-                            Color="{ThemeResource ControlStrokeColorDefault}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushDisabled"
-                            Color="{ThemeResource ControlStrokeColorDefault}" />
-                    </ResourceDictionary>
-                    <ResourceDictionary x:Key="Dark">
-                        <SolidColorBrush x:Key="ButtonBorderBrush"
-                            Color="{ThemeResource ControlStrokeColorDefault}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushPointerOver"
-                            Color="{ThemeResource ControlStrokeColorSecondary}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushPressed"
-                            Color="{ThemeResource ControlStrokeColorDefault}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushDisabled"
-                            Color="{ThemeResource ControlStrokeColorDefault}" />
-                    </ResourceDictionary>
-                    <ResourceDictionary x:Key="HighContrast">
-                        <SolidColorBrush x:Key="ButtonBorderBrush"
-                            Color="{ThemeResource SystemColorButtonTextColor}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushPointerOver"
-                            Color="{ThemeResource SystemColorButtonTextColor}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushPressed"
-                            Color="{ThemeResource SystemColorButtonTextColor}" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushDisabled"
-                            Color="{ThemeResource SystemColorButtonTextColor}" />
-                    </ResourceDictionary>
-                </ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary.MergedDictionaries>
+                    <ResourceDictionary Source="HomeCardButtonResources.xaml" />
+                </ResourceDictionary.MergedDictionaries>
             </ResourceDictionary>
         </Grid.Resources>
         <Button

--- a/src/Foundry/Controls/HomeTile.xaml.cs
+++ b/src/Foundry/Controls/HomeTile.xaml.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Controls;
+
+/// <summary>
+/// Displays a fixed-size action tile in the home landing page header.
+/// </summary>
+public sealed partial class HomeTile : UserControl
+{
+    public static readonly DependencyProperty TitleProperty = DependencyProperty.Register(
+        nameof(Title),
+        typeof(string),
+        typeof(HomeTile),
+        new PropertyMetadata(string.Empty));
+
+    public static readonly DependencyProperty DescriptionProperty = DependencyProperty.Register(
+        nameof(Description),
+        typeof(string),
+        typeof(HomeTile),
+        new PropertyMetadata(string.Empty));
+
+    public static readonly DependencyProperty IconGlyphProperty = DependencyProperty.Register(
+        nameof(IconGlyph),
+        typeof(string),
+        typeof(HomeTile),
+        new PropertyMetadata(string.Empty));
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HomeTile"/> class.
+    /// </summary>
+    public HomeTile()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// Occurs when the tile is activated.
+    /// </summary>
+    public event RoutedEventHandler? Click;
+
+    /// <summary>
+    /// Gets or sets the tile title.
+    /// </summary>
+    public string Title
+    {
+        get => (string)GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the tile description.
+    /// </summary>
+    public string Description
+    {
+        get => (string)GetValue(DescriptionProperty);
+        set => SetValue(DescriptionProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the Segoe Fluent Icons glyph displayed by the tile.
+    /// </summary>
+    public string IconGlyph
+    {
+        get => (string)GetValue(IconGlyphProperty);
+        set => SetValue(IconGlyphProperty, value);
+    }
+
+    private void TileButton_Click(object sender, RoutedEventArgs e)
+    {
+        Click?.Invoke(this, e);
+    }
+}

--- a/src/Foundry/Controls/HorizontalScrollContainer.xaml
+++ b/src/Foundry/Controls/HorizontalScrollContainer.xaml
@@ -1,0 +1,175 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<UserControl x:Class="Foundry.Controls.HorizontalScrollContainer"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <UserControl.Resources>
+        <Style x:Key="HomeScrollButtonStyle"
+            TargetType="Button">
+            <Setter
+                Property="Background"
+                Value="{ThemeResource FlipViewNextPreviousButtonBackground}" />
+            <Setter
+                Property="BackgroundSizing"
+                Value="InnerBorderEdge" />
+            <Setter
+                Property="Foreground"
+                Value="{ThemeResource ButtonForeground}" />
+            <Setter
+                Property="BorderBrush"
+                Value="{ThemeResource FlipViewNextPreviousButtonBorderBrush}" />
+            <Setter
+                Property="BorderThickness"
+                Value="1" />
+            <Setter
+                Property="Padding"
+                Value="0" />
+            <Setter
+                Property="HorizontalAlignment"
+                Value="Left" />
+            <Setter
+                Property="VerticalAlignment"
+                Value="Center" />
+            <Setter
+                Property="FontFamily"
+                Value="{ThemeResource ContentControlThemeFontFamily}" />
+            <Setter
+                Property="FontWeight"
+                Value="Normal" />
+            <Setter
+                Property="FontSize"
+                Value="{ThemeResource ControlContentThemeFontSize}" />
+            <Setter
+                Property="UseSystemFocusVisuals"
+                Value="{StaticResource UseSystemFocusVisuals}" />
+            <Setter
+                Property="FocusVisualMargin"
+                Value="-3" />
+            <Setter
+                Property="CornerRadius"
+                Value="{ThemeResource ControlCornerRadius}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <ContentPresenter x:Name="ContentPresenter"
+                            Padding="{TemplateBinding Padding}"
+                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                            AnimatedIcon.State="Normal"
+                            AutomationProperties.AccessibilityView="Raw"
+                            Background="{TemplateBinding Background}"
+                            BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            ContentTransitions="{TemplateBinding ContentTransitions}"
+                            CornerRadius="{TemplateBinding CornerRadius}">
+                            <ContentPresenter.BackgroundTransition>
+                                <BrushTransition Duration="0:0:0.083" />
+                            </ContentPresenter.BackgroundTransition>
+                            <VisualStateManager.VisualStateGroups>
+                                <VisualStateGroup x:Name="CommonStates">
+                                    <VisualState x:Name="Normal" />
+                                    <VisualState x:Name="PointerOver">
+                                        <VisualState.Setters>
+                                            <Setter
+                                                Target="ContentPresenter.Background"
+                                                Value="{ThemeResource FlipViewNextPreviousButtonBackgroundPointerOver}" />
+                                            <Setter
+                                                Target="ContentPresenter.BorderBrush"
+                                                Value="{ThemeResource FlipViewNextPreviousButtonBorderBrushPointerOver}" />
+                                            <Setter
+                                                Target="ContentPresenter.Foreground"
+                                                Value="{ThemeResource FlipViewNextPreviousArrowForegroundPointerOver}" />
+                                            <Setter
+                                                Target="ContentPresenter.(AnimatedIcon.State)"
+                                                Value="PointerOver" />
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                    <VisualState x:Name="Pressed">
+                                        <VisualState.Setters>
+                                            <Setter
+                                                Target="ContentPresenter.Background"
+                                                Value="{ThemeResource FlipViewNextPreviousButtonBackgroundPressed}" />
+                                            <Setter
+                                                Target="ContentPresenter.BorderBrush"
+                                                Value="{ThemeResource FlipViewNextPreviousButtonBorderBrushPressed}" />
+                                            <Setter
+                                                Target="ContentPresenter.Foreground"
+                                                Value="{ThemeResource FlipViewNextPreviousArrowForegroundPressed}" />
+                                            <Setter
+                                                Target="ContentPresenter.(AnimatedIcon.State)"
+                                                Value="Pressed" />
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                    <VisualState x:Name="Disabled">
+                                        <VisualState.Setters>
+                                            <Setter
+                                                Target="ContentPresenter.Background"
+                                                Value="{ThemeResource ButtonBackgroundDisabled}" />
+                                            <Setter
+                                                Target="ContentPresenter.BorderBrush"
+                                                Value="{ThemeResource ButtonBorderBrushDisabled}" />
+                                            <Setter
+                                                Target="ContentPresenter.Foreground"
+                                                Value="{ThemeResource ButtonForegroundDisabled}" />
+                                            <Setter
+                                                Target="ContentPresenter.(AnimatedIcon.State)"
+                                                Value="Normal" />
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                </VisualStateGroup>
+                            </VisualStateManager.VisualStateGroups>
+                        </ContentPresenter>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
+
+    <Grid>
+        <ScrollViewer x:Name="Scroller"
+            HorizontalScrollBarVisibility="Hidden"
+            HorizontalScrollMode="Enabled"
+            SizeChanged="Scroller_SizeChanged"
+            VerticalScrollBarVisibility="Hidden"
+            VerticalScrollMode="Disabled"
+            ViewChanging="Scroller_ViewChanging">
+            <Grid Margin="36,0">
+                <ContentPresenter
+                    Content="{x:Bind Source, Mode=OneWay}"
+                    SizeChanged="ContentPresenter_SizeChanged" />
+            </Grid>
+        </ScrollViewer>
+        <Button x:Name="ScrollBackButton"
+            Width="16"
+            Height="38"
+            Margin="8,-16,0,0"
+            AutomationProperties.Name="{x:Bind ScrollBackText, Mode=OneWay}"
+            Click="ScrollBackButton_Click"
+            Style="{StaticResource HomeScrollButtonStyle}"
+            ToolTipService.ToolTip="{x:Bind ScrollBackText, Mode=OneWay}"
+            Visibility="Collapsed">
+            <FontIcon
+                FontSize="{ThemeResource FlipViewButtonFontSize}"
+                Glyph="&#xEDD9;" />
+        </Button>
+        <Button x:Name="ScrollForwardButton"
+            Width="16"
+            Height="38"
+            Margin="0,-16,8,0"
+            HorizontalAlignment="Right"
+            AutomationProperties.Name="{x:Bind ScrollForwardText, Mode=OneWay}"
+            Click="ScrollForwardButton_Click"
+            Style="{StaticResource HomeScrollButtonStyle}"
+            ToolTipService.ToolTip="{x:Bind ScrollForwardText, Mode=OneWay}"
+            Visibility="Collapsed">
+            <FontIcon
+                FontSize="{ThemeResource FlipViewButtonFontSize}"
+                Glyph="&#xEDDA;" />
+        </Button>
+    </Grid>
+</UserControl>

--- a/src/Foundry/Controls/HorizontalScrollContainer.xaml.cs
+++ b/src/Foundry/Controls/HorizontalScrollContainer.xaml.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Controls;
+
+/// <summary>
+/// Hosts horizontally scrollable content with viewport navigation controls.
+/// </summary>
+public sealed partial class HorizontalScrollContainer : UserControl
+{
+    public static readonly DependencyProperty SourceProperty = DependencyProperty.Register(
+        nameof(Source),
+        typeof(object),
+        typeof(HorizontalScrollContainer),
+        new PropertyMetadata(null));
+
+    public static readonly DependencyProperty ScrollBackTextProperty = DependencyProperty.Register(
+        nameof(ScrollBackText),
+        typeof(string),
+        typeof(HorizontalScrollContainer),
+        new PropertyMetadata(string.Empty));
+
+    public static readonly DependencyProperty ScrollForwardTextProperty = DependencyProperty.Register(
+        nameof(ScrollForwardText),
+        typeof(string),
+        typeof(HorizontalScrollContainer),
+        new PropertyMetadata(string.Empty));
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HorizontalScrollContainer"/> class.
+    /// </summary>
+    public HorizontalScrollContainer()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// Gets or sets the content displayed inside the horizontal viewport.
+    /// </summary>
+    public object? Source
+    {
+        get => GetValue(SourceProperty);
+        set => SetValue(SourceProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the localized label for the back scroll button.
+    /// </summary>
+    public string ScrollBackText
+    {
+        get => (string)GetValue(ScrollBackTextProperty);
+        set => SetValue(ScrollBackTextProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the localized label for the forward scroll button.
+    /// </summary>
+    public string ScrollForwardText
+    {
+        get => (string)GetValue(ScrollForwardTextProperty);
+        set => SetValue(ScrollForwardTextProperty, value);
+    }
+
+    private void Scroller_ViewChanging(object sender, ScrollViewerViewChangingEventArgs e)
+    {
+        ScrollBackButton.Visibility = e.FinalView.HorizontalOffset < 1
+            ? Visibility.Collapsed
+            : Visibility.Visible;
+        ScrollForwardButton.Visibility = e.FinalView.HorizontalOffset > Scroller.ScrollableWidth - 1
+            ? Visibility.Collapsed
+            : Visibility.Visible;
+    }
+
+    private void ScrollBackButton_Click(object sender, RoutedEventArgs e)
+    {
+        Scroller.ChangeView(Scroller.HorizontalOffset - Scroller.ViewportWidth, null, null);
+        ScrollForwardButton.Focus(FocusState.Programmatic);
+    }
+
+    private void ScrollForwardButton_Click(object sender, RoutedEventArgs e)
+    {
+        Scroller.ChangeView(Scroller.HorizontalOffset + Scroller.ViewportWidth, null, null);
+        ScrollBackButton.Focus(FocusState.Programmatic);
+    }
+
+    private void Scroller_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        UpdateButtonsVisibility();
+    }
+
+    private void ContentPresenter_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        UpdateButtonsVisibility();
+    }
+
+    private void UpdateButtonsVisibility()
+    {
+        ScrollBackButton.Visibility = Scroller.HorizontalOffset < 1
+            ? Visibility.Collapsed
+            : Visibility.Visible;
+        ScrollForwardButton.Visibility = Scroller.ScrollableWidth > 0
+            && Scroller.HorizontalOffset < Scroller.ScrollableWidth - 1
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+    }
+}

--- a/src/Foundry/Controls/OpacityMaskView.cs
+++ b/src/Foundry/Controls/OpacityMaskView.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.UI.Composition;
+using Microsoft.UI.Xaml.Hosting;
+using Microsoft.UI.Xaml.Media;
+using System.Numerics;
+
+namespace Foundry.Controls;
+
+/// <summary>
+/// Applies the alpha channel of a XAML element as an opacity mask over its content.
+/// </summary>
+[TemplatePart(Name = RootGridTemplateName, Type = typeof(Grid))]
+[TemplatePart(Name = MaskContainerTemplateName, Type = typeof(Border))]
+[TemplatePart(Name = ContentPresenterTemplateName, Type = typeof(ContentPresenter))]
+public sealed partial class OpacityMaskView : ContentControl
+{
+    public static readonly DependencyProperty OpacityMaskProperty = DependencyProperty.Register(
+        nameof(OpacityMask),
+        typeof(UIElement),
+        typeof(OpacityMaskView),
+        new PropertyMetadata(null, OnOpacityMaskChanged));
+
+    private const string ContentPresenterTemplateName = "PART_ContentPresenter";
+    private const string MaskContainerTemplateName = "PART_MaskContainer";
+    private const string RootGridTemplateName = "PART_RootGrid";
+
+    private readonly Compositor compositor = CompositionTarget.GetCompositorForCurrentThread();
+    private CompositionBrush? mask;
+    private CompositionMaskBrush? maskBrush;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OpacityMaskView"/> class.
+    /// </summary>
+    public OpacityMaskView()
+    {
+        DefaultStyleKey = typeof(OpacityMaskView);
+    }
+
+    /// <summary>
+    /// Gets or sets the element whose alpha channel masks the rendered content.
+    /// </summary>
+    public UIElement? OpacityMask
+    {
+        get => (UIElement?)GetValue(OpacityMaskProperty);
+        set => SetValue(OpacityMaskProperty, value);
+    }
+
+    /// <inheritdoc />
+    protected override void OnApplyTemplate()
+    {
+        base.OnApplyTemplate();
+
+        if (GetTemplateChild(RootGridTemplateName) is not Grid rootGrid
+            || GetTemplateChild(ContentPresenterTemplateName) is not ContentPresenter contentPresenter
+            || GetTemplateChild(MaskContainerTemplateName) is not Border maskContainer)
+        {
+            return;
+        }
+
+        maskBrush = compositor.CreateMaskBrush();
+        maskBrush.Source = CreateVisualBrush(contentPresenter);
+        mask = CreateVisualBrush(maskContainer);
+        maskBrush.Mask = OpacityMask is null ? null : mask;
+
+        SpriteVisual redirectVisual = compositor.CreateSpriteVisual();
+        redirectVisual.RelativeSizeAdjustment = Vector2.One;
+        redirectVisual.Brush = maskBrush;
+        ElementCompositionPreview.SetElementChildVisual(rootGrid, redirectVisual);
+    }
+
+    private static CompositionBrush CreateVisualBrush(UIElement element)
+    {
+        Visual visual = ElementCompositionPreview.GetElementVisual(element);
+        Compositor compositor = visual.Compositor;
+        CompositionVisualSurface visualSurface = compositor.CreateVisualSurface();
+        visualSurface.SourceVisual = visual;
+
+        ExpressionAnimation sourceSizeAnimation = compositor.CreateExpressionAnimation($"{nameof(visual)}.Size");
+        sourceSizeAnimation.SetReferenceParameter(nameof(visual), visual);
+        visualSurface.StartAnimation(nameof(visualSurface.SourceSize), sourceSizeAnimation);
+
+        CompositionSurfaceBrush brush = compositor.CreateSurfaceBrush(visualSurface);
+        visual.Opacity = 0;
+        return brush;
+    }
+
+    private static void OnOpacityMaskChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+    {
+        OpacityMaskView view = (OpacityMaskView)dependencyObject;
+        if (view.maskBrush is null)
+        {
+            return;
+        }
+
+        view.maskBrush.Mask = e.NewValue is null ? null : view.mask;
+    }
+}

--- a/src/Foundry/Controls/OpacityMaskView.xaml
+++ b/src/Foundry/Controls/OpacityMaskView.xaml
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Foundry.Controls">
+
+    <Style x:Key="DefaultOpacityMaskViewStyle"
+        TargetType="controls:OpacityMaskView">
+        <Setter
+            Property="IsTabStop"
+            Value="False" />
+        <Setter
+            Property="HorizontalContentAlignment"
+            Value="Left" />
+        <Setter
+            Property="VerticalContentAlignment"
+            Value="Top" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="controls:OpacityMaskView">
+                    <Grid x:Name="PART_RootGrid"
+                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                        <Border x:Name="PART_MaskContainer"
+                            Child="{TemplateBinding OpacityMask}"
+                            IsHitTestVisible="False" />
+                        <ContentPresenter x:Name="PART_ContentPresenter"
+                            Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style
+        BasedOn="{StaticResource DefaultOpacityMaskViewStyle}"
+        TargetType="controls:OpacityMaskView" />
+</ResourceDictionary>

--- a/src/Foundry/Controls/WorkflowStep.xaml
+++ b/src/Foundry/Controls/WorkflowStep.xaml
@@ -1,0 +1,103 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<UserControl x:Class="Foundry.Controls.WorkflowStep"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <SolidColorBrush x:Key="WorkflowStepReadyBrush"
+                        Color="{ThemeResource SystemFillColorSuccess}" />
+                    <SolidColorBrush x:Key="WorkflowStepWarningBrush"
+                        Color="{ThemeResource SystemFillColorCaution}" />
+                    <SolidColorBrush x:Key="WorkflowStepPendingBrush"
+                        Color="{ThemeResource ControlFillColorSecondary}" />
+                    <SolidColorBrush x:Key="WorkflowStepReadyForegroundBrush"
+                        Color="White" />
+                    <SolidColorBrush x:Key="WorkflowStepWarningForegroundBrush"
+                        Color="{ThemeResource TextFillColorPrimary}" />
+                    <SolidColorBrush x:Key="WorkflowStepPendingForegroundBrush"
+                        Color="{ThemeResource TextFillColorSecondary}" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <SolidColorBrush x:Key="WorkflowStepReadyBrush"
+                        Color="{ThemeResource SystemFillColorSuccess}" />
+                    <SolidColorBrush x:Key="WorkflowStepWarningBrush"
+                        Color="{ThemeResource SystemFillColorCaution}" />
+                    <SolidColorBrush x:Key="WorkflowStepPendingBrush"
+                        Color="{ThemeResource ControlFillColorSecondary}" />
+                    <SolidColorBrush x:Key="WorkflowStepReadyForegroundBrush"
+                        Color="White" />
+                    <SolidColorBrush x:Key="WorkflowStepWarningForegroundBrush"
+                        Color="{ThemeResource TextFillColorPrimary}" />
+                    <SolidColorBrush x:Key="WorkflowStepPendingForegroundBrush"
+                        Color="{ThemeResource TextFillColorSecondary}" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="HighContrast">
+                    <SolidColorBrush x:Key="WorkflowStepReadyBrush"
+                        Color="{ThemeResource SystemColorButtonFaceColor}" />
+                    <SolidColorBrush x:Key="WorkflowStepWarningBrush"
+                        Color="{ThemeResource SystemColorButtonFaceColor}" />
+                    <SolidColorBrush x:Key="WorkflowStepPendingBrush"
+                        Color="{ThemeResource SystemColorButtonFaceColor}" />
+                    <SolidColorBrush x:Key="WorkflowStepReadyForegroundBrush"
+                        Color="{ThemeResource SystemColorButtonTextColor}" />
+                    <SolidColorBrush x:Key="WorkflowStepWarningForegroundBrush"
+                        Color="{ThemeResource SystemColorButtonTextColor}" />
+                    <SolidColorBrush x:Key="WorkflowStepPendingForegroundBrush"
+                        Color="{ThemeResource SystemColorButtonTextColor}" />
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Button
+        Padding="4"
+        HorizontalAlignment="Center"
+        HorizontalContentAlignment="Center"
+        AutomationProperties.Name="{x:Bind AutomationName, Mode=OneTime}"
+        Background="Transparent"
+        BorderThickness="0"
+        Click="StepButton_Click">
+        <StackPanel
+            HorizontalAlignment="Center"
+            Orientation="Vertical"
+            Spacing="8">
+            <Grid
+                Width="40"
+                Height="40"
+                HorizontalAlignment="Center"
+                Background="{x:Bind CircleBackground, Mode=OneTime}"
+                CornerRadius="20">
+                <FontIcon
+                    FontSize="16"
+                    Foreground="{x:Bind CircleForeground, Mode=OneTime}"
+                    Glyph="&#xE73E;"
+                    Visibility="{x:Bind IsReady, Mode=OneTime}" />
+                <FontIcon
+                    FontSize="16"
+                    Foreground="{x:Bind CircleForeground, Mode=OneTime}"
+                    Glyph="&#xE7BA;"
+                    Visibility="{x:Bind IsWarning, Mode=OneTime}" />
+                <TextBlock
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    FontSize="14"
+                    FontWeight="SemiBold"
+                    Foreground="{x:Bind CircleForeground, Mode=OneTime}"
+                    Text="{x:Bind StepNumber, Mode=OneWay}"
+                    Visibility="{x:Bind IsPending, Mode=OneTime}" />
+            </Grid>
+            <TextBlock
+                HorizontalAlignment="Center"
+                FontSize="12"
+                Foreground="{x:Bind LabelForeground, Mode=OneTime}"
+                Text="{x:Bind Label, Mode=OneWay}"
+                TextAlignment="Center" />
+        </StackPanel>
+    </Button>
+</UserControl>

--- a/src/Foundry/Controls/WorkflowStep.xaml
+++ b/src/Foundry/Controls/WorkflowStep.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Width="80"
     mc:Ignorable="d">
 
     <UserControl.Resources>
@@ -57,7 +58,7 @@
 
     <Button
         Padding="4"
-        HorizontalAlignment="Center"
+        HorizontalAlignment="Stretch"
         HorizontalContentAlignment="Center"
         AutomationProperties.Name="{x:Bind AutomationName, Mode=OneTime}"
         Background="Transparent"
@@ -97,7 +98,8 @@
                 FontSize="12"
                 Foreground="{x:Bind LabelForeground, Mode=OneTime}"
                 Text="{x:Bind Label, Mode=OneWay}"
-                TextAlignment="Center" />
+                TextAlignment="Center"
+                TextWrapping="Wrap" />
         </StackPanel>
     </Button>
 </UserControl>

--- a/src/Foundry/Controls/WorkflowStep.xaml
+++ b/src/Foundry/Controls/WorkflowStep.xaml
@@ -19,8 +19,8 @@
                         Color="{ThemeResource ControlFillColorSecondary}" />
                     <SolidColorBrush x:Key="WorkflowStepReadyForegroundBrush"
                         Color="White" />
-                    <SolidColorBrush x:Key="WorkflowStepWarningForegroundBrush"
-                        Color="{ThemeResource TextFillColorPrimary}" />
+                    <StaticResource x:Key="WorkflowStepWarningForegroundBrush"
+                        ResourceKey="TextFillColorInverseBrush" />
                     <SolidColorBrush x:Key="WorkflowStepPendingForegroundBrush"
                         Color="{ThemeResource TextFillColorSecondary}" />
                 </ResourceDictionary>
@@ -33,8 +33,8 @@
                         Color="{ThemeResource ControlFillColorSecondary}" />
                     <SolidColorBrush x:Key="WorkflowStepReadyForegroundBrush"
                         Color="White" />
-                    <SolidColorBrush x:Key="WorkflowStepWarningForegroundBrush"
-                        Color="{ThemeResource TextFillColorPrimary}" />
+                    <StaticResource x:Key="WorkflowStepWarningForegroundBrush"
+                        ResourceKey="TextFillColorInverseBrush" />
                     <SolidColorBrush x:Key="WorkflowStepPendingForegroundBrush"
                         Color="{ThemeResource TextFillColorSecondary}" />
                 </ResourceDictionary>

--- a/src/Foundry/Controls/WorkflowStep.xaml.cs
+++ b/src/Foundry/Controls/WorkflowStep.xaml.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.UI.Xaml.Media;
+
+namespace Foundry.Controls;
+
+/// <summary>
+/// Renders a single numbered step within the <see cref="WorkflowStepper"/>.
+/// Shows a colored circle (green/orange/gray) with a checkmark, warning icon, or step number.
+/// </summary>
+public sealed partial class WorkflowStep : UserControl
+{
+    /// <summary>Occurs when the step is activated.</summary>
+    public event RoutedEventHandler? Click;
+
+    /// <summary>Identifies the <see cref="Label"/> dependency property.</summary>
+    public static readonly DependencyProperty LabelProperty =
+        DependencyProperty.Register(nameof(Label), typeof(string), typeof(WorkflowStep), new PropertyMetadata(string.Empty, OnStateChanged));
+
+    /// <summary>Identifies the <see cref="StepNumber"/> dependency property.</summary>
+    public static readonly DependencyProperty StepNumberProperty =
+        DependencyProperty.Register(nameof(StepNumber), typeof(string), typeof(WorkflowStep), new PropertyMetadata(string.Empty));
+
+    public static readonly DependencyProperty StatusTextProperty =
+        DependencyProperty.Register(nameof(StatusText), typeof(string), typeof(WorkflowStep), new PropertyMetadata(string.Empty, OnStateChanged));
+
+    /// <summary>Identifies the <see cref="State"/> dependency property.</summary>
+    public static readonly DependencyProperty StateProperty =
+        DependencyProperty.Register(nameof(State), typeof(InfoBarSeverity), typeof(WorkflowStep), new PropertyMetadata(InfoBarSeverity.Informational, OnStateChanged));
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WorkflowStep"/> class.
+    /// </summary>
+    public WorkflowStep()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>Gets or sets the label displayed beneath the step circle.</summary>
+    public string Label
+    {
+        get => (string)GetValue(LabelProperty);
+        set => SetValue(LabelProperty, value);
+    }
+
+    /// <summary>Gets or sets the step number displayed when the step is pending.</summary>
+    public string StepNumber
+    {
+        get => (string)GetValue(StepNumberProperty);
+        set => SetValue(StepNumberProperty, value);
+    }
+
+    public string StatusText
+    {
+        get => (string)GetValue(StatusTextProperty);
+        set => SetValue(StatusTextProperty, value);
+    }
+
+    /// <summary>Gets or sets the current state of this step.</summary>
+    public InfoBarSeverity State
+    {
+        get => (InfoBarSeverity)GetValue(StateProperty);
+        set => SetValue(StateProperty, value);
+    }
+
+    /// <summary>Gets the background brush for the circle based on current state.</summary>
+    public Brush CircleBackground => State switch
+    {
+        InfoBarSeverity.Success => (Brush)Resources["WorkflowStepReadyBrush"],
+        InfoBarSeverity.Warning => (Brush)Resources["WorkflowStepWarningBrush"],
+        _ => (Brush)Resources["WorkflowStepPendingBrush"],
+    };
+
+    /// <summary>Gets the foreground brush for the circle icon/number based on current state.</summary>
+    public Brush CircleForeground => State switch
+    {
+        InfoBarSeverity.Success => (Brush)Resources["WorkflowStepReadyForegroundBrush"],
+        InfoBarSeverity.Warning => (Brush)Resources["WorkflowStepWarningForegroundBrush"],
+        _ => (Brush)Resources["WorkflowStepPendingForegroundBrush"],
+    };
+
+    /// <summary>Gets the foreground brush for the label text.</summary>
+    public Brush LabelForeground => State == InfoBarSeverity.Informational
+        ? (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]
+        : (Brush)Application.Current.Resources["TextFillColorPrimaryBrush"];
+
+    /// <summary>Gets the visibility of the checkmark icon (Ready state only).</summary>
+    public Visibility IsReady => State == InfoBarSeverity.Success ? Visibility.Visible : Visibility.Collapsed;
+
+    /// <summary>Gets the visibility of the warning icon (Warning state only).</summary>
+    public Visibility IsWarning => State == InfoBarSeverity.Warning ? Visibility.Visible : Visibility.Collapsed;
+
+    /// <summary>Gets the visibility of the step number (Pending state only).</summary>
+    public Visibility IsPending => State == InfoBarSeverity.Informational ? Visibility.Visible : Visibility.Collapsed;
+
+    public string AutomationName => string.IsNullOrWhiteSpace(StatusText) ? Label : $"{Label}, {StatusText}";
+
+    private static void OnStateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is WorkflowStep step)
+        {
+            step.UpdateBindings();
+        }
+    }
+
+    private void UpdateBindings()
+    {
+        Bindings.Update();
+    }
+
+    private void StepButton_Click(object sender, RoutedEventArgs e)
+    {
+        Click?.Invoke(this, e);
+    }
+}

--- a/src/Foundry/Controls/WorkflowStepper.xaml
+++ b/src/Foundry/Controls/WorkflowStepper.xaml
@@ -35,6 +35,7 @@
         <controls:WorkflowStep
             Grid.Column="2"
             Click="Step2_Click"
+            IsEnabled="{x:Bind IsPostAdkNavigationEnabled, Mode=OneWay}"
             Label="{x:Bind Step2Label, Mode=OneWay}"
             State="{x:Bind Step2State, Mode=OneWay}"
             StatusText="{x:Bind Step2StatusText, Mode=OneWay}"
@@ -51,6 +52,7 @@
         <controls:WorkflowStep
             Grid.Column="4"
             Click="Step3_Click"
+            IsEnabled="{x:Bind IsPostAdkNavigationEnabled, Mode=OneWay}"
             Label="{x:Bind Step3Label, Mode=OneWay}"
             State="{x:Bind Step3State, Mode=OneWay}"
             StatusText="{x:Bind Step3StatusText, Mode=OneWay}"

--- a/src/Foundry/Controls/WorkflowStepper.xaml
+++ b/src/Foundry/Controls/WorkflowStepper.xaml
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<UserControl x:Class="Foundry.Controls.WorkflowStepper"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Foundry.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid ColumnSpacing="0">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <controls:WorkflowStep
+            Grid.Column="0"
+            Click="Step1_Click"
+            Label="{x:Bind Step1Label, Mode=OneWay}"
+            State="{x:Bind Step1State, Mode=OneWay}"
+            StatusText="{x:Bind Step1StatusText, Mode=OneWay}"
+            StepNumber="1" />
+
+        <Rectangle
+            Grid.Column="1"
+            Height="2"
+            Margin="0,20,0,0"
+            VerticalAlignment="Top"
+            Fill="{ThemeResource DividerStrokeColorDefaultBrush}"
+            Opacity="0.5" />
+
+        <controls:WorkflowStep
+            Grid.Column="2"
+            Click="Step2_Click"
+            Label="{x:Bind Step2Label, Mode=OneWay}"
+            State="{x:Bind Step2State, Mode=OneWay}"
+            StatusText="{x:Bind Step2StatusText, Mode=OneWay}"
+            StepNumber="2" />
+
+        <Rectangle
+            Grid.Column="3"
+            Height="2"
+            Margin="0,20,0,0"
+            VerticalAlignment="Top"
+            Fill="{ThemeResource DividerStrokeColorDefaultBrush}"
+            Opacity="0.5" />
+
+        <controls:WorkflowStep
+            Grid.Column="4"
+            Click="Step3_Click"
+            Label="{x:Bind Step3Label, Mode=OneWay}"
+            State="{x:Bind Step3State, Mode=OneWay}"
+            StatusText="{x:Bind Step3StatusText, Mode=OneWay}"
+            StepNumber="3" />
+    </Grid>
+</UserControl>

--- a/src/Foundry/Controls/WorkflowStepper.xaml.cs
+++ b/src/Foundry/Controls/WorkflowStepper.xaml.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Controls;
+
+/// <summary>
+/// Displays the three-step ADK → Configuration → Create media workflow
+/// with colored step indicators and navigation affordances.
+/// </summary>
+public sealed partial class WorkflowStepper : UserControl
+{
+    /// <summary>Identifies the <see cref="Step1Label"/> dependency property.</summary>
+    public static readonly DependencyProperty Step1LabelProperty =
+        DependencyProperty.Register(nameof(Step1Label), typeof(string), typeof(WorkflowStepper), new PropertyMetadata(string.Empty));
+
+    /// <summary>Identifies the <see cref="Step2Label"/> dependency property.</summary>
+    public static readonly DependencyProperty Step2LabelProperty =
+        DependencyProperty.Register(nameof(Step2Label), typeof(string), typeof(WorkflowStepper), new PropertyMetadata(string.Empty));
+
+    /// <summary>Identifies the <see cref="Step3Label"/> dependency property.</summary>
+    public static readonly DependencyProperty Step3LabelProperty =
+        DependencyProperty.Register(nameof(Step3Label), typeof(string), typeof(WorkflowStepper), new PropertyMetadata(string.Empty));
+
+    public static readonly DependencyProperty Step1StatusTextProperty =
+        DependencyProperty.Register(nameof(Step1StatusText), typeof(string), typeof(WorkflowStepper), new PropertyMetadata(string.Empty));
+
+    public static readonly DependencyProperty Step2StatusTextProperty =
+        DependencyProperty.Register(nameof(Step2StatusText), typeof(string), typeof(WorkflowStepper), new PropertyMetadata(string.Empty));
+
+    public static readonly DependencyProperty Step3StatusTextProperty =
+        DependencyProperty.Register(nameof(Step3StatusText), typeof(string), typeof(WorkflowStepper), new PropertyMetadata(string.Empty));
+
+    /// <summary>Identifies the <see cref="Step1State"/> dependency property.</summary>
+    public static readonly DependencyProperty Step1StateProperty =
+        DependencyProperty.Register(nameof(Step1State), typeof(InfoBarSeverity), typeof(WorkflowStepper), new PropertyMetadata(InfoBarSeverity.Informational));
+
+    /// <summary>Identifies the <see cref="Step2State"/> dependency property.</summary>
+    public static readonly DependencyProperty Step2StateProperty =
+        DependencyProperty.Register(nameof(Step2State), typeof(InfoBarSeverity), typeof(WorkflowStepper), new PropertyMetadata(InfoBarSeverity.Informational));
+
+    /// <summary>Identifies the <see cref="Step3State"/> dependency property.</summary>
+    public static readonly DependencyProperty Step3StateProperty =
+        DependencyProperty.Register(nameof(Step3State), typeof(InfoBarSeverity), typeof(WorkflowStepper), new PropertyMetadata(InfoBarSeverity.Informational));
+
+    /// <summary>Raised when step 1 is activated.</summary>
+    public event EventHandler? Step1Requested;
+
+    /// <summary>Raised when step 2 is activated.</summary>
+    public event EventHandler? Step2Requested;
+
+    /// <summary>Raised when step 3 is activated.</summary>
+    public event EventHandler? Step3Requested;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WorkflowStepper"/> class.
+    /// </summary>
+    public WorkflowStepper()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>Gets or sets the label for step 1.</summary>
+    public string Step1Label
+    {
+        get => (string)GetValue(Step1LabelProperty);
+        set => SetValue(Step1LabelProperty, value);
+    }
+
+    /// <summary>Gets or sets the label for step 2.</summary>
+    public string Step2Label
+    {
+        get => (string)GetValue(Step2LabelProperty);
+        set => SetValue(Step2LabelProperty, value);
+    }
+
+    /// <summary>Gets or sets the label for step 3.</summary>
+    public string Step3Label
+    {
+        get => (string)GetValue(Step3LabelProperty);
+        set => SetValue(Step3LabelProperty, value);
+    }
+
+    public string Step1StatusText
+    {
+        get => (string)GetValue(Step1StatusTextProperty);
+        set => SetValue(Step1StatusTextProperty, value);
+    }
+
+    public string Step2StatusText
+    {
+        get => (string)GetValue(Step2StatusTextProperty);
+        set => SetValue(Step2StatusTextProperty, value);
+    }
+
+    public string Step3StatusText
+    {
+        get => (string)GetValue(Step3StatusTextProperty);
+        set => SetValue(Step3StatusTextProperty, value);
+    }
+
+    /// <summary>Gets or sets the state of step 1.</summary>
+    public InfoBarSeverity Step1State
+    {
+        get => (InfoBarSeverity)GetValue(Step1StateProperty);
+        set => SetValue(Step1StateProperty, value);
+    }
+
+    /// <summary>Gets or sets the state of step 2.</summary>
+    public InfoBarSeverity Step2State
+    {
+        get => (InfoBarSeverity)GetValue(Step2StateProperty);
+        set => SetValue(Step2StateProperty, value);
+    }
+
+    /// <summary>Gets or sets the state of step 3.</summary>
+    public InfoBarSeverity Step3State
+    {
+        get => (InfoBarSeverity)GetValue(Step3StateProperty);
+        set => SetValue(Step3StateProperty, value);
+    }
+
+    private void Step1_Click(object sender, RoutedEventArgs e) => Step1Requested?.Invoke(this, EventArgs.Empty);
+
+    private void Step2_Click(object sender, RoutedEventArgs e) => Step2Requested?.Invoke(this, EventArgs.Empty);
+
+    private void Step3_Click(object sender, RoutedEventArgs e) => Step3Requested?.Invoke(this, EventArgs.Empty);
+}

--- a/src/Foundry/Controls/WorkflowStepper.xaml.cs
+++ b/src/Foundry/Controls/WorkflowStepper.xaml.cs
@@ -43,6 +43,9 @@ public sealed partial class WorkflowStepper : UserControl
     public static readonly DependencyProperty Step3StateProperty =
         DependencyProperty.Register(nameof(Step3State), typeof(InfoBarSeverity), typeof(WorkflowStepper), new PropertyMetadata(InfoBarSeverity.Informational));
 
+    public static readonly DependencyProperty IsPostAdkNavigationEnabledProperty =
+        DependencyProperty.Register(nameof(IsPostAdkNavigationEnabled), typeof(bool), typeof(WorkflowStepper), new PropertyMetadata(true));
+
     /// <summary>Raised when step 1 is activated.</summary>
     public event EventHandler? Step1Requested;
 
@@ -118,6 +121,12 @@ public sealed partial class WorkflowStepper : UserControl
     {
         get => (InfoBarSeverity)GetValue(Step3StateProperty);
         set => SetValue(Step3StateProperty, value);
+    }
+
+    public bool IsPostAdkNavigationEnabled
+    {
+        get => (bool)GetValue(IsPostAdkNavigationEnabledProperty);
+        set => SetValue(IsPostAdkNavigationEnabledProperty, value);
     }
 
     private void Step1_Click(object sender, RoutedEventArgs e) => Step1Requested?.Invoke(this, EventArgs.Empty);

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE الوظيفة الإضافية</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>هل أنت جاهز لإنشاء الوسائط؟</value>
+    <value>حالة جاهزية الوسائط</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>التكوين</value>

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE الوظيفة الإضافية</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>هل أنت جاهز لإنشاء الوسائط؟</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>التكوين</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>التمهيد الآمن (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>لا شيء</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>مخصص</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>يتطلب ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>أنشئ وسائط نشر Windows باستخدام سير عمل سطح مكتب حديث مدعوم بواسطة WinPE.</value>
   </data>

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>راجع الجاهزية واختر إخراج ISO أو USB ثم ابدأ إنشاء الوسائط.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>التمرير إلى اليسار</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>التمرير إلى اليمين</value></data>
 </root>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Прегледайте готовността, изберете ISO или USB изход и стартирайте създаването на носител.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Превъртане наляво</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Превъртане надясно</value></data>
 </root>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Добавка</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Готови ли сте да създадете носител?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Конфигурация</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Защитено стартиране (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Няма</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>По избор</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Изисква ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Създайте Windows носител за внедряване с модерен работен процес на настолен компютър, захранван от WinPE.</value>
   </data>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Добавка</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Готови ли сте да създадете носител?</value>
+    <value>Състояние на готовност на носителя</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Конфигурация</value>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE doplněk</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Připraveni vytvořit médium?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Konfigurace</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Zabezpečené spouštění (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Žádné</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Vlastní</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Vyžaduje ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Sestavte média pro nasazení Windows s moderním pracovním postupem pro stolní počítače poháněným WinPE.</value>
   </data>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Zkontrolujte připravenost, vyberte výstup ISO nebo USB a spusťte vytvoření média.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Posunout doleva</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Posunout doprava</value></data>
 </root>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE doplněk</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Připraveni vytvořit médium?</value>
+    <value>Stav připravenosti média</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Konfigurace</value>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Tilføjelse</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Klar til at oprette medier?</value>
+    <value>Status for medieberedskab</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Konfiguration</value>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Tilføjelse</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Klar til at oprette medier?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Konfiguration</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Sikker start (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Ingen</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Brugerdefineret</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Kræver ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Byg Windows implementeringsmedier med en moderne desktop-workflow drevet af WinPE.</value>
   </data>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Gennemgå klarheden, vælg ISO- eller USB-output, og start medieoprettelsen.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Rul til venstre</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Rul til højre</value></data>
 </root>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Add-on</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Bereit zum Erstellen von Medien?</value>
+    <value>Status der Medienbereitschaft</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Konfiguration</value>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Prüfen Sie die Bereitschaft, wählen Sie eine ISO- oder USB-Ausgabe aus, und starten Sie die Medienerstellung.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Nach links scrollen</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Nach rechts scrollen</value></data>
 </root>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Add-on</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Bereit zum Erstellen von Medien?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Konfiguration</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Sicherer Start (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Keine</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Benutzerdefiniert</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Erfordert ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Erstellen Sie Windows Bereitstellungsmedien mit einem modernen Desktop-Workflow, der von WinPE unterstützt wird.</value>
   </data>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Πρόσθετο</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Έτοιμοι να δημιουργήσετε μέσα;</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Ρύθμιση παραμέτρων</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Ασφαλής εκκίνηση (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Κανένα</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Προσαρμοσμένο</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Απαιτεί ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Δημιουργήστε μέσα ανάπτυξης Windows με μια σύγχρονη ροή εργασίας για επιτραπέζιους υπολογιστές που υποστηρίζεται από το WinPE.</value>
   </data>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Ελέγξτε την ετοιμότητα, επιλέξτε έξοδο ISO ή USB και ξεκινήστε τη δημιουργία μέσου.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Κύλιση αριστερά</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Κύλιση δεξιά</value></data>
 </root>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Πρόσθετο</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Έτοιμοι να δημιουργήσετε μέσα;</value>
+    <value>Κατάσταση ετοιμότητας μέσου</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Ρύθμιση παραμέτρων</value>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Add-on</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Ready to create media?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Configuration</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Secure Boot (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Custom</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Requires ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Build Windows deployment media with a modern desktop workflow powered by WinPE.</value>
   </data>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Add-on</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Ready to create media?</value>
+    <value>Media readiness status</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Configuration</value>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Review readiness, choose ISO or USB output, and start media creation.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Scroll left</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Scroll right</value></data>
 </root>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Add-on</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Ready to create media?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Configuration</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Secure Boot (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Custom</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Requires ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Build Windows deployment media with a modern desktop workflow powered by WinPE.</value>
   </data>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Add-on</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Ready to create media?</value>
+    <value>Media readiness status</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Configuration</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Review readiness, choose ISO or USB output, and start media creation.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Scroll left</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Scroll right</value></data>
 </root>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Revise la preparación, elija una salida ISO o USB e inicie la creación del medio.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Desplazarse a la izquierda</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Desplazarse a la derecha</value></data>
 </root>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Complemento</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>¿Listo para crear medios?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Configuración</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Arranque seguro (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Ninguno</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Personalizado</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Requiere ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Cree medios de implementación Windows con un flujo de trabajo de escritorio moderno impulsado por WinPE.</value>
   </data>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Complemento</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>¿Listo para crear medios?</value>
+    <value>Estado de preparación del medio</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Configuración</value>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Revise la preparación, elija una salida ISO o USB e inicie la creación del medio.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Desplazarse a la izquierda</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Desplazarse a la derecha</value></data>
 </root>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Complemento</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>¿Listo para crear medios?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Configuración</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Arranque seguro (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Ninguno</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Personalizado</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Requiere ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Cree medios de implementación Windows con un flujo de trabajo de escritorio moderno impulsado por WinPE.</value>
   </data>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Complemento</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>¿Listo para crear medios?</value>
+    <value>Estado de preparación del medio</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Configuración</value>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Kontrollige valmisolekut, valige ISO või USB väljund ja alustage meediumi loomist.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Keri vasakule</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Keri paremale</value></data>
 </root>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Lisand</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Kas olete valmis kandjat looma?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Konfiguratsioon</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Turvaline algkäivitus (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Puudub</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Kohandatud</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Nõuab ADK-d</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Ehitage Windows juurutusmeedium kaasaegse töölaua töövooga, mida toetab WinPE.</value>
   </data>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Lisand</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Kas olete valmis kandjat looma?</value>
+    <value>Andmekandja valmisoleku olek</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Konfiguratsioon</value>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Tarkista valmius, valitse ISO- tai USB-tuloste ja käynnistä median luonti.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Vieritä vasemmalle</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Vieritä oikealle</value></data>
 </root>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Lisäosa</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Valmis luomaan tietovälineen?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Määritys</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Suojattu käynnistys (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Ei mitään</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Mukautettu</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Edellyttää ADK:ta</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Rakenna Windows käyttöönottomediaa nykyaikaisella työpöytätyönkululla, jota käyttää WinPE.</value>
   </data>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Lisäosa</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Valmis luomaan tietovälineen?</value>
+    <value>Tietovälineen valmiustila</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Määritys</value>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Module complémentaire</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Prêt à créer un média?</value>
+    <value>État de préparation du média</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Configuration</value>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Module complémentaire</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Prêt à créer un média?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Configuration</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Démarrage sécurisé (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Aucun</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Personnalisé</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Nécessite ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Créez des supports de déploiement Windows avec un workflow de bureau moderne optimisé par WinPE.</value>
   </data>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Vérifiez l’état, choisissez une sortie ISO ou USB, puis lancez la création du support.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Faire défiler vers la gauche</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Faire défiler vers la droite</value></data>
 </root>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Module complémentaire Windows PE</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Prêt à créer un média ?</value>
+    <value>État de préparation du média</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Configuration</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Module complémentaire Windows PE</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Prêt à créer un média ?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Configuration</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Démarrage sécurisé (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Aucun</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Personnalisé</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Nécessite ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Créez des médias de déploiement Windows avec un workflow desktop moderne basé sur WinPE.</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Vérifiez la disponibilité, choisissez une sortie ISO ou USB, puis démarrez la création du média.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Faire défiler vers la gauche</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Faire défiler vers la droite</value></data>
 </root>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE תוסף</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>מוכן ליצור מדיה?</value>
+    <value>מצב מוכנות המדיה</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>תצורה</value>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>בדוק מוכנות, בחר פלט ISO או USB והתחל ביצירת המדיה.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>גלילה שמאלה</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>גלילה ימינה</value></data>
 </root>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE תוסף</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>מוכן ליצור מדיה?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>תצורה</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>אתחול מאובטח (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>ללא</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>מותאם אישית</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>דורש ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>בנה מדיית פריסה של Windows עם זרימת עבודה מודרנית למחשב שולחני המופעל על ידי WinPE.</value>
   </data>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Pregledajte spremnost, odaberite ISO ili USB izlaz i pokrenite stvaranje medija.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Pomakni ulijevo</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Pomakni udesno</value></data>
 </root>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Dodatak</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Spremni za stvaranje medija?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Konfiguracija</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Sigurno pokretanje (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Nema</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Prilagođeno</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Zahtijeva ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Izgradite Windows medij za implementaciju s modernim radnim procesom na radnoj površini koji pokreće WinPE.</value>
   </data>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Dodatak</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Spremni za stvaranje medija?</value>
+    <value>Stanje spremnosti medija</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Konfiguracija</value>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Kiegészítő</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Készen áll az adathordozó létrehozására?</value>
+    <value>Az adathordozó készenléti állapota</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Konfiguráció</value>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Kiegészítő</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Készen áll az adathordozó létrehozására?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Konfiguráció</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Biztonságos rendszerindítás (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Nincs</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Egyéni</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>ADK szükséges</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Építsen Windows telepítési adathordozót a WinPE által hajtott modern asztali munkafolyamattal.</value>
   </data>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Tekintse át a készenlétet, válasszon ISO vagy USB kimenetet, majd indítsa el az adathordozó létrehozását.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Görgetés balra</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Görgetés jobbra</value></data>
 </root>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Componente aggiuntivo</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Pronto per creare il supporto?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Configurazione</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Avvio protetto (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Nessuno</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Personalizzato</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Richiede ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Crea supporti di distribuzione Windows con un flusso di lavoro desktop moderno basato su WinPE.</value>
   </data>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Verifica la preparazione, scegli un output ISO o USB e avvia la creazione del supporto.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Scorri a sinistra</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Scorri a destra</value></data>
 </root>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Componente aggiuntivo</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Pronto per creare il supporto?</value>
+    <value>Stato di preparazione del supporto</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Configurazione</value>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE アドオン</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>メディアを作成する準備はできましたか?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>構成</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>セキュア ブート (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>なし</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>カスタム</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>ADK が必要です</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>WinPE を活用した最新のデスクトップ ワークフローを使用して Windows 展開メディアを構築します。</value>
   </data>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>準備状況を確認し、ISO または USB 出力を選択して、メディアの作成を開始します。</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>左にスクロール</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>右にスクロール</value></data>
 </root>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE アドオン</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>メディアを作成する準備はできましたか?</value>
+    <value>メディアの準備状況</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>構成</value>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>준비 상태를 검토하고 ISO 또는 USB 출력을 선택한 다음 미디어 만들기를 시작합니다.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>왼쪽으로 스크롤</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>오른쪽으로 스크롤</value></data>
 </root>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE 부가기능</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>미디어를 만들 준비가 되었나요?</value>
+    <value>미디어 준비 상태</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>구성</value>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE 부가기능</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>미디어를 만들 준비가 되었나요?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>구성</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>보안 부팅(CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>없음</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>사용자 지정</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>ADK 필요</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>WinPE이 제공하는 최신 데스크탑 워크플로를 사용하여 Windows 배포 미디어를 구축하세요.</value>
   </data>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Priedas</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Pasirengę kurti laikmeną?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Konfigūracija</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Saugusis paleidimas (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Nėra</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Pasirinktinis</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Reikalingas ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Sukurkite Windows diegimo laikmeną naudodami modernią darbalaukio darbo eigą, kurią palaiko WinPE.</value>
   </data>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Peržiūrėkite parengtį, pasirinkite ISO arba USB išvestį ir pradėkite laikmenos kūrimą.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Slinkti kairėn</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Slinkti dešinėn</value></data>
 </root>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Priedas</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Pasirengę kurti laikmeną?</value>
+    <value>Laikmenos parengties būsena</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Konfigūracija</value>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Pārskatiet gatavību, izvēlieties ISO vai USB izvadi un sāciet datu nesēja izveidi.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Ritināt pa kreisi</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Ritināt pa labi</value></data>
 </root>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Papildinājums</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Vai esat gatavs izveidot datu nesēju?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Konfigurācija</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Drošā sāknēšana (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Nav</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Pielāgots</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Nepieciešams ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Veidojiet Windows izvietošanas datu nesēju ar modernu darbvirsmas darbplūsmu, ko nodrošina WinPE.</value>
   </data>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Papildinājums</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Vai esat gatavs izveidot datu nesēju?</value>
+    <value>Datu nesēja gatavības statuss</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Konfigurācija</value>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE tillegg</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Klar til å opprette medier?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Konfigurasjon</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Sikker oppstart (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Ingen</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Egendefinert</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Krever ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Bygg Windows distribusjonsmedier med en moderne skrivebordsarbeidsflyt drevet av WinPE.</value>
   </data>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Kontroller beredskapen, velg ISO- eller USB-utdata, og start medieopprettingen.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Rull til venstre</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Rull til høyre</value></data>
 </root>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE tillegg</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Klar til å opprette medier?</value>
+    <value>Status for medieberedskap</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Konfigurasjon</value>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE-add-on</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Klaar om media te maken?</value>
+    <value>Status van mediagereedheid</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Configuratie</value>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Controleer de gereedheid, kies ISO- of USB-uitvoer en start het maken van media.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Naar links schuiven</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Naar rechts schuiven</value></data>
 </root>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE-add-on</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Klaar om media te maken?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Configuratie</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Beveiligd opstarten (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Geen</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Aangepast</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Vereist ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Bouw Windows-implementatiemedia met een moderne desktopworkflow mogelijk gemaakt door WinPE.</value>
   </data>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Dodatek</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Gotowy do utworzenia nośnika?</value>
+    <value>Stan gotowości nośnika</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Konfiguracja</value>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Dodatek</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Gotowy do utworzenia nośnika?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Konfiguracja</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Bezpieczny rozruch (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Brak</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Niestandardowe</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Wymaga ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Twórz nośniki wdrożeniowe Windows za pomocą nowoczesnego przepływu pracy na komputerze stacjonarnym obsługiwanego przez WinPE.</value>
   </data>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Sprawdź gotowość, wybierz wyjście ISO lub USB i rozpocznij tworzenie nośnika.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Przewiń w lewo</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Przewiń w prawo</value></data>
 </root>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Complemento</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Pronto para criar a mídia?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Configuração</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Inicialização Segura (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Nenhum</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Personalizado</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Requer ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Crie mídia de implantação Windows com um fluxo de trabalho de desktop moderno desenvolvido por WinPE.</value>
   </data>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Revise a prontidão, escolha uma saída ISO ou USB e inicie a criação da mídia.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Rolar para a esquerda</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Rolar para a direita</value></data>
 </root>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Complemento</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Pronto para criar a mídia?</value>
+    <value>Status de preparação da mídia</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Configuração</value>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Reveja a preparação, escolha uma saída ISO ou USB e inicie a criação do suporte.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Deslocar para a esquerda</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Deslocar para a direita</value></data>
 </root>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Complemento</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Pronto para criar o suporte de dados?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Configuração</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Arranque Seguro (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Nenhum</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Personalizado</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Requer ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Crie mídia de implantação Windows com um fluxo de trabalho de desktop moderno desenvolvido por WinPE.</value>
   </data>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Complemento</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Pronto para criar o suporte de dados?</value>
+    <value>Estado de preparação do suporte de dados</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Configuração</value>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Supliment</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Sunteți gata să creați suportul media?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Configurație</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Pornire securizată (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Niciunul</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Particularizat</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Necesită ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Creați medii de implementare Windows cu un flux de lucru modern pentru desktop alimentat de WinPE.</value>
   </data>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Revizuiți starea, alegeți ieșirea ISO sau USB și porniți crearea suportului.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Derulați la stânga</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Derulați la dreapta</value></data>
 </root>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Supliment</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Sunteți gata să creați suportul media?</value>
+    <value>Starea de pregătire a suportului media</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Configurație</value>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Проверьте готовность, выберите вывод ISO или USB и запустите создание носителя.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Прокрутить влево</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Прокрутить вправо</value></data>
 </root>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Дополнение</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Готовы создать носитель?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Конфигурация</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Безопасная загрузка (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Нет</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Настраиваемые</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Требуется ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Создайте носитель развертывания Windows с помощью современного рабочего процесса на базе WinPE.</value>
   </data>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Дополнение</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Готовы создать носитель?</value>
+    <value>Состояние готовности носителя</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Конфигурация</value>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Skontrolujte pripravenosť, vyberte výstup ISO alebo USB a spustite vytvorenie média.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Posunúť doľava</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Posunúť doprava</value></data>
 </root>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Doplnok Windows PE</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Pripravení vytvoriť médium?</value>
+    <value>Stav pripravenosti média</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Konfigurácia</value>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Doplnok Windows PE</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Pripravení vytvoriť médium?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Konfigurácia</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Zabezpečené spustenie (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Žiadne</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Vlastné</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Vyžaduje ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Vytvorte nasadzovacie médium Windows s moderným pracovným postupom na pracovnej ploche, ktorý využíva WinPE.</value>
   </data>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Dodatek</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Ste pripravljeni ustvariti medij?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Konfiguracija</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Varni zagon (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Brez</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Po meri</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Zahteva ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Zgradite medije za uvajanje Windows s sodobnim potekom dela na namizju, ki ga poganja WinPE.</value>
   </data>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Dodatek</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Ste pripravljeni ustvariti medij?</value>
+    <value>Stanje pripravljenosti medija</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Konfiguracija</value>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Preverite pripravljenost, izberite izhod ISO ali USB in začnite ustvarjanje medija.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Pomakni levo</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Pomakni desno</value></data>
 </root>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Dodatak</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Spremni za kreiranje medijuma?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Konfiguracija</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Bezbedno pokretanje (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Nijedan</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Prilagođeno</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Zahteva ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Izgradite Windows medijum za primenu sa modernim radnim procesom na radnoj površini koji pokreće WinPE.</value>
   </data>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Pregledajte spremnost, izaberite ISO ili USB izlaz i pokrenite kreiranje medija.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Pomeri nalevo</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Pomeri nadesno</value></data>
 </root>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Dodatak</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Spremni za kreiranje medijuma?</value>
+    <value>Status spremnosti medijuma</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Konfiguracija</value>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Granska beredskapen, välj ISO- eller USB-utdata och starta medieskapandet.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Rulla åt vänster</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Rulla åt höger</value></data>
 </root>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Tillägg</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Redo att skapa media?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Konfiguration</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Säker start (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Ingen</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Anpassad</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Kräver ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Bygg Windows distributionsmedia med ett modernt skrivbordsarbetsflöde som drivs av WinPE.</value>
   </data>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Tillägg</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Redo att skapa media?</value>
+    <value>Status för medieberedskap</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Konfiguration</value>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>ตรวจสอบความพร้อม เลือกเอาต์พุต ISO หรือ USB แล้วเริ่มสร้างสื่อ</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>เลื่อนไปทางซ้าย</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>เลื่อนไปทางขวา</value></data>
 </root>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE ส่วนเสริม</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>พร้อมสร้างสื่อหรือยัง?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>การกำหนดค่า</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>การบูตแบบปลอดภัย (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>ไม่มี</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>กำหนดเอง</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>ต้องใช้ ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>สร้างสื่อการปรับใช้ Windows ด้วยเวิร์กโฟลว์เดสก์ท็อปสมัยใหม่ที่ขับเคลื่อนโดย WinPE</value>
   </data>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE ส่วนเสริม</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>พร้อมสร้างสื่อหรือยัง?</value>
+    <value>สถานะความพร้อมของสื่อ</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>การกำหนดค่า</value>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Eklenti</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Medya oluşturmaya hazır mısınız?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Yapılandırma</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Güvenli Önyükleme (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Yok</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Özel</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>ADK gerektirir</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>WinPE tarafından desteklenen modern bir masaüstü iş akışıyla Windows dağıtım ortamı oluşturun.</value>
   </data>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Eklenti</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Medya oluşturmaya hazır mısınız?</value>
+    <value>Medya hazırlık durumu</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Yapılandırma</value>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Hazırlığı gözden geçirin, ISO veya USB çıktısını seçin ve medya oluşturmayı başlatın.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Sola kaydır</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Sağa kaydır</value></data>
 </root>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE Надбудова</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>Готові створити носій?</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>Конфігурація</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>Безпечне завантаження (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>Немає</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>Настроювані</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>Потрібен ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>Створюйте носії для розгортання Windows за допомогою сучасного робочого процесу настільного комп’ютера на базі WinPE.</value>
   </data>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>Перевірте готовність, виберіть вихід ISO або USB і запустіть створення носія.</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>Прокрутити ліворуч</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>Прокрутити праворуч</value></data>
 </root>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE Надбудова</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>Готові створити носій?</value>
+    <value>Стан готовності носія</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>Конфігурація</value>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>检查就绪情况，选择 ISO 或 USB 输出，然后开始创建媒体。</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>向左滚动</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>向右滚动</value></data>
 </root>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE 附加组件</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>准备好创建媒体了吗？</value>
+    <value>媒体准备状态</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>配置</value>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE 附加组件</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>准备好创建媒体了吗？</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>配置</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>安全启动 (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>无</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>自定义</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>需要 ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>使用 WinPE 提供支持的现代桌面工作流程构建 Windows 部署媒体。</value>
   </data>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -1312,7 +1312,7 @@
     <value>Windows PE 附加元件</value>
   </data>
   <data name="Home.Status.SectionTitle" xml:space="preserve">
-    <value>準備好建立媒體了嗎？</value>
+    <value>媒體準備狀態</value>
   </data>
   <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
     <value>設定</value>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -2678,4 +2678,6 @@
   <data name="StartMedia.PageDescription" xml:space="preserve">
     <value>檢閱就緒狀態，選擇 ISO 或 USB 輸出，然後開始建立媒體。</value>
   </data>
+  <data name="Home.Scroll.Back" xml:space="preserve"><value>向左捲動</value></data>
+  <data name="Home.Scroll.Forward" xml:space="preserve"><value>向右捲動</value></data>
 </root>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -1311,6 +1311,24 @@
   <data name="Home.AdkStatus.WinPeAddonLabel" xml:space="preserve">
     <value>Windows PE 附加元件</value>
   </data>
+  <data name="Home.Status.SectionTitle" xml:space="preserve">
+    <value>準備好建立媒體了嗎？</value>
+  </data>
+  <data name="Home.Status.ConfigCard.Title" xml:space="preserve">
+    <value>設定</value>
+  </data>
+  <data name="Home.Status.ConfigCard.SecureBootLabel" xml:space="preserve">
+    <value>安全開機 (CA 2023)</value>
+  </data>
+  <data name="Home.Status.ConfigCard.NoDrivers" xml:space="preserve">
+    <value>無</value>
+  </data>
+  <data name="Home.Status.ConfigCard.CustomDrivers" xml:space="preserve">
+    <value>自訂</value>
+  </data>
+  <data name="Home.Status.ConfigCard.BlockedStatus" xml:space="preserve">
+    <value>需要 ADK</value>
+  </data>
   <data name="Home.Header.Subtitle" xml:space="preserve">
     <value>使用 WinPE 提供支援的現代桌面工作流程建置 Windows 部署媒體。</value>
   </data>

--- a/src/Foundry/Themes/ThemeResources.xaml
+++ b/src/Foundry/Themes/ThemeResources.xaml
@@ -3,10 +3,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Light">
-            <x:String x:Key="HeaderCover">/Assets/Cover/CoverLight.png</x:String>
-            <Color x:Key="HomeHeroFadeStartColor">#00F3F3F3</Color>
-            <StaticResource x:Key="HomeHeroFadeEndColor"
-                ResourceKey="SolidBackgroundFillColorBase" />
             <StaticResource x:Key="FoundryStatusReadyBrush"
                 ResourceKey="SystemFillColorSuccessBrush" />
             <StaticResource x:Key="FoundryStatusReadyForegroundBrush"
@@ -40,10 +36,6 @@
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="Dark">
-            <x:String x:Key="HeaderCover">/Assets/Cover/CoverDark.png</x:String>
-            <Color x:Key="HomeHeroFadeStartColor">#00202020</Color>
-            <StaticResource x:Key="HomeHeroFadeEndColor"
-                ResourceKey="SolidBackgroundFillColorBase" />
             <StaticResource x:Key="FoundryStatusReadyBrush"
                 ResourceKey="SystemFillColorSuccessBrush" />
             <StaticResource x:Key="FoundryStatusReadyForegroundBrush"
@@ -77,11 +69,6 @@
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="HighContrast">
-            <x:String x:Key="HeaderCover">/Assets/Cover/CoverDark.png</x:String>
-            <StaticResource x:Key="HomeHeroFadeStartColor"
-                ResourceKey="SystemColorWindowColor" />
-            <StaticResource x:Key="HomeHeroFadeEndColor"
-                ResourceKey="SystemColorWindowColor" />
             <StaticResource x:Key="FoundryStatusReadyBrush"
                 ResourceKey="SystemColorButtonFaceBrush" />
             <StaticResource x:Key="FoundryStatusReadyForegroundBrush"

--- a/src/Foundry/Themes/ThemeResources.xaml
+++ b/src/Foundry/Themes/ThemeResources.xaml
@@ -14,7 +14,7 @@
             <StaticResource x:Key="FoundryStatusWarningBrush"
                 ResourceKey="SystemFillColorCautionBrush" />
             <StaticResource x:Key="FoundryStatusWarningForegroundBrush"
-                ResourceKey="TextFillColorPrimaryBrush" />
+                ResourceKey="TextFillColorInverseBrush" />
             <StaticResource x:Key="FoundryStatusBlockedBrush"
                 ResourceKey="SystemFillColorCriticalBrush" />
             <StaticResource x:Key="FoundryStatusBlockedForegroundBrush"
@@ -47,7 +47,7 @@
             <StaticResource x:Key="FoundryStatusWarningBrush"
                 ResourceKey="SystemFillColorCautionBrush" />
             <StaticResource x:Key="FoundryStatusWarningForegroundBrush"
-                ResourceKey="TextFillColorPrimaryBrush" />
+                ResourceKey="TextFillColorInverseBrush" />
             <StaticResource x:Key="FoundryStatusBlockedBrush"
                 ResourceKey="SystemFillColorCriticalBrush" />
             <StaticResource x:Key="FoundryStatusBlockedForegroundBrush"

--- a/src/Foundry/ViewModels/HomeLandingViewModel.cs
+++ b/src/Foundry/ViewModels/HomeLandingViewModel.cs
@@ -52,6 +52,12 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
     public partial string OpenDocumentationDescription { get; set; }
 
     [ObservableProperty]
+    public partial string ScrollBackText { get; set; }
+
+    [ObservableProperty]
+    public partial string ScrollForwardText { get; set; }
+
+    [ObservableProperty]
     public partial string AdkStatusTitle { get; set; }
 
     [ObservableProperty]
@@ -96,6 +102,8 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
         ReviewAndStartDescription = string.Empty;
         OpenDocumentationTitle = string.Empty;
         OpenDocumentationDescription = string.Empty;
+        ScrollBackText = string.Empty;
+        ScrollForwardText = string.Empty;
         AdkStatusTitle = string.Empty;
         AdkStatusDescription = string.Empty;
         InstalledVersionLabel = string.Empty;
@@ -152,6 +160,8 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
         ReviewAndStartDescription = localizationService.GetString("Home.Action.ReviewAndStart.Description");
         OpenDocumentationTitle = localizationService.GetString("Home.Action.OpenDocumentation.Title");
         OpenDocumentationDescription = localizationService.GetString("Home.Action.OpenDocumentation.Description");
+        ScrollBackText = localizationService.GetString("Home.Scroll.Back");
+        ScrollForwardText = localizationService.GetString("Home.Scroll.Forward");
         InstalledVersionLabel = localizationService.GetString("Home.AdkStatus.InstalledVersionLabel");
         WinPeAddonLabel = localizationService.GetString("Home.AdkStatus.WinPeAddonLabel");
 

--- a/src/Foundry/ViewModels/HomeLandingViewModel.cs
+++ b/src/Foundry/ViewModels/HomeLandingViewModel.cs
@@ -2,9 +2,12 @@
 // Licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
+using Foundry.Core.Models.Configuration;
 using Foundry.Core.Services.Adk;
 using Foundry.Core.Services.Application;
+using Foundry.Core.Services.WinPe;
 using Foundry.Services.Adk;
+using Foundry.Services.Configuration;
 using Foundry.Services.Localization;
 using Microsoft.UI.Xaml.Controls;
 using Serilog;
@@ -12,11 +15,13 @@ using Serilog;
 namespace Foundry.ViewModels;
 
 /// <summary>
-/// Provides localized home page content and ADK readiness status.
+/// Provides localized home page content, ADK readiness status, and configuration
+/// summary data for the workflow stepper and status cards.
 /// </summary>
 public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
 {
     private readonly IAdkService adkService;
+    private readonly IFoundryConfigurationStateService configurationStateService;
     private readonly IApplicationLocalizationService localizationService;
     private readonly IAppDispatcher appDispatcher;
     private readonly ILogger logger;
@@ -58,36 +63,101 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
     public partial string ScrollForwardText { get; set; }
 
     [ObservableProperty]
-    public partial string AdkStatusTitle { get; set; }
+    public partial string StepperSectionTitle { get; set; }
 
     [ObservableProperty]
-    public partial string AdkStatusDescription { get; set; }
+    public partial string Step1Label { get; set; }
 
     [ObservableProperty]
-    public partial string InstalledVersionLabel { get; set; }
+    public partial string Step2Label { get; set; }
 
     [ObservableProperty]
-    public partial string InstalledVersion { get; set; }
+    public partial string Step3Label { get; set; }
 
     [ObservableProperty]
-    public partial string WinPeAddonLabel { get; set; }
+    public partial string Step1StatusText { get; set; }
 
     [ObservableProperty]
-    public partial string WinPeAddonStatus { get; set; }
+    public partial string Step2StatusText { get; set; }
 
     [ObservableProperty]
-    public partial InfoBarSeverity AdkStatusSeverity { get; set; }
+    public partial string Step3StatusText { get; set; }
+
+    [ObservableProperty]
+    public partial InfoBarSeverity Step1State { get; set; }
+
+    [ObservableProperty]
+    public partial InfoBarSeverity Step2State { get; set; }
+
+    [ObservableProperty]
+    public partial InfoBarSeverity Step3State { get; set; }
+
+    [ObservableProperty]
+    public partial string AdkCardTitle { get; set; }
+
+    [ObservableProperty]
+    public partial string AdkCardStatusText { get; set; }
+
+    [ObservableProperty]
+    public partial InfoBarSeverity AdkCardSeverity { get; set; }
+
+    [ObservableProperty]
+    public partial string AdkVersionLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string AdkVersionValue { get; set; }
+
+    [ObservableProperty]
+    public partial string AdkWinPeLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string AdkWinPeValue { get; set; }
+
+    [ObservableProperty]
+    public partial string ConfigCardTitle { get; set; }
+
+    [ObservableProperty]
+    public partial string ConfigCardStatusText { get; set; }
+
+    [ObservableProperty]
+    public partial InfoBarSeverity ConfigCardSeverity { get; set; }
+
+    [ObservableProperty]
+    public partial string ConfigArchitectureLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string ConfigArchitectureValue { get; set; }
+
+    [ObservableProperty]
+    public partial string ConfigWinPeLanguageLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string ConfigWinPeLanguageValue { get; set; }
+
+    [ObservableProperty]
+    public partial string ConfigSecureBootLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string ConfigSecureBootValue { get; set; }
+
+    [ObservableProperty]
+    public partial string ConfigDriversLabel { get; set; }
+
+    [ObservableProperty]
+    public partial string ConfigDriversValue { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HomeLandingViewModel"/> class.
     /// </summary>
     public HomeLandingViewModel(
         IAdkService adkService,
+        IFoundryConfigurationStateService configurationStateService,
         IApplicationLocalizationService localizationService,
         IAppDispatcher appDispatcher,
         ILogger logger)
     {
         this.adkService = adkService;
+        this.configurationStateService = configurationStateService;
         this.localizationService = localizationService;
         this.appDispatcher = appDispatcher;
         this.logger = logger.ForContext<HomeLandingViewModel>();
@@ -104,16 +174,38 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
         OpenDocumentationDescription = string.Empty;
         ScrollBackText = string.Empty;
         ScrollForwardText = string.Empty;
-        AdkStatusTitle = string.Empty;
-        AdkStatusDescription = string.Empty;
-        InstalledVersionLabel = string.Empty;
-        InstalledVersion = string.Empty;
-        WinPeAddonLabel = string.Empty;
-        WinPeAddonStatus = string.Empty;
-        AdkStatusSeverity = InfoBarSeverity.Informational;
+        StepperSectionTitle = string.Empty;
+        Step1Label = string.Empty;
+        Step2Label = string.Empty;
+        Step3Label = string.Empty;
+        Step1StatusText = string.Empty;
+        Step2StatusText = string.Empty;
+        Step3StatusText = string.Empty;
+        Step1State = InfoBarSeverity.Informational;
+        Step2State = InfoBarSeverity.Informational;
+        Step3State = InfoBarSeverity.Informational;
+        AdkCardTitle = string.Empty;
+        AdkCardStatusText = string.Empty;
+        AdkCardSeverity = InfoBarSeverity.Informational;
+        AdkVersionLabel = string.Empty;
+        AdkVersionValue = string.Empty;
+        AdkWinPeLabel = string.Empty;
+        AdkWinPeValue = string.Empty;
+        ConfigCardTitle = string.Empty;
+        ConfigCardStatusText = string.Empty;
+        ConfigCardSeverity = InfoBarSeverity.Informational;
+        ConfigArchitectureLabel = string.Empty;
+        ConfigArchitectureValue = string.Empty;
+        ConfigWinPeLanguageLabel = string.Empty;
+        ConfigWinPeLanguageValue = string.Empty;
+        ConfigSecureBootLabel = string.Empty;
+        ConfigSecureBootValue = string.Empty;
+        ConfigDriversLabel = string.Empty;
+        ConfigDriversValue = string.Empty;
 
         adkService.StatusChanged += OnAdkStatusChanged;
         localizationService.LanguageChanged += OnLanguageChanged;
+        configurationStateService.StateChanged += OnConfigurationStateChanged;
 
         ApplyLocalizedText();
     }
@@ -123,11 +215,12 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
     {
         adkService.StatusChanged -= OnAdkStatusChanged;
         localizationService.LanguageChanged -= OnLanguageChanged;
+        configurationStateService.StateChanged -= OnConfigurationStateChanged;
     }
 
     private void OnAdkStatusChanged(object? sender, AdkStatusChangedEventArgs e)
     {
-        if (!appDispatcher.TryEnqueue(() => ApplyStatus(e.Status)))
+        if (!appDispatcher.TryEnqueue(() => ApplyAdkStatus(e.Status)))
         {
             logger.Warning(
                 "Failed to enqueue Home ADK status refresh. IsInstalled={IsInstalled}, IsCompatible={IsCompatible}, IsWinPeAddonInstalled={IsWinPeAddonInstalled}",
@@ -148,6 +241,14 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
         }
     }
 
+    private void OnConfigurationStateChanged(object? sender, EventArgs e)
+    {
+        if (!appDispatcher.TryEnqueue(ApplyConfigurationSummary))
+        {
+            logger.Warning("Failed to enqueue Home configuration summary refresh.");
+        }
+    }
+
     private void ApplyLocalizedText()
     {
         HeaderTitle = FoundryApplicationInfo.AppNameAndVersion;
@@ -162,30 +263,117 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
         OpenDocumentationDescription = localizationService.GetString("Home.Action.OpenDocumentation.Description");
         ScrollBackText = localizationService.GetString("Home.Scroll.Back");
         ScrollForwardText = localizationService.GetString("Home.Scroll.Forward");
-        InstalledVersionLabel = localizationService.GetString("Home.AdkStatus.InstalledVersionLabel");
-        WinPeAddonLabel = localizationService.GetString("Home.AdkStatus.WinPeAddonLabel");
 
-        ApplyStatus(adkService.CurrentStatus);
+        StepperSectionTitle = localizationService.GetString("Home.Status.SectionTitle");
+        Step1Label = localizationService.GetString("Nav_AdkKey.Title");
+        Step2Label = localizationService.GetString("Nav_GeneralConfigurationKey.Title");
+        Step3Label = localizationService.GetString("Nav_StartKey.Title");
+        AdkCardTitle = localizationService.GetString("Nav_AdkKey.Title");
+        AdkVersionLabel = localizationService.GetString("Home.AdkStatus.InstalledVersionLabel");
+        AdkWinPeLabel = localizationService.GetString("Home.AdkStatus.WinPeAddonLabel");
+        ConfigCardTitle = localizationService.GetString("Home.Status.ConfigCard.Title");
+        ConfigArchitectureLabel = localizationService.GetString("StartMedia.Field.Architecture");
+        ConfigWinPeLanguageLabel = localizationService.GetString("StartMedia.Field.WinPeLanguage");
+        ConfigSecureBootLabel = localizationService.GetString("Home.Status.ConfigCard.SecureBootLabel");
+        ConfigDriversLabel = localizationService.GetString("StartMedia.Field.Drivers");
+
+        ApplyAdkStatus(adkService.CurrentStatus);
+        ApplyConfigurationSummary();
     }
 
-    private void ApplyStatus(AdkInstallationStatus status)
+    private void ApplyAdkStatus(AdkInstallationStatus status)
     {
-        AdkStatusTitle = GetStatusTitle(status);
-        AdkStatusDescription = GetStatusDescription(status);
-        InstalledVersion = status.InstalledVersion ?? localizationService.GetString("Adk.Version.NotDetected");
-        WinPeAddonStatus = status.IsWinPeAddonInstalled
+        bool ready = status.CanCreateMedia;
+
+        AdkCardSeverity = ready ? InfoBarSeverity.Success : InfoBarSeverity.Warning;
+        AdkCardStatusText = ready
+            ? localizationService.GetString("Adk.Status.ReadyTitle")
+            : GetAdkBlockingTitle(status);
+
+        AdkVersionValue = status.InstalledVersion ?? localizationService.GetString("Adk.Version.NotDetected");
+        AdkWinPeValue = status.IsWinPeAddonInstalled
             ? localizationService.GetString("Adk.WinPeAddon.Installed")
             : localizationService.GetString("Adk.WinPeAddon.Missing");
-        AdkStatusSeverity = status.CanCreateMedia ? InfoBarSeverity.Success : InfoBarSeverity.Warning;
+
+        ApplyWorkflowReadiness(ready, IsConfigurationReady());
     }
 
-    private string GetStatusTitle(AdkInstallationStatus status)
+    private void ApplyConfigurationSummary()
     {
-        if (status.CanCreateMedia)
+        GeneralSettings general = configurationStateService.Current.General;
+        bool adkReady = adkService.CurrentStatus.CanCreateMedia;
+
+        ConfigArchitectureValue = general.Architecture switch
         {
-            return localizationService.GetString("Adk.Status.ReadyTitle");
+            WinPeArchitecture.Arm64 => "arm64",
+            _ => "x64",
+        };
+
+        ConfigWinPeLanguageValue = string.IsNullOrWhiteSpace(general.WinPeLanguage)
+            ? localizationService.GetString("Common.AutomaticOption")
+            : general.WinPeLanguage;
+
+        ConfigSecureBootValue = general.UseCa2023
+            ? localizationService.GetString("Common.Enabled")
+            : localizationService.GetString("Common.Disabled");
+
+        List<string> drivers = [];
+        if (general.IncludeDellDrivers)
+        {
+            drivers.Add(localizationService.GetString("StartMedia.DriverVendor.Dell"));
         }
 
+        if (general.IncludeHpDrivers)
+        {
+            drivers.Add(localizationService.GetString("StartMedia.DriverVendor.Hp"));
+        }
+
+        if (!string.IsNullOrWhiteSpace(general.CustomDriverDirectoryPath))
+        {
+            drivers.Add(localizationService.GetString("Home.Status.ConfigCard.CustomDrivers"));
+        }
+
+        ConfigDriversValue = drivers.Count > 0
+            ? string.Join(", ", drivers)
+            : localizationService.GetString("Home.Status.ConfigCard.NoDrivers");
+
+        ApplyWorkflowReadiness(adkReady, IsConfigurationReady());
+    }
+
+    private bool IsConfigurationReady()
+    {
+        return configurationStateService.IsNetworkConfigurationReady &&
+               configurationStateService.IsDeployConfigurationReady &&
+               configurationStateService.IsConnectProvisioningReady &&
+               configurationStateService.AreRequiredSecretsReady &&
+               (!configurationStateService.IsAutopilotEnabled || configurationStateService.IsAutopilotConfigurationReady);
+    }
+
+    private void ApplyWorkflowReadiness(bool adkReady, bool configurationReady)
+    {
+        bool workflowReady = adkReady && configurationReady;
+        string readyText = localizationService.GetString("StartMedia.Readiness.State.Ready");
+        string blockedText = localizationService.GetString("StartMedia.Readiness.State.Blocked");
+
+        Step1State = adkReady ? InfoBarSeverity.Success : InfoBarSeverity.Warning;
+        Step1StatusText = adkReady ? readyText : AdkCardStatusText;
+        Step2State = !adkReady
+            ? InfoBarSeverity.Informational
+            : configurationReady ? InfoBarSeverity.Success : InfoBarSeverity.Warning;
+        Step2StatusText = workflowReady ? readyText : blockedText;
+        Step3State = workflowReady ? InfoBarSeverity.Success : InfoBarSeverity.Informational;
+        Step3StatusText = workflowReady ? readyText : blockedText;
+
+        ConfigCardSeverity = !adkReady
+            ? InfoBarSeverity.Informational
+            : configurationReady ? InfoBarSeverity.Success : InfoBarSeverity.Warning;
+        ConfigCardStatusText = !adkReady
+            ? localizationService.GetString("Home.Status.ConfigCard.BlockedStatus")
+            : configurationReady ? readyText : blockedText;
+    }
+
+    private string GetAdkBlockingTitle(AdkInstallationStatus status)
+    {
         if (!status.IsInstalled)
         {
             return localizationService.GetString("Adk.Status.MissingTitle");
@@ -197,25 +385,5 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
         }
 
         return localizationService.GetString("Adk.Status.WinPeMissingTitle");
-    }
-
-    private string GetStatusDescription(AdkInstallationStatus status)
-    {
-        if (status.CanCreateMedia)
-        {
-            return localizationService.GetString("Adk.Status.ReadyDescription");
-        }
-
-        if (!status.IsInstalled)
-        {
-            return localizationService.GetString("Adk.Status.MissingDescription");
-        }
-
-        if (!status.IsCompatible)
-        {
-            return localizationService.GetString("Adk.Status.IncompatibleDescription");
-        }
-
-        return localizationService.GetString("Adk.Status.WinPeMissingDescription");
     }
 }

--- a/src/Foundry/ViewModels/HomeLandingViewModel.cs
+++ b/src/Foundry/ViewModels/HomeLandingViewModel.cs
@@ -9,6 +9,7 @@ using Foundry.Core.Services.WinPe;
 using Foundry.Services.Adk;
 using Foundry.Services.Configuration;
 using Foundry.Services.Localization;
+using Foundry.Services.Shell;
 using Microsoft.UI.Xaml.Controls;
 using Serilog;
 
@@ -24,6 +25,7 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
     private readonly IFoundryConfigurationStateService configurationStateService;
     private readonly IApplicationLocalizationService localizationService;
     private readonly IAppDispatcher appDispatcher;
+    private readonly IShellNavigationGuardService shellNavigationGuardService;
     private readonly ILogger logger;
 
     [ObservableProperty]
@@ -93,6 +95,9 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
     public partial InfoBarSeverity Step3State { get; set; }
 
     [ObservableProperty]
+    public partial bool IsWorkflowNavigationEnabled { get; set; }
+
+    [ObservableProperty]
     public partial string AdkCardTitle { get; set; }
 
     [ObservableProperty]
@@ -154,12 +159,14 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
         IFoundryConfigurationStateService configurationStateService,
         IApplicationLocalizationService localizationService,
         IAppDispatcher appDispatcher,
+        IShellNavigationGuardService shellNavigationGuardService,
         ILogger logger)
     {
         this.adkService = adkService;
         this.configurationStateService = configurationStateService;
         this.localizationService = localizationService;
         this.appDispatcher = appDispatcher;
+        this.shellNavigationGuardService = shellNavigationGuardService;
         this.logger = logger.ForContext<HomeLandingViewModel>();
 
         HeaderTitle = string.Empty;
@@ -184,6 +191,7 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
         Step1State = InfoBarSeverity.Informational;
         Step2State = InfoBarSeverity.Informational;
         Step3State = InfoBarSeverity.Informational;
+        IsWorkflowNavigationEnabled = shellNavigationGuardService.State == ShellNavigationState.Ready;
         AdkCardTitle = string.Empty;
         AdkCardStatusText = string.Empty;
         AdkCardSeverity = InfoBarSeverity.Informational;
@@ -206,6 +214,7 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
         adkService.StatusChanged += OnAdkStatusChanged;
         localizationService.LanguageChanged += OnLanguageChanged;
         configurationStateService.StateChanged += OnConfigurationStateChanged;
+        shellNavigationGuardService.StateChanged += OnShellNavigationStateChanged;
 
         ApplyLocalizedText();
     }
@@ -216,6 +225,7 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
         adkService.StatusChanged -= OnAdkStatusChanged;
         localizationService.LanguageChanged -= OnLanguageChanged;
         configurationStateService.StateChanged -= OnConfigurationStateChanged;
+        shellNavigationGuardService.StateChanged -= OnShellNavigationStateChanged;
     }
 
     private void OnAdkStatusChanged(object? sender, AdkStatusChangedEventArgs e)
@@ -247,6 +257,21 @@ public sealed partial class HomeLandingViewModel : ObservableObject, IDisposable
         {
             logger.Warning("Failed to enqueue Home configuration summary refresh.");
         }
+    }
+
+    private void OnShellNavigationStateChanged(object? sender, EventArgs e)
+    {
+        if (!appDispatcher.TryEnqueue(ApplyNavigationAvailability))
+        {
+            logger.Warning(
+                "Failed to enqueue Home navigation availability refresh. ShellNavigationState={ShellNavigationState}",
+                shellNavigationGuardService.State);
+        }
+    }
+
+    private void ApplyNavigationAvailability()
+    {
+        IsWorkflowNavigationEnabled = shellNavigationGuardService.State == ShellNavigationState.Ready;
     }
 
     private void ApplyLocalizedText()

--- a/src/Foundry/Views/HomeLandingPage.xaml
+++ b/src/Foundry/Views/HomeLandingPage.xaml
@@ -25,7 +25,7 @@
                 Grid.Row="2"
                 MaxWidth="{ThemeResource FoundryContentMaxWidth}"
                 Margin="36,28,36,36"
-                HorizontalAlignment="Center"
+                HorizontalAlignment="Stretch"
                 Spacing="20">
 
                 <TextBlock
@@ -46,12 +46,15 @@
                     Step3State="{x:Bind ViewModel.Step3State, Mode=OneWay}"
                     Step3StatusText="{x:Bind ViewModel.Step3StatusText, Mode=OneWay}" />
 
-                <StackPanel
-                    Orientation="Horizontal"
-                    Spacing="12">
+                <Grid ColumnSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
 
                     <controls:HomeStatusCard
                         Title="{x:Bind ViewModel.AdkCardTitle, Mode=OneWay}"
+                        Grid.Column="0"
                         IconGlyph="&#xEC7A;"
                         Line1Label="{x:Bind ViewModel.AdkVersionLabel, Mode=OneWay}"
                         Line1Value="{x:Bind ViewModel.AdkVersionValue, Mode=OneWay}"
@@ -63,6 +66,7 @@
 
                     <controls:HomeStatusCard
                         Title="{x:Bind ViewModel.ConfigCardTitle, Mode=OneWay}"
+                        Grid.Column="1"
                         IconGlyph="&#xE713;"
                         Line1Label="{x:Bind ViewModel.ConfigArchitectureLabel, Mode=OneWay}"
                         Line1Value="{x:Bind ViewModel.ConfigArchitectureValue, Mode=OneWay}"
@@ -75,7 +79,7 @@
                         NavigationRequested="ConfigCard_NavigationRequested"
                         Severity="{x:Bind ViewModel.ConfigCardSeverity, Mode=OneWay}"
                         StatusText="{x:Bind ViewModel.ConfigCardStatusText, Mode=OneWay}" />
-                </StackPanel>
+                </Grid>
             </StackPanel>
         </Grid>
     </ScrollViewer>

--- a/src/Foundry/Views/HomeLandingPage.xaml
+++ b/src/Foundry/Views/HomeLandingPage.xaml
@@ -33,6 +33,7 @@
                     Text="{x:Bind ViewModel.StepperSectionTitle, Mode=OneWay}" />
 
                 <controls:WorkflowStepper
+                    IsPostAdkNavigationEnabled="{x:Bind ViewModel.IsWorkflowNavigationEnabled, Mode=OneWay}"
                     Step1Label="{x:Bind ViewModel.Step1Label, Mode=OneWay}"
                     Step1Requested="StepperStep1_Requested"
                     Step1State="{x:Bind ViewModel.Step1State, Mode=OneWay}"
@@ -68,6 +69,7 @@
                         Title="{x:Bind ViewModel.ConfigCardTitle, Mode=OneWay}"
                         Grid.Column="1"
                         IconGlyph="&#xE713;"
+                        IsEnabled="{x:Bind ViewModel.IsWorkflowNavigationEnabled, Mode=OneWay}"
                         Line1Label="{x:Bind ViewModel.ConfigArchitectureLabel, Mode=OneWay}"
                         Line1Value="{x:Bind ViewModel.ConfigArchitectureValue, Mode=OneWay}"
                         Line2Label="{x:Bind ViewModel.ConfigWinPeLanguageLabel, Mode=OneWay}"

--- a/src/Foundry/Views/HomeLandingPage.xaml
+++ b/src/Foundry/Views/HomeLandingPage.xaml
@@ -24,48 +24,58 @@
             <StackPanel
                 Grid.Row="2"
                 MaxWidth="{ThemeResource FoundryContentMaxWidth}"
-                Margin="36,24,36,36"
+                Margin="36,28,36,36"
                 HorizontalAlignment="Center"
-                Spacing="{ThemeResource FoundryContentGroupSpacing}">
-                <InfoBar
-                    Title="{x:Bind ViewModel.AdkStatusTitle, Mode=OneWay}"
-                    IsClosable="False"
-                    IsIconVisible="True"
-                    IsOpen="True"
-                    Message="{x:Bind ViewModel.AdkStatusDescription, Mode=OneWay}"
-                    Severity="{x:Bind ViewModel.AdkStatusSeverity, Mode=OneWay}" />
-                <Grid
-                    ColumnSpacing="{ThemeResource FoundrySpace24}"
-                    RowSpacing="{ThemeResource FoundrySpace4}">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
-                    <TextBlock
-                        Grid.Row="0"
-                        Grid.Column="0"
-                        Style="{ThemeResource FoundryCaptionTextBlockStyle}"
-                        Text="{x:Bind ViewModel.InstalledVersionLabel, Mode=OneWay}" />
-                    <TextBlock
-                        Grid.Row="0"
-                        Grid.Column="1"
-                        Text="{x:Bind ViewModel.InstalledVersion, Mode=OneWay}"
-                        TextTrimming="CharacterEllipsis" />
-                    <TextBlock
-                        Grid.Row="1"
-                        Grid.Column="0"
-                        Style="{ThemeResource FoundryCaptionTextBlockStyle}"
-                        Text="{x:Bind ViewModel.WinPeAddonLabel, Mode=OneWay}" />
-                    <TextBlock
-                        Grid.Row="1"
-                        Grid.Column="1"
-                        Text="{x:Bind ViewModel.WinPeAddonStatus, Mode=OneWay}"
-                        TextTrimming="CharacterEllipsis" />
-                </Grid>
+                Spacing="20">
+
+                <TextBlock
+                    Style="{StaticResource BodyStrongTextBlockStyle}"
+                    Text="{x:Bind ViewModel.StepperSectionTitle, Mode=OneWay}" />
+
+                <controls:WorkflowStepper
+                    Step1Label="{x:Bind ViewModel.Step1Label, Mode=OneWay}"
+                    Step1Requested="StepperStep1_Requested"
+                    Step1State="{x:Bind ViewModel.Step1State, Mode=OneWay}"
+                    Step1StatusText="{x:Bind ViewModel.Step1StatusText, Mode=OneWay}"
+                    Step2Label="{x:Bind ViewModel.Step2Label, Mode=OneWay}"
+                    Step2Requested="StepperStep2_Requested"
+                    Step2State="{x:Bind ViewModel.Step2State, Mode=OneWay}"
+                    Step2StatusText="{x:Bind ViewModel.Step2StatusText, Mode=OneWay}"
+                    Step3Label="{x:Bind ViewModel.Step3Label, Mode=OneWay}"
+                    Step3Requested="StepperStep3_Requested"
+                    Step3State="{x:Bind ViewModel.Step3State, Mode=OneWay}"
+                    Step3StatusText="{x:Bind ViewModel.Step3StatusText, Mode=OneWay}" />
+
+                <StackPanel
+                    Orientation="Horizontal"
+                    Spacing="12">
+
+                    <controls:HomeStatusCard
+                        Title="{x:Bind ViewModel.AdkCardTitle, Mode=OneWay}"
+                        IconGlyph="&#xEC7A;"
+                        Line1Label="{x:Bind ViewModel.AdkVersionLabel, Mode=OneWay}"
+                        Line1Value="{x:Bind ViewModel.AdkVersionValue, Mode=OneWay}"
+                        Line2Label="{x:Bind ViewModel.AdkWinPeLabel, Mode=OneWay}"
+                        Line2Value="{x:Bind ViewModel.AdkWinPeValue, Mode=OneWay}"
+                        NavigationRequested="AdkCard_NavigationRequested"
+                        Severity="{x:Bind ViewModel.AdkCardSeverity, Mode=OneWay}"
+                        StatusText="{x:Bind ViewModel.AdkCardStatusText, Mode=OneWay}" />
+
+                    <controls:HomeStatusCard
+                        Title="{x:Bind ViewModel.ConfigCardTitle, Mode=OneWay}"
+                        IconGlyph="&#xE713;"
+                        Line1Label="{x:Bind ViewModel.ConfigArchitectureLabel, Mode=OneWay}"
+                        Line1Value="{x:Bind ViewModel.ConfigArchitectureValue, Mode=OneWay}"
+                        Line2Label="{x:Bind ViewModel.ConfigWinPeLanguageLabel, Mode=OneWay}"
+                        Line2Value="{x:Bind ViewModel.ConfigWinPeLanguageValue, Mode=OneWay}"
+                        Line3Label="{x:Bind ViewModel.ConfigSecureBootLabel, Mode=OneWay}"
+                        Line3Value="{x:Bind ViewModel.ConfigSecureBootValue, Mode=OneWay}"
+                        Line4Label="{x:Bind ViewModel.ConfigDriversLabel, Mode=OneWay}"
+                        Line4Value="{x:Bind ViewModel.ConfigDriversValue, Mode=OneWay}"
+                        NavigationRequested="ConfigCard_NavigationRequested"
+                        Severity="{x:Bind ViewModel.ConfigCardSeverity, Mode=OneWay}"
+                        StatusText="{x:Bind ViewModel.ConfigCardStatusText, Mode=OneWay}" />
+                </StackPanel>
             </StackPanel>
         </Grid>
     </ScrollViewer>

--- a/src/Foundry/Views/HomeLandingPage.xaml
+++ b/src/Foundry/Views/HomeLandingPage.xaml
@@ -2,247 +2,27 @@
 <Page x:Class="Foundry.Views.HomeLandingPage" x:Name="RootPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Foundry.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
-    <Page.Resources>
-        <Style x:Key="HomeTileButtonStyle"
-            TargetType="Button">
-            <Setter
-                Property="Width"
-                Value="232" />
-            <Setter
-                Property="MinHeight"
-                Value="172" />
-            <Setter
-                Property="Padding"
-                Value="24" />
-            <Setter
-                Property="Background"
-                Value="{ThemeResource CardBackgroundFillColorDefaultBrush}" />
-            <Setter
-                Property="BorderBrush"
-                Value="{ThemeResource CardStrokeColorDefaultBrush}" />
-            <Setter
-                Property="BorderThickness"
-                Value="1" />
-            <Setter
-                Property="CornerRadius"
-                Value="{ThemeResource FoundryCardCornerRadius}" />
-            <Setter
-                Property="HorizontalContentAlignment"
-                Value="Stretch" />
-            <Setter
-                Property="VerticalContentAlignment"
-                Value="Stretch" />
-        </Style>
-    </Page.Resources>
-
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid MinHeight="{x:Bind RootPage.ActualHeight, Mode=OneWay}">
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <Grid MinHeight="164">
-                <Grid.Background>
-                    <ImageBrush
-                        ImageSource="{ThemeResource HeaderCover}"
-                        Stretch="UniformToFill" />
-                </Grid.Background>
-                <Rectangle
-                    Fill="{ThemeResource SystemControlBackgroundAltHighBrush}"
-                    Opacity="0.35" />
-                <Rectangle
-                    Height="48"
-                    VerticalAlignment="Bottom">
-                    <Rectangle.Fill>
-                        <LinearGradientBrush
-                            StartPoint="0,0"
-                            EndPoint="0,1">
-                            <GradientStop
-                                Offset="0"
-                                Color="{ThemeResource HomeHeroFadeStartColor}" />
-                            <GradientStop
-                                Offset="1"
-                                Color="{ThemeResource HomeHeroFadeEndColor}" />
-                        </LinearGradientBrush>
-                    </Rectangle.Fill>
-                </Rectangle>
-                <StackPanel
-                    Margin="36,48,36,24"
-                    VerticalAlignment="Center"
-                    Spacing="4">
-                    <TextBlock
-                        Foreground="{ThemeResource SystemControlForegroundChromeWhiteBrush}"
-                        Style="{ThemeResource BodyTextBlockStyle}"
-                        Text="{x:Bind ViewModel.HeaderSubtitle, Mode=OneWay}"
-                        TextWrapping="Wrap" />
-                    <TextBlock
-                        Foreground="{ThemeResource SystemControlForegroundChromeWhiteBrush}"
-                        Style="{ThemeResource TitleTextBlockStyle}"
-                        Text="{x:Bind ViewModel.HeaderTitle, Mode=OneWay}" />
-                </StackPanel>
-            </Grid>
-
-            <ScrollViewer
-                Grid.Row="1"
-                Margin="36,16,36,0"
-                HorizontalScrollBarVisibility="Auto"
-                HorizontalScrollMode="Enabled"
-                VerticalScrollBarVisibility="Disabled"
-                VerticalScrollMode="Disabled">
-                <StackPanel
-                    Orientation="Horizontal"
-                    Spacing="8">
-                    <Button
-                        AutomationProperties.HelpText="{x:Bind ViewModel.OpenAdkDescription, Mode=OneWay}"
-                        AutomationProperties.Name="{x:Bind ViewModel.OpenAdkTitle, Mode=OneWay}"
-                        Click="OpenAdkButton_Click"
-                        Style="{StaticResource HomeTileButtonStyle}">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="36" />
-                                <RowDefinition Height="*" />
-                            </Grid.RowDefinitions>
-                            <FontIcon
-                                HorizontalAlignment="Left"
-                                FontSize="{ThemeResource FoundryIconSizeHero}"
-                                Glyph="&#xEC7A;" />
-                            <FontIcon
-                                Grid.RowSpan="2"
-                                HorizontalAlignment="Right"
-                                VerticalAlignment="Bottom"
-                                FontSize="14"
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                Glyph="&#xE8A7;" />
-                            <StackPanel
-                                Grid.Row="1"
-                                Spacing="4">
-                                <TextBlock
-                                    Style="{ThemeResource BodyStrongTextBlockStyle}"
-                                    Text="{x:Bind ViewModel.OpenAdkTitle, Mode=OneWay}" />
-                                <TextBlock
-                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                    Style="{ThemeResource CaptionTextBlockStyle}"
-                                    Text="{x:Bind ViewModel.OpenAdkDescription, Mode=OneWay}"
-                                    TextWrapping="Wrap" />
-                            </StackPanel>
-                        </Grid>
-                    </Button>
-                    <Button
-                        AutomationProperties.HelpText="{x:Bind ViewModel.ConfigureMediaDescription, Mode=OneWay}"
-                        AutomationProperties.Name="{x:Bind ViewModel.ConfigureMediaTitle, Mode=OneWay}"
-                        Click="ConfigureMediaButton_Click"
-                        Style="{StaticResource HomeTileButtonStyle}">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="36" />
-                                <RowDefinition Height="*" />
-                            </Grid.RowDefinitions>
-                            <FontIcon
-                                HorizontalAlignment="Left"
-                                FontSize="{ThemeResource FoundryIconSizeHero}"
-                                Glyph="&#xE713;" />
-                            <FontIcon
-                                Grid.RowSpan="2"
-                                HorizontalAlignment="Right"
-                                VerticalAlignment="Bottom"
-                                FontSize="14"
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                Glyph="&#xE8A7;" />
-                            <StackPanel
-                                Grid.Row="1"
-                                Spacing="4">
-                                <TextBlock
-                                    Style="{ThemeResource BodyStrongTextBlockStyle}"
-                                    Text="{x:Bind ViewModel.ConfigureMediaTitle, Mode=OneWay}" />
-                                <TextBlock
-                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                    Style="{ThemeResource CaptionTextBlockStyle}"
-                                    Text="{x:Bind ViewModel.ConfigureMediaDescription, Mode=OneWay}"
-                                    TextWrapping="Wrap" />
-                            </StackPanel>
-                        </Grid>
-                    </Button>
-                    <Button
-                        AutomationProperties.HelpText="{x:Bind ViewModel.ReviewAndStartDescription, Mode=OneWay}"
-                        AutomationProperties.Name="{x:Bind ViewModel.ReviewAndStartTitle, Mode=OneWay}"
-                        Click="ReviewAndStartButton_Click"
-                        Style="{StaticResource HomeTileButtonStyle}">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="36" />
-                                <RowDefinition Height="*" />
-                            </Grid.RowDefinitions>
-                            <FontIcon
-                                HorizontalAlignment="Left"
-                                FontSize="{ThemeResource FoundryIconSizeHero}"
-                                Glyph="&#xE768;" />
-                            <FontIcon
-                                Grid.RowSpan="2"
-                                HorizontalAlignment="Right"
-                                VerticalAlignment="Bottom"
-                                FontSize="14"
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                Glyph="&#xE8A7;" />
-                            <StackPanel
-                                Grid.Row="1"
-                                Spacing="4">
-                                <TextBlock
-                                    Style="{ThemeResource BodyStrongTextBlockStyle}"
-                                    Text="{x:Bind ViewModel.ReviewAndStartTitle, Mode=OneWay}" />
-                                <TextBlock
-                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                    Style="{ThemeResource CaptionTextBlockStyle}"
-                                    Text="{x:Bind ViewModel.ReviewAndStartDescription, Mode=OneWay}"
-                                    TextWrapping="Wrap" />
-                            </StackPanel>
-                        </Grid>
-                    </Button>
-                    <Button
-                        AutomationProperties.HelpText="{x:Bind ViewModel.OpenDocumentationDescription, Mode=OneWay}"
-                        AutomationProperties.Name="{x:Bind ViewModel.OpenDocumentationTitle, Mode=OneWay}"
-                        Click="OpenDocumentationButton_Click"
-                        Style="{StaticResource HomeTileButtonStyle}">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="36" />
-                                <RowDefinition Height="*" />
-                            </Grid.RowDefinitions>
-                            <FontIcon
-                                HorizontalAlignment="Left"
-                                FontSize="{ThemeResource FoundryIconSizeHero}"
-                                Glyph="&#xE8A5;" />
-                            <FontIcon
-                                Grid.RowSpan="2"
-                                HorizontalAlignment="Right"
-                                VerticalAlignment="Bottom"
-                                FontSize="14"
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                Glyph="&#xE8A7;" />
-                            <StackPanel
-                                Grid.Row="1"
-                                Spacing="4">
-                                <TextBlock
-                                    Style="{ThemeResource BodyStrongTextBlockStyle}"
-                                    Text="{x:Bind ViewModel.OpenDocumentationTitle, Mode=OneWay}" />
-                                <TextBlock
-                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                    Style="{ThemeResource CaptionTextBlockStyle}"
-                                    Text="{x:Bind ViewModel.OpenDocumentationDescription, Mode=OneWay}"
-                                    TextWrapping="Wrap" />
-                            </StackPanel>
-                        </Grid>
-                    </Button>
-                </StackPanel>
-            </ScrollViewer>
+            <controls:HomeLandingHeader
+                ConfigureMediaRequested="ConfigureMediaButton_Click"
+                OpenAdkRequested="OpenAdkButton_Click"
+                OpenDocumentationRequested="OpenDocumentationButton_Click"
+                ReviewAndStartRequested="ReviewAndStartButton_Click"
+                ViewModel="{x:Bind ViewModel, Mode=OneWay}" />
 
             <StackPanel
-                Grid.Row="3"
+                Grid.Row="2"
                 MaxWidth="{ThemeResource FoundryContentMaxWidth}"
                 Margin="36,24,36,36"
                 HorizontalAlignment="Center"

--- a/src/Foundry/Views/HomeLandingPage.xaml.cs
+++ b/src/Foundry/Views/HomeLandingPage.xaml.cs
@@ -46,6 +46,40 @@ public sealed partial class HomeLandingPage : Page
         await ((MainWindow)App.MainWindow).OpenDocumentationAsync();
     }
 
+    private void StepperStep1_Requested(object sender, EventArgs e)
+    {
+        App.Current.NavigationService.NavigateTo(typeof(AdkPage));
+    }
+
+    private void StepperStep2_Requested(object sender, EventArgs e)
+    {
+        Type target = shellNavigationGuardService.State == ShellNavigationState.Ready
+            ? typeof(GeneralConfigurationPage)
+            : typeof(AdkPage);
+        App.Current.NavigationService.NavigateTo(target);
+    }
+
+    private void StepperStep3_Requested(object sender, EventArgs e)
+    {
+        Type target = shellNavigationGuardService.State == ShellNavigationState.Ready
+            ? typeof(StartPage)
+            : typeof(AdkPage);
+        App.Current.NavigationService.NavigateTo(target);
+    }
+
+    private void AdkCard_NavigationRequested(object sender, EventArgs e)
+    {
+        App.Current.NavigationService.NavigateTo(typeof(AdkPage));
+    }
+
+    private void ConfigCard_NavigationRequested(object sender, EventArgs e)
+    {
+        Type target = shellNavigationGuardService.State == ShellNavigationState.Ready
+            ? typeof(GeneralConfigurationPage)
+            : typeof(AdkPage);
+        App.Current.NavigationService.NavigateTo(target);
+    }
+
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
         Unloaded -= OnUnloaded;

--- a/src/Foundry/Views/HomeLandingPage.xaml.cs
+++ b/src/Foundry/Views/HomeLandingPage.xaml.cs
@@ -2,19 +2,14 @@
 // Licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
-using Foundry.Services.Shell;
-
 namespace Foundry.Views;
 
 public sealed partial class HomeLandingPage : Page
 {
-    private readonly IShellNavigationGuardService shellNavigationGuardService;
-
     public HomeLandingViewModel ViewModel { get; }
 
     public HomeLandingPage()
     {
-        shellNavigationGuardService = App.GetService<IShellNavigationGuardService>();
         ViewModel = App.GetService<HomeLandingViewModel>();
         InitializeComponent();
         Unloaded += OnUnloaded;
@@ -27,18 +22,12 @@ public sealed partial class HomeLandingPage : Page
 
     private void ConfigureMediaButton_Click(object sender, RoutedEventArgs e)
     {
-        Type target = shellNavigationGuardService.State == ShellNavigationState.Ready
-            ? typeof(GeneralConfigurationPage)
-            : typeof(AdkPage);
-        App.Current.NavigationService.NavigateTo(target);
+        App.Current.NavigationService.NavigateTo(typeof(GeneralConfigurationPage));
     }
 
     private void ReviewAndStartButton_Click(object sender, RoutedEventArgs e)
     {
-        Type target = shellNavigationGuardService.State == ShellNavigationState.Ready
-            ? typeof(StartPage)
-            : typeof(AdkPage);
-        App.Current.NavigationService.NavigateTo(target);
+        App.Current.NavigationService.NavigateTo(typeof(StartPage));
     }
 
     private async void OpenDocumentationButton_Click(object sender, RoutedEventArgs e)
@@ -53,18 +42,12 @@ public sealed partial class HomeLandingPage : Page
 
     private void StepperStep2_Requested(object sender, EventArgs e)
     {
-        Type target = shellNavigationGuardService.State == ShellNavigationState.Ready
-            ? typeof(GeneralConfigurationPage)
-            : typeof(AdkPage);
-        App.Current.NavigationService.NavigateTo(target);
+        App.Current.NavigationService.NavigateTo(typeof(GeneralConfigurationPage));
     }
 
     private void StepperStep3_Requested(object sender, EventArgs e)
     {
-        Type target = shellNavigationGuardService.State == ShellNavigationState.Ready
-            ? typeof(StartPage)
-            : typeof(AdkPage);
-        App.Current.NavigationService.NavigateTo(target);
+        App.Current.NavigationService.NavigateTo(typeof(StartPage));
     }
 
     private void AdkCard_NavigationRequested(object sender, EventArgs e)
@@ -74,10 +57,7 @@ public sealed partial class HomeLandingPage : Page
 
     private void ConfigCard_NavigationRequested(object sender, EventArgs e)
     {
-        Type target = shellNavigationGuardService.State == ShellNavigationState.Ready
-            ? typeof(GeneralConfigurationPage)
-            : typeof(AdkPage);
-        App.Current.NavigationService.NavigateTo(target);
+        App.Current.NavigationService.NavigateTo(typeof(GeneralConfigurationPage));
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary

Redesign the Foundry home landing page with the WinUI Gallery hero composition and add live workflow readiness while preserving Foundry content and imagery.

## Reason

The previous landing page separated a shallow hero from its action cards and duplicated hero-specific resources. The updated page aligns with the approved WinUI Gallery layout and gives users an immediate, accessible view of ADK and configuration readiness.

## Main changes

- Add a 400px composition-masked hero using the existing Foundry light and dark cover images.
- Overlay the four existing Foundry action cards with Gallery-style dimensions, acrylic styling, spacing, and horizontal navigation.
- Add an accessible three-step workflow and clickable ADK/configuration status cards.
- Restyle the two dense status cards with Gallery acrylic surfaces, equal responsive columns, theme-aware interaction states, and wrapping localized details.
- Drive Home readiness from live ADK, network, deploy, Connect, secrets, and Autopilot state.
- Preserve native button keyboard, focus, automation, and existing navigation behavior.
- Complete Home localization across all 38 supported cultures while reusing existing resource keys.
- Remove obsolete duplicate hero and status state code.
- Apply the Foundry Project copyright header to all new C# sources.

## Testing

- `scripts/Test-FoundryFormat.ps1` (51/51 files)
- `dotnet build Foundry/Foundry.csproj -p:Platform=x64 --no-restore` (0 errors)
- `dotnet build Foundry/Foundry.csproj -p:Platform=ARM64 --no-restore` (0 errors)
- `dotnet test Foundry.slnx --no-restore` (1,141 passed, 0 failed)
- Manual x64 visual validation of the Home landing page, readiness cards, localized wrapping, and equal-column layout