### PR TITLE
fix(deploy): verify cached artifacts from disk

### DIFF
--- a/src/Foundry.Deploy.Tests/ArtifactDownloadServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/ArtifactDownloadServiceTests.cs
@@ -52,14 +52,17 @@ public sealed class ArtifactDownloadServiceTests
     }
 
     [Fact]
-    public async Task DownloadAsync_WhenManifestMatches_UsesFastCacheHitWithoutRehashing()
+    public async Task DownloadAsync_WhenManifestMatchesButContentIsCorrupted_RedownloadsArtifact()
     {
         using TempDirectory temp = TempDirectory.Create();
         string destinationPath = Path.Combine(temp.Path, "install.esd");
-        byte[] content = Encoding.UTF8.GetBytes("tampered-content");
-        await File.WriteAllBytesAsync(destinationPath, content, TestContext.Current.CancellationToken);
+        byte[] corruptedContent = Encoding.UTF8.GetBytes("tampered-content");
+        byte[] downloadedContent = Encoding.UTF8.GetBytes("expected-content");
+        Assert.Equal(corruptedContent.Length, downloadedContent.Length);
+        await File.WriteAllBytesAsync(destinationPath, corruptedContent, TestContext.Current.CancellationToken);
         DateTimeOffset lastWriteTime = DateTimeOffset.UtcNow.AddMinutes(-3);
         File.SetLastWriteTimeUtc(destinationPath, lastWriteTime.UtcDateTime);
+        string expectedHash = ComputeSha256(downloadedContent);
 
         await WriteManifestAsync(
             destinationPath,
@@ -68,14 +71,14 @@ public sealed class ArtifactDownloadServiceTests
                 ArtifactKind = "OperatingSystemImage",
                 SourceUrl = "https://example.test/install.esd",
                 HashAlgorithm = "SHA256",
-                ExpectedHash = new string('A', 64),
-                ExpectedSizeBytes = content.Length,
-                FileSizeBytes = content.Length,
+                ExpectedHash = expectedHash,
+                ExpectedSizeBytes = corruptedContent.Length,
+                FileSizeBytes = corruptedContent.Length,
                 FileLastWriteTimeUtc = lastWriteTime,
                 ValidatedAtUtc = DateTimeOffset.UtcNow.AddMinutes(-2)
             });
 
-        var handler = new ThrowingHttpMessageHandler();
+        var handler = new StaticHttpMessageHandler(downloadedContent);
         var service = new ArtifactDownloadService(
             NullLogger<ArtifactDownloadService>.Instance,
             new HttpClient(handler));
