### PR TITLE
feat(shell): add bug report footer action

### DIFF
--- a/src/Foundry/FoundryApplicationInfo.cs
+++ b/src/Foundry/FoundryApplicationInfo.cs
@@ -108,6 +108,11 @@ public static class FoundryApplicationInfo
     public const string IssuesUrl = Constants.RepositoryUrl + "/issues";
 
     /// <summary>
+    /// Gets the GitHub bug report form URL.
+    /// </summary>
+    public const string BugReportUrl = IssuesUrl + "/new?template=bug-report.yml";
+
+    /// <summary>
     /// Gets the license document URL.
     /// </summary>
     public const string LicenseUrl = Constants.RepositoryUrl + "/blob/main/LICENSE";

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>يحتاج إلى اهتمام</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>الإبلاغ عن خطأ</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>افتح نموذج الإبلاغ عن الأخطاء على GitHub في متصفحك.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>تعذر فتح بلاغ الخطأ</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>تعذر على Foundry فتح نموذج الإبلاغ عن الخطأ. انسخ هذا الرابط وافتحه في متصفحك.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Изисква внимание</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Докладване на грешка</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Отворете формуляра за докладване на грешки в GitHub в браузъра си.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Докладът за грешка не можа да бъде отворен</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry не можа да отвори формуляра за докладване на грешка. Копирайте тази връзка и я отворете в браузъра си.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Vyžaduje pozornost</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Nahlásit chybu</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Otevřete formulář pro hlášení chyb na GitHubu ve svém prohlížeči.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Hlášení chyby se nepodařilo otevřít</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Aplikaci Foundry se nepodařilo otevřít formulář pro hlášení chyby. Zkopírujte tento odkaz a otevřete jej ve svém prohlížeči.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Kræver opmærksomhed</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Rapportér en fejl</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Åbn GitHubs formular til fejlrapportering i din browser.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Fejlrapporten kunne ikke åbnes</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry kunne ikke åbne formularen til fejlrapportering. Kopiér dette link, og åbn det i din browser.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Erfordert Aufmerksamkeit</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Fehler melden</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Öffnen Sie das GitHub-Formular zum Melden von Fehlern in Ihrem Browser.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Fehlerbericht konnte nicht geöffnet werden</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry konnte das Formular zum Melden des Fehlers nicht öffnen. Kopieren Sie diesen Link und öffnen Sie ihn in Ihrem Browser.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Χρειάζεται προσοχή</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Αναφορά σφάλματος</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Ανοίξτε τη φόρμα αναφοράς σφάλματος του GitHub στο πρόγραμμα περιήγησής σας.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Δεν ήταν δυνατό το άνοιγμα της αναφοράς σφάλματος</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Το Foundry δεν μπόρεσε να ανοίξει τη φόρμα αναφοράς σφάλματος. Αντιγράψτε αυτόν τον σύνδεσμο και ανοίξτε τον στο πρόγραμμα περιήγησής σας.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Needs attention</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Report a bug</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Open the GitHub bug report form in your browser.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Could not open bug report</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry could not open the bug report form. Copy this link and open it in your browser.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Needs attention</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Report a bug</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Open the GitHub bug report form in your browser.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Could not open bug report</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry could not open the bug report form. Copy this link and open it in your browser.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Requiere atención</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Informar de un error</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Abra el formulario de GitHub para informar de errores en su navegador.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>No se pudo abrir el informe de error</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry no pudo abrir el formulario para informar del error. Copie este enlace y ábralo en su navegador.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Requiere atención</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Reportar un error</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Abra el formulario de GitHub para reportar errores en su navegador.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>No se pudo abrir el reporte de error</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry no pudo abrir el formulario para reportar el error. Copie este enlace y ábralo en su navegador.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Vajab tähelepanu</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Teata veast</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Avage GitHubi veateate vorm oma brauseris.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Veateadet ei saanud avada</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry ei saanud veateate vormi avada. Kopeerige see link ja avage see oma brauseris.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Vaatii huomiota</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Ilmoita virheestä</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Avaa GitHubin virheraporttilomake selaimessasi.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Virheraporttia ei voitu avata</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry ei voinut avata virheraporttilomaketta. Kopioi tämä linkki ja avaa se selaimessasi.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Nécessite votre attention</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Signaler un bogue</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Ouvrez le formulaire de signalement de bogue GitHub dans votre navigateur.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Impossible d’ouvrir le rapport de bogue</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry n’a pas pu ouvrir le formulaire de signalement de bogue. Copiez ce lien et ouvrez-le dans votre navigateur.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Nécessite votre attention</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Signaler un bug</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Ouvrez le formulaire de signalement de bug GitHub dans votre navigateur.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Impossible d’ouvrir le rapport de bug</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry n’a pas pu ouvrir le formulaire de signalement de bug. Copiez ce lien et ouvrez-le dans votre navigateur.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>דורש טיפול</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>דיווח על באג</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>פתח את טופס הדיווח על באגים של GitHub בדפדפן שלך.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>לא ניתן לפתוח את דיווח הבאג</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry לא הצליח לפתוח את טופס הדיווח על הבאג. העתק את הקישור הזה ופתח אותו בדפדפן שלך.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Potrebna je pažnja</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Prijavi pogrešku</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Otvorite obrazac za prijavu pogreške na GitHubu u pregledniku.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Prijavu pogreške nije bilo moguće otvoriti</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry nije mogao otvoriti obrazac za prijavu pogreške. Kopirajte ovu poveznicu i otvorite je u pregledniku.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Beavatkozást igényel</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Hiba jelentése</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Nyissa meg a GitHub hibabejelentő űrlapját a böngészőjében.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>A hibajelentést nem lehetett megnyitni</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>A Foundry nem tudta megnyitni a hibabejelentő űrlapot. Másolja ezt a hivatkozást, és nyissa meg a böngészőjében.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Richiede attenzione</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Segnala un bug</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Apri il modulo di segnalazione bug di GitHub nel browser.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Impossibile aprire la segnalazione del bug</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry non è riuscito ad aprire il modulo di segnalazione del bug. Copia questo link e aprilo nel browser.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>確認が必要</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>バグを報告</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>GitHub のバグ報告フォームをブラウザーで開きます。</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>バグ報告を開けませんでした</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry はバグ報告フォームを開けませんでした。このリンクをコピーしてブラウザーで開いてください。</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>확인 필요</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>버그 신고</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>브라우저에서 GitHub 버그 신고 양식을 엽니다.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>버그 신고를 열 수 없음</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry에서 버그 신고 양식을 열 수 없습니다. 이 링크를 복사하여 브라우저에서 여세요.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Reikia dėmesio</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Pranešti apie klaidą</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Atidarykite „GitHub“ klaidos pranešimo formą naršyklėje.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Nepavyko atidaryti klaidos pranešimo</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>„Foundry“ nepavyko atidaryti klaidos pranešimo formos. Nukopijuokite šią nuorodą ir atidarykite ją naršyklėje.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Jāpievērš uzmanība</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Ziņot par kļūdu</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Pārlūkprogrammā atveriet GitHub kļūdu ziņojuma veidlapu.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Neizdevās atvērt kļūdas ziņojumu</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry neizdevās atvērt kļūdas ziņojuma veidlapu. Nokopējiet šo saiti un atveriet to pārlūkprogrammā.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Krever oppmerksomhet</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Rapporter en feil</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Åpne GitHubs skjema for feilrapportering i nettleseren.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Kunne ikke åpne feilrapporten</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry kunne ikke åpne skjemaet for feilrapportering. Kopier denne lenken, og åpne den i nettleseren.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Vereist aandacht</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Een bug melden</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Open het GitHub-formulier voor bugmeldingen in uw browser.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Bugmelding kon niet worden geopend</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry kon het formulier voor de bugmelding niet openen. Kopieer deze link en open deze in uw browser.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Wymaga uwagi</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Zgłoś błąd</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Otwórz formularz zgłaszania błędów w serwisie GitHub w przeglądarce.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Nie można otworzyć zgłoszenia błędu</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry nie mógł otworzyć formularza zgłoszenia błędu. Skopiuj ten link i otwórz go w przeglądarce.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Requer atenção</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Relatar um bug</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Abra o formulário de relatório de bugs do GitHub no navegador.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Não foi possível abrir o relatório de bug</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>O Foundry não conseguiu abrir o formulário de relatório de bug. Copie este link e abra-o no navegador.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Requer atenção</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Comunicar um erro</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Abra o formulário de comunicação de erros do GitHub no seu browser.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Não foi possível abrir o relatório de erro</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>O Foundry não conseguiu abrir o formulário de comunicação de erros. Copie esta ligação e abra-a no seu browser.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Necesită atenție</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Raportați o eroare</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Deschideți formularul GitHub pentru raportarea erorilor în browser.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Raportul de eroare nu a putut fi deschis</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry nu a putut deschide formularul de raportare a erorii. Copiați acest link și deschideți-l în browser.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Требует внимания</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Сообщить об ошибке</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Откройте форму сообщения об ошибке на GitHub в браузере.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Не удалось открыть сообщение об ошибке</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry не удалось открыть форму сообщения об ошибке. Скопируйте эту ссылку и откройте ее в браузере.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Vyžaduje pozornosť</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Nahlásiť chybu</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Otvorte formulár na hlásenie chýb na GitHube vo svojom prehliadači.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Hlásenie chyby nebolo možné otvoriť</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Aplikácii Foundry sa nepodarilo otvoriť formulár na hlásenie chyby. Skopírujte tento odkaz a otvorte ho vo svojom prehliadači.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Zahteva pozornost</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Prijavi napako</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>V brskalniku odprite obrazec GitHub za prijavo napak.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Poročila o napaki ni bilo mogoče odpreti</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry ni mogel odpreti obrazca za prijavo napake. Kopirajte to povezavo in jo odprite v brskalniku.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Zahteva pažnju</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Prijavi grešku</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Otvorite GitHub obrazac za prijavu greške u pretraživaču.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Nije moguće otvoriti prijavu greške</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry nije mogao da otvori obrazac za prijavu greške. Kopirajte ovu vezu i otvorite je u pretraživaču.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Kräver åtgärd</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Rapportera ett fel</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Öppna GitHubs formulär för felrapportering i webbläsaren.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Det gick inte att öppna felrapporten</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry kunde inte öppna formuläret för felrapportering. Kopiera den här länken och öppna den i webbläsaren.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>ต้องตรวจสอบ</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>รายงานข้อบกพร่อง</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>เปิดแบบฟอร์มรายงานข้อบกพร่องของ GitHub ในเบราว์เซอร์ของคุณ</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>ไม่สามารถเปิดรายงานข้อบกพร่องได้</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry ไม่สามารถเปิดแบบฟอร์มรายงานข้อบกพร่องได้ คัดลอกลิงก์นี้แล้วเปิดในเบราว์เซอร์ของคุณ</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Dikkat gerekiyor</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Hata bildir</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>GitHub hata bildirim formunu tarayıcınızda açın.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Hata bildirimi açılamadı</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry hata bildirim formunu açamadı. Bu bağlantıyı kopyalayıp tarayıcınızda açın.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>Потребує уваги</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>Повідомити про помилку</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>Відкрийте форму повідомлення про помилку GitHub у браузері.</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>Не вдалося відкрити повідомлення про помилку</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry не вдалося відкрити форму повідомлення про помилку. Скопіюйте це посилання та відкрийте його в браузері.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>需要注意</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>报告错误</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>在浏览器中打开 GitHub 错误报告表单。</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>无法打开错误报告</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry 无法打开错误报告表单。请复制此链接并在浏览器中打开。</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -2746,4 +2746,16 @@
   <data name="StartOverview.State.NeedsAttention" xml:space="preserve">
     <value>需要注意</value>
   </data>
