### PR TITLE
feat(format): enforce resource file formatting

### DIFF
--- a/scripts/Format-Foundry.ps1
+++ b/scripts/Format-Foundry.ps1
@@ -1,8 +1,143 @@
+param(
+    [switch]$VerifyResourceFormatting,
+    [string[]]$ResourceFiles
+)
+
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $solutionPath = Join-Path $repoRoot 'src\Foundry.slnx'
 $toolManifestPath = Join-Path $repoRoot '.config\dotnet-tools.json'
+if (-not $PSBoundParameters.ContainsKey('ResourceFiles')) {
+    $ResourceFiles = git -C $repoRoot ls-files '*.resw' '*.resx'
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Failed to list tracked resource files.'
+    }
+}
+
+function Format-ResourceWhitespaceNode {
+    param(
+        [Parameter(Mandatory)]
+        [System.Xml.XmlNode]$Node,
+
+        [Parameter(Mandatory)]
+        [string]$CarriageReturnToken
+    )
+
+    foreach ($childNode in @($Node.ChildNodes)) {
+        $isTextNode = $childNode.NodeType -in @(
+            [System.Xml.XmlNodeType]::Text,
+            [System.Xml.XmlNodeType]::Whitespace,
+            [System.Xml.XmlNodeType]::SignificantWhitespace)
+
+        if ($isTextNode -and
+            $Node.LocalName -notin @('value', 'comment') -and
+            [string]::IsNullOrWhiteSpace($childNode.Value)) {
+            [void]$Node.RemoveChild($childNode)
+        }
+        elseif ($isTextNode -and $Node.LocalName -eq 'value' -and $childNode.Value.Contains("`r")) {
+            $childNode.Value = $childNode.Value.Replace("`r", $CarriageReturnToken)
+        }
+        elseif ($childNode.HasChildNodes) {
+            Format-ResourceWhitespaceNode -Node $childNode -CarriageReturnToken $CarriageReturnToken
+        }
+    }
+}
+
+function ConvertTo-CanonicalResourceXml {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $document = [System.Xml.XmlDocument]::new()
+    $document.PreserveWhitespace = $true
+    $reader = [System.Xml.XmlReader]::Create($Path)
+    try {
+        $document.Load($reader)
+    }
+    finally {
+        $reader.Dispose()
+    }
+
+    $carriageReturnToken = "__FOUNDRY_XML_CR_$([System.Guid]::NewGuid().ToString('N'))__"
+    Format-ResourceWhitespaceNode -Node $document -CarriageReturnToken $carriageReturnToken
+
+    $dataNodes = [System.Collections.Generic.List[System.Xml.XmlElement]]::new()
+    foreach ($dataNode in $document.DocumentElement.SelectNodes('data')) {
+        $dataNodes.Add($dataNode)
+    }
+
+    $dataNodes.Sort([System.Comparison[System.Xml.XmlElement]] {
+            param($left, $right)
+
+            return [System.StringComparer]::Ordinal.Compare(
+                $left.GetAttribute('name'),
+                $right.GetAttribute('name'))
+        })
+
+    foreach ($dataNode in $dataNodes) {
+        [void]$document.DocumentElement.RemoveChild($dataNode)
+    }
+
+    foreach ($dataNode in $dataNodes) {
+        [void]$document.DocumentElement.AppendChild($dataNode)
+    }
+
+    $settings = [System.Xml.XmlWriterSettings]::new()
+    $settings.Encoding = [System.Text.UTF8Encoding]::new($false)
+    $settings.Indent = $true
+    $settings.IndentChars = '  '
+    $settings.NewLineChars = "`r`n"
+    $settings.NewLineHandling = [System.Xml.NewLineHandling]::Replace
+    $settings.OmitXmlDeclaration = $false
+
+    $stream = [System.IO.MemoryStream]::new()
+    try {
+        $writer = [System.Xml.XmlWriter]::Create($stream, $settings)
+        try {
+            $document.Save($writer)
+        }
+        finally {
+            $writer.Dispose()
+        }
+
+        $formattedXml = [System.Text.Encoding]::UTF8.GetString($stream.ToArray())
+    }
+    finally {
+        $stream.Dispose()
+    }
+
+    return $formattedXml.Replace($carriageReturnToken, '&#xD;').TrimEnd("`r", "`n") + "`r`n"
+}
+
+$invalidResourceFiles = @()
+foreach ($resourceFile in $ResourceFiles) {
+    $resourcePath = Join-Path $repoRoot $resourceFile
+    $actualBytes = [System.IO.File]::ReadAllBytes($resourcePath)
+    $expectedBytes = [System.Text.Encoding]::UTF8.GetBytes(
+        (ConvertTo-CanonicalResourceXml -Path $resourcePath))
+
+    if ([System.Convert]::ToBase64String($actualBytes) -cne [System.Convert]::ToBase64String($expectedBytes)) {
+        if ($VerifyResourceFormatting) {
+            $invalidResourceFiles += $resourceFile
+        }
+        else {
+            [System.IO.File]::WriteAllBytes($resourcePath, $expectedBytes)
+            Write-Output "Formatted resource file: $resourceFile"
+        }
+    }
+}
+
+if ($VerifyResourceFormatting) {
+    if ($invalidResourceFiles.Count -gt 0) {
+        $invalidResourceFiles | ForEach-Object { Write-Output "Resource formatting required: $_" }
+        throw 'Resource formatting verification failed. Run scripts\Format-Foundry.ps1.'
+    }
+
+    return
+}
+
 $xamlFiles = git -C $repoRoot ls-files '*.xaml'
 if ($LASTEXITCODE -ne 0) {
     throw 'Failed to list tracked XAML files.'

--- a/scripts/Format-Foundry.ps1
+++ b/scripts/Format-Foundry.ps1
@@ -1,18 +1,13 @@
-param(
-    [switch]$VerifyResourceFormatting,
-    [string[]]$ResourceFiles
-)
+param([switch]$VerifyResourceFormatting)
 
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $solutionPath = Join-Path $repoRoot 'src\Foundry.slnx'
 $toolManifestPath = Join-Path $repoRoot '.config\dotnet-tools.json'
-if (-not $PSBoundParameters.ContainsKey('ResourceFiles')) {
-    $ResourceFiles = git -C $repoRoot ls-files '*.resw' '*.resx'
-    if ($LASTEXITCODE -ne 0) {
-        throw 'Failed to list tracked resource files.'
-    }
+$resourceFiles = git -C $repoRoot ls-files '*.resw' '*.resx'
+if ($LASTEXITCODE -ne 0) {
+    throw 'Failed to list tracked resource files.'
 }
 
 function Format-ResourceWhitespaceNode {
@@ -31,7 +26,7 @@ function Format-ResourceWhitespaceNode {
             [System.Xml.XmlNodeType]::SignificantWhitespace)
 
         if ($isTextNode -and
-            $Node.LocalName -notin @('value', 'comment') -and
+            $Node.LocalName -ne 'value' -and
             [string]::IsNullOrWhiteSpace($childNode.Value)) {
             [void]$Node.RemoveChild($childNode)
         }
@@ -116,7 +111,7 @@ function ConvertTo-CanonicalResourceXml {
 }
 
 $invalidResourceFiles = @()
-foreach ($resourceFile in $ResourceFiles) {
+foreach ($resourceFile in $resourceFiles) {
     $resourcePath = Join-Path $repoRoot $resourceFile
     $actualBytes = [System.IO.File]::ReadAllBytes($resourcePath)
     $expectedBytes = [System.Text.Encoding]::UTF8.GetBytes(

--- a/scripts/Format-Foundry.ps1
+++ b/scripts/Format-Foundry.ps1
@@ -65,6 +65,10 @@ function ConvertTo-CanonicalResourceXml {
 
     $dataNodes = [System.Collections.Generic.List[System.Xml.XmlElement]]::new()
     foreach ($dataNode in $document.DocumentElement.SelectNodes('data')) {
+        foreach ($commentNode in @($dataNode.SelectNodes('comment'))) {
+            [void]$dataNode.RemoveChild($commentNode)
+        }
+
         $dataNodes.Add($dataNode)
     }
 

--- a/scripts/Test-FoundryFormat.ps1
+++ b/scripts/Test-FoundryFormat.ps1
@@ -3,6 +3,75 @@ $ErrorActionPreference = 'Stop'
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $solutionPath = Join-Path $repoRoot 'src\Foundry.slnx'
 $toolManifestPath = Join-Path $repoRoot '.config\dotnet-tools.json'
+
+function Get-ChangedResourceFile {
+    $resourceFiles = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase)
+
+    $workingTreeFiles = git -C $repoRoot diff --name-only --diff-filter=ACMR HEAD -- '*.resw' '*.resx'
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Failed to list locally changed resource files.'
+    }
+
+    foreach ($resourceFile in $workingTreeFiles) {
+        [void]$resourceFiles.Add($resourceFile)
+    }
+
+    $baseBranch = if ($env:GITHUB_BASE_REF) { $env:GITHUB_BASE_REF } else { 'main' }
+    $baseReference = "refs/remotes/origin/$baseBranch"
+    git -C $repoRoot show-ref --verify --quiet $baseReference
+    if ($LASTEXITCODE -ne 0 -and $env:GITHUB_BASE_REF) {
+        git -C $repoRoot fetch --no-tags --depth=1 origin "$($baseBranch):$baseReference"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to fetch base branch '$baseBranch'."
+        }
+    }
+
+    git -C $repoRoot show-ref --verify --quiet $baseReference
+    if ($LASTEXITCODE -eq 0) {
+        $mergeBase = git -C $repoRoot merge-base HEAD $baseReference
+        if ($LASTEXITCODE -ne 0 -and $env:GITHUB_BASE_REF) {
+            $isShallowRepository = git -C $repoRoot rev-parse --is-shallow-repository
+            if ($LASTEXITCODE -ne 0) {
+                throw 'Failed to determine whether the repository is shallow.'
+            }
+
+            if ($isShallowRepository -eq 'true') {
+                git -C $repoRoot fetch --no-tags --unshallow origin
+            }
+            else {
+                git -C $repoRoot fetch --no-tags origin $baseBranch
+            }
+
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to fetch history for base branch '$baseBranch'."
+            }
+
+            $mergeBase = git -C $repoRoot merge-base HEAD $baseReference
+        }
+
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to determine the merge base with '$baseReference'."
+        }
+
+        $branchFiles = git -C $repoRoot diff --name-only --diff-filter=ACMR "$mergeBase..HEAD" -- '*.resw' '*.resx'
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Failed to list resource files changed on the current branch.'
+        }
+
+        foreach ($resourceFile in $branchFiles) {
+            [void]$resourceFiles.Add($resourceFile)
+        }
+    }
+
+    return @($resourceFiles | Sort-Object)
+}
+
+$resourceFiles = Get-ChangedResourceFile
+if ($resourceFiles.Count -gt 0) {
+    & (Join-Path $PSScriptRoot 'Format-Foundry.ps1') -VerifyResourceFormatting -ResourceFiles $resourceFiles
+}
+
 $xamlFiles = git -C $repoRoot ls-files '*.xaml'
 if ($LASTEXITCODE -ne 0) {
     throw 'Failed to list tracked XAML files.'

--- a/scripts/Test-FoundryFormat.ps1
+++ b/scripts/Test-FoundryFormat.ps1
@@ -4,73 +4,7 @@ $repoRoot = Split-Path -Parent $PSScriptRoot
 $solutionPath = Join-Path $repoRoot 'src\Foundry.slnx'
 $toolManifestPath = Join-Path $repoRoot '.config\dotnet-tools.json'
 
-function Get-ChangedResourceFile {
-    $resourceFiles = [System.Collections.Generic.HashSet[string]]::new(
-        [System.StringComparer]::OrdinalIgnoreCase)
-
-    $workingTreeFiles = git -C $repoRoot diff --name-only --diff-filter=ACMR HEAD -- '*.resw' '*.resx'
-    if ($LASTEXITCODE -ne 0) {
-        throw 'Failed to list locally changed resource files.'
-    }
-
-    foreach ($resourceFile in $workingTreeFiles) {
-        [void]$resourceFiles.Add($resourceFile)
-    }
-
-    $baseBranch = if ($env:GITHUB_BASE_REF) { $env:GITHUB_BASE_REF } else { 'main' }
-    $baseReference = "refs/remotes/origin/$baseBranch"
-    git -C $repoRoot show-ref --verify --quiet $baseReference
-    if ($LASTEXITCODE -ne 0 -and $env:GITHUB_BASE_REF) {
-        git -C $repoRoot fetch --no-tags --depth=1 origin "$($baseBranch):$baseReference"
-        if ($LASTEXITCODE -ne 0) {
-            throw "Failed to fetch base branch '$baseBranch'."
-        }
-    }
-
-    git -C $repoRoot show-ref --verify --quiet $baseReference
-    if ($LASTEXITCODE -eq 0) {
-        $mergeBase = git -C $repoRoot merge-base HEAD $baseReference
-        if ($LASTEXITCODE -ne 0 -and $env:GITHUB_BASE_REF) {
-            $isShallowRepository = git -C $repoRoot rev-parse --is-shallow-repository
-            if ($LASTEXITCODE -ne 0) {
-                throw 'Failed to determine whether the repository is shallow.'
-            }
-
-            if ($isShallowRepository -eq 'true') {
-                git -C $repoRoot fetch --no-tags --unshallow origin
-            }
-            else {
-                git -C $repoRoot fetch --no-tags origin $baseBranch
-            }
-
-            if ($LASTEXITCODE -ne 0) {
-                throw "Failed to fetch history for base branch '$baseBranch'."
-            }
-
-            $mergeBase = git -C $repoRoot merge-base HEAD $baseReference
-        }
-
-        if ($LASTEXITCODE -ne 0) {
-            throw "Failed to determine the merge base with '$baseReference'."
-        }
-
-        $branchFiles = git -C $repoRoot diff --name-only --diff-filter=ACMR "$mergeBase..HEAD" -- '*.resw' '*.resx'
-        if ($LASTEXITCODE -ne 0) {
-            throw 'Failed to list resource files changed on the current branch.'
-        }
-
-        foreach ($resourceFile in $branchFiles) {
-            [void]$resourceFiles.Add($resourceFile)
-        }
-    }
-
-    return @($resourceFiles | Sort-Object)
-}
-
-$resourceFiles = Get-ChangedResourceFile
-if ($resourceFiles.Count -gt 0) {
-    & (Join-Path $PSScriptRoot 'Format-Foundry.ps1') -VerifyResourceFormatting -ResourceFiles $resourceFiles
-}
+& (Join-Path $PSScriptRoot 'Format-Foundry.ps1') -VerifyResourceFormatting
 
 $xamlFiles = git -C $repoRoot ls-files '*.xaml'
 if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
## Summary

Adds deterministic formatting and repository-wide validation for every tracked `.resx` and `.resw` file.

## Reason

Resource files were covered by `.editorconfig` but were not processed by the repository formatting scripts. This allowed inconsistent XML formatting, ordering, encoding, and unused resource comments.

## Main changes

- Canonicalize tracked resource files with UTF-8 without BOM, CRLF line endings, two-space indentation, and a final newline.
- Sort direct `<data>` elements ordinally by their `name` attribute.
- Remove direct `<comment>` elements from resource entries.
- Preserve resource names, values, schemas, headers, namespaces, and significant value whitespace.
- Make `Format-Foundry.ps1` apply the rules to all tracked resources.
- Make `Test-FoundryFormat.ps1` verify all tracked resources without modifying them.

## Testing notes

- A tracked-resource regression check confirmed that verification rejects a `<comment>` and that apply removes it while preserving the resource name and value.
- Applying the formatter processed all 116 tracked resources; 114 currently require canonicalization.
- The complete format verification passed after canonicalization: 0 changes across 1,172 C# files and 66/66 XAML files passed.
- PowerShell parsing, PSScriptAnalyzer, and `git diff --check` passed.
- Existing MSBuild warnings about missing local Foundry assemblies remain, but the format commands exit successfully.
- x64 and ARM64 builds were not run because this change is limited to formatting scripts.

## Scope

Only `scripts/Format-Foundry.ps1` and `scripts/Test-FoundryFormat.ps1` are included. Generated resource changes are intentionally excluded and should be committed separately. Until that normalization is committed, the repository-wide format check is expected to report the 114 existing noncanonical resources.