### PR TITLE
fix(build): align publishing and enforce warning-free CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         run: dotnet restore .\src\Foundry.slnx --nologo
 
       - name: Build solution
-        run: dotnet build .\src\Foundry.slnx -c Release -p:Platform=${{ matrix.platform }} -p:ContinuousIntegrationBuild=true --no-restore --nologo
+        run: dotnet build .\src\Foundry.slnx -c Release -p:Platform=${{ matrix.platform }} -p:ContinuousIntegrationBuild=true -warnaserror --no-restore --nologo
 
       - name: Run unit tests
         shell: pwsh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Build and test x64 changes locally:
 
 ```powershell
 dotnet restore .\src\Foundry.slnx --nologo
-dotnet build .\src\Foundry.slnx -c Release -p:Platform=x64 -p:ContinuousIntegrationBuild=true --no-restore --nologo
+dotnet build .\src\Foundry.slnx -c Release -p:Platform=x64 -p:ContinuousIntegrationBuild=true -warnaserror --no-restore --nologo
 
 $testProjects = Get-ChildItem .\src -Directory -Filter *.Tests |
     ForEach-Object { Join-Path $_.FullName "$($_.Name).csproj" }
@@ -75,6 +75,10 @@ foreach ($testProject in $testProjects) {
 ```
 
 Validate ARM64 when the change affects runtime behavior, packaging, architecture-specific code, or deployment assets. CI runs formatting, Release builds, and all test projects for both x64 and ARM64.
+
+CI treats build warnings as errors. Existing targeted suppressions remain in effect; fix new warnings instead of adding blanket suppressions.
+
+Foundry OSD publishes without trimming or Native AOT, matching its Velopack packaging settings, and keeps ReadyToRun enabled in Release. Foundry.Connect and Foundry.Deploy retain their self-contained WPF publication without trimming or Native AOT.
 
 Use disposable virtual machines, test disks, non-production tenants, and non-production credentials for manual media and deployment testing. Foundry workflows can erase disks and exercise privileged network or cloud operations.
 

--- a/src/Foundry.Core.Tests/WinPe/WinPeBuildServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeBuildServiceTests.cs
@@ -13,7 +13,7 @@ public sealed class WinPeBuildServiceTests
     {
         var service = new WinPeBuildService();
 
-        WinPeResult<WinPeBuildArtifact> result = await service.BuildAsync(null!);
+        WinPeResult<WinPeBuildArtifact> result = await service.BuildAsync(null!, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.IsSuccess);
         Assert.Equal(WinPeErrorCodes.ValidationFailed, result.Error?.Code);
@@ -24,7 +24,7 @@ public sealed class WinPeBuildServiceTests
     {
         var service = new WinPeBuildService();
 
-        WinPeResult<WinPeBuildArtifact> result = await service.BuildAsync(new WinPeBuildOptions());
+        WinPeResult<WinPeBuildArtifact> result = await service.BuildAsync(new WinPeBuildOptions(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.IsSuccess);
         Assert.Equal(WinPeErrorCodes.ValidationFailed, result.Error?.Code);
@@ -39,7 +39,7 @@ public sealed class WinPeBuildServiceTests
         {
             OutputDirectoryPath = "C:\\Temp",
             Architecture = (WinPeArchitecture)999
-        });
+        }, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.IsSuccess);
         Assert.Equal(WinPeErrorCodes.ValidationFailed, result.Error?.Code);

--- a/src/Foundry.Core.Tests/WinPe/WinPeDriverCatalogServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeDriverCatalogServiceTests.cs
@@ -47,7 +47,7 @@ public sealed class WinPeDriverCatalogServiceTests
                                                     <OsInfo releaseId="11" architecture="x64" />
                                                   </DriverPack>
                                                 </Catalog>
-                                                """);
+                                                """, TestContext.Current.CancellationToken);
 
         var service = new WinPeDriverCatalogService();
 