@@ -83,14 +86,74 @@ public sealed class ArtifactDownloadServiceTests
         ArtifactDownloadResult result = await service.DownloadAsync(
             "https://example.test/install.esd",
             destinationPath,
-            new string('A', 64),
-            expectedSizeBytes: content.Length,
+            expectedHash,
+            expectedSizeBytes: downloadedContent.Length,
             artifactKind: "OperatingSystemImage",
             cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.False(result.Downloaded);
-        Assert.Equal("cache-hit", result.Method);
-        Assert.Equal(0, handler.RequestCount);
+        Assert.True(result.Downloaded);
+        Assert.Equal("httpclient", result.Method);
+        Assert.Equal(1, handler.RequestCount);
+        Assert.Equal(downloadedContent, await File.ReadAllBytesAsync(destinationPath, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task DownloadAsync_WhenDownloadFails_DoesNotReplaceExistingArtifact()
+    {
+        using TempDirectory temp = TempDirectory.Create();
+        string destinationPath = Path.Combine(temp.Path, "install.esd");
+        byte[] existingContent = Encoding.UTF8.GetBytes("existing cached artifact");
+        await File.WriteAllBytesAsync(destinationPath, existingContent, TestContext.Current.CancellationToken);
+
+        var service = new ArtifactDownloadService(
+            NullLogger<ArtifactDownloadService>.Instance,
+            new HttpClient(new FailingDownloadHttpMessageHandler()));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.DownloadAsync(
+                "https://example.test/install.esd",
+                destinationPath,
+                new string('A', 64),
+                expectedSizeBytes: existingContent.Length + 1,
+                artifactKind: "OperatingSystemImage",
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal(existingContent, await File.ReadAllBytesAsync(destinationPath, TestContext.Current.CancellationToken));
+        Assert.Empty(Directory.GetFiles(temp.Path, "*.partial"));
+    }
+
+    [Fact]
+    public async Task DownloadAsync_WhenConcurrentDownloadsTargetSameArtifact_BothComplete()
+    {
+        using TempDirectory temp = TempDirectory.Create();
+        string destinationPath = Path.Combine(temp.Path, "install.esd");
+        byte[] downloadedContent = Encoding.UTF8.GetBytes("shared artifact content");
+        string expectedHash = ComputeSha256(downloadedContent);
+        var handler = new ConcurrentHttpMessageHandler(downloadedContent, expectedRequests: 2);
+        var service = new ArtifactDownloadService(
+            NullLogger<ArtifactDownloadService>.Instance,
+            new HttpClient(handler));
+
+        Task<ArtifactDownloadResult> firstDownload = service.DownloadAsync(
+            "https://example.test/install.esd",
+            destinationPath,
+            expectedHash,
+            expectedSizeBytes: downloadedContent.Length,
+            artifactKind: "OperatingSystemImage",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Task<ArtifactDownloadResult> secondDownload = service.DownloadAsync(
+            "https://example.test/install.esd",
+            destinationPath,
+            expectedHash,
+            expectedSizeBytes: downloadedContent.Length,
+            artifactKind: "OperatingSystemImage",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        ArtifactDownloadResult[] results = await Task.WhenAll(firstDownload, secondDownload);
+
+        Assert.All(results, result => Assert.True(result.Downloaded));
+        Assert.Equal(downloadedContent, await File.ReadAllBytesAsync(destinationPath, TestContext.Current.CancellationToken));
+        Assert.Empty(Directory.GetFiles(temp.Path, "*.partial"));
     }
 
     [Fact]
@@ -122,7 +185,7 @@ public sealed class ArtifactDownloadServiceTests
     }
 
     [Fact]
-    public async Task DownloadAsync_WhenDownloadedHashMatches_WritesManifestWithoutSecondFileHashPass()
+    public async Task DownloadAsync_WhenStoredHashMatches_PublishesArtifactAndManifest()
     {
         using TempDirectory temp = TempDirectory.Create();
         string destinationPath = Path.Combine(temp.Path, "firmware.cab");
@@ -195,15 +258,81 @@ public sealed class ArtifactDownloadServiceTests
         }
     }
 
-    private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
+    private sealed class FailingDownloadHttpMessageHandler : HttpMessageHandler
     {
-        public int RequestCount { get; private set; }
-
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            RequestCount++;
-            throw new InvalidOperationException("HTTP should not be used for a manifest-backed cache hit.");
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(new FailingReadStream())
+            });
         }
+    }
+
+    private sealed class ConcurrentHttpMessageHandler(byte[] content, int expectedRequests) : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource _allRequestsStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _requestCount;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (Interlocked.Increment(ref _requestCount) == expectedRequests)
+            {
+                _allRequestsStarted.SetResult();
+            }
+
+            await _allRequestsStarted.Task.WaitAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(content)
+            };
+        }
+    }
+
+    private sealed class FailingReadStream : Stream
+    {
+        private bool _firstRead = true;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return Read(buffer.AsSpan(offset, count));
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            if (!_firstRead)
+            {
+                throw new InvalidOperationException("Simulated interrupted download.");
+            }
+
+            _firstRead = false;
+            buffer[0] = 0x42;
+            return 1;
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult(Read(buffer.Span));
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 
     private sealed class TempDirectory : IDisposable

--- a/src/Foundry.Deploy/Services/Download/ArtifactCacheManifestService.cs
+++ b/src/Foundry.Deploy/Services/Download/ArtifactCacheManifestService.cs
@@ -17,8 +17,10 @@ internal static class ArtifactCacheManifestService
         WriteIndented = true
     };
 
