### PR TITLE
fix(deploy): match Lenovo driver packs by machine type

### DIFF
--- a/src/Foundry.Deploy.Tests/DriverPackCatalogServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DriverPackCatalogServiceTests.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Xml.Linq;
+using Foundry.Deploy.Models;
+using Foundry.Deploy.Services.Catalog;
+
+namespace Foundry.Deploy.Tests;
+
+public sealed class DriverPackCatalogServiceTests
+{
+    [Fact]
+    public void ParseItem_PreservesModelSystemIds()
+    {
+        XElement element = XElement.Parse("""
+            <DriverPack id="lenovo-e14" manufacturer="Lenovo" downloadUrl="https://example.test/driver.exe">
+              <Models>
+                <Model name="ThinkPad E14 Gen 8 Type 21Y6 21Y7" systemId="21Y6,21Y7" />
+              </Models>
+              <OsInfo name="Windows 11" releaseId="25H2" architecture="x64" />
+            </DriverPack>
+            """);
+
+        DriverPackCatalogItem item = DriverPackCatalogService.ParseItem(element);
+
+        Assert.Equal(["21Y6", "21Y7"], item.SystemIds);
+    }
+}

--- a/src/Foundry.Deploy.Tests/DriverPackSelectionServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DriverPackSelectionServiceTests.cs
@@ -172,13 +172,56 @@ public sealed class DriverPackSelectionServiceTests
         Assert.Equal("Matched by hardware model/product and compatible OS release.", result.SelectionReason);
     }
 
+    [Fact]
+    public void SelectBest_WhenLenovoModelsShareMarketingName_PrefersMatchingMachineType()
+    {
+        var service = new DriverPackSelectionService(NullLogger<DriverPackSelectionService>.Instance);
+        HardwareProfile hardware = new()
+        {
+            Manufacturer = "Lenovo",
+            Model = "21Y6000JMX",
+            Product = "ThinkPad E14 Gen 8"
+        };
+        OperatingSystemCatalogItem operatingSystem = new()
+        {
+            WindowsRelease = "11",
+            ReleaseId = "25H2",
+            Architecture = "x64"
+        };
+
+        DriverPackCatalogItem newerWrongType = CreateCatalogItem(
+            id: "21y2-21y3",
+            manufacturer: "Lenovo",
+            releaseId: "25H2",
+            architecture: "x64",
+            releaseDate: new DateTimeOffset(2026, 05, 19, 0, 0, 0, TimeSpan.Zero),
+            modelNames: ["ThinkPad E14 Gen 8 Type 21Y2 21Y3"],
+            systemIds: ["21Y2", "21Y3"]);
+        DriverPackCatalogItem olderMatchingType = CreateCatalogItem(
+            id: "21y6-21y7",
+            manufacturer: "Lenovo",
+            releaseId: "25H2",
+            architecture: "x64",
+            releaseDate: new DateTimeOffset(2026, 04, 28, 0, 0, 0, TimeSpan.Zero),
+            modelNames: ["ThinkPad E14 Gen 8 Type 21Y6 21Y7"],
+            systemIds: ["21Y6", "21Y7"]);
+
+        DriverPackSelectionResult result = service.SelectBest(
+            [newerWrongType, olderMatchingType],
+            hardware,
+            operatingSystem);
+
+        Assert.Equal("21y6-21y7", result.DriverPack?.Id);
+    }
+
     private static DriverPackCatalogItem CreateCatalogItem(
         string id,
         string manufacturer,
         string releaseId,
         string architecture,
         DateTimeOffset releaseDate,
-        IReadOnlyList<string> modelNames)
+        IReadOnlyList<string> modelNames,
+        IReadOnlyList<string>? systemIds = null)
     {
         return new DriverPackCatalogItem
         {
@@ -191,7 +234,8 @@ public sealed class DriverPackSelectionServiceTests
             OsReleaseId = releaseId,
             OsArchitecture = architecture,
             ReleaseDate = releaseDate,
-            ModelNames = modelNames
+            ModelNames = modelNames,
+            SystemIds = systemIds ?? []
         };
     }
 }

--- a/src/Foundry.Deploy.Tests/DriverPackSelectionViewModelTests.cs
+++ b/src/Foundry.Deploy.Tests/DriverPackSelectionViewModelTests.cs
@@ -76,10 +76,55 @@ public sealed class DriverPackSelectionViewModelTests
         Assert.Equal("23h2", selected?.Id);
     }
 
