### PR TITLE
fix(configuration): roll back schema version bump

### DIFF
--- a/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
@@ -28,8 +28,8 @@ public sealed class ConfigurationSchemaVersionsTests
     [Fact]
     public void CurrentSchemaVersions_MatchNextPublishedContractVersions()
     {
-        Assert.Equal(14, ConfigurationSchemaVersions.FoundryCurrent);
-        Assert.Equal(12, ConfigurationSchemaVersions.DeployCurrent);
+        Assert.Equal(13, ConfigurationSchemaVersions.FoundryCurrent);
+        Assert.Equal(11, ConfigurationSchemaVersions.DeployCurrent);
         Assert.Equal(3, ConfigurationSchemaVersions.ConnectCurrent);
     }
 }

--- a/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
+++ b/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
@@ -6,11 +6,11 @@ namespace Foundry.Core.Models.Configuration;
 
 public static class ConfigurationSchemaVersions
 {
-    public const int FoundryCurrent = 14;
+    public const int FoundryCurrent = 13;
 
     public const int ConnectCurrent = 3;
 
-    public const int DeployCurrent = 12;
+    public const int DeployCurrent = 11;
 
     public static bool IsBootMediaUpdateRecommended(int schemaVersion, int currentSchemaVersion)
     {


### PR DESCRIPTION
## Summary

Restore the Foundry and Deploy schema versions published in the latest GitHub release.

## Reason

PR #299 bumped both schema versions for a bug fix that did not change the persisted or generated configuration contract. Keeping the unpublished versions would create false compatibility boundaries for existing configuration and boot media.

## Main changes

- Restore Foundry schema version 13.
- Restore Deploy schema version 11.
- Keep Connect schema version 3 unchanged.
- Update the schema contract test to match release v26.8.26.1.

## Testing

- scripts\Test-FoundryFormat.ps1: passed; 65 of 65 XAML files passed.
- Release x64 solution build: passed.
- All six x64 test projects: 1,424 passed, 0 failed.
- ARM64 was not run locally because this constants-only compatibility correction is not architecture-sensitive; required CI remains authoritative.

## Merge strategy

Keep the commit history and merge without squashing.