### PR TITLE
docs(agents): align instructions with GPT-6 Astra guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,12 @@ Instruction handling:
 - Read relevant repository and skill instructions before applying them, and resolve conflicts using the current task context
 - If a skill or repository instruction blocks progress, identify the exact file and instruction, explain its relevance, and distinguish an explicit requirement from an interpretation
 
+Skill and documentation tools:
+- Use Context7 when implementation or verification depends on library or framework APIs, setup, or version-specific behavior; resolve the relevant library and consult documentation matching the repository version before relying on memory
+- Use the relevant Superpowers skill when the task calls for its workflow, such as brainstorming, debugging, planning, implementation, review, or verification; read and apply the selected skill rather than merely naming it
+- Keep skill use proportional to the task and follow the instruction precedence above; do not invoke unrelated skills or add unnecessary workflow steps
+- If Context7 or a required skill is unavailable, state the limitation and continue with official documentation or an equivalent workflow where possible; do not claim to have used unavailable tools
+
 Verification scope:
 - Run the smallest checks that validate the changed behavior, plus all checks explicitly required by this repository
 - Broaden or repeat checks only when changes, failures, or unresolved risks justify doing so

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ Task execution:
 
 Instruction handling:
 - Follow applicable system and developer instructions; within those boundaries, explicit user instructions take precedence over skill guidance and repository defaults
+- For agent workflow defaults, follow current official OpenAI guidance for the model in use over conflicting repository or skill preferences, within the system, developer, and explicit user instructions above
+- Apply guidance relevant to the task; distinguish official recommendations from local implementation choices and preserve product contracts, architecture, and security constraints
 - Read relevant repository and skill instructions before applying them, and resolve conflicts using the current task context
 - If a skill or repository instruction blocks progress, identify the exact file and instruction, explain its relevance, and distinguish an explicit requirement from an interpretation
 
@@ -136,7 +138,7 @@ Logging rules:
 - Persist WinPE logs best-effort without allowing persistence failures to replace the primary application outcome
 - Export sanitized support bundles by default without modifying source logs; raw export must require an explicit sensitive-data warning
 - Fail closed when a source cannot be sanitized, and publish support archives atomically only after manifest and summary generation succeeds
-- Add logging only from the main agent, not from subagents
+- Apply these logging rules to all changes, including delegated work; the main agent reviews logging behavior during integration
 
 Documentation rules:
 - Update docs and README files when behavior, packaging, install paths, release assets, or user-facing workflows change
@@ -151,10 +153,13 @@ Documentation rules:
 - Prefer accurate comments over more comments
 
 Format and verification rules:
-- Before opening or updating a pull request, run `scripts\Test-FoundryFormat.ps1` from the repository root
-- If the format check fails, run `scripts\Format-Foundry.ps1`, review the resulting diff, and rerun `scripts\Test-FoundryFormat.ps1`
+- Before opening or updating a pull request that changes application code, XAML, resources, or formatting configuration, run `scripts\Test-FoundryFormat.ps1` from the repository root
+- For documentation-only or instruction-only changes, review the affected prose and links and run `git diff --check`; skip application formatting and runtime tests
+- For other changes, such as scripts or workflows, run checks appropriate to the affected files
+- If formatting fails in changed files, run `scripts\Format-Foundry.ps1`, review its output, retain only relevant edits, and rerun `scripts\Test-FoundryFormat.ps1`
+- If formatting fails solely on unchanged baseline files, report the failure without reformatting unrelated files
 - Treat `scripts\Test-FoundryFormat.ps1` as the source of truth for formatting checks
-- Include the format check result in pull request testing notes
+- Include the format check result in pull request testing notes, or explain why it was skipped for the change scope
 
 Git, worktree, and pull request rules:
 - Follow Conventional Commits for all commit messages
@@ -186,12 +191,11 @@ Git, worktree, and pull request rules:
 - Treat local ARM64 validation as required only for architecture-sensitive changes; both x64 and ARM64 CI checks remain blocking
 
 Subagent rules:
