### PR TITLE
fix(telemetry): order exception frames for PostHog

### DIFF
--- a/src/Foundry.Telemetry.Tests/PostHogExceptionTrackerTests.cs
+++ b/src/Foundry.Telemetry.Tests/PostHogExceptionTrackerTests.cs
@@ -10,6 +10,57 @@ namespace Foundry.Telemetry.Tests;
 public sealed class PostHogExceptionTrackerTests
 {
     [Fact]
+    public void Track_OrdersEachExceptionStackFromEntryPointToCrashSite()
+    {
+        var client = new RecordingPostHogEventClient();
+        var tracker = new PostHogExceptionTracker(client, "install-1");
+        var record = new RemoteDiagnosticRecord(
+            DateTimeOffset.UtcNow,
+            LogEventLevel.Error,
+            "Deployment failed",
+            new Dictionary<string, object>(),
+            new RemoteDiagnosticException(
+                "System.InvalidOperationException",
+                "redacted outer",
+                "   at Foundry.Deploy.Validate() in <redacted:path>:line 30\r\n" +
+                "   at Foundry.Deploy.Run() in <redacted:path>:line 20\r\n" +
+                "--- End of stack trace from previous location ---\r\n" +
+                "   at Foundry.Deploy.Main() in <redacted:path>:line 10",
+                [new RemoteDiagnosticException(
+                    "System.IO.IOException",
+                    "redacted inner",
+                    "   at System.Net.Http.HttpClient.Send()\n" +
+                    "   at Foundry.Deploy.Download() in <redacted:path>:line 40",
+                    [])]));
+
+        tracker.Track(record);
+
+        CapturedPostHogEvent captured = Assert.Single(client.Events);
+        var exceptions = Assert.IsType<List<Dictionary<string, object>>>(captured.Properties["$exception_list"]);
+        Assert.Collection(exceptions,
+            outer =>
+            {
+                Assert.Equal("System.InvalidOperationException", outer["type"]);
+                Assert.Collection(GetFrames(outer),
+                    frame => AssertFrame(frame, "Foundry.Deploy.Main()", 10),
+                    frame => AssertFrame(frame, "Foundry.Deploy.Run()", 20),
+                    frame => AssertFrame(frame, "Foundry.Deploy.Validate()", 30));
+            },
+            inner =>
+            {
+                Assert.Equal("System.IO.IOException", inner["type"]);
+                Assert.Collection(GetFrames(inner),
+                    frame => AssertFrame(frame, "Foundry.Deploy.Download()", 40),
+                    frame =>
+                    {
+                        Assert.Equal("System.Net.Http.HttpClient.Send()", frame["function"]);
+                        Assert.False(frame.ContainsKey("lineno"));
+                    });
+            });
+        Assert.DoesNotContain("<redacted:path>", captured.SerializedProperties, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Track_CapturesSanitizedExceptionChainWithoutPersonProfile()
     {
         var client = new RecordingPostHogEventClient();
@@ -125,10 +176,20 @@ public sealed class PostHogExceptionTrackerTests
     }
 
     private static Dictionary<string, object> GetSingleFrame(Dictionary<string, object> exception)
+        => Assert.Single(GetFrames(exception));
+
+    private static List<Dictionary<string, object>> GetFrames(Dictionary<string, object> exception)
     {
         var stackTrace = Assert.IsType<Dictionary<string, object>>(exception["stacktrace"]);
-        var frames = Assert.IsType<List<Dictionary<string, object>>>(stackTrace["frames"]);
-        return Assert.Single(frames);
+        return Assert.IsType<List<Dictionary<string, object>>>(stackTrace["frames"]);
+    }
+
+    private static void AssertFrame(Dictionary<string, object> frame, string function, int lineNumber)
+    {
+        Assert.Equal(function, frame["function"]);
+        Assert.Equal(lineNumber, frame["lineno"]);
+        Assert.False(frame.ContainsKey("filename"));
+        Assert.False(frame.ContainsKey("abs_path"));
     }
 
     private sealed record CapturedPostHogEvent(

--- a/src/Foundry.Telemetry/PostHogExceptionTracker.cs
+++ b/src/Foundry.Telemetry/PostHogExceptionTracker.cs
@@ -144,6 +144,8 @@ internal sealed partial class PostHogExceptionTracker(
             frames.Add(frame);
         }
 
+        // .NET stacks are crash-first; PostHog requires the entry point first.
+        frames.Reverse();
         return frames;
     }
 


### PR DESCRIPTION
## Summary

Serialize each exception stack from entry point to crash site for PostHog Error Tracking.

## Reason

.NET provides crash-first stacks, while PostHog's wire contract requires the oldest frame first. Sending the native order produced incorrect frame ordering for ingestion and display.

## Main changes

- Reverse parsed frames while preserving exception-chain order and sanitization.
- Add a multi-frame outer/inner exception regression, including stack separators and sanitized source lines.

## Testing

- Regression failed before the fix: expected Main first, received Validate.
- `dotnet run --project src/Foundry.Telemetry.Tests/Foundry.Telemetry.Tests.csproj -c Release -p:Platform=x64`: 90 passed.
- `scripts/Test-FoundryFormat.ps1`: passed.
- `git diff --check`: passed; independent review completed.
- Checked the [PostHog stack frame ordering contract](https://github.com/PostHog/sdk-specs/blob/main/openspec/specs/capture-exception/spec.md#requirement-stack-frame-ordering).

No live PostHog project was used. Local ARM64 execution was not required for this architecture-independent change; x64 and ARM64 CI remain required.