@@ -86,7 +86,7 @@ public sealed class WinPeDriverCatalogServiceTests
                                                     <Hashes sha256="abc" />
                                                   </DriverPack>
                                                 </Catalog>
-                                                """);
+                                                """, TestContext.Current.CancellationToken);
 
         var service = new WinPeDriverCatalogService();
 

--- a/src/Foundry.Core.Tests/WinPe/WinPeDriverResolutionServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeDriverResolutionServiceTests.cs
@@ -83,7 +83,7 @@ public sealed class WinPeDriverResolutionServiceTests
     {
         string customDirectory = Path.Combine(Path.GetTempPath(), $"foundry-custom-drivers-{Guid.NewGuid():N}");
         Directory.CreateDirectory(customDirectory);
-        await File.WriteAllTextAsync(Path.Combine(customDirectory, "driver.inf"), string.Empty);
+        await File.WriteAllTextAsync(Path.Combine(customDirectory, "driver.inf"), string.Empty, TestContext.Current.CancellationToken);
 
         var catalogEntries = new[]
         {

--- a/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
@@ -39,10 +39,10 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
             CancellationToken.None);
 
         Assert.True(result.IsSuccess, result.Error?.Details);
-        Assert.Equal("Write-Host 'Foundry'", await File.ReadAllTextAsync(Path.Combine(image.System32Path, "FoundryBootstrap.ps1")));
-        Assert.Equal("curl", await File.ReadAllTextAsync(Path.Combine(image.System32Path, "curl.exe")));
+        Assert.Equal("Write-Host 'Foundry'", await File.ReadAllTextAsync(Path.Combine(image.System32Path, "FoundryBootstrap.ps1"), TestContext.Current.CancellationToken));
+        Assert.Equal("curl", await File.ReadAllTextAsync(Path.Combine(image.System32Path, "curl.exe"), TestContext.Current.CancellationToken));
 
-        string[] startnetLines = await File.ReadAllLinesAsync(startnetPath);
+        string[] startnetLines = await File.ReadAllLinesAsync(startnetPath, TestContext.Current.CancellationToken);
         Assert.Contains(startnetLines, line => line.Equals("wpeinit", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(startnetLines, line => line.Equals("echo existing", StringComparison.OrdinalIgnoreCase));
         Assert.Single(startnetLines, line => line.Contains("FoundryBootstrap.ps1", StringComparison.OrdinalIgnoreCase));
@@ -71,7 +71,7 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
         Assert.True(firstResult.IsSuccess, firstResult.Error?.Details);
         Assert.True(secondResult.IsSuccess, secondResult.Error?.Details);
 
-        string[] startnetLines = await File.ReadAllLinesAsync(Path.Combine(image.System32Path, "startnet.cmd"));
+        string[] startnetLines = await File.ReadAllLinesAsync(Path.Combine(image.System32Path, "startnet.cmd"), TestContext.Current.CancellationToken);
         Assert.Single(startnetLines, line => line.Contains("FoundryBootstrap.ps1", StringComparison.OrdinalIgnoreCase));
     }
 
@@ -122,15 +122,15 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
             CancellationToken.None);
 
         Assert.True(result.IsSuccess, result.Error?.Details);
-        Assert.Equal("{\"schemaVersion\":1}", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.connect.config.json")));
-        Assert.Equal("{\"schemaVersion\":2}", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.deploy.config.json")));
-        Assert.Equal("debug", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.connect.provisioning-source.txt")));
-        Assert.Equal("release", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.deploy.provisioning-source.txt")));
-        Assert.Equal("{\"zones\":[]}", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "iana-windows-timezones.json")));
-        Assert.Equal("<WLANProfile />", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Network", "Wifi", "Profiles", "profile.xml")));
+        Assert.Equal("{\"schemaVersion\":1}", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.connect.config.json"), TestContext.Current.CancellationToken));
+        Assert.Equal("{\"schemaVersion\":2}", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.deploy.config.json"), TestContext.Current.CancellationToken));
+        Assert.Equal("debug", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.connect.provisioning-source.txt"), TestContext.Current.CancellationToken));
+        Assert.Equal("release", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.deploy.provisioning-source.txt"), TestContext.Current.CancellationToken));
+        Assert.Equal("{\"zones\":[]}", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "iana-windows-timezones.json"), TestContext.Current.CancellationToken));
+        Assert.Equal("<WLANProfile />", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Network", "Wifi", "Profiles", "profile.xml"), TestContext.Current.CancellationToken));
         Assert.False(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Network", "Wired")));
         Assert.False(Directory.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Network", "Certificates")));
-        Assert.Equal("{\"profile\":1}", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Autopilot", "Profile1", "AutopilotConfigurationFile.json")));
+        Assert.Equal("{\"profile\":1}", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Autopilot", "Profile1", "AutopilotConfigurationFile.json"), TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -209,7 +209,7 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
             CancellationToken.None);
 
         Assert.True(result.IsSuccess, result.Error?.Details);
-        Assert.Equal("oa3", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Tools", "OA3", "oa3tool.exe")));
+        Assert.Equal("oa3", await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Tools", "OA3", "oa3tool.exe"), TestContext.Current.CancellationToken));
         string oa3ConfigPath = Path.Combine(image.MountedImagePath, "Foundry", "Runtime", "AutopilotHash", "OA3.cfg");
         string oa3InputPath = Path.Combine(image.MountedImagePath, "Foundry", "Runtime", "AutopilotHash", "input.xml");
         Assert.True(File.Exists(oa3ConfigPath));
@@ -293,7 +293,7 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
             CancellationToken.None);
 
         Assert.True(result.IsSuccess, result.Error?.Details);
-        string deployConfigurationJson = await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.deploy.config.json"));
+        string deployConfigurationJson = await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.deploy.config.json"), TestContext.Current.CancellationToken);
         using JsonDocument document = JsonDocument.Parse(deployConfigurationJson);
         JsonElement root = document.RootElement;
         Assert.Equal(
@@ -328,7 +328,7 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
             CancellationToken.None);
 
         Assert.True(result.IsSuccess, result.Error?.Details);
-        string connectConfigurationJson = await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.connect.config.json"));
+        string connectConfigurationJson = await File.ReadAllTextAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.connect.config.json"), TestContext.Current.CancellationToken);
         using JsonDocument document = JsonDocument.Parse(connectConfigurationJson);
         JsonElement root = document.RootElement;
         Assert.True(root.TryGetProperty("schemaVersion", out _));
@@ -366,7 +366,7 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
             CancellationToken.None);
 
         Assert.True(result.IsSuccess, result.Error?.Details);
-        Assert.Equal(secretKey, await File.ReadAllBytesAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Secrets", "media-secrets.key")));
+        Assert.Equal(secretKey, await File.ReadAllBytesAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Secrets", "media-secrets.key"), TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -392,7 +392,7 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
             CancellationToken.None);
 
         Assert.True(result.IsSuccess, result.Error?.Details);
-        Assert.Equal(secretKey, await File.ReadAllBytesAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Secrets", "deployment-secrets.key")));
+        Assert.Equal(secretKey, await File.ReadAllBytesAsync(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Secrets", "deployment-secrets.key"), TestContext.Current.CancellationToken));
         Assert.False(File.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Secrets", "media-secrets.key")));
     }
 
@@ -516,7 +516,7 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
         Assert.False(File.Exists(Path.Combine(image.MountedImagePath, "Foundry", "Config", "Secrets", "deployment-secrets.key")));
 
         SecretEnvelope envelope = JsonSerializer.Deserialize<SecretEnvelope>(
-            await File.ReadAllTextAsync(encryptedPath),
+            await File.ReadAllTextAsync(encryptedPath, TestContext.Current.CancellationToken),
             ConfigurationJsonDefaults.SerializerOptions)!;
         byte[] plaintext = MediaSecretEnvelopeProtector.DecryptBytes(
             envelope,
@@ -560,9 +560,9 @@ public sealed class WinPeMountedImageAssetProvisioningServiceTests
 
         Assert.True(result.IsSuccess, result.Error?.Details);
         string toolsPath = Path.Combine(image.MountedImagePath, "Foundry", "Tools", "7zip");
-        Assert.Equal("7za", await File.ReadAllTextAsync(Path.Combine(toolsPath, "x64", "7za.exe")));
-        Assert.Equal("license", await File.ReadAllTextAsync(Path.Combine(toolsPath, "License.txt")));
-        Assert.Equal("readme", await File.ReadAllTextAsync(Path.Combine(toolsPath, "readme.txt")));
+        Assert.Equal("7za", await File.ReadAllTextAsync(Path.Combine(toolsPath, "x64", "7za.exe"), TestContext.Current.CancellationToken));
+        Assert.Equal("license", await File.ReadAllTextAsync(Path.Combine(toolsPath, "License.txt"), TestContext.Current.CancellationToken));
+        Assert.Equal("readme", await File.ReadAllTextAsync(Path.Combine(toolsPath, "readme.txt"), TestContext.Current.CancellationToken));
     }
 
     private sealed class TempMountedImage : IDisposable

--- a/src/Foundry.Core.Tests/WinPe/WinPeRuntimePayloadProvisioningServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeRuntimePayloadProvisioningServiceTests.cs
@@ -156,7 +156,7 @@ public sealed class WinPeRuntimePayloadProvisioningServiceTests
     public async Task ProvisionAsync_WhenReleaseConnectIsEnabled_DownloadsAndExtractsReleaseAsset()
     {
         using TempRuntimeWorkspace workspace = TempRuntimeWorkspace.Create();
-        byte[] archiveBytes = await File.ReadAllBytesAsync(workspace.CreateArchive("connect-release.zip", "Foundry.Connect.exe"));
+        byte[] archiveBytes = await File.ReadAllBytesAsync(workspace.CreateArchive("connect-release.zip", "Foundry.Connect.exe"), TestContext.Current.CancellationToken);
         var httpHandler = new FakeReleaseHttpMessageHandler("Foundry.Connect-win-x64.zip", archiveBytes);
         var service = new WinPeRuntimePayloadProvisioningService(
             new FakeRuntimeProcessRunner(),

--- a/src/Foundry.Core.Tests/WinPe/WinReBootImagePreparationServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinReBootImagePreparationServiceTests.cs
@@ -109,7 +109,7 @@ public sealed class WinReBootImagePreparationServiceTests
     public async Task ValidateHashIfRequestedAsync_WhenHashMatches_ReturnsSuccess()
     {
         string filePath = Path.Combine(Path.GetTempPath(), $"foundry-hash-{Guid.NewGuid():N}.txt");
-        await File.WriteAllTextAsync(filePath, "foundry");
+        await File.WriteAllTextAsync(filePath, "foundry", TestContext.Current.CancellationToken);
 
         try
         {
@@ -166,8 +166,8 @@ public sealed class WinReBootImagePreparationServiceTests
 
         string bootWimPath = Path.Combine(sourcesPath, "boot.wim");
         string cachedSourcePath = Path.Combine(cachePath, "source.esd");
-        await File.WriteAllTextAsync(bootWimPath, "original");
-        await File.WriteAllTextAsync(cachedSourcePath, "cached source");
+        await File.WriteAllTextAsync(bootWimPath, "original", TestContext.Current.CancellationToken);
+        await File.WriteAllTextAsync(cachedSourcePath, "cached source", TestContext.Current.CancellationToken);
         string cachedSourceHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes("cached source")));
         string catalogXml = CreateCatalogXml(cachedSourceHash);
 
@@ -197,7 +197,7 @@ public sealed class WinReBootImagePreparationServiceTests
                 CancellationToken.None);
 
             Assert.True(result.IsSuccess, result.Error?.Details);
-            Assert.Equal("winre", await File.ReadAllTextAsync(bootWimPath));
+            Assert.Equal("winre", await File.ReadAllTextAsync(bootWimPath, TestContext.Current.CancellationToken));
             Assert.NotNull(result.Value);
             Assert.Equal(2, result.Value.DependencyFiles.Count);
             Assert.Contains(runner.Executions, execution => execution.Arguments.Contains("/Export-Image", StringComparison.OrdinalIgnoreCase));

--- a/src/Foundry.Deploy.Tests/AutopilotHardwareHashCsvWriterTests.cs
+++ b/src/Foundry.Deploy.Tests/AutopilotHardwareHashCsvWriterTests.cs
@@ -20,7 +20,7 @@ public sealed class AutopilotHardwareHashCsvWriterTests
             new AutopilotHardwareHashDeviceIdentity("SER,123", "HASHVALUE", "Sales, East"),
             CancellationToken.None);
 
-        byte[] bytes = await File.ReadAllBytesAsync(csvPath);
+        byte[] bytes = await File.ReadAllBytesAsync(csvPath, TestContext.Current.CancellationToken);
         string csv = Encoding.UTF8.GetString(bytes);
 
         Assert.False(bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF);
@@ -41,7 +41,7 @@ public sealed class AutopilotHardwareHashCsvWriterTests
             new AutopilotHardwareHashDeviceIdentity("SER123", "HASHVALUE", null),
             CancellationToken.None);
 
-        string[] lines = await File.ReadAllLinesAsync(csvPath);
+        string[] lines = await File.ReadAllLinesAsync(csvPath, TestContext.Current.CancellationToken);
 
         Assert.Equal("Device Serial Number,Windows Product ID,Hardware Hash,Group Tag", lines[0]);
         Assert.Equal("SER123,,HASHVALUE,", lines[1]);

--- a/src/Foundry.Deploy.Tests/AutopilotHardwareHashUploadServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/AutopilotHardwareHashUploadServiceTests.cs
@@ -52,7 +52,7 @@ public sealed class AutopilotHardwareHashUploadServiceTests
 
             Assert.Equal(AutopilotHardwareHashUploadState.UploadFailed, result.State);
             Assert.NotNull(result.ArtifactPath);
-            string json = await File.ReadAllTextAsync(result.ArtifactPath);
+            string json = await File.ReadAllTextAsync(result.ArtifactPath, TestContext.Current.CancellationToken);
             Assert.DoesNotContain("access_token", json, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("authorization", json, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("pfx", json, StringComparison.OrdinalIgnoreCase);
@@ -111,7 +111,7 @@ public sealed class AutopilotHardwareHashUploadServiceTests
             Assert.Equal(AutopilotHardwareHashUploadState.UploadFailed, result.State);
             Assert.Equal("PermissionMissing", result.FailureCode);
             Assert.NotNull(result.ArtifactPath);
-            string json = await File.ReadAllTextAsync(result.ArtifactPath);
+            string json = await File.ReadAllTextAsync(result.ArtifactPath, TestContext.Current.CancellationToken);
             Assert.DoesNotContain(Convert.ToBase64String(pfxBytes), json, StringComparison.Ordinal);
             Assert.DoesNotContain(pfxPassword, json, StringComparison.Ordinal);
             Assert.DoesNotContain(certificate.ExportCertificatePem(), json, StringComparison.Ordinal);

--- a/src/Foundry.Deploy.Tests/HttpRetryPolicyTests.cs
+++ b/src/Foundry.Deploy.Tests/HttpRetryPolicyTests.cs
@@ -30,7 +30,8 @@ public sealed class HttpRetryPolicyTests
             NullLogger.Instance,
             "download catalog",
             retryCount: 3,
-            retryDelay: TimeSpan.Zero);
+            retryDelay: TimeSpan.Zero,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal("ok", result);
         Assert.Equal(3, attempts);
@@ -51,7 +52,8 @@ public sealed class HttpRetryPolicyTests
                 NullLogger.Instance,
                 "download catalog",
                 retryCount: 3,
-                retryDelay: TimeSpan.Zero));
+                retryDelay: TimeSpan.Zero,
+                cancellationToken: TestContext.Current.CancellationToken));
 
         Assert.Equal(1, attempts);
     }

--- a/src/Foundry.Deploy.Tests/ProvisionAutopilotStepTests.cs
+++ b/src/Foundry.Deploy.Tests/ProvisionAutopilotStepTests.cs
@@ -22,7 +22,7 @@ public sealed class ProvisionAutopilotStepTests
     {
         using TempDeploymentWorkspace workspace = TempDeploymentWorkspace.Create();
         string sourceConfigurationPath = Path.Combine(workspace.RootPath, "AutopilotConfigurationFile.json");
-        await File.WriteAllTextAsync(sourceConfigurationPath, """{"profile":true}""");
+        await File.WriteAllTextAsync(sourceConfigurationPath, """{"profile":true}""", TestContext.Current.CancellationToken);
         ProvisionAutopilotStep step = CreateStep();
         DeploymentStepExecutionContext context = CreateContext(
             workspace,
@@ -199,7 +199,7 @@ public sealed class ProvisionAutopilotStepTests
         Assert.Contains("consent", result.Message, StringComparison.OrdinalIgnoreCase);
 
         string statusPath = Path.Combine(context.RuntimeState.AutopilotHardwareHashDiagnosticsPath!, "autopilot-hash-upload-status.json");
-        using JsonDocument status = JsonDocument.Parse(await File.ReadAllTextAsync(statusPath));
+        using JsonDocument status = JsonDocument.Parse(await File.ReadAllTextAsync(statusPath, TestContext.Current.CancellationToken));
         Assert.Equal("UploadFailed", status.RootElement.GetProperty("uploadState").GetString());
         Assert.Equal("ConsentMissing", status.RootElement.GetProperty("failureCode").GetString());
     }
@@ -294,7 +294,7 @@ public sealed class ProvisionAutopilotStepTests
         Assert.Equal(DeploymentStepState.Succeeded, result.State);
         Assert.True(File.Exists(manifestPath));
         Assert.Equal(AutopilotHardwareHashUploadState.DryRunPrepared, context.RuntimeState.AutopilotHardwareHashUploadState);
-        using JsonDocument manifest = JsonDocument.Parse(await File.ReadAllTextAsync(manifestPath));
+        using JsonDocument manifest = JsonDocument.Parse(await File.ReadAllTextAsync(manifestPath, TestContext.Current.CancellationToken));
         Assert.Equal("hardwareHashUpload", manifest.RootElement.GetProperty("provisioningMode").GetString());
         Assert.False(manifest.RootElement.TryGetProperty("certificatePfxSecret", out _));
         Assert.False(manifest.RootElement.TryGetProperty("certificatePfxPasswordSecret", out _));
@@ -320,7 +320,7 @@ public sealed class ProvisionAutopilotStepTests
         Assert.Equal(AutopilotHardwareHashUploadState.NotPlanned, context.RuntimeState.AutopilotHardwareHashUploadState);
         Assert.Equal(manifestPath, context.RuntimeState.StagedAutopilotConfigurationPath);
         Assert.True(File.Exists(manifestPath));
-        using JsonDocument manifest = JsonDocument.Parse(await File.ReadAllTextAsync(manifestPath));
+        using JsonDocument manifest = JsonDocument.Parse(await File.ReadAllTextAsync(manifestPath, TestContext.Current.CancellationToken));
         Assert.Equal("interactiveHardwareHashUpload", manifest.RootElement.GetProperty("provisioningMode").GetString());
         Assert.False(manifest.RootElement.TryGetProperty("certificatePfxSecret", out _));
         Assert.False(manifest.RootElement.TryGetProperty("certificatePfxPasswordSecret", out _));

--- a/src/Foundry.Deploy.Tests/WindowsDeploymentServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/WindowsDeploymentServiceTests.cs
@@ -733,7 +733,8 @@ public sealed class WindowsDeploymentServiceTests
             windowsRoot,
             "LAB01",
             "amd64",
-            "Romance Standard Time");
+            "Romance Standard Time",
+            cancellationToken: TestContext.Current.CancellationToken);
 
         string unattendPath = Path.Combine(windowsRoot, "Windows", "Panther", "unattend.xml");
         XDocument document = XDocument.Load(unattendPath);
@@ -756,7 +757,8 @@ public sealed class WindowsDeploymentServiceTests
             windowsRoot,
             "LAB01",
             "amd64",
-            "Europe/Paris");
+            "Europe/Paris",
+            cancellationToken: TestContext.Current.CancellationToken);
 
         string unattendPath = Path.Combine(windowsRoot, "Windows", "Panther", "unattend.xml");
         XDocument document = XDocument.Load(unattendPath);
@@ -1078,7 +1080,8 @@ public sealed class WindowsDeploymentServiceTests
                 DisablePaintAi = true,
                 DisableNotepadAi = true
             },
-            workingDirectory);
+            workingDirectory,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Contains(processRunner.Calls, call => call.Contains(@"LOAD HKLM\FoundrySoftware", StringComparison.Ordinal));
         Assert.Contains(processRunner.Calls, call => call.Contains(@"LOAD HKLM\FoundrySystem", StringComparison.Ordinal));
@@ -1108,7 +1111,8 @@ public sealed class WindowsDeploymentServiceTests
         await service.ConfigureOfflineAiComponentRemovalAsync(
             windowsRoot,
             new DeployAiComponentRemovalSettings(),
-            workingDirectory);
+            workingDirectory,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Empty(processRunner.Calls);
     }

--- a/src/Foundry.Telemetry.Tests/PostHogTelemetryServiceTests.cs
+++ b/src/Foundry.Telemetry.Tests/PostHogTelemetryServiceTests.cs
@@ -181,7 +181,7 @@ public sealed class PostHogTelemetryServiceTests
         using var httpClient = new HttpClient(new RecordingHttpMessageHandler { ThrowOnSend = true });
         var service = CreateService(httpClient);
 
-        await service.TrackAsync(TelemetryEvents.OsdBootMediaFinished, new Dictionary<string, object?> { ["boot_media_target"] = "iso" });
+        await service.TrackAsync(TelemetryEvents.OsdBootMediaFinished, new Dictionary<string, object?> { ["boot_media_target"] = "iso" }, cancellationToken: TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -192,7 +192,7 @@ public sealed class PostHogTelemetryServiceTests
         var options = new TelemetryOptions(false, TelemetryDefaults.PostHogEuHost, "project-token", "install-id");
         var service = CreateService(httpClient, options);
 
-        await service.TrackAsync(TelemetryEvents.OsdBootMediaFinished, new Dictionary<string, object?> { ["boot_media_target"] = "iso" });
+        await service.TrackAsync(TelemetryEvents.OsdBootMediaFinished, new Dictionary<string, object?> { ["boot_media_target"] = "iso" }, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(0, handler.SendCount);
     }
@@ -213,7 +213,8 @@ public sealed class PostHogTelemetryServiceTests
                 ["boot_media_architecture"] = "arm64",
                 ["boot_media_creation_failed_step_name"] = "Customize boot image",
                 ["ssid"] = "CorpWifi"
-            });
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal("https://eu.i.posthog.com/i/v0/e/", handler.RequestUri?.ToString());
 
@@ -253,7 +254,7 @@ public sealed class PostHogTelemetryServiceTests
         using var httpClient = new HttpClient(handler);
         var service = CreateService(httpClient);
 
-        await service.TrackAsync("unknown_event", new Dictionary<string, object?> { ["success"] = true });
+        await service.TrackAsync("unknown_event", new Dictionary<string, object?> { ["success"] = true }, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(0, handler.SendCount);
     }
@@ -271,7 +272,8 @@ public sealed class PostHogTelemetryServiceTests
             {
                 ["boot_media_target"] = "unknown",
                 ["connect_runtime_payload_source"] = "unknown"
-            });
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
 
         JsonElement properties = handler.ReadJson().GetProperty("properties");
         Assert.Equal(TelemetryBootMediaTargets.Usb, properties.GetProperty("boot_media_target").GetString());
@@ -293,7 +295,8 @@ public sealed class PostHogTelemetryServiceTests
             {
                 ["boot_media_target"] = "unknown",
                 ["deploy_runtime_payload_source"] = "unknown"
-            });
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
 
         JsonElement properties = handler.ReadJson().GetProperty("properties");
         Assert.Equal(TelemetryBootMediaTargets.Usb, properties.GetProperty("boot_media_target").GetString());
