### PR TITLE
fix(telemetry): preserve terminal failure diagnostics

### DIFF
--- a/src/Foundry.Telemetry.Tests/PostHogRemoteDiagnosticsSinkTests.cs
+++ b/src/Foundry.Telemetry.Tests/PostHogRemoteDiagnosticsSinkTests.cs
@@ -112,6 +112,7 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
         await service.FlushAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(6, exporter.Records.Count);
+        Assert.Equal(6, exporter.ExceptionEvents.Count);
     }
 
     [Fact]
@@ -133,18 +134,26 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
     }
 
     [Fact]
-    public async Task Emit_DropsDuplicateExceptionInstance()
+    public async Task Emit_PreservesTerminalFailureAfterLowerLevelException()
     {
         var exporter = new RecordingExporter();
         await using var service = CreateService(exporter);
         service.Configure(RemoteDiagnosticsTestData.EnabledOptions(), RemoteDiagnosticsTestData.Context());
         var sharedException = new InvalidOperationException("failed");
 
-        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "failed", sharedException));
-        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "failed again", sharedException));
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(
+            LogEventLevel.Error, "Artifact download failed", sharedException, ("OperationId", "deployment-1")));
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(
+            LogEventLevel.Error, "Deployment failed", sharedException,
+            ("OperationId", "deployment-1"), ("Outcome", "failed"), ("FailureCode", "download_failed")));
         await service.FlushAsync(TestContext.Current.CancellationToken);
 
-        Assert.Single(exporter.Records);
+        Assert.Equal(2, exporter.Records.Count);
+        RemoteDiagnosticRecord terminal = exporter.Records[1];
+        Assert.Equal("failed", terminal.Attributes["operation.outcome"]);
+        Assert.Equal("download_failed", terminal.Attributes["failure.code"]);
+        Assert.NotNull(terminal.Exception);
+        Assert.Single(exporter.ExceptionEvents);
     }
 
     [Fact]
@@ -168,6 +177,45 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
         await service.FlushAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(2, exporter.Records.Count);
+        Assert.Equal(2, exporter.ExceptionEvents.Count);
+    }
+
+    [Fact]
+    public async Task Emit_WarningDoesNotSuppressLaterErrorTracking()
+    {
+        var exporter = new RecordingExporter();
+        await using var service = CreateService(exporter);
+        service.Configure(RemoteDiagnosticsTestData.EnabledOptions(), RemoteDiagnosticsTestData.Context());
+        var exception = new InvalidOperationException("failed");
+
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Warning, "retrying", exception));
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "failed", exception));
+        await service.FlushAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, exporter.Records.Count);
+        Assert.Single(exporter.ExceptionEvents);
+    }
+
+    [Fact]
+    public async Task Emit_RateLimitedExceptionDoesNotSuppressLaterTerminalErrorTracking()
+    {
+        var exporter = new RecordingExporter();
+        await using var service = CreateService(exporter);
+        service.Configure(RemoteDiagnosticsTestData.EnabledOptions(), RemoteDiagnosticsTestData.Context());
+        for (int index = 0; index < 5; index++)
+        {
+            service.Emit(RemoteDiagnosticsTestData.LogEvent(
+                LogEventLevel.Error, "download failed", new InvalidOperationException("failed")));
+        }
+
+        var exception = new InvalidOperationException("failed");
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "download failed", exception));
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "deployment failed", exception));
+        await service.FlushAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, service.DroppedRecordCount);
+        Assert.Equal(6, exporter.Records.Count);
+        Assert.Equal(6, exporter.ExceptionEvents.Count);
     }
 
     [Fact]
@@ -316,6 +364,10 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
 
     private class RecordingExporter : IRemoteDiagnosticsExporter
     {
+        private readonly RecordingEventClient _eventClient = new();
+
+        public List<string> ExceptionEvents => _eventClient.Events;
+
         public List<RemoteDiagnosticRecord> Records { get; } = [];
 
         public int ExportAttempts { get; private set; }
@@ -331,12 +383,28 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
             }
 
             Records.Add(record);
+            new PostHogExceptionTracker(_eventClient, "install-1").Track(record);
             return ValueTask.CompletedTask;
         }
 
         public virtual Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
         public virtual ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class RecordingEventClient : IPostHogEventClient