+    [Fact]
+    public void ResolveEffectiveSelection_WhenLenovoModelsShareMarketingName_SelectsMatchingMachineType()
+    {
+        var viewModel = new DriverPackSelectionViewModel(
+            new DriverPackSelectionService(NullLogger<DriverPackSelectionService>.Instance),
+            new LocalizationService(),
+            "x64");
+        HardwareProfile hardware = new()
+        {
+            Manufacturer = "Lenovo",
+            Model = "21Y6000JMX",
+            Product = "ThinkPad E14 Gen 8"
+        };
+        OperatingSystemCatalogItem operatingSystem = new()
+        {
+            WindowsRelease = "11",
+            ReleaseId = "25H2",
+            Architecture = "x64"
+        };
+
+        viewModel.UpdateSelectionContext(hardware, operatingSystem, "x64");
+        viewModel.ApplyCatalog(
+        [
+            CreateCatalogItem(
+                "21y2-21y3",
+                "25H2",
+                new DateTimeOffset(2026, 05, 19, 0, 0, 0, TimeSpan.Zero),
+                "ThinkPad E14 Gen 8 Type 21Y2 21Y3",
+                ["21Y2", "21Y3"]),
+            CreateCatalogItem(
+                "21y6-21y7",
+                "25H2",
+                new DateTimeOffset(2026, 04, 28, 0, 0, 0, TimeSpan.Zero),
+                "ThinkPad E14 Gen 8 Type 21Y6 21Y7",
+                ["21Y6", "21Y7"])
+        ]);
+
+        DriverPackCatalogItem? selected = viewModel.ResolveEffectiveSelection();
+
+        Assert.Equal("ThinkPad E14 Gen 8 Type 21Y6 21Y7", viewModel.SelectedDriverPackModel);
+        Assert.Equal("21y6-21y7", selected?.Id);
+    }
+
     private static DriverPackCatalogItem CreateCatalogItem(
         string id,
         string releaseId,
-        DateTimeOffset releaseDate)
+        DateTimeOffset releaseDate,
+        string modelName = "ThinkPad X13 Yoga Gen 3 Type 21AW 21AX",
+        IReadOnlyList<string>? systemIds = null)
     {
         return new DriverPackCatalogItem
         {
@@ -92,7 +137,8 @@ public sealed class DriverPackSelectionViewModelTests
             OsReleaseId = releaseId,
             OsArchitecture = "x64",
             ReleaseDate = releaseDate,
-            ModelNames = ["ThinkPad X13 Yoga Gen 3 Type 21AW 21AX"]
+            ModelNames = [modelName],
+            SystemIds = systemIds ?? []
         };
     }
 }

--- a/src/Foundry.Deploy/Models/DriverPackCatalogItem.cs
+++ b/src/Foundry.Deploy/Models/DriverPackCatalogItem.cs
@@ -21,6 +21,7 @@ public sealed record DriverPackCatalogItem
     public string OsReleaseId { get; init; } = string.Empty;
     public string OsArchitecture { get; init; } = string.Empty;
     public IReadOnlyList<string> ModelNames { get; init; } = Array.Empty<string>();
+    public IReadOnlyList<string> SystemIds { get; init; } = Array.Empty<string>();
     public string Sha256 { get; init; } = string.Empty;
 
     public string DisplayLabel =>

--- a/src/Foundry.Deploy/Services/Catalog/DriverPackCatalogService.cs
+++ b/src/Foundry.Deploy/Services/Catalog/DriverPackCatalogService.cs
@@ -56,7 +56,7 @@ public sealed class DriverPackCatalogService : IDriverPackCatalogService
         }
     }
 
-    private static DriverPackCatalogItem ParseItem(XElement driverPack)
+    internal static DriverPackCatalogItem ParseItem(XElement driverPack)
     {
         XElement? osInfo = driverPack.Element("OsInfo");
         XElement? hashes = driverPack.Element("Hashes");
@@ -65,6 +65,12 @@ public sealed class DriverPackCatalogService : IDriverPackCatalogService
             .Descendants("Model")
             .Select(model => (model.Attribute("name")?.Value ?? string.Empty).Trim())
             .Where(modelName => !string.IsNullOrWhiteSpace(modelName))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        IReadOnlyList<string> systemIds = driverPack
+            .Descendants("Model")
+            .SelectMany(model => (model.Attribute("systemId")?.Value ?? string.Empty)
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
@@ -85,6 +91,7 @@ public sealed class DriverPackCatalogService : IDriverPackCatalogService
             OsReleaseId = ReadAttribute(osInfo, "releaseId"),
             OsArchitecture = NormalizeArchitecture(ReadAttribute(osInfo, "architecture")),
             ModelNames = models,
+            SystemIds = systemIds,
             Sha256 = ReadAttribute(hashes, "sha256")
         };
     }

--- a/src/Foundry.Deploy/Services/DriverPacks/DriverPackSelectionService.cs
+++ b/src/Foundry.Deploy/Services/DriverPacks/DriverPackSelectionService.cs
@@ -74,7 +74,12 @@ public sealed class DriverPackSelectionService : IDriverPackSelectionService
             };
         }
 
-        DriverPackCatalogItem[] modelCandidates = candidates
+        DriverPackCatalogItem[] systemIdCandidates = manufacturer == "lenovo"
+            ? candidates.Where(item => IsSystemIdMatch(item, hardware)).ToArray()
+            : [];
+        DriverPackCatalogItem[] modelCandidates = systemIdCandidates.Length > 0
+            ? systemIdCandidates
+            : candidates
             .Where(item => item.ModelNames.Any(modelName => ContainsIgnoreCase(modelName, model) || ContainsIgnoreCase(modelName, product)))
             .ToArray();
         DriverPackCatalogItem[] modelReleaseCandidates = SelectReleaseCandidates(modelCandidates, targetReleaseId);
