### PR TITLE
fix(proxy): refresh credentials for existing HTTP clients

### DIFF
--- a/src/Foundry.Core.Tests/Networking/MutableApplicationProxyAuthenticationTests.cs
+++ b/src/Foundry.Core.Tests/Networking/MutableApplicationProxyAuthenticationTests.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Foundry.Core.Services.Networking;
+
+namespace Foundry.Core.Tests.Networking;
+
+public sealed class MutableApplicationProxyAuthenticationTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ExistingClient_UsesCurrentCredentialsAfterPolicyChanges(bool initiallyAuthenticated)
+    {
+        await using var server = new ChallengeProxy();
+        var proxy = new MutableApplicationProxy(CreatePolicy(server.Endpoint,
+            initiallyAuthenticated ? new NetworkCredential("old", "secret") : null));
+        using var client = new HttpClient(new HttpClientHandler { Proxy = proxy }) { Timeout = TimeSpan.FromSeconds(10) };
+
+        await AssertResponseAsync(client, initiallyAuthenticated ? HttpStatusCode.OK : HttpStatusCode.ProxyAuthenticationRequired,
+            initiallyAuthenticated ? "Basic b2xkOnNlY3JldA==" : string.Empty);
+
+        proxy.Update(CreatePolicy(server.Endpoint, new NetworkCredential("new", "password")));
+        await AssertResponseAsync(client, HttpStatusCode.OK, "Basic bmV3OnBhc3N3b3Jk");
+
+        proxy.Update(CreatePolicy(server.Endpoint, null));
+        await AssertResponseAsync(client, HttpStatusCode.ProxyAuthenticationRequired, string.Empty);
+
+        proxy.Update(CreatePolicy(server.Endpoint, CredentialCache.DefaultNetworkCredentials));
+        await AssertResponseAsync(client, HttpStatusCode.ProxyAuthenticationRequired, string.Empty);
+    }
+
+    [Fact]
+    public async Task ExistingClient_DoesNotSendPreviousCredentialsToNewProxy()
+    {
+        await using var first = new ChallengeProxy();
+        await using var second = new ChallengeProxy();
+        var proxy = new MutableApplicationProxy(CreatePolicy(first.Endpoint, new NetworkCredential("old", "secret")));
+        using var client = new HttpClient(new HttpClientHandler { Proxy = proxy }) { Timeout = TimeSpan.FromSeconds(10) };
+        await AssertResponseAsync(client, HttpStatusCode.OK, "Basic b2xkOnNlY3JldA==");
+
+        proxy.Update(CreatePolicy(second.Endpoint, new NetworkCredential("new", "password")));
+
+        await AssertResponseAsync(client, HttpStatusCode.OK, "Basic bmV3OnBhc3N3b3Jk");
+    }
+
+    [Fact]
+    public void CachedCredentials_DoNotSendNewCredentialsToPreviousEndpoint()
+    {
+        var previousEndpoint = new Uri("http://old-proxy:8080");
+        var endpoint = new Uri("http://new-proxy:8080");
+        var proxy = new MutableApplicationProxy(CreatePolicy(previousEndpoint, new NetworkCredential("old", "secret")));
+        ICredentials credentials = proxy.Credentials!;
+        proxy.GetProxy(new Uri("https://example.com"));
+
+        proxy.Update(CreatePolicy(endpoint, new NetworkCredential("new", "password")));
+        proxy.GetProxy(new Uri("https://example.com"));
+
+        Assert.Null(credentials.GetCredential(previousEndpoint, "Basic"));
+        Assert.Equal("new", credentials.GetCredential(endpoint, "Basic")?.UserName);
+    }
+
+    [Fact]
+    public void CachedCredentials_UsesWindowsIdentityOnlyForIntegratedAuthentication()
+    {
+        var endpoint = new Uri("http://proxy:8080");
+        var proxy = new MutableApplicationProxy(CreatePolicy(endpoint, new NetworkCredential("old", "secret")));
+        ICredentials credentials = proxy.Credentials!;
+        proxy.Update(CreatePolicy(endpoint, CredentialCache.DefaultNetworkCredentials));
+        proxy.GetProxy(new Uri("https://example.com"));
+
+        Assert.Same(CredentialCache.DefaultNetworkCredentials, credentials.GetCredential(endpoint, "Negotiate"));
+        Assert.Same(CredentialCache.DefaultNetworkCredentials, credentials.GetCredential(endpoint, "NTLM"));
+        Assert.Null(credentials.GetCredential(endpoint, "Basic"));
+        Assert.Null(credentials.GetCredential(endpoint, "Digest"));
+    }
+
+    private static IWebProxy CreatePolicy(Uri endpoint, ICredentials? credentials) =>
+        ApplicationProxyFactory.CreateManual(endpoint.Host, endpoint.Port, false, null, credentials);
+
+    private static async Task AssertResponseAsync(HttpClient client, HttpStatusCode status, string authorization)
+    {
+        using HttpResponseMessage response = await client.GetAsync("http://download.invalid/package");
+        Assert.Equal(status, response.StatusCode);
+        Assert.Equal(authorization, await response.Content.ReadAsStringAsync());
+    }
+
+    private sealed class ChallengeProxy : IAsyncDisposable
+    {
+        private readonly TcpListener listener = new(IPAddress.Loopback, 0);
+        private readonly CancellationTokenSource shutdown = new();
+        private readonly Task serverTask;
+
+        public ChallengeProxy()
+        {
+            listener.Start();
+            Endpoint = new Uri($"http://127.0.0.1:{((IPEndPoint)listener.LocalEndpoint).Port}");
+            serverTask = ServeAsync();
+        }
+
+        public Uri Endpoint { get; }
+
+        public async ValueTask DisposeAsync()
+        {
+            await shutdown.CancelAsync();
+            listener.Stop();
+            try
+            {
+                await serverTask;
+            }
+            catch (OperationCanceledException) when (shutdown.IsCancellationRequested)
+            {
+            }
+            finally
+            {
+                shutdown.Dispose();
+            }
+        }
+
+        private async Task ServeAsync()
+        {
+            while (true)
+            {
+                using TcpClient connection = await listener.AcceptTcpClientAsync(shutdown.Token);
+                using NetworkStream stream = connection.GetStream();
+                using var reader = new StreamReader(stream, Encoding.ASCII, false, leaveOpen: true);
+                string authorization = string.Empty;
+                while (await reader.ReadLineAsync(shutdown.Token) is { Length: > 0 } line)
+                {
+                    if (line.StartsWith("Proxy-Authorization:", StringComparison.OrdinalIgnoreCase))
+                    {
+                        authorization = line["Proxy-Authorization:".Length..].Trim();
+                    }
+                }
+
+                string status = authorization.Length == 0 ? "407 Proxy Authentication Required" : "200 OK";
+                string response = $"HTTP/1.1 {status}\r\nProxy-Authenticate: Basic realm=\"test\"\r\nConnection: close\r\nContent-Length: {authorization.Length}\r\n\r\n{authorization}";
+                await stream.WriteAsync(Encoding.ASCII.GetBytes(response), shutdown.Token);
+            }
+        }
+    }
+}