-    public static bool TryValidate(
+    public static bool TryValidateMetadata(
         string artifactPath,
+        string sourceUrl,
+        string? artifactKind,
         string expectedHash,
         string hashAlgorithm,
         long? expectedSizeBytes,
@@ -45,6 +47,8 @@ internal static class ArtifactCacheManifestService
 
         if (manifest is null ||
             manifest.Version != CurrentVersion ||
+            !string.Equals(manifest.SourceUrl, sourceUrl, StringComparison.Ordinal) ||
+            !string.Equals(manifest.ArtifactKind, artifactKind, StringComparison.Ordinal) ||
             !string.Equals(manifest.HashAlgorithm, hashAlgorithm, StringComparison.OrdinalIgnoreCase) ||
             !string.Equals(manifest.ExpectedHash, expectedHash, StringComparison.OrdinalIgnoreCase))
         {
@@ -89,10 +93,25 @@ internal static class ArtifactCacheManifestService
             ValidatedAtUtc = DateTimeOffset.UtcNow
         };
 
-        await using FileStream stream = File.Create(GetManifestPath(artifactPath));
-        await JsonSerializer
-            .SerializeAsync(stream, manifest, SerializerOptions, cancellationToken)
-            .ConfigureAwait(false);
+        string manifestPath = GetManifestPath(artifactPath);
+        string temporaryPath = $"{manifestPath}.{Guid.NewGuid():N}.partial";
+        try
+        {
+            await using (FileStream stream = File.Create(temporaryPath))
+            {
+                await JsonSerializer
+                    .SerializeAsync(stream, manifest, SerializerOptions, cancellationToken)
+                    .ConfigureAwait(false);
+                await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                stream.Flush(flushToDisk: true);
+            }
+
+            File.Move(temporaryPath, manifestPath, overwrite: true);
+        }
+        finally
+        {
+            File.Delete(temporaryPath);
+        }
     }
 
     public static string GetManifestPath(string artifactPath)

--- a/src/Foundry.Deploy/Services/Download/ArtifactDownloadService.cs
+++ b/src/Foundry.Deploy/Services/Download/ArtifactDownloadService.cs
@@ -100,37 +100,59 @@ public sealed class ArtifactDownloadService : IArtifactDownloadService
                 };
             }
 
+            string temporaryPath = $"{destinationPath}.{Guid.NewGuid():N}.partial";
             DownloadedArtifact downloadedArtifact = new(null);
