### PR TITLE
feat(winui): add navigation icon badge foundation

### DIFF
--- a/src/Foundry/Services/Shell/NavigationInfoBadgeFactory.cs
+++ b/src/Foundry/Services/Shell/NavigationInfoBadgeFactory.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Services.Shell;
+
+/// <summary>
+/// Creates icon-only information badges for shell navigation items.
+/// </summary>
+internal static class NavigationInfoBadgeFactory
+{
+    /// <summary>
+    /// Creates an information badge using the built-in icon style for the specified severity.
+    /// </summary>
+    /// <param name="severity">The semantic severity represented by the badge.</param>
+    /// <returns>A styled icon information badge.</returns>
+    public static InfoBadge Create(NavigationInfoBadgeSeverity severity)
+    {
+        string styleKey = severity switch
+        {
+            NavigationInfoBadgeSeverity.Attention => "AttentionIconInfoBadgeStyle",
+            NavigationInfoBadgeSeverity.Informational => "InformationalIconInfoBadgeStyle",
+            NavigationInfoBadgeSeverity.Success => "SuccessIconInfoBadgeStyle",
+            NavigationInfoBadgeSeverity.Caution => "CautionIconInfoBadgeStyle",
+            NavigationInfoBadgeSeverity.Critical => "CriticalIconInfoBadgeStyle",
+            _ => throw new ArgumentOutOfRangeException(nameof(severity), severity, null)
+        };
+
+        if (App.Current.Resources.TryGetValue(styleKey, out object styleResource)
+            && styleResource is Style style)
+        {
+            return new InfoBadge { Style = style };
+        }
+
+        throw new InvalidOperationException($"The navigation InfoBadge style '{styleKey}' is unavailable.");
+    }
+}

--- a/src/Foundry/Services/Shell/NavigationInfoBadgeSeverity.cs
+++ b/src/Foundry/Services/Shell/NavigationInfoBadgeSeverity.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Services.Shell;
+
+/// <summary>
+/// Defines the supported icon badge severities for shell navigation items.
+/// </summary>
+internal enum NavigationInfoBadgeSeverity
+{
+    Attention,
+    Informational,
+    Success,
+    Caution,
+    Critical
+}

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>تحديث</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>جديد</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>معلومات المنتج والإصدار.</value>
   </data>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Актуализация</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Нов</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Информация за продукта и версията.</value>
   </data>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Aktualizovat</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Nové</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Informace o produktu a verzi.</value>
   </data>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Opdatering</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Ny</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Produkt- og versionsoplysninger.</value>
   </data>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Aktualisieren</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Neu</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Produkt- und Versionsinformationen.</value>
   </data>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Ενημέρωση</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Νέο</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Πληροφορίες προϊόντος και έκδοσης.</value>
   </data>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Update</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>New</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Product and version information.</value>
   </data>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -2133,9 +2133,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Update</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>New</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Product and version information.</value>
   </data>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Actualizar</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Nuevo</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Información de producto y versión.</value>
   </data>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Actualizar</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Nuevo</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Información de producto y versión.</value>
   </data>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Värskenda</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Uus</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Toote- ja versiooniteave.</value>
   </data>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Päivitä</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Uusi</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Tuote- ja versiotiedot.</value>
   </data>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Mise à jour</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Nouveau</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Informations sur le produit et la version.</value>
   </data>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -2133,9 +2133,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Mise à jour</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Nouveau</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Informations de produit et de version.</value>
   </data>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>עדכון</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>חדש</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>מידע על המוצר והגרסה.</value>
   </data>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Ažurirati</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Novi</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Informacije o proizvodu i verziji.</value>
   </data>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Frissítés</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Új</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Termék- és verzióinformáció.</value>
   </data>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Aggiorna</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Nuovo</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Informazioni sul prodotto e sulla versione.</value>
   </data>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>アップデート</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>新しい</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>製品とバージョンの情報。</value>
   </data>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>업데이트</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>새로운</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>제품 및 버전 정보.</value>
   </data>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Atnaujinti</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Nauja</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Informacija apie produktą ir versiją.</value>
   </data>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Atjaunināt</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Jauns</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Informācija par produktu un versiju.</value>
   </data>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Oppdater</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Nytt</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Produkt- og versjonsinformasjon.</value>
   </data>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Bijwerken</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Nieuw</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Product- en versie-informatie.</value>
   </data>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Aktualizacja</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Nowy</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Informacje o produkcie i wersji.</value>
   </data>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Atualizar</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Novo</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Informações sobre produto e versão.</value>
   </data>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Atualizar</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Novo</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Informações sobre produto e versão.</value>
   </data>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Actualizare</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Nou</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Informații despre produs și versiune.</value>
   </data>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Обновить</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Новый</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Информация о продукте и версии.</value>
   </data>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Aktualizovať</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Nové</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Informácie o produkte a verzii.</value>
   </data>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>posodobitev</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Novo</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Informacije o izdelku in različici.</value>
   </data>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Ažuriraj</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Novo</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Informacije o proizvodu i verziji.</value>
   </data>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Uppdatering</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Nytt</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Produkt- och versionsinformation.</value>
   </data>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>อัปเดต</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>ใหม่</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>ข้อมูลผลิตภัณฑ์และเวอร์ชัน</value>
   </data>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>Güncelleme</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>Yeni</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Ürün ve versiyon bilgileri.</value>
   </data>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>оновлення</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>новий</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>Інформація про продукт і версію.</value>
   </data>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>更新</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>新</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>产品和版本信息。</value>
   </data>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -2118,9 +2118,6 @@
   <data name="UpdateFooter.Title" xml:space="preserve">
     <value>更新</value>
   </data>