-- Use subagents when explicitly requested or when two or more independent read-only questions can be investigated in parallel while the main agent makes useful progress
-- Give each subagent a bounded question and clear scope, avoid duplicate exploration, and integrate its findings before deciding on changes
-- Use subagents only for read-only code exploration and analysis
-- Do not use subagents to modify files
-- Do not use subagents to write, add, or refactor logs
-- The main agent is responsible for all code edits, logging changes, commits, pushes, and pull requests
+- Delegate bounded, independent analysis, implementation, or verification tasks when parallel work materially improves delivery and the main agent can continue useful work
+- Keep simple or tightly coupled tasks local; do not delegate solely to increase agent count
+- Assign explicit file or module ownership for edits, avoid overlapping work, and tell subagents to preserve other contributors' changes
+- Give each subagent the relevant task context and acceptance criteria; avoid duplicate exploration
+- The main agent reviews and integrates delegated changes and owns final verification, commits, pushes, and pull requests
 
 Output rules:
 - Lead with the outcome and use plain, concise English

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,13 +8,11 @@ General behavior:
 - Follow the existing project structure and conventions
 
 Task execution:
-- Treat requests to implement, fix, or improve something as authorization to do the work, not merely propose a plan
-- Infer intent from the full conversation and carry the authorized task through implementation, relevant verification, and the requested delivery
-- Choose reasonable defaults for routine, reversible decisions; ask focused questions only when missing information materially changes scope, correctness, or an irreversible action
-- Continue independent authorized work while waiting for clarification
-- Incorporate new requirements and answer status questions without abandoning the original task unless the user cancels or replaces it
-- Before requesting approval for an action that needs it, complete the authorized preparation so the result is concrete and reviewable
-- Do not introduce approval steps or safety checklists for hypothetical risks; respect actual permission boundaries and repository constraints
+- Treat implementation requests as authorization to complete the scoped work, relevant verification, and requested delivery
+- Choose reasonable defaults for routine reversible decisions; ask only when missing information materially affects scope, correctness, or an irreversible action
+- Continue independent authorized work while awaiting clarification and prepare a reviewable result before requesting necessary approval
+- Incorporate follow-up requirements without abandoning the original task unless the user cancels or replaces it
+- Respect actual permission boundaries without adding approval steps for hypothetical risks
 
 Instruction handling:
 - Follow applicable system and developer instructions; within those boundaries, explicit user instructions take precedence over skill guidance and repository defaults
@@ -48,7 +46,7 @@ Project dependency rules:
 - Use `Foundry.Localization` for shared localization behavior instead of creating application-specific replacements.
 - Use `Foundry.Telemetry` for shared telemetry behavior instead of creating application-specific telemetry implementations.
 - `Foundry.Utilities` is a leaf project and must not reference another Foundry project.
-- `Foundry.Core`, `Foundry`, `Foundry.Connect`, `Foundry.Deploy`, and `Foundry.Localization` may consume `Foundry.Utilities` when a capability has a stable cross-project contract.
+- `Foundry.Core`, `Foundry`, `Foundry.Connect`, `Foundry.Deploy`, `Foundry.Localization`, and `Foundry.Telemetry` may consume `Foundry.Utilities` when a capability has a stable cross-project contract.
 - A type belongs in `Foundry.Utilities` only when it is technical, independently testable, and either has multiple consumers or replaces proven duplication.
 - Destructive deployment and media operations remain in the project that owns the workflow even when they use shared utility primitives.
 
@@ -80,9 +78,8 @@ Cleanup rules:
 
 Configuration schema rules:
 - Treat Foundry authoring configuration, Foundry.Deploy runtime configuration, and Foundry.Connect runtime configuration as separate schema contracts
-- Preserve the separate Foundry authoring, Foundry.Deploy runtime, and Foundry.Connect runtime configuration schemas when adding shared utility capabilities.
 - Treat the schema versions in the latest published GitHub Release tag as the production baseline; values present only on `main`, pull requests, or intermediate builds are not production versions