-            await HttpRetryPolicy
-                .ExecuteAsync(
-                    async ct =>
-                    {
-                        downloadedArtifact = await DownloadWithHttpClientAsync(
-                                effectiveSourceUrl,
-                                destinationPath,
-                                hashAlgorithm,
-                                progress,
-                                ct)
-                            .ConfigureAwait(false);
-                    },
-                    _logger,
-                    "Artifact download",
-                    cancellationToken)
-                .ConfigureAwait(false);
-            await EnsureDownloadedHashAsync(destinationPath, normalizedExpectedHash, hashAlgorithm, downloadedArtifact, cancellationToken).ConfigureAwait(false);
-
-            if (normalizedExpectedHash is not null && hashAlgorithm is not null)
+            try
             {
-                await ArtifactCacheManifestService
-                    .WriteAsync(
-                        destinationPath,
-                        sourceUrl,
-                        artifactKind,
-                        normalizedExpectedHash,
-                        hashAlgorithm.Value.Name ?? string.Empty,
-                        expectedSizeBytes,
+                await HttpRetryPolicy
+                    .ExecuteAsync(
+                        async ct =>
+                        {
+                            downloadedArtifact = await DownloadWithHttpClientAsync(
+                                    effectiveSourceUrl,
+                                    temporaryPath,
+                                    hashAlgorithm,
+                                    progress,
+                                    ct)
+                                .ConfigureAwait(false);
+                        },
+                        _logger,
+                        "Artifact download",
                         cancellationToken)
                     .ConfigureAwait(false);
+
+                EnsureExpectedSize(temporaryPath, expectedSizeBytes);
+                await EnsureDownloadedHashAsync(
+                    temporaryPath,
+                    normalizedExpectedHash,
+                    hashAlgorithm,
+                    downloadedArtifact,
+                    cancellationToken).ConfigureAwait(false);
+                await EnsureStoredHashAsync(
+                    temporaryPath,
+                    normalizedExpectedHash,
+                    hashAlgorithm,
+                    cancellationToken).ConfigureAwait(false);
+
+                File.Move(temporaryPath, destinationPath, overwrite: true);
+
+                if (normalizedExpectedHash is not null && hashAlgorithm is not null)
+                {
+                    await ArtifactCacheManifestService
+                        .WriteAsync(
+                            destinationPath,
+                            sourceUrl,
+                            artifactKind,
+                            normalizedExpectedHash,
+                            hashAlgorithm.Value.Name ?? string.Empty,
+                            expectedSizeBytes,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                TryDeleteFile(temporaryPath);
             }
 
             _logger.LogInformation("Artifact downloaded via HttpClient. DestinationPath={DestinationPath}", destinationPath);
@@ -182,35 +204,50 @@ public sealed class ArtifactDownloadService : IArtifactDownloadService
             return true;
         }
 
-        if (ArtifactCacheManifestService.TryValidate(
-                destinationPath,
-                normalizedExpectedHash,
-                hashAlgorithm.Value.Name ?? string.Empty,
-                expectedSizeBytes,
-                _logger,
-                out _))
-        {
-            progress?.Report(new DownloadProgress(artifact.Length, artifact.Length));
-            return true;
-        }
-
-        string actualHash = await ComputeHashAsync(destinationPath, hashAlgorithm.Value, cancellationToken).ConfigureAwait(false);
-        if (!string.Equals(normalizedExpectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        await ArtifactCacheManifestService
-            .WriteAsync(
+        bool hasCompatibleManifest = ArtifactCacheManifestService.TryValidateMetadata(
                 destinationPath,
                 sourceUrl,
                 artifactKind,
                 normalizedExpectedHash,
                 hashAlgorithm.Value.Name ?? string.Empty,
                 expectedSizeBytes,
-                cancellationToken)
-            .ConfigureAwait(false);
+                _logger,
+                out _);
 
+        _logger.LogDebug(
+            "Validating cached artifact content. DestinationPath={DestinationPath}, HashAlgorithm={HashAlgorithm}",
+            destinationPath,
+            hashAlgorithm.Value.Name);
+        string actualHash = await ComputeHashAsync(destinationPath, hashAlgorithm.Value, cancellationToken).ConfigureAwait(false);
+        if (!string.Equals(normalizedExpectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning(
+                "Cached artifact hash mismatch. DestinationPath={DestinationPath}, HashAlgorithm={HashAlgorithm}, ExpectedHash={ExpectedHash}, ActualHash={ActualHash}",
+                destinationPath,
+                hashAlgorithm.Value.Name,
+                normalizedExpectedHash,
+                actualHash);
+            return false;
+        }
+
+        if (!hasCompatibleManifest)
+        {
+            await ArtifactCacheManifestService
+                .WriteAsync(
+                    destinationPath,
+                    sourceUrl,
+                    artifactKind,
+                    normalizedExpectedHash,
+                    hashAlgorithm.Value.Name ?? string.Empty,
+                    expectedSizeBytes,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        _logger.LogInformation(
+            "Cached artifact hash validation succeeded. DestinationPath={DestinationPath}, HashAlgorithm={HashAlgorithm}",
+            destinationPath,
+            hashAlgorithm.Value.Name);
         progress?.Report(new DownloadProgress(artifact.Length, artifact.Length));
         return true;
     }
@@ -260,6 +297,8 @@ public sealed class ArtifactDownloadService : IArtifactDownloadService
             }
         }
 
+        await destinationStream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        destinationStream.Flush(flushToDisk: true);
         progress?.Report(new DownloadProgress(bytesDownloaded, totalBytes));
         string? actualHash = incrementalHash is null
             ? null
@@ -284,6 +323,49 @@ public sealed class ArtifactDownloadService : IArtifactDownloadService
         {
             throw new InvalidOperationException(
                 $"Hash verification failed for '{filePath}' ({hashAlgorithm.Value.Name}). Expected '{normalizedExpectedHash}', actual '{actual}'.");
+        }
+    }
+
+    private async Task EnsureStoredHashAsync(
+        string filePath,
+        string? normalizedExpectedHash,
+        HashAlgorithmName? hashAlgorithm,
+        CancellationToken cancellationToken)
+    {
+        if (normalizedExpectedHash is null || hashAlgorithm is null)
+        {
+            return;
+        }
+
+        _logger.LogDebug(
+            "Validating stored artifact content. FilePath={FilePath}, HashAlgorithm={HashAlgorithm}",
+            filePath,
+            hashAlgorithm.Value.Name);
+        string actualHash = await ComputeHashAsync(filePath, hashAlgorithm.Value, cancellationToken).ConfigureAwait(false);
+        if (!string.Equals(normalizedExpectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Stored artifact hash verification failed for '{filePath}' ({hashAlgorithm.Value.Name}). Expected '{normalizedExpectedHash}', actual '{actualHash}'.");
+        }
+
+        _logger.LogInformation(
+            "Stored artifact hash validation succeeded. FilePath={FilePath}, HashAlgorithm={HashAlgorithm}",
+            filePath,
+            hashAlgorithm.Value.Name);
+    }
+
+    private static void EnsureExpectedSize(string filePath, long? expectedSizeBytes)
+    {
+        if (expectedSizeBytes is not > 0)
+        {
+            return;
+        }
+
+        long actualSizeBytes = new FileInfo(filePath).Length;
+        if (actualSizeBytes != expectedSizeBytes.Value)
+        {
+            throw new InvalidDataException(
+                $"Artifact size verification failed for '{filePath}'. Expected '{expectedSizeBytes.Value}', actual '{actualSizeBytes}'.");
         }
     }
 
@@ -328,6 +410,20 @@ public sealed class ArtifactDownloadService : IArtifactDownloadService
         return Uri.TryCreate(sourceUrl, UriKind.Absolute, out Uri? uri)
             ? uri.Host
             : "invalid-url";
+    }
+
+    private static void TryDeleteFile(string filePath)
+    {
+        try
+        {
+            File.Delete(filePath);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
     }
 
     private sealed record DownloadedArtifact(string? Hash);


### PR DESCRIPTION
## Summary

Verify cached and freshly downloaded deployment artifacts from their persisted bytes before reuse or publication.

## Reason

A same-size ESD in a USB cache could retain valid manifest metadata while its on-disk content was corrupted, allowing deployment to continue until DISM failed.

## Main changes

- Rehash cached artifacts whenever an expected hash is available; manifests are metadata, not proof of content integrity.
- Download to unique same-directory staging files, flush and rehash persisted bytes, then atomically publish the artifact.
- Publish manifests atomically and bind their metadata to the source URL and artifact kind.
- Preserve existing cached artifacts when a replacement download fails.
- Add focused regression coverage for corrupted manifest-backed caches, interrupted downloads, and concurrent publication.

## Testing

- [x] `.\scripts\Test-FoundryFormat.ps1`
- [x] x64 Release build and relevant tests
- [ ] ARM64 Release build and relevant tests, when relevant
- [ ] Manual validation

Validation not run and reason:

ARM64 and an end-to-end deployment were not required for this architecture-neutral downloader change. All six x64 test projects passed, including 7 focused artifact download tests.

## Additional information

- Breaking or schema changes: None.
- Follow-up work: None.