### PR TITLE
chore(deps): update Foundry NuGet packages

### DIFF
--- a/src/Foundry.Connect/Foundry.Connect.csproj
+++ b/src/Foundry.Connect/Foundry.Connect.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <PackageReference Include="Serilog" Version="4.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />

--- a/src/Foundry.Deploy/Foundry.Deploy.csproj
+++ b/src/Foundry.Deploy/Foundry.Deploy.csproj
@@ -11,9 +11,9 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.13.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <PackageReference Include="Serilog" Version="4.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />

--- a/src/Foundry.Telemetry/Foundry.Telemetry.csproj
+++ b/src/Foundry.Telemetry/Foundry.Telemetry.csproj
@@ -16,7 +16,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
   </ItemGroup>
 
 </Project>

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -47,11 +47,11 @@
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.251219" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2270" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2705" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.4.0" />
     <PackageReference Include="Serilog" Version="4.4.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/src/Foundry/Services/Application/WinUiFilePickerService.cs
+++ b/src/Foundry/Services/Application/WinUiFilePickerService.cs
@@ -70,7 +70,7 @@ public sealed class WinUiFilePickerService : IFilePickerService
     {
         if (filters.Count == 0)
         {
-            return ["*"];
+            return (string[])["*"];
         }
 
         return filters.Select(NormalizeExtension).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();

--- a/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
+++ b/src/Foundry/Services/Autopilot/AutopilotTenantOnboardingService.cs
@@ -103,7 +103,7 @@ public sealed class AutopilotTenantOnboardingService(
                 TenantId = tenantId,
                 PersistedApplicationObjectId = application.ObjectId,
                 ManagedAppDisplayName = AutopilotHardwareHashUploadSettings.ManagedAppRegistrationDisplayName,
-                Applications = [application],
+                Applications = (AutopilotGraphApplication[])[application],
                 ServicePrincipal = servicePrincipal,
                 ActiveCertificate = currentSettings.ActiveCertificate,
                 KeyCredentials = keyCredentials,

--- a/src/Foundry/Services/Shell/NavigationRouteCatalog.cs
+++ b/src/Foundry/Services/Shell/NavigationRouteCatalog.cs
@@ -27,6 +27,7 @@ public sealed record NavigationRoute(
 public static class NavigationRouteCatalog
 {
     public static IReadOnlyList<NavigationRoute> PrimaryRoutes { get; } =
+    (NavigationRoute[])
     [
         CreatePrimary<HomeLandingPage>("Nav_HomeKey", "E80F", NavigationSection.General, true),
         CreatePrimary<AdkPage>("Nav_AdkKey", "EC7A", NavigationSection.General, true),
@@ -46,6 +47,7 @@ public static class NavigationRouteCatalog
     ];
 
     private static IReadOnlyList<NavigationRoute> Routes { get; } =
+    (NavigationRoute[])
     [
         .. PrimaryRoutes,
         CreateSettings<SettingsPage>("SettingsPage.PageTitle", null),

--- a/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/AutopilotConfigurationViewModel.cs
@@ -469,7 +469,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private async Task ImportProfileAsync()
     {
         string? filePath = await filePickerService.PickOpenFileAsync(
-            new FileOpenPickerRequest(localizationService.GetString("Autopilot.ImportPickerTitle"), [".json"]));
+            new FileOpenPickerRequest(localizationService.GetString("Autopilot.ImportPickerTitle"), (string[])[".json"]));
         if (string.IsNullOrWhiteSpace(filePath))
         {
             return;
@@ -479,7 +479,7 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         try
         {
             AutopilotProfileSettings profile = await autopilotProfileImportService.ImportFromJsonFileAsync(filePath);
-            MergeProfiles([profile]);
+            MergeProfiles((AutopilotProfileSettings[])[profile]);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or InvalidOperationException or ArgumentException)
         {
@@ -658,7 +658,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
         string? outputPath = await filePickerService.PickSaveFileAsync(new FileSavePickerRequest(
             localizationService.GetString("Autopilot.HardwareHashCertificateSavePickerTitle"),
             "foundry-osd-autopilot-registration.pfx",
-            [new FilePickerTypeChoice(localizationService.GetString("Autopilot.HardwareHashCertificatePfxFileType"), [".pfx"])],
+            (FilePickerTypeChoice[])[new FilePickerTypeChoice(
+                localizationService.GetString("Autopilot.HardwareHashCertificatePfxFileType"),
+                (string[])[".pfx"])],
             ".pfx"));
         if (string.IsNullOrWhiteSpace(outputPath) || SelectedCertificateValidityOption is null)
         {
@@ -771,7 +773,9 @@ public sealed partial class AutopilotConfigurationViewModel : ObservableObject, 
     private async Task SelectBootMediaCertificatePfxAsync()
     {
         string? filePath = await filePickerService.PickOpenFileAsync(
-            new FileOpenPickerRequest(localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePfxPickerTitle"), [".pfx"]));
+            new FileOpenPickerRequest(
+                localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePfxPickerTitle"),
+                (string[])[".pfx"]));
         if (string.IsNullOrWhiteSpace(filePath))
         {
             return;

--- a/src/Foundry/ViewModels/CustomizationConfigurationViewModel.WindowsOptionalFeatures.cs
+++ b/src/Foundry/ViewModels/CustomizationConfigurationViewModel.WindowsOptionalFeatures.cs
@@ -241,7 +241,7 @@ public sealed partial class CustomizationConfigurationViewModel
     private void ApplyWindowsOptionalFeatureItemState(
         WindowsOptionalFeatureItemViewModel item,
         WindowsOptionalFeatureState state)
-        => ApplyWindowsOptionalFeatureSelection([item.Id], state);
+        => ApplyWindowsOptionalFeatureSelection((string[])[item.Id], state);
 
     private void ApplyWindowsOptionalFeatureSelection(
         IEnumerable<string> featureIds,

--- a/src/Foundry/ViewModels/MediaCreationTelemetryProgressTracker.cs
+++ b/src/Foundry/ViewModels/MediaCreationTelemetryProgressTracker.cs
@@ -12,6 +12,7 @@ namespace Foundry.ViewModels;
 internal sealed class MediaCreationTelemetryProgressTracker
 {
     private static readonly IReadOnlyList<StatusStepMapping> CustomizationStatusMappings =
+    (StatusStepMapping[])
     [
         new("Resolving WinRE source catalog", MediaCreationStepNames.ResolveWinReSourceCatalog),
         new("Selected WinRE source package", MediaCreationStepNames.SelectWinReSourcePackage),
@@ -33,6 +34,7 @@ internal sealed class MediaCreationTelemetryProgressTracker
     ];
 
     private static readonly IReadOnlyList<StatusStepMapping> DownloadStatusMappings =
+    (StatusStepMapping[])
     [
         new("Downloading driver package", MediaCreationStepNames.DownloadWinPeDriverPackage),
         new("Downloading WinRE source package", MediaCreationStepNames.DownloadWinReSourcePackage),
@@ -41,6 +43,7 @@ internal sealed class MediaCreationTelemetryProgressTracker
     ];
 
     private static readonly IReadOnlyList<StatusStepMapping> FinalMediaStatusMappings =
+    (StatusStepMapping[])
     [
         new("Preparing ISO output path", MediaCreationStepNames.PrepareIsoOutputPath),
         new("Preparing ISO workspace", MediaCreationStepNames.PrepareIsoWorkspace),

--- a/src/Foundry/ViewModels/NetworkConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/NetworkConfigurationViewModel.cs
@@ -333,7 +333,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
     [RelayCommand]
     private async Task BrowseDot1xProfileTemplateAsync()
     {
-        string? path = await PickOpenFileAsync("Network.ProfileTemplatePickerTitle", [".xml"]);
+        string? path = await PickOpenFileAsync("Network.ProfileTemplatePickerTitle", (string[])[".xml"]);
         if (!string.IsNullOrWhiteSpace(path))
         {
             Dot1xProfileTemplatePath = path;
@@ -343,7 +343,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
     [RelayCommand]
     private async Task BrowseDot1xCertificateAsync()
     {
-        string? path = await PickOpenFileAsync("Dot1x.CertificatePickerTitle", [".cer", ".crt", ".pfx", "*"]);
+        string? path = await PickOpenFileAsync("Dot1x.CertificatePickerTitle", (string[])[".cer", ".crt", ".pfx", "*"]);
         if (!string.IsNullOrWhiteSpace(path))
         {
             Dot1xCertificatePath = path;
@@ -353,7 +353,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
     [RelayCommand]
     private async Task BrowseWifiEnterpriseProfileTemplateAsync()
     {
-        string? path = await PickOpenFileAsync("Network.ProfileTemplatePickerTitle", [".xml"]);
+        string? path = await PickOpenFileAsync("Network.ProfileTemplatePickerTitle", (string[])[".xml"]);
         if (!string.IsNullOrWhiteSpace(path))
         {
             WifiEnterpriseProfileTemplatePath = path;
@@ -363,7 +363,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
     [RelayCommand]
     private async Task BrowseWifiCertificateAsync()
     {
-        string? path = await PickOpenFileAsync("Wifi.CertificatePickerTitle", [".cer", ".crt", ".pfx", "*"]);
+        string? path = await PickOpenFileAsync("Wifi.CertificatePickerTitle", (string[])[".cer", ".crt", ".pfx", "*"]);
         if (!string.IsNullOrWhiteSpace(path))
         {
             WifiCertificatePath = path;

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -297,7 +297,9 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             new FileSavePickerRequest(
                 localizationService.GetString("StartMedia.IsoPicker.Title"),
                 "Foundry",
-                [new(localizationService.GetString("StartMedia.IsoPicker.Filter"), [".iso"])],
+                (FilePickerTypeChoice[])[new(
+                    localizationService.GetString("StartMedia.IsoPicker.Filter"),
+                    (string[])[".iso"])],
                 ".iso"));
 
         if (!string.IsNullOrWhiteSpace(path))
@@ -1592,6 +1594,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             MediaPreflightBlockingReason.CustomDriverDirectoryHasNoInfFiles);
 
         return
+        (StartConfigurationOverviewItemViewModel[])
         [
             CreateOverviewItem(ConfigurationOverviewItem.Architecture, overview, "StartMedia.Field.Architecture",
                 FormatArchitecture(options.Architecture), ConfigurationNavigationTarget.General),
@@ -1647,6 +1650,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         });
 
         return
+        (StartConfigurationOverviewItemViewModel[])
         [
             CreateOverviewItem(ConfigurationOverviewItem.EthernetDot1x, overview, "Nav_EthernetDot1xKey.Title",
                 GetNetworkDescription(overview[ConfigurationOverviewItem.EthernetDot1x], ethernetDescription, ethernetValidation),
@@ -1666,6 +1670,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             : GetAutopilotValidationText(options.AutopilotConfigurationValidationCode);
 
         return
+        (StartConfigurationOverviewItemViewModel[])
         [
             CreateOverviewItem(ConfigurationOverviewItem.AutopilotJsonProfile, overview, "Nav_AutopilotJsonProfileKey.Title",
                 overview[ConfigurationOverviewItem.AutopilotJsonProfile] == ConfigurationOverviewState.NotSelected
@@ -1706,6 +1711,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             optionalFeatures.DisabledFeatureIds.Count);
 
         return
+        (StartConfigurationOverviewItemViewModel[])
         [
             CreateOverviewItem(ConfigurationOverviewItem.OperatingSystemSelection, overview, "Nav_OsSelectionKey.Title",
                 string.IsNullOrWhiteSpace(osDescription) ? localizationService.GetString("Nav_OsSelectionKey.Description") : osDescription,


### PR DESCRIPTION
## Summary

Update Foundry's NuGet dependencies and keep the application compatible with the latest CsWinRT trim/AOT analysis.

## Reason

Apply the selected dependency servicing, parser, Windows SDK, CsWinRT, and Windows App SDK updates while checking their release notes for breaking changes.

## Main changes

- Update Microsoft.Extensions packages from 10.0.10 to 10.0.11.
- Update HtmlAgilityPack from 1.12.4 to 1.13.0.
- Update Microsoft.Windows.CsWinRT from 2.2.0 to 2.3.1.
- Update Microsoft.Windows.SDK.BuildTools from 10.0.28000.2270 to 10.0.28000.2705.
- Update Microsoft.WindowsAppSDK from 2.3.1 to 2.4.0.
- Give interface-typed collection expressions explicit array backing where required by CsWinRT trim/AOT analysis.

## Testing notes

- Restored the full solution.
- Built the full solution in Debug and Release configurations.
- Passed all 1,393 tests across the six test projects.
- Published Foundry as a self-contained, trimmed win-x64 application.
- Verified CsWinRT1032 as an error with no remaining diagnostics.
- Verified no known vulnerable direct or transitive NuGet packages.
- Passed C# and XAML formatting checks.
- Completed an independent diff review with no findings.