-- Set each affected schema version to the latest published GitHub Release version plus one, accumulating all unreleased contract changes under that single next version
+- Set each affected schema integer to its value in the source at the latest published release tag plus one; do not increment the product release number or accumulate multiple unreleased schema bumps
 - Do not increment a schema version again for additional unreleased changes before the next GitHub Release
 - Keep published schema versions monotonic within each contract
 - Bump a schema version only when the persisted or generated configuration contract changes in a way that affects runtime behavior or compatibility
@@ -90,8 +87,8 @@ Configuration schema rules:
 - Bump Foundry.Deploy runtime schema when Deploy consumes new generated configuration, requires new boot media assets, changes the meaning of an existing Deploy field, or needs older boot media to show a compatibility warning
 - Bump Foundry.Connect runtime schema when Connect consumes new generated configuration, requires new network provisioning assets, changes the meaning of an existing Connect field, or needs older boot media to show a compatibility warning
 - Do not bump schema versions for UI-only changes, localization updates, documentation changes, styling changes, internal refactors, or bug fixes that do not change the configuration contract
-- When bumping Deploy schema, update both the generator model in Foundry.Core and the runtime model in Foundry.Deploy
-- When bumping Connect schema, update both the generator model in Foundry.Core and the runtime model in Foundry.Connect
+- Update the affected constant in `src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs`; generated and runtime configurations share these constants
+- Verify the affected authoring, generator, runtime, and compatibility behavior when changing a schema contract
 - When bumping any schema, update the smallest relevant tests and compatibility warning expectations
 
 Unit testing rules:
@@ -113,7 +110,7 @@ Unit testing rules:
 - Do not create a test project for the `Foundry` WinUI 3 application.
 - Do not add automated tests for `Foundry` views, code-behind, bindings, navigation, or other WinUI 3 UI behavior.
 - Do not test WPF views, code-behind, bindings, or framework behavior unless explicitly requested.
-- Keep reusable business logic in `Foundry.Core` when it requires unit testing.
+- Test logic in its owning project; move it to `Foundry.Core` only when domain ownership and reuse justify it.
 
 Logging rules:
 - Use `FoundryLogConfiguration` for application file sinks so Foundry.OSD, Foundry.Connect, and Foundry.Deploy share the same structured text contract
@@ -123,7 +120,7 @@ Logging rules:
 - Use Debug as the default file level for WinPE Bootstrap, Foundry.Connect, and Foundry.Deploy; keep verbose console output opt-in
 - Write logs only when they add operational or diagnostic value
 - Use the log levels already defined by the project
-- Use Debug only for developer diagnostics
+- Use Debug for detailed troubleshooting; keep meaningful operation outcomes at Information or above
 - Use Information for meaningful lifecycle or business events
 - Use Warning for recoverable abnormal states
 - Use Error for failed operations that need attention
@@ -153,6 +150,9 @@ Documentation rules:
 - Prefer accurate comments over more comments
 
 Format and verification rules:
+- Use Windows and the .NET 10 SDK for `src/Foundry.slnx`; `.github/workflows/ci.yml` defines the build and test commands
+- Run the relevant executable test project with `dotnet run --project src/<Project>.Tests/<Project>.Tests.csproj -c Release -p:Platform=x64`; use `--no-build` only after building that configuration
+- The local documentation-only exemption does not skip CI: the current workflow runs Format and dependent x64 and ARM64 builds on PRs
 - Before opening or updating a pull request that changes application code, XAML, resources, or formatting configuration, run `scripts\Test-FoundryFormat.ps1` from the repository root
 - For documentation-only or instruction-only changes, review the affected prose and links and run `git diff --check`; skip application formatting and runtime tests
 - For other changes, such as scripts or workflows, run checks appropriate to the affected files