+  <data name="Nav_ReportBugKey.Title" xml:space="preserve">
+    <value>回報錯誤</value>
+  </data>
+  <data name="Nav_ReportBugKey.Description" xml:space="preserve">
+    <value>在瀏覽器中開啟 GitHub 錯誤回報表單。</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Title" xml:space="preserve">
+    <value>無法開啟錯誤報告</value>
+  </data>
+  <data name="BugReport.ExternalLaunchFailed.Message" xml:space="preserve">
+    <value>Foundry 無法開啟錯誤回報表單。請複製此連結並在瀏覽器中開啟。</value>
+  </data>
 </root>

--- a/src/Foundry/Views/MainWindow.xaml.cs
+++ b/src/Foundry/Views/MainWindow.xaml.cs
@@ -24,8 +24,10 @@ namespace Foundry.Views
         private readonly IExternalProcessLauncher externalProcessLauncher;
         private readonly ILogger logger = Log.ForContext<MainWindow>();
         private const string DocumentationNavigationTag = "Foundry.External.Documentation";
+        private const string BugReportNavigationTag = "Foundry.External.BugReport";
         private const string AboutNavigationTag = "Foundry.External.About";
         private const string UpdateNavigationTag = "Foundry.Navigation.UpdateAvailable";
+        private const string BugReportNavigationGlyph = "\uEBE8";
         private const string UpdateNavigationGlyph = "\uEBD3";
         private ContentDialog? operationDialog;
         private TextBlock? operationStatusText;
