### PR TITLE
fix(connect): translate support export dialog buttons

### DIFF
--- a/src/Foundry.Connect.Tests/LocalizationResourceTests.cs
+++ b/src/Foundry.Connect.Tests/LocalizationResourceTests.cs
@@ -10,7 +10,7 @@ namespace Foundry.Connect.Tests;
 
 public sealed class LocalizationResourceTests
 {
-    public static TheoryData<string> SatelliteCultures => new()
+    public static TheoryData<string> SupportedCultures => new()
     {
         "ar-SA",
         "bg-BG",
@@ -19,6 +19,7 @@ public sealed class LocalizationResourceTests
         "de-DE",
         "el-GR",
         "en-GB",
+        "en-US",
         "es-ES",
         "es-MX",
         "et-EE",
@@ -52,8 +53,8 @@ public sealed class LocalizationResourceTests
     };
 
     [Theory]
-    [MemberData(nameof(SatelliteCultures))]
-    public void SatelliteResourceSet_IsAvailableForAdkCulture(string cultureName)
+    [MemberData(nameof(SupportedCultures))]
+    public void ResourceSet_ContainsRequiredLabelsForAdkCulture(string cultureName)
     {
         ResourceManager resourceManager = new(
             "Foundry.Connect.Strings.Resources",
@@ -64,5 +65,7 @@ public sealed class LocalizationResourceTests
 
         Assert.NotNull(resourceSet);
         Assert.Equal("Foundry Connect", resourceSet.GetString("App.Name"));
+        Assert.False(string.IsNullOrWhiteSpace(resourceSet.GetString("Common.Cancel")));
+        Assert.False(string.IsNullOrWhiteSpace(resourceSet.GetString("Common.Close")));
     }
 }

--- a/src/Foundry.Connect/Strings/ar-SA/Resources.resx
+++ b/src/Foundry.Connect/Strings/ar-SA/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>تم إنشاء وسيط التمهيد هذا بتنسيق تكوين قديم لـ Foundry OSD. حدّث وسيط التمهيد لضمان التوافق مع أحدث الميزات.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>إلغاء</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>إغلاق</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>التكوين: الإعدادات الافتراضية المضمنة</value>
   </data>

--- a/src/Foundry.Connect/Strings/bg-BG/Resources.resx
+++ b/src/Foundry.Connect/Strings/bg-BG/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Този носител за стартиране е генериран с по-стар формат за конфигурация на Foundry OSD. Актуализирайте носителя за стартиране, за да осигурите съвместимост с най-новите функции.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Отказ</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Затваряне</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Конфигурация: вградени настройки по подразбиране</value>
   </data>

--- a/src/Foundry.Connect/Strings/cs-CZ/Resources.resx
+++ b/src/Foundry.Connect/Strings/cs-CZ/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Toto spouštěcí médium bylo vygenerováno pomocí staršího formátu konfigurace Foundry OSD. Aktualizujte spouštěcí médium, aby byla zajištěna kompatibilita s nejnovějšími funkcemi.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Zrušit</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Zavřít</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Konfigurace: vestavěné výchozí hodnoty</value>
   </data>

--- a/src/Foundry.Connect/Strings/da-DK/Resources.resx
+++ b/src/Foundry.Connect/Strings/da-DK/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Dette startmedie blev genereret med et ældre Foundry OSD-konfigurationsformat. Opdater startmediet for at sikre kompatibilitet med de nyeste funktioner.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Annuller</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Luk</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Konfiguration: indbyggede standardindstillinger</value>
   </data>

--- a/src/Foundry.Connect/Strings/de-DE/Resources.resx
+++ b/src/Foundry.Connect/Strings/de-DE/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Dieses Startmedium wurde mit einem älteren Foundry OSD-Konfigurationsformat erstellt. Aktualisieren Sie das Startmedium, um die Kompatibilität mit den neuesten Funktionen sicherzustellen.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Abbrechen</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Schließen</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Konfiguration: integrierte Standardeinstellungen</value>
   </data>

--- a/src/Foundry.Connect/Strings/el-GR/Resources.resx
+++ b/src/Foundry.Connect/Strings/el-GR/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Αυτό το μέσο εκκίνησης δημιουργήθηκε με παλαιότερη μορφή ρύθμισης παραμέτρων Foundry OSD. Ενημερώστε το μέσο εκκίνησης για να διασφαλίσετε τη συμβατότητα με τις πιο πρόσφατες δυνατότητες.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Ακύρωση</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Κλείσιμο</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Διαμόρφωση: ενσωματωμένες προεπιλογές</value>
   </data>

--- a/src/Foundry.Connect/Strings/en-GB/Resources.resx
+++ b/src/Foundry.Connect/Strings/en-GB/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Configuration: built-in defaults</value>
   </data>

--- a/src/Foundry.Connect/Strings/en-US/Resources.resx
+++ b/src/Foundry.Connect/Strings/en-US/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>This boot media was generated with an older Foundry OSD configuration format. Update the boot media to ensure compatibility with the latest features.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Configuration: built-in defaults</value>
   </data>

--- a/src/Foundry.Connect/Strings/es-ES/Resources.resx
+++ b/src/Foundry.Connect/Strings/es-ES/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Este medio de arranque se generó con un formato de configuración anterior de Foundry OSD. Actualice el medio de arranque para garantizar la compatibilidad con las funciones más recientes.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Cerrar ventana</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Configuración: valores predeterminados integrados</value>
   </data>

--- a/src/Foundry.Connect/Strings/es-MX/Resources.resx
+++ b/src/Foundry.Connect/Strings/es-MX/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Este medio de arranque se generó con un formato de configuración anterior de Foundry OSD. Actualiza el medio de arranque para garantizar la compatibilidad con las funciones más recientes.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Cerrar ventana</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Configuración: valores predeterminados integrados</value>
   </data>

--- a/src/Foundry.Connect/Strings/et-EE/Resources.resx
+++ b/src/Foundry.Connect/Strings/et-EE/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>See algkandja loodi vanema Foundry OSD konfiguratsioonivorminguga. Värskendage algkandjat, et tagada ühilduvus uusimate funktsioonidega.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Loobu</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Sule aken</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Konfiguratsioon: sisseehitatud vaikeseaded</value>
   </data>

--- a/src/Foundry.Connect/Strings/fi-FI/Resources.resx
+++ b/src/Foundry.Connect/Strings/fi-FI/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Tämä käynnistysmedia luotiin vanhemmalla Foundry OSD -määritysmuodolla. Päivitä käynnistysmedia varmistaaksesi yhteensopivuuden uusimpien ominaisuuksien kanssa.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Peruuta</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Sulje</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Kokoonpano: sisäänrakennetut oletusasetukset</value>
   </data>

--- a/src/Foundry.Connect/Strings/fr-CA/Resources.resx
+++ b/src/Foundry.Connect/Strings/fr-CA/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Ce support de démarrage a été généré avec un ancien format de configuration Foundry OSD. Mettez à jour le support de démarrage pour garantir la compatibilité avec les dernières fonctionnalités.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Fermer</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Configuration: paramètres par défaut intégrés</value>
   </data>

--- a/src/Foundry.Connect/Strings/fr-FR/Resources.resx
+++ b/src/Foundry.Connect/Strings/fr-FR/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Ce support de démarrage a été généré avec un ancien format de configuration Foundry OSD. Mettez à jour le support de démarrage pour garantir la compatibilité avec les dernières fonctionnalités.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Fermer</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Configuration : valeurs par défaut intégrées</value>
   </data>

--- a/src/Foundry.Connect/Strings/he-IL/Resources.resx
+++ b/src/Foundry.Connect/Strings/he-IL/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>מדיית האתחול הזו נוצרה באמצעות תבנית תצורה ישנה יותר של Foundry OSD. עדכן את מדיית האתחול כדי להבטיח תאימות לתכונות העדכניות ביותר.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>ביטול</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>סגור</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>תצורה: ברירות מחדל מובנות</value>
   </data>

--- a/src/Foundry.Connect/Strings/hr-HR/Resources.resx
+++ b/src/Foundry.Connect/Strings/hr-HR/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Ovaj medij za pokretanje generiran je starijim formatom konfiguracije Foundry OSD. Ažurirajte medij za pokretanje kako biste osigurali kompatibilnost s najnovijim značajkama.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Odustani</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Zatvori prozor</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Konfiguracija: ugrađene zadane postavke</value>
   </data>

--- a/src/Foundry.Connect/Strings/hu-HU/Resources.resx
+++ b/src/Foundry.Connect/Strings/hu-HU/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Ez a rendszerindító adathordozó egy régebbi Foundry OSD konfigurációs formátummal készült. Frissítse a rendszerindító adathordozót a legújabb funkciókkal való kompatibilitás biztosításához.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Mégse</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Bezárás</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Konfiguráció: beépített alapértékek</value>
   </data>

--- a/src/Foundry.Connect/Strings/it-IT/Resources.resx
+++ b/src/Foundry.Connect/Strings/it-IT/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Questo supporto di avvio è stato generato con un formato di configurazione Foundry OSD precedente. Aggiorna il supporto di avvio per garantire la compatibilità con le funzionalità più recenti.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Annulla</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Chiudi la finestra</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Configurazione: impostazioni predefinite integrate</value>
   </data>

--- a/src/Foundry.Connect/Strings/ja-JP/Resources.resx
+++ b/src/Foundry.Connect/Strings/ja-JP/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>このブート メディアは古い Foundry OSD 構成形式で生成されています。最新機能との互換性を確保するため、ブート メディアを更新してください。</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>キャンセル</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>閉じる</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>構成: 組み込みのデフォルト</value>
   </data>

--- a/src/Foundry.Connect/Strings/ko-KR/Resources.resx
+++ b/src/Foundry.Connect/Strings/ko-KR/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>이 부팅 미디어는 이전 Foundry OSD 구성 형식으로 생성되었습니다. 최신 기능과의 호환성을 보장하려면 부팅 미디어를 업데이트하세요.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>취소</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>닫기</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>구성: 내장 기본값</value>
   </data>

--- a/src/Foundry.Connect/Strings/lt-LT/Resources.resx
+++ b/src/Foundry.Connect/Strings/lt-LT/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Ši įkrovos laikmena buvo sugeneruota naudojant senesnį Foundry OSD konfigūracijos formatą. Atnaujinkite įkrovos laikmeną, kad užtikrintumėte suderinamumą su naujausiomis funkcijomis.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Atšaukti</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Uždaryti</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Konfigūracija: integruoti numatytieji nustatymai</value>
   </data>

--- a/src/Foundry.Connect/Strings/lv-LV/Resources.resx
+++ b/src/Foundry.Connect/Strings/lv-LV/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Šis sāknēšanas datu nesējs tika ģenerēts ar vecāku Foundry OSD konfigurācijas formātu. Atjauniniet sāknēšanas datu nesēju, lai nodrošinātu saderību ar jaunākajiem līdzekļiem.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Atcelt</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Aizvērt</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Konfigurācija: iebūvētie noklusējuma iestatījumi</value>
   </data>

--- a/src/Foundry.Connect/Strings/nb-NO/Resources.resx
+++ b/src/Foundry.Connect/Strings/nb-NO/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Dette oppstartsmediet ble generert med et eldre Foundry OSD-konfigurasjonsformat. Oppdater oppstartsmediet for å sikre kompatibilitet med de nyeste funksjonene.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Avbryt</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Lukk</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Konfigurasjon: innebygde standardinnstillinger</value>
   </data>

--- a/src/Foundry.Connect/Strings/nl-NL/Resources.resx
+++ b/src/Foundry.Connect/Strings/nl-NL/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Dit opstartmedium is gegenereerd met een ouder Foundry OSD-configuratieformaat. Werk het opstartmedium bij om compatibiliteit met de nieuwste functies te garanderen.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Annuleren</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Sluiten</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Configuratie: ingebouwde standaardinstellingen</value>
   </data>

--- a/src/Foundry.Connect/Strings/pl-PL/Resources.resx
+++ b/src/Foundry.Connect/Strings/pl-PL/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Ten nośnik rozruchowy został wygenerowany przy użyciu starszego formatu konfiguracji Foundry OSD. Zaktualizuj nośnik rozruchowy, aby zapewnić zgodność z najnowszymi funkcjami.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Anuluj</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Zamknij</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Konfiguracja: wbudowane ustawienia domyślne</value>
   </data>

--- a/src/Foundry.Connect/Strings/pt-BR/Resources.resx
+++ b/src/Foundry.Connect/Strings/pt-BR/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Esta mídia de inicialização foi gerada com um formato de configuração mais antigo do Foundry OSD. Atualize a mídia de inicialização para garantir compatibilidade com os recursos mais recentes.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Fechar janela</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Configuração: padrões integrados</value>
   </data>

--- a/src/Foundry.Connect/Strings/pt-PT/Resources.resx
+++ b/src/Foundry.Connect/Strings/pt-PT/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Este suporte de arranque foi gerado com um formato de configuração Foundry OSD mais antigo. Atualize o suporte de arranque para garantir compatibilidade com as funcionalidades mais recentes.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Fechar janela</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Configuração: padrões integrados</value>
   </data>

--- a/src/Foundry.Connect/Strings/ro-RO/Resources.resx
+++ b/src/Foundry.Connect/Strings/ro-RO/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Acest suport de pornire a fost generat cu un format de configurare Foundry OSD mai vechi. Actualizați suportul de pornire pentru a asigura compatibilitatea cu cele mai recente caracteristici.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Anulați</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Închide fereastra</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Configurație: setări implicite încorporate</value>
   </data>

--- a/src/Foundry.Connect/Strings/ru-RU/Resources.resx
+++ b/src/Foundry.Connect/Strings/ru-RU/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Этот загрузочный носитель был создан с использованием более старого формата конфигурации Foundry OSD. Обновите загрузочный носитель, чтобы обеспечить совместимость с новейшими функциями.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Отмена</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Закрыть</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Конфигурация: встроенные настройки по умолчанию</value>
   </data>

--- a/src/Foundry.Connect/Strings/sk-SK/Resources.resx
+++ b/src/Foundry.Connect/Strings/sk-SK/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Toto zavádzacie médium bolo vygenerované pomocou staršieho formátu konfigurácie Foundry OSD. Aktualizujte zavádzacie médium, aby ste zabezpečili kompatibilitu s najnovšími funkciami.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Zrušiť</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Zavrieť</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Konfigurácia: vstavané predvolené nastavenia</value>
   </data>

--- a/src/Foundry.Connect/Strings/sl-SI/Resources.resx
+++ b/src/Foundry.Connect/Strings/sl-SI/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Ta zagonski medij je bil ustvarjen s starejšo obliko konfiguracije Foundry OSD. Posodobite zagonski medij, da zagotovite združljivost z najnovejšimi funkcijami.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Prekliči</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Zapri okno</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Konfiguracija: vgrajene privzete nastavitve</value>
   </data>

--- a/src/Foundry.Connect/Strings/sr-Latn-RS/Resources.resx
+++ b/src/Foundry.Connect/Strings/sr-Latn-RS/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Ovaj medij za pokretanje je generisan starijim formatom konfiguracije Foundry OSD. Ažurirajte medij za pokretanje da biste obezbedili kompatibilnost sa najnovijim funkcijama.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Otkaži</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Zatvori prozor</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Konfiguracija: ugrađene podrazumevane vrednosti</value>
   </data>

--- a/src/Foundry.Connect/Strings/sv-SE/Resources.resx
+++ b/src/Foundry.Connect/Strings/sv-SE/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Detta startmedia skapades med ett äldre Foundry OSD-konfigurationsformat. Uppdatera startmediet för att säkerställa kompatibilitet med de senaste funktionerna.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Avbryt</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Stäng</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Konfiguration: inbyggda standardinställningar</value>
   </data>

--- a/src/Foundry.Connect/Strings/th-TH/Resources.resx
+++ b/src/Foundry.Connect/Strings/th-TH/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>สื่อบูตนี้ถูกสร้างด้วยรูปแบบการกำหนดค่า Foundry OSD รุ่นเก่า อัปเดตสื่อบูตเพื่อให้เข้ากันได้กับฟีเจอร์ล่าสุด</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>ยกเลิก</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>ปิด</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>การกำหนดค่า: ค่าเริ่มต้นในตัว</value>
   </data>

--- a/src/Foundry.Connect/Strings/tr-TR/Resources.resx
+++ b/src/Foundry.Connect/Strings/tr-TR/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Bu önyükleme medyası daha eski bir Foundry OSD yapılandırma biçimiyle oluşturuldu. En son özelliklerle uyumluluğu sağlamak için önyükleme medyasını güncelleyin.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>İptal</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Pencereyi kapat</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Yapılandırma: yerleşik varsayılanlar</value>
   </data>

--- a/src/Foundry.Connect/Strings/uk-UA/Resources.resx
+++ b/src/Foundry.Connect/Strings/uk-UA/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>Цей завантажувальний носій створено зі старішим форматом конфігурації Foundry OSD. Оновіть завантажувальний носій, щоб забезпечити сумісність із найновішими функціями.</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Скасувати</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>Закрити</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>Конфігурація: вбудовані параметри за замовчуванням</value>
   </data>

--- a/src/Foundry.Connect/Strings/zh-CN/Resources.resx
+++ b/src/Foundry.Connect/Strings/zh-CN/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>此启动介质是使用较旧的 Foundry OSD 配置格式生成的。请更新启动介质，以确保与最新功能兼容。</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>关闭</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>配置：内置默认值</value>
   </data>

--- a/src/Foundry.Connect/Strings/zh-TW/Resources.resx
+++ b/src/Foundry.Connect/Strings/zh-TW/Resources.resx
@@ -45,6 +45,12 @@
   <data name="BootMedia.UpdateRecommendedToolTip" xml:space="preserve">
     <value>此開機媒體是使用較舊的 Foundry OSD 設定格式產生的。請更新開機媒體，以確保與最新功能相容。</value>
   </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="Common.Close" xml:space="preserve">
+    <value>關閉</value>
+  </data>
   <data name="Common.ConfigurationBuiltInDefaults" xml:space="preserve">
     <value>配置：內建預設值</value>
   </data>


### PR DESCRIPTION
## Summary

Display translated Cancel and Close labels in Connect's support export dialogs.

## Reason

The dialogs request `Common.Cancel` and `Common.Close`, but neither key exists in Connect's resources. The localization fallback therefore displays the raw keys.

## Main changes

- Add both resource keys in all 38 cultures, using the existing translations from Deploy.
- Extend compiled-resource checks to require both labels in every supported culture, including en-US.

## Testing

- [x] `.\scripts\Test-FoundryFormat.ps1` — passed locally and in CI.
- [x] x64 Release build and relevant tests — passed in CI.
- [x] ARM64 Release build and relevant tests — passed in CI.

Local suites: Connect 107 passed; Localization 59 passed. All 38 cultures failed the missing-label check before the fix. Verified that all 76 added values match the corresponding Deploy resources.

- [ ] Manual validation

Validation not run and reason: no visual dialog check; compiled-resource tests verify the labels in all supported cultures.

## Additional information

- Breaking or schema changes: none.
