### PR TITLE
feat(deploy): add password protection to deployment media

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,10 @@ Cleanup rules:
 Configuration schema rules:
 - Treat Foundry authoring configuration, Foundry.Deploy runtime configuration, and Foundry.Connect runtime configuration as separate schema contracts
 - Preserve the separate Foundry authoring, Foundry.Deploy runtime, and Foundry.Connect runtime configuration schemas when adding shared utility capabilities.
-- Keep schema versions monotonic within each contract
+- Treat the schema versions in the latest published GitHub Release tag as the production baseline; values present only on `main`, pull requests, or intermediate builds are not production versions
+- Set each affected schema version to the latest published GitHub Release version plus one, accumulating all unreleased contract changes under that single next version
+- Do not increment a schema version again for additional unreleased changes before the next GitHub Release
+- Keep published schema versions monotonic within each contract
 - Bump a schema version only when the persisted or generated configuration contract changes in a way that affects runtime behavior or compatibility
 - Bump Foundry authoring schema when the user-facing persisted Foundry configuration shape, defaults, migration behavior, or semantic meaning changes
 - Bump Foundry.Deploy runtime schema when Deploy consumes new generated configuration, requires new boot media assets, changes the meaning of an existing Deploy field, or needs older boot media to show a compatibility warning

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Use the dedicated [network](https://foundry-osd.github.io/docs/configure/network
 
 Foundry OSD can optionally require a password before Foundry Deploy initializes. The password is defined by the administrator when creating the media and is never stored in the Foundry configuration or on the media. Deploy credentials and offline Autopilot JSON profiles are encrypted on protected media and decrypted only after successful authorization.
 
-The password cannot be recovered. If it is lost, recreate the deployment media with a new password. Foundry OSD keeps the password only for the current process session, so it must be entered again after restarting Foundry OSD or when recreating media.
+The password cannot be recovered. If it is lost, recreate the deployment media with a new password. Foundry OSD keeps the password only for the current process session, so it must be entered again after restarting Foundry OSD or after disabling and re-enabling password protection.
 
 Foundry Connect continues to handle network secrets automatically before Foundry Deploy starts. Password protection does not replace physical media controls, Secure Boot, restricted boot-device policies, or appropriate tenant permissions; keep deployment media secured and revoke exposed credentials when a device is lost.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This repository contains the Foundry OSD desktop application and the WinPE runti
 | Area | What Foundry provides | Why it matters |
 | --- | --- | --- |
 | Guided media creation | Build ISO or USB deployment media from a desktop UI | Reduces manual WinPE and scripting work |
+| Optional media protection | Require an administrator-defined password before Foundry Deploy initializes | Prevents casual or unauthorized deployment from lost media and protects Deploy credentials and offline Autopilot profiles |
 | Ethernet and Wi-Fi | Validate Ethernet, use pre-provisioned Wi-Fi, or connect to supported personal Wi-Fi networks from WinPE | Supports deployments on wired, wireless, enterprise, and non-enterprise networks |
 | Enterprise networking | Stage wired 802.1X and enterprise Wi-Fi profiles with optional trusted root CA certificates | Supports corporate network environments |
 | Deployment workflow | Choose target disk, Windows image, drivers, firmware, Autopilot, and deployment options from Foundry Deploy | Makes deployment decisions visible before execution |
@@ -97,6 +98,14 @@ Most deployments follow the standard path:
 7. Review the summary and start deployment.
 
 Use the dedicated [network](https://foundry-osd.github.io/docs/configure/network), [Windows Autopilot](https://foundry-osd.github.io/docs/autopilot/overview), and [customization](https://foundry-osd.github.io/docs/configure/customization) sections when deployment media must carry predefined connectivity, provisioning, or Windows configuration.
+
+### Protected deployment media
+
+Foundry OSD can optionally require a password before Foundry Deploy initializes. The password is defined by the administrator when creating the media and is never stored in the Foundry configuration or on the media. Deploy credentials and offline Autopilot JSON profiles are encrypted on protected media and decrypted only after successful authorization.
+
+The password cannot be recovered. If it is lost, recreate the deployment media with a new password. Foundry OSD keeps the password only for the current process session, so it must be entered again after restarting Foundry OSD or when recreating media.
+
+Foundry Connect continues to handle network secrets automatically before Foundry Deploy starts. Password protection does not replace physical media controls, Secure Boot, restricted boot-device policies, or appropriate tenant permissions; keep deployment media secured and revoke exposed credentials when a device is lost.
 
 ## Screenshots
 

--- a/src/Foundry.Connect/Services/Configuration/ConnectSecretEnvelopeProtector.cs
+++ b/src/Foundry.Connect/Services/Configuration/ConnectSecretEnvelopeProtector.cs
@@ -5,6 +5,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using Foundry.Connect.Models.Configuration;
+using Foundry.Utilities.Security;
 
 namespace Foundry.Connect.Services.Configuration;
 
@@ -13,9 +14,7 @@ internal static class ConnectSecretEnvelopeProtector
     private const string Kind = "encrypted";
     private const string Algorithm = "aes-gcm-v1";
     private const string KeyId = "media";
-    private const int KeySizeBytes = 32;
-    private const int NonceSizeBytes = 12;
-    private const int TagSizeBytes = 16;
+    private const int KeySizeBytes = AesGcmEncryption.KeySizeBytes;
 
     public static string Decrypt(SecretEnvelope envelope, byte[] key)
     {
@@ -23,26 +22,21 @@ internal static class ConnectSecretEnvelopeProtector
         ValidateEnvelope(envelope);
         ValidateKey(key);
 
-        byte[] nonce = Base64UrlDecode(envelope.Nonce);
-        byte[] tag = Base64UrlDecode(envelope.Tag);
-        byte[] ciphertext = Base64UrlDecode(envelope.Ciphertext);
-        byte[] plaintext = new byte[ciphertext.Length];
+        byte[]? plaintext = null;
 
         try
         {
-            if (nonce.Length != NonceSizeBytes)
-            {
-                throw new FoundryConnectConfigurationException("Encrypted secret nonce has an invalid length.");
-            }
-
-            if (tag.Length != TagSizeBytes)
-            {
-                throw new FoundryConnectConfigurationException("Encrypted secret tag has an invalid length.");
-            }
-
-            using var aes = new AesGcm(key, TagSizeBytes);
-            aes.Decrypt(nonce, ciphertext, tag, plaintext);
+            plaintext = AesGcmEncryption.Decrypt(
+                new AesGcmPayload(
+                    Base64Url.Decode(envelope.Nonce),
+                    Base64Url.Decode(envelope.Tag),
+                    Base64Url.Decode(envelope.Ciphertext)),
+                key);
             return Encoding.UTF8.GetString(plaintext);
+        }
+        catch (FormatException ex)
+        {
+            throw new FoundryConnectConfigurationException("Encrypted secret envelope contains invalid base64url data.", ex);
         }
         catch (CryptographicException ex)
         {
@@ -50,7 +44,10 @@ internal static class ConnectSecretEnvelopeProtector
         }
         finally
         {
-            CryptographicOperations.ZeroMemory(plaintext);
+            if (plaintext is not null)
+            {
+                CryptographicOperations.ZeroMemory(plaintext);
+            }
         }
     }
 
@@ -80,19 +77,4 @@ internal static class ConnectSecretEnvelopeProtector
         }
     }
 
-    private static byte[] Base64UrlDecode(string value)
-    {
-        string base64 = value.Replace('-', '+').Replace('_', '/');
-        int padding = (4 - base64.Length % 4) % 4;
-        base64 = base64.PadRight(base64.Length + padding, '=');
-
-        try
-        {
-            return Convert.FromBase64String(base64);
-        }
-        catch (FormatException ex)
-        {
-            throw new FoundryConnectConfigurationException("Encrypted secret envelope contains invalid base64url data.", ex);
-        }
-    }
 }

--- a/src/Foundry.Core.Tests/BootMediaTelemetryPropertyBuilderTests.cs
+++ b/src/Foundry.Core.Tests/BootMediaTelemetryPropertyBuilderTests.cs
@@ -32,6 +32,10 @@ public sealed class BootMediaTelemetryPropertyBuilderTests
         };
         var document = new FoundryConfigurationDocument
         {
+            General = new GeneralSettings
+            {
+                DeploymentProtection = new DeploymentProtectionSettings { IsEnabled = true }
+            },
             Customization = new CustomizationSettings
             {
                 MachineNaming = new MachineNamingSettings
@@ -145,6 +149,7 @@ public sealed class BootMediaTelemetryPropertyBuilderTests
         Assert.Equal(TelemetryRuntimePayloadSources.Debug, result["boot_media_deploy_runtime_payload_source"]);
         Assert.True((bool)result["autopilot_enabled"]!);
         Assert.Equal("hardware_hash_upload", result["autopilot_provisioning_mode"]);
+        Assert.True((bool)result["deployment_protection_enabled"]!);
         Assert.True((bool)result["customization_any_enabled"]!);
         Assert.Equal("auto_generated_editable", result["customization_machine_naming_mode"]);
         Assert.True((bool)result["customization_appx_removal_enabled"]!);

--- a/src/Foundry.Core.Tests/Configuration/ConfigurationNavigationTargetResolverTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/ConfigurationNavigationTargetResolverTests.cs
@@ -32,6 +32,16 @@ public sealed class ConfigurationNavigationTargetResolverTests
     }
 
     [Fact]
+    public void ResolveDeployFailure_WhenDeploymentProtectionRequiresAttention_ReturnsGeneralPage()
+    {
+        Assert.Equal(
+            ConfigurationNavigationTarget.General,
+            ConfigurationNavigationTargetResolver.ResolveDeployFailure(
+                AutopilotProvisioningMode.JsonProfile,
+                deploymentProtectionRequiresAttention: true));
+    }
+
+    [Fact]
     public void ResolveRequiredNetworkSecret_ReturnsWifiPage()
     {
         Assert.Equal(

--- a/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
@@ -26,10 +26,10 @@ public sealed class ConfigurationSchemaVersionsTests
     }
 
     [Fact]
-    public void CurrentSchemaVersions_MatchExpectedVersions()
+    public void CurrentSchemaVersions_MatchNextPublishedContractVersions()
     {
-        Assert.Equal(14, ConfigurationSchemaVersions.FoundryCurrent);
-        Assert.Equal(12, ConfigurationSchemaVersions.DeployCurrent);
+        Assert.Equal(13, ConfigurationSchemaVersions.FoundryCurrent);
+        Assert.Equal(11, ConfigurationSchemaVersions.DeployCurrent);
         Assert.Equal(3, ConfigurationSchemaVersions.ConnectCurrent);
     }
 }

--- a/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
@@ -706,7 +706,7 @@ public sealed class DeployConfigurationGeneratorTests
             }
         };
 
-        FoundryDeployConfigurationDocument result = generator.Generate(document, mediaSecretsKey: [1, 2, 3]);
+        FoundryDeployConfigurationDocument result = generator.Generate(document, deploymentSecretsKey: [1, 2, 3]);
 
         Assert.True(result.Autopilot.IsEnabled);
         Assert.Equal(AutopilotProvisioningMode.InteractiveHardwareHashUpload, result.Autopilot.ProvisioningMode);
@@ -839,7 +839,7 @@ public sealed class DeployConfigurationGeneratorTests
             };
 
             InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => generator.Generate(document, []));
-            Assert.Contains("media secret key", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Deploy secret key", exception.Message, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {

--- a/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/DeployConfigurationGeneratorTests.cs
@@ -785,8 +785,18 @@ public sealed class DeployConfigurationGeneratorTests
 
             Assert.NotNull(result.Autopilot.HardwareHashUpload.CertificatePfxSecret);
             Assert.NotNull(result.Autopilot.HardwareHashUpload.CertificatePfxPasswordSecret);
-            Assert.Equal(pfxBytes, MediaSecretEnvelopeProtector.DecryptBytes(result.Autopilot.HardwareHashUpload.CertificatePfxSecret!, mediaKey));
-            Assert.Equal("PfxPassword-DoNotLeak", MediaSecretEnvelopeProtector.DecryptString(result.Autopilot.HardwareHashUpload.CertificatePfxPasswordSecret!, mediaKey));
+            Assert.Equal(
+                pfxBytes,
+                MediaSecretEnvelopeProtector.DecryptBytes(
+                    result.Autopilot.HardwareHashUpload.CertificatePfxSecret!,
+                    mediaKey,
+                    MediaSecretEnvelopeProtector.DeploymentKeyId));
+            Assert.Equal(
+                "PfxPassword-DoNotLeak",
+                MediaSecretEnvelopeProtector.DecryptString(
+                    result.Autopilot.HardwareHashUpload.CertificatePfxPasswordSecret!,
+                    mediaKey,
+                    MediaSecretEnvelopeProtector.DeploymentKeyId));
 
             string json = generator.Serialize(result);
             Assert.DoesNotContain(Convert.ToBase64String(pfxBytes), json, StringComparison.Ordinal);

--- a/src/Foundry.Core.Tests/Configuration/DeploymentProtectionContractTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/DeploymentProtectionContractTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Models.Configuration.Deploy;
+using Foundry.Core.Services.Configuration;
+
+namespace Foundry.Core.Tests.Configuration;
+
+public sealed class DeploymentProtectionContractTests
+{
+    [Fact]
+    public void FoundryConfiguration_RoundTripPersistsOnlyProtectionEnabledState()
+    {
+        var service = new FoundryConfigurationService();
+        var document = new FoundryConfigurationDocument
+        {
+            General = new GeneralSettings
+            {
+                DeploymentProtection = new DeploymentProtectionSettings { IsEnabled = true }
+            }
+        };
+
+        string json = service.Serialize(document);
+        FoundryConfigurationDocument loaded = service.Deserialize(json);
+
+        Assert.True(loaded.General.DeploymentProtection.IsEnabled);
+        Assert.Contains("\"deploymentProtection\"", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("password", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("confirmation", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void MissingProtectionProperties_DefaultToDisabled()
+    {
+        var authoringService = new FoundryConfigurationService();
+
+        FoundryConfigurationDocument authoring = authoringService.Deserialize("{}");
+        FoundryDeployConfigurationDocument runtime = JsonSerializer.Deserialize<FoundryDeployConfigurationDocument>(
+            "{}",
+            ConfigurationJsonDefaults.SerializerOptions)!;
+
+        Assert.False(authoring.General.DeploymentProtection.IsEnabled);
+        Assert.False(runtime.Protection.IsEnabled);
+    }
+
+    [Fact]
+    public void DeployGenerator_IncludesProtectionMetadataWithoutPassword()
+    {
+        var generator = new DeployConfigurationGenerator();
+        var protection = new DeployProtectionSettings
+        {
+            IsEnabled = true,
+            KeyDerivationAlgorithm = "pbkdf2-sha256",
+            Iterations = 600_000,
+            Salt = "c2FsdA",
+            ProtectedDeploymentKey = new SecretEnvelope
+            {
+                Kind = "encrypted",
+                Algorithm = "aes-gcm-v1",
+                KeyId = "deployment-password",
+                Nonce = "bm9uY2U",
+                Tag = "dGFn",
+                Ciphertext = "Y2lwaGVydGV4dA"
+            }
+        };
+
+        FoundryDeployConfigurationDocument result = generator.Generate(
+            new FoundryConfigurationDocument(),
+            deploymentSecretsKey: null,
+            protectionSettings: protection);
+        string json = generator.Serialize(result);
+
+        Assert.Equal(protection, result.Protection);
+        Assert.Contains("\"keyDerivationAlgorithm\": \"pbkdf2-sha256\"", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"password\":", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("\"confirmation\":", json, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Foundry.Core.Tests/Configuration/DeploymentProtectionPasswordRulesTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/DeploymentProtectionPasswordRulesTests.cs
@@ -14,7 +14,7 @@ public sealed class DeploymentProtectionPasswordRulesTests
     [InlineData("12345678", true)]
     public void IsValid_RequiresEightCharacters(string? password, bool expected)
     {
-        Assert.Equal(expected, DeploymentProtectionPasswordRules.IsValid(password));
+        Assert.Equal(expected, DeploymentProtectionPasswordRules.IsValid(password.AsSpan()));
     }
 
     [Theory]
@@ -27,6 +27,6 @@ public sealed class DeploymentProtectionPasswordRulesTests
         string? password,
         bool expected)
     {
-        Assert.Equal(expected, DeploymentProtectionPasswordRules.ShouldRecommendStrongerPassword(password));
+        Assert.Equal(expected, DeploymentProtectionPasswordRules.ShouldRecommendStrongerPassword(password.AsSpan()));
     }
 }

--- a/src/Foundry.Core.Tests/Configuration/DeploymentProtectionPasswordRulesTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/DeploymentProtectionPasswordRulesTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Core.Services.Configuration;
+
+namespace Foundry.Core.Tests.Configuration;
+
+public sealed class DeploymentProtectionPasswordRulesTests
+{
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("1234567", false)]
+    [InlineData("12345678", true)]
+    public void IsValid_RequiresEightCharacters(string? password, bool expected)
+    {
+        Assert.Equal(expected, DeploymentProtectionPasswordRules.IsValid(password));
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("1234567", false)]
+    [InlineData("12345678", true)]
+    [InlineData("12345678901", true)]
+    [InlineData("123456789012", false)]
+    public void ShouldRecommendStrongerPassword_OnlyRecommendsForValidValuesBelowTwelveCharacters(
+        string? password,
+        bool expected)
+    {
+        Assert.Equal(expected, DeploymentProtectionPasswordRules.ShouldRecommendStrongerPassword(password));
+    }
+}

--- a/src/Foundry.Core.Tests/Configuration/DeploymentProtectionSecretStateTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/DeploymentProtectionSecretStateTests.cs
@@ -37,6 +37,20 @@ public sealed class DeploymentProtectionSecretStateTests
         Assert.Throws<InvalidOperationException>(() => state.GetConfirmedPasswordCopy());
     }
 
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("short", "short")]
+    [InlineData("deployment passphrase", "different passphrase")]
+    public void InvalidPasswordState_IsNotReady(string password, string confirmation)
+    {
+        using var state = new DeploymentProtectionSecretState();
+        state.SetPassword(password.AsSpan());
+        state.SetConfirmation(confirmation.AsSpan());
+
+        Assert.False(state.IsValid);
+        Assert.Throws<InvalidOperationException>(() => state.GetConfirmedPasswordCopy());
+    }
+
     [Fact]
     public void Clear_RemovesPasswordAndConfirmation()
     {

--- a/src/Foundry.Core.Tests/Configuration/DeploymentProtectionSecretStateTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/DeploymentProtectionSecretStateTests.cs
@@ -37,6 +37,22 @@ public sealed class DeploymentProtectionSecretStateTests
         Assert.Throws<InvalidOperationException>(() => state.GetConfirmedPasswordCopy());
     }
 
+    [Fact]
+    public void SetDifferentValues_ExposesIndependentCopiesForUiRestoration()
+    {
+        using var state = new DeploymentProtectionSecretState();
+        state.SetPassword("deployment passphrase".AsSpan());
+        state.SetConfirmation("different passphrase".AsSpan());
+
+        char[] password = state.GetPasswordCopy();
+        char[] confirmation = state.GetConfirmationCopy();
+
+        Assert.Equal("deployment passphrase", new string(password));
+        Assert.Equal("different passphrase", new string(confirmation));
+        Assert.NotSame(password, state.GetPasswordCopy());
+        Assert.NotSame(confirmation, state.GetConfirmationCopy());
+    }
+
     [Theory]
     [InlineData("", "")]
     [InlineData("short", "short")]

--- a/src/Foundry.Core.Tests/Configuration/DeploymentProtectionSecretStateTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/DeploymentProtectionSecretStateTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Core.Services.Configuration;
+
+namespace Foundry.Core.Tests.Configuration;
+
+public sealed class DeploymentProtectionSecretStateTests
+{
+    [Fact]
+    public void SetMatchingValues_ExposesConfirmedPasswordCopy()
+    {
+        using var state = new DeploymentProtectionSecretState();
+        state.SetPassword("deployment passphrase".AsSpan());
+        state.SetConfirmation("deployment passphrase".AsSpan());
+
+        char[] first = state.GetConfirmedPasswordCopy();
+        char[] second = state.GetConfirmedPasswordCopy();
+
+        Assert.True(state.IsValid);
+        Assert.Equal("deployment passphrase", new string(first));
+        Assert.Equal(first, second);
+        Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public void ReplacingPassword_InvalidatesPreviousConfirmation()
+    {
+        using var state = new DeploymentProtectionSecretState();
+        state.SetPassword("deployment passphrase".AsSpan());
+        state.SetConfirmation("deployment passphrase".AsSpan());
+
+        state.SetPassword("different passphrase".AsSpan());
+
+        Assert.False(state.IsValid);
+        Assert.Throws<InvalidOperationException>(() => state.GetConfirmedPasswordCopy());
+    }
+
+    [Fact]
+    public void Clear_RemovesPasswordAndConfirmation()
+    {
+        using var state = new DeploymentProtectionSecretState();
+        state.SetPassword("deployment passphrase".AsSpan());
+        state.SetConfirmation("deployment passphrase".AsSpan());
+
+        state.Clear();
+
+        Assert.False(state.HasPassword);
+        Assert.False(state.HasConfirmation);
+        Assert.False(state.IsValid);
+    }
+
+    [Fact]
+    public void Dispose_PreventsFurtherSecretAccess()
+    {
+        var state = new DeploymentProtectionSecretState();
+        state.SetPassword("deployment passphrase".AsSpan());
+        state.SetConfirmation("deployment passphrase".AsSpan());
+
+        state.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => state.GetConfirmedPasswordCopy());
+        Assert.Throws<ObjectDisposedException>(() => state.SetPassword("another password".AsSpan()));
+    }
+}

--- a/src/Foundry.Core.Tests/WinPe/DeploymentMediaProtectionServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/DeploymentMediaProtectionServiceTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using System.Text.Json;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.WinPe;
+using Foundry.Utilities.Security;
+
+namespace Foundry.Core.Tests.WinPe;
+
+public sealed class DeploymentMediaProtectionServiceTests
+{
+    [Fact]
+    public void CreateProtected_WrapsDeploymentKeyWithoutPersistingPassword()
+    {
+        using DeploymentMediaProtectionMaterial material =
+            DeploymentMediaProtectionService.CreateProtected("deployment passphrase".AsSpan());
+
+        Assert.True(material.Settings.IsEnabled);
+        Assert.Equal("pbkdf2-sha256", material.Settings.KeyDerivationAlgorithm);
+        Assert.Equal(600_000, material.Settings.Iterations);
+        Assert.Equal(32, material.DeploymentKey.Length);
+        Assert.NotNull(material.Settings.ProtectedDeploymentKey);
+        Assert.DoesNotContain(
+            "deployment passphrase",
+            JsonSerializer.Serialize(material.Settings),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateProtected_EnvelopeDecryptsToGeneratedDeploymentKey()
+    {
+        const string password = "deployment passphrase";
+        using DeploymentMediaProtectionMaterial material =
+            DeploymentMediaProtectionService.CreateProtected(password.AsSpan());
+        byte[] salt = Base64Url.Decode(material.Settings.Salt!);
+        byte[] derivedKey = PasswordKeyDerivation.DeriveKey(
+            password.AsSpan(),
+            salt,
+            material.Settings.Iterations,
+            AesGcmEncryption.KeySizeBytes);
+
+        try
+        {
+            SecretEnvelope envelope = material.Settings.ProtectedDeploymentKey!;
+            byte[] decrypted = AesGcmEncryption.Decrypt(
+                new AesGcmPayload(
+                    Base64Url.Decode(envelope.Nonce),
+                    Base64Url.Decode(envelope.Tag),
+                    Base64Url.Decode(envelope.Ciphertext)),
+                derivedKey);
+
+            try
+            {
+                Assert.Equal(material.DeploymentKey, decrypted);
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(decrypted);
+            }
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(derivedKey);
+        }
+    }
+
+    [Fact]
+    public void CreateUnprotected_GeneratesDeploymentKeyWithoutProtectionMetadata()
+    {
+        using DeploymentMediaProtectionMaterial material = DeploymentMediaProtectionService.CreateUnprotected();
+
+        Assert.Equal(32, material.DeploymentKey.Length);
+        Assert.False(material.Settings.IsEnabled);
+        Assert.Null(material.Settings.ProtectedDeploymentKey);
+    }
+
+    [Fact]
+    public void Dispose_ClearsOwnedDeploymentKey()
+    {
+        DeploymentMediaProtectionMaterial material = DeploymentMediaProtectionService.CreateUnprotected();
+        byte[] ownedKey = material.DeploymentKey;
+
+        material.Dispose();
+
+        Assert.All(ownedKey, value => Assert.Equal(0, value));
+    }
+}

--- a/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
@@ -2,9 +2,13 @@
 // Licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using System.Xml.Linq;
 using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Autopilot;
+using Foundry.Core.Services.Configuration;
 using Foundry.Core.Services.WinPe;
 
 namespace Foundry.Core.Tests.WinPe;
@@ -357,7 +361,7 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
                 CurlExecutableSourcePath = curlSourcePath,
                 IanaWindowsTimeZoneMapJson = "{}",
                 FoundryConnectConfigurationJson = CreateConnectConfigurationWithEncryptedSecret(),
-                MediaSecretsKey = secretKey
+                NetworkSecretsKey = secretKey
             },
             CancellationToken.None);
 
@@ -366,7 +370,7 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
     }
 
     [Fact]
-    public async Task ProvisionAsync_WhenDeployConfigurationHasEncryptedSecret_WritesSecretKeyUnderConfigSecrets()
+    public async Task ProvisionAsync_WhenUnprotectedDeploymentKeyIsProvided_WritesSeparateDeploymentKey()
     {
         using TempMountedImage image = TempMountedImage.Create();
         string curlSourcePath = Path.Combine(image.RootPath, "curl.exe");
@@ -383,13 +387,13 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
                 BootstrapScriptContent = "bootstrap",
                 CurlExecutableSourcePath = curlSourcePath,
                 IanaWindowsTimeZoneMapJson = "{}",
-                DeployConfigurationJson = CreateDeployConfigurationWithEncryptedSecret(),
-                MediaSecretsKey = secretKey
+                DeploymentSecretsKey = secretKey
             },
             CancellationToken.None);
 
         Assert.True(result.IsSuccess, result.Error?.Details);
-        Assert.Equal(secretKey, await File.ReadAllBytesAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Secrets", "media-secrets.key")));
+        Assert.Equal(secretKey, await File.ReadAllBytesAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Secrets", "deployment-secrets.key")));
+        Assert.False(File.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Secrets", "media-secrets.key")));
     }
 
     [Fact]
@@ -410,7 +414,7 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
                 BootstrapScriptContent = "bootstrap",
                 CurlExecutableSourcePath = curlSourcePath,
                 IanaWindowsTimeZoneMapJson = "{}",
-                MediaSecretsKey = secretKey
+                NetworkSecretsKey = secretKey
             },
             CancellationToken.None);
 
@@ -467,6 +471,65 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
 
         Assert.True(result.IsSuccess, result.Error?.Details);
         Assert.False(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Secrets")));
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_WhenDeploymentProtectionIsEnabled_EncryptsProfilesWithoutWritingDeploymentKey()
+    {
+        using TempMountedImage image = TempMountedImage.Create();
+        string curlSourcePath = Path.Combine(image.RootPath, "curl.exe");
+        File.WriteAllText(curlSourcePath, "curl");
+        byte[] deploymentKey = Enumerable.Range(32, 32).Select(static value => (byte)value).ToArray();
+        const string profileJson = "{\"Comment_File\":\"Protected profile\"}";
+        var service = new WinPeMountedImageAssetProvisioningService();
+
+        WinPeResult result = await service.ProvisionAsync(
+            new WinPeMountedImageAssetProvisioningOptions
+            {
+                MountedImagePath = image.MountedImagePath,
+                Architecture = WinPeArchitecture.X64,
+                BootstrapScriptContent = "bootstrap",
+                CurlExecutableSourcePath = curlSourcePath,
+                IanaWindowsTimeZoneMapJson = "{}",
+                IsDeploymentProtectionEnabled = true,
+                DeploymentSecretsKey = deploymentKey,
+                AutopilotProfiles =
+                [
+                    new AutopilotProfileSettings
+                    {
+                        Id = "protected-profile",
+                        DisplayName = "Protected profile",
+                        FolderName = "ProtectedProfile",
+                        Source = "import",
+                        ImportedAtUtc = DateTimeOffset.UtcNow,
+                        JsonContent = profileJson
+                    }
+                ]
+            },
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Error?.Details);
+        string profileRoot = Path.Combine(image.MountedImagePath, "Foundry", "Config", "Autopilot", "ProtectedProfile");
+        string encryptedPath = Path.Combine(profileRoot, "AutopilotConfigurationFile.json.encrypted");
+        Assert.True(File.Exists(encryptedPath));
+        Assert.False(File.Exists(Path.Combine(profileRoot, "AutopilotConfigurationFile.json")));
+        Assert.False(File.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Secrets", "deployment-secrets.key")));
+
+        SecretEnvelope envelope = JsonSerializer.Deserialize<SecretEnvelope>(
+            await File.ReadAllTextAsync(encryptedPath),
+            ConfigurationJsonDefaults.SerializerOptions)!;
+        byte[] plaintext = MediaSecretEnvelopeProtector.DecryptBytes(
+            envelope,
+            deploymentKey,
+            MediaSecretEnvelopeProtector.DeploymentKeyId);
+        try
+        {
+            Assert.Equal(profileJson, Encoding.UTF8.GetString(plaintext));
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(plaintext);
+        }
     }
 
     [Fact]

--- a/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
+++ b/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
@@ -6,11 +6,11 @@ namespace Foundry.Core.Models.Configuration;
 
 public static class ConfigurationSchemaVersions
 {
-    public const int FoundryCurrent = 14;
+    public const int FoundryCurrent = 13;
 
     public const int ConnectCurrent = 3;
 
-    public const int DeployCurrent = 12;
+    public const int DeployCurrent = 11;
 
     public static bool IsBootMediaUpdateRecommended(int schemaVersion, int currentSchemaVersion)
     {

--- a/src/Foundry.Core/Models/Configuration/Deploy/DeployProtectionSettings.cs
+++ b/src/Foundry.Core/Models/Configuration/Deploy/DeployProtectionSettings.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Core.Models.Configuration.Deploy;
+
+/// <summary>
+/// Describes how protected deployment media unlocks its Deploy secret key.
+/// </summary>
+public sealed record DeployProtectionSettings
+{
+    /// <summary>
+    /// Gets a value indicating whether the deployment media requires a password.
+    /// </summary>
+    public bool IsEnabled { get; init; }
+
+    /// <summary>
+    /// Gets the password key derivation algorithm identifier.
+    /// </summary>
+    public string? KeyDerivationAlgorithm { get; init; }
+
+    /// <summary>
+    /// Gets the password key derivation iteration count.
+    /// </summary>
+    public int Iterations { get; init; }
+
+    /// <summary>
+    /// Gets the unpadded Base64URL-encoded password salt.
+    /// </summary>
+    public string? Salt { get; init; }
+
+    /// <summary>
+    /// Gets the password-wrapped Deploy key.
+    /// </summary>
+    public SecretEnvelope? ProtectedDeploymentKey { get; init; }
+}

--- a/src/Foundry.Core/Models/Configuration/Deploy/FoundryDeployConfigurationDocument.cs
+++ b/src/Foundry.Core/Models/Configuration/Deploy/FoundryDeployConfigurationDocument.cs
@@ -23,6 +23,11 @@ public sealed record FoundryDeployConfigurationDocument
     public int SchemaVersion { get; init; } = CurrentSchemaVersion;
 
     /// <summary>
+    /// Gets deployment media password-protection metadata.
+    /// </summary>
+    public DeployProtectionSettings Protection { get; init; } = new();
+
+    /// <summary>
     /// Gets successful deployment completion behavior.
     /// </summary>
     public DeployCompletionSettings Completion { get; init; } = new();

--- a/src/Foundry.Core/Models/Configuration/DeploymentProtectionSettings.cs
+++ b/src/Foundry.Core/Models/Configuration/DeploymentProtectionSettings.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Core.Models.Configuration;
+
+/// <summary>
+/// Stores the user-authored deployment media protection preference.
+/// </summary>
+public sealed record DeploymentProtectionSettings
+{
+    /// <summary>
+    /// Gets a value indicating whether Foundry Deploy requires a media password.
+    /// </summary>
+    public bool IsEnabled { get; init; }
+}

--- a/src/Foundry.Core/Models/Configuration/GeneralSettings.cs
+++ b/src/Foundry.Core/Models/Configuration/GeneralSettings.cs
@@ -12,6 +12,11 @@ namespace Foundry.Core.Models.Configuration;
 public sealed record GeneralSettings
 {
     /// <summary>
+    /// Gets optional deployment media password-protection settings.
+    /// </summary>
+    public DeploymentProtectionSettings DeploymentProtection { get; init; } = new();
+
+    /// <summary>
     /// Gets the optional ISO output path requested by the user.
     /// </summary>
     public string? IsoOutputPath { get; init; }

--- a/src/Foundry.Core/Services/Autopilot/MediaSecretEnvelopeProtector.cs
+++ b/src/Foundry.Core/Services/Autopilot/MediaSecretEnvelopeProtector.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Foundry.Core.Models.Configuration;
+using Foundry.Utilities.Security;
 
 namespace Foundry.Core.Services.Autopilot;
 
@@ -37,17 +38,17 @@ public static class MediaSecretEnvelopeProtector
     /// <summary>
     /// Required AES-256 media secret key length.
     /// </summary>
-    public const int KeySizeBytes = 32;
+    public const int KeySizeBytes = AesGcmEncryption.KeySizeBytes;
 
     /// <summary>
     /// Required AES-GCM nonce length.
     /// </summary>
-    public const int NonceSizeBytes = 12;
+    public const int NonceSizeBytes = AesGcmEncryption.NonceSizeBytes;
 
     /// <summary>
     /// Required AES-GCM authentication tag length.
     /// </summary>
-    public const int TagSizeBytes = 16;
+    public const int TagSizeBytes = AesGcmEncryption.TagSizeBytes;
 
     /// <summary>
     /// Creates a new random media secret key for generated boot media.
@@ -55,9 +56,7 @@ public static class MediaSecretEnvelopeProtector
     /// <returns>A 32-byte media secret key.</returns>
     public static byte[] GenerateMediaKey()
     {
-        byte[] key = new byte[KeySizeBytes];
-        RandomNumberGenerator.Fill(key);
-        return key;
+        return AesGcmEncryption.GenerateKey();
     }
 
     /// <summary>
@@ -135,22 +134,16 @@ public static class MediaSecretEnvelopeProtector
         ValidateKey(key);
         ValidateKeyId(keyId);
 
-        byte[] nonce = new byte[NonceSizeBytes];
-        byte[] tag = new byte[TagSizeBytes];
-        byte[] ciphertext = new byte[plaintext.Length];
-
-        RandomNumberGenerator.Fill(nonce);
-        using var aes = new AesGcm(key, TagSizeBytes);
-        aes.Encrypt(nonce, plaintext, ciphertext, tag);
+        AesGcmPayload payload = AesGcmEncryption.Encrypt(plaintext, key);
 
         return new SecretEnvelope
         {
             Kind = Kind,
             Algorithm = Algorithm,
             KeyId = keyId,
-            Nonce = Base64UrlEncode(nonce),
-            Tag = Base64UrlEncode(tag),
-            Ciphertext = Base64UrlEncode(ciphertext)
+            Nonce = Base64Url.Encode(payload.Nonce),
+            Tag = Base64Url.Encode(payload.Tag),
+            Ciphertext = Base64Url.Encode(payload.Ciphertext)
         };
     }
 
@@ -175,30 +168,17 @@ public static class MediaSecretEnvelopeProtector
         ValidateEnvelope(envelope, keyId);
         ValidateKey(key);
 
-        byte[] nonce = Base64UrlDecode(envelope.Nonce);
-        byte[] tag = Base64UrlDecode(envelope.Tag);
-        byte[] ciphertext = Base64UrlDecode(envelope.Ciphertext);
-        byte[] plaintext = new byte[ciphertext.Length];
-
-        if (nonce.Length != NonceSizeBytes)
-        {
-            throw new CryptographicException("Encrypted secret nonce has an invalid length.");
-        }
-
-        if (tag.Length != TagSizeBytes)
-        {
-            throw new CryptographicException("Encrypted secret tag has an invalid length.");
-        }
-
         try
         {
-            using var aes = new AesGcm(key, TagSizeBytes);
-            aes.Decrypt(nonce, ciphertext, tag, plaintext);
-            return plaintext;
+            return AesGcmEncryption.Decrypt(
+                new AesGcmPayload(
+                    Base64Url.Decode(envelope.Nonce),
+                    Base64Url.Decode(envelope.Tag),
+                    Base64Url.Decode(envelope.Ciphertext)),
+                key);
         }
         catch (CryptographicException ex)
         {
-            CryptographicOperations.ZeroMemory(plaintext);
             throw new CryptographicException("Encrypted secret could not be decrypted.", ex);
         }
     }
@@ -298,22 +278,6 @@ public static class MediaSecretEnvelopeProtector
         {
             throw new ArgumentException("Encrypted secret key identifier is required.", nameof(keyId));
         }
-    }
-
-    private static string Base64UrlEncode(byte[] value)
-    {
-        return Convert.ToBase64String(value)
-            .TrimEnd('=')
-            .Replace('+', '-')
-            .Replace('/', '_');
-    }
-
-    private static byte[] Base64UrlDecode(string value)
-    {
-        string base64 = value.Replace('-', '+').Replace('_', '/');
-        int padding = (4 - base64.Length % 4) % 4;
-        base64 = base64.PadRight(base64.Length + padding, '=');
-        return Convert.FromBase64String(base64);
     }
 
     private static bool HasStringProperty(JsonElement element, string propertyName, string expectedValue)

--- a/src/Foundry.Core/Services/Autopilot/MediaSecretEnvelopeProtector.cs
+++ b/src/Foundry.Core/Services/Autopilot/MediaSecretEnvelopeProtector.cs
@@ -30,6 +30,11 @@ public static class MediaSecretEnvelopeProtector
     public const string KeyId = "media";
 
     /// <summary>
+    /// Logical key identifier for Deploy-only secrets.
+    /// </summary>
+    public const string DeploymentKeyId = "deployment";
+
+    /// <summary>
     /// Required AES-256 media secret key length.
     /// </summary>
     public const int KeySizeBytes = 32;
@@ -63,11 +68,19 @@ public static class MediaSecretEnvelopeProtector
     /// <returns>Encrypted secret envelope safe to serialize into generated configuration.</returns>
     public static SecretEnvelope EncryptString(string plaintext, byte[] key)
     {
+        return EncryptString(plaintext, key, KeyId);
+    }
+
+    /// <summary>
+    /// Encrypts a UTF-8 string with an explicit logical key identifier.
+    /// </summary>
+    public static SecretEnvelope EncryptString(string plaintext, byte[] key, string keyId)
+    {
         ArgumentNullException.ThrowIfNull(plaintext);
         byte[] plaintextBytes = Encoding.UTF8.GetBytes(plaintext);
         try
         {
-            return EncryptBytes(plaintextBytes, key);
+            return EncryptBytes(plaintextBytes, key, keyId);
         }
         finally
         {
@@ -83,7 +96,15 @@ public static class MediaSecretEnvelopeProtector
     /// <returns>Decrypted string value.</returns>
     public static string DecryptString(SecretEnvelope envelope, byte[] key)
     {
-        byte[] plaintextBytes = DecryptBytes(envelope, key);
+        return DecryptString(envelope, key, KeyId);
+    }
+
+    /// <summary>
+    /// Decrypts a UTF-8 string with an explicit logical key identifier.
+    /// </summary>
+    public static string DecryptString(SecretEnvelope envelope, byte[] key, string keyId)
+    {
+        byte[] plaintextBytes = DecryptBytes(envelope, key, keyId);
         try
         {
             return Encoding.UTF8.GetString(plaintextBytes);
@@ -102,8 +123,17 @@ public static class MediaSecretEnvelopeProtector
     /// <returns>Encrypted secret envelope safe to serialize into generated configuration.</returns>
     public static SecretEnvelope EncryptBytes(byte[] plaintext, byte[] key)
     {
+        return EncryptBytes(plaintext, key, KeyId);
+    }
+
+    /// <summary>
+    /// Encrypts binary secret material with an explicit logical key identifier.
+    /// </summary>
+    public static SecretEnvelope EncryptBytes(byte[] plaintext, byte[] key, string keyId)
+    {
         ArgumentNullException.ThrowIfNull(plaintext);
         ValidateKey(key);
+        ValidateKeyId(keyId);
 
         byte[] nonce = new byte[NonceSizeBytes];
         byte[] tag = new byte[TagSizeBytes];
@@ -117,7 +147,7 @@ public static class MediaSecretEnvelopeProtector
         {
             Kind = Kind,
             Algorithm = Algorithm,
-            KeyId = KeyId,
+            KeyId = keyId,
             Nonce = Base64UrlEncode(nonce),
             Tag = Base64UrlEncode(tag),
             Ciphertext = Base64UrlEncode(ciphertext)
@@ -132,8 +162,17 @@ public static class MediaSecretEnvelopeProtector
     /// <returns>Decrypted bytes. The caller is responsible for zeroing the returned buffer.</returns>
     public static byte[] DecryptBytes(SecretEnvelope envelope, byte[] key)
     {
+        return DecryptBytes(envelope, key, KeyId);
+    }
+
+    /// <summary>
+    /// Decrypts binary secret material with an explicit logical key identifier.
+    /// </summary>
+    public static byte[] DecryptBytes(SecretEnvelope envelope, byte[] key, string keyId)
+    {
         ArgumentNullException.ThrowIfNull(envelope);
-        ValidateEnvelope(envelope);
+        ValidateKeyId(keyId);
+        ValidateEnvelope(envelope, keyId);
         ValidateKey(key);
 
         byte[] nonce = Base64UrlDecode(envelope.Nonce);
@@ -227,11 +266,11 @@ public static class MediaSecretEnvelopeProtector
         return false;
     }
 
-    private static void ValidateEnvelope(SecretEnvelope envelope)
+    private static void ValidateEnvelope(SecretEnvelope envelope, string keyId)
     {
         if (!string.Equals(envelope.Kind, Kind, StringComparison.Ordinal) ||
             !string.Equals(envelope.Algorithm, Algorithm, StringComparison.Ordinal) ||
-            !string.Equals(envelope.KeyId, KeyId, StringComparison.Ordinal))
+            !string.Equals(envelope.KeyId, keyId, StringComparison.Ordinal))
         {
             throw new CryptographicException("Encrypted secret envelope is not supported.");
         }
@@ -250,6 +289,14 @@ public static class MediaSecretEnvelopeProtector
         if (key.Length != KeySizeBytes)
         {
             throw new ArgumentException($"Media secret key must be {KeySizeBytes} bytes.", nameof(key));
+        }
+    }
+
+    private static void ValidateKeyId(string keyId)
+    {
+        if (string.IsNullOrWhiteSpace(keyId))
+        {
+            throw new ArgumentException("Encrypted secret key identifier is required.", nameof(keyId));
         }
     }
 

--- a/src/Foundry.Core/Services/Configuration/ConfigurationNavigationTargetResolver.cs
+++ b/src/Foundry.Core/Services/Configuration/ConfigurationNavigationTargetResolver.cs
@@ -46,7 +46,11 @@ public static class ConfigurationNavigationTargetResolver
         _ => ConfigurationNavigationTarget.AutopilotJsonProfile
     };
 
-    public static ConfigurationNavigationTarget ResolveDeployFailure(AutopilotProvisioningMode mode) =>
-        ResolveAutopilot(mode);
+    public static ConfigurationNavigationTarget ResolveDeployFailure(
+        AutopilotProvisioningMode mode,
+        bool deploymentProtectionRequiresAttention = false) =>
+        deploymentProtectionRequiresAttention
+            ? ConfigurationNavigationTarget.General
+            : ResolveAutopilot(mode);
 
 }

--- a/src/Foundry.Core/Services/Configuration/ConnectSecretEnvelopeProtector.cs
+++ b/src/Foundry.Core/Services/Configuration/ConnectSecretEnvelopeProtector.cs
@@ -9,13 +9,6 @@ namespace Foundry.Core.Services.Configuration;
 
 internal static class ConnectSecretEnvelopeProtector
 {
-    public const string Kind = MediaSecretEnvelopeProtector.Kind;
-    public const string Algorithm = MediaSecretEnvelopeProtector.Algorithm;
-    public const string KeyId = MediaSecretEnvelopeProtector.KeyId;
-    public const int KeySizeBytes = MediaSecretEnvelopeProtector.KeySizeBytes;
-    public const int NonceSizeBytes = MediaSecretEnvelopeProtector.NonceSizeBytes;
-    public const int TagSizeBytes = MediaSecretEnvelopeProtector.TagSizeBytes;
-
     public static byte[] GenerateMediaKey()
     {
         return MediaSecretEnvelopeProtector.GenerateMediaKey();

--- a/src/Foundry.Core/Services/Configuration/DeployConfigurationGenerator.cs
+++ b/src/Foundry.Core/Services/Configuration/DeployConfigurationGenerator.cs
@@ -25,11 +25,11 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
     /// Generates the reduced Foundry.Deploy runtime configuration and embeds encrypted media-only secrets when required.
     /// </summary>
     /// <param name="document">User-facing Foundry configuration.</param>
-    /// <param name="mediaSecretsKey">Media secret key used to encrypt boot-media-only secrets.</param>
+    /// <param name="deploymentSecretsKey">Deploy secret key used to encrypt boot-media-only secrets.</param>
     /// <returns>Reduced Foundry.Deploy configuration document.</returns>
-    public FoundryDeployConfigurationDocument Generate(FoundryConfigurationDocument document, byte[]? mediaSecretsKey)
+    public FoundryDeployConfigurationDocument Generate(FoundryConfigurationDocument document, byte[]? deploymentSecretsKey)
     {
-        return Generate(document, mediaSecretsKey, protectionSettings: null);
+        return Generate(document, deploymentSecretsKey, protectionSettings: null);
     }
 
     /// <summary>
@@ -123,7 +123,7 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
 
     private static DeployAutopilotHardwareHashUploadSettings CreateDeployHardwareHashUploadSettings(
         AutopilotSettings autopilot,
-        byte[]? mediaSecretsKey)
+        byte[]? deploymentSecretsKey)
     {
         if (!autopilot.IsEnabled ||
             autopilot.ProvisioningMode != AutopilotProvisioningMode.HardwareHashUpload)
@@ -139,11 +139,11 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
 
         SecretEnvelope? pfxSecret = null;
         SecretEnvelope? pfxPasswordSecret = null;
-        if (mediaSecretsKey is not null)
+        if (deploymentSecretsKey is not null)
         {
-            if (mediaSecretsKey.Length == 0)
+            if (deploymentSecretsKey.Length == 0)
             {
-                throw new InvalidOperationException("Autopilot hardware hash upload media generation requires a media secret key.");
+                throw new InvalidOperationException("Autopilot hardware hash upload media generation requires a Deploy secret key.");
             }
 
             AutopilotBootMediaCertificateSettings bootMediaCertificate = settings.BootMediaCertificate;
@@ -163,7 +163,7 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
             {
                 pfxSecret = MediaSecretEnvelopeProtector.EncryptBytes(
                     pfxBytes,
-                    mediaSecretsKey,
+                    deploymentSecretsKey,
                     MediaSecretEnvelopeProtector.DeploymentKeyId);
             }
             finally
@@ -173,7 +173,7 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
 
             pfxPasswordSecret = MediaSecretEnvelopeProtector.EncryptString(
                 bootMediaCertificate.PfxPassword,
-                mediaSecretsKey,
+                deploymentSecretsKey,
                 MediaSecretEnvelopeProtector.DeploymentKeyId);
         }
 

--- a/src/Foundry.Core/Services/Configuration/DeployConfigurationGenerator.cs
+++ b/src/Foundry.Core/Services/Configuration/DeployConfigurationGenerator.cs
@@ -161,7 +161,10 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
             byte[] pfxBytes = File.ReadAllBytes(bootMediaCertificate.PfxPath);
             try
             {
-                pfxSecret = MediaSecretEnvelopeProtector.EncryptBytes(pfxBytes, mediaSecretsKey);
+                pfxSecret = MediaSecretEnvelopeProtector.EncryptBytes(
+                    pfxBytes,
+                    mediaSecretsKey,
+                    MediaSecretEnvelopeProtector.DeploymentKeyId);
             }
             finally
             {
@@ -170,7 +173,8 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
 
             pfxPasswordSecret = MediaSecretEnvelopeProtector.EncryptString(
                 bootMediaCertificate.PfxPassword,
-                mediaSecretsKey);
+                mediaSecretsKey,
+                MediaSecretEnvelopeProtector.DeploymentKeyId);
         }
 
         return new DeployAutopilotHardwareHashUploadSettings

--- a/src/Foundry.Core/Services/Configuration/DeployConfigurationGenerator.cs
+++ b/src/Foundry.Core/Services/Configuration/DeployConfigurationGenerator.cs
@@ -18,7 +18,7 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
     /// <inheritdoc />
     public FoundryDeployConfigurationDocument Generate(FoundryConfigurationDocument document)
     {
-        return Generate(document, mediaSecretsKey: null);
+        return Generate(document, deploymentSecretsKey: null, protectionSettings: null);
     }
 
     /// <summary>
@@ -29,11 +29,27 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
     /// <returns>Reduced Foundry.Deploy configuration document.</returns>
     public FoundryDeployConfigurationDocument Generate(FoundryConfigurationDocument document, byte[]? mediaSecretsKey)
     {
+        return Generate(document, mediaSecretsKey, protectionSettings: null);
+    }
+
+    /// <summary>
+    /// Generates the reduced Foundry.Deploy runtime configuration with Deploy secrets and protection metadata.
+    /// </summary>
+    /// <param name="document">User-facing Foundry configuration.</param>
+    /// <param name="deploymentSecretsKey">Deploy secret key used to encrypt boot-media-only Deploy secrets.</param>
+    /// <param name="protectionSettings">Deployment media password-protection metadata.</param>
+    /// <returns>Reduced Foundry.Deploy configuration document.</returns>
+    public FoundryDeployConfigurationDocument Generate(
+        FoundryConfigurationDocument document,
+        byte[]? deploymentSecretsKey,
+        DeployProtectionSettings? protectionSettings)
+    {
         ArgumentNullException.ThrowIfNull(document);
         AutopilotConfigurationValidator.ThrowIfNotReady(document.Autopilot, DateTimeOffset.UtcNow);
 
         return new FoundryDeployConfigurationDocument
         {
+            Protection = protectionSettings ?? new DeployProtectionSettings(),
             Completion = new DeployCompletionSettings
             {
                 AutomaticRebootEnabled = document.General.AutomaticRebootEnabled,
@@ -92,7 +108,7 @@ public sealed class DeployConfigurationGenerator : IDeployConfigurationGenerator
                     : null,
                 HardwareHashUpload = CreateDeployHardwareHashUploadSettings(
                     document.Autopilot,
-                    mediaSecretsKey)
+                    deploymentSecretsKey)
             },
             Telemetry = document.Telemetry
         };

--- a/src/Foundry.Core/Services/Configuration/DeploymentProtectionPasswordRules.cs
+++ b/src/Foundry.Core/Services/Configuration/DeploymentProtectionPasswordRules.cs
@@ -9,13 +9,13 @@ public static class DeploymentProtectionPasswordRules
     public const int MinimumLength = 8;
     public const int RecommendedLength = 12;
 
-    public static bool IsValid(string? password)
+    public static bool IsValid(ReadOnlySpan<char> password)
     {
-        return password?.Length >= MinimumLength;
+        return password.Length >= MinimumLength;
     }
 
-    public static bool ShouldRecommendStrongerPassword(string? password)
+    public static bool ShouldRecommendStrongerPassword(ReadOnlySpan<char> password)
     {
-        return IsValid(password) && password!.Length < RecommendedLength;
+        return IsValid(password) && password.Length < RecommendedLength;
     }
 }

--- a/src/Foundry.Core/Services/Configuration/DeploymentProtectionPasswordRules.cs
+++ b/src/Foundry.Core/Services/Configuration/DeploymentProtectionPasswordRules.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Core.Services.Configuration;
+
+public static class DeploymentProtectionPasswordRules
+{
+    public const int MinimumLength = 8;
+    public const int RecommendedLength = 12;
+
+    public static bool IsValid(string? password)
+    {
+        return password?.Length >= MinimumLength;
+    }
+
+    public static bool ShouldRecommendStrongerPassword(string? password)
+    {
+        return IsValid(password) && password!.Length < RecommendedLength;
+    }
+}

--- a/src/Foundry.Core/Services/Configuration/DeploymentProtectionSecretState.cs
+++ b/src/Foundry.Core/Services/Configuration/DeploymentProtectionSecretState.cs
@@ -21,12 +21,12 @@ public sealed class DeploymentProtectionSecretState : IDisposable
     public bool HasConfirmation => confirmation is { Length: > 0 };
 
     public bool IsValid =>
-        password is { Length: >= DeploymentProtectionPasswordRules.MinimumLength } &&
+        DeploymentProtectionPasswordRules.IsValid(password) &&
         confirmation is not null &&
         password.AsSpan().SequenceEqual(confirmation);
 
     public bool ShouldRecommendStrongerPassword =>
-        IsValid && password!.Length < DeploymentProtectionPasswordRules.RecommendedLength;
+        IsValid && DeploymentProtectionPasswordRules.ShouldRecommendStrongerPassword(password);
 
     public void SetPassword(ReadOnlySpan<char> value)
     {

--- a/src/Foundry.Core/Services/Configuration/DeploymentProtectionSecretState.cs
+++ b/src/Foundry.Core/Services/Configuration/DeploymentProtectionSecretState.cs
@@ -40,6 +40,18 @@ public sealed class DeploymentProtectionSecretState : IDisposable
         Replace(ref confirmation, value);
     }
 
+    public char[] GetPasswordCopy()
+    {
+        ObjectDisposedException.ThrowIf(isDisposed, this);
+        return password?.ToArray() ?? [];
+    }
+
+    public char[] GetConfirmationCopy()
+    {
+        ObjectDisposedException.ThrowIf(isDisposed, this);
+        return confirmation?.ToArray() ?? [];
+    }
+
     public char[] GetConfirmedPasswordCopy()
     {
         ObjectDisposedException.ThrowIf(isDisposed, this);

--- a/src/Foundry.Core/Services/Configuration/DeploymentProtectionSecretState.cs
+++ b/src/Foundry.Core/Services/Configuration/DeploymentProtectionSecretState.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace Foundry.Core.Services.Configuration;
+
+/// <summary>
+/// Owns deployment media password values for the current Foundry OSD process only.
+/// </summary>
+public sealed class DeploymentProtectionSecretState : IDisposable
+{
+    private char[]? password;
+    private char[]? confirmation;
+    private bool isDisposed;
+
+    public bool HasPassword => password is { Length: > 0 };
+
+    public bool HasConfirmation => confirmation is { Length: > 0 };
+
+    public bool IsValid =>
+        password is { Length: >= DeploymentProtectionPasswordRules.MinimumLength } &&
+        confirmation is not null &&
+        password.AsSpan().SequenceEqual(confirmation);
+
+    public bool ShouldRecommendStrongerPassword =>
+        IsValid && password!.Length < DeploymentProtectionPasswordRules.RecommendedLength;
+
+    public void SetPassword(ReadOnlySpan<char> value)
+    {
+        ObjectDisposedException.ThrowIf(isDisposed, this);
+        Replace(ref password, value);
+    }
+
+    public void SetConfirmation(ReadOnlySpan<char> value)
+    {
+        ObjectDisposedException.ThrowIf(isDisposed, this);
+        Replace(ref confirmation, value);
+    }
+
+    public char[] GetConfirmedPasswordCopy()
+    {
+        ObjectDisposedException.ThrowIf(isDisposed, this);
+        if (!IsValid)
+        {
+            throw new InvalidOperationException("A valid confirmed deployment media password is not available.");
+        }
+
+        return password!.ToArray();
+    }
+
+    public void Clear()
+    {
+        ClearBuffer(ref password);
+        ClearBuffer(ref confirmation);
+    }
+
+    public void Dispose()
+    {
+        if (isDisposed)
+        {
+            return;
+        }
+
+        Clear();
+        isDisposed = true;
+    }
+
+    private static void Replace(ref char[]? target, ReadOnlySpan<char> value)
+    {
+        ClearBuffer(ref target);
+        target = value.IsEmpty ? null : value.ToArray();
+    }
+
+    private static void ClearBuffer(ref char[]? value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(value.AsSpan()));
+        value = null;
+    }
+}

--- a/src/Foundry.Core/Services/Configuration/IDeployConfigurationGenerator.cs
+++ b/src/Foundry.Core/Services/Configuration/IDeployConfigurationGenerator.cs
@@ -28,6 +28,18 @@ public interface IDeployConfigurationGenerator
     FoundryDeployConfigurationDocument Generate(FoundryConfigurationDocument document, byte[]? mediaSecretsKey);
 
     /// <summary>
+    /// Generates the deployment runtime configuration with Deploy secret key and protection metadata.
+    /// </summary>
+    /// <param name="document">The Foundry configuration document.</param>
+    /// <param name="deploymentSecretsKey">Optional Deploy secret key used for generated boot media secrets.</param>
+    /// <param name="protectionSettings">Deployment media protection metadata.</param>
+    /// <returns>The deployment runtime configuration.</returns>
+    FoundryDeployConfigurationDocument Generate(
+        FoundryConfigurationDocument document,
+        byte[]? deploymentSecretsKey,
+        DeployProtectionSettings? protectionSettings);
+
+    /// <summary>
     /// Serializes a deployment runtime configuration document to JSON.
     /// </summary>
     /// <param name="document">The deployment runtime document.</param>

--- a/src/Foundry.Core/Services/Configuration/IDeployConfigurationGenerator.cs
+++ b/src/Foundry.Core/Services/Configuration/IDeployConfigurationGenerator.cs
@@ -23,9 +23,9 @@ public interface IDeployConfigurationGenerator
     /// Generates the deployment runtime configuration and encrypts media-only secrets when a media key is provided.
     /// </summary>
     /// <param name="document">The Foundry configuration document.</param>
-    /// <param name="mediaSecretsKey">Optional media secret key used for generated boot media secrets.</param>
+    /// <param name="deploymentSecretsKey">Optional Deploy secret key used for generated boot media secrets.</param>
     /// <returns>The deployment runtime configuration.</returns>
-    FoundryDeployConfigurationDocument Generate(FoundryConfigurationDocument document, byte[]? mediaSecretsKey);
+    FoundryDeployConfigurationDocument Generate(FoundryConfigurationDocument document, byte[]? deploymentSecretsKey);
 
     /// <summary>
     /// Generates the deployment runtime configuration with Deploy secret key and protection metadata.

--- a/src/Foundry.Core/Services/Telemetry/BootMediaTelemetryPropertyBuilder.cs
+++ b/src/Foundry.Core/Services/Telemetry/BootMediaTelemetryPropertyBuilder.cs
@@ -73,6 +73,7 @@ public static class BootMediaTelemetryPropertyBuilder
             ["boot_media_deploy_runtime_payload_source"] = deployRuntimePayloadSource,
             ["autopilot_enabled"] = options.IsAutopilotEnabled,
             ["autopilot_provisioning_mode"] = ResolveAutopilotProvisioningMode(options),
+            ["deployment_protection_enabled"] = document.General.DeploymentProtection.IsEnabled,
             ["deployment_reboot_mode"] = rebootPolicy.Mode
         };
 

--- a/src/Foundry.Core/Services/WinPe/DeploymentMediaProtectionMaterial.cs
+++ b/src/Foundry.Core/Services/WinPe/DeploymentMediaProtectionMaterial.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using Foundry.Core.Models.Configuration.Deploy;
+
+namespace Foundry.Core.Services.WinPe;
+
+/// <summary>
+/// Owns generated Deploy key material for one media creation operation.
+/// </summary>
+public sealed class DeploymentMediaProtectionMaterial : IDisposable
+{
+    internal DeploymentMediaProtectionMaterial(byte[] deploymentKey, DeployProtectionSettings settings)
+    {
+        DeploymentKey = deploymentKey;
+        Settings = settings;
+    }
+
+    public byte[] DeploymentKey { get; }
+
+    public DeployProtectionSettings Settings { get; }
+
+    public void Dispose()
+    {
+        CryptographicOperations.ZeroMemory(DeploymentKey);
+    }
+}

--- a/src/Foundry.Core/Services/WinPe/DeploymentMediaProtectionService.cs
+++ b/src/Foundry.Core/Services/WinPe/DeploymentMediaProtectionService.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Models.Configuration.Deploy;
+using Foundry.Utilities.Security;
+
+namespace Foundry.Core.Services.WinPe;
+
+/// <summary>
+/// Creates per-media Deploy keys and optional password-wrapping metadata.
+/// </summary>
+public static class DeploymentMediaProtectionService
+{
+    public const string KeyDerivationAlgorithm = "pbkdf2-sha256";
+    public const string EnvelopeKind = "encrypted";
+    public const string EnvelopeAlgorithm = "aes-gcm-v1";
+    public const string PasswordDerivedKeyId = "deployment-password";
+
+    public static DeploymentMediaProtectionMaterial CreateProtected(ReadOnlySpan<char> password)
+    {
+        if (password.Length < Configuration.DeploymentProtectionPasswordRules.MinimumLength)
+        {
+            throw new ArgumentException(
+                $"The deployment media password must contain at least {Configuration.DeploymentProtectionPasswordRules.MinimumLength} characters.",
+                nameof(password));
+        }
+
+        byte[] salt = PasswordKeyDerivation.GenerateSalt();
+        byte[] derivedKey = PasswordKeyDerivation.DeriveKey(
+            password,
+            salt,
+            PasswordKeyDerivation.DefaultIterations,
+            AesGcmEncryption.KeySizeBytes);
+        byte[] deploymentKey = AesGcmEncryption.GenerateKey();
+
+        try
+        {
+            AesGcmPayload payload = AesGcmEncryption.Encrypt(deploymentKey, derivedKey);
+            var envelope = new SecretEnvelope
+            {
+                Kind = EnvelopeKind,
+                Algorithm = EnvelopeAlgorithm,
+                KeyId = PasswordDerivedKeyId,
+                Nonce = Base64Url.Encode(payload.Nonce),
+                Tag = Base64Url.Encode(payload.Tag),
+                Ciphertext = Base64Url.Encode(payload.Ciphertext)
+            };
+            var settings = new DeployProtectionSettings
+            {
+                IsEnabled = true,
+                KeyDerivationAlgorithm = KeyDerivationAlgorithm,
+                Iterations = PasswordKeyDerivation.DefaultIterations,
+                Salt = Base64Url.Encode(salt),
+                ProtectedDeploymentKey = envelope
+            };
+
+            return new DeploymentMediaProtectionMaterial(deploymentKey, settings);
+        }
+        catch
+        {
+            CryptographicOperations.ZeroMemory(deploymentKey);
+            throw;
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(derivedKey);
+            CryptographicOperations.ZeroMemory(salt);
+        }
+    }
+
+    public static DeploymentMediaProtectionMaterial CreateUnprotected()
+    {
+        return new DeploymentMediaProtectionMaterial(
+            AesGcmEncryption.GenerateKey(),
+            new DeployProtectionSettings());
+    }
+}

--- a/src/Foundry.Core/Services/WinPe/DeploymentMediaProtectionService.cs
+++ b/src/Foundry.Core/Services/WinPe/DeploymentMediaProtectionService.cs
@@ -21,7 +21,7 @@ public static class DeploymentMediaProtectionService
 
     public static DeploymentMediaProtectionMaterial CreateProtected(ReadOnlySpan<char> password)
     {
-        if (password.Length < Configuration.DeploymentProtectionPasswordRules.MinimumLength)
+        if (!Configuration.DeploymentProtectionPasswordRules.IsValid(password))
         {
             throw new ArgumentException(
                 $"The deployment media password must contain at least {Configuration.DeploymentProtectionPasswordRules.MinimumLength} characters.",

--- a/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningOptions.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningOptions.cs
@@ -16,7 +16,9 @@ public sealed record WinPeMountedImageAssetProvisioningOptions
     public string IanaWindowsTimeZoneMapJson { get; init; } = string.Empty;
     public string FoundryConnectConfigurationJson { get; init; } = string.Empty;
     public string DeployConfigurationJson { get; init; } = string.Empty;
-    public byte[]? MediaSecretsKey { get; init; }
+    public byte[]? NetworkSecretsKey { get; init; }
+    public byte[]? DeploymentSecretsKey { get; init; }
+    public bool IsDeploymentProtectionEnabled { get; init; }
     public IReadOnlyList<FoundryConnectProvisionedAssetFile> FoundryConnectAssetFiles { get; init; } = [];
 
     /// <summary>

--- a/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Foundry.Core.Models.Configuration;
@@ -128,11 +129,16 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
             Utf8NoBom,
             cancellationToken).ConfigureAwait(false);
 
-        await WriteMediaSecretsKeyAsync(
+        await WriteNetworkSecretsKeyAsync(
             foundryConfigPath,
             connectConfigurationJson,
-            deployConfigurationJson,
-            options.MediaSecretsKey,
+            options.NetworkSecretsKey,
+            cancellationToken).ConfigureAwait(false);
+
+        await WriteDeploymentSecretsKeyAsync(
+            foundryConfigPath,
+            options.DeploymentSecretsKey,
+            options.IsDeploymentProtectionEnabled,
             cancellationToken).ConfigureAwait(false);
 
         await File.WriteAllTextAsync(
@@ -163,20 +169,18 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
         }
         else
         {
-            await WriteAutopilotProfilesAsync(foundryConfigPath, options.AutopilotProfiles, cancellationToken).ConfigureAwait(false);
+            await WriteAutopilotProfilesAsync(foundryConfigPath, options, cancellationToken).ConfigureAwait(false);
         }
     }
 
-    private static async Task WriteMediaSecretsKeyAsync(
+    private static async Task WriteNetworkSecretsKeyAsync(
         string foundryConfigPath,
         string connectConfigurationJson,
-        string deployConfigurationJson,
-        byte[]? mediaSecretsKey,
+        byte[]? networkSecretsKey,
         CancellationToken cancellationToken)
     {
-        bool hasEncryptedSecrets = MediaSecretEnvelopeProtector.HasEncryptedSecrets(connectConfigurationJson) ||
-                                   MediaSecretEnvelopeProtector.HasEncryptedSecrets(deployConfigurationJson);
-        if (mediaSecretsKey is null || mediaSecretsKey.Length == 0)
+        bool hasEncryptedSecrets = MediaSecretEnvelopeProtector.HasEncryptedSecrets(connectConfigurationJson);
+        if (networkSecretsKey is null || networkSecretsKey.Length == 0)
         {
             if (hasEncryptedSecrets)
             {
@@ -191,7 +195,7 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
             throw new ArgumentException("A media secret key must not be provisioned without encrypted Foundry media secrets.");
         }
 
-        if (mediaSecretsKey.Length != 32)
+        if (networkSecretsKey.Length != 32)
         {
             throw new ArgumentException("Media secret key must be 32 bytes.");
         }
@@ -200,7 +204,41 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
         Directory.CreateDirectory(secretsPath);
         await File.WriteAllBytesAsync(
             Path.Combine(secretsPath, "media-secrets.key"),
-            mediaSecretsKey,
+            networkSecretsKey,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task WriteDeploymentSecretsKeyAsync(
+        string foundryConfigPath,
+        byte[]? deploymentSecretsKey,
+        bool isDeploymentProtectionEnabled,
+        CancellationToken cancellationToken)
+    {
+        if (deploymentSecretsKey is null || deploymentSecretsKey.Length == 0)
+        {
+            if (isDeploymentProtectionEnabled)
+            {
+                throw new ArgumentException("Protected deployment media requires a Deploy secret key during provisioning.");
+            }
+
+            return;
+        }
+
+        if (deploymentSecretsKey.Length != 32)
+        {
+            throw new ArgumentException("Deploy secret key must be 32 bytes.");
+        }
+
+        if (isDeploymentProtectionEnabled)
+        {
+            return;
+        }
+
+        string secretsPath = Path.Combine(foundryConfigPath, "Secrets");
+        Directory.CreateDirectory(secretsPath);
+        await File.WriteAllBytesAsync(
+            Path.Combine(secretsPath, "deployment-secrets.key"),
+            deploymentSecretsKey,
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -285,22 +323,55 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
 
     private static async Task WriteAutopilotProfilesAsync(
         string foundryConfigPath,
-        IReadOnlyList<AutopilotProfileSettings> autopilotProfiles,
+        WinPeMountedImageAssetProvisioningOptions options,
         CancellationToken cancellationToken)
     {
-        foreach (AutopilotProfileSettings profile in autopilotProfiles)
+        foreach (AutopilotProfileSettings profile in options.AutopilotProfiles)
         {
             if (string.IsNullOrWhiteSpace(profile.FolderName))
             {
                 throw new ArgumentException("Autopilot profile folder name is required.");
             }
 
-            string profilePath = ResolveSafeRelativePath(
-                foundryConfigPath,
-                Path.Combine("Autopilot", profile.FolderName, "AutopilotConfigurationFile.json"));
+            if (options.IsDeploymentProtectionEnabled)
+            {
+                if (options.DeploymentSecretsKey is not { Length: 32 })
+                {
+                    throw new ArgumentException("Protected Autopilot profiles require a 32-byte Deploy secret key.");
+                }
 
-            Directory.CreateDirectory(Path.GetDirectoryName(profilePath)!);
-            await File.WriteAllTextAsync(profilePath, profile.JsonContent, Utf8NoBom, cancellationToken).ConfigureAwait(false);
+                string encryptedProfilePath = ResolveSafeRelativePath(
+                    foundryConfigPath,
+                    Path.Combine("Autopilot", profile.FolderName, "AutopilotConfigurationFile.json.encrypted"));
+                byte[] plaintext = Utf8NoBom.GetBytes(profile.JsonContent);
+                try
+                {
+                    SecretEnvelope envelope = MediaSecretEnvelopeProtector.EncryptBytes(
+                        plaintext,
+                        options.DeploymentSecretsKey,
+                        MediaSecretEnvelopeProtector.DeploymentKeyId);
+                    string envelopeJson = JsonSerializer.Serialize(envelope, ConfigurationJsonDefaults.SerializerOptions);
+                    Directory.CreateDirectory(Path.GetDirectoryName(encryptedProfilePath)!);
+                    await File.WriteAllTextAsync(
+                        encryptedProfilePath,
+                        envelopeJson,
+                        Utf8NoBom,
+                        cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(plaintext);
+                }
+            }
+            else
+            {
+                string profilePath = ResolveSafeRelativePath(
+                    foundryConfigPath,
+                    Path.Combine("Autopilot", profile.FolderName, "AutopilotConfigurationFile.json"));
+
+                Directory.CreateDirectory(Path.GetDirectoryName(profilePath)!);
+                await File.WriteAllTextAsync(profilePath, profile.JsonContent, Utf8NoBom, cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 

--- a/src/Foundry.Deploy.Tests/AutopilotHardwareHashUploadServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/AutopilotHardwareHashUploadServiceTests.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Foundry.Deploy.Models.Configuration;
 using Foundry.Deploy.Services.Autopilot;
+using Foundry.Deploy.Services.Security;
 using Foundry.Deploy.Services.Deployment;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -149,7 +150,7 @@ public sealed class AutopilotHardwareHashUploadServiceTests
         {
             Kind = DeployMediaSecretEnvelopeProtector.Kind,
             Algorithm = DeployMediaSecretEnvelopeProtector.Algorithm,
-            KeyId = DeployMediaSecretEnvelopeProtector.KeyId,
+            KeyId = DeployMediaSecretEnvelopeProtector.DeploymentKeyId,
             Nonce = Base64UrlEncode(nonce),
             Tag = Base64UrlEncode(tag),
             Ciphertext = Base64UrlEncode(ciphertext)
@@ -164,7 +165,7 @@ public sealed class AutopilotHardwareHashUploadServiceTests
             .Replace('/', '_');
     }
 
-    private sealed class StaticMediaSecretKeyReader(byte[]? key = null) : IMediaSecretKeyReader
+    private sealed class StaticMediaSecretKeyReader(byte[]? key = null) : IDeploymentSecretKeyProvider
     {
         public Task<byte[]> ReadAsync(string workspaceRootPath, CancellationToken cancellationToken = default)
         {

--- a/src/Foundry.Deploy.Tests/AutopilotProfileCatalogServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/AutopilotProfileCatalogServiceTests.cs
@@ -12,6 +12,27 @@ namespace Foundry.Deploy.Tests;
 public sealed class AutopilotProfileCatalogServiceTests
 {
     [Fact]
+    public void LoadAvailableProfiles_WhenPlaintextProfileExists_PreservesLegacyDiscovery()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"foundry-profile-catalog-{Guid.NewGuid():N}");
+        string profileRoot = Path.Combine(root, "Legacy");
+        Directory.CreateDirectory(profileRoot);
+        string path = Path.Combine(profileRoot, "AutopilotConfigurationFile.json");
+        File.WriteAllText(path, "plaintext");
+        var service = new AutopilotProfileCatalogService(
+            new FakeContentService("""{"Comment_File":"Legacy devices"}"""),
+            NullLogger<AutopilotProfileCatalogService>.Instance,
+            root);
+
+        AutopilotProfileCatalogItem profile = Assert.Single(service.LoadAvailableProfiles());
+
+        Assert.False(profile.IsProtected);
+        Assert.Equal("Legacy devices", profile.DisplayName);
+        Assert.Equal(path, profile.ConfigurationFilePath);
+        Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
     public void LoadAvailableProfiles_WhenEncryptedProfileExists_UsesDecryptedDisplayName()
     {
         string root = Path.Combine(Path.GetTempPath(), $"foundry-profile-catalog-{Guid.NewGuid():N}");

--- a/src/Foundry.Deploy.Tests/AutopilotProfileCatalogServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/AutopilotProfileCatalogServiceTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+using Foundry.Deploy.Models;
+using Foundry.Deploy.Services.Autopilot;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class AutopilotProfileCatalogServiceTests
+{
+    [Fact]
+    public void LoadAvailableProfiles_WhenEncryptedProfileExists_UsesDecryptedDisplayName()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"foundry-profile-catalog-{Guid.NewGuid():N}");
+        string profileRoot = Path.Combine(root, "Corporate");
+        Directory.CreateDirectory(profileRoot);
+        string path = Path.Combine(profileRoot, "AutopilotConfigurationFile.json.encrypted");
+        File.WriteAllText(path, "encrypted");
+        var service = new AutopilotProfileCatalogService(
+            new FakeContentService("""{"Comment_File":"Corporate devices"}"""),
+            NullLogger<AutopilotProfileCatalogService>.Instance,
+            root);
+
+        IReadOnlyList<AutopilotProfileCatalogItem> profiles = service.LoadAvailableProfiles();
+
+        AutopilotProfileCatalogItem profile = Assert.Single(profiles);
+        Assert.True(profile.IsProtected);
+        Assert.Equal("Corporate devices", profile.DisplayName);
+        Assert.Equal(path, profile.ConfigurationFilePath);
+        Directory.Delete(root, recursive: true);
+    }
+
+    private sealed class FakeContentService(string json) : IAutopilotProfileContentService
+    {
+        public Task<byte[]> ReadAsync(AutopilotProfileCatalogItem profile, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Encoding.UTF8.GetBytes(json));
+        }
+    }
+}

--- a/src/Foundry.Deploy.Tests/AutopilotProfileContentServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/AutopilotProfileContentServiceTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Foundry.Core.Services.Autopilot;
+using Foundry.Deploy.Models;
+using Foundry.Deploy.Services.Autopilot;
+using Foundry.Deploy.Services.Security;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class AutopilotProfileContentServiceTests
+{
+    [Fact]
+    public async Task ReadAsync_WhenProfileIsProtected_DecryptsWithUnlockedSessionKey()
+    {
+        string root = CreateTempDirectory();
+        byte[] key = RandomNumberGenerator.GetBytes(32);
+        using var session = new DeploymentSecretKeySession();
+        session.SetKey(key);
+        const string json = """{"Comment_File":"Corporate"}""";
+        Foundry.Core.Models.Configuration.SecretEnvelope envelope = MediaSecretEnvelopeProtector.EncryptString(
+            json,
+            key,
+            MediaSecretEnvelopeProtector.DeploymentKeyId);
+        string path = Path.Combine(root, "AutopilotConfigurationFile.json.encrypted");
+        await File.WriteAllTextAsync(path, JsonSerializer.Serialize(envelope), TestContext.Current.CancellationToken);
+        var service = new AutopilotProfileContentService(session);
+
+        byte[] content = await service.ReadAsync(
+            new AutopilotProfileCatalogItem
+            {
+                FolderName = "Corporate",
+                DisplayName = "Corporate",
+                ConfigurationFilePath = path,
+                IsProtected = true
+            },
+            TestContext.Current.CancellationToken);
+
+        try
+        {
+            Assert.Equal(json, Encoding.UTF8.GetString(content));
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(content);
+            CryptographicOperations.ZeroMemory(key);
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ReadAsync_WhenProtectedProfileIsTampered_ReturnsSanitizedFailure()
+    {
+        string root = CreateTempDirectory();
+        string path = Path.Combine(root, "AutopilotConfigurationFile.json.encrypted");
+        await File.WriteAllTextAsync(path, """{"ciphertext":"secret-value"}""", TestContext.Current.CancellationToken);
+        using var session = new DeploymentSecretKeySession();
+        session.SetKey(RandomNumberGenerator.GetBytes(32));
+        var service = new AutopilotProfileContentService(session);
+
+        InvalidDataException exception = await Assert.ThrowsAsync<InvalidDataException>(() => service.ReadAsync(
+            new AutopilotProfileCatalogItem
+            {
+                FolderName = "Corporate",
+                DisplayName = "Corporate",
+                ConfigurationFilePath = path,
+                IsProtected = true
+            },
+            TestContext.Current.CancellationToken));
+
+        Assert.DoesNotContain("secret-value", exception.ToString(), StringComparison.Ordinal);
+        Directory.Delete(root, recursive: true);
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"foundry-profile-content-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/src/Foundry.Deploy.Tests/AutopilotProfileContentServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/AutopilotProfileContentServiceTests.cs
@@ -15,6 +15,51 @@ namespace Foundry.Deploy.Tests;
 public sealed class AutopilotProfileContentServiceTests
 {
     [Fact]
+    public async Task ReadAsync_WhenProfileIsPlaintext_ReturnsFileContentWithoutUnlockedSession()
+    {
+        string root = CreateTempDirectory();
+        string path = Path.Combine(root, "AutopilotConfigurationFile.json");
+        const string json = """{"Comment_File":"Legacy"}""";
+        await File.WriteAllTextAsync(path, json, TestContext.Current.CancellationToken);
+        using var session = new DeploymentSecretKeySession();
+        var service = new AutopilotProfileContentService(session);
+
+        byte[] content = await service.ReadAsync(new AutopilotProfileCatalogItem
+        {
+            FolderName = "Legacy",
+            DisplayName = "Legacy",
+            ConfigurationFilePath = path
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(json, Encoding.UTF8.GetString(content));
+        CryptographicOperations.ZeroMemory(content);
+        Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
+    public async Task ReadAsync_WhenProtectedProfileSessionIsLocked_ReturnsSanitizedFailure()
+    {
+        string root = CreateTempDirectory();
+        string path = Path.Combine(root, "AutopilotConfigurationFile.json.encrypted");
+        await File.WriteAllTextAsync(path, "encrypted", TestContext.Current.CancellationToken);
+        using var session = new DeploymentSecretKeySession();
+        var service = new AutopilotProfileContentService(session);
+
+        InvalidDataException exception = await Assert.ThrowsAsync<InvalidDataException>(() => service.ReadAsync(
+            new AutopilotProfileCatalogItem
+            {
+                FolderName = "Corporate",
+                DisplayName = "Corporate",
+                ConfigurationFilePath = path,
+                IsProtected = true
+            },
+            TestContext.Current.CancellationToken));
+
+        Assert.Equal("Protected Autopilot profile could not be read.", exception.Message);
+        Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
     public async Task ReadAsync_WhenProfileIsProtected_DecryptsWithUnlockedSessionKey()
     {
         string root = CreateTempDirectory();

--- a/src/Foundry.Deploy.Tests/DeployConfigurationModelTests.cs
+++ b/src/Foundry.Deploy.Tests/DeployConfigurationModelTests.cs
@@ -11,6 +11,50 @@ namespace Foundry.Deploy.Tests;
 public sealed class DeployConfigurationModelTests
 {
     [Fact]
+    public void Deserialize_WhenProtectionIsMissing_DefaultsToDisabled()
+    {
+        FoundryDeployConfigurationDocument? document = JsonSerializer.Deserialize<FoundryDeployConfigurationDocument>(
+            """{ "schemaVersion": 11 }""");
+
+        Assert.NotNull(document);
+        Assert.False(document.Protection.IsEnabled);
+    }
+
+    [Fact]
+    public void Deserialize_WhenProtectionIsConfigured_PreservesPasswordWrappingMetadata()
+    {
+        const string json = """
+            {
+              "schemaVersion": 11,
+              "protection": {
+                "isEnabled": true,
+                "keyDerivationAlgorithm": "pbkdf2-sha256",
+                "iterations": 600000,
+                "salt": "c2FsdA",
+                "protectedDeploymentKey": {
+                  "kind": "encrypted",
+                  "algorithm": "aes-gcm-v1",
+                  "keyId": "deployment-password",
+                  "nonce": "bm9uY2U",
+                  "tag": "dGFn",
+                  "ciphertext": "Y2lwaGVydGV4dA"
+                }
+              }
+            }
+            """;
+
+        FoundryDeployConfigurationDocument? document = JsonSerializer.Deserialize<FoundryDeployConfigurationDocument>(
+            json,
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+        Assert.NotNull(document);
+        Assert.True(document.Protection.IsEnabled);
+        Assert.Equal("pbkdf2-sha256", document.Protection.KeyDerivationAlgorithm);
+        Assert.Equal(600000, document.Protection.Iterations);
+        Assert.Equal("deployment-password", document.Protection.ProtectedDeploymentKey.KeyId);
+    }
+
+    [Fact]
     public void Deserialize_WhenWindowsOptionalFeaturesAreConfigured_PreservesActions()
     {
         const string json = """

--- a/src/Foundry.Deploy.Tests/DeployMediaSecretEnvelopeProtectorTests.cs
+++ b/src/Foundry.Deploy.Tests/DeployMediaSecretEnvelopeProtectorTests.cs
@@ -25,7 +25,7 @@ public sealed class DeployMediaSecretEnvelopeProtectorTests
     }
 
     [Fact]
-    public void DecryptString_WhenEnvelopeIsTampered_ThrowsWithoutLeakingSecret()
+    public void DecryptDeployChars_WhenEnvelopeIsTampered_ThrowsWithoutLeakingSecret()
     {
         byte[] key = RandomNumberGenerator.GetBytes(DeployMediaSecretEnvelopeProtector.KeySizeBytes);
         const string secret = "PfxPassword-DoNotLeak";
@@ -35,10 +35,22 @@ public sealed class DeployMediaSecretEnvelopeProtectorTests
         };
 
         CryptographicException exception = Assert.Throws<CryptographicException>(
-            () => DeployMediaSecretEnvelopeProtector.DecryptString(envelope, key));
+            () => DeployMediaSecretEnvelopeProtector.DecryptDeployChars(envelope, key));
 
         Assert.DoesNotContain(secret, exception.ToString(), StringComparison.Ordinal);
         Assert.DoesNotContain(Convert.ToBase64String(Encoding.UTF8.GetBytes(secret)), exception.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DecryptDeployChars_ReturnsClearableCharacterBuffer()
+    {
+        byte[] key = RandomNumberGenerator.GetBytes(DeployMediaSecretEnvelopeProtector.KeySizeBytes);
+        SecretEnvelope envelope = Encrypt(Encoding.UTF8.GetBytes("PfxPassword"), key);
+
+        char[] decrypted = DeployMediaSecretEnvelopeProtector.DecryptDeployChars(envelope, key);
+
+        Assert.Equal("PfxPassword", new string(decrypted));
+        Assert.IsType<char[]>(decrypted);
     }
 
     private static SecretEnvelope Encrypt(byte[] plaintext, byte[] key)

--- a/src/Foundry.Deploy.Tests/DeploymentAccessGateTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentAccessGateTests.cs
@@ -77,6 +77,28 @@ public sealed class DeploymentAccessGateTests
     }
 
     [Fact]
+    public async Task AuthorizeAsync_WhenConfigurationIsMissingButEncryptedProfileRemains_DeniesAccess()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"foundry-access-gate-{Guid.NewGuid():N}");
+        string configurationPath = Path.Combine(root, "Config", "foundry.deploy.config.json");
+        string profilePath = Path.Combine(root, "Config", "Autopilot", "Profile", "AutopilotConfigurationFile.json.encrypted");
+        Directory.CreateDirectory(Path.GetDirectoryName(profilePath)!);
+        await File.WriteAllTextAsync(profilePath, "encrypted", TestContext.Current.CancellationToken);
+        var dialog = new FakePasswordDialogService("unused");
+        var gate = new DeploymentAccessGate(
+            new FakeConfigurationService(document: null, exists: false, configurationPath: configurationPath),
+            new FakeUnlockService(),
+            dialog,
+            new ImmediateRetryDelay());
+
+        bool authorized = await gate.AuthorizeAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(authorized);
+        Assert.Equal(0, dialog.PromptCount);
+        Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
     public async Task AuthorizeAsync_WhenPasswordFails_AllowsRetryUntilSuccessful()
     {
         var dialog = new FakePasswordDialogService("wrong", "correct");

--- a/src/Foundry.Deploy.Tests/DeploymentAccessGateTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentAccessGateTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Deploy.Models.Configuration;
+using Foundry.Deploy.Services.Configuration;
+using Foundry.Deploy.Services.Security;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class DeploymentAccessGateTests
+{
+    [Fact]
+    public async Task AuthorizeAsync_WhenProtectionIsDisabled_DoesNotPrompt()
+    {
+        var dialog = new FakePasswordDialogService();
+        var gate = new DeploymentAccessGate(
+            new FakeConfigurationService(new FoundryDeployConfigurationDocument()),
+            new FakeUnlockService(),
+            dialog,
+            new ImmediateRetryDelay());
+
+        bool authorized = await gate.AuthorizeAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(authorized);
+        Assert.Equal(0, dialog.PromptCount);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenPasswordFails_AllowsRetryUntilSuccessful()
+    {
+        var dialog = new FakePasswordDialogService("wrong", "correct");
+        var unlock = new FakeUnlockService("correct");
+        var gate = new DeploymentAccessGate(
+            new FakeConfigurationService(new FoundryDeployConfigurationDocument
+            {
+                Protection = new DeployProtectionSettings { IsEnabled = true }
+            }),
+            unlock,
+            dialog,
+            new ImmediateRetryDelay());
+
+        bool authorized = await gate.AuthorizeAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(authorized);
+        Assert.Equal(2, dialog.PromptCount);
+        Assert.Equal([false, true], dialog.PreviousAttemptFailedValues);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenPromptIsCancelled_DeniesAccess()
+    {
+        var gate = new DeploymentAccessGate(
+            new FakeConfigurationService(new FoundryDeployConfigurationDocument
+            {
+                Protection = new DeployProtectionSettings { IsEnabled = true }
+            }),
+            new FakeUnlockService(),
+            new FakePasswordDialogService(),
+            new ImmediateRetryDelay());
+
+        bool authorized = await gate.AuthorizeAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(authorized);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenExistingConfigurationCannotBeParsed_DeniesAccess()
+    {
+        var gate = new DeploymentAccessGate(
+            new FakeConfigurationService(document: null, exists: true),
+            new FakeUnlockService(),
+            new FakePasswordDialogService("unused"),
+            new ImmediateRetryDelay());
+
+        bool authorized = await gate.AuthorizeAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(authorized);
+    }
+
+    private sealed class FakeConfigurationService(
+        FoundryDeployConfigurationDocument? document,
+        bool exists = true) : IDeployConfigurationService
+    {
+        public DeployConfigurationLoadResult LoadOptional() => new() { Exists = exists, Document = document };
+    }
+
+    private sealed class FakeUnlockService(string acceptedPassword = "") : IDeploymentProtectionUnlockService
+    {
+        public bool TryUnlock(DeployProtectionSettings settings, ReadOnlySpan<char> password)
+        {
+            return password.SequenceEqual(acceptedPassword);
+        }
+    }
+
+    private sealed class FakePasswordDialogService(params string[] passwords) : IDeploymentPasswordDialogService
+    {
+        private readonly Queue<string> remainingPasswords = new(passwords);
+
+        public int PromptCount { get; private set; }
+
+        public List<bool> PreviousAttemptFailedValues { get; } = [];
+
+        public DeploymentPasswordPromptResult Prompt(bool previousAttemptFailed)
+        {
+            PromptCount++;
+            PreviousAttemptFailedValues.Add(previousAttemptFailed);
+            return remainingPasswords.Count == 0
+                ? DeploymentPasswordPromptResult.Cancelled()
+                : DeploymentPasswordPromptResult.Submitted(remainingPasswords.Dequeue().AsSpan());
+        }
+    }
+
+    private sealed class ImmediateRetryDelay : IDeploymentAccessRetryDelay
+    {
+        public Task WaitAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/Foundry.Deploy.Tests/DeploymentAccessGateTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentAccessGateTests.cs
@@ -10,6 +10,15 @@ namespace Foundry.Deploy.Tests;
 
 public sealed class DeploymentAccessGateTests
 {
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(6, 5)]
+    public void RetryDelay_IsProgressiveAndCapped(int failedAttemptNumber, int expectedSeconds)
+    {
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), DeploymentAccessRetryDelay.GetDelay(failedAttemptNumber));
+    }
+
     [Fact]
     public async Task AuthorizeAsync_WhenProtectionIsDisabled_DoesNotPrompt()
     {
@@ -31,6 +40,7 @@ public sealed class DeploymentAccessGateTests
     {
         var dialog = new FakePasswordDialogService("wrong", "correct");
         var unlock = new FakeUnlockService("correct");
+        var retryDelay = new ImmediateRetryDelay();
         var gate = new DeploymentAccessGate(
             new FakeConfigurationService(new FoundryDeployConfigurationDocument
             {
@@ -38,13 +48,14 @@ public sealed class DeploymentAccessGateTests
             }),
             unlock,
             dialog,
-            new ImmediateRetryDelay());
+            retryDelay);
 
         bool authorized = await gate.AuthorizeAsync(TestContext.Current.CancellationToken);
 
         Assert.True(authorized);
         Assert.Equal(2, dialog.PromptCount);
         Assert.Equal([false, true], dialog.PreviousAttemptFailedValues);
+        Assert.Equal([1], retryDelay.Attempts);
     }
 
     [Fact]
@@ -113,6 +124,12 @@ public sealed class DeploymentAccessGateTests
 
     private sealed class ImmediateRetryDelay : IDeploymentAccessRetryDelay
     {
-        public Task WaitAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public List<int> Attempts { get; } = [];
+
+        public Task WaitAsync(int failedAttemptNumber, CancellationToken cancellationToken)
+        {
+            Attempts.Add(failedAttemptNumber);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Foundry.Deploy.Tests/DeploymentAccessGateTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentAccessGateTests.cs
@@ -36,6 +36,47 @@ public sealed class DeploymentAccessGateTests
     }
 
     [Fact]
+    public async Task AuthorizeAsync_WhenEnabledFlagIsClearedButWrappedKeyRemains_StillPrompts()
+    {
+        var dialog = new FakePasswordDialogService("correct");
+        var gate = new DeploymentAccessGate(
+            new FakeConfigurationService(new FoundryDeployConfigurationDocument
+            {
+                Protection = CreateWrappedProtection(isEnabled: false)
+            }),
+            new FakeUnlockService("correct"),
+            dialog,
+            new ImmediateRetryDelay());
+
+        bool authorized = await gate.AuthorizeAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(authorized);
+        Assert.Equal(1, dialog.PromptCount);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenEncryptedProfileRemainsWithoutProtectionMetadata_DeniesAccess()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"foundry-access-gate-{Guid.NewGuid():N}");
+        string configurationPath = Path.Combine(root, "Config", "foundry.deploy.config.json");
+        string profilePath = Path.Combine(root, "Config", "Autopilot", "Profile", "AutopilotConfigurationFile.json.encrypted");
+        Directory.CreateDirectory(Path.GetDirectoryName(profilePath)!);
+        await File.WriteAllTextAsync(profilePath, "encrypted", TestContext.Current.CancellationToken);
+        var dialog = new FakePasswordDialogService("unused");
+        var gate = new DeploymentAccessGate(
+            new FakeConfigurationService(new FoundryDeployConfigurationDocument(), configurationPath: configurationPath),
+            new FakeUnlockService(),
+            dialog,
+            new ImmediateRetryDelay());
+
+        bool authorized = await gate.AuthorizeAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(authorized);
+        Assert.Equal(0, dialog.PromptCount);
+        Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
     public async Task AuthorizeAsync_WhenPasswordFails_AllowsRetryUntilSuccessful()
     {
         var dialog = new FakePasswordDialogService("wrong", "correct");
@@ -91,10 +132,33 @@ public sealed class DeploymentAccessGateTests
 
     private sealed class FakeConfigurationService(
         FoundryDeployConfigurationDocument? document,
-        bool exists = true) : IDeployConfigurationService
+        bool exists = true,
+        string configurationPath = "") : IDeployConfigurationService
     {
-        public DeployConfigurationLoadResult LoadOptional() => new() { Exists = exists, Document = document };
+        public DeployConfigurationLoadResult LoadOptional() => new()
+        {
+            ConfigurationPath = configurationPath,
+            Exists = exists,
+            Document = document
+        };
     }
+
+    private static DeployProtectionSettings CreateWrappedProtection(bool isEnabled) => new()
+    {
+        IsEnabled = isEnabled,
+        KeyDerivationAlgorithm = "pbkdf2-sha256",
+        Iterations = 600_000,
+        Salt = "salt",
+        ProtectedDeploymentKey = new SecretEnvelope
+        {
+            Kind = "encrypted",
+            Algorithm = "aes-gcm-v1",
+            KeyId = "deployment-password",
+            Nonce = "nonce",
+            Tag = "tag",
+            Ciphertext = "ciphertext"
+        }
+    };
 
     private sealed class FakeUnlockService(string acceptedPassword = "") : IDeploymentProtectionUnlockService
     {

--- a/src/Foundry.Deploy.Tests/DeploymentExecutionServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentExecutionServiceTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Deploy.Models;
+using Foundry.Deploy.Models.Configuration;
+using Foundry.Deploy.Services.Configuration;
+using Foundry.Deploy.Services.Deployment;
+using Foundry.Deploy.Services.Security;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class DeploymentExecutionServiceTests
+{
+    [Fact]
+    public async Task ExecuteAsync_WhenProtectedSessionIsLocked_DoesNotRunOrchestrator()
+    {
+        var orchestrator = new RecordingOrchestrator();
+        using var session = new DeploymentSecretKeySession();
+        var service = new DeploymentExecutionService(
+            orchestrator,
+            new FakeConfigurationService(isProtected: true),
+            session,
+            NullLogger<DeploymentExecutionService>.Instance);
+
+        DeploymentExecutionRunResult result = await service.ExecuteAsync(CreateContext());
+
+        Assert.False(result.IsSuccess);
+        Assert.False(orchestrator.WasRun);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenProtectionIsDisabled_RunsOrchestrator()
+    {
+        var orchestrator = new RecordingOrchestrator();
+        using var session = new DeploymentSecretKeySession();
+        var service = new DeploymentExecutionService(
+            orchestrator,
+            new FakeConfigurationService(isProtected: false),
+            session,
+            NullLogger<DeploymentExecutionService>.Instance);
+
+        DeploymentExecutionRunResult result = await service.ExecuteAsync(CreateContext());
+
+        Assert.True(result.IsSuccess);
+        Assert.True(orchestrator.WasRun);
+    }
+
+    private static DeploymentContext CreateContext() => new()
+    {
+        Mode = DeploymentMode.Iso,
+        CacheRootPath = "X:\\Cache",
+        TargetDiskNumber = 1,
+        TargetComputerName = "TEST-PC",
+        OperatingSystem = new OperatingSystemCatalogItem(),
+        DriverPackSelectionKind = DriverPackSelectionKind.None
+    };
+
+    private sealed class FakeConfigurationService(bool isProtected) : IDeployConfigurationService
+    {
+        public DeployConfigurationLoadResult LoadOptional() => new()
+        {
+            Exists = true,
+            Document = new FoundryDeployConfigurationDocument
+            {
+                Protection = new DeployProtectionSettings { IsEnabled = isProtected }
+            }
+        };
+    }
+
+    private sealed class RecordingOrchestrator : IDeploymentOrchestrator
+    {
+        public IReadOnlyList<string> PlannedSteps => [];
+
+        public event EventHandler<DeploymentStepProgress>? StepProgressChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public bool WasRun { get; private set; }
+
+        public Task<DeploymentResult> RunAsync(DeploymentContext context, CancellationToken cancellationToken = default)
+        {
+            WasRun = true;
+            return Task.FromResult(new DeploymentResult
+            {
+                IsSuccess = true,
+                Message = "Completed"
+            });
+        }
+    }
+}

--- a/src/Foundry.Deploy.Tests/DeploymentExecutionServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentExecutionServiceTests.cs
@@ -47,6 +47,23 @@ public sealed class DeploymentExecutionServiceTests
         Assert.True(orchestrator.WasRun);
     }
 
+    [Fact]
+    public async Task ExecuteAsync_WhenEnabledFlagIsClearedButWrappedKeyRemains_DoesNotRunOrchestrator()
+    {
+        var orchestrator = new RecordingOrchestrator();
+        using var session = new DeploymentSecretKeySession();
+        var service = new DeploymentExecutionService(
+            orchestrator,
+            new FakeConfigurationService(isProtected: false, hasWrappedKey: true),
+            session,
+            NullLogger<DeploymentExecutionService>.Instance);
+
+        DeploymentExecutionRunResult result = await service.ExecuteAsync(CreateContext());
+
+        Assert.False(result.IsSuccess);
+        Assert.False(orchestrator.WasRun);
+    }
+
     private static DeploymentContext CreateContext() => new()
     {
         Mode = DeploymentMode.Iso,
@@ -57,14 +74,21 @@ public sealed class DeploymentExecutionServiceTests
         DriverPackSelectionKind = DriverPackSelectionKind.None
     };
 
-    private sealed class FakeConfigurationService(bool isProtected) : IDeployConfigurationService
+    private sealed class FakeConfigurationService(bool isProtected, bool hasWrappedKey = false) : IDeployConfigurationService
     {
         public DeployConfigurationLoadResult LoadOptional() => new()
         {
+            ConfigurationPath = string.Empty,
             Exists = true,
             Document = new FoundryDeployConfigurationDocument
             {
-                Protection = new DeployProtectionSettings { IsEnabled = isProtected }
+                Protection = new DeployProtectionSettings
+                {
+                    IsEnabled = isProtected,
+                    ProtectedDeploymentKey = hasWrappedKey
+                        ? new SecretEnvelope { Ciphertext = "wrapped" }
+                        : new SecretEnvelope()
+                }
             }
         };
     }

--- a/src/Foundry.Deploy.Tests/DeploymentLaunchPreparationServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentLaunchPreparationServiceTests.cs
@@ -353,5 +353,9 @@ public sealed class DeploymentLaunchPreparationServiceTests
             LastConfirmationMessage = message;
             return ConfirmationResult;
         }
+
+        public void Shutdown()
+        {
+        }
     }
 }

--- a/src/Foundry.Deploy.Tests/DeploymentProtectionUnlockServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentProtectionUnlockServiceTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using Foundry.Core.Services.WinPe;
+using Foundry.Deploy.Models.Configuration;
+using Foundry.Deploy.Services.Security;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class DeploymentProtectionUnlockServiceTests
+{
+    [Fact]
+    public void TryUnlock_WithCorrectPassword_PopulatesSessionWithDeploymentKey()
+    {
+        using DeploymentMediaProtectionMaterial material = DeploymentMediaProtectionService.CreateProtected("correct horse battery staple");
+        using var session = new DeploymentSecretKeySession();
+        var service = new DeploymentProtectionUnlockService(session);
+
+        bool unlocked = service.TryUnlock(Map(material.Settings), "correct horse battery staple");
+
+        Assert.True(unlocked);
+        Assert.True(session.IsUnlocked);
+        byte[] key = session.GetKeyCopy();
+        try
+        {
+            Assert.Equal(material.DeploymentKey, key);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(key);
+        }
+    }
+
+    [Fact]
+    public void TryUnlock_WithWrongPassword_DoesNotPopulateSession()
+    {
+        using DeploymentMediaProtectionMaterial material = DeploymentMediaProtectionService.CreateProtected("correct horse battery staple");
+        using var session = new DeploymentSecretKeySession();
+        var service = new DeploymentProtectionUnlockService(session);
+
+        bool unlocked = service.TryUnlock(Map(material.Settings), "incorrect password");
+
+        Assert.False(unlocked);
+        Assert.False(session.IsUnlocked);
+    }
+
+    [Fact]
+    public void TryUnlock_WithTamperedEnvelope_DoesNotExposeCryptographicFailure()
+    {
+        using DeploymentMediaProtectionMaterial material = DeploymentMediaProtectionService.CreateProtected("correct horse battery staple");
+        DeployProtectionSettings settings = Map(material.Settings) with
+        {
+            ProtectedDeploymentKey = Map(material.Settings).ProtectedDeploymentKey with { Ciphertext = "AAAA" }
+        };
+        using var session = new DeploymentSecretKeySession();
+        var service = new DeploymentProtectionUnlockService(session);
+
+        bool unlocked = service.TryUnlock(settings, "correct horse battery staple");
+
+        Assert.False(unlocked);
+        Assert.False(session.IsUnlocked);
+    }
+
+    [Fact]
+    public void Session_ClonesAndClearsOwnedKeyMaterial()
+    {
+        byte[] source = RandomNumberGenerator.GetBytes(32);
+        byte[] expected = source.ToArray();
+        using var session = new DeploymentSecretKeySession();
+
+        session.SetKey(source);
+        CryptographicOperations.ZeroMemory(source);
+        byte[] copy = session.GetKeyCopy();
+
+        Assert.Equal(expected, copy);
+        session.Clear();
+        Assert.False(session.IsUnlocked);
+        Assert.Throws<InvalidOperationException>(() => session.GetKeyCopy());
+
+        CryptographicOperations.ZeroMemory(copy);
+        CryptographicOperations.ZeroMemory(expected);
+    }
+
+    private static DeployProtectionSettings Map(Foundry.Core.Models.Configuration.Deploy.DeployProtectionSettings settings)
+    {
+        Foundry.Core.Models.Configuration.SecretEnvelope sourceEnvelope =
+            settings.ProtectedDeploymentKey ?? throw new InvalidOperationException("Protected deployment key is required.");
+
+        return new DeployProtectionSettings
+        {
+            IsEnabled = settings.IsEnabled,
+            KeyDerivationAlgorithm = settings.KeyDerivationAlgorithm ?? string.Empty,
+            Iterations = settings.Iterations,
+            Salt = settings.Salt ?? string.Empty,
+            ProtectedDeploymentKey = new SecretEnvelope
+            {
+                Kind = sourceEnvelope.Kind,
+                Algorithm = sourceEnvelope.Algorithm,
+                KeyId = sourceEnvelope.KeyId,
+                Nonce = sourceEnvelope.Nonce,
+                Tag = sourceEnvelope.Tag,
+                Ciphertext = sourceEnvelope.Ciphertext
+            }
+        };
+    }
+}

--- a/src/Foundry.Deploy.Tests/DeploymentProtectionUnlockServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentProtectionUnlockServiceTests.cs
@@ -47,6 +47,20 @@ public sealed class DeploymentProtectionUnlockServiceTests
     }
 
     [Fact]
+    public void TryUnlock_WhenEnabledFlagIsClearedButMetadataRemains_StillValidatesPassword()
+    {
+        using DeploymentMediaProtectionMaterial material = DeploymentMediaProtectionService.CreateProtected("correct horse battery staple");
+        DeployProtectionSettings settings = Map(material.Settings) with { IsEnabled = false };
+        using var session = new DeploymentSecretKeySession();
+        var service = new DeploymentProtectionUnlockService(session);
+
+        bool unlocked = service.TryUnlock(settings, "correct horse battery staple");
+
+        Assert.True(unlocked);
+        Assert.True(session.IsUnlocked);
+    }
+
+    [Fact]
     public void TryUnlock_WithTamperedEnvelope_DoesNotExposeCryptographicFailure()
     {
         using DeploymentMediaProtectionMaterial material = DeploymentMediaProtectionService.CreateProtected("correct horse battery staple");

--- a/src/Foundry.Deploy.Tests/DeploymentSecretKeyProviderTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentSecretKeyProviderTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using Foundry.Deploy.Models.Configuration;
+using Foundry.Deploy.Services.Autopilot;
+using Foundry.Deploy.Services.Configuration;
+using Foundry.Deploy.Services.Security;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class DeploymentSecretKeyProviderTests
+{
+    [Fact]
+    public async Task ReadAsync_WhenProtectionIsEnabled_ReturnsUnlockedSessionKey()
+    {
+        string root = CreateWorkspace();
+        byte[] expected = RandomNumberGenerator.GetBytes(32);
+        using var session = new DeploymentSecretKeySession();
+        session.SetKey(expected);
+        var provider = new DeploymentSecretKeyProvider(
+            new FakeConfigurationService(isProtected: true),
+            session);
+
+        byte[] actual = await provider.ReadAsync(root, TestContext.Current.CancellationToken);
+
+        Assert.Equal(expected, actual);
+        CryptographicOperations.ZeroMemory(expected);
+        CryptographicOperations.ZeroMemory(actual);
+        Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
+    public async Task ReadAsync_WhenUnprotectedDeploymentKeyExists_ReturnsDeploymentKey()
+    {
+        string root = CreateWorkspace();
+        byte[] expected = RandomNumberGenerator.GetBytes(32);
+        string keyPath = Path.Combine(root, "Config", "Secrets", "deployment-secrets.key");
+        Directory.CreateDirectory(Path.GetDirectoryName(keyPath)!);
+        await File.WriteAllBytesAsync(keyPath, expected, TestContext.Current.CancellationToken);
+        using var session = new DeploymentSecretKeySession();
+        var provider = new DeploymentSecretKeyProvider(
+            new FakeConfigurationService(isProtected: false),
+            session);
+
+        byte[] actual = await provider.ReadAsync(root, TestContext.Current.CancellationToken);
+
+        Assert.Equal(expected, actual);
+        CryptographicOperations.ZeroMemory(expected);
+        CryptographicOperations.ZeroMemory(actual);
+        Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
+    public async Task ReadAsync_WhenLegacyMediaHasOnlyMediaKey_ReturnsLegacyKey()
+    {
+        string root = CreateWorkspace();
+        byte[] expected = RandomNumberGenerator.GetBytes(32);
+        string keyPath = Path.Combine(root, "Config", "Secrets", "media-secrets.key");
+        Directory.CreateDirectory(Path.GetDirectoryName(keyPath)!);
+        await File.WriteAllBytesAsync(keyPath, expected, TestContext.Current.CancellationToken);
+        using var session = new DeploymentSecretKeySession();
+        var provider = new DeploymentSecretKeyProvider(
+            new FakeConfigurationService(isProtected: false),
+            session);
+
+        byte[] actual = await provider.ReadAsync(root, TestContext.Current.CancellationToken);
+
+        Assert.Equal(expected, actual);
+        CryptographicOperations.ZeroMemory(expected);
+        CryptographicOperations.ZeroMemory(actual);
+        Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
+    public async Task ReadAsync_WhenProtectionIsEnabledButSessionIsLocked_DoesNotUseFiles()
+    {
+        string root = CreateWorkspace();
+        string keyPath = Path.Combine(root, "Config", "Secrets", "deployment-secrets.key");
+        Directory.CreateDirectory(Path.GetDirectoryName(keyPath)!);
+        await File.WriteAllBytesAsync(keyPath, RandomNumberGenerator.GetBytes(32), TestContext.Current.CancellationToken);
+        using var session = new DeploymentSecretKeySession();
+        var provider = new DeploymentSecretKeyProvider(
+            new FakeConfigurationService(isProtected: true),
+            session);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => provider.ReadAsync(root, TestContext.Current.CancellationToken));
+
+        Directory.Delete(root, recursive: true);
+    }
+
+    private static string CreateWorkspace()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"foundry-deploy-key-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private sealed class FakeConfigurationService(bool isProtected) : IDeployConfigurationService
+    {
+        public DeployConfigurationLoadResult LoadOptional() => new()
+        {
+            Exists = true,
+            Document = new FoundryDeployConfigurationDocument
+            {
+                Protection = new DeployProtectionSettings { IsEnabled = isProtected }
+            }
+        };
+    }
+}

--- a/src/Foundry.Deploy.Tests/DeploymentSecretKeyProviderTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentSecretKeyProviderTests.cs
@@ -62,7 +62,7 @@ public sealed class DeploymentSecretKeyProviderTests
         await File.WriteAllBytesAsync(keyPath, expected, TestContext.Current.CancellationToken);
         using var session = new DeploymentSecretKeySession();
         var provider = new DeploymentSecretKeyProvider(
-            new FakeConfigurationService(isProtected: false),
+            new FakeConfigurationService(isProtected: false, schemaVersion: 10),
             session);
 
         byte[] actual = await provider.ReadAsync(root, TestContext.Current.CancellationToken);
@@ -91,6 +91,24 @@ public sealed class DeploymentSecretKeyProviderTests
         Directory.Delete(root, recursive: true);
     }
 
+    [Fact]
+    public async Task ReadAsync_WhenEnabledFlagIsClearedButWrappedKeyRemains_DoesNotUseFiles()
+    {
+        string root = CreateWorkspace();
+        string keyPath = Path.Combine(root, "Config", "Secrets", "deployment-secrets.key");
+        Directory.CreateDirectory(Path.GetDirectoryName(keyPath)!);
+        await File.WriteAllBytesAsync(keyPath, RandomNumberGenerator.GetBytes(32), TestContext.Current.CancellationToken);
+        using var session = new DeploymentSecretKeySession();
+        var provider = new DeploymentSecretKeyProvider(
+            new FakeConfigurationService(isProtected: false, hasWrappedKey: true),
+            session);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => provider.ReadAsync(root, TestContext.Current.CancellationToken));
+
+        Directory.Delete(root, recursive: true);
+    }
+
     private static string CreateWorkspace()
     {
         string path = Path.Combine(Path.GetTempPath(), $"foundry-deploy-key-{Guid.NewGuid():N}");
@@ -98,14 +116,24 @@ public sealed class DeploymentSecretKeyProviderTests
         return path;
     }
 
-    private sealed class FakeConfigurationService(bool isProtected) : IDeployConfigurationService
+    private sealed class FakeConfigurationService(
+        bool isProtected,
+        bool hasWrappedKey = false,
+        int schemaVersion = Foundry.Core.Models.Configuration.ConfigurationSchemaVersions.DeployCurrent) : IDeployConfigurationService
     {
         public DeployConfigurationLoadResult LoadOptional() => new()
         {
             Exists = true,
             Document = new FoundryDeployConfigurationDocument
             {
-                Protection = new DeployProtectionSettings { IsEnabled = isProtected }
+                SchemaVersion = schemaVersion,
+                Protection = new DeployProtectionSettings
+                {
+                    IsEnabled = isProtected,
+                    ProtectedDeploymentKey = hasWrappedKey
+                        ? new SecretEnvelope { Ciphertext = "wrapped" }
+                        : new SecretEnvelope()
+                }
             }
         };
     }

--- a/src/Foundry.Deploy.Tests/LocalizationResourceTests.cs
+++ b/src/Foundry.Deploy.Tests/LocalizationResourceTests.cs
@@ -10,6 +10,16 @@ namespace Foundry.Deploy.Tests;
 
 public sealed class LocalizationResourceTests
 {
+    private static readonly string[] DeploymentAccessResourceKeys =
+    [
+        "Common.Cancel",
+        "DeploymentAccess.Title",
+        "DeploymentAccess.Prompt",
+        "DeploymentAccess.PasswordPlaceholder",
+        "DeploymentAccess.Unlock",
+        "DeploymentAccess.InvalidPassword"
+    ];
+
     public static TheoryData<string> SatelliteCultures => new()
     {
         "ar-SA",
@@ -64,5 +74,9 @@ public sealed class LocalizationResourceTests
 
         Assert.NotNull(resourceSet);
         Assert.Equal("Foundry Deploy", resourceSet.GetString("App.Name"));
+        foreach (string key in DeploymentAccessResourceKeys)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(resourceSet.GetString(key)), $"Resource '{key}' is missing for '{cultureName}'.");
+        }
     }
 }

--- a/src/Foundry.Deploy.Tests/LocalizationResourceTests.cs
+++ b/src/Foundry.Deploy.Tests/LocalizationResourceTests.cs
@@ -14,9 +14,11 @@ public sealed class LocalizationResourceTests
     [
         "Common.Cancel",
         "DeploymentAccess.Title",
-        "DeploymentAccess.Prompt",
+        "DeploymentAccess.Heading",
+        "DeploymentAccess.Description",
         "DeploymentAccess.PasswordPlaceholder",
-        "DeploymentAccess.Unlock",
+        "DeploymentAccess.Continue",
+        "DeploymentAccess.TogglePasswordVisibility",
         "DeploymentAccess.InvalidPassword"
     ];
 
@@ -63,7 +65,7 @@ public sealed class LocalizationResourceTests
 
     [Theory]
     [MemberData(nameof(SatelliteCultures))]
-    public void SatelliteResourceSet_IsAvailableForAdkCulture(string cultureName)
+    public void SatelliteResourceSet_IsAvailableForSupportedCulture(string cultureName)
     {
         CultureInfo culture = CultureInfo.GetCultureInfo(cultureName);
 

--- a/src/Foundry.Deploy.Tests/NetworkProfileRoamingArtifactServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/NetworkProfileRoamingArtifactServiceTests.cs
@@ -467,7 +467,7 @@ public sealed class NetworkProfileRoamingArtifactServiceTests
         return Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
     }
 
-    private sealed class FakeMediaSecretKeyReader(byte[] key) : IMediaSecretKeyReader
+    private sealed class FakeMediaSecretKeyReader(byte[] key) : INetworkSecretKeyReader
     {
         public Task<byte[]> ReadAsync(string workspaceRootPath, CancellationToken cancellationToken = default)
         {

--- a/src/Foundry.Deploy.Tests/ProvisionAutopilotStepTests.cs
+++ b/src/Foundry.Deploy.Tests/ProvisionAutopilotStepTests.cs
@@ -11,6 +11,7 @@ using Foundry.Deploy.Services.Hardware;
 using Foundry.Deploy.Services.Logging;
 using Foundry.Deploy.Services.Operations;
 using System.Text.Json;
+using System.Text;
 
 namespace Foundry.Deploy.Tests;
 
@@ -42,6 +43,34 @@ public sealed class ProvisionAutopilotStepTests
         Assert.Equal(expectedPath, context.RuntimeState.StagedAutopilotConfigurationPath);
         Assert.Equal(AutopilotProvisioningMode.JsonProfile, context.RuntimeState.AutopilotProvisioningMode);
         Assert.Equal(AutopilotHardwareHashUploadState.NotPlanned, context.RuntimeState.AutopilotHardwareHashUploadState);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenLiveJsonModeUsesProtectedProfile_WritesOnlyDecryptedTargetContent()
+    {
+        using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
+        string sourceConfigurationPath = Path.Combine(workspace.RootPath, "AutopilotConfigurationFile.json.encrypted");
+        await File.WriteAllTextAsync(sourceConfigurationPath, "encrypted", TestContext.Current.CancellationToken);
+        const string decryptedJson = """{"profile":"protected"}""";
+        ProvisionAutopilotStep step = CreateStep(contentService: new FakeAutopilotProfileContentService(decryptedJson));
+        DeploymentStepExecutionContext context = CreateContext(
+            workspace,
+            isDryRun: false,
+            provisioningMode: AutopilotProvisioningMode.JsonProfile,
+            selectedProfile: new AutopilotProfileCatalogItem
+            {
+                FolderName = "Corporate",
+                DisplayName = "Corporate",
+                ConfigurationFilePath = sourceConfigurationPath,
+                IsProtected = true
+            });
+
+        DeploymentStepResult result = await step.ExecuteAsync(context, TestContext.Current.CancellationToken);
+
+        string targetPath = Path.Combine(workspace.TargetWindowsRootPath, "Windows", "Provisioning", "Autopilot", "AutopilotConfigurationFile.json");
+        Assert.Equal(DeploymentStepState.Succeeded, result.State);
+        Assert.Equal(decryptedJson, await File.ReadAllTextAsync(targetPath, TestContext.Current.CancellationToken));
+        Assert.DoesNotContain("encrypted", await File.ReadAllTextAsync(targetPath, TestContext.Current.CancellationToken), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -313,13 +342,15 @@ public sealed class ProvisionAutopilotStepTests
 
     private static ProvisionAutopilotStep CreateStep(
         IAutopilotHardwareHashCaptureService? captureService = null,
-        IAutopilotHardwareHashUploadService? uploadService = null)
+        IAutopilotHardwareHashUploadService? uploadService = null,
+        IAutopilotProfileContentService? contentService = null)
     {
         return new ProvisionAutopilotStep(
             captureService ?? new FakeAutopilotHardwareHashCaptureService(),
             uploadService ?? new FakeAutopilotHardwareHashUploadService(
                 AutopilotHardwareHashUploadResult.Completed("Device imported.")),
-            new AutopilotInteractiveRegistrationProvisioningService(new SetupCompleteScriptService()));
+            new AutopilotInteractiveRegistrationProvisioningService(new SetupCompleteScriptService()),
+            contentService ?? new FakeAutopilotProfileContentService());
     }
 
     private static DeploymentStepExecutionContext CreateContext(
@@ -456,6 +487,16 @@ public sealed class ProvisionAutopilotStepTests
         {
             Requests.Add(request);
             return Task.FromResult(result);
+        }
+    }
+
+    private sealed class FakeAutopilotProfileContentService(string? content = null) : IAutopilotProfileContentService
+    {
+        public Task<byte[]> ReadAsync(AutopilotProfileCatalogItem profile, CancellationToken cancellationToken = default)
+        {
+            return content is null
+                ? File.ReadAllBytesAsync(profile.ConfigurationFilePath, cancellationToken)
+                : Task.FromResult(Encoding.UTF8.GetBytes(content));
         }
     }
 

--- a/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
@@ -61,6 +61,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IDeployConfigurationService, DeployConfigurationService>();
         services.AddSingleton<IDeploymentSecretKeySession, DeploymentSecretKeySession>();
         services.AddSingleton<IDeploymentProtectionUnlockService, DeploymentProtectionUnlockService>();
+        services.AddSingleton<IDeploymentPasswordDialogService, DeploymentPasswordDialogService>();
+        services.AddSingleton<IDeploymentAccessRetryDelay, DeploymentAccessRetryDelay>();
+        services.AddSingleton<IDeploymentAccessGate, DeploymentAccessGate>();
         services.AddSingleton(CreateTelemetryOptions);
         services.AddSingleton(CreateTelemetryContext);
         services.AddSingleton<ITelemetryService>(sp =>

--- a/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ using Foundry.Deploy.Services.Logging;
 using Foundry.Deploy.Services.Localization;
 using Foundry.Deploy.Services.Operations;
 using Foundry.Deploy.Services.Runtime;
+using Foundry.Deploy.Services.Security;
 using Foundry.Deploy.Services.Startup;
 using Foundry.Deploy.Services.System;
 using Foundry.Deploy.Services.Theme;
@@ -58,6 +59,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IVolumeDiscovery, WindowsVolumeDiscovery>();
         services.AddSingleton<IDeploymentRuntimeContextService, DeploymentRuntimeContextService>();
         services.AddSingleton<IDeployConfigurationService, DeployConfigurationService>();
+        services.AddSingleton<IDeploymentSecretKeySession, DeploymentSecretKeySession>();
+        services.AddSingleton<IDeploymentProtectionUnlockService, DeploymentProtectionUnlockService>();
         services.AddSingleton(CreateTelemetryOptions);
         services.AddSingleton(CreateTelemetryContext);
         services.AddSingleton<ITelemetryService>(sp =>

--- a/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
@@ -60,6 +60,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IDeploymentRuntimeContextService, DeploymentRuntimeContextService>();
         services.AddSingleton<IDeployConfigurationService, DeployConfigurationService>();
         services.AddSingleton<IDeploymentSecretKeySession, DeploymentSecretKeySession>();
+        services.AddSingleton<IDeploymentSecretKeyProvider, DeploymentSecretKeyProvider>();
         services.AddSingleton<IDeploymentProtectionUnlockService, DeploymentProtectionUnlockService>();
         services.AddSingleton<IDeploymentPasswordDialogService, DeploymentPasswordDialogService>();
         services.AddSingleton<IDeploymentAccessRetryDelay, DeploymentAccessRetryDelay>();

--- a/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
@@ -118,6 +118,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IPreOobeScriptProvisioningService, PreOobeScriptProvisioningService>();
         services.AddSingleton<PreOobeScriptDefinitionBuilder>();
         services.AddSingleton<INetworkProfileRoamingArtifactService, NetworkProfileRoamingArtifactService>();
+        services.AddSingleton<IAutopilotProfileContentService, AutopilotProfileContentService>();
         services.AddSingleton<IAutopilotProfileCatalogService, AutopilotProfileCatalogService>();
         services.AddSingleton<IAutopilotHardwareHashCaptureService, AutopilotHardwareHashCaptureService>();
         services.AddSingleton<IAutopilotInteractiveRegistrationProvisioningService, AutopilotInteractiveRegistrationProvisioningService>();

--- a/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
@@ -123,7 +123,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IAutopilotProfileCatalogService, AutopilotProfileCatalogService>();
         services.AddSingleton<IAutopilotHardwareHashCaptureService, AutopilotHardwareHashCaptureService>();
         services.AddSingleton<IAutopilotInteractiveRegistrationProvisioningService, AutopilotInteractiveRegistrationProvisioningService>();
-        services.AddSingleton<IMediaSecretKeyReader, MediaSecretKeyReader>();
+        services.AddSingleton<INetworkSecretKeyReader, NetworkSecretKeyReader>();
         services.AddSingleton<IAutopilotGraphTokenService>(sp =>
             new AutopilotGraphTokenService(
                 new HttpClient(),

--- a/src/Foundry.Deploy/Models/AutopilotProfileCatalogItem.cs
+++ b/src/Foundry.Deploy/Models/AutopilotProfileCatalogItem.cs
@@ -9,4 +9,5 @@ public sealed record AutopilotProfileCatalogItem
     public required string FolderName { get; init; }
     public required string DisplayName { get; init; }
     public required string ConfigurationFilePath { get; init; }
+    public bool IsProtected { get; init; }
 }

--- a/src/Foundry.Deploy/Models/Configuration/DeployProtectionSettings.cs
+++ b/src/Foundry.Deploy/Models/Configuration/DeployProtectionSettings.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Deploy.Models.Configuration;
+
+/// <summary>
+/// Describes optional password protection for deployment media.
+/// </summary>
+public sealed record DeployProtectionSettings
+{
+    public bool IsEnabled { get; init; }
+
+    public string KeyDerivationAlgorithm { get; init; } = string.Empty;
+
+    public int Iterations { get; init; }
+
+    public string Salt { get; init; } = string.Empty;
+
+    public SecretEnvelope ProtectedDeploymentKey { get; init; } = new();
+}

--- a/src/Foundry.Deploy/Models/Configuration/FoundryDeployConfigurationDocument.cs
+++ b/src/Foundry.Deploy/Models/Configuration/FoundryDeployConfigurationDocument.cs
@@ -24,6 +24,11 @@ public sealed record FoundryDeployConfigurationDocument
     public int SchemaVersion { get; init; } = CurrentSchemaVersion;
 
     /// <summary>
+    /// Gets deployment media access-protection settings.
+    /// </summary>
+    public DeployProtectionSettings Protection { get; init; } = new();
+
+    /// <summary>
     /// Gets successful deployment completion behavior.
     /// </summary>
     public DeployCompletionSettings Completion { get; init; } = new();

--- a/src/Foundry.Deploy/Services/ApplicationShell/ApplicationShellService.cs
+++ b/src/Foundry.Deploy/Services/ApplicationShell/ApplicationShellService.cs
@@ -57,6 +57,11 @@ public sealed class ApplicationShellService : IApplicationShellService
         return result == MessageBoxResult.Yes;
     }
 
+    public void Shutdown()
+    {
+        Application.Current?.Shutdown();
+    }
+
     private static Window? ResolveOwnerWindow()
     {
         if (Application.Current?.Windows is null)

--- a/src/Foundry.Deploy/Services/ApplicationShell/IApplicationShellService.cs
+++ b/src/Foundry.Deploy/Services/ApplicationShell/IApplicationShellService.cs
@@ -9,4 +9,6 @@ public interface IApplicationShellService
     void ShowAbout();
 
     bool ConfirmWarning(string title, string message);
+
+    void Shutdown();
 }

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotCertificateCredential.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotCertificateCredential.cs
@@ -12,10 +12,14 @@ namespace Foundry.Deploy.Services.Autopilot;
 /// </summary>
 public static class AutopilotCertificateCredential
 {
-    public static X509Certificate2 Load(byte[] pfxBytes, string password, string expectedThumbprint)
+    public static X509Certificate2 Load(byte[] pfxBytes, ReadOnlySpan<char> password, string expectedThumbprint)
     {
         ArgumentNullException.ThrowIfNull(pfxBytes);
-        ArgumentException.ThrowIfNullOrWhiteSpace(password);
+        if (password.IsEmpty || password.Trim().IsEmpty)
+        {
+            throw new ArgumentException("The PFX password is required.", nameof(password));
+        }
+
         ArgumentException.ThrowIfNullOrWhiteSpace(expectedThumbprint);
 
         try

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotGroupTagDiscoveryService.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotGroupTagDiscoveryService.cs
@@ -4,6 +4,7 @@
 
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Runtime.InteropServices;
 using Foundry.Deploy.Models.Configuration;
 using Foundry.Deploy.Services.Security;
 
@@ -43,12 +44,13 @@ public sealed class AutopilotGroupTagDiscoveryService(
         byte[] deploymentKey = await deploymentSecretKeyProvider.ReadAsync(workspaceRootPath, cancellationToken)
             .ConfigureAwait(false);
         byte[]? pfxBytes = null;
+        char[]? pfxPassword = null;
         try
         {
             pfxBytes = DeployMediaSecretEnvelopeProtector.DecryptDeployBytes(
                 settings.CertificatePfxSecret!,
                 deploymentKey);
-            string pfxPassword = DeployMediaSecretEnvelopeProtector.DecryptDeployString(
+            pfxPassword = DeployMediaSecretEnvelopeProtector.DecryptDeployChars(
                 settings.CertificatePfxPasswordSecret!,
                 deploymentKey);
 
@@ -71,6 +73,11 @@ public sealed class AutopilotGroupTagDiscoveryService(
             if (pfxBytes is not null)
             {
                 CryptographicOperations.ZeroMemory(pfxBytes);
+            }
+
+            if (pfxPassword is not null)
+            {
+                CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(pfxPassword.AsSpan()));
             }
         }
     }

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotGroupTagDiscoveryService.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotGroupTagDiscoveryService.cs
@@ -5,6 +5,7 @@
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Foundry.Deploy.Models.Configuration;
+using Foundry.Deploy.Services.Security;
 
 namespace Foundry.Deploy.Services.Autopilot;
 
@@ -23,11 +24,11 @@ public interface IAutopilotGroupTagDiscoveryService
 /// Uses the media certificate to authenticate to Graph and read current Windows Autopilot group tags.
 /// </summary>
 public sealed class AutopilotGroupTagDiscoveryService(
-    IMediaSecretKeyReader mediaSecretKeyReader,
+    IDeploymentSecretKeyProvider deploymentSecretKeyProvider,
     IAutopilotGraphTokenService tokenService,
     AutopilotGraphImportClient graphImportClient) : IAutopilotGroupTagDiscoveryService
 {
-    private readonly IMediaSecretKeyReader mediaSecretKeyReader = mediaSecretKeyReader;
+    private readonly IDeploymentSecretKeyProvider deploymentSecretKeyProvider = deploymentSecretKeyProvider;
     private readonly IAutopilotGraphTokenService tokenService = tokenService;
     private readonly AutopilotGraphImportClient graphImportClient = graphImportClient;
 
@@ -39,17 +40,17 @@ public sealed class AutopilotGroupTagDiscoveryService(
         ArgumentNullException.ThrowIfNull(settings);
         ValidateSettings(settings);
 
-        byte[] mediaKey = await mediaSecretKeyReader.ReadAsync(workspaceRootPath, cancellationToken)
+        byte[] deploymentKey = await deploymentSecretKeyProvider.ReadAsync(workspaceRootPath, cancellationToken)
             .ConfigureAwait(false);
         byte[]? pfxBytes = null;
         try
         {
-            pfxBytes = DeployMediaSecretEnvelopeProtector.DecryptBytes(
+            pfxBytes = DeployMediaSecretEnvelopeProtector.DecryptDeployBytes(
                 settings.CertificatePfxSecret!,
-                mediaKey);
-            string pfxPassword = DeployMediaSecretEnvelopeProtector.DecryptString(
+                deploymentKey);
+            string pfxPassword = DeployMediaSecretEnvelopeProtector.DecryptDeployString(
                 settings.CertificatePfxPasswordSecret!,
-                mediaKey);
+                deploymentKey);
 
             using X509Certificate2 certificate = AutopilotCertificateCredential.Load(
                 pfxBytes,
@@ -66,7 +67,7 @@ public sealed class AutopilotGroupTagDiscoveryService(
         }
         finally
         {
-            CryptographicOperations.ZeroMemory(mediaKey);
+            CryptographicOperations.ZeroMemory(deploymentKey);
             if (pfxBytes is not null)
             {
                 CryptographicOperations.ZeroMemory(pfxBytes);

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashUploadService.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashUploadService.cs
@@ -10,6 +10,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Foundry.Deploy.Services.Deployment;
+using Foundry.Deploy.Services.Security;
 using Microsoft.Extensions.Logging;
 
 namespace Foundry.Deploy.Services.Autopilot;
@@ -18,14 +19,14 @@ namespace Foundry.Deploy.Services.Autopilot;
 /// Decrypts media certificate material in memory, authenticates to Graph, and imports the captured hardware hash.
 /// </summary>
 public sealed class AutopilotHardwareHashUploadService(
-    IMediaSecretKeyReader mediaSecretKeyReader,
+    IDeploymentSecretKeyProvider deploymentSecretKeyProvider,
     IAutopilotGraphTokenService tokenService,
     AutopilotGraphImportClient graphImportClient,
     ILogger<AutopilotHardwareHashUploadService> logger) : IAutopilotHardwareHashUploadService
 {
     private const string UploadResultFileName = "AutopilotUploadResult.json";
 
-    private readonly IMediaSecretKeyReader mediaSecretKeyReader = mediaSecretKeyReader;
+    private readonly IDeploymentSecretKeyProvider deploymentSecretKeyProvider = deploymentSecretKeyProvider;
     private readonly IAutopilotGraphTokenService tokenService = tokenService;
     private readonly AutopilotGraphImportClient graphImportClient = graphImportClient;
     private readonly ILogger logger = logger;
@@ -65,17 +66,17 @@ public sealed class AutopilotHardwareHashUploadService(
             "Preparing Autopilot hardware hash upload...",
             "Decrypting media certificate..."));
 
-        byte[] mediaKey = await mediaSecretKeyReader.ReadAsync(request.WorkspaceRootPath, cancellationToken)
+        byte[] deploymentKey = await deploymentSecretKeyProvider.ReadAsync(request.WorkspaceRootPath, cancellationToken)
             .ConfigureAwait(false);
         byte[]? pfxBytes = null;
         try
         {
-            pfxBytes = DeployMediaSecretEnvelopeProtector.DecryptBytes(
+            pfxBytes = DeployMediaSecretEnvelopeProtector.DecryptDeployBytes(
                 request.Settings.CertificatePfxSecret!,
-                mediaKey);
-            string pfxPassword = DeployMediaSecretEnvelopeProtector.DecryptString(
+                deploymentKey);
+            string pfxPassword = DeployMediaSecretEnvelopeProtector.DecryptDeployString(
                 request.Settings.CertificatePfxPasswordSecret!,
-                mediaKey);
+                deploymentKey);
 
             progress?.Report(new AutopilotHardwareHashUploadProgress(
                 "Authenticating Autopilot hardware hash upload...",
@@ -106,7 +107,7 @@ public sealed class AutopilotHardwareHashUploadService(
         }
         finally
         {
-            CryptographicOperations.ZeroMemory(mediaKey);
+            CryptographicOperations.ZeroMemory(deploymentKey);
             if (pfxBytes is not null)
             {
                 CryptographicOperations.ZeroMemory(pfxBytes);

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashUploadService.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotHardwareHashUploadService.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
@@ -69,12 +70,13 @@ public sealed class AutopilotHardwareHashUploadService(
         byte[] deploymentKey = await deploymentSecretKeyProvider.ReadAsync(request.WorkspaceRootPath, cancellationToken)
             .ConfigureAwait(false);
         byte[]? pfxBytes = null;
+        char[]? pfxPassword = null;
         try
         {
             pfxBytes = DeployMediaSecretEnvelopeProtector.DecryptDeployBytes(
                 request.Settings.CertificatePfxSecret!,
                 deploymentKey);
-            string pfxPassword = DeployMediaSecretEnvelopeProtector.DecryptDeployString(
+            pfxPassword = DeployMediaSecretEnvelopeProtector.DecryptDeployChars(
                 request.Settings.CertificatePfxPasswordSecret!,
                 deploymentKey);
 
@@ -111,6 +113,11 @@ public sealed class AutopilotHardwareHashUploadService(
             if (pfxBytes is not null)
             {
                 CryptographicOperations.ZeroMemory(pfxBytes);
+            }
+
+            if (pfxPassword is not null)
+            {
+                CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(pfxPassword.AsSpan()));
             }
         }
     }

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotProfileCatalogService.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotProfileCatalogService.cs
@@ -3,33 +3,53 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Security.Cryptography;
 using System.Text.Json;
 using Foundry.Deploy.Models;
 using Microsoft.Extensions.Logging;
 
 namespace Foundry.Deploy.Services.Autopilot;
 
-public sealed class AutopilotProfileCatalogService(
-    ILogger<AutopilotProfileCatalogService> logger) : IAutopilotProfileCatalogService
+public sealed class AutopilotProfileCatalogService : IAutopilotProfileCatalogService
 {
     public const string DefaultAutopilotRootPath = @"X:\Foundry\Config\Autopilot";
     private const string ConfigurationFileName = "AutopilotConfigurationFile.json";
+    private const string EncryptedConfigurationFileName = "AutopilotConfigurationFile.json.encrypted";
     private const string CommentFilePropertyName = "Comment_File";
 
-    private readonly ILogger<AutopilotProfileCatalogService> _logger = logger;
+    private readonly IAutopilotProfileContentService _contentService;
+    private readonly ILogger<AutopilotProfileCatalogService> _logger;
+    private readonly string _autopilotRootPath;
+
+    public AutopilotProfileCatalogService(
+        IAutopilotProfileContentService contentService,
+        ILogger<AutopilotProfileCatalogService> logger)
+        : this(contentService, logger, DefaultAutopilotRootPath)
+    {
+    }
+
+    internal AutopilotProfileCatalogService(
+        IAutopilotProfileContentService contentService,
+        ILogger<AutopilotProfileCatalogService> logger,
+        string autopilotRootPath)
+    {
+        _contentService = contentService;
+        _logger = logger;
+        _autopilotRootPath = autopilotRootPath;
+    }
 
     public IReadOnlyList<AutopilotProfileCatalogItem> LoadAvailableProfiles()
     {
-        if (!Directory.Exists(DefaultAutopilotRootPath))
+        if (!Directory.Exists(_autopilotRootPath))
         {
             _logger.LogInformation(
                 "Autopilot profile root was not found at '{AutopilotRootPath}'.",
-                DefaultAutopilotRootPath);
+                _autopilotRootPath);
             return [];
         }
 
         var profiles = new List<AutopilotProfileCatalogItem>();
-        foreach (string directoryPath in Directory.EnumerateDirectories(DefaultAutopilotRootPath))
+        foreach (string directoryPath in Directory.EnumerateDirectories(_autopilotRootPath))
         {
             string folderName = Path.GetFileName(directoryPath);
             if (string.IsNullOrWhiteSpace(folderName))
@@ -37,7 +57,11 @@ public sealed class AutopilotProfileCatalogService(
                 continue;
             }
 
-            string configurationFilePath = Path.Combine(directoryPath, ConfigurationFileName);
+            string encryptedConfigurationFilePath = Path.Combine(directoryPath, EncryptedConfigurationFileName);
+            bool isProtected = File.Exists(encryptedConfigurationFilePath);
+            string configurationFilePath = isProtected
+                ? encryptedConfigurationFilePath
+                : Path.Combine(directoryPath, ConfigurationFileName);
             if (!File.Exists(configurationFilePath))
             {
                 _logger.LogDebug(
@@ -46,12 +70,14 @@ public sealed class AutopilotProfileCatalogService(
                 continue;
             }
 
-            profiles.Add(new AutopilotProfileCatalogItem
+            var profile = new AutopilotProfileCatalogItem
             {
                 FolderName = folderName,
-                DisplayName = ResolveDisplayName(configurationFilePath, folderName),
-                ConfigurationFilePath = configurationFilePath
-            });
+                DisplayName = folderName,
+                ConfigurationFilePath = configurationFilePath,
+                IsProtected = isProtected
+            };
+            profiles.Add(profile with { DisplayName = ResolveDisplayName(profile) });
         }
 
         AutopilotProfileCatalogItem[] ordered = profiles
@@ -62,16 +88,18 @@ public sealed class AutopilotProfileCatalogService(
         _logger.LogInformation(
             "Loaded {ProfileCount} Autopilot profile(s) from '{AutopilotRootPath}'.",
             ordered.Length,
-            DefaultAutopilotRootPath);
+            _autopilotRootPath);
 
         return ordered;
     }
 
-    private string ResolveDisplayName(string configurationFilePath, string fallbackFolderName)
+    private string ResolveDisplayName(AutopilotProfileCatalogItem profile)
     {
+        byte[]? content = null;
         try
         {
-            using JsonDocument document = JsonDocument.Parse(File.ReadAllText(configurationFilePath));
+            content = _contentService.ReadAsync(profile).GetAwaiter().GetResult();
+            using JsonDocument document = JsonDocument.Parse(content);
             if (document.RootElement.TryGetProperty(CommentFilePropertyName, out JsonElement commentElement) &&
                 commentElement.ValueKind == JsonValueKind.String)
             {
@@ -82,14 +110,21 @@ public sealed class AutopilotProfileCatalogService(
                 }
             }
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or InvalidDataException)
         {
             _logger.LogWarning(
                 ex,
                 "Failed to read Autopilot profile metadata from '{ConfigurationFilePath}'. Falling back to folder name.",
-                configurationFilePath);
+                profile.ConfigurationFilePath);
+        }
+        finally
+        {
+            if (content is not null)
+            {
+                CryptographicOperations.ZeroMemory(content);
+            }
         }
 
-        return fallbackFolderName;
+        return profile.FolderName;
     }
 }

--- a/src/Foundry.Deploy/Services/Autopilot/AutopilotProfileContentService.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/AutopilotProfileContentService.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Foundry.Deploy.Models;
+using Foundry.Deploy.Models.Configuration;
+using Foundry.Deploy.Services.Configuration;
+using Foundry.Deploy.Services.Security;
+
+namespace Foundry.Deploy.Services.Autopilot;
+
+public sealed class AutopilotProfileContentService(IDeploymentSecretKeySession deploymentSecretKeySession)
+    : IAutopilotProfileContentService
+{
+    public async Task<byte[]> ReadAsync(
+        AutopilotProfileCatalogItem profile,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+        if (!profile.IsProtected)
+        {
+            return await File.ReadAllBytesAsync(profile.ConfigurationFilePath, cancellationToken).ConfigureAwait(false);
+        }
+
+        byte[]? deploymentKey = null;
+        try
+        {
+            deploymentKey = deploymentSecretKeySession.GetKeyCopy();
+            byte[] envelopeJson = await File.ReadAllBytesAsync(profile.ConfigurationFilePath, cancellationToken).ConfigureAwait(false);
+            SecretEnvelope? envelope = JsonSerializer.Deserialize<SecretEnvelope>(
+                envelopeJson,
+                ConfigurationJsonDefaults.SerializerOptions);
+            if (envelope is null)
+            {
+                throw new InvalidDataException();
+            }
+
+            return DeployMediaSecretEnvelopeProtector.DecryptBytes(
+                envelope,
+                deploymentKey,
+                DeployMediaSecretEnvelopeProtector.DeploymentKeyId);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or
+                                   InvalidOperationException or ArgumentException or FormatException or
+                                   CryptographicException or InvalidDataException)
+        {
+            throw new InvalidDataException("Protected Autopilot profile could not be read.");
+        }
+        finally
+        {
+            if (deploymentKey is not null)
+            {
+                CryptographicOperations.ZeroMemory(deploymentKey);
+            }
+        }
+    }
+}

--- a/src/Foundry.Deploy/Services/Autopilot/DeployMediaSecretEnvelopeProtector.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/DeployMediaSecretEnvelopeProtector.cs
@@ -46,40 +46,24 @@ public static class DeployMediaSecretEnvelopeProtector
         }
     }
 
-    public static string DecryptString(SecretEnvelope envelope, byte[] key)
-    {
-        byte[] plaintext = DecryptBytes(envelope, key);
-        try
-        {
-            return Encoding.UTF8.GetString(plaintext);
-        }
-        finally
-        {
-            CryptographicOperations.ZeroMemory(plaintext);
-        }
-    }
-
-    public static string DecryptString(SecretEnvelope envelope, byte[] key, string expectedKeyId)
-    {
-        byte[] plaintext = DecryptBytes(envelope, key, expectedKeyId);
-        try
-        {
-            return Encoding.UTF8.GetString(plaintext);
-        }
-        finally
-        {
-            CryptographicOperations.ZeroMemory(plaintext);
-        }
-    }
-
     public static byte[] DecryptDeployBytes(SecretEnvelope envelope, byte[] key)
     {
         return DecryptBytes(envelope, key, ResolveDeployKeyId(envelope));
     }
 
-    public static string DecryptDeployString(SecretEnvelope envelope, byte[] key)
+    public static char[] DecryptDeployChars(SecretEnvelope envelope, byte[] key)
     {
-        return DecryptString(envelope, key, ResolveDeployKeyId(envelope));
+        byte[] plaintext = DecryptBytes(envelope, key, ResolveDeployKeyId(envelope));
+        try
+        {
+            char[] characters = new char[Encoding.UTF8.GetCharCount(plaintext)];
+            Encoding.UTF8.GetChars(plaintext, characters);
+            return characters;
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(plaintext);
+        }
     }
 
     private static string ResolveDeployKeyId(SecretEnvelope envelope)

--- a/src/Foundry.Deploy/Services/Autopilot/DeployMediaSecretEnvelopeProtector.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/DeployMediaSecretEnvelopeProtector.cs
@@ -16,14 +16,20 @@ public static class DeployMediaSecretEnvelopeProtector
     public const string Kind = "encrypted";
     public const string Algorithm = "aes-gcm-v1";
     public const string KeyId = "media";
+    public const string DeploymentKeyId = "deployment";
     public const int KeySizeBytes = 32;
     private const int NonceSizeBytes = 12;
     private const int TagSizeBytes = 16;
 
     public static byte[] DecryptBytes(SecretEnvelope envelope, byte[] key)
     {
+        return DecryptBytes(envelope, key, KeyId);
+    }
+
+    public static byte[] DecryptBytes(SecretEnvelope envelope, byte[] key, string expectedKeyId)
+    {
         ArgumentNullException.ThrowIfNull(envelope);
-        ValidateEnvelope(envelope);
+        ValidateEnvelope(envelope, expectedKeyId);
         ValidateKey(key);
 
         byte[] nonce = Base64UrlDecode(envelope.Nonce);
@@ -67,11 +73,25 @@ public static class DeployMediaSecretEnvelopeProtector
         }
     }
 
-    private static void ValidateEnvelope(SecretEnvelope envelope)
+    public static string DecryptString(SecretEnvelope envelope, byte[] key, string expectedKeyId)
     {
+        byte[] plaintext = DecryptBytes(envelope, key, expectedKeyId);
+        try
+        {
+            return Encoding.UTF8.GetString(plaintext);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(plaintext);
+        }
+    }
+
+    private static void ValidateEnvelope(SecretEnvelope envelope, string expectedKeyId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedKeyId);
         if (!string.Equals(envelope.Kind, Kind, StringComparison.Ordinal) ||
             !string.Equals(envelope.Algorithm, Algorithm, StringComparison.Ordinal) ||
-            !string.Equals(envelope.KeyId, KeyId, StringComparison.Ordinal))
+            !string.Equals(envelope.KeyId, expectedKeyId, StringComparison.Ordinal))
         {
             throw new CryptographicException("Encrypted secret envelope is not supported.");
         }

--- a/src/Foundry.Deploy/Services/Autopilot/DeployMediaSecretEnvelopeProtector.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/DeployMediaSecretEnvelopeProtector.cs
@@ -5,6 +5,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using Foundry.Deploy.Models.Configuration;
+using Foundry.Utilities.Security;
 
 namespace Foundry.Deploy.Services.Autopilot;
 
@@ -17,9 +18,7 @@ public static class DeployMediaSecretEnvelopeProtector
     public const string Algorithm = "aes-gcm-v1";
     public const string KeyId = "media";
     public const string DeploymentKeyId = "deployment";
-    public const int KeySizeBytes = 32;
-    private const int NonceSizeBytes = 12;
-    private const int TagSizeBytes = 16;
+    public const int KeySizeBytes = AesGcmEncryption.KeySizeBytes;
 
     public static byte[] DecryptBytes(SecretEnvelope envelope, byte[] key)
     {
@@ -32,30 +31,17 @@ public static class DeployMediaSecretEnvelopeProtector
         ValidateEnvelope(envelope, expectedKeyId);
         ValidateKey(key);
 
-        byte[] nonce = Base64UrlDecode(envelope.Nonce);
-        byte[] tag = Base64UrlDecode(envelope.Tag);
-        byte[] ciphertext = Base64UrlDecode(envelope.Ciphertext);
-        byte[] plaintext = new byte[ciphertext.Length];
-
-        if (nonce.Length != NonceSizeBytes)
-        {
-            throw new CryptographicException("Encrypted secret nonce has an invalid length.");
-        }
-
-        if (tag.Length != TagSizeBytes)
-        {
-            throw new CryptographicException("Encrypted secret tag has an invalid length.");
-        }
-
         try
         {
-            using var aes = new AesGcm(key, TagSizeBytes);
-            aes.Decrypt(nonce, ciphertext, tag, plaintext);
-            return plaintext;
+            return AesGcmEncryption.Decrypt(
+                new AesGcmPayload(
+                    Base64Url.Decode(envelope.Nonce),
+                    Base64Url.Decode(envelope.Tag),
+                    Base64Url.Decode(envelope.Ciphertext)),
+                key);
         }
         catch (CryptographicException ex)
         {
-            CryptographicOperations.ZeroMemory(plaintext);
             throw new CryptographicException("Encrypted secret could not be decrypted.", ex);
         }
     }
@@ -86,6 +72,28 @@ public static class DeployMediaSecretEnvelopeProtector
         }
     }
 
+    public static byte[] DecryptDeployBytes(SecretEnvelope envelope, byte[] key)
+    {
+        return DecryptBytes(envelope, key, ResolveDeployKeyId(envelope));
+    }
+
+    public static string DecryptDeployString(SecretEnvelope envelope, byte[] key)
+    {
+        return DecryptString(envelope, key, ResolveDeployKeyId(envelope));
+    }
+
+    private static string ResolveDeployKeyId(SecretEnvelope envelope)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+        if (string.Equals(envelope.KeyId, DeploymentKeyId, StringComparison.Ordinal) ||
+            string.Equals(envelope.KeyId, KeyId, StringComparison.Ordinal))
+        {
+            return envelope.KeyId;
+        }
+
+        throw new CryptographicException("Encrypted secret envelope is not supported.");
+    }
+
     private static void ValidateEnvelope(SecretEnvelope envelope, string expectedKeyId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(expectedKeyId);
@@ -113,10 +121,4 @@ public static class DeployMediaSecretEnvelopeProtector
         }
     }
 
-    private static byte[] Base64UrlDecode(string value)
-    {
-        string base64 = value.Replace('-', '+').Replace('_', '/');
-        int padding = (4 - base64.Length % 4) % 4;
-        return Convert.FromBase64String(base64.PadRight(base64.Length + padding, '='));
-    }
 }

--- a/src/Foundry.Deploy/Services/Autopilot/IAutopilotProfileContentService.cs
+++ b/src/Foundry.Deploy/Services/Autopilot/IAutopilotProfileContentService.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Deploy.Models;
+
+namespace Foundry.Deploy.Services.Autopilot;
+
+public interface IAutopilotProfileContentService
+{
+    Task<byte[]> ReadAsync(AutopilotProfileCatalogItem profile, CancellationToken cancellationToken = default);
+}

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentExecutionService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentExecutionService.cs
@@ -3,19 +3,27 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
+using Foundry.Deploy.Services.Configuration;
+using Foundry.Deploy.Services.Security;
 
 namespace Foundry.Deploy.Services.Deployment;
 
 public sealed class DeploymentExecutionService : IDeploymentExecutionService
 {
     private readonly IDeploymentOrchestrator _deploymentOrchestrator;
+    private readonly IDeployConfigurationService _configurationService;
+    private readonly IDeploymentSecretKeySession _deploymentSecretKeySession;
     private readonly ILogger<DeploymentExecutionService> _logger;
 
     public DeploymentExecutionService(
         IDeploymentOrchestrator deploymentOrchestrator,
+        IDeployConfigurationService configurationService,
+        IDeploymentSecretKeySession deploymentSecretKeySession,
         ILogger<DeploymentExecutionService> logger)
     {
         _deploymentOrchestrator = deploymentOrchestrator;
+        _configurationService = configurationService;
+        _deploymentSecretKeySession = deploymentSecretKeySession;
         _logger = logger;
     }
 
@@ -25,6 +33,17 @@ public sealed class DeploymentExecutionService : IDeploymentExecutionService
 
         try
         {
+            DeployConfigurationLoadResult configuration = _configurationService.LoadOptional();
+            if (configuration.Exists && configuration.Document is null)
+            {
+                return AccessDenied();
+            }
+
+            if (configuration.Document?.Protection.IsEnabled == true && !_deploymentSecretKeySession.IsUnlocked)
+            {
+                return AccessDenied();
+            }
+
             DeploymentResult result = await _deploymentOrchestrator
                 .RunAsync(context)
                 .ConfigureAwait(false);
@@ -51,4 +70,10 @@ public sealed class DeploymentExecutionService : IDeploymentExecutionService
             };
         }
     }
+
+    private static DeploymentExecutionRunResult AccessDenied() => new()
+    {
+        IsSuccess = false,
+        Message = "Deployment access has not been authorized."
+    };
 }

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentExecutionService.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentExecutionService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
+using Foundry.Deploy.Models.Configuration;
 using Foundry.Deploy.Services.Configuration;
 using Foundry.Deploy.Services.Security;
 
@@ -39,7 +40,10 @@ public sealed class DeploymentExecutionService : IDeploymentExecutionService
                 return AccessDenied();
             }
 
-            if (configuration.Document?.Protection.IsEnabled == true && !_deploymentSecretKeySession.IsUnlocked)
+            DeployProtectionSettings protection = configuration.Document?.Protection ?? new DeployProtectionSettings();
+            bool requiresAuthorization = DeploymentProtectionDetector.RequiresUnlock(protection) ||
+                                         DeploymentProtectionDetector.HasProtectedArtifacts(configuration);
+            if (requiresAuthorization && !_deploymentSecretKeySession.IsUnlocked)
             {
                 return AccessDenied();
             }

--- a/src/Foundry.Deploy/Services/Deployment/Steps/ProvisionAutopilotStep.cs
+++ b/src/Foundry.Deploy/Services/Deployment/Steps/ProvisionAutopilotStep.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Security.Cryptography;
 using System.Text.Json;
 using Foundry.Deploy.Models.Configuration;
 using Foundry.Deploy.Services.Autopilot;
@@ -23,15 +24,18 @@ public sealed class ProvisionAutopilotStep : DeploymentStepBase
     private readonly IAutopilotHardwareHashCaptureService _hardwareHashCaptureService;
     private readonly IAutopilotHardwareHashUploadService _hardwareHashUploadService;
     private readonly IAutopilotInteractiveRegistrationProvisioningService _interactiveRegistrationProvisioningService;
+    private readonly IAutopilotProfileContentService _autopilotProfileContentService;
 
     public ProvisionAutopilotStep(
         IAutopilotHardwareHashCaptureService hardwareHashCaptureService,
         IAutopilotHardwareHashUploadService hardwareHashUploadService,
-        IAutopilotInteractiveRegistrationProvisioningService interactiveRegistrationProvisioningService)
+        IAutopilotInteractiveRegistrationProvisioningService interactiveRegistrationProvisioningService,
+        IAutopilotProfileContentService autopilotProfileContentService)
     {
         _hardwareHashCaptureService = hardwareHashCaptureService;
         _hardwareHashUploadService = hardwareHashUploadService;
         _interactiveRegistrationProvisioningService = interactiveRegistrationProvisioningService;
+        _autopilotProfileContentService = autopilotProfileContentService;
     }
 
     public override int Order => 19;
@@ -85,7 +89,17 @@ public sealed class ProvisionAutopilotStep : DeploymentStepBase
 
         context.EmitCurrentStepIndeterminate("Staging Autopilot profile...", "Copying AutopilotConfigurationFile.json...", DeploymentOperationNames.StageAutopilotProfile);
         Directory.CreateDirectory(targetDirectoryPath);
-        File.Copy(sourceConfigurationPath, targetConfigurationPath, overwrite: true);
+        byte[] profileContent = await _autopilotProfileContentService
+            .ReadAsync(context.Request.SelectedAutopilotProfile, cancellationToken)
+            .ConfigureAwait(false);
+        try
+        {
+            await File.WriteAllBytesAsync(targetConfigurationPath, profileContent, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(profileContent);
+        }
 
         context.RuntimeState.StagedAutopilotConfigurationPath = targetConfigurationPath;
         context.RuntimeState.AutopilotHardwareHashUploadState = AutopilotHardwareHashUploadState.NotPlanned;

--- a/src/Foundry.Deploy/Services/Network/NetworkProfileRoamingArtifactService.cs
+++ b/src/Foundry.Deploy/Services/Network/NetworkProfileRoamingArtifactService.cs
@@ -8,7 +8,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Foundry.Core.Models.Network;
 using Foundry.Core.Models.Configuration;
-using Foundry.Deploy.Services.Autopilot;
 using Foundry.Deploy.Services.Deployment.PreOobe;
 using Microsoft.Extensions.Logging;
 using CoreDeployNetworkProfileRoamingSettings = Foundry.Core.Models.Configuration.Deploy.DeployNetworkProfileRoamingSettings;
@@ -31,14 +30,14 @@ public sealed class NetworkProfileRoamingArtifactService : INetworkProfileRoamin
         WriteIndented = true
     };
 
-    private readonly IMediaSecretKeyReader _mediaSecretKeyReader;
+    private readonly INetworkSecretKeyReader _networkSecretKeyReader;
     private readonly ILogger<NetworkProfileRoamingArtifactService> _logger;
 
     public NetworkProfileRoamingArtifactService(
-        IMediaSecretKeyReader mediaSecretKeyReader,
+        INetworkSecretKeyReader networkSecretKeyReader,
         ILogger<NetworkProfileRoamingArtifactService> logger)
     {
-        _mediaSecretKeyReader = mediaSecretKeyReader;
+        _networkSecretKeyReader = networkSecretKeyReader;
         _logger = logger;
     }
 
@@ -218,7 +217,7 @@ public sealed class NetworkProfileRoamingArtifactService : INetworkProfileRoamin
             {
                 if (!string.IsNullOrWhiteSpace(certificate.PasswordSecretRelativePath))
                 {
-                    mediaSecretKey ??= await _mediaSecretKeyReader.ReadAsync(workspaceRootPath, cancellationToken).ConfigureAwait(false);
+                    mediaSecretKey ??= await _networkSecretKeyReader.ReadAsync(workspaceRootPath, cancellationToken).ConfigureAwait(false);
                 }
 
                 passwordRelativePath = await AddPfxPasswordDataFileAsync(

--- a/src/Foundry.Deploy/Services/Network/NetworkProfileRoamingArtifactService.cs
+++ b/src/Foundry.Deploy/Services/Network/NetworkProfileRoamingArtifactService.cs
@@ -177,75 +177,80 @@ public sealed class NetworkProfileRoamingArtifactService : INetworkProfileRoamin
         var importCertificates = new List<NetworkProfileRoamingImportCertificate>();
         byte[]? mediaSecretKey = null;
 
-        foreach (NetworkProfileRoamingCertificate certificate in certificates)
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            if (string.IsNullOrWhiteSpace(certificate.RelativePath))
+            foreach (NetworkProfileRoamingCertificate certificate in certificates)
             {
-                continue;
-            }
+                cancellationToken.ThrowIfCancellationRequested();
 
-            NetworkProfileRoamingTransportSettings? transportSettings = ResolveTransportSettings(certificate, settings);
-            if (transportSettings is null || !transportSettings.IsEnabled)
-            {
-                continue;
-            }
-
-            bool isPfxPrivateKey = string.Equals(certificate.Kind, NetworkProfileRoamingArtifacts.PfxPrivateKeyKind, StringComparison.OrdinalIgnoreCase);
-            if (isPfxPrivateKey && !transportSettings.IncludePrivateKeyMaterial)
-            {
-                continue;
-            }
-
-            string sourcePath = ResolveArtifactPath(artifactRootPath, certificate.RelativePath);
-            if (!File.Exists(sourcePath))
-            {
-                continue;
-            }
-
-            string stagedRelativePath = ToStagedDataRelativePath(certificate.RelativePath);
-            dataFiles.Add(new PreOobeScriptDataFile
-            {
-                FileName = stagedRelativePath,
-                Bytes = File.ReadAllBytes(sourcePath),
-                IsSensitive = isPfxPrivateKey
-            });
-
-            string? passwordRelativePath = null;
-            if (isPfxPrivateKey)
-            {
-                if (!string.IsNullOrWhiteSpace(certificate.PasswordSecretRelativePath))
+                if (string.IsNullOrWhiteSpace(certificate.RelativePath))
                 {
-                    mediaSecretKey ??= await _networkSecretKeyReader.ReadAsync(workspaceRootPath, cancellationToken).ConfigureAwait(false);
+                    continue;
                 }
 
-                passwordRelativePath = await AddPfxPasswordDataFileAsync(
-                        dataFiles,
-                        artifactRootPath,
-                        certificate,
-                        mediaSecretKey,
-                        cancellationToken)
-                    .ConfigureAwait(false);
+                NetworkProfileRoamingTransportSettings? transportSettings = ResolveTransportSettings(certificate, settings);
+                if (transportSettings is null || !transportSettings.IsEnabled)
+                {
+                    continue;
+                }
+
+                bool isPfxPrivateKey = string.Equals(certificate.Kind, NetworkProfileRoamingArtifacts.PfxPrivateKeyKind, StringComparison.OrdinalIgnoreCase);
+                if (isPfxPrivateKey && !transportSettings.IncludePrivateKeyMaterial)
+                {
+                    continue;
+                }
+
+                string sourcePath = ResolveArtifactPath(artifactRootPath, certificate.RelativePath);
+                if (!File.Exists(sourcePath))
+                {
+                    continue;
+                }
+
+                string stagedRelativePath = ToStagedDataRelativePath(certificate.RelativePath);
+                dataFiles.Add(new PreOobeScriptDataFile
+                {
+                    FileName = stagedRelativePath,
+                    Bytes = File.ReadAllBytes(sourcePath),
+                    IsSensitive = isPfxPrivateKey
+                });
+
+                string? passwordRelativePath = null;
+                if (isPfxPrivateKey)
+                {
+                    if (!string.IsNullOrWhiteSpace(certificate.PasswordSecretRelativePath))
+                    {
+                        mediaSecretKey ??= await _networkSecretKeyReader.ReadAsync(workspaceRootPath, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    passwordRelativePath = await AddPfxPasswordDataFileAsync(
+                            dataFiles,
+                            artifactRootPath,
+                            certificate,
+                            mediaSecretKey,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
+                importCertificates.Add(new NetworkProfileRoamingImportCertificate
+                {
+                    RelativePath = stagedRelativePath,
+                    Kind = isPfxPrivateKey ? "pfx" : "certificate",
+                    StoreName = string.IsNullOrWhiteSpace(certificate.StoreName)
+                        ? (isPfxPrivateKey ? "My" : "Root")
+                        : certificate.StoreName.Trim(),
+                    PasswordRelativePath = passwordRelativePath
+                });
             }
 
-            importCertificates.Add(new NetworkProfileRoamingImportCertificate
-            {
-                RelativePath = stagedRelativePath,
-                Kind = isPfxPrivateKey ? "pfx" : "certificate",
-                StoreName = string.IsNullOrWhiteSpace(certificate.StoreName)
-                    ? (isPfxPrivateKey ? "My" : "Root")
-                    : certificate.StoreName.Trim(),
-                PasswordRelativePath = passwordRelativePath
-            });
+            return importCertificates;
         }
-
-        if (mediaSecretKey is not null)
+        finally
         {
-            CryptographicOperations.ZeroMemory(mediaSecretKey);
+            if (mediaSecretKey is not null)
+            {
+                CryptographicOperations.ZeroMemory(mediaSecretKey);
+            }
         }
-
-        return importCertificates;
     }
 
     private static NetworkProfileRoamingTransportSettings? ResolveTransportSettings(

--- a/src/Foundry.Deploy/Services/Network/NetworkSecretKeyReader.cs
+++ b/src/Foundry.Deploy/Services/Network/NetworkSecretKeyReader.cs
@@ -3,18 +3,19 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using Foundry.Utilities.Security;
 
-namespace Foundry.Deploy.Services.Autopilot;
+namespace Foundry.Deploy.Services.Network;
 
-public interface IMediaSecretKeyReader
+public interface INetworkSecretKeyReader
 {
     Task<byte[]> ReadAsync(string workspaceRootPath, CancellationToken cancellationToken = default);
 }
 
 /// <summary>
-/// Reads the generated boot media secret key from X:\Foundry\Config\Secrets\media-secrets.key.
+/// Reads the Foundry Connect network key from the generated boot media.
 /// </summary>
-public sealed class MediaSecretKeyReader : IMediaSecretKeyReader
+public sealed class NetworkSecretKeyReader : INetworkSecretKeyReader
 {
     private const string KeyRelativePath = @"Config\Secrets\media-secrets.key";
 
@@ -25,13 +26,13 @@ public sealed class MediaSecretKeyReader : IMediaSecretKeyReader
         string keyPath = Path.Combine(workspaceRootPath, KeyRelativePath);
         if (!File.Exists(keyPath))
         {
-            throw new FileNotFoundException("Autopilot media secret key was not found in the boot media configuration.", keyPath);
+            throw new FileNotFoundException("Network secret key was not found in the boot media configuration.", keyPath);
         }
 
         byte[] key = await File.ReadAllBytesAsync(keyPath, cancellationToken).ConfigureAwait(false);
-        if (key.Length != DeployMediaSecretEnvelopeProtector.KeySizeBytes)
+        if (key.Length != AesGcmEncryption.KeySizeBytes)
         {
-            throw new InvalidOperationException("Autopilot media secret key has an invalid length.");
+            throw new InvalidOperationException("Network secret key has an invalid length.");
         }
 
         return key;

--- a/src/Foundry.Deploy/Services/Network/NetworkSecretKeyReader.cs
+++ b/src/Foundry.Deploy/Services/Network/NetworkSecretKeyReader.cs
@@ -32,6 +32,7 @@ public sealed class NetworkSecretKeyReader : INetworkSecretKeyReader
         byte[] key = await File.ReadAllBytesAsync(keyPath, cancellationToken).ConfigureAwait(false);
         if (key.Length != AesGcmEncryption.KeySizeBytes)
         {
+            global::System.Security.Cryptography.CryptographicOperations.ZeroMemory(key);
             throw new InvalidOperationException("Network secret key has an invalid length.");
         }
 

--- a/src/Foundry.Deploy/Services/Security/DeploymentAccessGate.cs
+++ b/src/Foundry.Deploy/Services/Security/DeploymentAccessGate.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
+using Foundry.Deploy.Models.Configuration;
 using Foundry.Deploy.Services.Configuration;
 
 namespace Foundry.Deploy.Services.Security;
@@ -20,7 +21,14 @@ public sealed class DeploymentAccessGate(
             return false;
         }
 
-        if (loadResult.Document?.Protection.IsEnabled != true)
+        DeployProtectionSettings protection = loadResult.Document?.Protection ?? new DeployProtectionSettings();
+        bool requiresUnlock = DeploymentProtectionDetector.RequiresUnlock(protection);
+        if (!requiresUnlock && DeploymentProtectionDetector.HasProtectedArtifacts(loadResult))
+        {
+            return false;
+        }
+
+        if (!requiresUnlock)
         {
             return true;
         }
@@ -36,7 +44,7 @@ public sealed class DeploymentAccessGate(
                 return false;
             }
 
-            if (unlockService.TryUnlock(loadResult.Document.Protection, prompt.Password))
+            if (unlockService.TryUnlock(protection, prompt.Password))
             {
                 return true;
             }

--- a/src/Foundry.Deploy/Services/Security/DeploymentAccessGate.cs
+++ b/src/Foundry.Deploy/Services/Security/DeploymentAccessGate.cs
@@ -26,6 +26,7 @@ public sealed class DeploymentAccessGate(
         }
 
         bool previousAttemptFailed = false;
+        int failedAttemptCount = 0;
         while (true)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -41,7 +42,8 @@ public sealed class DeploymentAccessGate(
             }
 
             previousAttemptFailed = true;
-            await retryDelay.WaitAsync(cancellationToken);
+            failedAttemptCount++;
+            await retryDelay.WaitAsync(failedAttemptCount, cancellationToken);
         }
     }
 }

--- a/src/Foundry.Deploy/Services/Security/DeploymentAccessGate.cs
+++ b/src/Foundry.Deploy/Services/Security/DeploymentAccessGate.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Deploy.Services.Configuration;
+
+namespace Foundry.Deploy.Services.Security;
+
+public sealed class DeploymentAccessGate(
+    IDeployConfigurationService configurationService,
+    IDeploymentProtectionUnlockService unlockService,
+    IDeploymentPasswordDialogService passwordDialogService,
+    IDeploymentAccessRetryDelay retryDelay) : IDeploymentAccessGate
+{
+    public async Task<bool> AuthorizeAsync(CancellationToken cancellationToken = default)
+    {
+        DeployConfigurationLoadResult loadResult = configurationService.LoadOptional();
+        if (loadResult.Exists && loadResult.Document is null)
+        {
+            return false;
+        }
+
+        if (loadResult.Document?.Protection.IsEnabled != true)
+        {
+            return true;
+        }
+
+        bool previousAttemptFailed = false;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using DeploymentPasswordPromptResult prompt = passwordDialogService.Prompt(previousAttemptFailed);
+            if (!prompt.WasSubmitted)
+            {
+                return false;
+            }
+
+            if (unlockService.TryUnlock(loadResult.Document.Protection, prompt.Password))
+            {
+                return true;
+            }
+
+            previousAttemptFailed = true;
+            await retryDelay.WaitAsync(cancellationToken);
+        }
+    }
+}

--- a/src/Foundry.Deploy/Services/Security/DeploymentAccessRetryDelay.cs
+++ b/src/Foundry.Deploy/Services/Security/DeploymentAccessRetryDelay.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Deploy.Services.Security;
+
+public sealed class DeploymentAccessRetryDelay : IDeploymentAccessRetryDelay
+{
+    public Task WaitAsync(CancellationToken cancellationToken) =>
+        Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken);
+}

--- a/src/Foundry.Deploy/Services/Security/DeploymentAccessRetryDelay.cs
+++ b/src/Foundry.Deploy/Services/Security/DeploymentAccessRetryDelay.cs
@@ -6,6 +6,14 @@ namespace Foundry.Deploy.Services.Security;
 
 public sealed class DeploymentAccessRetryDelay : IDeploymentAccessRetryDelay
 {
-    public Task WaitAsync(CancellationToken cancellationToken) =>
-        Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken);
+    public Task WaitAsync(int failedAttemptNumber, CancellationToken cancellationToken)
+    {
+        return Task.Delay(GetDelay(failedAttemptNumber), cancellationToken);
+    }
+
+    internal static TimeSpan GetDelay(int failedAttemptNumber)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(failedAttemptNumber);
+        return TimeSpan.FromSeconds(Math.Min(failedAttemptNumber, 5));
+    }
 }

--- a/src/Foundry.Deploy/Services/Security/DeploymentPasswordDialogService.cs
+++ b/src/Foundry.Deploy/Services/Security/DeploymentPasswordDialogService.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows;
+using Foundry.Deploy.Services.Localization;
+using Foundry.Deploy.Views;
+
+namespace Foundry.Deploy.Services.Security;
+
+public sealed class DeploymentPasswordDialogService(ILocalizationService localizationService)
+    : IDeploymentPasswordDialogService
+{
+    public DeploymentPasswordPromptResult Prompt(bool previousAttemptFailed)
+    {
+        var dialog = new DeploymentPasswordDialog
+        {
+            Title = localizationService.Strings["DeploymentAccess.Title"],
+            PromptText = localizationService.Strings["DeploymentAccess.Prompt"],
+            PasswordPlaceholder = localizationService.Strings["DeploymentAccess.PasswordPlaceholder"],
+            UnlockText = localizationService.Strings["DeploymentAccess.Unlock"],
+            CancelText = localizationService.Strings["Common.Cancel"],
+            ErrorText = previousAttemptFailed
+                ? localizationService.Strings["DeploymentAccess.InvalidPassword"]
+                : string.Empty,
+            Owner = ResolveOwnerWindow()
+        };
+
+        bool? submitted = dialog.ShowDialog();
+        if (submitted != true)
+        {
+            return DeploymentPasswordPromptResult.Cancelled();
+        }
+
+        return DeploymentPasswordPromptResult.SubmittedOwned(dialog.TakePassword());
+    }
+
+    private static Window? ResolveOwnerWindow()
+    {
+        if (Application.Current?.Windows is not null)
+        {
+            foreach (Window window in Application.Current.Windows)
+            {
+                if (window.IsActive)
+                {
+                    return window;
+                }
+            }
+        }
+
+        return Application.Current?.MainWindow;
+    }
+}

--- a/src/Foundry.Deploy/Services/Security/DeploymentPasswordDialogService.cs
+++ b/src/Foundry.Deploy/Services/Security/DeploymentPasswordDialogService.cs
@@ -16,10 +16,12 @@ public sealed class DeploymentPasswordDialogService(ILocalizationService localiz
         var dialog = new DeploymentPasswordDialog
         {
             Title = localizationService.Strings["DeploymentAccess.Title"],
-            PromptText = localizationService.Strings["DeploymentAccess.Prompt"],
+            HeadingText = localizationService.Strings["DeploymentAccess.Heading"],
+            DescriptionText = localizationService.Strings["DeploymentAccess.Description"],
             PasswordPlaceholder = localizationService.Strings["DeploymentAccess.PasswordPlaceholder"],
-            UnlockText = localizationService.Strings["DeploymentAccess.Unlock"],
+            ContinueText = localizationService.Strings["DeploymentAccess.Continue"],
             CancelText = localizationService.Strings["Common.Cancel"],
+            TogglePasswordVisibilityText = localizationService.Strings["DeploymentAccess.TogglePasswordVisibility"],
             ErrorText = previousAttemptFailed
                 ? localizationService.Strings["DeploymentAccess.InvalidPassword"]
                 : string.Empty,

--- a/src/Foundry.Deploy/Services/Security/DeploymentPasswordPromptResult.cs
+++ b/src/Foundry.Deploy/Services/Security/DeploymentPasswordPromptResult.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace Foundry.Deploy.Services.Security;
+
+public sealed class DeploymentPasswordPromptResult : IDisposable
+{
+    private DeploymentPasswordPromptResult(bool wasSubmitted, char[] password)
+    {
+        WasSubmitted = wasSubmitted;
+        Password = password;
+    }
+
+    public bool WasSubmitted { get; }
+
+    public char[] Password { get; }
+
+    public static DeploymentPasswordPromptResult Submitted(ReadOnlySpan<char> password) =>
+        new(wasSubmitted: true, password.ToArray());
+
+    internal static DeploymentPasswordPromptResult SubmittedOwned(char[] password) =>
+        new(wasSubmitted: true, password);
+
+    public static DeploymentPasswordPromptResult Cancelled() =>
+        new(wasSubmitted: false, []);
+
+    public void Dispose()
+    {
+        CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(Password.AsSpan()));
+    }
+}

--- a/src/Foundry.Deploy/Services/Security/DeploymentProtectionDetector.cs
+++ b/src/Foundry.Deploy/Services/Security/DeploymentProtectionDetector.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using Foundry.Deploy.Models.Configuration;
+using Foundry.Deploy.Services.Configuration;
+using ConfigurationSchemaVersions = Foundry.Core.Models.Configuration.ConfigurationSchemaVersions;
+
+namespace Foundry.Deploy.Services.Security;
+
+internal static class DeploymentProtectionDetector
+{
+    private const string DeploymentKeyRelativePath = @"Config\Secrets\deployment-secrets.key";
+    private const string AutopilotProfilesRelativePath = @"Config\Autopilot";
+
+    public static bool RequiresUnlock(DeployProtectionSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        SecretEnvelope? envelope = settings.ProtectedDeploymentKey;
+
+        return settings.IsEnabled ||
+               !string.IsNullOrWhiteSpace(settings.KeyDerivationAlgorithm) ||
+               settings.Iterations != 0 ||
+               !string.IsNullOrWhiteSpace(settings.Salt) ||
+               envelope is null ||
+               !string.IsNullOrWhiteSpace(envelope.Kind) ||
+               !string.IsNullOrWhiteSpace(envelope.Algorithm) ||
+               !string.IsNullOrWhiteSpace(envelope.KeyId) ||
+               !string.IsNullOrWhiteSpace(envelope.Nonce) ||
+               !string.IsNullOrWhiteSpace(envelope.Tag) ||
+               !string.IsNullOrWhiteSpace(envelope.Ciphertext);
+    }
+
+    public static bool HasProtectedArtifacts(
+        DeployConfigurationLoadResult configuration,
+        string? workspaceRootPath = null)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        if (configuration.Document is null)
+        {
+            return configuration.Exists;
+        }
+
+        string? rootPath = ResolveWorkspaceRootPath(configuration.ConfigurationPath, workspaceRootPath);
+        if (string.IsNullOrWhiteSpace(rootPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            string autopilotRootPath = Path.Combine(rootPath, AutopilotProfilesRelativePath);
+            if (Directory.Exists(autopilotRootPath) &&
+                Directory.EnumerateFiles(
+                    autopilotRootPath,
+                    "*.encrypted",
+                    SearchOption.AllDirectories).Any())
+            {
+                return true;
+            }
+
+            return configuration.Document.SchemaVersion >= ConfigurationSchemaVersions.DeployCurrent &&
+                   !File.Exists(Path.Combine(rootPath, DeploymentKeyRelativePath));
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            return true;
+        }
+    }
+
+    private static string? ResolveWorkspaceRootPath(string configurationPath, string? workspaceRootPath)
+    {
+        if (!string.IsNullOrWhiteSpace(workspaceRootPath))
+        {
+            return workspaceRootPath;
+        }
+
+        if (string.IsNullOrWhiteSpace(configurationPath))
+        {
+            return null;
+        }
+
+        string? configurationDirectoryPath = Path.GetDirectoryName(configurationPath);
+        return string.IsNullOrWhiteSpace(configurationDirectoryPath)
+            ? null
+            : Directory.GetParent(configurationDirectoryPath)?.FullName;
+    }
+}

--- a/src/Foundry.Deploy/Services/Security/DeploymentProtectionDetector.cs
+++ b/src/Foundry.Deploy/Services/Security/DeploymentProtectionDetector.cs
@@ -37,9 +37,9 @@ internal static class DeploymentProtectionDetector
         string? workspaceRootPath = null)
     {
         ArgumentNullException.ThrowIfNull(configuration);
-        if (configuration.Document is null)
+        if (configuration.Document is null && configuration.Exists)
         {
-            return configuration.Exists;
+            return true;
         }
 
         string? rootPath = ResolveWorkspaceRootPath(configuration.ConfigurationPath, workspaceRootPath);
@@ -58,6 +58,11 @@ internal static class DeploymentProtectionDetector
                     SearchOption.AllDirectories).Any())
             {
                 return true;
+            }
+
+            if (configuration.Document is null)
+            {
+                return false;
             }
 
             return configuration.Document.SchemaVersion >= ConfigurationSchemaVersions.DeployCurrent &&

--- a/src/Foundry.Deploy/Services/Security/DeploymentProtectionUnlockService.cs
+++ b/src/Foundry.Deploy/Services/Security/DeploymentProtectionUnlockService.cs
@@ -21,7 +21,7 @@ public sealed class DeploymentProtectionUnlockService(IDeploymentSecretKeySessio
         ArgumentNullException.ThrowIfNull(settings);
         session.Clear();
 
-        if (!settings.IsEnabled)
+        if (!DeploymentProtectionDetector.RequiresUnlock(settings))
         {
             return true;
         }
@@ -84,7 +84,8 @@ public sealed class DeploymentProtectionUnlockService(IDeploymentSecretKeySessio
 
     private static void ValidateSettings(DeployProtectionSettings settings)
     {
-        SecretEnvelope envelope = settings.ProtectedDeploymentKey;
+        SecretEnvelope envelope = settings.ProtectedDeploymentKey ??
+            throw new CryptographicException("Deployment protection metadata is invalid.");
         if (!string.Equals(settings.KeyDerivationAlgorithm, KeyDerivationAlgorithm, StringComparison.Ordinal) ||
             settings.Iterations != PasswordKeyDerivation.DefaultIterations ||
             string.IsNullOrWhiteSpace(settings.Salt) ||

--- a/src/Foundry.Deploy/Services/Security/DeploymentProtectionUnlockService.cs
+++ b/src/Foundry.Deploy/Services/Security/DeploymentProtectionUnlockService.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using Foundry.Deploy.Models.Configuration;
+using Foundry.Utilities.Security;
+
+namespace Foundry.Deploy.Services.Security;
+
+public sealed class DeploymentProtectionUnlockService(IDeploymentSecretKeySession session)
+    : IDeploymentProtectionUnlockService
+{
+    public const string KeyDerivationAlgorithm = "pbkdf2-sha256";
+    public const string EnvelopeKind = "encrypted";
+    public const string EnvelopeAlgorithm = "aes-gcm-v1";
+    public const string PasswordDerivedKeyId = "deployment-password";
+
+    public bool TryUnlock(DeployProtectionSettings settings, ReadOnlySpan<char> password)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        session.Clear();
+
+        if (!settings.IsEnabled)
+        {
+            return true;
+        }
+
+        byte[]? derivedKey = null;
+        byte[]? deploymentKey = null;
+        try
+        {
+            ValidateSettings(settings);
+            byte[] salt = Base64Url.Decode(settings.Salt);
+            try
+            {
+                if (salt.Length != PasswordKeyDerivation.SaltSizeBytes)
+                {
+                    return false;
+                }
+
+                derivedKey = PasswordKeyDerivation.DeriveKey(
+                    password,
+                    salt,
+                    settings.Iterations,
+                    AesGcmEncryption.KeySizeBytes);
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(salt);
+            }
+
+            SecretEnvelope envelope = settings.ProtectedDeploymentKey;
+            var payload = new AesGcmPayload(
+                Base64Url.Decode(envelope.Nonce),
+                Base64Url.Decode(envelope.Tag),
+                Base64Url.Decode(envelope.Ciphertext));
+            deploymentKey = AesGcmEncryption.Decrypt(payload, derivedKey);
+            if (deploymentKey.Length != AesGcmEncryption.KeySizeBytes)
+            {
+                return false;
+            }
+
+            session.SetKey(deploymentKey);
+            return true;
+        }
+        catch (Exception ex) when (ex is ArgumentException or FormatException or CryptographicException)
+        {
+            return false;
+        }
+        finally
+        {
+            if (derivedKey is not null)
+            {
+                CryptographicOperations.ZeroMemory(derivedKey);
+            }
+
+            if (deploymentKey is not null)
+            {
+                CryptographicOperations.ZeroMemory(deploymentKey);
+            }
+        }
+    }
+
+    private static void ValidateSettings(DeployProtectionSettings settings)
+    {
+        SecretEnvelope envelope = settings.ProtectedDeploymentKey;
+        if (!string.Equals(settings.KeyDerivationAlgorithm, KeyDerivationAlgorithm, StringComparison.Ordinal) ||
+            settings.Iterations != PasswordKeyDerivation.DefaultIterations ||
+            string.IsNullOrWhiteSpace(settings.Salt) ||
+            !string.Equals(envelope.Kind, EnvelopeKind, StringComparison.Ordinal) ||
+            !string.Equals(envelope.Algorithm, EnvelopeAlgorithm, StringComparison.Ordinal) ||
+            !string.Equals(envelope.KeyId, PasswordDerivedKeyId, StringComparison.Ordinal) ||
+            string.IsNullOrWhiteSpace(envelope.Nonce) ||
+            string.IsNullOrWhiteSpace(envelope.Tag) ||
+            string.IsNullOrWhiteSpace(envelope.Ciphertext))
+        {
+            throw new CryptographicException("Deployment protection metadata is invalid.");
+        }
+    }
+}

--- a/src/Foundry.Deploy/Services/Security/DeploymentSecretKeyProvider.cs
+++ b/src/Foundry.Deploy/Services/Security/DeploymentSecretKeyProvider.cs
@@ -50,6 +50,7 @@ public sealed class DeploymentSecretKeyProvider(
         byte[] key = await File.ReadAllBytesAsync(keyPath, cancellationToken).ConfigureAwait(false);
         if (key.Length != AesGcmEncryption.KeySizeBytes)
         {
+            global::System.Security.Cryptography.CryptographicOperations.ZeroMemory(key);
             throw new InvalidOperationException("Deploy secret key has an invalid length.");
         }
 

--- a/src/Foundry.Deploy/Services/Security/DeploymentSecretKeyProvider.cs
+++ b/src/Foundry.Deploy/Services/Security/DeploymentSecretKeyProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using Foundry.Deploy.Models.Configuration;
 using Foundry.Deploy.Services.Configuration;
 using Foundry.Utilities.Security;
 
@@ -24,7 +25,10 @@ public sealed class DeploymentSecretKeyProvider(
             throw new InvalidOperationException("Deploy configuration is invalid.");
         }
 
-        if (configuration.Document?.Protection.IsEnabled == true)
+        DeployProtectionSettings protection = configuration.Document?.Protection ?? new DeployProtectionSettings();
+        bool requiresUnlock = DeploymentProtectionDetector.RequiresUnlock(protection) ||
+                              DeploymentProtectionDetector.HasProtectedArtifacts(configuration, workspaceRootPath);
+        if (requiresUnlock)
         {
             if (!deploymentSecretKeySession.IsUnlocked)
             {

--- a/src/Foundry.Deploy/Services/Security/DeploymentSecretKeyProvider.cs
+++ b/src/Foundry.Deploy/Services/Security/DeploymentSecretKeyProvider.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using Foundry.Deploy.Services.Configuration;
+using Foundry.Utilities.Security;
+
+namespace Foundry.Deploy.Services.Security;
+
+public sealed class DeploymentSecretKeyProvider(
+    IDeployConfigurationService configurationService,
+    IDeploymentSecretKeySession deploymentSecretKeySession) : IDeploymentSecretKeyProvider
+{
+    private const string DeploymentKeyRelativePath = @"Config\Secrets\deployment-secrets.key";
+    private const string LegacyKeyRelativePath = @"Config\Secrets\media-secrets.key";
+
+    public async Task<byte[]> ReadAsync(string workspaceRootPath, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRootPath);
+        DeployConfigurationLoadResult configuration = configurationService.LoadOptional();
+        if (configuration.Exists && configuration.Document is null)
+        {
+            throw new InvalidOperationException("Deploy configuration is invalid.");
+        }
+
+        if (configuration.Document?.Protection.IsEnabled == true)
+        {
+            if (!deploymentSecretKeySession.IsUnlocked)
+            {
+                throw new InvalidOperationException("Deployment secrets are not unlocked.");
+            }
+
+            return deploymentSecretKeySession.GetKeyCopy();
+        }
+
+        string deploymentKeyPath = Path.Combine(workspaceRootPath, DeploymentKeyRelativePath);
+        string keyPath = File.Exists(deploymentKeyPath)
+            ? deploymentKeyPath
+            : Path.Combine(workspaceRootPath, LegacyKeyRelativePath);
+        if (!File.Exists(keyPath))
+        {
+            throw new FileNotFoundException("Deploy secret key was not found in the boot media configuration.", keyPath);
+        }
+
+        byte[] key = await File.ReadAllBytesAsync(keyPath, cancellationToken).ConfigureAwait(false);
+        if (key.Length != AesGcmEncryption.KeySizeBytes)
+        {
+            throw new InvalidOperationException("Deploy secret key has an invalid length.");
+        }
+
+        return key;
+    }
+}

--- a/src/Foundry.Deploy/Services/Security/DeploymentSecretKeySession.cs
+++ b/src/Foundry.Deploy/Services/Security/DeploymentSecretKeySession.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+
+namespace Foundry.Deploy.Services.Security;
+
+public sealed class DeploymentSecretKeySession : IDeploymentSecretKeySession, IDisposable
+{
+    private byte[]? key;
+    private bool isDisposed;
+
+    public bool IsUnlocked => !isDisposed && key is { Length: 32 };
+
+    public void SetKey(ReadOnlySpan<byte> value)
+    {
+        ObjectDisposedException.ThrowIf(isDisposed, this);
+        if (value.Length != 32)
+        {
+            throw new ArgumentException("Deploy secret key must be 32 bytes.", nameof(value));
+        }
+
+        ClearKey();
+        key = value.ToArray();
+    }
+
+    public byte[] GetKeyCopy()
+    {
+        ObjectDisposedException.ThrowIf(isDisposed, this);
+        return key?.ToArray() ?? throw new InvalidOperationException("Deployment secrets are not unlocked.");
+    }
+
+    public void Clear()
+    {
+        ObjectDisposedException.ThrowIf(isDisposed, this);
+        ClearKey();
+    }
+
+    public void Dispose()
+    {
+        if (isDisposed)
+        {
+            return;
+        }
+
+        ClearKey();
+        isDisposed = true;
+    }
+
+    private void ClearKey()
+    {
+        if (key is null)
+        {
+            return;
+        }
+
+        CryptographicOperations.ZeroMemory(key);
+        key = null;
+    }
+}

--- a/src/Foundry.Deploy/Services/Security/IDeploymentAccessGate.cs
+++ b/src/Foundry.Deploy/Services/Security/IDeploymentAccessGate.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Deploy.Services.Security;
+
+public interface IDeploymentAccessGate
+{
+    Task<bool> AuthorizeAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Foundry.Deploy/Services/Security/IDeploymentAccessRetryDelay.cs
+++ b/src/Foundry.Deploy/Services/Security/IDeploymentAccessRetryDelay.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Deploy.Services.Security;
+
+public interface IDeploymentAccessRetryDelay
+{
+    Task WaitAsync(CancellationToken cancellationToken);
+}

--- a/src/Foundry.Deploy/Services/Security/IDeploymentAccessRetryDelay.cs
+++ b/src/Foundry.Deploy/Services/Security/IDeploymentAccessRetryDelay.cs
@@ -6,5 +6,5 @@ namespace Foundry.Deploy.Services.Security;
 
 public interface IDeploymentAccessRetryDelay
 {
-    Task WaitAsync(CancellationToken cancellationToken);
+    Task WaitAsync(int failedAttemptNumber, CancellationToken cancellationToken);
 }

--- a/src/Foundry.Deploy/Services/Security/IDeploymentPasswordDialogService.cs
+++ b/src/Foundry.Deploy/Services/Security/IDeploymentPasswordDialogService.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Deploy.Services.Security;
+
+public interface IDeploymentPasswordDialogService
+{
+    DeploymentPasswordPromptResult Prompt(bool previousAttemptFailed);
+}

--- a/src/Foundry.Deploy/Services/Security/IDeploymentProtectionUnlockService.cs
+++ b/src/Foundry.Deploy/Services/Security/IDeploymentProtectionUnlockService.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Deploy.Models.Configuration;
+
+namespace Foundry.Deploy.Services.Security;
+
+public interface IDeploymentProtectionUnlockService
+{
+    bool TryUnlock(DeployProtectionSettings settings, ReadOnlySpan<char> password);
+}

--- a/src/Foundry.Deploy/Services/Security/IDeploymentSecretKeyProvider.cs
+++ b/src/Foundry.Deploy/Services/Security/IDeploymentSecretKeyProvider.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Deploy.Services.Security;
+
+public interface IDeploymentSecretKeyProvider
+{
+    Task<byte[]> ReadAsync(string workspaceRootPath, CancellationToken cancellationToken = default);
+}

--- a/src/Foundry.Deploy/Services/Security/IDeploymentSecretKeySession.cs
+++ b/src/Foundry.Deploy/Services/Security/IDeploymentSecretKeySession.cs
@@ -4,7 +4,7 @@
 
 namespace Foundry.Deploy.Services.Security;
 
-public interface IDeploymentSecretKeySession
+public interface IDeploymentSecretKeySession : IDisposable
 {
     bool IsUnlocked { get; }
 

--- a/src/Foundry.Deploy/Services/Security/IDeploymentSecretKeySession.cs
+++ b/src/Foundry.Deploy/Services/Security/IDeploymentSecretKeySession.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Deploy.Services.Security;
+
+public interface IDeploymentSecretKeySession
+{
+    bool IsUnlocked { get; }
+
+    void SetKey(ReadOnlySpan<byte> key);
+
+    byte[] GetKeyCopy();
+
+    void Clear();
+}

--- a/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
@@ -530,9 +530,11 @@
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>فشل التحقق من الميزات الاختيارية لنظام التشغيل Windows لـ &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>مصدر NetFx3 المطابق غير متوفر. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>إلغاء</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>الوصول إلى النشر</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>أدخل كلمة مرور النشر للمتابعة.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>النشر المحمي</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>كلمة المرور مطلوبة</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>أدخل كلمة مرور الفني للمتابعة.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>كلمة مرور النشر</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>إلغاء القفل</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>متابعة</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>إظهار كلمة المرور أو إخفاؤها</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>كلمة المرور غير صحيحة. حاول مرة أخرى.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
@@ -529,10 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>تحتوي ميزة Windows الاختيارية &#39;{0}&#39; على حمولة تمت إزالتها ولا يوجد تعيين مصدر محلي مدعوم.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>فشل التحقق من الميزات الاختيارية لنظام التشغيل Windows لـ &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>مصدر NetFx3 المطابق غير متوفر. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>إلغاء</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>الوصول إلى النشر</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>أدخل كلمة مرور النشر للمتابعة.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>كلمة مرور النشر</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>إلغاء القفل</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>كلمة المرور غير صحيحة. حاول مرة أخرى.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ar-SA/Resources.resx
@@ -529,4 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>تحتوي ميزة Windows الاختيارية &#39;{0}&#39; على حمولة تمت إزالتها ولا يوجد تعيين مصدر محلي مدعوم.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>فشل التحقق من الميزات الاختيارية لنظام التشغيل Windows لـ &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>مصدر NetFx3 المطابق غير متوفر. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
+++ b/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
@@ -530,9 +530,11 @@
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Неуспешна проверка на допълнителната функция на Windows за „{0}“.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Съответстващият източник NetFx3 не е наличен. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Отказ</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Достъп до разполагането</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Въведете паролата за разполагане, за да продължите.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Защитено разполагане</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Изисква се парола</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Въведете паролата на техника, за да продължите.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Парола за разполагане</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Отключване</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Продължи</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Показване или скриване на паролата</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Паролата е неправилна. Опитайте отново.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
+++ b/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
@@ -529,10 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Допълнителната функция на Windows „{0}“ е с премахнат полезен товар и няма поддържано съпоставяне на локален източник.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Неуспешна проверка на допълнителната функция на Windows за „{0}“.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Съответстващият източник NetFx3 не е наличен. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Отказ</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Достъп до разполагането</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Въведете паролата за разполагане, за да продължите.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Парола за разполагане</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Отключване</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Паролата е неправилна. Опитайте отново.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
+++ b/src/Foundry.Deploy/Strings/bg-BG/Resources.resx
@@ -529,4 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Допълнителната функция на Windows „{0}“ е с премахнат полезен товар и няма поддържано съпоставяне на локален източник.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Неуспешна проверка на допълнителната функция на Windows за „{0}“.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Съответстващият източник NetFx3 не е наличен. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
+++ b/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
@@ -530,9 +530,11 @@ Pokračovat v nasazování?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Ověřen&#237; voliteln&#233; funkce syst&#233;mu Windows pro &#39;{0}&#39; se nezdařilo.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Odpov&#237;daj&#237;c&#237; zdroj NetFx3 nen&#237; k dispozici. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Zrušit</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Přístup k nasazení</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Pokračujte zadáním hesla pro nasazení.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Chráněné nasazení</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Je vyžadováno heslo</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Pokračujte zadáním hesla technika.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Heslo pro nasazení</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Odemknout</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Pokračovat</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Zobrazit nebo skrýt heslo</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Heslo není správné. Zkuste to znovu.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
+++ b/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
@@ -529,10 +529,10 @@ Pokračovat v nasazování?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Voliteln&#225; funkce syst&#233;mu Windows &#39;{0}&#39; m&#225; odstraněnou datovou č&#225;st a nen&#237; podporov&#225;no mapov&#225;n&#237; m&#237;stn&#237;ho zdroje.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Ověřen&#237; voliteln&#233; funkce syst&#233;mu Windows pro &#39;{0}&#39; se nezdařilo.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Odpov&#237;daj&#237;c&#237; zdroj NetFx3 nen&#237; k dispozici. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Zrušit</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Přístup k nasazení</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Pokračujte zadáním hesla pro nasazení.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Heslo pro nasazení</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Odemknout</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Heslo není správné. Zkuste to znovu.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
+++ b/src/Foundry.Deploy/Strings/cs-CZ/Resources.resx
@@ -529,4 +529,10 @@ Pokračovat v nasazování?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Voliteln&#225; funkce syst&#233;mu Windows &#39;{0}&#39; m&#225; odstraněnou datovou č&#225;st a nen&#237; podporov&#225;no mapov&#225;n&#237; m&#237;stn&#237;ho zdroje.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Ověřen&#237; voliteln&#233; funkce syst&#233;mu Windows pro &#39;{0}&#39; se nezdařilo.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Odpov&#237;daj&#237;c&#237; zdroj NetFx3 nen&#237; k dispozici. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/da-DK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/da-DK/Resources.resx
@@ -530,9 +530,11 @@ Vil du fortsætte med implementeringen?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Bekr&#230;ftelse af valgfri Windows-funktion mislykkedes for &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Matchende NetFx3-kilde er ikke tilg&#230;ngelig. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Annuller</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Adgang til installation</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Indtast adgangskoden til installationen for at fortsætte.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Beskyttet installation</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Adgangskode påkrævet</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Indtast teknikerens adgangskode for at fortsætte.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Adgangskode til installation</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Lås op</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Fortsæt</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Vis eller skjul adgangskoden</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Adgangskoden er forkert. Prøv igen.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/da-DK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/da-DK/Resources.resx
@@ -529,10 +529,10 @@ Vil du fortsætte med implementeringen?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Den valgfrie Windows-funktion &#39;{0}&#39; har en fjernet nyttelast og ingen understøttet lokal kildetilknytning.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Bekr&#230;ftelse af valgfri Windows-funktion mislykkedes for &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Matchende NetFx3-kilde er ikke tilg&#230;ngelig. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Annuller</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Adgang til installation</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Indtast adgangskoden til installationen for at fortsætte.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Adgangskode til installation</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Lås op</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Adgangskoden er forkert. Prøv igen.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/da-DK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/da-DK/Resources.resx
@@ -529,4 +529,10 @@ Vil du fortsætte med implementeringen?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Den valgfrie Windows-funktion &#39;{0}&#39; har en fjernet nyttelast og ingen understøttet lokal kildetilknytning.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Bekr&#230;ftelse af valgfri Windows-funktion mislykkedes for &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Matchende NetFx3-kilde er ikke tilg&#230;ngelig. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/de-DE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/de-DE/Resources.resx
@@ -529,4 +529,10 @@ Mit der Bereitstellung fortfahren?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Die optionale Windows-Funktion „{0}“ hat eine entfernte Nutzlast und keine unterst&#252;tzte lokale Quellenzuordnung.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Die &#220;berpr&#252;fung der optionalen Windows-Funktion f&#252;r „{0}“ ist fehlgeschlagen.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Die passende NetFx3-Quelle ist nicht verf&#252;gbar. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/de-DE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/de-DE/Resources.resx
@@ -530,9 +530,11 @@ Mit der Bereitstellung fortfahren?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Die &#220;berpr&#252;fung der optionalen Windows-Funktion f&#252;r „{0}“ ist fehlgeschlagen.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Die passende NetFx3-Quelle ist nicht verf&#252;gbar. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Abbrechen</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Bereitstellungszugriff</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Geben Sie das Bereitstellungskennwort ein, um fortzufahren.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Geschützte Bereitstellung</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Kennwort erforderlich</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Geben Sie das Technikerkennwort ein, um fortzufahren.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Bereitstellungskennwort</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Entsperren</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Fortfahren</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Kennwort anzeigen oder ausblenden</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Das Kennwort ist falsch. Versuchen Sie es erneut.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/de-DE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/de-DE/Resources.resx
@@ -529,10 +529,10 @@ Mit der Bereitstellung fortfahren?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Die optionale Windows-Funktion „{0}“ hat eine entfernte Nutzlast und keine unterst&#252;tzte lokale Quellenzuordnung.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Die &#220;berpr&#252;fung der optionalen Windows-Funktion f&#252;r „{0}“ ist fehlgeschlagen.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Die passende NetFx3-Quelle ist nicht verf&#252;gbar. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Abbrechen</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Bereitstellungszugriff</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Geben Sie das Bereitstellungskennwort ein, um fortzufahren.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Bereitstellungskennwort</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Entsperren</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Das Kennwort ist falsch. Versuchen Sie es erneut.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/el-GR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/el-GR/Resources.resx
@@ -529,10 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Το ωφέλιμο φορτίο της προαιρετικής δυνατότητας των Windows &quot;{0}&quot; έχει καταργηθεί και δεν υπάρχει υποστηριζόμενη αντιστοίχιση τοπικής πηγής.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Η επαλήθευση της προαιρετικής δυνατότητας των Windows απέτυχε για το &quot;{0}&quot;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Η αντίστοιχη πηγή NetFx3 δεν είναι διαθέσιμη. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Ακύρωση</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Πρόσβαση στην ανάπτυξη</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Εισαγάγετε τον κωδικό πρόσβασης ανάπτυξης για να συνεχίσετε.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Κωδικός πρόσβασης ανάπτυξης</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Ξεκλείδωμα</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Ο κωδικός πρόσβασης είναι λανθασμένος. Δοκιμάστε ξανά.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/el-GR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/el-GR/Resources.resx
@@ -530,9 +530,11 @@
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Η επαλήθευση της προαιρετικής δυνατότητας των Windows απέτυχε για το &quot;{0}&quot;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Η αντίστοιχη πηγή NetFx3 δεν είναι διαθέσιμη. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Ακύρωση</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Πρόσβαση στην ανάπτυξη</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Εισαγάγετε τον κωδικό πρόσβασης ανάπτυξης για να συνεχίσετε.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Προστατευμένη ανάπτυξη</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Απαιτείται κωδικός πρόσβασης</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Εισαγάγετε τον κωδικό πρόσβασης τεχνικού για να συνεχίσετε.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Κωδικός πρόσβασης ανάπτυξης</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Ξεκλείδωμα</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Συνέχεια</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Εμφάνιση ή απόκρυψη κωδικού πρόσβασης</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Ο κωδικός πρόσβασης είναι λανθασμένος. Δοκιμάστε ξανά.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/el-GR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/el-GR/Resources.resx
@@ -529,4 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Το ωφέλιμο φορτίο της προαιρετικής δυνατότητας των Windows &quot;{0}&quot; έχει καταργηθεί και δεν υπάρχει υποστηριζόμενη αντιστοίχιση τοπικής πηγής.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Η επαλήθευση της προαιρετικής δυνατότητας των Windows απέτυχε για το &quot;{0}&quot;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Η αντίστοιχη πηγή NetFx3 δεν είναι διαθέσιμη. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/en-GB/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-GB/Resources.resx
@@ -530,9 +530,11 @@ Continue with deployment?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Windows optional feature verification failed for '{0}'.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Matching NetFx3 source is unavailable. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Protected deployment</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Password required</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Enter the technician password to continue.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Continue</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Show or hide password</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/en-GB/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-GB/Resources.resx
@@ -529,4 +529,10 @@ Continue with deployment?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows optional feature '{0}' has a removed payload and no supported local source mapping.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Windows optional feature verification failed for '{0}'.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Matching NetFx3 source is unavailable. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/en-US/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-US/Resources.resx
@@ -530,9 +530,11 @@ Continue with deployment?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Windows optional feature verification failed for '{0}'.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Matching NetFx3 source is unavailable. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Protected deployment</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Password required</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Enter the technician password to continue.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Continue</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Show or hide password</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/en-US/Resources.resx
+++ b/src/Foundry.Deploy/Strings/en-US/Resources.resx
@@ -529,4 +529,10 @@ Continue with deployment?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows optional feature '{0}' has a removed payload and no supported local source mapping.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Windows optional feature verification failed for '{0}'.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Matching NetFx3 source is unavailable. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/es-ES/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-ES/Resources.resx
@@ -529,10 +529,10 @@ Sistema operativo: {4}
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>La caracter&#237;stica opcional de Windows &#39;{0}&#39; tiene una carga &#250;til eliminada y no se admite ninguna asignaci&#243;n de fuente local.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>La verificaci&#243;n de la funci&#243;n opcional de Windows fall&#243; para &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>La fuente NetFx3 coincidente no est&#225; disponible. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancelar</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Acceso a la implementación</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Introduzca la contraseña de implementación para continuar.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Contraseña de implementación</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Desbloquear</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>La contraseña es incorrecta. Inténtelo de nuevo.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/es-ES/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-ES/Resources.resx
@@ -529,4 +529,10 @@ Sistema operativo: {4}
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>La caracter&#237;stica opcional de Windows &#39;{0}&#39; tiene una carga &#250;til eliminada y no se admite ninguna asignaci&#243;n de fuente local.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>La verificaci&#243;n de la funci&#243;n opcional de Windows fall&#243; para &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>La fuente NetFx3 coincidente no est&#225; disponible. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/es-ES/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-ES/Resources.resx
@@ -530,9 +530,11 @@ Sistema operativo: {4}
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>La verificaci&#243;n de la funci&#243;n opcional de Windows fall&#243; para &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>La fuente NetFx3 coincidente no est&#225; disponible. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Cancelar</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Acceso a la implementación</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Introduzca la contraseña de implementación para continuar.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Implementación protegida</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Se requiere contraseña</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Introduzca la contraseña del técnico para continuar.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Contraseña de implementación</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Desbloquear</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Continuar</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Mostrar u ocultar la contraseña</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>La contraseña es incorrecta. Inténtelo de nuevo.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/es-MX/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-MX/Resources.resx
@@ -529,10 +529,10 @@ Sistema operativo: {4}
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>La caracter&#237;stica opcional de Windows &#39;{0}&#39; tiene una carga &#250;til eliminada y no se admite ninguna asignaci&#243;n de fuente local.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>La verificaci&#243;n de la funci&#243;n opcional de Windows fall&#243; para &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>La fuente NetFx3 coincidente no est&#225; disponible. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancelar</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Acceso a la implementación</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Ingresa la contraseña de implementación para continuar.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Contraseña de implementación</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Desbloquear</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>La contraseña es incorrecta. Inténtalo de nuevo.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/es-MX/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-MX/Resources.resx
@@ -530,9 +530,11 @@ Sistema operativo: {4}
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>La verificaci&#243;n de la funci&#243;n opcional de Windows fall&#243; para &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>La fuente NetFx3 coincidente no est&#225; disponible. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Cancelar</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Acceso a la implementación</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Ingresa la contraseña de implementación para continuar.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Implementación protegida</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Contraseña requerida</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Ingresa la contraseña del técnico para continuar.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Contraseña de implementación</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Desbloquear</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Continuar</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Mostrar u ocultar la contraseña</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>La contraseña es incorrecta. Inténtalo de nuevo.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/es-MX/Resources.resx
+++ b/src/Foundry.Deploy/Strings/es-MX/Resources.resx
@@ -529,4 +529,10 @@ Sistema operativo: {4}
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>La caracter&#237;stica opcional de Windows &#39;{0}&#39; tiene una carga &#250;til eliminada y no se admite ninguna asignaci&#243;n de fuente local.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>La verificaci&#243;n de la funci&#243;n opcional de Windows fall&#243; para &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>La fuente NetFx3 coincidente no est&#225; disponible. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/et-EE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/et-EE/Resources.resx
@@ -530,9 +530,11 @@ Kas jätkata juurutamisega?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Windowsi valikulise funktsiooni kinnitamine eba&#245;nnestus &#39;{0}&#39; puhul.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Sobiv NetFx3 allikas pole saadaval. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Loobu</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Juurutuse juurdepääs</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Jätkamiseks sisesta juurutusparool.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Kaitstud juurutus</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Parool on nõutav</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Jätkamiseks sisesta tehniku parool.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Juurutusparool</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Ava lukustus</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Jätka</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Kuva või peida parool</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Parool on vale. Proovi uuesti.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/et-EE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/et-EE/Resources.resx
@@ -529,4 +529,10 @@ Kas jätkata juurutamisega?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windowsi valikulise funktsiooni „{0}” last on eemaldatud ja toetatud kohaliku allika vastendus puudub.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Windowsi valikulise funktsiooni kinnitamine eba&#245;nnestus &#39;{0}&#39; puhul.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Sobiv NetFx3 allikas pole saadaval. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/et-EE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/et-EE/Resources.resx
@@ -529,10 +529,10 @@ Kas jätkata juurutamisega?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windowsi valikulise funktsiooni „{0}” last on eemaldatud ja toetatud kohaliku allika vastendus puudub.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Windowsi valikulise funktsiooni kinnitamine eba&#245;nnestus &#39;{0}&#39; puhul.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Sobiv NetFx3 allikas pole saadaval. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Loobu</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Juurutuse juurdepääs</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Jätkamiseks sisesta juurutusparool.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Juurutusparool</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Ava lukustus</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Parool on vale. Proovi uuesti.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
@@ -529,4 +529,10 @@ Jatketaanko käyttöönottoa?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windowsin valinnaisen ominaisuuden &#39;{0}&#39; hyötykuorma on poistettu, eikä tuettua paikallisen lähteen määritystä ole.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Windowsin valinnaisen ominaisuuden vahvistus epäonnistui kohteelle &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Vastaavaa NetFx3-l&#228;hdett&#228; ei ole saatavilla. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
@@ -530,9 +530,11 @@ Jatketaanko käyttöönottoa?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Windowsin valinnaisen ominaisuuden vahvistus epäonnistui kohteelle &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Vastaavaa NetFx3-l&#228;hdett&#228; ei ole saatavilla. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Peruuta</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Käyttöönoton käyttöoikeus</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Jatka antamalla käyttöönoton salasana.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Suojattu käyttöönotto</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Salasana vaaditaan</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Jatka antamalla teknikon salasana.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Käyttöönoton salasana</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Avaa lukitus</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Jatka</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Näytä tai piilota salasana</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Salasana on virheellinen. Yritä uudelleen.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fi-FI/Resources.resx
@@ -529,10 +529,10 @@ Jatketaanko käyttöönottoa?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windowsin valinnaisen ominaisuuden &#39;{0}&#39; hyötykuorma on poistettu, eikä tuettua paikallisen lähteen määritystä ole.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Windowsin valinnaisen ominaisuuden vahvistus epäonnistui kohteelle &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Vastaavaa NetFx3-l&#228;hdett&#228; ei ole saatavilla. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Peruuta</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Käyttöönoton käyttöoikeus</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Jatka antamalla käyttöönoton salasana.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Käyttöönoton salasana</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Avaa lukitus</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Salasana on virheellinen. Yritä uudelleen.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
@@ -531,7 +531,7 @@ Continuer le déploiement?</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>La source NetFx3 correspondante n&#39;est pas disponible. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Annuler</value></data>
   <data name="DeploymentAccess.Title" xml:space="preserve"><value>Accès au déploiement</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Saisissez le mot de passe de déploiement pour continuer.</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Entrez le mot de passe de déploiement pour continuer.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Mot de passe de déploiement</value></data>
   <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Déverrouiller</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Le mot de passe est incorrect. Réessayez.</value></data>

--- a/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
@@ -529,4 +529,10 @@ Continuer le déploiement?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>La charge utile de la fonctionnalité facultative Windows &#171;&#160;{0}&#160;&#187; a été supprimée et aucun mappage de source locale n’est pris en charge.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>La v&#233;rification des fonctionnalit&#233;s facultatives de Windows a &#233;chou&#233; pour &#171;&#160;{0}&#160;&#187;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>La source NetFx3 correspondante n&#39;est pas disponible. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Annuler</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Accès au déploiement</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Saisissez le mot de passe de déploiement pour continuer.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Mot de passe de déploiement</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Déverrouiller</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Le mot de passe est incorrect. Réessayez.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-CA/Resources.resx
@@ -530,9 +530,11 @@ Continuer le déploiement?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>La v&#233;rification des fonctionnalit&#233;s facultatives de Windows a &#233;chou&#233; pour &#171;&#160;{0}&#160;&#187;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>La source NetFx3 correspondante n&#39;est pas disponible. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Annuler</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Accès au déploiement</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Entrez le mot de passe de déploiement pour continuer.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Déploiement protégé</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Mot de passe requis</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Entrez le mot de passe du technicien pour continuer.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Mot de passe de déploiement</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Déverrouiller</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Continuer</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Afficher ou masquer le mot de passe</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Le mot de passe est incorrect. Réessayez.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
@@ -529,4 +529,10 @@ Continuer le déploiement ?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>La charge utile de la fonctionnalité facultative Windows « {0} » a été supprimée et aucun mappage de source locale n’est pris en charge.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>La vérification de la fonctionnalité facultative Windows « {0} » a échoué.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>La source NetFx3 correspondante est indisponible. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Annuler</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Accès au déploiement</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Saisissez le mot de passe de déploiement pour continuer.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Mot de passe de déploiement</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Déverrouiller</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Le mot de passe est incorrect. Réessayez.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/fr-FR/Resources.resx
@@ -530,9 +530,11 @@ Continuer le déploiement ?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>La vérification de la fonctionnalité facultative Windows « {0} » a échoué.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>La source NetFx3 correspondante est indisponible. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Annuler</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Accès au déploiement</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Saisissez le mot de passe de déploiement pour continuer.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Déploiement protégé</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Mot de passe requis</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Saisissez le mot de passe du technicien pour continuer.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Mot de passe de déploiement</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Déverrouiller</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Continuer</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Afficher ou masquer le mot de passe</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Le mot de passe est incorrect. Réessayez.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/he-IL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/he-IL/Resources.resx
@@ -530,9 +530,11 @@ ErrorCode=0x80070005
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>אימות התכונה האופציונלית של Windows נכשל עבור &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>מקור NetFx3 תואם אינו זמין. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>ביטול</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>גישה לפריסה</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>הזן את סיסמת הפריסה כדי להמשיך.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>פריסה מוגנת</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>נדרשת סיסמה</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>הזן את סיסמת הטכנאי כדי להמשיך.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>סיסמת פריסה</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>ביטול נעילה</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>המשך</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>הצג או הסתר את הסיסמה</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>הסיסמה שגויה. נסה שוב.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/he-IL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/he-IL/Resources.resx
@@ -529,10 +529,10 @@ ErrorCode=0x80070005
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>לתכונה האופציונלית של Windows &#39;{0}&#39; יש מטען שהוסר ואין מיפוי מקור מקומי נתמך.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>אימות התכונה האופציונלית של Windows נכשל עבור &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>מקור NetFx3 תואם אינו זמין. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>ביטול</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>גישה לפריסה</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>הזן את סיסמת הפריסה כדי להמשיך.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>סיסמת פריסה</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>ביטול נעילה</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>הסיסמה שגויה. נסה שוב.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/he-IL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/he-IL/Resources.resx
@@ -529,4 +529,10 @@ ErrorCode=0x80070005
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>לתכונה האופציונלית של Windows &#39;{0}&#39; יש מטען שהוסר ואין מיפוי מקור מקומי נתמך.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>אימות התכונה האופציונלית של Windows נכשל עבור &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>מקור NetFx3 תואם אינו זמין. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
@@ -530,9 +530,11 @@ Nastaviti s implementacijom?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Provjera izborne značajke sustava Windows nije uspjela za &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Odgovarajući izvor NetFx3 nije dostupan. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Odustani</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Pristup implementaciji</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Za nastavak unesite lozinku za implementaciju.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Zaštićena implementacija</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Potrebna je lozinka</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Za nastavak unesite lozinku tehničara.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Lozinka za implementaciju</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Otključaj</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Nastavi</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Prikaži ili sakrij lozinku</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Lozinka nije točna. Pokušajte ponovno.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
@@ -529,10 +529,10 @@ Nastaviti s implementacijom?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Opcijska značajka sustava Windows &#39;{0}&#39; ima uklonjeni sadržaj i nema podržanog mapiranja lokalnog izvora.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Provjera izborne značajke sustava Windows nije uspjela za &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Odgovarajući izvor NetFx3 nije dostupan. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Odustani</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Pristup implementaciji</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Za nastavak unesite lozinku za implementaciju.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Lozinka za implementaciju</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Otključaj</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Lozinka nije točna. Pokušajte ponovno.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hr-HR/Resources.resx
@@ -529,4 +529,10 @@ Nastaviti s implementacijom?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Opcijska značajka sustava Windows &#39;{0}&#39; ima uklonjeni sadržaj i nema podržanog mapiranja lokalnog izvora.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Provjera izborne značajke sustava Windows nije uspjela za &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Odgovarajući izvor NetFx3 nije dostupan. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
@@ -529,4 +529,10 @@ Folytatja a telepítést?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>A Windows opcion&#225;lis „{0}” funkci&#243;j&#225;nak hasznos tartalma elt&#225;vol&#237;tva, &#233;s nincs t&#225;mogatott helyi forr&#225;slek&#233;pez&#233;s.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>A Windows opcion&#225;lis funkci&#243;j&#225;nak ellenőrz&#233;se nem siker&#252;lt a(z) „{0}” eset&#233;ben.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>A megfelelő NetFx3 forr&#225;s nem &#233;rhető el. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
@@ -530,9 +530,11 @@ Folytatja a telepítést?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>A Windows opcion&#225;lis funkci&#243;j&#225;nak ellenőrz&#233;se nem siker&#252;lt a(z) „{0}” eset&#233;ben.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>A megfelelő NetFx3 forr&#225;s nem &#233;rhető el. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Mégse</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Hozzáférés a telepítéshez</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>A folytatáshoz adja meg a telepítési jelszót.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Védett telepítés</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Jelszó szükséges</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>A folytatáshoz adja meg a technikusi jelszót.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Telepítési jelszó</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Feloldás</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Folytatás</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Jelszó megjelenítése vagy elrejtése</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>A jelszó helytelen. Próbálja újra.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/hu-HU/Resources.resx
@@ -529,10 +529,10 @@ Folytatja a telepítést?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>A Windows opcion&#225;lis „{0}” funkci&#243;j&#225;nak hasznos tartalma elt&#225;vol&#237;tva, &#233;s nincs t&#225;mogatott helyi forr&#225;slek&#233;pez&#233;s.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>A Windows opcion&#225;lis funkci&#243;j&#225;nak ellenőrz&#233;se nem siker&#252;lt a(z) „{0}” eset&#233;ben.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>A megfelelő NetFx3 forr&#225;s nem &#233;rhető el. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Mégse</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Hozzáférés a telepítéshez</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>A folytatáshoz adja meg a telepítési jelszót.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Telepítési jelszó</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Feloldás</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>A jelszó helytelen. Próbálja újra.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/it-IT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/it-IT/Resources.resx
@@ -529,10 +529,10 @@ Continuare con la distribuzione?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>La funzionalit&#224; facoltativa di Windows &#39;{0}&#39; presenta un payload rimosso e nessuna mappatura dell&#39;origine locale supportata.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>La verifica delle funzionalit&#224; facoltative di Windows non &#232; riuscita per &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>La sorgente NetFx3 corrispondente non &#232; disponibile. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Annulla</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Accesso alla distribuzione</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Inserisci la password di distribuzione per continuare.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Password di distribuzione</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Sblocca</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>La password non è corretta. Riprova.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/it-IT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/it-IT/Resources.resx
@@ -529,4 +529,10 @@ Continuare con la distribuzione?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>La funzionalit&#224; facoltativa di Windows &#39;{0}&#39; presenta un payload rimosso e nessuna mappatura dell&#39;origine locale supportata.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>La verifica delle funzionalit&#224; facoltative di Windows non &#232; riuscita per &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>La sorgente NetFx3 corrispondente non &#232; disponibile. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/it-IT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/it-IT/Resources.resx
@@ -530,9 +530,11 @@ Continuare con la distribuzione?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>La verifica delle funzionalit&#224; facoltative di Windows non &#232; riuscita per &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>La sorgente NetFx3 corrispondente non &#232; disponibile. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Annulla</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Accesso alla distribuzione</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Inserisci la password di distribuzione per continuare.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Distribuzione protetta</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Password richiesta</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Inserisci la password del tecnico per continuare.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Password di distribuzione</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Sblocca</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Continua</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Mostra o nascondi la password</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>La password non è corretta. Riprova.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
@@ -530,9 +530,11 @@
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>&#39;{0}&#39; の Windows オプション機能の検証に失敗しました。</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>一致する NetFx3 ソースは利用できません。 {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>キャンセル</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>展開へのアクセス</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>続行するには展開パスワードを入力してください。</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>保護された展開</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>パスワードが必要です</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>続行するには、技術者用パスワードを入力してください。</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>展開パスワード</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>ロック解除</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>続行</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>パスワードの表示と非表示を切り替える</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>パスワードが正しくありません。もう一度お試しください。</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
@@ -529,10 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows のオプション機能 &#39;{0}&#39; のペイロードが削除されており、サポートされているローカル ソース マッピングがありません。</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>&#39;{0}&#39; の Windows オプション機能の検証に失敗しました。</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>一致する NetFx3 ソースは利用できません。 {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>キャンセル</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>展開へのアクセス</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>続行するには展開パスワードを入力してください。</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>展開パスワード</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>ロック解除</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>パスワードが正しくありません。もう一度お試しください。</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ja-JP/Resources.resx
@@ -529,4 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows のオプション機能 &#39;{0}&#39; のペイロードが削除されており、サポートされているローカル ソース マッピングがありません。</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>&#39;{0}&#39; の Windows オプション機能の検証に失敗しました。</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>一致する NetFx3 ソースは利用できません。 {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
@@ -529,4 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows 선택적 기능 &#39;{0}&#39;의 페이로드가 제거되어 있으며 지원되는 로컬 원본 매핑이 없습니다.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>&#39;{0}&#39;에 대한 Windows 선택적 기능 확인에 실패했습니다.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>일치하는 NetFx3 소스를 사용할 수 없습니다. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
@@ -529,10 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows 선택적 기능 &#39;{0}&#39;의 페이로드가 제거되어 있으며 지원되는 로컬 원본 매핑이 없습니다.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>&#39;{0}&#39;에 대한 Windows 선택적 기능 확인에 실패했습니다.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>일치하는 NetFx3 소스를 사용할 수 없습니다. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>취소</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>배포 액세스</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>계속하려면 배포 암호를 입력하세요.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>배포 암호</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>잠금 해제</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>암호가 올바르지 않습니다. 다시 시도하세요.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ko-KR/Resources.resx
@@ -530,9 +530,11 @@
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>&#39;{0}&#39;에 대한 Windows 선택적 기능 확인에 실패했습니다.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>일치하는 NetFx3 소스를 사용할 수 없습니다. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>취소</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>배포 액세스</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>계속하려면 배포 암호를 입력하세요.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>보호된 배포</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>암호 필요</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>계속하려면 기술자 암호를 입력하세요.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>배포 암호</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>잠금 해제</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>계속</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>암호 표시 또는 숨기기</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>암호가 올바르지 않습니다. 다시 시도하세요.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
@@ -530,9 +530,11 @@ Tęsti diegimą?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Nepavyko patvirtinti „Windows“ pasirenkamos funkcijos „{0}“.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Atitinkantis NetFx3 šaltinis nepasiekiamas. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Atšaukti</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Prieiga prie diegimo</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Norėdami tęsti, įveskite diegimo slaptažodį.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Apsaugotas diegimas</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Reikalingas slaptažodis</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Norėdami tęsti, įveskite techniko slaptažodį.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Diegimo slaptažodis</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Atrakinti</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Tęsti</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Rodyti arba slėpti slaptažodį</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Slaptažodis neteisingas. Bandykite dar kartą.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
@@ -529,10 +529,10 @@ Tęsti diegimą?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>„Windows“ pasirenkama funkcija „{0}“ turi pašalintą naudingą apkrovą ir nepalaikoma vietinio šaltinio atvaizdavimo.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Nepavyko patvirtinti „Windows“ pasirenkamos funkcijos „{0}“.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Atitinkantis NetFx3 šaltinis nepasiekiamas. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Atšaukti</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Prieiga prie diegimo</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Norėdami tęsti, įveskite diegimo slaptažodį.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Diegimo slaptažodis</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Atrakinti</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Slaptažodis neteisingas. Bandykite dar kartą.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lt-LT/Resources.resx
@@ -529,4 +529,10 @@ Tęsti diegimą?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>„Windows“ pasirenkama funkcija „{0}“ turi pašalintą naudingą apkrovą ir nepalaikoma vietinio šaltinio atvaizdavimo.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Nepavyko patvirtinti „Windows“ pasirenkamos funkcijos „{0}“.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Atitinkantis NetFx3 šaltinis nepasiekiamas. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
@@ -530,9 +530,11 @@ Vai turpināt izvietošanu?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Neizdevās pārbaudīt operētājsistēmas Windows papildu funkciju “{0}”.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Atbilstošs NetFx3 avots nav pieejams. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Atcelt</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Piekļuve izvietošanai</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Lai turpinātu, ievadiet izvietošanas paroli.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Aizsargāta izvietošana</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Nepieciešama parole</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Lai turpinātu, ievadiet tehniķa paroli.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Izvietošanas parole</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Atbloķēt</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Turpināt</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Rādīt vai paslēpt paroli</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Parole nav pareiza. Mēģiniet vēlreiz.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
@@ -529,4 +529,10 @@ Vai turpināt izvietošanu?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows papildu funkcijai “{0}” ir noņemta lietderīgā slodze un netiek atbalstīta vietējā avota kartēšana.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Neizdevās pārbaudīt operētājsistēmas Windows papildu funkciju “{0}”.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Atbilstošs NetFx3 avots nav pieejams. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
+++ b/src/Foundry.Deploy/Strings/lv-LV/Resources.resx
@@ -529,10 +529,10 @@ Vai turpināt izvietošanu?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows papildu funkcijai “{0}” ir noņemta lietderīgā slodze un netiek atbalstīta vietējā avota kartēšana.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Neizdevās pārbaudīt operētājsistēmas Windows papildu funkciju “{0}”.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Atbilstošs NetFx3 avots nav pieejams. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Atcelt</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Piekļuve izvietošanai</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Lai turpinātu, ievadiet izvietošanas paroli.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Izvietošanas parole</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Atbloķēt</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Parole nav pareiza. Mēģiniet vēlreiz.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
@@ -530,9 +530,11 @@ Vil du fortsette med distribusjonen?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Windows valgfri funksjonsbekreftelse mislyktes for &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Matchende NetFx3-kilde er ikke tilgjengelig. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Avbryt</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Tilgang til distribusjon</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Skriv inn distribusjonspassordet for å fortsette.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Beskyttet distribusjon</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Passord kreves</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Skriv inn teknikerpassordet for å fortsette.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Distribusjonspassord</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Lås opp</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Fortsett</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Vis eller skjul passord</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Passordet er feil. Prøv på nytt.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
@@ -529,4 +529,10 @@ Vil du fortsette med distribusjonen?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows valgfri funksjon &#39;{0}&#39; har en fjernet nyttelast og ingen st&#248;ttet lokal kildetilordning.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Windows valgfri funksjonsbekreftelse mislyktes for &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Matchende NetFx3-kilde er ikke tilgjengelig. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nb-NO/Resources.resx
@@ -529,10 +529,10 @@ Vil du fortsette med distribusjonen?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows valgfri funksjon &#39;{0}&#39; har en fjernet nyttelast og ingen st&#248;ttet lokal kildetilordning.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Windows valgfri funksjonsbekreftelse mislyktes for &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Matchende NetFx3-kilde er ikke tilgjengelig. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Avbryt</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Tilgang til distribusjon</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Skriv inn distribusjonspassordet for å fortsette.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Distribusjonspassord</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Lås opp</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Passordet er feil. Prøv på nytt.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
@@ -529,4 +529,10 @@ Doorgaan met de implementatie?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>De optionele Windows-functie &#39;{0}&#39; heeft een verwijderde payload en geen ondersteunde lokale brontoewijzing.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Verificatie van optionele Windows-functies mislukt voor &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Overeenkomende NetFx3-bron is niet beschikbaar. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
@@ -529,10 +529,10 @@ Doorgaan met de implementatie?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>De optionele Windows-functie &#39;{0}&#39; heeft een verwijderde payload en geen ondersteunde lokale brontoewijzing.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Verificatie van optionele Windows-functies mislukt voor &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Overeenkomende NetFx3-bron is niet beschikbaar. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Annuleren</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Toegang tot implementatie</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Voer het implementatiewachtwoord in om door te gaan.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Implementatiewachtwoord</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Ontgrendelen</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Het wachtwoord is onjuist. Probeer het opnieuw.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/nl-NL/Resources.resx
@@ -530,9 +530,11 @@ Doorgaan met de implementatie?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Verificatie van optionele Windows-functies mislukt voor &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Overeenkomende NetFx3-bron is niet beschikbaar. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Annuleren</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Toegang tot implementatie</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Voer het implementatiewachtwoord in om door te gaan.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Beveiligde implementatie</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Wachtwoord vereist</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Voer het wachtwoord van de technicus in om door te gaan.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Implementatiewachtwoord</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Ontgrendelen</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Doorgaan</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Wachtwoord tonen of verbergen</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Het wachtwoord is onjuist. Probeer het opnieuw.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
@@ -529,4 +529,10 @@ Kontynuować wdrażanie?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Opcjonalna funkcja systemu Windows „{0}” ma usunięty ładunek i nie jest obsługiwane lokalne mapowanie źr&#243;dła.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Weryfikacja opcjonalnych funkcji systemu Windows nie powiodła się dla „{0}”.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Pasujące źr&#243;dło NetFx3 jest niedostępne. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
@@ -529,10 +529,10 @@ Kontynuować wdrażanie?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Opcjonalna funkcja systemu Windows „{0}” ma usunięty ładunek i nie jest obsługiwane lokalne mapowanie źr&#243;dła.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Weryfikacja opcjonalnych funkcji systemu Windows nie powiodła się dla „{0}”.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Pasujące źr&#243;dło NetFx3 jest niedostępne. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Anuluj</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Dostęp do wdrożenia</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Wprowadź hasło wdrożenia, aby kontynuować.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Hasło wdrożenia</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Odblokuj</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Hasło jest nieprawidłowe. Spróbuj ponownie.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pl-PL/Resources.resx
@@ -530,9 +530,11 @@ Kontynuować wdrażanie?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Weryfikacja opcjonalnych funkcji systemu Windows nie powiodła się dla „{0}”.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Pasujące źr&#243;dło NetFx3 jest niedostępne. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Anuluj</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Dostęp do wdrożenia</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Wprowadź hasło wdrożenia, aby kontynuować.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Chronione wdrożenie</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Wymagane hasło</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Wprowadź hasło technika, aby kontynuować.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Hasło wdrożenia</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Odblokuj</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Kontynuuj</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Pokaż lub ukryj hasło</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Hasło jest nieprawidłowe. Spróbuj ponownie.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
@@ -530,9 +530,11 @@ Continuar com a implantação?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>A verifica&#231;&#227;o do recurso opcional do Windows falhou para &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>A fonte NetFx3 correspondente n&#227;o est&#225; dispon&#237;vel. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Cancelar</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Acesso à implantação</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Insira a senha de implantação para continuar.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Implantação protegida</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Senha obrigatória</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Insira a senha do técnico para continuar.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Senha de implantação</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Desbloquear</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Continuar</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Mostrar ou ocultar senha</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>A senha está incorreta. Tente novamente.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
@@ -529,4 +529,10 @@ Continuar com a implantação?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>O recurso opcional do Windows &#39;{0}&#39; tem uma carga &#250;til removida e nenhum mapeamento de origem local compat&#237;vel.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>A verifica&#231;&#227;o do recurso opcional do Windows falhou para &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>A fonte NetFx3 correspondente n&#227;o est&#225; dispon&#237;vel. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-BR/Resources.resx
@@ -529,10 +529,10 @@ Continuar com a implantação?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>O recurso opcional do Windows &#39;{0}&#39; tem uma carga &#250;til removida e nenhum mapeamento de origem local compat&#237;vel.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>A verifica&#231;&#227;o do recurso opcional do Windows falhou para &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>A fonte NetFx3 correspondente n&#227;o est&#225; dispon&#237;vel. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancelar</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Acesso à implantação</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Insira a senha de implantação para continuar.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Senha de implantação</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Desbloquear</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>A senha está incorreta. Tente novamente.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
@@ -529,10 +529,10 @@ Continuar com a implantação?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>A funcionalidade opcional do Windows &#39;{0}&#39; tem uma carga &#250;til removida e n&#227;o tem mapeamento de origem local compat&#237;vel.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>A verifica&#231;&#227;o do recurso opcional do Windows falhou para &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>A fonte NetFx3 correspondente n&#227;o est&#225; dispon&#237;vel. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancelar</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Acesso à implementação</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Introduza a palavra-passe de implementação para continuar.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Palavra-passe de implementação</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Desbloquear</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>A palavra-passe está incorreta. Tente novamente.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
@@ -530,9 +530,11 @@ Continuar com a implantação?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>A verifica&#231;&#227;o do recurso opcional do Windows falhou para &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>A fonte NetFx3 correspondente n&#227;o est&#225; dispon&#237;vel. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Cancelar</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Acesso à implementação</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Introduza a palavra-passe de implementação para continuar.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Implementação protegida</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Palavra-passe necessária</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Introduza a palavra-passe do técnico para continuar.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Palavra-passe de implementação</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Desbloquear</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Continuar</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Mostrar ou ocultar a palavra-passe</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>A palavra-passe está incorreta. Tente novamente.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
+++ b/src/Foundry.Deploy/Strings/pt-PT/Resources.resx
@@ -529,4 +529,10 @@ Continuar com a implantação?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>A funcionalidade opcional do Windows &#39;{0}&#39; tem uma carga &#250;til removida e n&#227;o tem mapeamento de origem local compat&#237;vel.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>A verifica&#231;&#227;o do recurso opcional do Windows falhou para &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>A fonte NetFx3 correspondente n&#227;o est&#225; dispon&#237;vel. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
@@ -529,10 +529,10 @@ Continuați cu implementarea?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Caracteristica opțională Windows „{0}” are o sarcină utilă eliminată și nu este acceptată maparea surselor locale.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Verificarea caracteristicilor opționale Windows nu a reușit pentru „{0}”.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Sursa NetFx3 corespunzătoare nu este disponibilă. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Anulați</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Acces la implementare</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Introduceți parola de implementare pentru a continua.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Parolă de implementare</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Deblocați</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Parola este incorectă. Încercați din nou.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
@@ -530,9 +530,11 @@ Continuați cu implementarea?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Verificarea caracteristicilor opționale Windows nu a reușit pentru „{0}”.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Sursa NetFx3 corespunzătoare nu este disponibilă. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Anulați</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Acces la implementare</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Introduceți parola de implementare pentru a continua.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Implementare protejată</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Parolă necesară</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Introduceți parola tehnicianului pentru a continua.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Parolă de implementare</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Deblocați</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Continuați</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Afișați sau ascundeți parola</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Parola este incorectă. Încercați din nou.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ro-RO/Resources.resx
@@ -529,4 +529,10 @@ Continuați cu implementarea?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Caracteristica opțională Windows „{0}” are o sarcină utilă eliminată și nu este acceptată maparea surselor locale.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Verificarea caracteristicilor opționale Windows nu a reușit pentru „{0}”.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Sursa NetFx3 corespunzătoare nu este disponibilă. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
@@ -529,10 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Дополнительная функция Windows &#171;{0}&#187; имеет удаленную полезную нагрузку и не поддерживает сопоставление локального источника.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Не удалось выполнить проверку дополнительных функций Windows для &#171;{0}&#187;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Соответствующий источник NetFx3 недоступен. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Отмена</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Доступ к развертыванию</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Введите пароль развертывания, чтобы продолжить.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Пароль развертывания</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Разблокировать</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Неверный пароль. Повторите попытку.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
@@ -529,4 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Дополнительная функция Windows &#171;{0}&#187; имеет удаленную полезную нагрузку и не поддерживает сопоставление локального источника.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Не удалось выполнить проверку дополнительных функций Windows для &#171;{0}&#187;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Соответствующий источник NetFx3 недоступен. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
+++ b/src/Foundry.Deploy/Strings/ru-RU/Resources.resx
@@ -530,9 +530,11 @@
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Не удалось выполнить проверку дополнительных функций Windows для &#171;{0}&#187;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Соответствующий источник NetFx3 недоступен. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Отмена</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Доступ к развертыванию</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Введите пароль развертывания, чтобы продолжить.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Защищенное развертывание</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Требуется пароль</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Введите пароль технического специалиста, чтобы продолжить.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Пароль развертывания</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Разблокировать</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Продолжить</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Показать или скрыть пароль</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Неверный пароль. Повторите попытку.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
@@ -529,10 +529,10 @@ Pokračovať v nasadzovaní?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Voliteľn&#225; funkcia syst&#233;mu Windows &#39;{0}&#39; m&#225; odstr&#225;nen&#233; užitočn&#233; zaťaženie a žiadne podporovan&#233; mapovanie lok&#225;lneho zdroja.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Overenie voliteľnej funkcie syst&#233;mu Windows pre &#39;{0}&#39; zlyhalo.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Zodpovedaj&#250;ci zdroj NetFx3 nie je k dispoz&#237;cii. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Zrušiť</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Prístup k nasadeniu</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Ak chcete pokračovať, zadajte heslo nasadenia.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Heslo nasadenia</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Odomknúť</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Heslo je nesprávne. Skúste to znova.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
@@ -530,9 +530,11 @@ Pokračovať v nasadzovaní?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Overenie voliteľnej funkcie syst&#233;mu Windows pre &#39;{0}&#39; zlyhalo.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Zodpovedaj&#250;ci zdroj NetFx3 nie je k dispoz&#237;cii. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Zrušiť</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Prístup k nasadeniu</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Ak chcete pokračovať, zadajte heslo nasadenia.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Chránené nasadenie</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Vyžaduje sa heslo</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Ak chcete pokračovať, zadajte heslo technika.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Heslo nasadenia</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Odomknúť</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Pokračovať</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Zobraziť alebo skryť heslo</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Heslo je nesprávne. Skúste to znova.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sk-SK/Resources.resx
@@ -529,4 +529,10 @@ Pokračovať v nasadzovaní?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Voliteľn&#225; funkcia syst&#233;mu Windows &#39;{0}&#39; m&#225; odstr&#225;nen&#233; užitočn&#233; zaťaženie a žiadne podporovan&#233; mapovanie lok&#225;lneho zdroja.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Overenie voliteľnej funkcie syst&#233;mu Windows pre &#39;{0}&#39; zlyhalo.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Zodpovedaj&#250;ci zdroj NetFx3 nie je k dispoz&#237;cii. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
@@ -530,9 +530,11 @@ Ali želite nadaljevati z uvajanjem?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Preverjanje izbirne funkcije Windows ni uspelo za &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Ujemanje vira NetFx3 ni na voljo. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Prekliči</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Dostop do uvajanja</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Za nadaljevanje vnesite geslo za uvajanje.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Zaščiteno uvajanje</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Zahtevano je geslo</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Za nadaljevanje vnesite geslo tehnika.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Geslo za uvajanje</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Odkleni</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Nadaljuj</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Pokaži ali skrij geslo</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Geslo ni pravilno. Poskusite znova.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
@@ -529,4 +529,10 @@ Ali želite nadaljevati z uvajanjem?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Izbirna funkcija sistema Windows &#187;{0}&#171; ima odstranjeno vsebino in nima podprtega lokalnega preslikave vira.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Preverjanje izbirne funkcije Windows ni uspelo za &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Ujemanje vira NetFx3 ni na voljo. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sl-SI/Resources.resx
@@ -529,10 +529,10 @@ Ali želite nadaljevati z uvajanjem?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Izbirna funkcija sistema Windows &#187;{0}&#171; ima odstranjeno vsebino in nima podprtega lokalnega preslikave vira.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Preverjanje izbirne funkcije Windows ni uspelo za &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Ujemanje vira NetFx3 ni na voljo. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Prekliči</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Dostop do uvajanja</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Za nadaljevanje vnesite geslo za uvajanje.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Geslo za uvajanje</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Odkleni</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Geslo ni pravilno. Poskusite znova.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
@@ -530,9 +530,11 @@ Operativni sistem: {4}
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Verifikacija opcionalne funkcije Windows-a nije uspela za „{0}“.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Odgovarajući NetFx3 izvor je nedostupan. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Otkaži</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Pristup primeni</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Unesite lozinku za primenu da biste nastavili.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Zaštićena primena</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Potrebna je lozinka</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Unesite lozinku tehničara da biste nastavili.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Lozinka za primenu</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Otključaj</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Nastavi</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Prikaži ili sakrij lozinku</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Lozinka nije tačna. Pokušajte ponovo.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
@@ -529,4 +529,10 @@ Operativni sistem: {4}
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows opciona funkcija „{0}“ ima uklonjeno opterećenje i nema podržano lokalno mapiranje izvora.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Verifikacija opcionalne funkcije Windows-a nije uspela za „{0}“.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Odgovarajući NetFx3 izvor je nedostupan. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sr-Latn-RS/Resources.resx
@@ -529,10 +529,10 @@ Operativni sistem: {4}
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows opciona funkcija „{0}“ ima uklonjeno opterećenje i nema podržano lokalno mapiranje izvora.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Verifikacija opcionalne funkcije Windows-a nije uspela za „{0}“.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Odgovarajući NetFx3 izvor je nedostupan. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Otkaži</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Pristup primeni</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Unesite lozinku za primenu da biste nastavili.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Lozinka za primenu</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Otključaj</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Lozinka nije tačna. Pokušajte ponovo.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
@@ -529,4 +529,10 @@ Fortsätt med implementeringen?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows valfria funktion &#39;{0}&#39; har en borttagen nyttolast och ingen lokal k&#228;llmappning som st&#246;ds.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Windows valfri funktionsverifiering misslyckades f&#246;r &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Matchande NetFx3-k&#228;lla &#228;r inte tillg&#228;nglig. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
@@ -529,10 +529,10 @@ Fortsätt med implementeringen?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows valfria funktion &#39;{0}&#39; har en borttagen nyttolast och ingen lokal k&#228;llmappning som st&#246;ds.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Windows valfri funktionsverifiering misslyckades f&#246;r &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Matchande NetFx3-k&#228;lla &#228;r inte tillg&#228;nglig. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Avbryt</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Åtkomst till distribution</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Ange distributionslösenordet för att fortsätta.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Distributionslösenord</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Lås upp</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Lösenordet är felaktigt. Försök igen.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
+++ b/src/Foundry.Deploy/Strings/sv-SE/Resources.resx
@@ -530,9 +530,11 @@ Fortsätt med implementeringen?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Windows valfri funktionsverifiering misslyckades f&#246;r &#39;{0}&#39;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Matchande NetFx3-k&#228;lla &#228;r inte tillg&#228;nglig. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Avbryt</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Åtkomst till distribution</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Ange distributionslösenordet för att fortsätta.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Skyddad distribution</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Lösenord krävs</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Ange teknikerns lösenord för att fortsätta.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Distributionslösenord</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Lås upp</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Fortsätt</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Visa eller dölj lösenordet</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Lösenordet är felaktigt. Försök igen.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/th-TH/Resources.resx
+++ b/src/Foundry.Deploy/Strings/th-TH/Resources.resx
@@ -530,9 +530,11 @@
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>การตรวจสอบคุณสมบัติเสริมของ Windows ล้มเหลวสำหรับ &#39;{0}&#39;</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>การจับคู่แหล่งที่มา NetFx3 ไม่พร้อมใช้งาน {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>ยกเลิก</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>การเข้าถึงการปรับใช้</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>ป้อนรหัสผ่านการปรับใช้เพื่อดำเนินการต่อ</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>การปรับใช้ที่ได้รับการป้องกัน</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>ต้องใช้รหัสผ่าน</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>ป้อนรหัสผ่านของช่างเทคนิคเพื่อดำเนินการต่อ</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>รหัสผ่านการปรับใช้</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>ปลดล็อก</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>ดำเนินการต่อ</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>แสดงหรือซ่อนรหัสผ่าน</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>รหัสผ่านไม่ถูกต้อง โปรดลองอีกครั้ง</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/th-TH/Resources.resx
+++ b/src/Foundry.Deploy/Strings/th-TH/Resources.resx
@@ -529,4 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>คุณลักษณะเสริมของ Windows &#39;{0}&#39; มีเพย์โหลดที่ถูกลบออก และไม่มีการแมปแหล่งที่มาในเครื่องที่สนับสนุน</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>การตรวจสอบคุณสมบัติเสริมของ Windows ล้มเหลวสำหรับ &#39;{0}&#39;</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>การจับคู่แหล่งที่มา NetFx3 ไม่พร้อมใช้งาน {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/th-TH/Resources.resx
+++ b/src/Foundry.Deploy/Strings/th-TH/Resources.resx
@@ -529,10 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>คุณลักษณะเสริมของ Windows &#39;{0}&#39; มีเพย์โหลดที่ถูกลบออก และไม่มีการแมปแหล่งที่มาในเครื่องที่สนับสนุน</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>การตรวจสอบคุณสมบัติเสริมของ Windows ล้มเหลวสำหรับ &#39;{0}&#39;</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>การจับคู่แหล่งที่มา NetFx3 ไม่พร้อมใช้งาน {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>ยกเลิก</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>การเข้าถึงการปรับใช้</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>ป้อนรหัสผ่านการปรับใช้เพื่อดำเนินการต่อ</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>รหัสผ่านการปรับใช้</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>ปลดล็อก</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>รหัสผ่านไม่ถูกต้อง โปรดลองอีกครั้ง</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
@@ -529,4 +529,10 @@ Dağıtıma devam edilsin mi?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>İsteğe bağlı Windows &#246;zelliği &#39;{0}&#39; kaldırılmış bir veriye sahip ve desteklenen yerel kaynak eşlemesi yok.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>&#39;{0}&#39; i&#231;in Windows isteğe bağlı &#246;zellik doğrulaması başarısız oldu.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Eşleşen NetFx3 kaynağı kullanılamıyor. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
@@ -530,9 +530,11 @@ Dağıtıma devam edilsin mi?</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>&#39;{0}&#39; i&#231;in Windows isteğe bağlı &#246;zellik doğrulaması başarısız oldu.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Eşleşen NetFx3 kaynağı kullanılamıyor. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>İptal</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Dağıtım erişimi</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Devam etmek için dağıtım parolasını girin.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Korumalı dağıtım</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Parola gerekli</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Devam etmek için teknisyen parolasını girin.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Dağıtım parolası</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Kilidi aç</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Devam</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Parolayı göster veya gizle</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Parola yanlış. Tekrar deneyin.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
+++ b/src/Foundry.Deploy/Strings/tr-TR/Resources.resx
@@ -529,10 +529,10 @@ Dağıtıma devam edilsin mi?</value></data>
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>İsteğe bağlı Windows &#246;zelliği &#39;{0}&#39; kaldırılmış bir veriye sahip ve desteklenen yerel kaynak eşlemesi yok.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>&#39;{0}&#39; i&#231;in Windows isteğe bağlı &#246;zellik doğrulaması başarısız oldu.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Eşleşen NetFx3 kaynağı kullanılamıyor. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>İptal</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Dağıtım erişimi</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Devam etmek için dağıtım parolasını girin.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Dağıtım parolası</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Kilidi aç</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Parola yanlış. Tekrar deneyin.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
@@ -529,10 +529,10 @@ ErrorCode=0x80070005
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Додаткова функція Windows &quot;{0}&quot; має вилучене корисне навантаження та не підтримує локальне відображення джерела.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Помилка перевірки додаткової функції Windows для &quot;{0}&quot;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Відповідне джерело NetFx3 недоступне. {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Скасувати</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Доступ до розгортання</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Введіть пароль розгортання, щоб продовжити.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Пароль розгортання</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Розблокувати</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Пароль неправильний. Спробуйте ще раз.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
@@ -529,4 +529,10 @@ ErrorCode=0x80070005
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Додаткова функція Windows &quot;{0}&quot; має вилучене корисне навантаження та не підтримує локальне відображення джерела.</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Помилка перевірки додаткової функції Windows для &quot;{0}&quot;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Відповідне джерело NetFx3 недоступне. {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
+++ b/src/Foundry.Deploy/Strings/uk-UA/Resources.resx
@@ -530,9 +530,11 @@ ErrorCode=0x80070005
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>Помилка перевірки додаткової функції Windows для &quot;{0}&quot;.</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>Відповідне джерело NetFx3 недоступне. {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>Скасувати</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Доступ до розгортання</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Введіть пароль розгортання, щоб продовжити.</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Захищене розгортання</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>Потрібен пароль</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>Введіть пароль технічного спеціаліста, щоб продовжити.</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Пароль розгортання</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Розблокувати</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>Продовжити</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>Показати або приховати пароль</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>Пароль неправильний. Спробуйте ще раз.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
@@ -529,10 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows 可选功能“{0}”已删除有效负载并且不支持本地源映射。</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>“{0}”的 Windows 可选功能验证失败。</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>匹配的 NetFx3 源不可用。 {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>取消</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>部署访问</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>请输入部署密码以继续。</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>部署密码</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>解锁</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>密码不正确，请重试。</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
@@ -530,9 +530,11 @@
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>“{0}”的 Windows 可选功能验证失败。</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>匹配的 NetFx3 源不可用。 {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>取消</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>部署访问</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>请输入部署密码以继续。</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>受保护的部署</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>需要密码</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>请输入技术人员密码以继续。</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>部署密码</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>解锁</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>继续</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>显示或隐藏密码</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>密码不正确，请重试。</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-CN/Resources.resx
@@ -529,4 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows 可选功能“{0}”已删除有效负载并且不支持本地源映射。</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>“{0}”的 Windows 可选功能验证失败。</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>匹配的 NetFx3 源不可用。 {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
@@ -529,10 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows 選用功能「{0}」已刪除有效負載且不支援本機來源對應。</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>“{0}”的 Windows 選用功能驗證失敗。</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>符合的 NetFx3 來源不可用。 {0}</value></data>
-  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
-  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
-  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>取消</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>部署存取</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>請輸入部署密碼以繼續。</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>部署密碼</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>解除鎖定</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>密碼不正確，請再試一次。</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
@@ -530,9 +530,11 @@
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>“{0}”的 Windows 選用功能驗證失敗。</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>符合的 NetFx3 來源不可用。 {0}</value></data>
   <data name="Common.Cancel" xml:space="preserve"><value>取消</value></data>
-  <data name="DeploymentAccess.Title" xml:space="preserve"><value>部署存取</value></data>
-  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>請輸入部署密碼以繼續。</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>受保護的部署</value></data>
+  <data name="DeploymentAccess.Heading" xml:space="preserve"><value>需要密碼</value></data>
+  <data name="DeploymentAccess.Description" xml:space="preserve"><value>請輸入技術人員密碼以繼續。</value></data>
   <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>部署密碼</value></data>
-  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>解除鎖定</value></data>
+  <data name="DeploymentAccess.Continue" xml:space="preserve"><value>繼續</value></data>
+  <data name="DeploymentAccess.TogglePasswordVisibility" xml:space="preserve"><value>顯示或隱藏密碼</value></data>
   <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>密碼不正確，請再試一次。</value></data>
 </root>

--- a/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
+++ b/src/Foundry.Deploy/Strings/zh-TW/Resources.resx
@@ -529,4 +529,10 @@
   <data name="StepResult.WindowsOptionalFeatureRemovedPayloadFormat" xml:space="preserve"><value>Windows 選用功能「{0}」已刪除有效負載且不支援本機來源對應。</value></data>
   <data name="StepResult.WindowsOptionalFeatureVerificationFailedFormat" xml:space="preserve"><value>“{0}”的 Windows 選用功能驗證失敗。</value></data>
   <data name="StepResult.WindowsOptionalFeatureMatchingSourceUnavailableFormat" xml:space="preserve"><value>符合的 NetFx3 來源不可用。 {0}</value></data>
+  <data name="Common.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeploymentAccess.Title" xml:space="preserve"><value>Deployment access</value></data>
+  <data name="DeploymentAccess.Prompt" xml:space="preserve"><value>Enter the deployment password to continue.</value></data>
+  <data name="DeploymentAccess.PasswordPlaceholder" xml:space="preserve"><value>Deployment password</value></data>
+  <data name="DeploymentAccess.Unlock" xml:space="preserve"><value>Unlock</value></data>
+  <data name="DeploymentAccess.InvalidPassword" xml:space="preserve"><value>The password is incorrect. Try again.</value></data>
 </root>

--- a/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/MainWindowViewModel.cs
@@ -16,6 +16,7 @@ using Foundry.Deploy.Models.Configuration;
 using Foundry.Deploy.Services.Deployment;
 using Foundry.Deploy.Services.Operations;
 using Foundry.Deploy.Services.Runtime;
+using Foundry.Deploy.Services.Security;
 using Foundry.Deploy.Services.Startup;
 using Foundry.Deploy.Services.ApplicationShell;
 using Foundry.Deploy.Services.Localization;
@@ -34,6 +35,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
 {
     private readonly IThemeService _themeService;
     private readonly IDeploymentStartupCoordinator _deploymentStartupCoordinator;
+    private readonly IDeploymentAccessGate _deploymentAccessGate;
     private readonly IDeploymentLaunchPreparationService _deploymentLaunchPreparationService;
     private readonly IDeploymentExecutionService _deploymentExecutionService;
     private readonly IDeploymentWizardStateService _deploymentWizardStateService;
@@ -126,6 +128,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         ILocalizationService localizationService,
         IThemeService themeService,
         IOperationProgressService operationProgressService,
+        IDeploymentAccessGate deploymentAccessGate,
         IDeploymentStartupCoordinator deploymentStartupCoordinator,
         IDeploymentRuntimeContextService deploymentRuntimeContextService,
         IDeploymentLaunchPreparationService deploymentLaunchPreparationService,
@@ -140,6 +143,7 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
         : base(localizationService)
     {
         _themeService = themeService;
+        _deploymentAccessGate = deploymentAccessGate;
         _deploymentStartupCoordinator = deploymentStartupCoordinator;
         _deploymentLaunchPreparationService = deploymentLaunchPreparationService;
         _deploymentExecutionService = deploymentExecutionService;
@@ -177,6 +181,12 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
     {
         if (_isInitialized)
         {
+            return;
+        }
+
+        if (!await _deploymentAccessGate.AuthorizeAsync())
+        {
+            _applicationShellService.Shutdown();
             return;
         }
 

--- a/src/Foundry.Deploy/Views/DeploymentPasswordDialog.xaml
+++ b/src/Foundry.Deploy/Views/DeploymentPasswordDialog.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="Foundry.Deploy.Views.DeploymentPasswordDialog"
+﻿<Window x:Class="Foundry.Deploy.Views.DeploymentPasswordDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="Deployment access"
@@ -23,8 +23,7 @@
             Text="{Binding PromptText, RelativeSource={RelativeSource AncestorType=Window}}"
             TextWrapping="Wrap" />
 
-        <PasswordBox
-            x:Name="PasswordInput"
+        <PasswordBox x:Name="PasswordInput"
             Grid.Row="1"
             Margin="0,20,0,0"
             AutomationProperties.Name="{Binding PasswordPlaceholder, RelativeSource={RelativeSource AncestorType=Window}}"
@@ -44,11 +43,11 @@
             Orientation="Horizontal">
             <Button
                 MinWidth="96"
-                IsCancel="True"
-                Content="{Binding CancelText, RelativeSource={RelativeSource AncestorType=Window}}" />
+                Content="{Binding CancelText, RelativeSource={RelativeSource AncestorType=Window}}"
+                IsCancel="True" />
             <Button
-                Margin="12,0,0,0"
                 MinWidth="96"
+                Margin="12,0,0,0"
                 Click="UnlockButton_Click"
                 Content="{Binding UnlockText, RelativeSource={RelativeSource AncestorType=Window}}"
                 IsDefault="True" />

--- a/src/Foundry.Deploy/Views/DeploymentPasswordDialog.xaml
+++ b/src/Foundry.Deploy/Views/DeploymentPasswordDialog.xaml
@@ -1,0 +1,57 @@
+<Window x:Class="Foundry.Deploy.Views.DeploymentPasswordDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="Deployment access"
+    Width="460"
+    Height="260"
+    Icon="/Assets/Icons/app.ico"
+    ResizeMode="NoResize"
+    ShowInTaskbar="False"
+    WindowStartupLocation="CenterOwner">
+    <Grid Margin="28">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock
+            Grid.Row="0"
+            Style="{DynamicResource SubtitleTextBlockStyle}"
+            Text="{Binding PromptText, RelativeSource={RelativeSource AncestorType=Window}}"
+            TextWrapping="Wrap" />
+
+        <PasswordBox
+            x:Name="PasswordInput"
+            Grid.Row="1"
+            Margin="0,20,0,0"
+            AutomationProperties.Name="{Binding PasswordPlaceholder, RelativeSource={RelativeSource AncestorType=Window}}"
+            ToolTip="{Binding PasswordPlaceholder, RelativeSource={RelativeSource AncestorType=Window}}" />
+
+        <TextBlock
+            Grid.Row="2"
+            Margin="0,10,0,0"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ErrorText, RelativeSource={RelativeSource AncestorType=Window}}"
+            TextWrapping="Wrap" />
+
+        <StackPanel
+            Grid.Row="4"
+            Margin="0,24,0,0"
+            HorizontalAlignment="Right"
+            Orientation="Horizontal">
+            <Button
+                MinWidth="96"
+                IsCancel="True"
+                Content="{Binding CancelText, RelativeSource={RelativeSource AncestorType=Window}}" />
+            <Button
+                Margin="12,0,0,0"
+                MinWidth="96"
+                Click="UnlockButton_Click"
+                Content="{Binding UnlockText, RelativeSource={RelativeSource AncestorType=Window}}"
+                IsDefault="True" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/Foundry.Deploy/Views/DeploymentPasswordDialog.xaml
+++ b/src/Foundry.Deploy/Views/DeploymentPasswordDialog.xaml
@@ -3,10 +3,11 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="Deployment access"
     Width="460"
-    Height="260"
+    MinHeight="260"
     Icon="/Assets/Icons/app.ico"
     ResizeMode="NoResize"
     ShowInTaskbar="False"
+    SizeToContent="Height"
     WindowStartupLocation="CenterOwner">
     <Grid Margin="28">
         <Grid.RowDefinitions>

--- a/src/Foundry.Deploy/Views/DeploymentPasswordDialog.xaml
+++ b/src/Foundry.Deploy/Views/DeploymentPasswordDialog.xaml
@@ -1,44 +1,114 @@
 ﻿<Window x:Class="Foundry.Deploy.Views.DeploymentPasswordDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Title="Deployment access"
-    Width="460"
-    MinHeight="260"
+    Title="Protected deployment"
     Icon="/Assets/Icons/app.ico"
     ResizeMode="NoResize"
     ShowInTaskbar="False"
-    SizeToContent="Height"
+    SizeToContent="WidthAndHeight"
     WindowStartupLocation="CenterOwner">
-    <Grid Margin="28">
+    <Grid
+        MinWidth="420"
+        Margin="32">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <TextBlock
-            Grid.Row="0"
-            Style="{DynamicResource SubtitleTextBlockStyle}"
-            Text="{Binding PromptText, RelativeSource={RelativeSource AncestorType=Window}}"
-            TextWrapping="Wrap" />
+        <Grid Grid.Row="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
 
-        <PasswordBox x:Name="PasswordInput"
+            <TextBlock
+                Width="32"
+                VerticalAlignment="Center"
+                FontFamily="{StaticResource SymbolThemeFontFamily}"
+                FontSize="28"
+                Text="&#xE72E;"
+                TextAlignment="Center" />
+
+            <StackPanel
+                Grid.Column="1"
+                Margin="16,0,0,0"
+                VerticalAlignment="Center">
+                <TextBlock
+                    Style="{DynamicResource TitleLargeTextBlockStyle}"
+                    Text="{Binding HeadingText, RelativeSource={RelativeSource AncestorType=Window}}"
+                    TextWrapping="Wrap" />
+                <TextBlock
+                    Margin="0,4,0,0"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{DynamicResource BodyTextBlockStyle}"
+                    Text="{Binding DescriptionText, RelativeSource={RelativeSource AncestorType=Window}}"
+                    TextWrapping="Wrap" />
+            </StackPanel>
+        </Grid>
+
+        <Grid
             Grid.Row="1"
-            Margin="0,20,0,0"
-            AutomationProperties.Name="{Binding PasswordPlaceholder, RelativeSource={RelativeSource AncestorType=Window}}"
-            ToolTip="{Binding PasswordPlaceholder, RelativeSource={RelativeSource AncestorType=Window}}" />
+            Margin="0,24,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <Grid Grid.Column="0">
+                <PasswordBox x:Name="PasswordInput"
+                    AutomationProperties.Name="{Binding PasswordPlaceholder, RelativeSource={RelativeSource AncestorType=Window}}"
+                    PasswordChanged="PasswordInput_OnPasswordChanged"
+                    ToolTip="{Binding PasswordPlaceholder, RelativeSource={RelativeSource AncestorType=Window}}" />
+                <TextBox x:Name="PasswordRevealInput"
+                    AutomationProperties.Name="{Binding PasswordPlaceholder, RelativeSource={RelativeSource AncestorType=Window}}"
+                    TextChanged="PasswordRevealInput_OnTextChanged"
+                    ToolTip="{Binding PasswordPlaceholder, RelativeSource={RelativeSource AncestorType=Window}}"
+                    Visibility="Collapsed" />
+            </Grid>
+
+            <Button x:Name="PasswordRevealButton"
+                Grid.Column="1"
+                MinWidth="40"
+                Margin="8,0,0,0"
+                Padding="10,0"
+                AutomationProperties.Name="{Binding TogglePasswordVisibilityText, RelativeSource={RelativeSource AncestorType=Window}}"
+                Click="PasswordRevealButton_OnClick"
+                ToolTip="{Binding TogglePasswordVisibilityText, RelativeSource={RelativeSource AncestorType=Window}}">
+                <TextBlock
+                    FontFamily="{StaticResource SymbolThemeFontFamily}"
+                    FontSize="14"
+                    Text="&#xF78D;" />
+            </Button>
+        </Grid>
 
         <TextBlock
             Grid.Row="2"
-            Margin="0,10,0,0"
+            Margin="0,8,0,0"
             Foreground="{DynamicResource SystemFillColorCriticalBrush}"
             Text="{Binding ErrorText, RelativeSource={RelativeSource AncestorType=Window}}"
-            TextWrapping="Wrap" />
+            TextWrapping="Wrap">
+            <TextBlock.Style>
+                <Style TargetType="TextBlock">
+                    <Setter
+                        Property="Visibility"
+                        Value="Visible" />
+                    <Style.Triggers>
+                        <Trigger
+                            Property="Text"
+                            Value="">
+                            <Setter
+                                Property="Visibility"
+                                Value="Collapsed" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBlock.Style>
+        </TextBlock>
 
         <StackPanel
-            Grid.Row="4"
+            Grid.Row="3"
             Margin="0,24,0,0"
             HorizontalAlignment="Right"
             Orientation="Horizontal">
@@ -48,10 +118,11 @@
                 IsCancel="True" />
             <Button
                 MinWidth="96"
-                Margin="12,0,0,0"
-                Click="UnlockButton_Click"
-                Content="{Binding UnlockText, RelativeSource={RelativeSource AncestorType=Window}}"
-                IsDefault="True" />
+                Margin="8,0,0,0"
+                Click="ContinueButton_OnClick"
+                Content="{Binding ContinueText, RelativeSource={RelativeSource AncestorType=Window}}"
+                IsDefault="True"
+                Style="{DynamicResource AccentButtonStyle}" />
         </StackPanel>
     </Grid>
 </Window>

--- a/src/Foundry.Deploy/Views/DeploymentPasswordDialog.xaml
+++ b/src/Foundry.Deploy/Views/DeploymentPasswordDialog.xaml
@@ -36,7 +36,7 @@
                 Margin="16,0,0,0"
                 VerticalAlignment="Center">
                 <TextBlock
-                    Style="{DynamicResource TitleLargeTextBlockStyle}"
+                    Style="{DynamicResource TitleTextBlockStyle}"
                     Text="{Binding HeadingText, RelativeSource={RelativeSource AncestorType=Window}}"
                     TextWrapping="Wrap" />
                 <TextBlock
@@ -73,6 +73,8 @@
                 MinWidth="40"
                 Margin="8,0,0,0"
                 Padding="10,0"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch"
                 AutomationProperties.Name="{Binding TogglePasswordVisibilityText, RelativeSource={RelativeSource AncestorType=Window}}"
                 Click="PasswordRevealButton_OnClick"
                 ToolTip="{Binding TogglePasswordVisibilityText, RelativeSource={RelativeSource AncestorType=Window}}">

--- a/src/Foundry.Deploy/Views/DeploymentPasswordDialog.xaml.cs
+++ b/src/Foundry.Deploy/Views/DeploymentPasswordDialog.xaml.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows;
+
+namespace Foundry.Deploy.Views;
+
+public partial class DeploymentPasswordDialog : Window
+{
+    private char[] password = [];
+
+    public static readonly DependencyProperty PromptTextProperty = DependencyProperty.Register(
+        nameof(PromptText), typeof(string), typeof(DeploymentPasswordDialog), new PropertyMetadata(string.Empty));
+    public static readonly DependencyProperty PasswordPlaceholderProperty = DependencyProperty.Register(
+        nameof(PasswordPlaceholder), typeof(string), typeof(DeploymentPasswordDialog), new PropertyMetadata(string.Empty));
+    public static readonly DependencyProperty UnlockTextProperty = DependencyProperty.Register(
+        nameof(UnlockText), typeof(string), typeof(DeploymentPasswordDialog), new PropertyMetadata(string.Empty));
+    public static readonly DependencyProperty CancelTextProperty = DependencyProperty.Register(
+        nameof(CancelText), typeof(string), typeof(DeploymentPasswordDialog), new PropertyMetadata(string.Empty));
+    public static readonly DependencyProperty ErrorTextProperty = DependencyProperty.Register(
+        nameof(ErrorText), typeof(string), typeof(DeploymentPasswordDialog), new PropertyMetadata(string.Empty));
+
+    public DeploymentPasswordDialog()
+    {
+        InitializeComponent();
+        Loaded += (_, _) => PasswordInput.Focus();
+        Closed += (_, _) => PasswordInput.Password = string.Empty;
+    }
+
+    public string PromptText { get => (string)GetValue(PromptTextProperty); set => SetValue(PromptTextProperty, value); }
+
+    public string PasswordPlaceholder { get => (string)GetValue(PasswordPlaceholderProperty); set => SetValue(PasswordPlaceholderProperty, value); }
+
+    public string UnlockText { get => (string)GetValue(UnlockTextProperty); set => SetValue(UnlockTextProperty, value); }
+
+    public string CancelText { get => (string)GetValue(CancelTextProperty); set => SetValue(CancelTextProperty, value); }
+
+    public string ErrorText { get => (string)GetValue(ErrorTextProperty); set => SetValue(ErrorTextProperty, value); }
+
+    public char[] TakePassword()
+    {
+        char[] value = password;
+        password = [];
+        return value;
+    }
+
+    private void UnlockButton_Click(object sender, RoutedEventArgs e)
+    {
+        password = PasswordInput.Password.ToCharArray();
+        PasswordInput.Password = string.Empty;
+        DialogResult = true;
+    }
+}

--- a/src/Foundry.Deploy/Views/DeploymentPasswordDialog.xaml.cs
+++ b/src/Foundry.Deploy/Views/DeploymentPasswordDialog.xaml.cs
@@ -2,22 +2,31 @@
 // Licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Windows;
+using System.Windows.Controls;
 
 namespace Foundry.Deploy.Views;
 
 public partial class DeploymentPasswordDialog : Window
 {
     private char[] password = [];
+    private bool isPasswordRevealed;
+    private bool isSynchronizingPasswordEditors;
 
-    public static readonly DependencyProperty PromptTextProperty = DependencyProperty.Register(
-        nameof(PromptText), typeof(string), typeof(DeploymentPasswordDialog), new PropertyMetadata(string.Empty));
+    public static readonly DependencyProperty HeadingTextProperty = DependencyProperty.Register(
+        nameof(HeadingText), typeof(string), typeof(DeploymentPasswordDialog), new PropertyMetadata(string.Empty));
+    public static readonly DependencyProperty DescriptionTextProperty = DependencyProperty.Register(
+        nameof(DescriptionText), typeof(string), typeof(DeploymentPasswordDialog), new PropertyMetadata(string.Empty));
     public static readonly DependencyProperty PasswordPlaceholderProperty = DependencyProperty.Register(
         nameof(PasswordPlaceholder), typeof(string), typeof(DeploymentPasswordDialog), new PropertyMetadata(string.Empty));
-    public static readonly DependencyProperty UnlockTextProperty = DependencyProperty.Register(
-        nameof(UnlockText), typeof(string), typeof(DeploymentPasswordDialog), new PropertyMetadata(string.Empty));
+    public static readonly DependencyProperty ContinueTextProperty = DependencyProperty.Register(
+        nameof(ContinueText), typeof(string), typeof(DeploymentPasswordDialog), new PropertyMetadata(string.Empty));
     public static readonly DependencyProperty CancelTextProperty = DependencyProperty.Register(
         nameof(CancelText), typeof(string), typeof(DeploymentPasswordDialog), new PropertyMetadata(string.Empty));
+    public static readonly DependencyProperty TogglePasswordVisibilityTextProperty = DependencyProperty.Register(
+        nameof(TogglePasswordVisibilityText), typeof(string), typeof(DeploymentPasswordDialog), new PropertyMetadata(string.Empty));
     public static readonly DependencyProperty ErrorTextProperty = DependencyProperty.Register(
         nameof(ErrorText), typeof(string), typeof(DeploymentPasswordDialog), new PropertyMetadata(string.Empty));
 
@@ -25,16 +34,20 @@ public partial class DeploymentPasswordDialog : Window
     {
         InitializeComponent();
         Loaded += (_, _) => PasswordInput.Focus();
-        Closed += (_, _) => PasswordInput.Password = string.Empty;
+        Closed += (_, _) => ClearPasswordEditors();
     }
 
-    public string PromptText { get => (string)GetValue(PromptTextProperty); set => SetValue(PromptTextProperty, value); }
+    public string HeadingText { get => (string)GetValue(HeadingTextProperty); set => SetValue(HeadingTextProperty, value); }
+
+    public string DescriptionText { get => (string)GetValue(DescriptionTextProperty); set => SetValue(DescriptionTextProperty, value); }
 
     public string PasswordPlaceholder { get => (string)GetValue(PasswordPlaceholderProperty); set => SetValue(PasswordPlaceholderProperty, value); }
 
-    public string UnlockText { get => (string)GetValue(UnlockTextProperty); set => SetValue(UnlockTextProperty, value); }
+    public string ContinueText { get => (string)GetValue(ContinueTextProperty); set => SetValue(ContinueTextProperty, value); }
 
     public string CancelText { get => (string)GetValue(CancelTextProperty); set => SetValue(CancelTextProperty, value); }
+
+    public string TogglePasswordVisibilityText { get => (string)GetValue(TogglePasswordVisibilityTextProperty); set => SetValue(TogglePasswordVisibilityTextProperty, value); }
 
     public string ErrorText { get => (string)GetValue(ErrorTextProperty); set => SetValue(ErrorTextProperty, value); }
 
@@ -45,10 +58,76 @@ public partial class DeploymentPasswordDialog : Window
         return value;
     }
 
-    private void UnlockButton_Click(object sender, RoutedEventArgs e)
+    private void PasswordInput_OnPasswordChanged(object sender, RoutedEventArgs e)
     {
-        password = PasswordInput.Password.ToCharArray();
-        PasswordInput.Password = string.Empty;
+        ClearErrorAfterUserInput();
+    }
+
+    private void PasswordRevealInput_OnTextChanged(object sender, TextChangedEventArgs e)
+    {
+        ClearErrorAfterUserInput();
+    }
+
+    private void ClearErrorAfterUserInput()
+    {
+        if (!isSynchronizingPasswordEditors)
+        {
+            ErrorText = string.Empty;
+        }
+    }
+
+    private void PasswordRevealButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        isSynchronizingPasswordEditors = true;
+        try
+        {
+            if (isPasswordRevealed)
+            {
+                PasswordInput.Password = PasswordRevealInput.Text;
+                PasswordRevealInput.Text = string.Empty;
+                PasswordRevealInput.Visibility = Visibility.Collapsed;
+                PasswordInput.Visibility = Visibility.Visible;
+                PasswordRevealButton.ClearValue(StyleProperty);
+                PasswordInput.Focus();
+            }
+            else
+            {
+                PasswordRevealInput.Text = PasswordInput.Password;
+                PasswordInput.Password = string.Empty;
+                PasswordInput.Visibility = Visibility.Collapsed;
+                PasswordRevealInput.Visibility = Visibility.Visible;
+                PasswordRevealButton.SetResourceReference(StyleProperty, "AccentButtonStyle");
+                PasswordRevealInput.Focus();
+                PasswordRevealInput.CaretIndex = PasswordRevealInput.Text.Length;
+            }
+
+            isPasswordRevealed = !isPasswordRevealed;
+        }
+        finally
+        {
+            isSynchronizingPasswordEditors = false;
+        }
+    }
+
+    private void ContinueButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(password.AsSpan()));
+        password = (isPasswordRevealed ? PasswordRevealInput.Text : PasswordInput.Password).ToCharArray();
+        ClearPasswordEditors();
         DialogResult = true;
+    }
+
+    private void ClearPasswordEditors()
+    {
+        isSynchronizingPasswordEditors = true;
+        try
+        {
+            PasswordInput.Password = string.Empty;
+            PasswordRevealInput.Text = string.Empty;
+        }
+        finally
+        {
+            isSynchronizingPasswordEditors = false;
+        }
     }
 }

--- a/src/Foundry.Telemetry.Tests/TelemetryEventPropertyPolicyTests.cs
+++ b/src/Foundry.Telemetry.Tests/TelemetryEventPropertyPolicyTests.cs
@@ -328,14 +328,16 @@ public sealed class TelemetryEventPropertyPolicyTests
         {
             ["deployment_reboot_mode"] = "countdown",
             ["deployment_reboot_delay_seconds"] = 42,
+            ["deployment_protection_enabled"] = true,
             ["automatic_reboot_enabled"] = true
         };
 
         IReadOnlyDictionary<string, object?> result = TelemetryEventPropertyPolicy.Sanitize(TelemetryEvents.OsdBootMediaFinished, input);
 
-        Assert.Equal(2, result.Count);
+        Assert.Equal(3, result.Count);
         Assert.Equal("countdown", result["deployment_reboot_mode"]);
         Assert.Equal(42, result["deployment_reboot_delay_seconds"]);
+        Assert.True((bool)result["deployment_protection_enabled"]!);
         Assert.False(result.ContainsKey("automatic_reboot_enabled"));
     }
 

--- a/src/Foundry.Telemetry/TelemetryEventPropertyPolicy.cs
+++ b/src/Foundry.Telemetry/TelemetryEventPropertyPolicy.cs
@@ -67,6 +67,7 @@ public static class TelemetryEventPropertyPolicy
                 "boot_media_deploy_runtime_payload_source",
                 "autopilot_enabled",
                 "autopilot_provisioning_mode",
+                "deployment_protection_enabled",
                 "deployment_reboot_mode",
                 "deployment_reboot_delay_seconds",
                 "customization_any_enabled",

--- a/src/Foundry.Utilities.Tests/Security/AesGcmEncryptionTests.cs
+++ b/src/Foundry.Utilities.Tests/Security/AesGcmEncryptionTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using Foundry.Utilities.Security;
+
+namespace Foundry.Utilities.Tests.Security;
+
+public sealed class AesGcmEncryptionTests
+{
+    [Fact]
+    public void EncryptDecrypt_RoundTripsBinaryPayload()
+    {
+        byte[] key = AesGcmEncryption.GenerateKey();
+        byte[] plaintext = "Foundry deployment secret"u8.ToArray();
+
+        AesGcmPayload payload = AesGcmEncryption.Encrypt(plaintext, key);
+        byte[] result = AesGcmEncryption.Decrypt(payload, key);
+
+        Assert.Equal(plaintext, result);
+        Assert.Equal(AesGcmEncryption.NonceSizeBytes, payload.Nonce.Length);
+        Assert.Equal(AesGcmEncryption.TagSizeBytes, payload.Tag.Length);
+    }
+
+    [Fact]
+    public void Decrypt_WhenCiphertextIsModified_ThrowsCryptographicException()
+    {
+        byte[] key = AesGcmEncryption.GenerateKey();
+        AesGcmPayload payload = AesGcmEncryption.Encrypt("secret"u8, key);
+        payload.Ciphertext[0] ^= 0x01;
+
+        Assert.Throws<CryptographicException>(() => AesGcmEncryption.Decrypt(payload, key));
+    }
+
+    [Fact]
+    public void Encrypt_WithNon32ByteKey_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => AesGcmEncryption.Encrypt("secret"u8, new byte[16]));
+    }
+
+    [Fact]
+    public void Decrypt_WithInvalidNonceLength_ThrowsCryptographicException()
+    {
+        byte[] key = AesGcmEncryption.GenerateKey();
+        AesGcmPayload payload = new(new byte[11], new byte[16], new byte[6]);
+
+        Assert.Throws<CryptographicException>(() => AesGcmEncryption.Decrypt(payload, key));
+    }
+}

--- a/src/Foundry.Utilities.Tests/Security/Base64UrlTests.cs
+++ b/src/Foundry.Utilities.Tests/Security/Base64UrlTests.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Utilities.Security;
+
+namespace Foundry.Utilities.Tests.Security;
+
+public sealed class Base64UrlTests
+{
+    [Fact]
+    public void EncodeDecode_RoundTripsWithoutPaddingCharacters()
+    {
+        byte[] value = [0xfb, 0xff, 0x00, 0x01];
+
+        string encoded = Base64Url.Encode(value);
+
+        Assert.DoesNotContain("+", encoded, StringComparison.Ordinal);
+        Assert.DoesNotContain("/", encoded, StringComparison.Ordinal);
+        Assert.DoesNotContain("=", encoded, StringComparison.Ordinal);
+        Assert.Equal(value, Base64Url.Decode(encoded));
+    }
+
+    [Theory]
+    [InlineData("not+url")]
+    [InlineData("not/url")]
+    [InlineData("padded=")]
+    [InlineData("a")]
+    public void Decode_WithInvalidValue_ThrowsFormatException(string value)
+    {
+        Assert.Throws<FormatException>(() => Base64Url.Decode(value));
+    }
+}

--- a/src/Foundry.Utilities.Tests/Security/PasswordKeyDerivationTests.cs
+++ b/src/Foundry.Utilities.Tests/Security/PasswordKeyDerivationTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Utilities.Security;
+
+namespace Foundry.Utilities.Tests.Security;
+
+public sealed class PasswordKeyDerivationTests
+{
+    [Fact]
+    public void DeriveKey_WithSameInputs_ReturnsSameKey()
+    {
+        byte[] salt = Enumerable.Range(0, 16).Select(value => (byte)value).ToArray();
+
+        byte[] first = PasswordKeyDerivation.DeriveKey("correct horse".AsSpan(), salt, 600_000, 32);
+        byte[] second = PasswordKeyDerivation.DeriveKey("correct horse".AsSpan(), salt, 600_000, 32);
+
+        Assert.Equal(first, second);
+        Assert.Equal(32, first.Length);
+    }
+
+    [Fact]
+    public void GenerateSalt_ReturnsRandom16ByteValues()
+    {
+        byte[] first = PasswordKeyDerivation.GenerateSalt();
+        byte[] second = PasswordKeyDerivation.GenerateSalt();
+
+        Assert.Equal(16, first.Length);
+        Assert.Equal(16, second.Length);
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void DeriveKey_WithZeroIterations_ThrowsArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            PasswordKeyDerivation.DeriveKey("password".AsSpan(), new byte[16], 0, 32));
+    }
+
+    [Fact]
+    public void DeriveKey_WithNon16ByteSalt_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            PasswordKeyDerivation.DeriveKey("password".AsSpan(), new byte[15], 600_000, 32));
+    }
+}

--- a/src/Foundry.Utilities/Security/AesGcmEncryption.cs
+++ b/src/Foundry.Utilities/Security/AesGcmEncryption.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+
+namespace Foundry.Utilities.Security;
+
+public static class AesGcmEncryption
+{
+    public const int KeySizeBytes = 32;
+    public const int NonceSizeBytes = 12;
+    public const int TagSizeBytes = 16;
+
+    public static byte[] GenerateKey()
+    {
+        return RandomNumberGenerator.GetBytes(KeySizeBytes);
+    }
+
+    public static AesGcmPayload Encrypt(ReadOnlySpan<byte> plaintext, ReadOnlySpan<byte> key)
+    {
+        ValidateKey(key);
+
+        byte[] nonce = RandomNumberGenerator.GetBytes(NonceSizeBytes);
+        byte[] tag = new byte[TagSizeBytes];
+        byte[] ciphertext = new byte[plaintext.Length];
+
+        using AesGcm aes = new(key, TagSizeBytes);
+        aes.Encrypt(nonce, plaintext, ciphertext, tag);
+        return new AesGcmPayload(nonce, tag, ciphertext);
+    }
+
+    public static byte[] Decrypt(AesGcmPayload payload, ReadOnlySpan<byte> key)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        ValidateKey(key);
+
+        if (payload.Nonce is null || payload.Nonce.Length != NonceSizeBytes)
+        {
+            throw new CryptographicException($"The AES-GCM nonce must be {NonceSizeBytes} bytes.");
+        }
+
+        if (payload.Tag is null || payload.Tag.Length != TagSizeBytes)
+        {
+            throw new CryptographicException($"The AES-GCM authentication tag must be {TagSizeBytes} bytes.");
+        }
+
+        if (payload.Ciphertext is null)
+        {
+            throw new CryptographicException("The AES-GCM ciphertext is missing.");
+        }
+
+        byte[] plaintext = new byte[payload.Ciphertext.Length];
+        try
+        {
+            using AesGcm aes = new(key, TagSizeBytes);
+            aes.Decrypt(payload.Nonce, payload.Ciphertext, payload.Tag, plaintext);
+            return plaintext;
+        }
+        catch (CryptographicException exception)
+        {
+            CryptographicOperations.ZeroMemory(plaintext);
+            throw new CryptographicException("AES-GCM authentication failed.", exception);
+        }
+        catch
+        {
+            CryptographicOperations.ZeroMemory(plaintext);
+            throw;
+        }
+    }
+
+    private static void ValidateKey(ReadOnlySpan<byte> key)
+    {
+        if (key.Length != KeySizeBytes)
+        {
+            throw new ArgumentException($"The AES-GCM key must be {KeySizeBytes} bytes.", nameof(key));
+        }
+    }
+}

--- a/src/Foundry.Utilities/Security/AesGcmPayload.cs
+++ b/src/Foundry.Utilities/Security/AesGcmPayload.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Utilities.Security;
+
+public sealed record AesGcmPayload(byte[] Nonce, byte[] Tag, byte[] Ciphertext);

--- a/src/Foundry.Utilities/Security/Base64Url.cs
+++ b/src/Foundry.Utilities/Security/Base64Url.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Utilities.Security;
+
+public static class Base64Url
+{
+    public static string Encode(ReadOnlySpan<byte> value)
+    {
+        return Convert.ToBase64String(value)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    public static byte[] Decode(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        if (value.Any(character => !IsBase64UrlCharacter(character)) || value.Length % 4 == 1)
+        {
+            throw new FormatException("The value is not valid unpadded Base64URL.");
+        }
+
+        string padded = value.Replace('-', '+').Replace('_', '/');
+        padded += new string('=', (4 - (padded.Length % 4)) % 4);
+
+        byte[] decoded = Convert.FromBase64String(padded);
+        if (!string.Equals(Encode(decoded), value, StringComparison.Ordinal))
+        {
+            throw new FormatException("The value is not canonical unpadded Base64URL.");
+        }
+
+        return decoded;
+    }
+
+    private static bool IsBase64UrlCharacter(char value)
+    {
+        return value is >= 'A' and <= 'Z'
+            or >= 'a' and <= 'z'
+            or >= '0' and <= '9'
+            or '-'
+            or '_';
+    }
+}

--- a/src/Foundry.Utilities/Security/PasswordKeyDerivation.cs
+++ b/src/Foundry.Utilities/Security/PasswordKeyDerivation.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+
+namespace Foundry.Utilities.Security;
+
+public static class PasswordKeyDerivation
+{
+    public const int DefaultIterations = 600_000;
+    public const int SaltSizeBytes = 16;
+
+    public static byte[] GenerateSalt()
+    {
+        return RandomNumberGenerator.GetBytes(SaltSizeBytes);
+    }
+
+    public static byte[] DeriveKey(
+        ReadOnlySpan<char> password,
+        ReadOnlySpan<byte> salt,
+        int iterations,
+        int keySizeBytes)
+    {
+        if (salt.Length != SaltSizeBytes)
+        {
+            throw new ArgumentException($"The PBKDF2 salt must be {SaltSizeBytes} bytes.", nameof(salt));
+        }
+
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(iterations);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(keySizeBytes);
+
+        byte[] key = new byte[keySizeBytes];
+        Rfc2898DeriveBytes.Pbkdf2(password, salt, key, iterations, HashAlgorithmName.SHA256);
+        return key;
+    }
+}

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -102,6 +102,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IAutopilotHardwareHashSessionState, AutopilotHardwareHashSessionState>();
         services.AddSingleton<ILanguageRegistryService, EmbeddedLanguageRegistryService>();
         services.AddSingleton<INetworkSecretStateService, NetworkSecretStateService>();
+        services.AddSingleton<IDeploymentProtectionSecretStateService, DeploymentProtectionSecretStateService>();
         services.AddSingleton<IFoundryConfigurationStateService, FoundryConfigurationStateService>();
         services.AddSingleton<IWinPeLanguageDiscoveryService, WinPeLanguageDiscoveryService>();
         services.AddSingleton<IWinPeEmbeddedAssetService, WinPeEmbeddedAssetService>();

--- a/src/Foundry/Services/Configuration/DeploymentProtectionSecretStateService.cs
+++ b/src/Foundry/Services/Configuration/DeploymentProtectionSecretStateService.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Core.Services.Configuration;
+
+namespace Foundry.Services.Configuration;
+
+internal sealed partial class DeploymentProtectionSecretStateService : IDeploymentProtectionSecretStateService, IDisposable
+{
+    private readonly DeploymentProtectionSecretState state = new();
+
+    public bool HasPassword => state.HasPassword;
+
+    public bool HasConfirmation => state.HasConfirmation;
+
+    public bool IsValid => state.IsValid;
+
+    public bool ShouldRecommendStrongerPassword => state.ShouldRecommendStrongerPassword;
+
+    public void SetPassword(string? value)
+    {
+        state.SetPassword(value.AsSpan());
+    }
+
+    public void SetConfirmation(string? value)
+    {
+        state.SetConfirmation(value.AsSpan());
+    }
+
+    public char[] GetConfirmedPasswordCopy()
+    {
+        return state.GetConfirmedPasswordCopy();
+    }
+
+    public void Clear()
+    {
+        state.Clear();
+    }
+
+    public void Dispose()
+    {
+        state.Dispose();
+    }
+}

--- a/src/Foundry/Services/Configuration/DeploymentProtectionSecretStateService.cs
+++ b/src/Foundry/Services/Configuration/DeploymentProtectionSecretStateService.cs
@@ -28,6 +28,16 @@ internal sealed partial class DeploymentProtectionSecretStateService : IDeployme
         state.SetConfirmation(value.AsSpan());
     }
 
+    public char[] GetPasswordCopy()
+    {
+        return state.GetPasswordCopy();
+    }
+
+    public char[] GetConfirmationCopy()
+    {
+        return state.GetConfirmationCopy();
+    }
+
     public char[] GetConfirmedPasswordCopy()
     {
         return state.GetConfirmedPasswordCopy();

--- a/src/Foundry/Services/Configuration/FoundryConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/FoundryConfigurationStateService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Foundry.Core.Models.Configuration;
+using Foundry.Core.Models.Configuration.Deploy;
 using Foundry.Core.Services.Autopilot;
 using Foundry.Core.Services.Configuration;
 using Foundry.Core.Services.WinPe;
@@ -69,12 +70,23 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
         {
             try
             {
-                byte[]? mediaSecretsKey = Current.Autopilot.IsEnabled &&
-                                          Current.Autopilot.ProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload
+                byte[]? deploymentSecretsKey = Current.Autopilot.IsEnabled &&
+                                               Current.Autopilot.ProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload
                     ? MediaSecretEnvelopeProtector.GenerateMediaKey()
                     : null;
-                _ = GenerateDeployConfigurationJson(mediaSecretsKey: mediaSecretsKey);
-                return true;
+
+                try
+                {
+                    _ = GenerateDeployConfigurationJson(deploymentSecretsKey: deploymentSecretsKey);
+                    return true;
+                }
+                finally
+                {
+                    if (deploymentSecretsKey is not null)
+                    {
+                        System.Security.Cryptography.CryptographicOperations.ZeroMemory(deploymentSecretsKey);
+                    }
+                }
             }
             catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
             {
@@ -180,11 +192,15 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
     }
 
     /// <inheritdoc />
-    public string GenerateDeployConfigurationJson(TelemetrySettings? telemetryOverride = null, byte[]? mediaSecretsKey = null)
+    public string GenerateDeployConfigurationJson(
+        TelemetrySettings? telemetryOverride = null,
+        byte[]? deploymentSecretsKey = null,
+        DeployProtectionSettings? protectionSettings = null)
     {
         FoundryConfigurationDocument document = CreateDocumentForDeployGeneration(telemetryOverride);
 
-        return deployConfigurationGenerator.Serialize(deployConfigurationGenerator.Generate(document, mediaSecretsKey));
+        return deployConfigurationGenerator.Serialize(
+            deployConfigurationGenerator.Generate(document, deploymentSecretsKey, protectionSettings));
     }
 
     /// <inheritdoc />

--- a/src/Foundry/Services/Configuration/FoundryConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/FoundryConfigurationStateService.cs
@@ -4,11 +4,11 @@
 
 using Foundry.Core.Models.Configuration;
 using Foundry.Core.Models.Configuration.Deploy;
-using Foundry.Core.Services.Autopilot;
 using Foundry.Core.Services.Configuration;
 using Foundry.Core.Services.WinPe;
 using Foundry.Services.Autopilot;
 using Foundry.Telemetry;
+using Foundry.Utilities.Security;
 using Serilog;
 using AppSettingsService = Foundry.Services.Settings.IAppSettingsService;
 
@@ -81,7 +81,7 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
             {
                 byte[]? deploymentSecretsKey = Current.Autopilot.IsEnabled &&
                                                Current.Autopilot.ProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload
-                    ? MediaSecretEnvelopeProtector.GenerateMediaKey()
+                    ? AesGcmEncryption.GenerateKey()
                     : null;
 
                 try

--- a/src/Foundry/Services/Configuration/FoundryConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/FoundryConfigurationStateService.cs
@@ -27,6 +27,7 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
     private readonly IDeployConfigurationGenerator deployConfigurationGenerator;
     private readonly IConnectConfigurationGenerator connectConfigurationGenerator;
     private readonly INetworkSecretStateService networkSecretStateService;
+    private readonly IDeploymentProtectionSecretStateService deploymentProtectionSecretStateService;
     private readonly IAutopilotHardwareHashSessionState autopilotHardwareHashSessionState;
     private readonly AppSettingsService appSettingsService;
     private readonly ILogger logger;
@@ -36,6 +37,7 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
         IDeployConfigurationGenerator deployConfigurationGenerator,
         IConnectConfigurationGenerator connectConfigurationGenerator,
         INetworkSecretStateService networkSecretStateService,
+        IDeploymentProtectionSecretStateService deploymentProtectionSecretStateService,
         IAutopilotHardwareHashSessionState autopilotHardwareHashSessionState,
         AppSettingsService appSettingsService,
         ILogger logger)
@@ -44,6 +46,7 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
         this.deployConfigurationGenerator = deployConfigurationGenerator;
         this.connectConfigurationGenerator = connectConfigurationGenerator;
         this.networkSecretStateService = networkSecretStateService;
+        this.deploymentProtectionSecretStateService = deploymentProtectionSecretStateService;
         this.autopilotHardwareHashSessionState = autopilotHardwareHashSessionState;
         this.appSettingsService = appSettingsService;
         this.logger = logger.ForContext<FoundryConfigurationStateService>();
@@ -68,6 +71,12 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
     {
         get
         {
+            if (Current.General.DeploymentProtection.IsEnabled &&
+                !deploymentProtectionSecretStateService.IsValid)
+            {
+                return false;
+            }
+
             try
             {
                 byte[]? deploymentSecretsKey = Current.Autopilot.IsEnabled &&

--- a/src/Foundry/Services/Configuration/IDeploymentProtectionSecretStateService.cs
+++ b/src/Foundry/Services/Configuration/IDeploymentProtectionSecretStateService.cs
@@ -21,6 +21,10 @@ public interface IDeploymentProtectionSecretStateService
 
     void SetConfirmation(string? value);
 
+    char[] GetPasswordCopy();
+
+    char[] GetConfirmationCopy();
+
     char[] GetConfirmedPasswordCopy();
 
     void Clear();

--- a/src/Foundry/Services/Configuration/IDeploymentProtectionSecretStateService.cs
+++ b/src/Foundry/Services/Configuration/IDeploymentProtectionSecretStateService.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Services.Configuration;
+
+/// <summary>
+/// Keeps deployment media password values in volatile process memory.
+/// </summary>
+public interface IDeploymentProtectionSecretStateService
+{
+    bool HasPassword { get; }
+
+    bool HasConfirmation { get; }
+
+    bool IsValid { get; }
+
+    bool ShouldRecommendStrongerPassword { get; }
+
+    void SetPassword(string? value);
+
+    void SetConfirmation(string? value);
+
+    char[] GetConfirmedPasswordCopy();
+
+    void Clear();
+}

--- a/src/Foundry/Services/Configuration/IFoundryConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/IFoundryConfigurationStateService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Foundry.Core.Models.Configuration;
+using Foundry.Core.Models.Configuration.Deploy;
 using Foundry.Core.Services.Configuration;
 using Foundry.Telemetry;
 
@@ -136,7 +137,11 @@ public interface IFoundryConfigurationStateService
     /// Generates the Deploy configuration JSON for the current Foundry configuration.
     /// </summary>
     /// <param name="telemetryOverride">Optional runtime telemetry settings used only for the generated Deploy document.</param>
-    /// <param name="mediaSecretsKey">Optional media secret key used for boot-media-only Deploy secrets.</param>
+    /// <param name="deploymentSecretsKey">Optional Deploy secret key used for boot-media-only Deploy secrets.</param>
+    /// <param name="protectionSettings">Optional deployment media protection metadata.</param>
     /// <returns>Serialized Deploy configuration JSON.</returns>
-    string GenerateDeployConfigurationJson(TelemetrySettings? telemetryOverride = null, byte[]? mediaSecretsKey = null);
+    string GenerateDeployConfigurationJson(
+        TelemetrySettings? telemetryOverride = null,
+        byte[]? deploymentSecretsKey = null,
+        DeployProtectionSettings? protectionSettings = null);
 }

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>تغيير النمط</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>حماية وسائط النشر</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>اطلب كلمة مرور قبل أن يتمكن Foundry Deploy من استخدام هذه الوسائط.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>حماية وسائط النشر بكلمة مرور</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>كلمة مرور النشر</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>لا يمكن استرداد كلمة المرور. يتم استخدامها لتشفير بيانات الاعتماد وملفات تعريف Autopilot الموجودة على الوسائط المحمية.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>كلمة المرور</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>تأكيد كلمة المرور</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>أدخل كلمتي مرور متطابقتين تتكونان من 8 أحرف على الأقل.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>لحماية أقوى، استخدم 12 حرفًا على الأقل أو عبارة مرور.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>اختر المنطقة الزمنية المطبقة أثناء النشر.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>بعد النشر الناجح</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>اختر ما إذا كان الجهاز سيُعاد تشغيله بعد النشر وموعد ذلك.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
     <value>إعادة التشغيل تلقائيًا</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>اختر ما إذا كان الجهاز سيُعاد تشغيله تلقائيًا بعد نجاح عملية النشر.</value>
+  </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>التأخير قبل إعادة التشغيل</value>
+    <value>مهلة إعادة التشغيل</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>أدخل مهلة من 0 إلى 3600 ثانية. استخدم 0 لإعادة التشغيل فورًا.</value>
+    <value>حدّد المهلة قبل إعادة تشغيل الجهاز. استخدم 0 لإعادة التشغيل فورًا.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>التمهيد الآمن</value>
@@ -2771,13 +2768,10 @@
     <value>تغيير النمط</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>حماية وسائط النشر</value>
+    <value>الحماية بكلمة مرور</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>اطلب كلمة مرور قبل أن يتمكن Foundry Deploy من استخدام هذه الوسائط.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>حماية وسائط النشر بكلمة مرور</value>
+    <value>اطلب كلمة مرور فني قبل بدء عملية النشر.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>كلمة مرور النشر</value>

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>تغيير النمط</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Промяна на режима</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Защита на носителя за разполагане</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Изискване на парола, преди Foundry Deploy да може да използва този носител.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Защита на носителя за разполагане с парола</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Парола за разполагане</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Паролата не може да бъде възстановена. С нея се шифроват идентификационните данни и профилите на Autopilot в защитения носител.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Парола</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Потвърдете паролата</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Въведете съвпадащи пароли с поне 8 знака.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>За по-силна защита използвайте поне 12 знака или фраза за достъп.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Изберете часовата зона, прилагана по време на разполагане.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>След успешно разполагане</value>
+    <value>Автоматично рестартиране</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Изберете дали и кога устройството да се рестартира след разполагането.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Автоматично рестартиране</value>
+    <value>Изберете дали устройството да се рестартира автоматично след успешно разполагане.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
     <value>Забавяне преди рестартиране</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Въведете забавяне от 0 до 3600 секунди. Използвайте 0 за незабавно рестартиране.</value>
+    <value>Задайте забавянето преди рестартиране на устройството. Използвайте 0 за незабавно рестартиране.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Защитено стартиране</value>
@@ -2771,13 +2768,10 @@
     <value>Промяна на режима</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Защита на носителя за разполагане</value>
+    <value>Защита с парола</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Изискване на парола, преди Foundry Deploy да може да използва този носител.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Защита на носителя за разполагане с парола</value>
+    <value>Изискване на парола на техник преди започване на разполагането.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Парола за разполагане</value>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Промяна на режима</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Vyberte časové pásmo použité během nasazení.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Po úspěšném nasazení</value>
+    <value>Automatické restartování</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Zvolte, zda a kdy se má zařízení po nasazení restartovat.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Restartovat automaticky</value>
+    <value>Zvolte, zda se má zařízení po úspěšném nasazení automaticky restartovat.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Prodleva před restartováním</value>
+    <value>Prodleva restartování</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Zadejte prodlevu od 0 do 3600 sekund. Hodnota 0 znamená okamžité restartování.</value>
+    <value>Nastavte prodlevu před restartováním zařízení. Zadáním hodnoty 0 se zařízení restartuje okamžitě.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Zabezpečené spouštění</value>
@@ -2771,13 +2768,10 @@
     <value>Změnit režim</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Ochrana instalačního média</value>
+    <value>Ochrana heslem</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Před použitím tohoto média aplikací Foundry Deploy vyžadovat heslo.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Chránit instalační médium heslem</value>
+    <value>Před zahájením nasazení vyžadovat heslo technika.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Heslo pro nasazení</value>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Změnit režim</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Změnit režim</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Ochrana instalačního média</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Před použitím tohoto média aplikací Foundry Deploy vyžadovat heslo.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Chránit instalační médium heslem</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Heslo pro nasazení</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Heslo nelze obnovit. Přihlašovací údaje a profily Autopilot na chráněném médiu jsou tímto heslem zašifrovány.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Heslo</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Potvrďte heslo</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Zadejte shodná hesla o délce alespoň 8 znaků.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Pro vyšší úroveň ochrany použijte alespoň 12 znaků nebo přístupovou frázi.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Skift tilstand</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Skift tilstand</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Beskyttelse af installationsmedie</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Kræv en adgangskode, før Foundry Deploy kan bruge dette medie.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Beskyt installationsmediet med en adgangskode</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Adgangskode til installation</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Adgangskoden kan ikke gendannes. Legitimationsoplysninger og Autopilot-profiler på beskyttede medier krypteres med den.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Adgangskode</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Bekræft adgangskode</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Indtast ens adgangskoder på mindst 8 tegn.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Brug mindst 12 tegn eller en adgangssætning for at opnå bedre beskyttelse.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Vælg den tidszone, der anvendes under udrulningen.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Efter fuldført installation</value>
+    <value>Automatisk genstart</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Vælg, om og hvornår enheden skal genstarte efter installationen.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Genstart automatisk</value>
+    <value>Vælg, om enheden skal genstarte automatisk efter en vellykket installation.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
     <value>Forsinkelse før genstart</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Angiv en forsinkelse på 0 til 3600 sekunder. Brug 0 for at genstarte med det samme.</value>
+    <value>Angiv forsinkelsen, før enheden genstarter. Brug 0 for at genstarte med det samme.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Sikker start</value>
@@ -2771,13 +2768,10 @@
     <value>Skift tilstand</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Beskyttelse af installationsmedie</value>
+    <value>Adgangskodebeskyttelse</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Kræv en adgangskode, før Foundry Deploy kan bruge dette medie.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Beskyt installationsmediet med en adgangskode</value>
+    <value>Kræv en teknikeradgangskode, før en installation startes.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Adgangskode til installation</value>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Wählen Sie die Zeitzone aus, die während der Bereitstellung angewendet wird.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Nach erfolgreicher Bereitstellung</value>
+    <value>Automatischer Neustart</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Wählen Sie aus, ob und wann das Gerät nach der Bereitstellung neu gestartet wird.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Automatisch neu starten</value>
+    <value>Legen Sie fest, ob das Gerät nach einer erfolgreichen Bereitstellung automatisch neu gestartet wird.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Verzögerung vor dem Neustart</value>
+    <value>Neustartverzögerung</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Geben Sie eine Verzögerung von 0 bis 3600 Sekunden ein. Mit 0 wird sofort neu gestartet.</value>
+    <value>Legen Sie die Verzögerung vor dem Neustart des Geräts fest. Verwenden Sie 0 für einen sofortigen Neustart.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Sicherer Start</value>
@@ -2771,13 +2768,10 @@
     <value>Modus ändern</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Schutz des Bereitstellungsmediums</value>
+    <value>Kennwortschutz</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Ein Kennwort anfordern, bevor Foundry Deploy dieses Medium verwenden kann.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Bereitstellungsmedium mit einem Kennwort schützen</value>
+    <value>Vor dem Start einer Bereitstellung ein Technikerkennwort anfordern.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Bereitstellungskennwort</value>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Modus ändern</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Schutz des Bereitstellungsmediums</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Ein Kennwort anfordern, bevor Foundry Deploy dieses Medium verwenden kann.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Bereitstellungsmedium mit einem Kennwort schützen</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Bereitstellungskennwort</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Das Kennwort kann nicht wiederhergestellt werden. Anmeldeinformationen und Autopilot-Profile auf geschützten Medien werden damit verschlüsselt.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Kennwort</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Kennwort bestätigen</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Geben Sie übereinstimmende Kennwörter mit mindestens 8 Zeichen ein.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Verwenden Sie für stärkeren Schutz mindestens 12 Zeichen oder eine Passphrase.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Modus ändern</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Αλλαγή λειτουργίας</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Επιλέξτε τη ζώνη ώρας που εφαρμόζεται κατά την ανάπτυξη.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Μετά την επιτυχή ανάπτυξη</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Επιλέξτε αν και πότε θα γίνει επανεκκίνηση της συσκευής μετά την ανάπτυξη.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
     <value>Αυτόματη επανεκκίνηση</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Επιλέξτε αν η συσκευή θα επανεκκινείται αυτόματα μετά από μια επιτυχημένη ανάπτυξη.</value>
+  </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Καθυστέρηση πριν από την επανεκκίνηση</value>
+    <value>Καθυστέρηση επανεκκίνησης</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Εισαγάγετε καθυστέρηση από 0 έως 3600 δευτερόλεπτα. Χρησιμοποιήστε το 0 για άμεση επανεκκίνηση.</value>
+    <value>Ορίστε την καθυστέρηση πριν από την επανεκκίνηση της συσκευής. Χρησιμοποιήστε 0 για άμεση επανεκκίνηση.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Ασφαλής εκκίνηση</value>
@@ -2771,13 +2768,10 @@
     <value>Αλλαγή λειτουργίας</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Προστασία μέσου ανάπτυξης</value>
+    <value>Προστασία με κωδικό πρόσβασης</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Να απαιτείται κωδικός πρόσβασης πριν το Foundry Deploy χρησιμοποιήσει αυτό το μέσο.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Προστασία του μέσου ανάπτυξης με κωδικό πρόσβασης</value>
+    <value>Να απαιτείται κωδικός πρόσβασης τεχνικού πριν από την έναρξη μιας ανάπτυξης.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Κωδικός πρόσβασης ανάπτυξης</value>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Αλλαγή λειτουργίας</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Προστασία μέσου ανάπτυξης</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Να απαιτείται κωδικός πρόσβασης πριν το Foundry Deploy χρησιμοποιήσει αυτό το μέσο.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Προστασία του μέσου ανάπτυξης με κωδικό πρόσβασης</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Κωδικός πρόσβασης ανάπτυξης</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Δεν είναι δυνατή η ανάκτηση του κωδικού πρόσβασης. Τα διαπιστευτήρια και τα προφίλ Autopilot στα προστατευμένα μέσα κρυπτογραφούνται με αυτόν.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Κωδικός πρόσβασης</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Επιβεβαίωση κωδικού πρόσβασης</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Εισαγάγετε ίδιους κωδικούς πρόσβασης με τουλάχιστον 8 χαρακτήρες.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Για ισχυρότερη προστασία, χρησιμοποιήστε τουλάχιστον 12 χαρακτήρες ή μια φράση πρόσβασης.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Change mode</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Choose the time zone applied during deployment.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>After successful deployment</value>
+    <value>Automatic restart</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Choose whether and when the device restarts after deployment.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Restart automatically</value>
+    <value>Choose whether the device restarts automatically after a successful deployment.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Delay before restart</value>
+    <value>Restart delay</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Enter a delay from 0 to 3600 seconds. Use 0 to restart immediately.</value>
+    <value>Set the delay before the device restarts. Use 0 to restart immediately.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Secure Boot</value>
@@ -2771,13 +2768,10 @@
     <value>Change mode</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Password protection</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Require a technician password before starting a deployment.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Deployment password</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Change mode</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Choose the time zone applied during deployment.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>After successful deployment</value>
+    <value>Automatic restart</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Choose whether and when the device restarts after deployment.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Restart automatically</value>
+    <value>Choose whether the device restarts automatically after a successful deployment.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Delay before restart</value>
+    <value>Restart delay</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Enter a delay from 0 to 3600 seconds. Use 0 to restart immediately.</value>
+    <value>Set the delay before the device restarts. Use 0 to restart immediately.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Secure Boot</value>
@@ -2771,13 +2768,10 @@
     <value>Change mode</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Password protection</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Require a technician password before starting a deployment.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Deployment password</value>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Elige la zona horaria aplicada durante la implementación.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Después de una implementación correcta</value>
+    <value>Reinicio automático</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Elija si el dispositivo se reinicia después de la implementación y cuándo.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Reiniciar automáticamente</value>
+    <value>Elija si el dispositivo se reinicia automáticamente tras una implementación correcta.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Retraso antes del reinicio</value>
+    <value>Retraso del reinicio</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Especifique un retraso de 0 a 3600 segundos. Use 0 para reiniciar inmediatamente.</value>
+    <value>Establezca el tiempo de espera antes de que el dispositivo se reinicie. Use 0 para reiniciarlo inmediatamente.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Arranque seguro</value>
@@ -2771,13 +2768,10 @@
     <value>Cambiar modo</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Protección del medio de implementación</value>
+    <value>Protección con contraseña</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Solicitar una contraseña antes de que Foundry Deploy pueda usar este medio.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Proteger el medio de implementación con una contraseña</value>
+    <value>Solicitar la contraseña de un técnico antes de iniciar una implementación.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Contraseña de implementación</value>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Cambiar modo</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Protección del medio de implementación</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Solicitar una contraseña antes de que Foundry Deploy pueda usar este medio.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Proteger el medio de implementación con una contraseña</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Contraseña de implementación</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>La contraseña no se puede recuperar. Las credenciales y los perfiles de Autopilot del medio protegido se cifran con ella.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Contraseña</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Confirmar contraseña</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Introduzca contraseñas coincidentes de al menos 8 caracteres.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Para reforzar la protección, use al menos 12 caracteres o una frase de contraseña.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Cambiar modo</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Cambiar modo</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Protección del medio de implementación</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Solicitar una contraseña antes de que Foundry Deploy pueda usar este medio.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Proteger el medio de implementación con una contraseña</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Contraseña de implementación</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>La contraseña no se puede recuperar. Las credenciales y los perfiles de Autopilot del medio protegido se cifran con ella.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Contraseña</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Confirmar contraseña</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Ingresa contraseñas coincidentes de al menos 8 caracteres.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Para una mayor protección, usa al menos 12 caracteres o una frase de contraseña.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Cambiar modo</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Elige la zona horaria aplicada durante la implementación.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Después de una implementación correcta</value>
+    <value>Reinicio automático</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Elija si el dispositivo se reinicia después de la implementación y cuándo.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Reiniciar automáticamente</value>
+    <value>Elige si el dispositivo se reinicia automáticamente después de una implementación exitosa.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Retraso antes del reinicio</value>
+    <value>Retraso del reinicio</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Ingrese un retraso de 0 a 3600 segundos. Use 0 para reiniciar inmediatamente.</value>
+    <value>Establece el tiempo de espera antes de que el dispositivo se reinicie. Usa 0 para reiniciarlo de inmediato.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Arranque seguro</value>
@@ -2771,13 +2768,10 @@
     <value>Cambiar modo</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Protección del medio de implementación</value>
+    <value>Protección con contraseña</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Solicitar una contraseña antes de que Foundry Deploy pueda usar este medio.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Proteger el medio de implementación con una contraseña</value>
+    <value>Solicitar la contraseña de un técnico antes de iniciar una implementación.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Contraseña de implementación</value>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Valige juurutamise ajal rakendatav ajavöönd.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Pärast edukat juurutamist</value>
+    <value>Automaatne taaskäivitamine</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Valige, kas ja millal seade pärast juurutamist taaskäivitatakse.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Taaskäivita automaatselt</value>
+    <value>Vali, kas seade taaskäivitatakse pärast edukat juurutamist automaatselt.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Viivitus enne taaskäivitamist</value>
+    <value>Taaskäivitamise viivitus</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Sisestage viivitus 0 kuni 3600 sekundit. Kohe taaskäivitamiseks kasutage väärtust 0.</value>
+    <value>Määra viivitus enne seadme taaskäivitamist. Koheseks taaskäivitamiseks kasuta väärtust 0.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Turvaline algkäivitus</value>
@@ -2771,13 +2768,10 @@
     <value>Muuda režiimi</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Juurutusandmekandja kaitse</value>
+    <value>Paroolikaitse</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Nõua parooli, enne kui Foundry Deploy saab seda andmekandjat kasutada.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Kaitse juurutusandmekandjat parooliga</value>
+    <value>Nõua enne juurutamise alustamist tehniku parooli.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Juurutusparool</value>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Muuda režiimi</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Juurutusandmekandja kaitse</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Nõua parooli, enne kui Foundry Deploy saab seda andmekandjat kasutada.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Kaitse juurutusandmekandjat parooliga</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Juurutusparool</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Parooli ei saa taastada. Kaitstud andmekandjal olevad identimisteave ja Autopiloti profiilid krüptitakse selle parooliga.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Parool</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Kinnita parool</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Sisesta kattuvad paroolid, milles on vähemalt 8 märki.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Tugevama kaitse tagamiseks kasuta vähemalt 12 märki või paroolifraasi.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Muuda režiimi</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Valitse käyttöönoton aikana käytettävä aikavyöhyke.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Onnistuneen käyttöönoton jälkeen</value>
+    <value>Automaattinen uudelleenkäynnistys</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Valitse, käynnistetäänkö laite uudelleen käyttöönoton jälkeen ja milloin.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Käynnistä automaattisesti uudelleen</value>
+    <value>Valitse, käynnistetäänkö laite automaattisesti uudelleen onnistuneen käyttöönoton jälkeen.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Viive ennen uudelleenkäynnistystä</value>
+    <value>Uudelleenkäynnistyksen viive</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Anna viive väliltä 0–3600 sekuntia. Arvo 0 käynnistää uudelleen heti.</value>
+    <value>Määritä viive ennen laitteen uudelleenkäynnistystä. Arvolla 0 laite käynnistyy uudelleen heti.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Suojattu käynnistys</value>
@@ -2771,13 +2768,10 @@
     <value>Vaihda tilaa</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Käyttöönottomedian suojaus</value>
+    <value>Salasanasuojaus</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Vaadi salasana, ennen kuin Foundry Deploy voi käyttää tätä mediaa.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Suojaa käyttöönottomedia salasanalla</value>
+    <value>Vaadi teknikon salasana ennen käyttöönoton aloittamista.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Käyttöönoton salasana</value>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Vaihda tilaa</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Käyttöönottomedian suojaus</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Vaadi salasana, ennen kuin Foundry Deploy voi käyttää tätä mediaa.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Suojaa käyttöönottomedia salasanalla</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Käyttöönoton salasana</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Salasanaa ei voi palauttaa. Suojatun median tunnistetiedot ja Autopilot-profiilit salataan sillä.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Salasana</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Vahvista salasana</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Anna samat vähintään 8 merkkiä pitkät salasanat.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Saat vahvemman suojauksen käyttämällä vähintään 12 merkkiä tai salauslausetta.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Vaihda tilaa</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Modifier le mode</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Modifier le mode</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Protection du support de déploiement</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Exiger un mot de passe avant que Foundry Deploy puisse utiliser ce support.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Protéger le support de déploiement par un mot de passe</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Mot de passe de déploiement</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Le mot de passe ne peut pas être récupéré. Il sert à chiffrer les informations d’identification et les profils Autopilot sur les supports protégés.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Mot de passe</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Confirmer le mot de passe</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Entrez des mots de passe identiques d’au moins 8 caractères.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Pour une protection accrue, utilisez au moins 12 caractères ou une phrase de passe.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Choisissez le fuseau horaire appliqué pendant le déploiement.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Après un déploiement réussi</value>
+    <value>Redémarrage automatique</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Choisissez si et quand l’appareil redémarre après le déploiement.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Redémarrer automatiquement</value>
+    <value>Choisissez si l’appareil redémarre automatiquement après un déploiement réussi.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Délai avant le redémarrage</value>
+    <value>Délai de redémarrage</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Entrez un délai de 0 à 3 600 secondes. Utilisez 0 pour redémarrer immédiatement.</value>
+    <value>Définissez le délai avant le redémarrage de l’appareil. Utilisez 0 pour le redémarrer immédiatement.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Démarrage sécurisé</value>
@@ -2771,13 +2768,10 @@
     <value>Modifier le mode</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Protection du support de déploiement</value>
+    <value>Protection par mot de passe</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Exiger un mot de passe avant que Foundry Deploy puisse utiliser ce support.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protéger le support de déploiement par un mot de passe</value>
+    <value>Exiger le mot de passe d’un technicien avant de lancer un déploiement.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Mot de passe de déploiement</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Modifier le mode</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Choisissez le fuseau horaire appliqué pendant le déploiement.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Après un déploiement réussi</value>
+    <value>Redémarrage automatique</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Choisissez si et quand l’appareil redémarre après le déploiement.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Redémarrer automatiquement</value>
+    <value>Choisissez si l’appareil redémarre automatiquement après un déploiement réussi.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Délai avant le redémarrage</value>
+    <value>Délai de redémarrage</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Saisissez un délai de 0 à 3 600 secondes. Utilisez 0 pour redémarrer immédiatement.</value>
+    <value>Définissez le délai avant le redémarrage de l’appareil. Utilisez 0 pour le redémarrer immédiatement.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Démarrage sécurisé</value>
@@ -2771,13 +2768,10 @@
     <value>Modifier le mode</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Protection du support de déploiement</value>
+    <value>Protection par mot de passe</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Exiger un mot de passe avant que Foundry Deploy puisse utiliser ce support.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protéger le support de déploiement par un mot de passe</value>
+    <value>Exiger le mot de passe d’un technicien avant de lancer un déploiement.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Mot de passe de déploiement</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Modifier le mode</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Protection du support de déploiement</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Exiger un mot de passe avant que Foundry Deploy puisse utiliser ce support.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Protéger le support de déploiement par un mot de passe</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Mot de passe de déploiement</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Le mot de passe ne peut pas être récupéré. Il sert à chiffrer les identifiants et les profils Autopilot sur les supports protégés.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Mot de passe</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Confirmer le mot de passe</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Saisissez des mots de passe identiques d’au moins 8 caractères.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Pour une protection renforcée, utilisez au moins 12 caractères ou une phrase secrète.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>בחר את אזור הזמן שיוחל במהלך הפריסה.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>לאחר פריסה מוצלחת</value>
+    <value>הפעלה מחדש אוטומטית</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>בחר אם ומתי המכשיר יופעל מחדש לאחר הפריסה.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>הפעל מחדש באופן אוטומטי</value>
+    <value>בחר אם המכשיר יופעל מחדש באופן אוטומטי לאחר פריסה מוצלחת.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>השהיה לפני הפעלה מחדש</value>
+    <value>השהיית הפעלה מחדש</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>הזן השהיה של 0 עד 3600 שניות. השתמש ב-0 להפעלה מחדש מיידית.</value>
+    <value>הגדר את ההשהיה לפני הפעלת המכשיר מחדש. השתמש ב-0 להפעלה מחדש מיידית.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>אתחול מאובטח</value>
@@ -2771,13 +2768,10 @@
     <value>שינוי מצב</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>הגנה על מדיית הפריסה</value>
+    <value>הגנה באמצעות סיסמה</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>דרוש סיסמה לפני ש-Foundry Deploy יוכל להשתמש במדיה זו.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>הגן על מדיית הפריסה באמצעות סיסמה</value>
+    <value>דרוש סיסמת טכנאי לפני התחלת פריסה.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>סיסמת פריסה</value>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>שינוי מצב</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>הגנה על מדיית הפריסה</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>דרוש סיסמה לפני ש-Foundry Deploy יוכל להשתמש במדיה זו.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>הגן על מדיית הפריסה באמצעות סיסמה</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>סיסמת פריסה</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>לא ניתן לשחזר את הסיסמה. פרטי הכניסה ופרופילי Autopilot במדיה המוגנת מוצפנים באמצעותה.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>סיסמה</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>אישור הסיסמה</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>הזן סיסמאות תואמות באורך 8 תווים לפחות.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>להגנה חזקה יותר, השתמש ב-12 תווים לפחות או בביטוי סיסמה.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>שינוי מצב</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Odaberite vremensku zonu koja se primjenjuje tijekom implementacije.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Nakon uspješne implementacije</value>
+    <value>Automatsko ponovno pokretanje</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Odaberite hoće li se i kada uređaj ponovno pokrenuti nakon implementacije.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Automatski ponovno pokreni</value>
+    <value>Odaberite hoće li se uređaj automatski ponovno pokrenuti nakon uspješne implementacije.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Odgoda prije ponovnog pokretanja</value>
+    <value>Odgoda ponovnog pokretanja</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Unesite odgodu od 0 do 3600 sekundi. Upotrijebite 0 za trenutačno ponovno pokretanje.</value>
+    <value>Postavite odgodu prije ponovnog pokretanja uređaja. Upotrijebite 0 za trenutačno ponovno pokretanje.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Sigurno pokretanje</value>
@@ -2771,13 +2768,10 @@
     <value>Promijeni način</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Zaštita medija za implementaciju</value>
+    <value>Zaštita lozinkom</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Zahtijevajte lozinku prije nego što Foundry Deploy može upotrijebiti ovaj medij.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Zaštiti medij za implementaciju lozinkom</value>
+    <value>Zahtijevajte lozinku tehničara prije pokretanja implementacije.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Lozinka za implementaciju</value>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Promijeni način</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Promijeni način</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Zaštita medija za implementaciju</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Zahtijevajte lozinku prije nego što Foundry Deploy može upotrijebiti ovaj medij.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Zaštiti medij za implementaciju lozinkom</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Lozinka za implementaciju</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Lozinku nije moguće oporaviti. Vjerodajnice i profili za Autopilot na zaštićenom mediju šifrirani su tom lozinkom.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Lozinka</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Potvrdite lozinku</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Unesite podudarne lozinke od najmanje 8 znakova.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Za bolju zaštitu upotrijebite najmanje 12 znakova ili pristupnu frazu.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Mód módosítása</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>A telepítési adathordozó védelme</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Jelszó megkövetelése, mielőtt a Foundry Deploy használhatná ezt az adathordozót.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>A telepítési adathordozó védelme jelszóval</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Telepítési jelszó</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>A jelszó nem állítható helyre. A védett adathordozón lévő hitelesítő adatok és Autopilot-profilok ezzel vannak titkosítva.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Jelszó</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Jelszó megerősítése</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Adjon meg egyező, legalább 8 karakteres jelszavakat.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Az erősebb védelem érdekében használjon legalább 12 karaktert vagy jelmondatot.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Mód módosítása</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Válassza ki a telepítés során alkalmazott időzónát.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Sikeres üzembe helyezés után</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Válassza ki, hogy az eszköz újrainduljon-e az üzembe helyezés után, és mikor.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
     <value>Automatikus újraindítás</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Adja meg, hogy az eszköz automatikusan újrainduljon-e a sikeres telepítés után.</value>
+  </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Késleltetés újraindítás előtt</value>
+    <value>Újraindítás késleltetése</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Adjon meg 0 és 3600 másodperc közötti késleltetést. A 0 azonnali újraindítást jelent.</value>
+    <value>Állítsa be az eszköz újraindítása előtti késleltetést. Az azonnali újraindításhoz használjon 0 értéket.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Biztonságos rendszerindítás</value>
@@ -2771,13 +2768,10 @@
     <value>Mód módosítása</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>A telepítési adathordozó védelme</value>
+    <value>Jelszavas védelem</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Jelszó megkövetelése, mielőtt a Foundry Deploy használhatná ezt az adathordozót.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>A telepítési adathordozó védelme jelszóval</value>
+    <value>A telepítés megkezdése előtt technikusi jelszó megkövetelése.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Telepítési jelszó</value>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Cambia modalità</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Cambia modalità</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Protezione del supporto di distribuzione</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Richiedi una password prima che Foundry Deploy possa utilizzare questo supporto.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Proteggi il supporto di distribuzione con una password</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Password di distribuzione</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>La password non può essere recuperata. Le credenziali e i profili Autopilot presenti sul supporto protetto vengono crittografati con questa password.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
     <value>Password</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Conferma password</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Inserisci password corrispondenti di almeno 8 caratteri.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Per una protezione maggiore, utilizza almeno 12 caratteri o una passphrase.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Scegli il fuso orario applicato durante la distribuzione.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Dopo la distribuzione completata</value>
+    <value>Riavvio automatico</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Scegliere se e quando riavviare il dispositivo dopo la distribuzione.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Riavvia automaticamente</value>
+    <value>Scegli se riavviare automaticamente il dispositivo dopo una distribuzione riuscita.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Ritardo prima del riavvio</value>
+    <value>Ritardo del riavvio</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Immettere un ritardo da 0 a 3600 secondi. Usare 0 per riavviare immediatamente.</value>
+    <value>Imposta il ritardo prima del riavvio del dispositivo. Utilizza 0 per riavviarlo immediatamente.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Avvio protetto</value>
@@ -2771,13 +2768,10 @@
     <value>Cambia modalità</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Protezione del supporto di distribuzione</value>
+    <value>Protezione con password</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Richiedi una password prima che Foundry Deploy possa utilizzare questo supporto.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Proteggi il supporto di distribuzione con una password</value>
+    <value>Richiedi la password di un tecnico prima di avviare una distribuzione.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Password di distribuzione</value>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>モードを変更</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>展開メディアの保護</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Foundry Deploy がこのメディアを使用する前にパスワードを要求します。</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>展開メディアをパスワードで保護する</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>展開パスワード</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>パスワードは復元できません。保護されたメディア上の資格情報と Autopilot プロファイルは、このパスワードで暗号化されます。</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>パスワード</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>パスワードの確認</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>8 文字以上の一致するパスワードを入力してください。</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>保護を強化するには、12 文字以上のパスワードまたはパスフレーズを使用してください。</value>
   </data>
 </root>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>展開中に適用するタイム ゾーンを選択します。</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>展開が正常に完了した後</value>
+    <value>自動再起動</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>展開後にデバイスを再起動するかどうかと、そのタイミングを選択します。</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>自動的に再起動する</value>
+    <value>展開が正常に完了した後、デバイスを自動的に再起動するかどうかを選択します。</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>再起動までの待機時間</value>
+    <value>再起動の遅延</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>0～3600 秒の待機時間を入力します。すぐに再起動するには 0 を使用します。</value>
+    <value>デバイスが再起動するまでの遅延時間を設定します。すぐに再起動するには 0 を指定します。</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>セキュア ブート</value>
@@ -2771,13 +2768,10 @@
     <value>モードを変更</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>展開メディアの保護</value>
+    <value>パスワード保護</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Foundry Deploy がこのメディアを使用する前にパスワードを要求します。</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>展開メディアをパスワードで保護する</value>
+    <value>展開を開始する前に技術者用パスワードを要求します。</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>展開パスワード</value>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>モードを変更</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>배포 중에 적용할 표준 시간대를 선택합니다.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>배포 성공 후</value>
+    <value>자동 다시 시작</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>배포 후 장치를 다시 시작할지 여부와 시점을 선택합니다.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>자동으로 다시 시작</value>
+    <value>배포에 성공한 후 장치를 자동으로 다시 시작할지 선택합니다.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>다시 시작 전 지연 시간</value>
+    <value>다시 시작 지연</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>0~3600초의 지연 시간을 입력합니다. 즉시 다시 시작하려면 0을 사용하세요.</value>
+    <value>장치를 다시 시작하기 전의 지연 시간을 설정합니다. 즉시 다시 시작하려면 0을 사용하세요.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>보안 부팅</value>
@@ -2771,13 +2768,10 @@
     <value>모드 변경</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>배포 미디어 보호</value>
+    <value>암호 보호</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Foundry Deploy에서 이 미디어를 사용하기 전에 암호를 요구합니다.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>암호로 배포 미디어 보호</value>
+    <value>배포를 시작하기 전에 기술자 암호를 요구합니다.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>배포 암호</value>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>모드 변경</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>모드 변경</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>배포 미디어 보호</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Foundry Deploy에서 이 미디어를 사용하기 전에 암호를 요구합니다.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>암호로 배포 미디어 보호</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>배포 암호</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>암호는 복구할 수 없습니다. 보호된 미디어의 자격 증명과 Autopilot 프로필은 이 암호로 암호화됩니다.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>암호</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>암호 확인</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>8자 이상의 일치하는 암호를 입력하세요.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>보안을 강화하려면 12자 이상의 암호 또는 암호 구문을 사용하세요.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Keisti režimą</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Diegimo laikmenos apsauga</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Reikalauti slaptažodžio prieš leidžiant „Foundry Deploy“ naudoti šią laikmeną.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Apsaugoti diegimo laikmeną slaptažodžiu</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Diegimo slaptažodis</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Slaptažodžio atkurti negalima. Apsaugotoje laikmenoje esantys prisijungimo duomenys ir „Autopilot“ profiliai juo užšifruojami.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Slaptažodis</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Patvirtinkite slaptažodį</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Įveskite sutampančius bent 8 simbolių slaptažodžius.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Kad apsauga būtų patikimesnė, naudokite bent 12 simbolių arba slaptafrazę.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Pasirinkite diegimo metu taikomą laiko juostą.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Po sėkmingo diegimo</value>
+    <value>Automatinis paleidimas iš naujo</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Pasirinkite, ar ir kada įrenginys bus paleistas iš naujo po diegimo.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Paleisti iš naujo automatiškai</value>
+    <value>Pasirinkite, ar sėkmingai įdiegus įrenginys bus automatiškai paleistas iš naujo.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Delsa prieš paleidžiant iš naujo</value>
+    <value>Paleidimo iš naujo delsa</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Įveskite delsą nuo 0 iki 3600 sekundžių. Norėdami paleisti iš naujo iš karto, naudokite 0.</value>
+    <value>Nustatykite delsą prieš paleidžiant įrenginį iš naujo. Norėdami paleisti iš naujo iškart, naudokite 0.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Saugioji įkrova</value>
@@ -2771,13 +2768,10 @@
     <value>Keisti režimą</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Diegimo laikmenos apsauga</value>
+    <value>Apsauga slaptažodžiu</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Reikalauti slaptažodžio prieš leidžiant „Foundry Deploy“ naudoti šią laikmeną.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Apsaugoti diegimo laikmeną slaptažodžiu</value>
+    <value>Reikalauti techniko slaptažodžio prieš pradedant diegimą.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Diegimo slaptažodis</value>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Keisti režimą</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Mainīt režīmu</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Izvietošanas datu nesēja aizsardzība</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Pieprasīt paroli, pirms Foundry Deploy var izmantot šo datu nesēju.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Aizsargāt izvietošanas datu nesēju ar paroli</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Izvietošanas parole</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Paroli nevar atkopt. Ar to tiek šifrēti aizsargātajā datu nesējā esošie akreditācijas dati un Autopilot profili.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Parole</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Apstipriniet paroli</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Ievadiet vienādas paroles, kurās ir vismaz 8 rakstzīmes.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Lai nodrošinātu labāku aizsardzību, izmantojiet vismaz 12 rakstzīmes vai paroles frāzi.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Mainīt režīmu</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Izvēlieties laika joslu, kas tiek lietota izvietošanas laikā.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Pēc sekmīgas izvietošanas</value>
+    <value>Automātiska restartēšana</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Izvēlieties, vai un kad ierīce pēc izvietošanas tiek restartēta.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Restartēt automātiski</value>
+    <value>Izvēlieties, vai pēc veiksmīgas izvietošanas ierīce tiek automātiski restartēta.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Aizkave pirms restartēšanas</value>
+    <value>Restartēšanas aizkave</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Ievadiet aizkavi no 0 līdz 3600 sekundēm. Izmantojiet 0, lai restartētu nekavējoties.</value>
+    <value>Iestatiet aizkavi pirms ierīces restartēšanas. Lai restartētu nekavējoties, izmantojiet 0.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Drošā sāknēšana</value>
@@ -2771,13 +2768,10 @@
     <value>Mainīt režīmu</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Izvietošanas datu nesēja aizsardzība</value>
+    <value>Aizsardzība ar paroli</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Pieprasīt paroli, pirms Foundry Deploy var izmantot šo datu nesēju.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Aizsargāt izvietošanas datu nesēju ar paroli</value>
+    <value>Pieprasīt tehniķa paroli pirms izvietošanas sākšanas.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Izvietošanas parole</value>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Endre modus</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Endre modus</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Beskyttelse av distribusjonsmedier</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Krev et passord før Foundry Deploy kan bruke dette mediet.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Beskytt distribusjonsmediet med et passord</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Distribusjonspassord</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Passordet kan ikke gjenopprettes. Påloggingsinformasjon og Autopilot-profiler på beskyttede medier krypteres med passordet.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Passord</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Bekreft passord</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Skriv inn samsvarende passord med minst 8 tegn.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Bruk minst 12 tegn eller en passfrase for bedre beskyttelse.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Velg tidssonen som brukes under distribusjon.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Etter vellykket distribusjon</value>
+    <value>Automatisk omstart</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Velg om og når enheten skal starte på nytt etter distribusjonen.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Start på nytt automatisk</value>
+    <value>Velg om enheten skal startes på nytt automatisk etter en vellykket distribusjon.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
     <value>Forsinkelse før omstart</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Angi en forsinkelse fra 0 til 3600 sekunder. Bruk 0 for å starte på nytt umiddelbart.</value>
+    <value>Angi forsinkelsen før enheten startes på nytt. Bruk 0 for å starte på nytt umiddelbart.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Sikker oppstart</value>
@@ -2771,13 +2768,10 @@
     <value>Endre modus</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Beskyttelse av distribusjonsmedier</value>
+    <value>Passordbeskyttelse</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Krev et passord før Foundry Deploy kan bruke dette mediet.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Beskytt distribusjonsmediet med et passord</value>
+    <value>Krev et teknikerpassord før en distribusjon startes.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Distribusjonspassord</value>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Modus wijzigen</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Beveiliging van implementatiemedia</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Een wachtwoord vereisen voordat Foundry Deploy dit medium kan gebruiken.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Implementatiemedia beveiligen met een wachtwoord</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Implementatiewachtwoord</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Het wachtwoord kan niet worden hersteld. Referenties en Autopilot-profielen op beveiligde media worden ermee versleuteld.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Wachtwoord</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Wachtwoord bevestigen</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Voer overeenkomende wachtwoorden van minimaal 8 tekens in.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Gebruik voor betere beveiliging minimaal 12 tekens of een wachtwoordzin.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Modus wijzigen</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Kies de tijdzone die tijdens de implementatie wordt toegepast.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Na een geslaagde implementatie</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Kies of en wanneer het apparaat na de implementatie opnieuw wordt opgestart.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
     <value>Automatisch opnieuw opstarten</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Kies of het apparaat automatisch opnieuw wordt opgestart na een geslaagde implementatie.</value>
+  </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Vertraging vóór opnieuw opstarten</value>
+    <value>Vertraging voor opnieuw opstarten</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Voer een vertraging van 0 tot 3600 seconden in. Gebruik 0 om onmiddellijk opnieuw op te starten.</value>
+    <value>Stel de vertraging in voordat het apparaat opnieuw wordt opgestart. Gebruik 0 om het direct opnieuw op te starten.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Veilig opstarten</value>
@@ -2771,13 +2768,10 @@
     <value>Modus wijzigen</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Beveiliging van implementatiemedia</value>
+    <value>Wachtwoordbeveiliging</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Een wachtwoord vereisen voordat Foundry Deploy dit medium kan gebruiken.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Implementatiemedia beveiligen met een wachtwoord</value>
+    <value>Vereis een technicuswachtwoord voordat een implementatie wordt gestart.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Implementatiewachtwoord</value>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Zmień tryb</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Wybierz strefę czasową stosowaną podczas wdrażania.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Po pomyślnym wdrożeniu</value>
+    <value>Automatyczne ponowne uruchamianie</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Wybierz, czy i kiedy urządzenie ma zostać ponownie uruchomione po wdrożeniu.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Uruchom ponownie automatycznie</value>
+    <value>Wybierz, czy urządzenie ma zostać automatycznie ponownie uruchomione po pomyślnym wdrożeniu.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Opóźnienie przed ponownym uruchomieniem</value>
+    <value>Opóźnienie ponownego uruchomienia</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Wprowadź opóźnienie od 0 do 3600 sekund. Użyj wartości 0, aby uruchomić ponownie natychmiast.</value>
+    <value>Ustaw opóźnienie przed ponownym uruchomieniem urządzenia. Użyj wartości 0, aby uruchomić je ponownie natychmiast.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Bezpieczny rozruch</value>
@@ -2771,13 +2768,10 @@
     <value>Zmień tryb</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Ochrona nośnika wdrożeniowego</value>
+    <value>Ochrona hasłem</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Wymagaj hasła, zanim Foundry Deploy będzie mógł użyć tego nośnika.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Chroń nośnik wdrożeniowy hasłem</value>
+    <value>Wymagaj hasła technika przed rozpoczęciem wdrożenia.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Hasło wdrożenia</value>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Zmień tryb</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Ochrona nośnika wdrożeniowego</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Wymagaj hasła, zanim Foundry Deploy będzie mógł użyć tego nośnika.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Chroń nośnik wdrożeniowy hasłem</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Hasło wdrożenia</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Hasła nie można odzyskać. Dane uwierzytelniające i profile Autopilot na chronionym nośniku są nim szyfrowane.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Hasło</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Potwierdź hasło</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Wprowadź zgodne hasła o długości co najmniej 8 znaków.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Aby zwiększyć ochronę, użyj co najmniej 12 znaków lub frazy hasłowej.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Escolha o fuso horário aplicado durante a implantação.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Após a implantação bem-sucedida</value>
+    <value>Reinicialização automática</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Escolha se e quando o dispositivo será reiniciado após a implantação.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Reiniciar automaticamente</value>
+    <value>Escolha se o dispositivo será reiniciado automaticamente após uma implantação bem-sucedida.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Atraso antes de reiniciar</value>
+    <value>Atraso da reinicialização</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Insira um atraso de 0 a 3600 segundos. Use 0 para reiniciar imediatamente.</value>
+    <value>Defina o atraso antes da reinicialização do dispositivo. Use 0 para reiniciar imediatamente.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Inicialização segura</value>
@@ -2771,13 +2768,10 @@
     <value>Alterar modo</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Proteção da mídia de implantação</value>
+    <value>Proteção por senha</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Exija uma senha antes que o Foundry Deploy possa usar esta mídia.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Proteger a mídia de implantação com uma senha</value>
+    <value>Exija uma senha de técnico antes de iniciar uma implantação.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Senha de implantação</value>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Alterar modo</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Proteção da mídia de implantação</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Exija uma senha antes que o Foundry Deploy possa usar esta mídia.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Proteger a mídia de implantação com uma senha</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Senha de implantação</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>A senha não pode ser recuperada. As credenciais e os perfis do Autopilot na mídia protegida são criptografados com ela.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Senha</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Confirmar senha</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Insira senhas iguais com pelo menos 8 caracteres.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Para maior proteção, use pelo menos 12 caracteres ou uma frase secreta.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Alterar modo</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Alterar modo</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Proteção do suporte de implementação</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Exigir uma palavra-passe antes de o Foundry Deploy poder utilizar este suporte.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Proteger o suporte de implementação com uma palavra-passe</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Palavra-passe de implementação</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Não é possível recuperar a palavra-passe. As credenciais e os perfis do Autopilot no suporte protegido são encriptados com esta palavra-passe.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Palavra-passe</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Confirmar palavra-passe</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Introduza palavras-passe correspondentes com, pelo menos, 8 carateres.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Para uma proteção mais forte, utilize pelo menos 12 carateres ou uma frase-passe.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Escolha o fuso horário aplicado durante a implementação.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Após a implementação bem-sucedida</value>
+    <value>Reinício automático</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Escolha se e quando o dispositivo é reiniciado após a implementação.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Reiniciar automaticamente</value>
+    <value>Escolha se o dispositivo é reiniciado automaticamente após uma implementação bem-sucedida.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Atraso antes do reinício</value>
+    <value>Atraso do reinício</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Introduza um atraso de 0 a 3600 segundos. Utilize 0 para reiniciar imediatamente.</value>
+    <value>Defina o atraso antes de o dispositivo reiniciar. Utilize 0 para reiniciar imediatamente.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Arranque seguro</value>
@@ -2771,13 +2768,10 @@
     <value>Alterar modo</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Proteção do suporte de implementação</value>
+    <value>Proteção por palavra-passe</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Exigir uma palavra-passe antes de o Foundry Deploy poder utilizar este suporte.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Proteger o suporte de implementação com uma palavra-passe</value>
+    <value>Exigir uma palavra-passe de técnico antes de iniciar uma implementação.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Palavra-passe de implementação</value>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Alterar modo</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Schimbați modul</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Protecția suportului de implementare</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Solicitați o parolă înainte ca Foundry Deploy să poată utiliza acest suport.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Protejați suportul de implementare cu o parolă</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Parolă de implementare</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Parola nu poate fi recuperată. Datele de autentificare și profilurile Autopilot de pe suportul protejat sunt criptate cu aceasta.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Parolă</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Confirmați parola</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Introduceți parole identice de cel puțin 8 caractere.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Pentru o protecție mai puternică, utilizați cel puțin 12 caractere sau o frază de acces.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Schimbați modul</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Alegeți fusul orar aplicat în timpul implementării.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>După implementarea reușită</value>
+    <value>Repornire automată</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Alegeți dacă și când repornește dispozitivul după implementare.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Repornește automat</value>
+    <value>Alegeți dacă dispozitivul repornește automat după o implementare reușită.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Întârziere înainte de repornire</value>
+    <value>Întârziere la repornire</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Introduceți o întârziere între 0 și 3600 de secunde. Utilizați 0 pentru repornire imediată.</value>
+    <value>Setați întârzierea înainte ca dispozitivul să repornească. Utilizați 0 pentru repornire imediată.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Pornire securizată</value>
@@ -2771,13 +2768,10 @@
     <value>Schimbați modul</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Protecția suportului de implementare</value>
+    <value>Protecție prin parolă</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Solicitați o parolă înainte ca Foundry Deploy să poată utiliza acest suport.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protejați suportul de implementare cu o parolă</value>
+    <value>Solicitați parola unui tehnician înainte de a începe o implementare.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Parolă de implementare</value>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Изменить режим</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Изменить режим</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Защита носителя развертывания</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Запрашивать пароль, прежде чем Foundry Deploy сможет использовать этот носитель.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Защитить носитель развертывания паролем</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Пароль развертывания</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Пароль невозможно восстановить. Учетные данные и профили Autopilot на защищенном носителе шифруются с его помощью.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Пароль</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Подтвердите пароль</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Введите совпадающие пароли длиной не менее 8 символов.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Для более надежной защиты используйте не менее 12 символов или парольную фразу.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Выберите часовой пояс, применяемый во время развертывания.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>После успешного развертывания</value>
+    <value>Автоматическая перезагрузка</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Выберите, следует ли и когда перезапускать устройство после развертывания.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Перезапускать автоматически</value>
+    <value>Выберите, должно ли устройство автоматически перезагружаться после успешного развертывания.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Задержка перед перезапуском</value>
+    <value>Задержка перезагрузки</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Введите задержку от 0 до 3600 секунд. Значение 0 означает немедленный перезапуск.</value>
+    <value>Задайте задержку перед перезагрузкой устройства. Укажите 0 для немедленной перезагрузки.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Безопасная загрузка</value>
@@ -2771,13 +2768,10 @@
     <value>Изменить режим</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Защита носителя развертывания</value>
+    <value>Защита паролем</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Запрашивать пароль, прежде чем Foundry Deploy сможет использовать этот носитель.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Защитить носитель развертывания паролем</value>
+    <value>Требовать пароль технического специалиста перед началом развертывания.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Пароль развертывания</value>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Zmeniť režim</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Ochrana média na nasadenie</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Pred použitím tohto média v aplikácii Foundry Deploy vyžadovať heslo.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Chrániť médium na nasadenie heslom</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Heslo nasadenia</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Heslo nie je možné obnoviť. Prihlasovacie údaje a profily Autopilot na chránenom médiu sú ním šifrované.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Heslo</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Potvrďte heslo</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Zadajte zhodné heslá s najmenej 8 znakmi.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Na zvýšenie ochrany použite najmenej 12 znakov alebo prístupovú frázu.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Zmeniť režim</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Vyberte časové pásmo použité počas nasadenia.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Po úspešnom nasadení</value>
+    <value>Automatické reštartovanie</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Vyberte, či a kedy sa má zariadenie po nasadení reštartovať.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Reštartovať automaticky</value>
+    <value>Vyberte, či sa má zariadenie po úspešnom nasadení automaticky reštartovať.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Oneskorenie pred reštartovaním</value>
+    <value>Oneskorenie reštartovania</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Zadajte oneskorenie od 0 do 3600 sekúnd. Hodnota 0 znamená okamžité reštartovanie.</value>
+    <value>Nastavte oneskorenie pred reštartovaním zariadenia. Ak chcete zariadenie reštartovať okamžite, použite hodnotu 0.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Zabezpečené spustenie</value>
@@ -2771,13 +2768,10 @@
     <value>Zmeniť režim</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Ochrana média na nasadenie</value>
+    <value>Ochrana heslom</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Pred použitím tohto média v aplikácii Foundry Deploy vyžadovať heslo.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Chrániť médium na nasadenie heslom</value>
+    <value>Pred spustením nasadenia vyžadovať heslo technika.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Heslo nasadenia</value>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Spremeni način</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Zaščita medija za uvajanje</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Zahtevajte geslo, preden lahko Foundry Deploy uporabi ta medij.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Zaščiti medij za uvajanje z geslom</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Geslo za uvajanje</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Gesla ni mogoče obnoviti. Poverilnice in profili Autopilot na zaščitenem mediju so šifrirani z njim.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Geslo</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Potrdite geslo</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Vnesite ujemajoči se gesli z vsaj 8 znaki.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Za močnejšo zaščito uporabite vsaj 12 znakov ali geselsko frazo.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Spremeni način</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Izberite časovni pas, uporabljen med uvedbo.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Po uspešni uvedbi</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Izberite, ali in kdaj naj se naprava po uvedbi znova zažene.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
     <value>Samodejni ponovni zagon</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>Izberite, ali naj se naprava po uspešnem uvajanju samodejno znova zažene.</value>
+  </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Zakasnitev pred ponovnim zagonom</value>
+    <value>Zakasnitev ponovnega zagona</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Vnesite zakasnitev od 0 do 3600 sekund. Za takojšnji ponovni zagon uporabite 0.</value>
+    <value>Nastavite zakasnitev pred ponovnim zagonom naprave. Za takojšen ponovni zagon uporabite 0.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Varni zagon</value>
@@ -2771,13 +2768,10 @@
     <value>Spremeni način</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Zaščita medija za uvajanje</value>
+    <value>Zaščita z geslom</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Zahtevajte geslo, preden lahko Foundry Deploy uporabi ta medij.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Zaščiti medij za uvajanje z geslom</value>
+    <value>Pred začetkom uvajanja zahtevajte geslo tehnika.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Geslo za uvajanje</value>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Promeni režim</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Zaštita medijuma za primenu</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Zahtevaj lozinku pre nego što Foundry Deploy može da koristi ovaj medijum.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Zaštiti medijum za primenu lozinkom</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Lozinka za primenu</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Lozinku nije moguće oporaviti. Akreditivi i Autopilot profili na zaštićenom medijumu šifruju se pomoću nje.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Lozinka</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Potvrdite lozinku</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Unesite lozinke koje se podudaraju i imaju najmanje 8 znakova.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Za bolju zaštitu koristite najmanje 12 znakova ili pristupnu frazu.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Promeni režim</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Izaberite vremensku zonu koja se primenjuje tokom primene.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Nakon uspešne primene</value>
+    <value>Automatsko ponovno pokretanje</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Odaberite da li će se i kada uređaj ponovo pokrenuti nakon primene.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Automatski ponovo pokreni</value>
+    <value>Izaberite da li će se uređaj automatski ponovo pokrenuti nakon uspešne primene.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Odlaganje pre ponovnog pokretanja</value>
+    <value>Odlaganje ponovnog pokretanja</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Unesite odlaganje od 0 do 3600 sekundi. Koristite 0 za trenutno ponovno pokretanje.</value>
+    <value>Podesite vreme odlaganja pre nego što se uređaj ponovo pokrene. Koristite 0 za trenutno ponovno pokretanje.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Bezbedno pokretanje</value>
@@ -2771,13 +2768,10 @@
     <value>Promeni režim</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Zaštita medijuma za primenu</value>
+    <value>Zaštita lozinkom</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Zahtevaj lozinku pre nego što Foundry Deploy može da koristi ovaj medijum.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Zaštiti medijum za primenu lozinkom</value>
+    <value>Zahtevaj lozinku tehničara pre pokretanja primene.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Lozinka za primenu</value>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Ändra läge</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Skydd av distributionsmedia</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Kräv ett lösenord innan Foundry Deploy kan använda det här mediet.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Skydda distributionsmedia med ett lösenord</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Distributionslösenord</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Lösenordet kan inte återställas. Autentiseringsuppgifter och Autopilot-profiler på det skyddade mediet krypteras med det.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Lösenord</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Bekräfta lösenord</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Ange matchande lösenord med minst 8 tecken.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Använd minst 12 tecken eller en lösenordsfras för starkare skydd.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Ändra läge</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Välj tidszonen som används under distributionen.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Efter slutförd distribution</value>
+    <value>Automatisk omstart</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Välj om och när enheten ska startas om efter distributionen.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Starta om automatiskt</value>
+    <value>Välj om enheten ska startas om automatiskt efter en lyckad distribution.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
     <value>Fördröjning före omstart</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Ange en fördröjning från 0 till 3600 sekunder. Använd 0 för att starta om direkt.</value>
+    <value>Ange fördröjningen innan enheten startas om. Använd 0 för att starta om omedelbart.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Säker start</value>
@@ -2771,13 +2768,10 @@
     <value>Ändra läge</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Skydd av distributionsmedia</value>
+    <value>Lösenordsskydd</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Kräv ett lösenord innan Foundry Deploy kan använda det här mediet.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Skydda distributionsmedia med ett lösenord</value>
+    <value>Kräv ett teknikerlösenord innan en distribution startas.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Distributionslösenord</value>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>เปลี่ยนโหมด</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>เปลี่ยนโหมด</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>การป้องกันสื่อการปรับใช้</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>กำหนดให้ป้อนรหัสผ่านก่อนที่ Foundry Deploy จะใช้สื่อนี้ได้</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>ป้องกันสื่อการปรับใช้ด้วยรหัสผ่าน</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>รหัสผ่านการปรับใช้</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>ไม่สามารถกู้คืนรหัสผ่านได้ ข้อมูลประจำตัวและโปรไฟล์ Autopilot ในสื่อที่มีการป้องกันจะถูกเข้ารหัสด้วยรหัสผ่านนี้</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>รหัสผ่าน</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>ยืนยันรหัสผ่าน</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>ป้อนรหัสผ่านที่ตรงกันและมีความยาวอย่างน้อย 8 อักขระ</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>เพื่อการป้องกันที่รัดกุมยิ่งขึ้น ให้ใช้อย่างน้อย 12 อักขระหรือวลีรหัสผ่าน</value>
   </data>
 </root>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>เลือกเขตเวลาที่ใช้ระหว่างการปรับใช้</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>หลังจากการปรับใช้สำเร็จ</value>
+    <value>การรีสตาร์ตอัตโนมัติ</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>เลือกว่าจะให้รีสตาร์ตอุปกรณ์หลังการปรับใช้หรือไม่และเมื่อใด</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>รีสตาร์ตโดยอัตโนมัติ</value>
+    <value>เลือกว่าจะให้อุปกรณ์รีสตาร์ตโดยอัตโนมัติหลังจากการปรับใช้สำเร็จหรือไม่</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
     <value>ระยะเวลาก่อนรีสตาร์ต</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>ป้อนระยะเวลาตั้งแต่ 0 ถึง 3600 วินาที ใช้ 0 เพื่อรีสตาร์ตทันที</value>
+    <value>กำหนดระยะเวลาก่อนที่อุปกรณ์จะรีสตาร์ต ใช้ 0 เพื่อรีสตาร์ตทันที</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>การบูตแบบปลอดภัย</value>
@@ -2771,13 +2768,10 @@
     <value>เปลี่ยนโหมด</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>การป้องกันสื่อการปรับใช้</value>
+    <value>การป้องกันด้วยรหัสผ่าน</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>กำหนดให้ป้อนรหัสผ่านก่อนที่ Foundry Deploy จะใช้สื่อนี้ได้</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>ป้องกันสื่อการปรับใช้ด้วยรหัสผ่าน</value>
+    <value>กำหนดให้ป้อนรหัสผ่านของช่างเทคนิคก่อนเริ่มการปรับใช้</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>รหัสผ่านการปรับใช้</value>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Dağıtım sırasında uygulanacak saat dilimini seçin.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Başarılı dağıtımdan sonra</value>
+    <value>Otomatik yeniden başlatma</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Dağıtımdan sonra cihazın yeniden başlatılıp başlatılmayacağını ve zamanını seçin.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Otomatik olarak yeniden başlat</value>
+    <value>Başarılı bir dağıtımdan sonra cihazın otomatik olarak yeniden başlatılıp başlatılmayacağını seçin.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Yeniden başlatma öncesi gecikme</value>
+    <value>Yeniden başlatma gecikmesi</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>0 ile 3600 saniye arasında bir gecikme girin. Hemen yeniden başlatmak için 0 kullanın.</value>
+    <value>Cihaz yeniden başlatılmadan önceki gecikmeyi ayarlayın. Hemen yeniden başlatmak için 0 kullanın.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Güvenli Önyükleme</value>
@@ -2771,13 +2768,10 @@
     <value>Modu değiştir</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Dağıtım medyası koruması</value>
+    <value>Parola koruması</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Foundry Deploy bu medyayı kullanmadan önce parola isteyin.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Dağıtım medyasını parolayla koru</value>
+    <value>Dağıtımı başlatmadan önce teknisyen parolası isteyin.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Dağıtım parolası</value>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Modu değiştir</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Dağıtım medyası koruması</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Foundry Deploy bu medyayı kullanmadan önce parola isteyin.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Dağıtım medyasını parolayla koru</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Dağıtım parolası</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Parola kurtarılamaz. Korumalı medyadaki kimlik bilgileri ve Autopilot profilleri bu parolayla şifrelenir.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Parola</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Parolayı doğrulayın</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>En az 8 karakterden oluşan eşleşen parolalar girin.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Daha güçlü koruma için en az 12 karakter veya bir parola tümcesi kullanın.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Modu değiştir</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>Змінити режим</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>Змінити режим</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>Захист носія розгортання</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>Вимагати пароль, перш ніж Foundry Deploy зможе використовувати цей носій.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>Захистити носій розгортання паролем</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>Пароль розгортання</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>Пароль неможливо відновити. Облікові дані та профілі Autopilot на захищеному носії шифруються за його допомогою.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>Пароль</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>Підтвердьте пароль</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>Введіть однакові паролі довжиною щонайменше 8 символів.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>Для надійнішого захисту використовуйте щонайменше 12 символів або парольну фразу.</value>
   </data>
 </root>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>Виберіть часовий пояс, який застосовується під час розгортання.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>Після успішного розгортання</value>
+    <value>Автоматичне перезавантаження</value>
   </data>
   <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>Виберіть, чи потрібно та коли перезавантажувати пристрій після розгортання.</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
-    <value>Перезавантажувати автоматично</value>
+    <value>Виберіть, чи має пристрій автоматично перезавантажуватися після успішного розгортання.</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>Затримка перед перезавантаженням</value>
+    <value>Затримка перезавантаження</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>Введіть затримку від 0 до 3600 секунд. Значення 0 означає негайне перезавантаження.</value>
+    <value>Установіть затримку перед перезавантаженням пристрою. Укажіть 0, щоб перезавантажити негайно.</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>Безпечне завантаження</value>
@@ -2771,13 +2768,10 @@
     <value>Змінити режим</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Захист носія розгортання</value>
+    <value>Захист паролем</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Вимагати пароль, перш ніж Foundry Deploy зможе використовувати цей носій.</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Захистити носій розгортання паролем</value>
+    <value>Вимагати пароль технічного спеціаліста перед початком розгортання.</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>Пароль розгортання</value>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>更改模式</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>部署介质保护</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>要求先输入密码，Foundry Deploy 才能使用此介质。</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>使用密码保护部署介质</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>部署密码</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>密码无法恢复。受保护介质上的凭据和 Autopilot 配置文件将使用该密码加密。</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>密码</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>确认密码</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>请输入至少包含 8 个字符且相同的密码。</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>为增强保护，请使用至少 12 个字符或密码短语。</value>
   </data>
 </root>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>选择部署期间应用的时区。</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>成功部署后</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>选择设备是否以及何时在部署后重启。</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
     <value>自动重启</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>选择设备是否在部署成功后自动重启。</value>
+  </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>重启前延迟</value>
+    <value>重启延迟</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>输入 0 到 3600 秒的延迟。使用 0 可立即重启。</value>
+    <value>设置设备重启前的延迟时间。输入 0 可立即重启。</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>安全启动</value>
@@ -2771,13 +2768,10 @@
     <value>更改模式</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>部署介质保护</value>
+    <value>密码保护</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>要求先输入密码，Foundry Deploy 才能使用此介质。</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>使用密码保护部署介质</value>
+    <value>开始部署前要求输入技术人员密码。</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>部署密码</value>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>更改模式</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -2770,4 +2770,31 @@
   <data name="Autopilot.ModeSwitchConfirmationPrimaryButton" xml:space="preserve">
     <value>變更模式</value>
   </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
+    <value>Deployment media protection</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
+    <value>Require a password before Foundry Deploy can use this media.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
+    <value>Protect deployment media with a password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
+    <value>Deployment password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
+    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
+    <value>Enter matching passwords with at least 8 characters.</value>
+  </data>
+  <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
+    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -2771,30 +2771,30 @@
     <value>變更模式</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>Deployment media protection</value>
+    <value>部署媒體保護</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>Require a password before Foundry Deploy can use this media.</value>
+    <value>要求先輸入密碼，Foundry Deploy 才能使用此媒體。</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>Protect deployment media with a password</value>
+    <value>使用密碼保護部署媒體</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
-    <value>Deployment password</value>
+    <value>部署密碼</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Description" xml:space="preserve">
-    <value>The password cannot be recovered. Credentials and Autopilot profiles on protected media are encrypted with it.</value>
+    <value>密碼無法復原。受保護媒體上的認證和 Autopilot 設定檔會使用此密碼加密。</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Password.Placeholder" xml:space="preserve">
-    <value>Password</value>
+    <value>密碼</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder" xml:space="preserve">
-    <value>Confirm password</value>
+    <value>確認密碼</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Validation" xml:space="preserve">
-    <value>Enter matching passwords with at least 8 characters.</value>
+    <value>請輸入至少包含 8 個字元且相符的密碼。</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Recommendation" xml:space="preserve">
-    <value>For stronger protection, use at least 12 characters or a passphrase.</value>
+    <value>為加強保護，請使用至少 12 個字元或密碼片語。</value>
   </data>
 </root>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -1294,19 +1294,16 @@
     <value>選擇部署期間套用的時區。</value>
   </data>
   <data name="GeneralConfiguration.Completion.Header" xml:space="preserve">
-    <value>成功部署後</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
-    <value>選擇裝置是否以及何時在部署後重新啟動。</value>
-  </data>
-  <data name="GeneralConfiguration.Completion.AutomaticReboot" xml:space="preserve">
     <value>自動重新啟動</value>
   </data>
+  <data name="GeneralConfiguration.Completion.Description" xml:space="preserve">
+    <value>選擇裝置是否在成功部署後自動重新啟動。</value>
+  </data>
   <data name="GeneralConfiguration.Completion.Delay.Header" xml:space="preserve">
-    <value>重新啟動前的延遲</value>
+    <value>重新啟動延遲</value>
   </data>
   <data name="GeneralConfiguration.Completion.Delay.Description" xml:space="preserve">
-    <value>輸入 0 到 3600 秒的延遲。使用 0 可立即重新啟動。</value>
+    <value>設定裝置重新啟動前的延遲時間。輸入 0 可立即重新啟動。</value>
   </data>
   <data name="GeneralConfiguration.SecureBoot.Header" xml:space="preserve">
     <value>安全開機</value>
@@ -2771,13 +2768,10 @@
     <value>變更模式</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Header" xml:space="preserve">
-    <value>部署媒體保護</value>
+    <value>密碼保護</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.Description" xml:space="preserve">
-    <value>要求先輸入密碼，Foundry Deploy 才能使用此媒體。</value>
-  </data>
-  <data name="GeneralConfiguration.DeploymentProtection.Toggle" xml:space="preserve">
-    <value>使用密碼保護部署媒體</value>
+    <value>開始部署前要求輸入技術人員密碼。</value>
   </data>
   <data name="GeneralConfiguration.DeploymentProtection.PasswordCard.Header" xml:space="preserve">
     <value>部署密碼</value>

--- a/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
@@ -202,6 +202,16 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
         RefreshDeploymentProtectionState();
     }
 
+    public char[] GetDeploymentProtectionPasswordCopy()
+    {
+        return deploymentProtectionSecretStateService.GetPasswordCopy();
+    }
+
+    public char[] GetDeploymentProtectionPasswordConfirmationCopy()
+    {
+        return deploymentProtectionSecretStateService.GetConfirmationCopy();
+    }
+
     public void RefreshLocalizedText()
     {
         PageTitle = localizationService.GetString("GeneralConfigurationPage_Title.Text");

--- a/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/GeneralConfigurationViewModel.cs
@@ -24,6 +24,7 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
     private const string AutomaticSelectionValue = "";
 
     private readonly IFoundryConfigurationStateService configurationStateService;
+    private readonly IDeploymentProtectionSecretStateService deploymentProtectionSecretStateService;
     private readonly IAdkService adkService;
     private readonly IWinPeLanguageDiscoveryService winPeLanguageDiscoveryService;
     private readonly IFilePickerService filePickerService;
@@ -36,6 +37,7 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
 
     public GeneralConfigurationViewModel(
         IFoundryConfigurationStateService configurationStateService,
+        IDeploymentProtectionSecretStateService deploymentProtectionSecretStateService,
         IAdkService adkService,
         IWinPeLanguageDiscoveryService winPeLanguageDiscoveryService,
         IFilePickerService filePickerService,
@@ -43,6 +45,7 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
         ILogger logger)
     {
         this.configurationStateService = configurationStateService;
+        this.deploymentProtectionSecretStateService = deploymentProtectionSecretStateService;
         this.adkService = adkService;
         this.winPeLanguageDiscoveryService = winPeLanguageDiscoveryService;
         this.filePickerService = filePickerService;
@@ -58,6 +61,7 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
         GeneralSettings general = configurationStateService.Current.General;
         SelectedArchitecture = SelectOption(Architectures, general.Architecture);
         UseCa2023Signature = general.UseCa2023;
+        IsDeploymentProtectionEnabled = general.DeploymentProtection.IsEnabled;
         IncludeDellDrivers = general.IncludeDellDrivers;
         IncludeHpDrivers = general.IncludeHpDrivers;
         AutomaticRebootEnabled = general.AutomaticRebootEnabled;
@@ -70,6 +74,7 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
 
         configurationStateService.StateChanged += OnConfigurationStateChanged;
         isInitializing = false;
+        RefreshDeploymentProtectionState();
     }
 
     /// <summary>
@@ -98,6 +103,15 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
 
     [ObservableProperty]
     public partial bool UseCa2023Signature { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsDeploymentProtectionEnabled { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsDeploymentProtectionPasswordValid { get; set; }
+
+    [ObservableProperty]
+    public partial bool ShouldRecommendStrongerDeploymentPassword { get; set; }
 
     [ObservableProperty]
     public partial bool IncludeDellDrivers { get; set; }
@@ -135,6 +149,19 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
     /// </summary>
     public Visibility WinPeLanguageUnavailableVisibility => HasWinPeLanguages ? Visibility.Collapsed : Visibility.Visible;
 
+    public Visibility DeploymentProtectionFieldsVisibility =>
+        IsDeploymentProtectionEnabled ? Visibility.Visible : Visibility.Collapsed;
+
+    public Visibility DeploymentProtectionValidationVisibility =>
+        IsDeploymentProtectionEnabled &&
+        (deploymentProtectionSecretStateService.HasPassword || deploymentProtectionSecretStateService.HasConfirmation) &&
+        !IsDeploymentProtectionPasswordValid
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+
+    public Visibility DeploymentProtectionRecommendationVisibility =>
+        ShouldRecommendStrongerDeploymentPassword ? Visibility.Visible : Visibility.Collapsed;
+
     public string DocumentationUrl => FoundryApplicationInfo.GeneralConfigurationDocumentationUrl;
 
     /// <inheritdoc />
@@ -160,7 +187,19 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
     /// </summary>
     public void RefreshAdkState()
     {
-        CanCreateMedia = adkService.CurrentStatus.CanCreateMedia;
+        RefreshMediaReadiness();
+    }
+
+    public void SetDeploymentProtectionPassword(string? value)
+    {
+        deploymentProtectionSecretStateService.SetPassword(value);
+        RefreshDeploymentProtectionState();
+    }
+
+    public void SetDeploymentProtectionPasswordConfirmation(string? value)
+    {
+        deploymentProtectionSecretStateService.SetConfirmation(value);
+        RefreshDeploymentProtectionState();
     }
 
     public void RefreshLocalizedText()
@@ -178,7 +217,7 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
         AvailableWinPeLanguages.Clear();
         HasWinPeLanguages = false;
 
-        if (!CanCreateMedia)
+        if (!adkService.CurrentStatus.CanCreateMedia)
         {
             WinPeLanguageUnavailableDescription = localizationService.GetString("GeneralConfiguration.WinPeLanguage.AdkBlocked");
             SelectedWinPeLanguage = null;
@@ -292,6 +331,26 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
         Save(configurationStateService.Current.General with { UseCa2023 = value });
     }
 
+    partial void OnIsDeploymentProtectionEnabledChanged(bool value)
+    {
+        OnPropertyChanged(nameof(DeploymentProtectionFieldsVisibility));
+        if (isInitializing)
+        {
+            return;
+        }
+
+        if (!value)
+        {
+            deploymentProtectionSecretStateService.Clear();
+        }
+
+        Save(configurationStateService.Current.General with
+        {
+            DeploymentProtection = new DeploymentProtectionSettings { IsEnabled = value }
+        });
+        RefreshDeploymentProtectionState();
+    }
+
     partial void OnIncludeDellDriversChanged(bool value)
     {
         if (isInitializing)
@@ -360,6 +419,21 @@ public sealed partial class GeneralConfigurationViewModel : ObservableObject, ID
     private void Save(GeneralSettings settings)
     {
         configurationStateService.UpdateGeneral(settings);
+    }
+
+    private void RefreshDeploymentProtectionState()
+    {
+        IsDeploymentProtectionPasswordValid = deploymentProtectionSecretStateService.IsValid;
+        ShouldRecommendStrongerDeploymentPassword = deploymentProtectionSecretStateService.ShouldRecommendStrongerPassword;
+        OnPropertyChanged(nameof(DeploymentProtectionValidationVisibility));
+        OnPropertyChanged(nameof(DeploymentProtectionRecommendationVisibility));
+        RefreshMediaReadiness();
+    }
+
+    private void RefreshMediaReadiness()
+    {
+        CanCreateMedia = adkService.CurrentStatus.CanCreateMedia &&
+            (!IsDeploymentProtectionEnabled || deploymentProtectionSecretStateService.IsValid);
     }
 
     private void ApplyLocalizationState(LocalizationSettings settings)

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -489,7 +489,6 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         finally
         {
             deploymentProtectionMaterial?.Dispose();
-            deploymentProtectionSecretStateService.Clear();
             await TrackMediaCreatedAsync(
                 target,
                 options,

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -1679,7 +1679,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 : GetBlockingReasonText(MediaPreflightBlockingReason.DeployConfigurationNotReady),
             options.IsDeployConfigurationReady
                 ? ConfigurationNavigationTarget.None
-                : ConfigurationNavigationTargetResolver.ResolveDeployFailure(options.AutopilotProvisioningMode));
+                : ConfigurationNavigationTargetResolver.ResolveDeployFailure(
+                    options.AutopilotProvisioningMode,
+                    foundryConfigurationStateService.Current.General.DeploymentProtection.IsEnabled &&
+                    !deploymentProtectionSecretStateService.IsValid));
     }
 
     private StartReadinessItemViewModel BuildConnectProvisioningReadinessItem(MediaPreflightOptions options)

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -5,6 +5,8 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text;
 using Foundry.Core.Models.Configuration;
 using Foundry.Core.Services.Autopilot;
@@ -39,6 +41,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     private readonly IWinPeUsbMediaService usbMediaService;
     private readonly IFilePickerService filePickerService;
     private readonly IFoundryConfigurationStateService foundryConfigurationStateService;
+    private readonly IDeploymentProtectionSecretStateService deploymentProtectionSecretStateService;
     private readonly ITelemetryService telemetryService;
     private readonly IOperationProgressService operationProgressService;
     private readonly IShellNavigationGuardService shellNavigationGuardService;
@@ -64,6 +67,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         IWinPeUsbMediaService usbMediaService,
         IFilePickerService filePickerService,
         IFoundryConfigurationStateService foundryConfigurationStateService,
+        IDeploymentProtectionSecretStateService deploymentProtectionSecretStateService,
         ITelemetryService telemetryService,
         IOperationProgressService operationProgressService,
         IShellNavigationGuardService shellNavigationGuardService,
@@ -82,6 +86,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         this.usbMediaService = usbMediaService;
         this.filePickerService = filePickerService;
         this.foundryConfigurationStateService = foundryConfigurationStateService;
+        this.deploymentProtectionSecretStateService = deploymentProtectionSecretStateService;
         this.telemetryService = telemetryService;
         this.operationProgressService = operationProgressService;
         this.shellNavigationGuardService = shellNavigationGuardService;
@@ -417,9 +422,11 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         Stopwatch stopwatch = Stopwatch.StartNew();
         bool success = false;
         var telemetryProgressTracker = new MediaCreationTelemetryProgressTracker();
+        DeploymentMediaProtectionMaterial? deploymentProtectionMaterial = null;
 
         try
         {
+            deploymentProtectionMaterial = CreateDeploymentProtectionMaterial();
             string startStatus = target switch
             {
                 FinalMediaTarget.Iso => localizationService.GetString("StartMedia.Operation.CreatingIso"),
@@ -439,12 +446,12 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
             if (target == FinalMediaTarget.Iso)
             {
-                _ = await CreateIsoMediaAsync(options, telemetryProgressTracker, CancellationToken.None);
+                _ = await CreateIsoMediaAsync(options, deploymentProtectionMaterial, telemetryProgressTracker, CancellationToken.None);
                 successMessage = localizationService.GetString("StartMedia.Operation.IsoSuccessMessage");
             }
             else if (target == FinalMediaTarget.UsbUpdate)
             {
-                WinPeUsbProvisionResult usbResult = await UpdateUsbMediaAsync(options, telemetryProgressTracker, CancellationToken.None);
+                WinPeUsbProvisionResult usbResult = await UpdateUsbMediaAsync(options, deploymentProtectionMaterial, telemetryProgressTracker, CancellationToken.None);
                 successMessage = string.Format(
                     CultureInfo.CurrentCulture,
                     localizationService.GetString("StartMedia.Operation.UsbUpdateSuccessMessage"),
@@ -453,7 +460,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             }
             else
             {
-                WinPeUsbProvisionResult usbResult = await CreateUsbMediaAsync(options, telemetryProgressTracker, CancellationToken.None);
+                WinPeUsbProvisionResult usbResult = await CreateUsbMediaAsync(options, deploymentProtectionMaterial, telemetryProgressTracker, CancellationToken.None);
                 successMessage = string.Format(
                     CultureInfo.CurrentCulture,
                     localizationService.GetString("StartMedia.Operation.UsbSuccessMessage"),
@@ -481,6 +488,8 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         }
         finally
         {
+            deploymentProtectionMaterial?.Dispose();
+            deploymentProtectionSecretStateService.Clear();
             await TrackMediaCreatedAsync(
                 target,
                 options,
@@ -499,6 +508,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private async Task<string> CreateIsoMediaAsync(
         MediaPreflightOptions options,
+        DeploymentMediaProtectionMaterial deploymentProtectionMaterial,
         MediaCreationTelemetryProgressTracker telemetryProgressTracker,
         CancellationToken cancellationToken)
     {
@@ -509,6 +519,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             workspace = await PrepareMediaWorkspaceAsync(
                 options,
                 includeRuntimePayloadInImage: true,
+                deploymentProtectionMaterial,
                 telemetryProgressTracker: telemetryProgressTracker,
                 cancellationToken);
 
@@ -542,6 +553,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private async Task<WinPeUsbProvisionResult> CreateUsbMediaAsync(
         MediaPreflightOptions options,
+        DeploymentMediaProtectionMaterial deploymentProtectionMaterial,
         MediaCreationTelemetryProgressTracker telemetryProgressTracker,
         CancellationToken cancellationToken)
     {
@@ -558,6 +570,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             workspace = await PrepareMediaWorkspaceAsync(
                 options,
                 includeRuntimePayloadInImage: false,
+                deploymentProtectionMaterial,
                 telemetryProgressTracker: telemetryProgressTracker,
                 cancellationToken);
 
@@ -608,6 +621,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private async Task<WinPeUsbProvisionResult> UpdateUsbMediaAsync(
         MediaPreflightOptions options,
+        DeploymentMediaProtectionMaterial deploymentProtectionMaterial,
         MediaCreationTelemetryProgressTracker telemetryProgressTracker,
         CancellationToken cancellationToken)
     {
@@ -624,6 +638,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             workspace = await PrepareMediaWorkspaceAsync(
                 options,
                 includeRuntimePayloadInImage: false,
+                deploymentProtectionMaterial,
                 telemetryProgressTracker: telemetryProgressTracker,
                 cancellationToken);
 
@@ -673,6 +688,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     private async Task<PreparedMediaWorkspace> PrepareMediaWorkspaceAsync(
         MediaPreflightOptions options,
         bool includeRuntimePayloadInImage,
+        DeploymentMediaProtectionMaterial deploymentProtectionMaterial,
         MediaCreationTelemetryProgressTracker telemetryProgressTracker,
         CancellationToken cancellationToken)
     {
@@ -760,27 +776,44 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                     new Progress<WinPeWorkspacePreparationStage>(ReportWorkspacePreparationStage));
 
             operationProgressService.Report(25, localizationService.GetString("StartMedia.Operation.PreparingWorkspace"));
-            WinPeResult<WinPeWorkspacePreparationResult> preparationResult = await workspacePreparationService.PrepareAsync(
-                new WinPeWorkspacePreparationOptions
+            WinPeResult<WinPeWorkspacePreparationResult> preparationResult;
+            try
+            {
+                preparationResult = await workspacePreparationService.PrepareAsync(
+                    new WinPeWorkspacePreparationOptions
+                    {
+                        Artifact = artifact,
+                        Tools = tools,
+                        SignatureMode = options.SignatureMode,
+                        BootImageSource = options.BootImageSource,
+                        DriverCatalogUri = new WinPeDriverCatalogOptions().CatalogUri,
+                        DriverVendors = options.DriverVendors,
+                        CustomDriverDirectoryPath = options.CustomDriverDirectoryPath,
+                        WinPeLanguage = options.WinPeLanguage,
+                        AssetProvisioning = CreateAssetProvisioningOptions(
+                            options,
+                            tools,
+                            connectBundle,
+                            deploymentProtectionMaterial,
+                            runtimePayloadProvisioning,
+                            deployTelemetrySettings),
+                        RuntimePayloadProvisioning = includeRuntimePayloadInImage ? artifactRuntimePayloadProvisioning : null,
+                        WinReCacheDirectoryPath = Constants.WinReTempDirectoryPath,
+                        Progress = workspacePreparationProgress,
+                        DownloadProgress = telemetryProgressTracker.CreateDownloadProgress(
+                            new Progress<WinPeDownloadProgress>(ReportDownloadProgress)),
+                        CustomizationProgress = telemetryProgressTracker.CreateCustomizationProgress(
+                            new Progress<WinPeMountedImageCustomizationProgress>(ReportCustomizationProgress))
+                    },
+                    cancellationToken);
+            }
+            finally
+            {
+                if (connectBundle.MediaSecretsKey is not null)
                 {
-                    Artifact = artifact,
-                    Tools = tools,
-                    SignatureMode = options.SignatureMode,
-                    BootImageSource = options.BootImageSource,
-                    DriverCatalogUri = new WinPeDriverCatalogOptions().CatalogUri,
-                    DriverVendors = options.DriverVendors,
-                    CustomDriverDirectoryPath = options.CustomDriverDirectoryPath,
-                    WinPeLanguage = options.WinPeLanguage,
-                    AssetProvisioning = CreateAssetProvisioningOptions(options, tools, connectBundle, runtimePayloadProvisioning, deployTelemetrySettings),
-                    RuntimePayloadProvisioning = includeRuntimePayloadInImage ? artifactRuntimePayloadProvisioning : null,
-                    WinReCacheDirectoryPath = Constants.WinReTempDirectoryPath,
-                    Progress = workspacePreparationProgress,
-                    DownloadProgress = telemetryProgressTracker.CreateDownloadProgress(
-                        new Progress<WinPeDownloadProgress>(ReportDownloadProgress)),
-                    CustomizationProgress = telemetryProgressTracker.CreateCustomizationProgress(
-                        new Progress<WinPeMountedImageCustomizationProgress>(ReportCustomizationProgress))
-                },
-                cancellationToken);
+                    CryptographicOperations.ZeroMemory(connectBundle.MediaSecretsKey);
+                }
+            }
             EnsureSuccess(preparationResult);
 
             logger.Debug(
@@ -808,17 +841,12 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         MediaPreflightOptions options,
         WinPeToolPaths tools,
         FoundryConnectProvisioningBundle connectBundle,
+        DeploymentMediaProtectionMaterial deploymentProtectionMaterial,
         WinPeRuntimePayloadProvisioningOptions runtimePayloadProvisioning,
         TelemetrySettings deployTelemetrySettings)
     {
         bool isHardwareHashMode = options.IsAutopilotEnabled &&
                                   options.AutopilotProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload;
-        byte[]? mediaSecretsKey = connectBundle.MediaSecretsKey;
-        if (isHardwareHashMode && mediaSecretsKey is null)
-        {
-            mediaSecretsKey = MediaSecretEnvelopeProtector.GenerateMediaKey();
-        }
-
         string? oa3ToolSourcePath = null;
         if (isHardwareHashMode)
         {
@@ -834,8 +862,13 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             SevenZipSourceDirectoryPath = embeddedAssetService.GetSevenZipSourceDirectoryPath(),
             IanaWindowsTimeZoneMapJson = embeddedAssetService.GetIanaWindowsTimeZoneMapJson(),
             FoundryConnectConfigurationJson = connectBundle.ConfigurationJson,
-            DeployConfigurationJson = foundryConfigurationStateService.GenerateDeployConfigurationJson(deployTelemetrySettings, mediaSecretsKey),
-            MediaSecretsKey = mediaSecretsKey,
+            DeployConfigurationJson = foundryConfigurationStateService.GenerateDeployConfigurationJson(
+                deployTelemetrySettings,
+                deploymentProtectionMaterial.DeploymentKey,
+                deploymentProtectionMaterial.Settings),
+            NetworkSecretsKey = connectBundle.MediaSecretsKey,
+            DeploymentSecretsKey = deploymentProtectionMaterial.DeploymentKey,
+            IsDeploymentProtectionEnabled = deploymentProtectionMaterial.Settings.IsEnabled,
             FoundryConnectAssetFiles = connectBundle.AssetFiles,
             AutopilotProvisioningMode = options.IsAutopilotEnabled
                 ? options.AutopilotProvisioningMode
@@ -847,6 +880,24 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             ConnectProvisioningSource = ResolveProvisioningSource(runtimePayloadProvisioning.Connect),
             DeployProvisioningSource = ResolveProvisioningSource(runtimePayloadProvisioning.Deploy)
         };
+    }
+
+    private DeploymentMediaProtectionMaterial CreateDeploymentProtectionMaterial()
+    {
+        if (!foundryConfigurationStateService.Current.General.DeploymentProtection.IsEnabled)
+        {
+            return DeploymentMediaProtectionService.CreateUnprotected();
+        }
+
+        char[] password = deploymentProtectionSecretStateService.GetConfirmedPasswordCopy();
+        try
+        {
+            return DeploymentMediaProtectionService.CreateProtected(password);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(password.AsSpan()));
+        }
     }
 
     private static WinPeProvisioningSource ResolveProvisioningSource(WinPeRuntimePayloadApplicationOptions options)

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml
@@ -2,6 +2,7 @@
 <Page x:Class="Foundry.Views.GeneralConfigurationPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Foundry.Behaviors"
     xmlns:controls="using:Foundry.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -78,6 +79,7 @@
                             <FontIcon Glyph="&#xE777;" />
                         </wct:SettingsExpander.HeaderIcon>
                         <ToggleSwitch x:Name="AutomaticRebootToggle"
+                            behaviors:LocalizedToggleSwitch.UseLocalizedStateContent="True"
                             IsOn="{x:Bind ViewModel.AutomaticRebootEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         <wct:SettingsExpander.Items>
                             <wct:SettingsCard x:Name="RebootDelayCard">
@@ -100,6 +102,7 @@
                             <FontIcon Glyph="&#xE72E;" />
                         </wct:SettingsExpander.HeaderIcon>
                         <ToggleSwitch x:Name="DeploymentProtectionToggle"
+                            behaviors:LocalizedToggleSwitch.UseLocalizedStateContent="True"
                             IsOn="{x:Bind ViewModel.IsDeploymentProtectionEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                             Toggled="DeploymentProtectionToggle_Toggled" />
                         <wct:SettingsExpander.Items>

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml
@@ -110,7 +110,7 @@
                                 Visibility="{x:Bind ViewModel.DeploymentProtectionFieldsVisibility, Mode=OneWay}">
                                 <StackPanel
                                     MinWidth="{ThemeResource FoundryWideInputMinWidth}"
-                                    Spacing="{ThemeResource FoundryCompactStackSpacing}">
+                                    Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
                                     <PasswordBox x:Name="DeploymentProtectionPasswordBox"
                                         PasswordChanged="DeploymentProtectionPasswordBox_PasswordChanged" />
                                     <PasswordBox x:Name="DeploymentProtectionConfirmationBox"

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml
@@ -112,8 +112,10 @@
                                     MinWidth="{ThemeResource FoundryWideInputMinWidth}"
                                     Spacing="{ThemeResource FoundrySettingsSectionSpacing}">
                                     <PasswordBox x:Name="DeploymentProtectionPasswordBox"
+                                        Loaded="DeploymentProtectionPasswordBox_Loaded"
                                         PasswordChanged="DeploymentProtectionPasswordBox_PasswordChanged" />
                                     <PasswordBox x:Name="DeploymentProtectionConfirmationBox"
+                                        Loaded="DeploymentProtectionConfirmationBox_Loaded"
                                         PasswordChanged="DeploymentProtectionConfirmationBox_PasswordChanged" />
                                     <TextBlock x:Name="DeploymentProtectionValidationText"
                                         Foreground="{ThemeResource SystemFillColorCriticalBrush}"

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml
@@ -94,6 +94,37 @@
                         </wct:SettingsExpander.Items>
                     </wct:SettingsExpander>
 
+                    <wct:SettingsExpander x:Name="DeploymentProtectionCard"
+                        IsExpanded="{x:Bind ViewModel.IsDeploymentProtectionEnabled, Mode=OneWay}">
+                        <wct:SettingsExpander.HeaderIcon>
+                            <FontIcon Glyph="&#xE72E;" />
+                        </wct:SettingsExpander.HeaderIcon>
+                        <ToggleSwitch x:Name="DeploymentProtectionToggle"
+                            IsOn="{x:Bind ViewModel.IsDeploymentProtectionEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                            Toggled="DeploymentProtectionToggle_Toggled" />
+                        <wct:SettingsExpander.Items>
+                            <wct:SettingsCard x:Name="DeploymentProtectionPasswordCard"
+                                Visibility="{x:Bind ViewModel.DeploymentProtectionFieldsVisibility, Mode=OneWay}">
+                                <StackPanel
+                                    MinWidth="{ThemeResource FoundryWideInputMinWidth}"
+                                    Spacing="{ThemeResource FoundryCompactStackSpacing}">
+                                    <PasswordBox x:Name="DeploymentProtectionPasswordBox"
+                                        PasswordChanged="DeploymentProtectionPasswordBox_PasswordChanged" />
+                                    <PasswordBox x:Name="DeploymentProtectionConfirmationBox"
+                                        PasswordChanged="DeploymentProtectionConfirmationBox_PasswordChanged" />
+                                    <TextBlock x:Name="DeploymentProtectionValidationText"
+                                        Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                        TextWrapping="WrapWholeWords"
+                                        Visibility="{x:Bind ViewModel.DeploymentProtectionValidationVisibility, Mode=OneWay}" />
+                                    <TextBlock x:Name="DeploymentProtectionRecommendationText"
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        TextWrapping="WrapWholeWords"
+                                        Visibility="{x:Bind ViewModel.DeploymentProtectionRecommendationVisibility, Mode=OneWay}" />
+                                </StackPanel>
+                            </wct:SettingsCard>
+                        </wct:SettingsExpander.Items>
+                    </wct:SettingsExpander>
+
                     <wct:SettingsExpander x:Name="DriverOptionsCard">
                         <wct:SettingsExpander.HeaderIcon>
                             <FontIcon Glyph="&#xE90F;" />

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
@@ -49,6 +49,28 @@ public sealed partial class GeneralConfigurationPage : Page
         App.Current.NavigationService.NavigateTo(typeof(StartPage));
     }
 
+    private void DeploymentProtectionToggle_Toggled(object sender, RoutedEventArgs e)
+    {
+        if (DeploymentProtectionToggle.IsOn)
+        {
+            DeploymentProtectionPasswordBox.Focus(FocusState.Programmatic);
+            return;
+        }
+
+        DeploymentProtectionPasswordBox.Password = string.Empty;
+        DeploymentProtectionConfirmationBox.Password = string.Empty;
+    }
+
+    private void DeploymentProtectionPasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
+    {
+        ViewModel.SetDeploymentProtectionPassword(DeploymentProtectionPasswordBox.Password);
+    }
+
+    private void DeploymentProtectionConfirmationBox_PasswordChanged(object sender, RoutedEventArgs e)
+    {
+        ViewModel.SetDeploymentProtectionPasswordConfirmation(DeploymentProtectionConfirmationBox.Password);
+    }
+
     private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
     {
         if (DispatcherQueue.HasThreadAccess)
@@ -88,6 +110,18 @@ public sealed partial class GeneralConfigurationPage : Page
         AutomaticRebootToggle.OffContent = automaticRebootText;
         RebootDelayCard.Header = localizationService.GetString("GeneralConfiguration.Completion.Delay.Header");
         RebootDelayCard.Description = localizationService.GetString("GeneralConfiguration.Completion.Delay.Description");
+
+        DeploymentProtectionCard.Header = localizationService.GetString("GeneralConfiguration.DeploymentProtection.Header");
+        DeploymentProtectionCard.Description = localizationService.GetString("GeneralConfiguration.DeploymentProtection.Description");
+        string protectionToggleText = localizationService.GetString("GeneralConfiguration.DeploymentProtection.Toggle");
+        DeploymentProtectionToggle.OnContent = protectionToggleText;
+        DeploymentProtectionToggle.OffContent = protectionToggleText;
+        DeploymentProtectionPasswordCard.Header = localizationService.GetString("GeneralConfiguration.DeploymentProtection.PasswordCard.Header");
+        DeploymentProtectionPasswordCard.Description = localizationService.GetString("GeneralConfiguration.DeploymentProtection.PasswordCard.Description");
+        DeploymentProtectionPasswordBox.PlaceholderText = localizationService.GetString("GeneralConfiguration.DeploymentProtection.Password.Placeholder");
+        DeploymentProtectionConfirmationBox.PlaceholderText = localizationService.GetString("GeneralConfiguration.DeploymentProtection.Confirmation.Placeholder");
+        DeploymentProtectionValidationText.Text = localizationService.GetString("GeneralConfiguration.DeploymentProtection.Validation");
+        DeploymentProtectionRecommendationText.Text = localizationService.GetString("GeneralConfiguration.DeploymentProtection.Recommendation");
 
         DriverOptionsCard.Header = localizationService.GetString("StartMedia.DriverOptions.Header");
         DriverOptionsCard.Description = localizationService.GetString("StartMedia.DriverOptions.Description");

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
@@ -105,17 +105,11 @@ public sealed partial class GeneralConfigurationPage : Page
         TimeZoneCard.Description = localizationService.GetString("GeneralConfiguration.TimeZone.Description");
         DeploymentCompletionCard.Header = localizationService.GetString("GeneralConfiguration.Completion.Header");
         DeploymentCompletionCard.Description = localizationService.GetString("GeneralConfiguration.Completion.Description");
-        string automaticRebootText = localizationService.GetString("GeneralConfiguration.Completion.AutomaticReboot");
-        AutomaticRebootToggle.OnContent = automaticRebootText;
-        AutomaticRebootToggle.OffContent = automaticRebootText;
         RebootDelayCard.Header = localizationService.GetString("GeneralConfiguration.Completion.Delay.Header");
         RebootDelayCard.Description = localizationService.GetString("GeneralConfiguration.Completion.Delay.Description");
 
         DeploymentProtectionCard.Header = localizationService.GetString("GeneralConfiguration.DeploymentProtection.Header");
         DeploymentProtectionCard.Description = localizationService.GetString("GeneralConfiguration.DeploymentProtection.Description");
-        string protectionToggleText = localizationService.GetString("GeneralConfiguration.DeploymentProtection.Toggle");
-        DeploymentProtectionToggle.OnContent = protectionToggleText;
-        DeploymentProtectionToggle.OffContent = protectionToggleText;
         DeploymentProtectionPasswordCard.Header = localizationService.GetString("GeneralConfiguration.DeploymentProtection.PasswordCard.Header");
         DeploymentProtectionPasswordCard.Description = localizationService.GetString("GeneralConfiguration.DeploymentProtection.PasswordCard.Description");
         DeploymentProtectionPasswordBox.PlaceholderText = localizationService.GetString("GeneralConfiguration.DeploymentProtection.Password.Placeholder");

--- a/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
+++ b/src/Foundry/Views/GeneralConfigurationPage.xaml.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using Foundry.Services.Localization;
 using Serilog;
 
@@ -10,6 +12,7 @@ namespace Foundry.Views;
 public sealed partial class GeneralConfigurationPage : Page
 {
     private bool isInitializingWinPeLanguageSelection = true;
+    private bool isSynchronizingDeploymentProtectionPasswordBoxes;
     private readonly IApplicationLocalizationService localizationService;
     private readonly ILogger logger = Log.ForContext<GeneralConfigurationPage>();
 
@@ -63,12 +66,50 @@ public sealed partial class GeneralConfigurationPage : Page
 
     private void DeploymentProtectionPasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
     {
+        if (isSynchronizingDeploymentProtectionPasswordBoxes)
+        {
+            return;
+        }
+
         ViewModel.SetDeploymentProtectionPassword(DeploymentProtectionPasswordBox.Password);
     }
 
     private void DeploymentProtectionConfirmationBox_PasswordChanged(object sender, RoutedEventArgs e)
     {
+        if (isSynchronizingDeploymentProtectionPasswordBoxes)
+        {
+            return;
+        }
+
         ViewModel.SetDeploymentProtectionPasswordConfirmation(DeploymentProtectionConfirmationBox.Password);
+    }
+
+    private void DeploymentProtectionPasswordBox_Loaded(object sender, RoutedEventArgs e)
+    {
+        SyncDeploymentProtectionPasswordBox(
+            DeploymentProtectionPasswordBox,
+            ViewModel.GetDeploymentProtectionPasswordCopy());
+    }
+
+    private void DeploymentProtectionConfirmationBox_Loaded(object sender, RoutedEventArgs e)
+    {
+        SyncDeploymentProtectionPasswordBox(
+            DeploymentProtectionConfirmationBox,
+            ViewModel.GetDeploymentProtectionPasswordConfirmationCopy());
+    }
+
+    private void SyncDeploymentProtectionPasswordBox(PasswordBox passwordBox, char[] value)
+    {
+        try
+        {
+            isSynchronizingDeploymentProtectionPasswordBoxes = true;
+            passwordBox.Password = new string(value);
+        }
+        finally
+        {
+            isSynchronizingDeploymentProtectionPasswordBoxes = false;
+            CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(value.AsSpan()));
+        }
     }
 
     private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)


### PR DESCRIPTION
## Summary

Adds optional administrator-defined password protection to deployment media and requires technician authorization before Foundry Deploy initializes.

## Reason

Lost USB or ISO media should not allow casual unauthorized OS deployment or expose Deploy credentials and offline Autopilot profiles.

## Main changes

- adds optional password protection to the Foundry OSD General page
- keeps the password only for the current Foundry OSD session, allowing multiple media to be created without persisting it
- derives a wrapping key with PBKDF2-HMAC-SHA256 and encrypts protected data with AES-256-GCM
- separates Foundry Connect network secrets from Foundry Deploy secrets and keeps protected Deploy keys off the media
- encrypts offline Autopilot JSON profiles and Deploy credentials on protected media
- requires authorization before Foundry Deploy startup, supports retry and cancellation, and prevents deployment without an authorized key session
- fails closed when protected artifacts, wrapped-key metadata, or an inconsistent protected-media layout is detected
- preserves compatibility with existing media and new unprotected media
- localizes the Foundry OSD protection settings and Foundry Deploy password dialog across all supported languages
- centralizes duplicated cryptographic primitives and removes obsolete secret-handling paths
- reports only the protection-enabled state in telemetry
- aligns unreleased schema versions with the latest GitHub Release plus one rule

## Security boundary

This feature prevents casual unauthorized use and protects encrypted Deploy material. It does not replace physical media controls or provide immutable-media integrity against an attacker who can rewrite all files on the boot media.

## Testing notes

- 1,277 automated tests passed across all 6 test projects; 0 failed and 0 skipped
- Release builds passed for x64 and ARM64; 0 errors
- format and analyzer verification passed; 61/61 XAML files passed
- manual validation completed for protected, unprotected, and legacy media
- manual validation covered incorrect and correct passwords, cancellation, Autopilot profiles, protected-media artifacts, and representative localized interfaces