@@ -309,7 +312,7 @@ public sealed class PostHogTelemetryServiceTests
         using var httpClient = new HttpClient(handler);
         var service = CreateService(httpClient);
 
-        await service.FlushAsync();
+        await service.FlushAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(0, handler.SendCount);
     }
@@ -319,8 +322,8 @@ public sealed class PostHogTelemetryServiceTests
     {
         var service = new NullTelemetryService();
 
-        await service.TrackAsync(TelemetryEvents.OsdBootMediaFinished, new Dictionary<string, object?> { ["boot_media_target"] = "iso" });
-        await service.FlushAsync();
+        await service.TrackAsync(TelemetryEvents.OsdBootMediaFinished, new Dictionary<string, object?> { ["boot_media_target"] = "iso" }, cancellationToken: TestContext.Current.CancellationToken);
+        await service.FlushAsync(cancellationToken: TestContext.Current.CancellationToken);
     }
 
     private static PostHogTelemetryService CreateService(HttpClient httpClient, TelemetryOptions? options = null)

--- a/src/Foundry/Foundry.csproj
+++ b/src/Foundry/Foundry.csproj
@@ -13,12 +13,9 @@
     <UseWinUI>true</UseWinUI>
     <WinUISDKReferences>false</WinUISDKReferences>
     <Nullable>enable</Nullable>