@@ -168,7 +168,7 @@ Git, worktree, and pull request rules:
 - Keep commits atomic and focused
 - Use a dedicated git worktree for implementation work when the task changes code
 - Create worktrees outside the main repository folder
-- Sync the base branch before creating a worktree
+- Fetch the remote base before creating a worktree; preserve existing checkout changes and reuse the task worktree for follow-ups
 - Create a focused branch for each implementation task
 - Keep branch names short, descriptive, and aligned with the task scope
 - Do not mix unrelated changes in the same branch
@@ -178,9 +178,9 @@ Git, worktree, and pull request rules:
 - If a merge is requested while required CI checks are pending, do not wait and do not merge; report the pending checks to the user
 - Check CI status before merging a pull request
 - Treat x64 and ARM64 CI checks as blocking for Foundry changes
-- Ignore submit-nuget failures unless the user explicitly asks to investigate that check
-- Prefer squash merge when merging Foundry pull requests
-- Delete merged feature branches and clean up worktrees after PR merge
+- Assess failures against the actual required checks; do not assume an unfamiliar check is non-blocking
+- Merge only when requested and follow the requested merge strategy
+- After a requested merge, clean up only the merged task branch and its clean worktree; preserve other work
 - Do not remove a worktree before merge unless the user explicitly approves it
 - Write pull request titles in English using Conventional Commits
 - Prefer scoped pull request titles when the change has a clear area, for example `feat(winpe): ...`, `fix(packaging): ...`, or `docs(readme): ...`
@@ -205,7 +205,5 @@ Output rules:
 - In the final response, state what changed, relevant verification, and any blocker or required follow-up without repeating the work log
 - Do not add emojis
 - Do not add unnecessary comments