@@ -115,6 +120,20 @@ public sealed class DriverPackSelectionService : IDriverPackSelectionService
         }
 
         return source.Contains(value, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsSystemIdMatch(DriverPackCatalogItem item, HardwareProfile hardware)
+    {
+        return item.SystemIds.Any(systemId =>
+            StartsWithIgnoreCase(hardware.Model, systemId) ||
+            StartsWithIgnoreCase(hardware.Product, systemId));
+    }
+
+    private static bool StartsWithIgnoreCase(string value, string prefix)
+    {
+        return !string.IsNullOrWhiteSpace(value) &&
+               !string.IsNullOrWhiteSpace(prefix) &&
+               value.Trim().StartsWith(prefix.Trim(), StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsReleaseIdMatch(DriverPackCatalogItem item, string targetReleaseId)

--- a/src/Foundry.Deploy/ViewModels/DriverPackSelectionViewModel.cs
+++ b/src/Foundry.Deploy/ViewModels/DriverPackSelectionViewModel.cs
@@ -365,45 +365,14 @@ public sealed partial class DriverPackSelectionViewModel : LocalizedViewModelBas
             return string.Empty;
         }
 
-        if (_detectedHardware is null)
+        if (_detectedHardware is null || _selectedOperatingSystem is null)
         {
             return modelOptions[0];
         }
 
-        string[] hardwareTokens =
-        [
-            _detectedHardware.Model.Trim(),
-            _detectedHardware.Product.Trim()
-        ];
-        hardwareTokens = hardwareTokens
-            .Where(token => !string.IsNullOrWhiteSpace(token))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-
-        if (hardwareTokens.Length == 0)
-        {
-            return modelOptions[0];
-        }
-
-        string? exactOptionMatch = modelOptions.FirstOrDefault(option =>
-            hardwareTokens.Any(token => option.Equals(token, StringComparison.OrdinalIgnoreCase)));
-        if (!string.IsNullOrWhiteSpace(exactOptionMatch))
-        {
-            return exactOptionMatch;
-        }
-
-        string? containsOptionMatch = modelOptions.FirstOrDefault(option =>
-            hardwareTokens.Any(token => IsFuzzyModelMatch(option, token)));
-        if (!string.IsNullOrWhiteSpace(containsOptionMatch))
-        {
-            return containsOptionMatch;
-        }
-
-        DriverPackCatalogItem? bestPackMatch = SortDriverPackCandidates(sourceCandidates
-            .Where(item => item.ModelNames.Any(modelName =>
-                hardwareTokens.Any(token => IsFuzzyModelMatch(modelName, token)))),
-            _selectedOperatingSystem?.ReleaseId ?? string.Empty)
-            .FirstOrDefault();
+        DriverPackCatalogItem? bestPackMatch = _driverPackSelectionService
+            .SelectBest(sourceCandidates, _detectedHardware, _selectedOperatingSystem)
+            .DriverPack;
 
         if (bestPackMatch is not null)
         {
@@ -681,21 +650,6 @@ public sealed partial class DriverPackSelectionViewModel : LocalizedViewModelBas
                extension.Equals(".msi", StringComparison.OrdinalIgnoreCase) ||
                extension.Equals(".zip", StringComparison.OrdinalIgnoreCase) ||
                extension.Equals(".7z", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool ContainsIgnoreCase(string source, string value)
-    {
-        if (string.IsNullOrWhiteSpace(source) || string.IsNullOrWhiteSpace(value))
-        {
-            return false;
-        }
-
-        return source.Contains(value, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool IsFuzzyModelMatch(string source, string value)
-    {
-        return ContainsIgnoreCase(source, value) || ContainsIgnoreCase(value, source);
     }
 
     private static DriverPackCatalogItem[] SortDriverPackCandidates(


### PR DESCRIPTION
## Summary

Match Lenovo OEM driver packs using the catalog machine type before marketing model names.

## Reason

Lenovo variants can share the same marketing model while requiring different driver packs. Hardware `21Y6000JMX` was selecting the newer `21Y2/21Y3` pack instead of its `21Y6/21Y7` pack.

## Main changes

- Preserve `Model@systemId` values from the unified driver-pack catalog.
- Prefer matching Lenovo machine types during automatic selection.
- Reuse the same selector for UI model defaulting and remove duplicate fuzzy matching.
- Add regression coverage for catalog parsing, automatic selection, and UI defaulting.

## Testing

- `dotnet run --project src/Foundry.Deploy.Tests/Foundry.Deploy.Tests.csproj --no-restore -- -noColor` (473 passed)
- `scripts\Test-FoundryFormat.ps1` (passed)

Fixes #289