### PR TITLE
fix(connect): refresh Wi-Fi actions after connection changes

### DIFF
--- a/src/Foundry.Connect.Tests/MainWindowViewModelTests.cs
+++ b/src/Foundry.Connect.Tests/MainWindowViewModelTests.cs
@@ -23,8 +23,44 @@ using Serilog.Events;
 namespace Foundry.Connect.Tests;
 
 [Collection(ConnectRemoteDiagnosticsCollection.Name)]
-public sealed class MainWindowViewModelTelemetryTests
+public sealed class MainWindowViewModelTests
 {
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RefreshStatusCommand_WhenSelectedNetworkConnectionChanges_RefreshesWifiCommandAvailability(bool initiallyConnected)
+    {
+        static NetworkStatusSnapshot Snapshot(bool connected) => new()
+        {
+            LayoutMode = NetworkLayoutMode.EthernetWifi,
+            IsWifiRuntimeAvailable = true,
+            HasWirelessAdapter = true,
+            ConnectedWifiSsid = connected ? "Foundry" : null,
+            WifiNetworks = [new WifiNetworkSummary { Ssid = "Foundry", Authentication = "Open" }]
+        };
+
+        using MainWindowViewModel viewModel = CreateViewModel(
+            new RecordingTelemetryService(),
+            new QueueNetworkStatusService(Snapshot(initiallyConnected), Snapshot(!initiallyConnected)));
+        await viewModel.RefreshStatusCommand.ExecuteAsync(null);
+        viewModel.SelectedWifiNetwork = Assert.Single(viewModel.WifiNetworks);
+        MainWindowViewModel.WifiNetworkItemViewModel selectedNetwork = viewModel.SelectedWifiNetwork;
+        bool canConnect = viewModel.ConnectSelectedWifiCommand.CanExecute(null);
+        bool canDisconnect = viewModel.DisconnectSelectedWifiCommand.CanExecute(null);
+        Assert.Equal(!initiallyConnected, canConnect);
+        Assert.Equal(initiallyConnected, canDisconnect);
+        viewModel.ConnectSelectedWifiCommand.CanExecuteChanged += (_, _) =>
+            canConnect = viewModel.ConnectSelectedWifiCommand.CanExecute(null);
+        viewModel.DisconnectSelectedWifiCommand.CanExecuteChanged += (_, _) =>
+            canDisconnect = viewModel.DisconnectSelectedWifiCommand.CanExecute(null);
+
+        await viewModel.RefreshStatusCommand.ExecuteAsync(null);
+
+        Assert.Same(selectedNetwork, viewModel.SelectedWifiNetwork);
+        Assert.Equal(initiallyConnected, canConnect);
+        Assert.Equal(!initiallyConnected, canDisconnect);
+    }
+
     [Fact]
     public async Task InitializeAsync_WhenNetworkIsReady_DoesNotTrackSessionReadyImmediately()
     {

--- a/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
@@ -1003,6 +1003,8 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
             SelectedWifiPassphrase = string.Empty;
         }
 
+        ConnectSelectedWifiCommand.NotifyCanExecuteChanged();
+        DisconnectSelectedWifiCommand.NotifyCanExecuteChanged();
         OnPropertyChanged(nameof(HasWifiNetworks));
         OnPropertyChanged(nameof(WifiDiscoveryEmptyStateText));
         OnPropertyChanged(nameof(CanConnectSelectedWifi));


### PR DESCRIPTION
## Summary

Keep Connect's Wi-Fi action buttons in sync when Windows connects or disconnects the selected network.

## Reason

Snapshot refreshes reuse the selected network object. Updating its connection state does not invalidate the commands, so an available action can remain disabled until the operator changes selection.

## Main changes

- Notify both selected-network commands after Wi-Fi snapshot synchronization.
- Cover external connection and disconnection while retaining the selected network.
- Rename the existing view-model test class to reflect its broader coverage and reuse its fixtures.

## Testing

- [x] `.\scripts\Test-FoundryFormat.ps1` — passed locally and in CI.
- [x] x64 Release build and relevant tests — passed in CI.
- [x] ARM64 Release build and relevant tests — passed in CI.

Local Connect suite: 108 passed. Both new regression cases failed before the fix and passed afterward.

- [ ] Manual validation

Validation not run and reason: no live Wi-Fi or WinPE test; the regression exercises connection-state transitions on the real view model with controlled network snapshots.

## Additional information

- Breaking or schema changes: none.