-- Only explain decisions when useful
-- When making assumptions, choose the most reasonable one and proceed
 
 Instruction guidance source: [OpenAI GPT-6 Astra prompting best practices](https://developers.openai.com/api/docs/guides/latest-model#prompting-best-practices).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,26 @@ General behavior:
 - Avoid overengineering
 - Follow the existing project structure and conventions
 
+Task execution:
+- Treat requests to implement, fix, or improve something as authorization to do the work, not merely propose a plan
+- Infer intent from the full conversation and carry the authorized task through implementation, relevant verification, and the requested delivery
+- Choose reasonable defaults for routine, reversible decisions; ask focused questions only when missing information materially changes scope, correctness, or an irreversible action
+- Continue independent authorized work while waiting for clarification
+- Incorporate new requirements and answer status questions without abandoning the original task unless the user cancels or replaces it
+- Before requesting approval for an action that needs it, complete the authorized preparation so the result is concrete and reviewable
+- Do not introduce approval steps or safety checklists for hypothetical risks; respect actual permission boundaries and repository constraints
+
+Instruction handling:
+- Follow applicable system and developer instructions; within those boundaries, explicit user instructions take precedence over skill guidance and repository defaults
+- Read relevant repository and skill instructions before applying them, and resolve conflicts using the current task context
+- If a skill or repository instruction blocks progress, identify the exact file and instruction, explain its relevance, and distinguish an explicit requirement from an interpretation
+
+Verification scope:
+- Run the smallest checks that validate the changed behavior, plus all checks explicitly required by this repository
+- Broaden or repeat checks only when changes, failures, or unresolved risks justify doing so
+- For instruction-only or documentation-only edits, review accuracy, links, and the diff; do not add application tests solely to mirror prose
+- Report checks actually run and any limitations; do not claim unverified results
+
 Solution architecture and project ownership:
 - `Foundry` is the WinUI 3 authoring application. It owns the desktop authoring experience, navigation, views, view models, and UI-specific services used to configure and generate deployment media.
 - `Foundry.Core` contains shared business logic, configuration models, validation, media creation, Windows ADK and WinPE operations, Autopilot integration, and framework-independent orchestration used by the applications.
@@ -166,14 +186,22 @@ Git, worktree, and pull request rules:
 - Treat local ARM64 validation as required only for architecture-sensitive changes; both x64 and ARM64 CI checks remain blocking
 
 Subagent rules:
-- Use subagents when the user explicitly asks for them or when parallel read-only analysis materially helps the task
+- Use subagents when explicitly requested or when two or more independent read-only questions can be investigated in parallel while the main agent makes useful progress
+- Give each subagent a bounded question and clear scope, avoid duplicate exploration, and integrate its findings before deciding on changes
 - Use subagents only for read-only code exploration and analysis
 - Do not use subagents to modify files
 - Do not use subagents to write, add, or refactor logs
 - The main agent is responsible for all code edits, logging changes, commits, pushes, and pull requests
 
 Output rules:
+- Lead with the outcome and use plain, concise English
+- Prefer short paragraphs; use lists only for steps or genuinely parallel information
+- Explain decisions, tradeoffs, and technical details only when they help the user assess the result
+- During sustained work, provide brief updates on findings, remaining uncertainty, and the next step
+- In the final response, state what changed, relevant verification, and any blocker or required follow-up without repeating the work log
 - Do not add emojis
 - Do not add unnecessary comments
 - Only explain decisions when useful
 - When making assumptions, choose the most reasonable one and proceed
+
+Instruction guidance source: [OpenAI GPT-6 Astra prompting best practices](https://developers.openai.com/api/docs/guides/latest-model#prompting-best-practices).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ Instruction handling:
 Skill and documentation tools:
 - Use Context7 when implementation or verification depends on library or framework APIs, setup, or version-specific behavior; resolve the relevant library and consult documentation matching the repository version before relying on memory
 - Use the relevant Superpowers skill when the task calls for its workflow, such as brainstorming, debugging, planning, implementation, review, or verification; read and apply the selected skill rather than merely naming it
+- Use the relevant PostHog skill for Foundry telemetry instrumentation, event contracts, privacy behavior, analytics queries, or PostHog investigations; read and apply the task-specific skill before implementation or tool calls
+- Keep telemetry implementation in `Foundry.Telemetry` and relevant tests in `Foundry.Telemetry.Tests`; preserve consent and privacy contracts, and resolve the target PostHog project from verified context before accessing live data
 - Keep skill use proportional to the task and follow the instruction precedence above; do not invoke unrelated skills or add unnecessary workflow steps
 - If Context7 or a required skill is unavailable, state the limitation and continue with official documentation or an equivalent workflow where possible; do not claim to have used unavailable tools
 


### PR DESCRIPTION
## Summary
Align repository agent instructions with official GPT-6 Astra recommendations and the actual repository structure.

## Reason
Improve follow-through and remove stale or conflicting workflow guidance while keeping product and architecture constraints intact.

## Main changes
- Prioritize official model workflow guidance over conflicting local preferences, within higher-priority instructions.
- Define bounded delegation with explicit ownership and main-agent integration.
- Keep verification proportional, clarify worktree reuse, and remove repeated prose.
- Correct centralized schema versioning, Utilities consumers, runtime test ownership, and Debug logging guidance. Document executable .NET 10 test commands and local-versus-CI formatting scope. Remove the unsupported submit-nuget exemption and automatic squash preference.

- Require Context7 for relevant library/framework documentation and the applicable Superpowers workflow, with explicit unavailable-tool fallbacks.

- Require task-specific PostHog skills for telemetry and analytics work, preserving shared telemetry ownership and privacy contracts.

## Testing
- Audited instructions against tracked source, configuration, and workflows.
- Verified referenced repository paths and reviewed instruction consistency.
- git diff --check passed; only AGENTS.md changed.
- Application tests skipped for this instruction-only update.
- Earlier full formatting verification found existing resource-formatting failures. Formatter changes to 114 unrelated resource files were reviewed and reverted; no formatting changes are included. Local prose-only checks now apply, while existing CI remains unchanged.

Guidance: https://developers.openai.com/api/docs/guides/latest-model#prompting-best-practices

Left open for user review and merge; no commits squashed.