### PR TITLE
feat(settings): add Foundry OSD proxy configuration

### DIFF
--- a/src/Foundry.Core.Tests/Networking/ApplicationProxyTests.cs
+++ b/src/Foundry.Core.Tests/Networking/ApplicationProxyTests.cs
@@ -30,6 +30,12 @@ public sealed class ApplicationProxyTests
     [Fact]
     public void CreateManual_RejectsInvalidConfiguration()
     {
+        Assert.Throws<ArgumentNullException>(() => ApplicationProxyFactory.CreateManual(
+            null!,
+            8080,
+            bypassLocal: false,
+            string.Empty,
+            credentials: null));
         Assert.Throws<ArgumentException>(() => ApplicationProxyFactory.CreateManual(
             "not a host/path",
             8080,

--- a/src/Foundry.Core.Tests/Networking/ApplicationProxyTests.cs
+++ b/src/Foundry.Core.Tests/Networking/ApplicationProxyTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Net;
+using Foundry.Core.Services.Networking;
+
+namespace Foundry.Core.Tests.Networking;
+
+public sealed class ApplicationProxyTests
+{
+    [Fact]
+    public void CreateManual_UsesConfiguredEndpointAndBypassRules()
+    {
+        IWebProxy proxy = ApplicationProxyFactory.CreateManual(
+            "proxy.contoso.com",
+            8080,
+            bypassLocal: true,
+            "*.contoso.com;downloads.example.net",
+            CredentialCache.DefaultNetworkCredentials);
+
+        Assert.Equal(new Uri("http://proxy.contoso.com:8080"), proxy.GetProxy(new Uri("https://github.com")));
+        Assert.True(proxy.IsBypassed(new Uri("http://intranet")));
+        Assert.True(proxy.IsBypassed(new Uri("https://packages.contoso.com")));
+        Assert.True(proxy.IsBypassed(new Uri("https://downloads.example.net")));
+        Assert.Equal(new Uri("https://packages.contoso.com"), proxy.GetProxy(new Uri("https://packages.contoso.com")));
+        Assert.Same(CredentialCache.DefaultNetworkCredentials, proxy.Credentials);
+    }
+
+    [Fact]
+    public void CreateManual_RejectsInvalidConfiguration()
+    {
+        Assert.Throws<ArgumentException>(() => ApplicationProxyFactory.CreateManual(
+            "not a host/path",
+            8080,
+            bypassLocal: false,
+            string.Empty,
+            credentials: null));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ApplicationProxyFactory.CreateManual(
+            "proxy.contoso.com",
+            0,
+            bypassLocal: false,
+            string.Empty,
+            credentials: null));
+    }
+
+    [Fact]
+    public void MutableProxy_UsesUpdatedPolicyForExistingReference()
+    {
+        var initial = new StubProxy(new Uri("http://old-proxy:8080"));
+        var updated = new StubProxy(new Uri("http://new-proxy:8080"));
+        var proxy = new MutableApplicationProxy(initial);
+        IWebProxy existingReference = proxy;
+
+        Assert.Equal(initial.Endpoint, existingReference.GetProxy(new Uri("https://github.com")));
+
+        proxy.Update(updated);
+
+        Assert.Equal(updated.Endpoint, existingReference.GetProxy(new Uri("https://github.com")));
+    }
+
+    private sealed class StubProxy(Uri endpoint) : IWebProxy
+    {
+        public Uri Endpoint { get; } = endpoint;
+
+        public ICredentials? Credentials { get; set; }
+
+        public Uri GetProxy(Uri destination) => Endpoint;
+
+        public bool IsBypassed(Uri host) => false;
+    }
+}

--- a/src/Foundry.Core.Tests/Networking/ApplicationProxyTests.cs
+++ b/src/Foundry.Core.Tests/Networking/ApplicationProxyTests.cs
@@ -59,6 +59,14 @@ public sealed class ApplicationProxyTests
         Assert.Equal(updated.Endpoint, existingReference.GetProxy(new Uri("https://github.com")));
     }
 
+    [Fact]
+    public void MutableProxy_RejectsSelfReference()
+    {
+        var proxy = new MutableApplicationProxy(new StubProxy(new Uri("http://system-proxy:8080")));
+
+        Assert.Throws<ArgumentException>(() => proxy.Update(proxy));
+    }
+
     private sealed class StubProxy(Uri endpoint) : IWebProxy
     {
         public Uri Endpoint { get; } = endpoint;

--- a/src/Foundry.Core/Services/Networking/ApplicationProxyFactory.cs
+++ b/src/Foundry.Core/Services/Networking/ApplicationProxyFactory.cs
@@ -35,6 +35,7 @@ public static class ApplicationProxyFactory
 
     private static Uri CreateEndpoint(string address, int port)
     {
+        ArgumentNullException.ThrowIfNull(address);
         string normalized = address.Trim();
         if (!normalized.Contains("://", StringComparison.Ordinal))
         {

--- a/src/Foundry.Core/Services/Networking/ApplicationProxyFactory.cs
+++ b/src/Foundry.Core/Services/Networking/ApplicationProxyFactory.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Net;
+using System.Text.RegularExpressions;
+
+namespace Foundry.Core.Services.Networking;
+
+/// <summary>
+/// Creates proxy policies used by the Foundry OSD desktop application.
+/// </summary>
+public static class ApplicationProxyFactory
+{
+    public static IWebProxy CreateDirect() => new DirectApplicationProxy();
+
+    /// <summary>
+    /// Creates a manually configured HTTP proxy.
+    /// </summary>
+    public static IWebProxy CreateManual(
+        string address,
+        int port,
+        bool bypassLocal,
+        string? bypassList,
+        ICredentials? credentials)
+    {
+        if (port is < 1 or > 65535)
+        {
+            throw new ArgumentOutOfRangeException(nameof(port));
+        }
+
+        Uri endpoint = CreateEndpoint(address, port);
+        return new ManualApplicationProxy(endpoint, bypassLocal, ParseBypassList(bypassList), credentials);
+    }
+
+    private static Uri CreateEndpoint(string address, int port)
+    {
+        string normalized = address.Trim();
+        if (!normalized.Contains("://", StringComparison.Ordinal))
+        {
+            normalized = $"http://{normalized}";
+        }
+
+        if (!Uri.TryCreate(normalized, UriKind.Absolute, out Uri? parsed) ||
+            parsed.Scheme is not ("http" or "https") ||
+            string.IsNullOrWhiteSpace(parsed.Host) ||
+            parsed.AbsolutePath != "/" ||
+            !string.IsNullOrEmpty(parsed.Query) ||
+            !string.IsNullOrEmpty(parsed.Fragment) ||
+            !string.IsNullOrEmpty(parsed.UserInfo))
+        {
+            throw new ArgumentException("Enter a valid HTTP or HTTPS proxy address.", nameof(address));
+        }
+
+        return new UriBuilder(parsed) { Port = port }.Uri;
+    }
+
+    private static string[] ParseBypassList(string? bypassList)
+    {
+        return string.IsNullOrWhiteSpace(bypassList)
+            ? []
+            : bypassList.Split([';', ','], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    private sealed class ManualApplicationProxy(
+        Uri endpoint,
+        bool bypassLocal,
+        string[] bypassList,
+        ICredentials? credentials) : IWebProxy
+    {
+        public ICredentials? Credentials { get; set; } = credentials;
+
+        public Uri GetProxy(Uri destination) => IsBypassed(destination) ? destination : endpoint;
+
+        public bool IsBypassed(Uri host)
+        {
+            if (bypassLocal && !host.Host.Contains('.', StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            return bypassList.Any(pattern => Matches(host.Host, pattern));
+        }
+
+        private static bool Matches(string host, string pattern)
+        {
+            string normalizedPattern = pattern.Trim();
+            if (Uri.TryCreate(normalizedPattern, UriKind.Absolute, out Uri? uri))
+            {
+                normalizedPattern = uri.Host;
+            }
+
+            string expression = $"^{Regex.Escape(normalizedPattern).Replace("\\*", ".*", StringComparison.Ordinal)}$";
+            return Regex.IsMatch(host, expression, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        }
+    }
+
+    private sealed class DirectApplicationProxy : IWebProxy
+    {
+        public ICredentials? Credentials { get; set; }
+
+        public Uri GetProxy(Uri destination) => destination;
+
+        public bool IsBypassed(Uri host) => true;
+    }
+}

--- a/src/Foundry.Core/Services/Networking/MutableApplicationProxy.cs
+++ b/src/Foundry.Core/Services/Networking/MutableApplicationProxy.cs
@@ -32,6 +32,11 @@ public sealed class MutableApplicationProxy : IWebProxy
     public void Update(IWebProxy proxy)
     {
         ArgumentNullException.ThrowIfNull(proxy);
+        if (ReferenceEquals(this, proxy))
+        {
+            throw new ArgumentException("A mutable proxy cannot reference itself.", nameof(proxy));
+        }
+
         Volatile.Write(ref current, proxy);
     }
 }

--- a/src/Foundry.Core/Services/Networking/MutableApplicationProxy.cs
+++ b/src/Foundry.Core/Services/Networking/MutableApplicationProxy.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Net;
+
+namespace Foundry.Core.Services.Networking;
+
+/// <summary>
+/// Keeps a stable proxy reference while allowing its active policy to change.
+/// </summary>
+public sealed class MutableApplicationProxy : IWebProxy
+{
+    private IWebProxy current;
+
+    public MutableApplicationProxy(IWebProxy initial)
+    {
+        ArgumentNullException.ThrowIfNull(initial);
+        current = initial;
+    }
+
+    public ICredentials? Credentials
+    {
+        get => Volatile.Read(ref current).Credentials;
+        set => Volatile.Read(ref current).Credentials = value;
+    }
+
+    public Uri GetProxy(Uri destination) => Volatile.Read(ref current).GetProxy(destination) ?? destination;
+
+    public bool IsBypassed(Uri host) => Volatile.Read(ref current).IsBypassed(host);
+
+    public void Update(IWebProxy proxy)
+    {
+        ArgumentNullException.ThrowIfNull(proxy);
+        Volatile.Write(ref current, proxy);
+    }
+}

--- a/src/Foundry.Telemetry.Tests/TelemetryEventPropertyPolicyTests.cs
+++ b/src/Foundry.Telemetry.Tests/TelemetryEventPropertyPolicyTests.cs
@@ -9,6 +9,27 @@ namespace Foundry.Telemetry.Tests;
 public sealed class TelemetryEventPropertyPolicyTests
 {
     [Fact]
+    public void Sanitize_ForDailyActive_AllowsOnlyNonSensitiveProxyConfiguration()
+    {
+        Dictionary<string, object?> input = new()
+        {
+            ["proxy_method"] = "manual",
+            ["proxy_authentication_mode"] = "explicit",
+            ["proxy_address"] = "proxy.contoso.com",
+            ["proxy_username"] = "admin"
+        };
+
+        IReadOnlyDictionary<string, object?> result = TelemetryEventPropertyPolicy.Sanitize(
+            TelemetryEvents.AppDailyActive,
+            input);
+
+        Assert.Equal("manual", result["proxy_method"]);
+        Assert.Equal("explicit", result["proxy_authentication_mode"]);
+        Assert.False(result.ContainsKey("proxy_address"));
+        Assert.False(result.ContainsKey("proxy_username"));
+    }
+
+    [Fact]
     public void Sanitize_ForBootMediaFinished_DropsPropertiesOutsideEventAllowlist()
     {
         Dictionary<string, object?> input = new()

--- a/src/Foundry.Telemetry/TelemetryEventPropertyPolicy.cs
+++ b/src/Foundry.Telemetry/TelemetryEventPropertyPolicy.cs
@@ -46,7 +46,11 @@ public static class TelemetryEventPropertyPolicy
     private static readonly IReadOnlyDictionary<string, HashSet<string>> AllowedPropertiesByEvent =
         new Dictionary<string, HashSet<string>>(StringComparer.Ordinal)
         {
-            [TelemetryEvents.AppDailyActive] = new(StringComparer.Ordinal),
+            [TelemetryEvents.AppDailyActive] = new(StringComparer.Ordinal)
+            {
+                "proxy_method",
+                "proxy_authentication_mode"
+            },
             [TelemetryEvents.OsdBootMediaFinished] = new(StringComparer.Ordinal)
             {
                 "boot_media_target",

--- a/src/Foundry/App.xaml.cs
+++ b/src/Foundry/App.xaml.cs
@@ -6,6 +6,7 @@ using Foundry.DependencyInjection;
 using Foundry.Services.Configuration;
 using Foundry.Services.Appearance;
 using Foundry.Services.Localization;
+using Foundry.Services.Networking;
 using Foundry.Services.Settings;
 using Foundry.Services.Shell;
 using Foundry.Services.Startup;
@@ -76,6 +77,7 @@ namespace Foundry
         public App()
         {
             Host = FoundryHost.Create();
+            _ = Host.Services.GetRequiredService<IApplicationProxyService>();
             SetDeveloperModeEnabled(Host.Services.GetRequiredService<IAppSettingsService>().Current.Diagnostics.DeveloperMode);
             _ = Host.Services.GetRequiredService<IFoundryConfigurationStateService>();
             Host.Services.GetRequiredService<IApplicationLocalizationService>().InitializeAsync().GetAwaiter().GetResult();
@@ -135,7 +137,14 @@ namespace Foundry
             }
 
             AppLogger.Debug("Tracking Foundry daily-active telemetry event.");
-            await GetService<ITelemetryService>().TrackAsync(TelemetryEvents.AppDailyActive, new Dictionary<string, object?>());
+            ProxyAppSettings proxy = settingsService.Current.Proxy;
+            await GetService<ITelemetryService>().TrackAsync(TelemetryEvents.AppDailyActive, new Dictionary<string, object?>
+            {
+                ["proxy_method"] = proxy.Method.ToString().ToLowerInvariant(),
+                ["proxy_authentication_mode"] = proxy.Method == ProxyMethod.Manual
+                    ? proxy.AuthenticationMode.ToString().ToLowerInvariant()
+                    : "not_applicable"
+            });
             settingsService.Current.Telemetry.LastDailyActiveDate = TelemetryDailyActivityGate.FormatDate(today);
             settingsService.Save();
             AppLogger.Debug("Foundry daily-active telemetry event queued.");

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ using Foundry.Services.Autopilot;
 using Foundry.Services.Configuration;
 using Foundry.Services.GitHub;
 using Foundry.Services.Localization;
+using Foundry.Services.Networking;
 using Foundry.Services.Operations;
 using Foundry.Services.Settings;
 using Foundry.Services.Shell;
@@ -44,6 +45,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<MainWindow>();
 
         services.AddSingleton<IAppSettingsService, JsonAppSettingsService>();
+        services.AddSingleton<IProxyCredentialStore, ProxyCredentialStore>();
+        services.AddSingleton<IApplicationProxyService, ApplicationProxyService>();
         services.AddSingleton(sp =>
         {
             FoundryAppSettings settings = sp.GetRequiredService<IAppSettingsService>().Current;
@@ -141,6 +144,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<GeneralSettingViewModel>();
         services.AddTransient<AdkPageViewModel>();
         services.AddTransient<AppUpdateSettingViewModel>();
+        services.AddTransient<ProxySettingViewModel>();
         services.AddTransient<AboutUsSettingViewModel>();
 
         return services;

--- a/src/Foundry/Services/Networking/ApplicationProxyService.cs
+++ b/src/Foundry/Services/Networking/ApplicationProxyService.cs
@@ -44,7 +44,8 @@ internal sealed class ApplicationProxyService : IApplicationProxyService
         this.appSettingsService = appSettingsService;
         this.credentialStore = credentialStore;
         this.logger = logger.ForContext<ApplicationProxyService>();
-        systemProxy = WebRequest.GetSystemWebProxy();
+        systemProxy = HttpClient.DefaultProxy;
+        systemProxy.Credentials ??= CredentialCache.DefaultNetworkCredentials;
         proxy = new MutableApplicationProxy(systemProxy);
         HttpClient.DefaultProxy = proxy;
         ProxyCredential? credential = null;
@@ -59,7 +60,8 @@ internal sealed class ApplicationProxyService : IApplicationProxyService
 
         try
         {
-            proxy.Update(CreateProxy(appSettingsService.Current.Proxy, credential));
+            ProxyAppSettings persistedSettings = appSettingsService.Current.Proxy ??= new ProxyAppSettings();
+            proxy.Update(CreateProxy(persistedSettings, credential));
         }
         catch (ArgumentException ex)
         {
@@ -125,12 +127,21 @@ internal sealed class ApplicationProxyService : IApplicationProxyService
             {
                 throw new HttpRequestException("The proxy rejected the configured authentication.");
             }
-
         }
     }
 
     private IWebProxy CreateProxy(ProxyAppSettings settings, ProxyCredential? credential)
     {
+        if (!Enum.IsDefined(settings.Method))
+        {
+            throw new ArgumentException("Select a valid proxy method.", nameof(settings));
+        }
+
+        if (!Enum.IsDefined(settings.AuthenticationMode))
+        {
+            throw new ArgumentException("Select a valid proxy authentication method.", nameof(settings));
+        }
+
         return settings.Method switch
         {
             ProxyMethod.System => systemProxy,
@@ -172,9 +183,9 @@ internal sealed class ApplicationProxyService : IApplicationProxyService
     {
         destination.Method = source.Method;
         destination.AuthenticationMode = source.AuthenticationMode;
-        destination.Address = source.Address.Trim();
+        destination.Address = source.Address?.Trim() ?? string.Empty;
         destination.Port = source.Port;
         destination.BypassLocalAddresses = source.BypassLocalAddresses;
-        destination.BypassList = source.BypassList.Trim();
+        destination.BypassList = source.BypassList?.Trim() ?? string.Empty;
     }
 }

--- a/src/Foundry/Services/Networking/ApplicationProxyService.cs
+++ b/src/Foundry/Services/Networking/ApplicationProxyService.cs
@@ -1,0 +1,183 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Net;
+using Foundry.Core.Services.Networking;
+using Foundry.Services.Settings;
+using Serilog;
+
+namespace Foundry.Services.Networking;
+
+public interface IApplicationProxyService
+{
+    ProxyCredential? ReadCredential();
+
+    void ApplyAndSave(ProxyAppSettings settings, ProxyCredential? credential);
+
+    Task TestConnectionAsync(
+        ProxyAppSettings settings,
+        ProxyCredential? credential,
+        CancellationToken cancellationToken = default);
+}
+
+internal sealed class ApplicationProxyService : IApplicationProxyService
+{
+    private static readonly Uri[] TestEndpoints =
+    [
+        new("https://github.com"),
+        new("https://login.microsoftonline.com"),
+        new("https://graph.microsoft.com")
+    ];
+
+    private readonly IAppSettingsService appSettingsService;
+    private readonly IProxyCredentialStore credentialStore;
+    private readonly MutableApplicationProxy proxy;
+    private readonly ILogger logger;
+
+    public ApplicationProxyService(
+        IAppSettingsService appSettingsService,
+        IProxyCredentialStore credentialStore,
+        ILogger logger)
+    {
+        this.appSettingsService = appSettingsService;
+        this.credentialStore = credentialStore;
+        this.logger = logger.ForContext<ApplicationProxyService>();
+        proxy = new MutableApplicationProxy(CreateSystemProxy());
+        HttpClient.DefaultProxy = proxy;
+        ProxyCredential? credential = null;
+        try
+        {
+            credential = credentialStore.Read();
+        }
+        catch (Exception ex)
+        {
+            logger.Warning(ex, "Stored proxy credentials could not be read. Continuing without explicit credentials.");
+        }
+
+        try
+        {
+            proxy.Update(CreateProxy(appSettingsService.Current.Proxy, credential));
+        }
+        catch (ArgumentException ex)
+        {
+            logger.Warning(ex, "Invalid persisted proxy settings were ignored. Falling back to Windows proxy settings.");
+            appSettingsService.Current.Proxy = new ProxyAppSettings();
+            appSettingsService.Save();
+            DeleteStoredCredential();
+        }
+    }
+
+    public ProxyCredential? ReadCredential()
+    {
+        try
+        {
+            return credentialStore.Read();
+        }
+        catch (Exception ex)
+        {
+            logger.Warning(ex, "Stored proxy credentials could not be read.");
+            return null;
+        }
+    }
+
+    public void ApplyAndSave(ProxyAppSettings settings, ProxyCredential? credential)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        IWebProxy activeProxy = CreateProxy(settings, credential);
+
+        if (settings.Method == ProxyMethod.Manual &&
+            settings.AuthenticationMode == ProxyAuthenticationMode.Explicit &&
+            credential is not null)
+        {
+            credentialStore.Save(credential);
+        }
+        else
+        {
+            credentialStore.Delete();
+        }
+
+        Copy(settings, appSettingsService.Current.Proxy);
+        appSettingsService.Save();
+        proxy.Update(activeProxy);
+        logger.Information(
+            "Foundry OSD proxy settings updated. Method={Method}, AuthenticationMode={AuthenticationMode}",
+            settings.Method,
+            settings.AuthenticationMode);
+    }
+
+    public async Task TestConnectionAsync(
+        ProxyAppSettings settings,
+        ProxyCredential? credential,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        IWebProxy candidateProxy = CreateProxy(settings, credential);
+        using var handler = new HttpClientHandler { Proxy = candidateProxy, UseProxy = true };
+        using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(15) };
+        foreach (Uri endpoint in TestEndpoints)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Head, endpoint);
+            using HttpResponseMessage response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            if ((int)response.StatusCode == 407)
+            {
+                throw new HttpRequestException("The proxy rejected the configured authentication.");
+            }
+
+        }
+    }
+
+    private IWebProxy CreateProxy(ProxyAppSettings settings, ProxyCredential? credential)
+    {
+        return settings.Method switch
+        {
+            ProxyMethod.System => CreateSystemProxy(),
+            ProxyMethod.Direct => ApplicationProxyFactory.CreateDirect(),
+            ProxyMethod.Manual => ApplicationProxyFactory.CreateManual(
+                settings.Address,
+                settings.Port,
+                settings.BypassLocalAddresses,
+                settings.BypassList,
+                CreateCredentials(settings.AuthenticationMode, credential)),
+            _ => CreateSystemProxy()
+        };
+    }
+
+    private static IWebProxy CreateSystemProxy()
+    {
+        return WebRequest.GetSystemWebProxy();
+    }
+
+    private void DeleteStoredCredential()
+    {
+        try
+        {
+            credentialStore.Delete();
+        }
+        catch (Exception ex)
+        {
+            logger.Warning(ex, "Obsolete proxy credentials could not be deleted.");
+        }
+    }
+
+    private static ICredentials? CreateCredentials(ProxyAuthenticationMode mode, ProxyCredential? credential)
+    {
+        return mode switch
+        {
+            ProxyAuthenticationMode.Automatic => CredentialCache.DefaultNetworkCredentials,
+            ProxyAuthenticationMode.Explicit when credential is not null =>
+                new NetworkCredential(credential.Username, credential.Password, credential.Domain),
+            _ => null
+        };
+    }
+
+    private static void Copy(ProxyAppSettings source, ProxyAppSettings destination)
+    {
+        destination.Method = source.Method;
+        destination.AuthenticationMode = source.AuthenticationMode;
+        destination.Address = source.Address.Trim();
+        destination.Port = source.Port;
+        destination.BypassLocalAddresses = source.BypassLocalAddresses;
+        destination.BypassList = source.BypassList.Trim();
+    }
+}

--- a/src/Foundry/Services/Networking/ApplicationProxyService.cs
+++ b/src/Foundry/Services/Networking/ApplicationProxyService.cs
@@ -32,6 +32,7 @@ internal sealed class ApplicationProxyService : IApplicationProxyService
 
     private readonly IAppSettingsService appSettingsService;
     private readonly IProxyCredentialStore credentialStore;
+    private readonly IWebProxy systemProxy;
     private readonly MutableApplicationProxy proxy;
     private readonly ILogger logger;
 
@@ -43,7 +44,8 @@ internal sealed class ApplicationProxyService : IApplicationProxyService
         this.appSettingsService = appSettingsService;
         this.credentialStore = credentialStore;
         this.logger = logger.ForContext<ApplicationProxyService>();
-        proxy = new MutableApplicationProxy(CreateSystemProxy());
+        systemProxy = WebRequest.GetSystemWebProxy();
+        proxy = new MutableApplicationProxy(systemProxy);
         HttpClient.DefaultProxy = proxy;
         ProxyCredential? credential = null;
         try
@@ -131,7 +133,7 @@ internal sealed class ApplicationProxyService : IApplicationProxyService
     {
         return settings.Method switch
         {
-            ProxyMethod.System => CreateSystemProxy(),
+            ProxyMethod.System => systemProxy,
             ProxyMethod.Direct => ApplicationProxyFactory.CreateDirect(),
             ProxyMethod.Manual => ApplicationProxyFactory.CreateManual(
                 settings.Address,
@@ -139,13 +141,8 @@ internal sealed class ApplicationProxyService : IApplicationProxyService
                 settings.BypassLocalAddresses,
                 settings.BypassList,
                 CreateCredentials(settings.AuthenticationMode, credential)),
-            _ => CreateSystemProxy()
+            _ => systemProxy
         };
-    }
-
-    private static IWebProxy CreateSystemProxy()
-    {
-        return WebRequest.GetSystemWebProxy();
     }
 
     private void DeleteStoredCredential()

--- a/src/Foundry/Services/Networking/ProxyCredentialStore.cs
+++ b/src/Foundry/Services/Networking/ProxyCredentialStore.cs
@@ -7,7 +7,21 @@ using System.Runtime.InteropServices;
 
 namespace Foundry.Services.Networking;
 
-public sealed record ProxyCredential(string Username, string Domain, string Password);
+public sealed class ProxyCredential
+{
+    public ProxyCredential(string username, string domain, string password)
+    {
+        Username = username;
+        Domain = domain;
+        Password = password;
+    }
+
+    public string Username { get; }
+
+    public string Domain { get; }
+
+    public string Password { get; }
+}
 
 public interface IProxyCredentialStore
 {

--- a/src/Foundry/Services/Networking/ProxyCredentialStore.cs
+++ b/src/Foundry/Services/Networking/ProxyCredentialStore.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace Foundry.Services.Networking;
+
+public sealed record ProxyCredential(string Username, string Domain, string Password);
+
+public interface IProxyCredentialStore
+{
+    ProxyCredential? Read();
+
+    void Save(ProxyCredential credential);
+
+    void Delete();
+}
+
+internal sealed class ProxyCredentialStore : IProxyCredentialStore
+{
+    private const string TargetName = "FoundryOSD/Proxy";
+    private const int CredentialTypeGeneric = 1;
+    private const int CredentialPersistLocalMachine = 2;
+    private const int ErrorNotFound = 1168;
+
+    public ProxyCredential? Read()
+    {
+        if (!CredRead(TargetName, CredentialTypeGeneric, 0, out nint credentialPointer))
+        {
+            int error = Marshal.GetLastWin32Error();
+            return error == ErrorNotFound ? null : throw new Win32Exception(error);
+        }
+
+        try
+        {
+            NativeCredential credential = Marshal.PtrToStructure<NativeCredential>(credentialPointer);
+            string username = credential.UserName ?? string.Empty;
+            string password = credential.CredentialBlobSize == 0
+                ? string.Empty
+                : Marshal.PtrToStringUni(credential.CredentialBlob, credential.CredentialBlobSize / sizeof(char)) ?? string.Empty;
+            (string domain, string user) = SplitUsername(username);
+            return new ProxyCredential(user, domain, password);
+        }
+        finally
+        {
+            CredFree(credentialPointer);
+        }
+    }
+
+    public void Save(ProxyCredential credential)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+        string username = string.IsNullOrWhiteSpace(credential.Domain)
+            ? credential.Username
+            : $"{credential.Domain}\\{credential.Username}";
+        nint passwordPointer = Marshal.StringToCoTaskMemUni(credential.Password);
+        try
+        {
+            var nativeCredential = new NativeCredential
+            {
+                Type = CredentialTypeGeneric,
+                TargetName = TargetName,
+                CredentialBlobSize = credential.Password.Length * sizeof(char),
+                CredentialBlob = passwordPointer,
+                Persist = CredentialPersistLocalMachine,
+                UserName = username
+            };
+
+            if (!CredWrite(ref nativeCredential, 0))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+        }
+        finally
+        {
+            Marshal.ZeroFreeCoTaskMemUnicode(passwordPointer);
+        }
+    }
+
+    public void Delete()
+    {
+        if (CredDelete(TargetName, CredentialTypeGeneric, 0))
+        {
+            return;
+        }
+
+        int error = Marshal.GetLastWin32Error();
+        if (error != ErrorNotFound)
+        {
+            throw new Win32Exception(error);
+        }
+    }
+
+    private static (string Domain, string Username) SplitUsername(string value)
+    {
+        int separator = value.IndexOf('\\');
+        return separator > 0
+            ? (value[..separator], value[(separator + 1)..])
+            : (string.Empty, value);
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct NativeCredential
+    {
+        public int Flags;
+        public int Type;
+        public string TargetName;
+        public string? Comment;
+        public long LastWritten;
+        public int CredentialBlobSize;
+        public nint CredentialBlob;
+        public int Persist;
+        public int AttributeCount;
+        public nint Attributes;
+        public string? TargetAlias;
+        public string UserName;
+    }
+
+    [DllImport("advapi32.dll", EntryPoint = "CredReadW", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CredRead(string target, int type, int flags, out nint credential);
+
+    [DllImport("advapi32.dll", EntryPoint = "CredWriteW", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CredWrite(ref NativeCredential credential, int flags);
+
+    [DllImport("advapi32.dll", EntryPoint = "CredDeleteW", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CredDelete(string target, int type, int flags);
+
+    [DllImport("advapi32.dll")]
+    private static extern void CredFree(nint buffer);
+}

--- a/src/Foundry/Services/Settings/FoundryAppSettings.cs
+++ b/src/Foundry/Services/Settings/FoundryAppSettings.cs
@@ -42,6 +42,43 @@ public sealed class FoundryAppSettings
     /// Gets or sets anonymous telemetry preferences and identity.
     /// </summary>
     public TelemetryAppSettings Telemetry { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets network proxy preferences used only by the Foundry OSD desktop application.
+    /// </summary>
+    public ProxyAppSettings Proxy { get; set; } = new();
+}
+
+public enum ProxyMethod
+{
+    System,
+    Manual,
+    Direct
+}
+
+public enum ProxyAuthenticationMode
+{
+    Automatic,
+    None,
+    Explicit
+}
+
+/// <summary>
+/// Stores non-secret proxy preferences for the Foundry OSD desktop application.
+/// </summary>
+public sealed class ProxyAppSettings
+{
+    public ProxyMethod Method { get; set; } = ProxyMethod.System;
+
+    public ProxyAuthenticationMode AuthenticationMode { get; set; } = ProxyAuthenticationMode.Automatic;
+
+    public string Address { get; set; } = string.Empty;
+
+    public int Port { get; set; } = 8080;
+
+    public bool BypassLocalAddresses { get; set; } = true;
+
+    public string BypassList { get; set; } = string.Empty;
 }
 
 /// <summary>

--- a/src/Foundry/Services/Shell/NavigationRouteCatalog.cs
+++ b/src/Foundry/Services/Shell/NavigationRouteCatalog.cs
@@ -52,6 +52,7 @@ public static class NavigationRouteCatalog
         .. PrimaryRoutes,
         CreateSettings<SettingsPage>("SettingsPage.PageTitle", null),
         CreateSettings<GeneralSettingPage>("SettingsPage_GeneralCard.Header", typeof(SettingsPage)),
+        CreateSettings<ProxySettingPage>("SettingsPage_ProxyCard.Header", typeof(SettingsPage)),
         CreateSettings<ThemeSettingPage>("SettingsPage_ThemeCard.Header", typeof(SettingsPage)),
         CreateSettings<AppUpdateSettingPage>("SettingsPage_UpdateCard.Header", typeof(SettingsPage))
     ];

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>تعذر تصدير التشخيصات. تحقق من السجل للحصول على التفاصيل.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Диагностиката не можа да бъде експортирана. Проверете регистрационния файл за подробности.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Diagnostiku se nepodařilo exportovat. Podrobnosti najdete v protokolu.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Diagnostik kunne ikke eksporteres. Se logfilen for detaljer.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Die Diagnose konnte nicht exportiert werden. Weitere Details finden Sie im Protokoll.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Δεν ήταν δυνατή η εξαγωγή των διαγνωστικών. Ελέγξτε το αρχείο καταγραφής για λεπτομέρειες.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Diagnostics could not be exported. Check the log for details.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Diagnostics could not be exported. Check the log for details.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>No se pudieron exportar los diagnósticos. Consulte el registro para obtener más detalles.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>No se pudieron exportar los diagnósticos. Revise el registro para obtener más detalles.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Diagnostikat ei saanud eksportida. Vaadake üksikasju logist.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Diagnostiikkaa ei voitu viedä. Tarkista lokista lisätiedot.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Les diagnostics n’ont pas pu être exportés. Consultez le journal pour plus de détails.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configurez la manière dont Foundry OSD se connecte aux services en ligne.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD uniquement</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>Ces paramètres s’appliquent uniquement à cette application. Ils ne sont pas ajoutés au média de déploiement et n’affectent ni Foundry Connect ni Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Méthode de proxy</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choisissez comment Foundry OSD se connecte à Internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Utiliser les paramètres Windows (recommandé)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Proxy manuel</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>Aucun proxy (connexion directe)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Serveur proxy</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Saisissez l’adresse et le port du proxy.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Contourner les adresses locales</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Se connecter directement aux noms d’hôte ne contenant pas de point.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Liste d’exclusion</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Noms d’hôte ou motifs génériques facultatifs, séparés par des points-virgules.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentification</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choisissez comment le proxy authentifie Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Utiliser les identifiants Windows actuels</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>Aucune authentification</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Nom d’utilisateur et mot de passe</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Identifiants du proxy</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Les identifiants sont stockés de manière sécurisée dans le Gestionnaire d’identification Windows.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Nom d’utilisateur</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domaine (facultatif)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Mot de passe</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Appliquer</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Tester la connexion</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Paramètres du proxy appliqués</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>Les nouvelles connexions de Foundry OSD utilisent désormais ces paramètres.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Vérifiez les paramètres du proxy</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connexion réussie</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD a joint les services GitHub et Microsoft avec les paramètres sélectionnés.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Échec de la connexion</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Saisissez un nom d’utilisateur et un mot de passe pour l’authentification explicite du proxy.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Les diagnostics n’ont pas pu être exportés. Consultez le journal pour plus de détails.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configurez la manière dont Foundry OSD se connecte aux services en ligne.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD uniquement</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>Ces paramètres s’appliquent uniquement à cette application. Ils ne sont pas ajoutés au média de déploiement et n’affectent ni Foundry Connect ni Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Méthode de proxy</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choisissez comment Foundry OSD se connecte à Internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Utiliser les paramètres Windows (recommandé)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Proxy manuel</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>Aucun proxy (connexion directe)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Serveur proxy</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Saisissez l’adresse et le port du proxy.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Contourner les adresses locales</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Se connecter directement aux noms d’hôte ne contenant pas de point.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Liste d’exclusion</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Noms d’hôte ou motifs génériques facultatifs, séparés par des points-virgules.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentification</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choisissez comment le proxy authentifie Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Utiliser les identifiants Windows actuels</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>Aucune authentification</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Nom d’utilisateur et mot de passe</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Identifiants du proxy</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Les identifiants sont stockés de manière sécurisée dans le Gestionnaire d’identification Windows.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Nom d’utilisateur</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domaine (facultatif)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Mot de passe</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Appliquer</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Tester la connexion</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Paramètres du proxy appliqués</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>Les nouvelles connexions de Foundry OSD utilisent désormais ces paramètres.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Vérifiez les paramètres du proxy</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connexion réussie</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD a joint les services GitHub et Microsoft avec les paramètres sélectionnés.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Échec de la connexion</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Saisissez un nom d’utilisateur et un mot de passe pour l’authentification explicite du proxy.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>לא ניתן היה לייצא את האבחון. בדוק את היומן לפרטים.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Dijagnostiku nije bilo moguće izvesti. Provjerite zapisnik za detalje.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>A diagnosztikát nem sikerült exportálni. Részletekért ellenőrizze a naplót.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Non è stato possibile esportare la diagnostica. Controlla il log per i dettagli.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>診断をエクスポートできませんでした。詳細はログを確認してください。</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>진단을 내보낼 수 없습니다. 자세한 내용은 로그를 확인하세요.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Nepavyko eksportuoti diagnostikos. Išsamesnės informacijos ieškokite žurnale.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Diagnostiku neizdevās eksportēt. Plašāku informāciju skatiet žurnālā.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Diagnostikken kunne ikke eksporteres. Se loggen for detaljer.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Diagnostiek kon niet worden geëxporteerd. Controleer het logboek voor details.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Nie można było wyeksportować diagnostyki. Sprawdź dziennik, aby uzyskać szczegóły.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Não foi possível exportar os diagnósticos. Verifique o log para obter detalhes.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Não foi possível exportar os diagnósticos. Consulte o registo para obter detalhes.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Diagnosticele nu au putut fi exportate. Verificați jurnalul pentru detalii.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Не удалось экспортировать диагностику. Подробности см. в журнале.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Diagnostiku sa nepodarilo exportovať. Podrobnosti nájdete v denníku.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Diagnostike ni bilo mogoče izvoziti. Za podrobnosti preverite dnevnik.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Dijagnostiku nije bilo moguće izvesti. Proverite dnevnik za detalje.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Det gick inte att exportera diagnostik. Kontrollera loggen för mer information.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>ไม่สามารถส่งออกข้อมูลการวินิจฉัยได้ โปรดตรวจสอบบันทึกเพื่อดูรายละเอียด</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Tanılama dışa aktarılamadı. Ayrıntılar için günlüğü denetleyin.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>Не вдалося експортувати діагностику. Перевірте журнал для отримання подробиць.</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>无法导出诊断信息。请检查日志以获取详细信息。</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -2791,4 +2791,115 @@
   <data name="Diagnostics.ExportFailedMessage" xml:space="preserve">
     <value>無法匯出診斷資訊。請檢查記錄以取得詳細資料。</value>
   </data>
+  <data name="SettingsPage_ProxyCard.Header" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
+    <value>Configure how Foundry OSD connects to online services.</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Title" xml:space="preserve">
+    <value>Foundry OSD only</value>
+  </data>
+  <data name="Proxy_ScopeInfo.Message" xml:space="preserve">
+    <value>These settings apply only to this app. They are not added to deployment media and do not affect Foundry Connect or Foundry Deploy.</value>
+  </data>
+  <data name="Proxy_MethodCard.Header" xml:space="preserve">
+    <value>Proxy method</value>
+  </data>
+  <data name="Proxy_MethodCard.Description" xml:space="preserve">
+    <value>Choose how Foundry OSD connects to the internet.</value>
+  </data>
+  <data name="Proxy_MethodSystem.Content" xml:space="preserve">
+    <value>Use Windows settings (recommended)</value>
+  </data>
+  <data name="Proxy_MethodManual.Content" xml:space="preserve">
+    <value>Manual proxy</value>
+  </data>
+  <data name="Proxy_MethodDirect.Content" xml:space="preserve">
+    <value>No proxy (direct connection)</value>
+  </data>
+  <data name="Proxy_EndpointCard.Header" xml:space="preserve">
+    <value>Proxy server</value>
+  </data>
+  <data name="Proxy_EndpointCard.Description" xml:space="preserve">
+    <value>Enter the proxy address and port.</value>
+  </data>
+  <data name="Proxy_AddressTextBox.PlaceholderText" xml:space="preserve">
+    <value>proxy.contoso.com</value>
+  </data>
+  <data name="Proxy_PortNumberBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Header" xml:space="preserve">
+    <value>Bypass local addresses</value>
+  </data>
+  <data name="Proxy_BypassLocalCard.Description" xml:space="preserve">
+    <value>Connect directly to host names that do not contain a period.</value>
+  </data>
+  <data name="Proxy_BypassListCard.Header" xml:space="preserve">
+    <value>Bypass list</value>
+  </data>
+  <data name="Proxy_BypassListCard.Description" xml:space="preserve">
+    <value>Optional host names or wildcard patterns separated by semicolons.</value>
+  </data>
+  <data name="Proxy_BypassListTextBox.PlaceholderText" xml:space="preserve">
+    <value>*.contoso.com;downloads.example.net</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Header" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationCard.Description" xml:space="preserve">
+    <value>Choose how the proxy authenticates Foundry OSD.</value>
+  </data>
+  <data name="Proxy_AuthenticationAutomatic.Content" xml:space="preserve">
+    <value>Use current Windows credentials</value>
+  </data>
+  <data name="Proxy_AuthenticationNone.Content" xml:space="preserve">
+    <value>No authentication</value>
+  </data>
+  <data name="Proxy_AuthenticationExplicit.Content" xml:space="preserve">
+    <value>Username and password</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Header" xml:space="preserve">
+    <value>Proxy credentials</value>
+  </data>
+  <data name="Proxy_CredentialsCard.Description" xml:space="preserve">
+    <value>Credentials are stored securely in Windows Credential Manager.</value>
+  </data>
+  <data name="Proxy_UsernameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Proxy_DomainTextBox.PlaceholderText" xml:space="preserve">
+    <value>Domain (optional)</value>
+  </data>
+  <data name="Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Proxy_ApplyButton.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Proxy_TestButton.Content" xml:space="preserve">
+    <value>Test connection</value>
+  </data>
+  <data name="Proxy.Status.SavedTitle" xml:space="preserve">
+    <value>Proxy settings applied</value>
+  </data>
+  <data name="Proxy.Status.SavedMessage" xml:space="preserve">
+    <value>New connections from Foundry OSD now use these settings.</value>
+  </data>
+  <data name="Proxy.Status.InvalidTitle" xml:space="preserve">
+    <value>Check the proxy settings</value>
+  </data>
+  <data name="Proxy.Status.SuccessTitle" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="Proxy.Status.SuccessMessage" xml:space="preserve">
+    <value>Foundry OSD reached GitHub and Microsoft services using the selected settings.</value>
+  </data>
+  <data name="Proxy.Status.FailedTitle" xml:space="preserve">
+    <value>Connection failed</value>
+  </data>
+  <data name="Proxy.Validation.CredentialsRequired" xml:space="preserve">
+    <value>Enter a username and password for explicit proxy authentication.</value>
+  </data>
 </root>

--- a/src/Foundry/ViewModels/Settings/ProxySettingViewModel.cs
+++ b/src/Foundry/ViewModels/Settings/ProxySettingViewModel.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Services.Localization;
+using Foundry.Services.Networking;
+using Foundry.Services.Settings;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Foundry.ViewModels;
+
+public sealed partial class ProxySettingViewModel : ObservableObject
+{
+    private readonly IApplicationProxyService proxyService;
+    private readonly IApplicationLocalizationService localizationService;
+
+    public ProxySettingViewModel(
+        IAppSettingsService appSettingsService,
+        IApplicationProxyService proxyService,
+        IApplicationLocalizationService localizationService)
+    {
+        this.proxyService = proxyService;
+        this.localizationService = localizationService;
+        ProxyAppSettings settings = appSettingsService.Current.Proxy;
+        Method = settings.Method;
+        AuthenticationMode = settings.AuthenticationMode;
+        Address = settings.Address;
+        Port = settings.Port;
+        BypassLocalAddresses = settings.BypassLocalAddresses;
+        BypassList = settings.BypassList;
+        ProxyCredential? credential = proxyService.ReadCredential();
+        Username = credential?.Username ?? string.Empty;
+        Domain = credential?.Domain ?? string.Empty;
+        Password = credential?.Password ?? string.Empty;
+    }
+
+    [ObservableProperty] public partial ProxyMethod Method { get; set; }
+    [ObservableProperty] public partial ProxyAuthenticationMode AuthenticationMode { get; set; }
+    [ObservableProperty] public partial string Address { get; set; }
+    [ObservableProperty] public partial int Port { get; set; }
+    [ObservableProperty] public partial bool BypassLocalAddresses { get; set; }
+    [ObservableProperty] public partial string BypassList { get; set; }
+    [ObservableProperty] public partial string Username { get; set; }
+    [ObservableProperty] public partial string Domain { get; set; }
+    [ObservableProperty] public partial string Password { get; set; }
+    [ObservableProperty] public partial bool IsBusy { get; set; }
+    [ObservableProperty] public partial bool IsStatusOpen { get; set; }
+    [ObservableProperty] public partial string StatusTitle { get; set; } = string.Empty;
+    [ObservableProperty] public partial string StatusMessage { get; set; } = string.Empty;
+    [ObservableProperty] public partial InfoBarSeverity StatusSeverity { get; set; }
+
+    public void Apply()
+    {
+        try
+        {
+            ApplySettings();
+            SetStatus("Proxy.Status.SavedTitle", "Proxy.Status.SavedMessage", InfoBarSeverity.Success);
+        }
+        catch (Exception ex)
+        {
+            SetStatus("Proxy.Status.InvalidTitle", ex.Message, InfoBarSeverity.Error, false);
+        }
+    }
+
+    public async Task TestConnectionAsync()
+    {
+        IsBusy = true;
+        IsStatusOpen = false;
+        try
+        {
+            (ProxyAppSettings settings, ProxyCredential? credential) = CreateCandidate();
+            await proxyService.TestConnectionAsync(settings, credential);
+            SetStatus("Proxy.Status.SuccessTitle", "Proxy.Status.SuccessMessage", InfoBarSeverity.Success);
+        }
+        catch (Exception ex)
+        {
+            SetStatus("Proxy.Status.FailedTitle", ex.Message, InfoBarSeverity.Error, false);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private void ApplySettings()
+    {
+        (ProxyAppSettings settings, ProxyCredential? credential) = CreateCandidate();
+        proxyService.ApplyAndSave(settings, credential);
+    }
+
+    private (ProxyAppSettings Settings, ProxyCredential? Credential) CreateCandidate()
+    {
+        ProxyCredential? credential = null;
+        if (Method == ProxyMethod.Manual && AuthenticationMode == ProxyAuthenticationMode.Explicit)
+        {
+            if (string.IsNullOrWhiteSpace(Username) || string.IsNullOrEmpty(Password))
+            {
+                throw new ArgumentException(localizationService.GetString("Proxy.Validation.CredentialsRequired"));
+            }
+
+            credential = new ProxyCredential(Username.Trim(), Domain.Trim(), Password);
+        }
+
+        return (new ProxyAppSettings
+        {
+            Method = Method,
+            AuthenticationMode = AuthenticationMode,
+            Address = Address,
+            Port = Port,
+            BypassLocalAddresses = BypassLocalAddresses,
+            BypassList = BypassList
+        }, credential);
+    }
+
+    private void SetStatus(string titleKey, string message, InfoBarSeverity severity, bool localizeMessage = true)
+    {
+        StatusTitle = localizationService.GetString(titleKey);
+        StatusMessage = localizeMessage ? localizationService.GetString(message) : message;
+        StatusSeverity = severity;
+        IsStatusOpen = true;
+    }
+}

--- a/src/Foundry/Views/Settings/ProxySettingPage.xaml
+++ b/src/Foundry/Views/Settings/ProxySettingPage.xaml
@@ -1,0 +1,115 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Page x:Class="Foundry.Views.ProxySettingPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:wct="using:CommunityToolkit.WinUI.Controls"
+    mc:Ignorable="d">
+    <ScrollView
+        Margin="{ThemeResource ContentPageMargin}"
+        Padding="{ThemeResource ContentPagePadding}"
+        VerticalScrollBarVisibility="Auto">
+        <StackPanel Spacing="{ThemeResource FoundryCompactStackSpacing}">
+            <InfoBar
+                x:Uid="Proxy_ScopeInfo"
+                IsClosable="False"
+                IsOpen="True"
+                Severity="Informational" />
+            <wct:SettingsCard x:Uid="Proxy_MethodCard">
+                <wct:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE774;" />
+                </wct:SettingsCard.HeaderIcon>
+                <ComboBox x:Name="MethodComboBox"
+                    SelectionChanged="MethodComboBox_SelectionChanged">
+                    <ComboBoxItem
+                        x:Uid="Proxy_MethodSystem"
+                        Tag="System" />
+                    <ComboBoxItem
+                        x:Uid="Proxy_MethodManual"
+                        Tag="Manual" />
+                    <ComboBoxItem
+                        x:Uid="Proxy_MethodDirect"
+                        Tag="Direct" />
+                </ComboBox>
+            </wct:SettingsCard>
+            <StackPanel x:Name="ManualSettingsPanel"
+                Spacing="{ThemeResource FoundryCompactStackSpacing}">
+                <wct:SettingsCard x:Uid="Proxy_EndpointCard">
+                    <StackPanel
+                        Orientation="Horizontal"
+                        Spacing="8">
+                        <TextBox
+                            x:Uid="Proxy_AddressTextBox"
+                            MinWidth="260"
+                            Text="{x:Bind ViewModel.Address, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <NumberBox x:Name="PortNumberBox"
+                            x:Uid="Proxy_PortNumberBox"
+                            Width="110"
+                            Maximum="65535"
+                            Minimum="1"
+                            SpinButtonPlacementMode="Compact"
+                            ValueChanged="PortNumberBox_ValueChanged" />
+                    </StackPanel>
+                </wct:SettingsCard>
+                <wct:SettingsCard x:Uid="Proxy_BypassLocalCard">
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.BypassLocalAddresses, Mode=TwoWay}" />
+                </wct:SettingsCard>
+                <wct:SettingsCard x:Uid="Proxy_BypassListCard">
+                    <TextBox
+                        x:Uid="Proxy_BypassListTextBox"
+                        MinWidth="360"
+                        Text="{x:Bind ViewModel.BypassList, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </wct:SettingsCard>
+                <wct:SettingsCard x:Uid="Proxy_AuthenticationCard">
+                    <ComboBox x:Name="AuthenticationComboBox"
+                        SelectionChanged="AuthenticationComboBox_SelectionChanged">
+                        <ComboBoxItem
+                            x:Uid="Proxy_AuthenticationAutomatic"
+                            Tag="Automatic" />
+                        <ComboBoxItem
+                            x:Uid="Proxy_AuthenticationNone"
+                            Tag="None" />
+                        <ComboBoxItem
+                            x:Uid="Proxy_AuthenticationExplicit"
+                            Tag="Explicit" />
+                    </ComboBox>
+                </wct:SettingsCard>
+                <wct:SettingsCard x:Name="CredentialsCard"
+                    x:Uid="Proxy_CredentialsCard">
+                    <StackPanel
+                        MinWidth="360"
+                        Spacing="8">
+                        <TextBox
+                            x:Uid="Proxy_UsernameTextBox"
+                            Text="{x:Bind ViewModel.Username, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <TextBox
+                            x:Uid="Proxy_DomainTextBox"
+                            Text="{x:Bind ViewModel.Domain, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <PasswordBox x:Name="PasswordBox"
+                            x:Uid="Proxy_PasswordBox" />
+                    </StackPanel>
+                </wct:SettingsCard>
+            </StackPanel>
+            <StackPanel
+                Orientation="Horizontal"
+                Spacing="8">
+                <Button
+                    x:Uid="Proxy_ApplyButton"
+                    Click="ApplyButton_Click" />
+                <Button x:Name="TestButton"
+                    x:Uid="Proxy_TestButton"
+                    Click="TestButton_Click" />
+                <ProgressRing
+                    Width="20"
+                    Height="20"
+                    IsActive="{x:Bind ViewModel.IsBusy, Mode=OneWay}" />
+            </StackPanel>
+            <InfoBar
+                Title="{x:Bind ViewModel.StatusTitle, Mode=OneWay}"
+                IsOpen="{x:Bind ViewModel.IsStatusOpen, Mode=TwoWay}"
+                Message="{x:Bind ViewModel.StatusMessage, Mode=OneWay}"
+                Severity="{x:Bind ViewModel.StatusSeverity, Mode=OneWay}" />
+        </StackPanel>
+    </ScrollView>
+</Page>

--- a/src/Foundry/Views/Settings/ProxySettingPage.xaml
+++ b/src/Foundry/Views/Settings/ProxySettingPage.xaml
@@ -23,6 +23,7 @@
                         <FontIcon Glyph="&#xE774;" />
                     </wct:SettingsCard.HeaderIcon>
                     <ComboBox x:Name="MethodComboBox"
+                        Width="{ThemeResource FoundryWideInputMinWidth}"
                         SelectionChanged="MethodComboBox_SelectionChanged">
                         <ComboBoxItem
                             x:Uid="Proxy_MethodSystem"
@@ -72,6 +73,7 @@
                     </wct:SettingsCard>
                     <wct:SettingsCard x:Uid="Proxy_AuthenticationCard">
                         <ComboBox x:Name="AuthenticationComboBox"
+                            Width="{ThemeResource FoundryWideInputMinWidth}"
                             SelectionChanged="AuthenticationComboBox_SelectionChanged">
                             <ComboBoxItem
                                 x:Uid="Proxy_AuthenticationAutomatic"

--- a/src/Foundry/Views/Settings/ProxySettingPage.xaml
+++ b/src/Foundry/Views/Settings/ProxySettingPage.xaml
@@ -16,8 +16,7 @@
                 IsClosable="False"
                 IsOpen="True"
                 Severity="Informational" />
-            <StackPanel
-                Spacing="{ThemeResource FoundryCompactStackSpacing}">
+            <StackPanel Spacing="{ThemeResource FoundryCompactStackSpacing}">
                 <wct:SettingsCard x:Uid="Proxy_MethodCard">
                     <wct:SettingsCard.HeaderIcon>
                         <FontIcon Glyph="&#xE774;" />
@@ -51,8 +50,8 @@
                                 MinWidth="{ThemeResource FoundryCompactInputMinWidth}"
                                 Text="{x:Bind ViewModel.Address, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <NumberBox x:Name="PortNumberBox"
-                                Grid.Column="1"
                                 x:Uid="Proxy_PortNumberBox"
+                                Grid.Column="1"
                                 Width="112"
                                 Maximum="65535"
                                 Minimum="1"

--- a/src/Foundry/Views/Settings/ProxySettingPage.xaml
+++ b/src/Foundry/Views/Settings/ProxySettingPage.xaml
@@ -10,106 +10,120 @@
         Margin="{ThemeResource ContentPageMargin}"
         Padding="{ThemeResource ContentPagePadding}"
         VerticalScrollBarVisibility="Auto">
-        <StackPanel Spacing="{ThemeResource FoundryCompactStackSpacing}">
+        <StackPanel Spacing="{ThemeResource FoundrySpace24}">
             <InfoBar
                 x:Uid="Proxy_ScopeInfo"
                 IsClosable="False"
                 IsOpen="True"
                 Severity="Informational" />
-            <wct:SettingsCard x:Uid="Proxy_MethodCard">
-                <wct:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE774;" />
-                </wct:SettingsCard.HeaderIcon>
-                <ComboBox x:Name="MethodComboBox"
-                    SelectionChanged="MethodComboBox_SelectionChanged">
-                    <ComboBoxItem
-                        x:Uid="Proxy_MethodSystem"
-                        Tag="System" />
-                    <ComboBoxItem
-                        x:Uid="Proxy_MethodManual"
-                        Tag="Manual" />
-                    <ComboBoxItem
-                        x:Uid="Proxy_MethodDirect"
-                        Tag="Direct" />
-                </ComboBox>
-            </wct:SettingsCard>
-            <StackPanel x:Name="ManualSettingsPanel"
+            <StackPanel
                 Spacing="{ThemeResource FoundryCompactStackSpacing}">
-                <wct:SettingsCard x:Uid="Proxy_EndpointCard">
-                    <StackPanel
-                        Orientation="Horizontal"
-                        Spacing="8">
-                        <TextBox
-                            x:Uid="Proxy_AddressTextBox"
-                            MinWidth="260"
-                            Text="{x:Bind ViewModel.Address, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                        <NumberBox x:Name="PortNumberBox"
-                            x:Uid="Proxy_PortNumberBox"
-                            Width="110"
-                            Maximum="65535"
-                            Minimum="1"
-                            SpinButtonPlacementMode="Compact"
-                            ValueChanged="PortNumberBox_ValueChanged" />
-                    </StackPanel>
-                </wct:SettingsCard>
-                <wct:SettingsCard x:Uid="Proxy_BypassLocalCard">
-                    <ToggleSwitch IsOn="{x:Bind ViewModel.BypassLocalAddresses, Mode=TwoWay}" />
-                </wct:SettingsCard>
-                <wct:SettingsCard x:Uid="Proxy_BypassListCard">
-                    <TextBox
-                        x:Uid="Proxy_BypassListTextBox"
-                        MinWidth="360"
-                        Text="{x:Bind ViewModel.BypassList, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                </wct:SettingsCard>
-                <wct:SettingsCard x:Uid="Proxy_AuthenticationCard">
-                    <ComboBox x:Name="AuthenticationComboBox"
-                        SelectionChanged="AuthenticationComboBox_SelectionChanged">
+                <wct:SettingsCard x:Uid="Proxy_MethodCard">
+                    <wct:SettingsCard.HeaderIcon>
+                        <FontIcon Glyph="&#xE774;" />
+                    </wct:SettingsCard.HeaderIcon>
+                    <ComboBox x:Name="MethodComboBox"
+                        SelectionChanged="MethodComboBox_SelectionChanged">
                         <ComboBoxItem
-                            x:Uid="Proxy_AuthenticationAutomatic"
-                            Tag="Automatic" />
+                            x:Uid="Proxy_MethodSystem"
+                            Tag="System" />
                         <ComboBoxItem
-                            x:Uid="Proxy_AuthenticationNone"
-                            Tag="None" />
+                            x:Uid="Proxy_MethodManual"
+                            Tag="Manual" />
                         <ComboBoxItem
-                            x:Uid="Proxy_AuthenticationExplicit"
-                            Tag="Explicit" />
+                            x:Uid="Proxy_MethodDirect"
+                            Tag="Direct" />
                     </ComboBox>
                 </wct:SettingsCard>
-                <wct:SettingsCard x:Name="CredentialsCard"
-                    x:Uid="Proxy_CredentialsCard">
-                    <StackPanel
-                        MinWidth="360"
-                        Spacing="8">
+                <StackPanel x:Name="ManualSettingsPanel"
+                    Spacing="{ThemeResource FoundryCompactStackSpacing}">
+                    <wct:SettingsCard
+                        x:Uid="Proxy_EndpointCard"
+                        HorizontalContentAlignment="Stretch">
+                        <Grid ColumnSpacing="{ThemeResource FoundryInlineControlSpacing}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBox
+                                x:Uid="Proxy_AddressTextBox"
+                                MinWidth="{ThemeResource FoundryCompactInputMinWidth}"
+                                Text="{x:Bind ViewModel.Address, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <NumberBox x:Name="PortNumberBox"
+                                Grid.Column="1"
+                                x:Uid="Proxy_PortNumberBox"
+                                Width="112"
+                                Maximum="65535"
+                                Minimum="1"
+                                SpinButtonPlacementMode="Compact"
+                                ValueChanged="PortNumberBox_ValueChanged" />
+                        </Grid>
+                    </wct:SettingsCard>
+                    <wct:SettingsCard x:Uid="Proxy_BypassLocalCard">
+                        <ToggleSwitch IsOn="{x:Bind ViewModel.BypassLocalAddresses, Mode=TwoWay}" />
+                    </wct:SettingsCard>
+                    <wct:SettingsCard
+                        x:Uid="Proxy_BypassListCard"
+                        HorizontalContentAlignment="Stretch">
                         <TextBox
-                            x:Uid="Proxy_UsernameTextBox"
-                            Text="{x:Bind ViewModel.Username, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                        <TextBox
-                            x:Uid="Proxy_DomainTextBox"
-                            Text="{x:Bind ViewModel.Domain, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                        <PasswordBox x:Name="PasswordBox"
-                            x:Uid="Proxy_PasswordBox" />
-                    </StackPanel>
-                </wct:SettingsCard>
+                            x:Uid="Proxy_BypassListTextBox"
+                            MinWidth="{ThemeResource FoundryCompactInputMinWidth}"
+                            Text="{x:Bind ViewModel.BypassList, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </wct:SettingsCard>
+                    <wct:SettingsCard x:Uid="Proxy_AuthenticationCard">
+                        <ComboBox x:Name="AuthenticationComboBox"
+                            SelectionChanged="AuthenticationComboBox_SelectionChanged">
+                            <ComboBoxItem
+                                x:Uid="Proxy_AuthenticationAutomatic"
+                                Tag="Automatic" />
+                            <ComboBoxItem
+                                x:Uid="Proxy_AuthenticationNone"
+                                Tag="None" />
+                            <ComboBoxItem
+                                x:Uid="Proxy_AuthenticationExplicit"
+                                Tag="Explicit" />
+                        </ComboBox>
+                    </wct:SettingsCard>
+                    <wct:SettingsCard x:Name="CredentialsCard"
+                        x:Uid="Proxy_CredentialsCard"
+                        HorizontalContentAlignment="Stretch">
+                        <StackPanel
+                            MinWidth="{ThemeResource FoundryCompactInputMinWidth}"
+                            Spacing="{ThemeResource FoundryInlineControlSpacing}">
+                            <TextBox
+                                x:Uid="Proxy_UsernameTextBox"
+                                Text="{x:Bind ViewModel.Username, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBox
+                                x:Uid="Proxy_DomainTextBox"
+                                Text="{x:Bind ViewModel.Domain, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <PasswordBox x:Name="PasswordBox"
+                                x:Uid="Proxy_PasswordBox" />
+                        </StackPanel>
+                    </wct:SettingsCard>
+                </StackPanel>
             </StackPanel>
-            <StackPanel
-                Orientation="Horizontal"
-                Spacing="8">
-                <Button
-                    x:Uid="Proxy_ApplyButton"
-                    Click="ApplyButton_Click" />
-                <Button x:Name="TestButton"
-                    x:Uid="Proxy_TestButton"
-                    Click="TestButton_Click" />
-                <ProgressRing
-                    Width="20"
-                    Height="20"
-                    IsActive="{x:Bind ViewModel.IsBusy, Mode=OneWay}" />
+            <StackPanel Spacing="{ThemeResource FoundryContentGroupSpacing}">
+                <StackPanel
+                    Orientation="Horizontal"
+                    Spacing="{ThemeResource FoundryInlineControlSpacing}">
+                    <Button
+                        x:Uid="Proxy_ApplyButton"
+                        Click="ApplyButton_Click"
+                        Style="{ThemeResource AccentButtonStyle}" />
+                    <Button x:Name="TestButton"
+                        x:Uid="Proxy_TestButton"
+                        Click="TestButton_Click" />
+                    <ProgressRing
+                        Width="20"
+                        Height="20"
+                        IsActive="{x:Bind ViewModel.IsBusy, Mode=OneWay}" />
+                </StackPanel>
+                <InfoBar
+                    Title="{x:Bind ViewModel.StatusTitle, Mode=OneWay}"
+                    IsOpen="{x:Bind ViewModel.IsStatusOpen, Mode=TwoWay}"
+                    Message="{x:Bind ViewModel.StatusMessage, Mode=OneWay}"
+                    Severity="{x:Bind ViewModel.StatusSeverity, Mode=OneWay}" />
             </StackPanel>
-            <InfoBar
-                Title="{x:Bind ViewModel.StatusTitle, Mode=OneWay}"
-                IsOpen="{x:Bind ViewModel.IsStatusOpen, Mode=TwoWay}"
-                Message="{x:Bind ViewModel.StatusMessage, Mode=OneWay}"
-                Severity="{x:Bind ViewModel.StatusSeverity, Mode=OneWay}" />
         </StackPanel>
     </ScrollView>
 </Page>

--- a/src/Foundry/Views/Settings/ProxySettingPage.xaml.cs
+++ b/src/Foundry/Views/Settings/ProxySettingPage.xaml.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Services.Settings;
+using Foundry.ViewModels;
+
+namespace Foundry.Views;
+
+public sealed partial class ProxySettingPage : Page
+{
+    private bool isInitializing = true;
+
+    public ProxySettingViewModel ViewModel { get; }
+
+    public ProxySettingPage()
+    {
+        ViewModel = App.GetService<ProxySettingViewModel>();
+        InitializeComponent();
+        SelectItem(MethodComboBox, ViewModel.Method.ToString());
+        SelectItem(AuthenticationComboBox, ViewModel.AuthenticationMode.ToString());
+        PortNumberBox.Value = ViewModel.Port;
+        PasswordBox.Password = ViewModel.Password;
+        isInitializing = false;
+        UpdateVisibility();
+    }
+
+    private void MethodComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (!isInitializing && MethodComboBox.SelectedItem is ComboBoxItem { Tag: string value } && Enum.TryParse(value, true, out ProxyMethod method))
+        {
+            ViewModel.Method = method;
+            UpdateVisibility();
+        }
+    }
+
+    private void AuthenticationComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (!isInitializing && AuthenticationComboBox.SelectedItem is ComboBoxItem { Tag: string value } && Enum.TryParse(value, true, out ProxyAuthenticationMode mode))
+        {
+            ViewModel.AuthenticationMode = mode;
+            UpdateVisibility();
+        }
+    }
+
+    private void PortNumberBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+    {
+        if (!isInitializing && !double.IsNaN(args.NewValue))
+        {
+            ViewModel.Port = (int)args.NewValue;
+        }
+    }
+
+    private void ApplyButton_Click(object sender, RoutedEventArgs e)
+    {
+        ViewModel.Password = PasswordBox.Password;
+        ViewModel.Apply();
+    }
+
+    private async void TestButton_Click(object sender, RoutedEventArgs e)
+    {
+        ViewModel.Password = PasswordBox.Password;
+        TestButton.IsEnabled = false;
+        try
+        {
+            await ViewModel.TestConnectionAsync();
+        }
+        finally
+        {
+            TestButton.IsEnabled = true;
+        }
+    }
+
+    private void UpdateVisibility()
+    {
+        ManualSettingsPanel.Visibility = ViewModel.Method == ProxyMethod.Manual ? Visibility.Visible : Visibility.Collapsed;
+        CredentialsCard.Visibility = ViewModel.AuthenticationMode == ProxyAuthenticationMode.Explicit ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private static void SelectItem(ComboBox comboBox, string value)
+    {
+        comboBox.SelectedItem = comboBox.Items.OfType<ComboBoxItem>()
+            .FirstOrDefault(item => string.Equals(item.Tag as string, value, StringComparison.Ordinal));
+    }
+}

--- a/src/Foundry/Views/SettingsPage.xaml
+++ b/src/Foundry/Views/SettingsPage.xaml
@@ -31,6 +31,14 @@
                     behaviors:LocalizedToggleSwitch.UseLocalizedStateContent="True"
                     IsOn="{x:Bind ViewModel.IsTelemetryEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </wct:SettingsCard>
+            <wct:SettingsCard x:Name="ProxySettingsCard"
+                x:Uid="SettingsPage_ProxyCard"
+                Click="ProxySettingsCard_Click"
+                IsClickEnabled="True">
+                <wct:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE774;" />
+                </wct:SettingsCard.HeaderIcon>
+            </wct:SettingsCard>
             <wct:SettingsCard x:Name="ThemeSettingsCard"
                 x:Uid="SettingsPage_ThemeCard"
                 Click="ThemeSettingsCard_Click"

--- a/src/Foundry/Views/SettingsPage.xaml.cs
+++ b/src/Foundry/Views/SettingsPage.xaml.cs
@@ -64,6 +64,11 @@ namespace Foundry.Views
             App.Current.NavigationService.NavigateTo(typeof(ThemeSettingPage));
         }
 
+        private void ProxySettingsCard_Click(object sender, RoutedEventArgs e)
+        {
+            App.Current.NavigationService.NavigateTo(typeof(ProxySettingPage));
+        }
+
         private void UpdateSettingsCard_Click(object sender, RoutedEventArgs e)
         {
             App.Current.NavigationService.NavigateTo(typeof(AppUpdateSettingPage));
@@ -97,6 +102,7 @@ namespace Foundry.Views
         {
             GeneralSettingsCard.IsEnabled = true;
             ThemeSettingsCard.IsEnabled = true;
+            ProxySettingsCard.IsEnabled = true;
             UpdateSettingsCard.IsEnabled = true;
         }
     }


### PR DESCRIPTION
## Summary
Add Foundry OSD-only proxy configuration under Settings.

## Reason
Foundry OSD needs an application-level proxy configuration for environments where online services require a system or authenticated proxy.

## Main changes
- add Windows, manual, and direct connection modes
- support current Windows credentials, no authentication, and explicit credentials stored in Windows Credential Manager
- apply proxy changes to Foundry OSD outbound connections without adding them to deployment media or affecting Foundry Connect or Foundry Deploy
- add a non-destructive GitHub and Microsoft connectivity test
- record only the proxy method and authentication mode in telemetry
- remove stale credentials when a saved proxy configuration is invalid

## Testing
- `dotnet build src\Foundry.slnx --configuration Release --no-restore`
- all six x64 Release test executables
- `scripts\Test-FoundryFormat.ps1`