-  <data name="UpdateFooter.BadgeFallback" xml:space="preserve">
-    <value>新</value>
-  </data>
   <data name="Nav_AboutKey.Description" xml:space="preserve">
     <value>產品和版本資訊。</value>
   </data>

--- a/src/Foundry/ViewModels/MainViewModel.cs
+++ b/src/Foundry/ViewModels/MainViewModel.cs
@@ -29,9 +29,6 @@ namespace Foundry.ViewModels
         [ObservableProperty]
         public partial string UpdateFooterToolTip { get; set; }
 
-        [ObservableProperty]
-        public partial string UpdateFooterBadgeValue { get; set; }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MainViewModel"/> class.
         /// </summary>
@@ -48,7 +45,6 @@ namespace Foundry.ViewModels
 
             UpdateFooterTitle = localizationService.GetString("UpdateFooter.Title");
             UpdateFooterToolTip = localizationService.GetString("Update.Status.UpdateAvailable");
-            UpdateFooterBadgeValue = localizationService.GetString("UpdateFooter.BadgeFallback");
 
             updateStateService.StateChanged += OnUpdateStateChanged;
             localizationService.LanguageChanged += OnLanguageChanged;
@@ -95,13 +91,11 @@ namespace Foundry.ViewModels
                     ? localizationService.FormatString("Update.Status.UpdateAvailableWithVersion", result.Version)
                     : localizationService.GetString("Update.Status.UpdateAvailable");
 
-                UpdateFooterBadgeValue = localizationService.GetString("UpdateFooter.BadgeFallback");
                 IsUpdateFooterItemVisible = true;
                 return;
             }
 
             UpdateFooterToolTip = localizationService.GetString("Update.Status.UpdateAvailable");
-            UpdateFooterBadgeValue = localizationService.GetString("UpdateFooter.BadgeFallback");
             IsUpdateFooterItemVisible = false;
         }
     }

--- a/src/Foundry/Views/MainWindow.xaml.cs
+++ b/src/Foundry/Views/MainWindow.xaml.cs
@@ -27,7 +27,6 @@ namespace Foundry.Views
         private const string AboutNavigationTag = "Foundry.External.About";
         private const string UpdateNavigationTag = "Foundry.Navigation.UpdateAvailable";
         private const string UpdateNavigationGlyph = "\uEBD3";
-        private const string StringInfoBadgeStyleKey = "StringInfoBadgeStyle";
         private ContentDialog? operationDialog;
         private TextBlock? operationStatusText;
         private ProgressBar? operationProgressBar;
@@ -132,8 +131,7 @@ namespace Foundry.Views
         {
             if (e.PropertyName is nameof(MainViewModel.IsUpdateFooterItemVisible)
                 or nameof(MainViewModel.UpdateFooterTitle)
-                or nameof(MainViewModel.UpdateFooterToolTip)
-                or nameof(MainViewModel.UpdateFooterBadgeValue))
+                or nameof(MainViewModel.UpdateFooterToolTip))
             {
                 RefreshUpdateFooterItem();
             }
@@ -473,7 +471,8 @@ namespace Foundry.Views
                 item = new()
                 {
                     Tag = UpdateNavigationTag,
-                    Icon = new FontIcon { Glyph = UpdateNavigationGlyph }
+                    Icon = new FontIcon { Glyph = UpdateNavigationGlyph },
+                    InfoBadge = NavigationInfoBadgeFactory.Create(NavigationInfoBadgeSeverity.Attention)
                 };
                 NavView.FooterMenuItems.Insert(0, item);
             }
@@ -488,10 +487,10 @@ namespace Foundry.Views
             }
 
             item.Content = ViewModel.UpdateFooterTitle;
-            item.InfoBadge = CreateUpdateInfoBadge();
             ToolTipService.SetToolTip(item, ViewModel.UpdateFooterToolTip);
             AutomationProperties.SetName(item, ViewModel.UpdateFooterTitle);
             AutomationProperties.SetHelpText(item, ViewModel.UpdateFooterToolTip);
+            AutomationProperties.SetItemStatus(item, ViewModel.UpdateFooterToolTip);
             item.IsEnabled = shellNavigationGuardService.State != ShellNavigationState.OperationRunning;
         }
 
@@ -504,22 +503,6 @@ namespace Foundry.Views
             }
 
             NavView.FooterMenuItems.Remove(item);
-        }
-
-        private InfoBadge CreateUpdateInfoBadge()
-        {
-            InfoBadge badge = new()
-            {
-                Tag = ViewModel.UpdateFooterBadgeValue
-            };
-
-            if (App.Current.Resources.TryGetValue(StringInfoBadgeStyleKey, out object style)
-                && style is Style infoBadgeStyle)
-            {
-                badge.Style = infoBadgeStyle;
-            }
-
-            return badge;
         }
 
         private void EnsureExternalAboutFooterItem()


### PR DESCRIPTION
## Summary

Adds a minimal icon-only InfoBadge foundation for Foundry navigation items.

## Reason

Navigation badges need one consistent mapping to the supported built-in WinUI icon styles before adding consumers.

## Main changes

- Adds the five supported navigation badge severities.
- Adds a focused factory that resolves the matching WinUI style.
- Fails explicitly when a required style resource is unavailable.

## Testing notes

- `scripts\Test-FoundryFormat.ps1` passed.
- Release x64 build passed with 0 errors.
- Existing x64 tests passed: 1,141 passed, 0 failed.
- ARM64 was not tested as requested.
- CI is pending and was not awaited.