### PR TITLE
chore(deps): update PostHog to 2.15.5

### DIFF
--- a/src/Foundry.Telemetry/Foundry.Telemetry.csproj
+++ b/src/Foundry.Telemetry/Foundry.Telemetry.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-    <PackageReference Include="PostHog" Version="2.10.0" />
+    <PackageReference Include="PostHog" Version="2.15.5" />
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Update PostHog from 2.10.0 to the latest stable NuGet release, 2.15.5.

## Reason

Adopt upstream SDK fixes while retaining compatibility with Foundry telemetry.

## Main changes

- Update only the PostHog package reference in Foundry.Telemetry.
- Reviewed every intervening release in the [versioned upstream changelog](https://github.com/PostHog/posthog-dotnet/blob/PostHog-v2.15.5/src/PostHog/CHANGELOG.md). No breaking API changes are documented, and existing SDK calls compile unchanged.
- The 2.11.1 buffering defaults do not affect Foundry, which explicitly configures queue size, batch size, flush threshold, and interval.
- Feature flag behavior changes do not affect current Foundry usage. Capture fixes preserve caller dictionaries and normalize timestamps to the equivalent UTC instant.
- No schema changes or migration required.

## Testing

- Passed: 92/92 Foundry.Telemetry.Tests before and after the update, using `dotnet run --project src/Foundry.Telemetry.Tests/Foundry.Telemetry.Tests.csproj -c Release -p:Platform=x64`.
- Passed: full x64 Release solution build with `ContinuousIntegrationBuild=true` and `-warnaserror`; zero warnings and errors.
- Passed: `git diff --check`; verified restored assets resolve PostHog 2.15.5.
- Formatting script skipped because this changes only a package version in a project file; no application source, XAML, resources, or formatting configuration changed.
- Local ARM64 and live ingestion validation not run; architecture-independent dependency update. Required x64/ARM64 CI checks remain pending.

Leave this PR unmerged for manual review and squash by the maintainer.