--- a/src/Foundry.Core/Services/Networking/MutableApplicationProxy.cs
+++ b/src/Foundry.Core/Services/Networking/MutableApplicationProxy.cs
@@ -2,33 +2,54 @@
 // Licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Concurrent;
 using System.Net;
 
 namespace Foundry.Core.Services.Networking;
 
 /// <summary>
-/// Keeps a stable proxy reference while allowing its active policy to change.
+/// Keeps stable proxy and credential references while allowing the active policy to change.
 /// </summary>
 public sealed class MutableApplicationProxy : IWebProxy
 {
-    private IWebProxy current;
+    private ProxyPolicy current;
+    private readonly ICredentials credentials;
 
     public MutableApplicationProxy(IWebProxy initial)
     {
         ArgumentNullException.ThrowIfNull(initial);
-        current = initial;
+        current = new ProxyPolicy(initial);
+        credentials = new CurrentProxyCredentials(this);
     }
 
+    /// <summary>
+    /// Resolves credentials at authentication time because HTTP handlers cache this reference.
+    /// Setting credentials updates the active policy without replacing the stable reference.
+    /// </summary>
     public ICredentials? Credentials
     {
-        get => Volatile.Read(ref current).Credentials;
-        set => Volatile.Read(ref current).Credentials = value;
+        get => credentials;
+        set => Volatile.Read(ref current).Proxy.Credentials = value;
     }
 
-    public Uri? GetProxy(Uri destination) => Volatile.Read(ref current).GetProxy(destination);
+    public Uri? GetProxy(Uri destination)
+    {
+        ProxyPolicy policy = Volatile.Read(ref current);
+        Uri? endpoint = policy.Proxy.GetProxy(destination);
+        if (endpoint is not null && endpoint != destination)
+        {
+            policy.Endpoints.TryAdd(endpoint, 0);
+        }
 
-    public bool IsBypassed(Uri host) => Volatile.Read(ref current).IsBypassed(host);
+        return endpoint;
+    }
 
+    public bool IsBypassed(Uri host) => Volatile.Read(ref current).Proxy.IsBypassed(host);
+
+    /// <summary>
+    /// Applies a policy to subsequent routing and authentication lookups. Existing authenticated
+    /// connections and authentication exchanges already in progress are not interrupted.
+    /// </summary>
     public void Update(IWebProxy proxy)
     {
         ArgumentNullException.ThrowIfNull(proxy);
@@ -37,6 +58,40 @@ public sealed class MutableApplicationProxy : IWebProxy
             throw new ArgumentException("A mutable proxy cannot reference itself.", nameof(proxy));
         }
 
-        Volatile.Write(ref current, proxy);
+        Volatile.Write(ref current, new ProxyPolicy(proxy));
+    }
+
+    private sealed class ProxyPolicy(IWebProxy proxy)
+    {
+        public IWebProxy Proxy { get; } = proxy;
+
+        // Track proxy endpoints, not destinations. Replacing the policy also drops old endpoints,
+        // so a delayed challenge from an old proxy cannot receive the new policy's credentials.
+        public ConcurrentDictionary<Uri, byte> Endpoints { get; } = new();
+    }
+
+    private sealed class CurrentProxyCredentials(MutableApplicationProxy owner) : ICredentials
+    {
+        public NetworkCredential? GetCredential(Uri uri, string authType)
+        {
+            ProxyPolicy policy = Volatile.Read(ref owner.current);
+            if (!policy.Endpoints.ContainsKey(uri))
+            {
+                return null;
+            }
+
+            NetworkCredential? credential = policy.Proxy.Credentials?.GetCredential(uri, authType);
+            if (ReferenceEquals(credential, CredentialCache.DefaultNetworkCredentials) &&
+                !authType.Equals("Negotiate", StringComparison.OrdinalIgnoreCase) &&
+                !authType.Equals("NTLM", StringComparison.OrdinalIgnoreCase) &&
+                !authType.Equals("Kerberos", StringComparison.OrdinalIgnoreCase))
+            {
+                // The handler cannot recognize default credentials through this wrapper.
+                // Windows identity is only valid for integrated authentication.
+                return null;
+            }
+
+            return credential;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Existing HTTP clients now use the current proxy credentials on subsequent authentication challenges after proxy settings are applied.

## Reason

.NET caches the proxy credentials reference when initializing a client. Replacing that reference left existing downloads using missing or stale credentials even when the settings page connection test succeeded.

## Main changes

- Keep a stable credential provider that resolves the active proxy policy at authentication time.
- Scope credential lookup to proxy endpoints resolved by that policy; replacing it prevents delayed challenges from old endpoints receiving new credentials.
- Preserve Windows integrated authentication and suppress default credentials for Basic/Digest.

## Testing

- Five regressions failed before the fix and pass afterward, including real loopback HTTP proxy challenges, credential replacement/removal and endpoint changes.
- `dotnet run --project src/Foundry.Core.Tests/Foundry.Core.Tests.csproj -c Release -p:Platform=x64`: 631 passed.
- `scripts/Test-FoundryFormat.ps1`: passed.
- `git diff --check`: passed; independent review completed.

Already-authenticated connections and authentication exchanges underway are not interrupted. A live Windows-domain proxy was not exercised. Local ARM64 execution was not required for this architecture-independent change; x64 and ARM64 CI remain required.