@@ -85,6 +87,7 @@ namespace Foundry.Views
         private void ApplyLocalizedShellText()
         {
             EnsureExternalDocumentationFooterItem();
+            EnsureExternalBugReportFooterItem();
             EnsureExternalAboutFooterItem();
             RefreshUpdateFooterItem();
         }
@@ -179,6 +182,9 @@ namespace Foundry.Views
                     return;
                 case DocumentationNavigationTag:
                     await OpenDocumentationAsync();
+                    return;
+                case BugReportNavigationTag:
+                    await OpenBugReportAsync();
                     return;
                 case AboutNavigationTag:
                     await ShowAboutDialogAsync();
@@ -515,11 +521,32 @@ namespace Foundry.Views
                     Tag = AboutNavigationTag,
                     Icon = new FontIcon { Glyph = "\uE946" }
                 };
-                NavView.FooterMenuItems.Insert(Math.Min(1, NavView.FooterMenuItems.Count), item);
+                NavView.FooterMenuItems.Insert(Math.Min(2, NavView.FooterMenuItems.Count), item);
             }
 
             item.Content = localizationService.GetString("Nav_AboutKey.Title");
             string description = localizationService.GetString("Nav_AboutKey.Description");
+            ToolTipService.SetToolTip(item, description);
+            AutomationProperties.SetName(item, item.Content?.ToString() ?? string.Empty);
+            AutomationProperties.SetHelpText(item, description);
+            item.IsEnabled = shellNavigationGuardService.State != ShellNavigationState.OperationRunning;
+        }
+
+        private void EnsureExternalBugReportFooterItem()
+        {
+            NavigationViewItem? item = FindNavigationItem(NavView.FooterMenuItems, BugReportNavigationTag);
+            if (item is null)
+            {
+                item = new()
+                {
+                    Tag = BugReportNavigationTag,
+                    Icon = new FontIcon { Glyph = BugReportNavigationGlyph }
+                };
+                NavView.FooterMenuItems.Insert(Math.Min(1, NavView.FooterMenuItems.Count), item);
+            }
+
+            item.Content = localizationService.GetString("Nav_ReportBugKey.Title");
+            string description = localizationService.GetString("Nav_ReportBugKey.Description");
             ToolTipService.SetToolTip(item, description);
             AutomationProperties.SetName(item, item.Content?.ToString() ?? string.Empty);
             AutomationProperties.SetHelpText(item, description);
@@ -544,6 +571,28 @@ namespace Foundry.Views
 
         internal async Task OpenDocumentationAsync()
         {
+            await OpenExternalUriAsync(
+                new Uri(FoundryApplicationInfo.DocumentationUrl),
+                "Documentation.ExternalLaunchFailed.Title",
+                "Documentation.ExternalLaunchFailed.Message",
+                "Documentation");
+        }
+
+        private async Task OpenBugReportAsync()
+        {
+            await OpenExternalUriAsync(
+                new Uri(FoundryApplicationInfo.BugReportUrl),
+                "BugReport.ExternalLaunchFailed.Title",
+                "BugReport.ExternalLaunchFailed.Message",
+                "BugReport");
+        }
+
+        private async Task OpenExternalUriAsync(
+            Uri uri,
+            string failureTitleResourceKey,
+            string failureMessageResourceKey,
+            string target)
+        {
             if (shellNavigationGuardService.State == ShellNavigationState.OperationRunning)
             {
                 return;
@@ -551,21 +600,24 @@ namespace Foundry.Views
 
             try
             {
-                await externalProcessLauncher.OpenUriAsync(new Uri(FoundryApplicationInfo.DocumentationUrl));
+                await externalProcessLauncher.OpenUriAsync(uri);
             }
             catch (Exception ex)
             {
-                logger.Warning(ex, "Failed to open documentation URL.");
-                await ShowDocumentationFallbackDialogAsync();
+                logger.Warning(ex, "Failed to open external URI. Target={Target}", target);
+                await ShowExternalUriFallbackDialogAsync(uri, failureTitleResourceKey, failureMessageResourceKey);
             }
         }
 
-        private async Task ShowDocumentationFallbackDialogAsync()
+        private async Task ShowExternalUriFallbackDialogAsync(
+            Uri uri,
+            string failureTitleResourceKey,
+            string failureMessageResourceKey)
         {
             ContentDialog dialog = new()
             {
                 XamlRoot = RootGrid.XamlRoot,
-                Title = localizationService.GetString("Documentation.ExternalLaunchFailed.Title"),
+                Title = localizationService.GetString(failureTitleResourceKey),
                 PrimaryButtonText = localizationService.GetString("Common.Close"),
                 DefaultButton = ContentDialogButton.Primary,
                 Content = new StackPanel
@@ -575,12 +627,12 @@ namespace Foundry.Views
                     {
                         new TextBlock
                         {
-                            Text = localizationService.GetString("Documentation.ExternalLaunchFailed.Message"),
+                            Text = localizationService.GetString(failureMessageResourceKey),
                             TextWrapping = TextWrapping.Wrap
                         },
                         new Microsoft.UI.Xaml.Controls.TextBox
                         {
-                            Text = FoundryApplicationInfo.DocumentationUrl,
+                            Text = uri.AbsoluteUri,
                             IsReadOnly = true
                         }
                     }


### PR DESCRIPTION
## Summary

Add a localized Report a bug action to the Foundry navigation footer.

## Reason

Give users a direct path from Foundry OSD to the repository bug report form.

## Main changes

- add a Bug glyph footer item between Documentation and About
- open the GitHub bug report template through the existing external URI launcher
- share the external launch fallback flow with Documentation and remove the duplicated dialog code
- add localized labels and fallback messages for all 38 supported languages

## Testing

- Resource contract check: 38 locales, 4 required keys present
- Foundry.Localization.Tests: 59 passed, 0 failed
- Release x64 solution build: succeeded with 0 errors
- scripts/Test-FoundryFormat.ps1: passed (61/61 XAML files)

CI checks are pending.