+    {
+        public List<string> Events { get; } = [];
+
+        public bool Capture(string distinctId, string eventName, Dictionary<string, object> properties, DateTimeOffset timestamp)
+        {
+            Events.Add(eventName);
+            return true;
+        }
+
+        public Task FlushAsync() => Task.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private sealed class BlockingExporter : RecordingExporter

--- a/src/Foundry.Telemetry/PostHogExceptionTracker.cs
+++ b/src/Foundry.Telemetry/PostHogExceptionTracker.cs
@@ -42,7 +42,7 @@ internal sealed partial class PostHogExceptionTracker(
 {
     public void Track(RemoteDiagnosticRecord record)
     {
-        if (record.Exception is null || record.Level < Serilog.Events.LogEventLevel.Error)
+        if (!record.ShouldTrackException || record.Exception is null || record.Level < Serilog.Events.LogEventLevel.Error)
         {
             return;
         }

--- a/src/Foundry.Telemetry/PostHogRemoteDiagnosticsSink.cs
+++ b/src/Foundry.Telemetry/PostHogRemoteDiagnosticsSink.cs
@@ -144,24 +144,29 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
                     return;
                 }
 
-                if (logEvent.Exception is not null && !TryAcquireException(logEvent.Exception, GetScalarText(logEvent, "OperationId")))
-                {
-                    return;
-                }
-
                 if (!TryAcquireFingerprint(logEvent))
                 {
                     Interlocked.Increment(ref _droppedRecordCount);
                     return;
                 }
 
-                RemoteDiagnosticRecord record = RemoteDiagnosticPropertyPolicy.CreateSanitizedRecord(logEvent, context);
+                RemoteDiagnosticRecord record = RemoteDiagnosticPropertyPolicy.CreateSanitizedRecord(logEvent, context) with
+                {
+                    ShouldTrackException = logEvent.Exception is not null &&
+                        logEvent.Level >= LogEventLevel.Error &&
+                        !HasTrackedException(logEvent.Exception, GetScalarText(logEvent, "OperationId"))
+                };
                 var queuedRecord = new QueuedRemoteDiagnosticRecord(
                     Volatile.Read(ref _consentGeneration),
                     record);
                 if (!channel.Writer.TryWrite(queuedRecord))
                 {
                     Interlocked.Increment(ref _droppedRecordCount);
+                }
+                else if (record.ShouldTrackException)
+                {
+                    _seenExceptions.GetValue(logEvent.Exception!, static _ => new ExceptionDedupeState())
+                        .OperationIds.Add(GetScalarText(logEvent, "OperationId"));
                 }
             }
         }
@@ -287,14 +292,9 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
             ? scalar.Value?.ToString() ?? string.Empty
             : string.Empty;
 
-    private bool TryAcquireException(Exception exception, string operationId)
-    {
-        ExceptionDedupeState state = _seenExceptions.GetValue(exception, static _ => new ExceptionDedupeState());
-        lock (state.OperationIds)
-        {
-            return state.OperationIds.Add(operationId);
-        }
-    }
+    private bool HasTrackedException(Exception exception, string operationId) =>
+        _seenExceptions.TryGetValue(exception, out ExceptionDedupeState? state) &&
+        state.OperationIds.Contains(operationId);
 
     private async Task ProcessQueueAsync(
         ChannelReader<QueuedRemoteDiagnosticRecord> reader,

--- a/src/Foundry.Telemetry/RemoteDiagnosticRecord.cs
+++ b/src/Foundry.Telemetry/RemoteDiagnosticRecord.cs
@@ -14,7 +14,13 @@ public sealed record RemoteDiagnosticRecord(
     LogEventLevel Level,
     string Body,
     IReadOnlyDictionary<string, object> Attributes,
-    RemoteDiagnosticException? Exception);
+    RemoteDiagnosticException? Exception)
+{
+    /// <summary>
+    /// Allows repeated log context to retain its exception without duplicating Error Tracking events.
+    /// </summary>
+    internal bool ShouldTrackException { get; init; } = true;
+}
 
 /// <summary>
 /// Represents a privacy-filtered exception chain.


### PR DESCRIPTION
## Summary

Retain classified terminal deployment diagnostics when a lower-level service has already logged the same exception in the same operation.

## Reason

Exception deduplication discarded the entire later record, losing its final outcome, failed step and failure classification from remote logs.

## Main changes

- Preserve eligible sanitized log records and deduplicate only Error Tracking events.
- Record exception deduplication only after successful queue admission; warnings and rejected records cannot suppress a later error event.
- Cover lower-level error followed by terminal failure, separate operations, warning escalation, rate limiting and consent reset.

## Testing

- Regression failed before the fix: expected two exported logs, received one.
- `dotnet run --project src/Foundry.Telemetry.Tests/Foundry.Telemetry.Tests.csproj -c Release -p:Platform=x64`: 91 passed.
- `scripts/Test-FoundryFormat.ps1`: passed.
- `git diff --check`: passed; independent review completed.

Transport behavior was tested with a recording exporter and the real exception tracker; no live PostHog project was used. Local ARM64 execution was not required for this architecture-independent change; x64 and ARM64 CI remain required.