-    <TrimMode>partial</TrimMode>
     <ImplicitUsings>true</ImplicitUsings>
     <LangVersion>Latest</LangVersion>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
-    <IsAotCompatible>true</IsAotCompatible>
-    <CsWinRTAotWarningLevel>2</CsWinRTAotWarningLevel>
     <WindowsPackageType>None</WindowsPackageType>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
     <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_MAIN</DefineConstants>
@@ -28,8 +25,7 @@
     <PublishAot>False</PublishAot>
     <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
     <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-    <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
-    <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
+    <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>
   <ItemGroup>
     <None Include="Assets\**\*">


### PR DESCRIPTION
## Summary

Align Foundry OSD publishing settings with the release pipeline and make new build warnings fail CI.

## Reason

The project enabled trimming and AOT compatibility analysis although Velopack releases disable trimming and Native AOT. Correcting this mismatch and 54 xUnit cancellation warnings provides a clean baseline without adding suppressions.

## Main changes

- Disable trimming in all Foundry OSD configurations and remove unused AOT compatibility settings; retain Release ReadyToRun and disabled Native AOT.
- Pass TestContext.Current.CancellationToken at 54 test call sites, preserving explicit cancellation scenarios.
- Add MSBuild -warnaserror to CI and the documented validation command.
- Preserve existing targeted suppressions and document the policies.

## Testing

- [x] `.\scripts\Test-FoundryFormat.ps1`
- [x] x64 Release build and relevant tests: zero warnings/errors with -warnaserror; all 1,711 tests passed.
- [ ] ARM64 Release build and relevant tests: build passed with zero warnings/errors; runtime tests remain for CI.
- [ ] Manual validation.

Validation not run and reason:

ARM64 runtime tests were not run on the local x64 host. Installer publication and UI smoke testing were not performed; no UI bindings or production application logic changed. Independent review and git diff --check passed.

## Additional information

- Breaking or schema changes: None.
- Follow-up work: Validate ARM64 runtime tests in CI.
