### PR TITLE
fix(naming): reject numeric-only names and clean up release tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Operating system, driver pack, firmware, and WinPE metadata come from the mainta
 
 - **Deployment content** — Windows release, language, edition, licensing channel, drivers, and optional firmware.
 - **Windows setup** — localization, OOBE, privacy, optional features, AppX packages, and offline component choices.
+- **Computer naming** — compose names from device data or enter them manually. Numeric-only names are rejected before deployment; use a prefix such as `PC-` with numeric serial numbers.
 - **Custom answer files** — [import and select an Unattend file](https://docs.foundryosd.com/foundry-osd/customization/unattend) to configure Windows beyond the options exposed in Foundry, within the supported setup passes.
 - **Network readiness** — Ethernet, Wi-Fi, and enterprise 802.1X settings for WinPE.
 - **Provisioning and protection** — Windows Autopilot options and optional protection for deployment media and embedded configuration.

--- a/src/Foundry.Core.Tests/Configuration/ComputerNameRulesTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/ComputerNameRulesTests.cs
@@ -4,7 +4,7 @@
 
 using Foundry.Core.Services.Configuration;
 
-namespace Foundry.Deploy.Tests;
+namespace Foundry.Core.Tests.Configuration;
 
 public sealed class ComputerNameRulesTests
 {
@@ -22,6 +22,16 @@ public sealed class ComputerNameRulesTests
         bool isValid = ComputerNameRules.IsValid("Computer-Name-Too-Long");
 
         Assert.False(isValid);
-        Assert.Equal(ComputerNameRules.ValidationMessage, ComputerNameRules.GetValidationMessage("Computer-Name-Too-Long"));
+    }
+
+    [Theory]
+    [InlineData("0", false)]
+    [InlineData("123456789012345", false)]
+    [InlineData("PC1234567890123", true)]
+    [InlineData("1234567890123PC", true)]
+    [InlineData("123-456", true)]
+    public void IsValid_RejectsNumericOnlyNames(string computerName, bool expected)
+    {
+        Assert.Equal(expected, ComputerNameRules.IsValid(computerName));
     }
 }

--- a/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
@@ -3,20 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using Foundry.Core.Models.Configuration;
-using Foundry.Core.Models.Configuration.Deploy;
 
 namespace Foundry.Core.Tests.Configuration;
 
 public sealed class ConfigurationSchemaVersionsTests
 {
-    [Fact]
-    public void CurrentVersions_MatchConfigurationDocumentContracts()
-    {
-        Assert.Equal(FoundryConfigurationDocument.CurrentSchemaVersion, ConfigurationSchemaVersions.FoundryCurrent);
-        Assert.Equal(FoundryConnectConfigurationDocument.CurrentSchemaVersion, ConfigurationSchemaVersions.ConnectCurrent);
-        Assert.Equal(FoundryDeployConfigurationDocument.CurrentSchemaVersion, ConfigurationSchemaVersions.DeployCurrent);
-    }
-
     [Fact]
     public void IsBootMediaUpdateRecommended_UsesCurrentSchemaVersion()
     {

--- a/src/Foundry.Core.Tests/Configuration/MachineNameComposerTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/MachineNameComposerTests.cs
@@ -16,11 +16,11 @@ public sealed class MachineNameComposerTests
             [Hardware(MachineNameComponentType.SerialNumber, 15, MachineNameTruncation.KeepRight)],
             new Dictionary<MachineNameComponentType, string?>
             {
-                [MachineNameComponentType.SerialNumber] = "SERIAL-123456789012345"
+                [MachineNameComponentType.SerialNumber] = "SERIAL-A23456789012345"
             });
 
         Assert.True(result.IsSuccess);
-        Assert.Equal("123456789012345", result.ComputerName);
+        Assert.Equal("A23456789012345", result.ComputerName);
     }
 
     [Fact]
@@ -51,10 +51,27 @@ public sealed class MachineNameComposerTests
             [Hardware(MachineNameComponentType.Model, 5, MachineNameTruncation.KeepRight)],
             new Dictionary<MachineNameComponentType, string?>
             {
-                [MachineNameComponentType.Model] = "Model / 12345"
+                [MachineNameComponentType.Model] = "Model / a2345"
             });
 
-        Assert.Equal("12345", result.ComputerName);
+        Assert.Equal("a2345", result.ComputerName);
+    }
+
+    [Theory]
+    [InlineData("123456789012345")]
+    [InlineData("SERIAL-123456789012345")]
+    public void Compose_WhenFinalNameContainsOnlyDigits_ReturnsInvalidFinalName(string serialNumber)
+    {
+        MachineNameCompositionResult result = Compose(
+            [Hardware(MachineNameComponentType.SerialNumber, 15, MachineNameTruncation.KeepRight)],
+            new Dictionary<MachineNameComponentType, string?>
+            {
+                [MachineNameComponentType.SerialNumber] = serialNumber
+            });
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(MachineNameCompositionFailureKind.InvalidFinalName, result.FailureKind);
+        Assert.Null(result.ComputerName);
     }
 
     [Theory]

--- a/src/Foundry.Core/Services/Configuration/ComputerNameRules.cs
+++ b/src/Foundry.Core/Services/Configuration/ComputerNameRules.cs
@@ -10,7 +10,6 @@ public static class ComputerNameRules
 {
     public const int MaxLength = 15;
     public const string FallbackName = "PC";
-    public const string ValidationMessage = "Computer name must contain 1 to 15 characters using A-Z, a-z, 0-9, or -.";
 
     public static string Normalize(string? value)
     {
@@ -46,6 +45,9 @@ public static class ComputerNameRules
         return builder.ToString();
     }
 
+    /// <summary>
+    /// Validates a complete computer name, including Windows Setup's restriction on numeric-only names.
+    /// </summary>
     public static bool IsValid(string? value)
     {
         if (string.IsNullOrWhiteSpace(value) || value.Length > MaxLength)
@@ -53,15 +55,18 @@ public static class ComputerNameRules
             return false;
         }
 
+        bool hasNonDigit = false;
         foreach (char character in value)
         {
             if (!IsAllowedCharacter(character))
             {
                 return false;
             }
+
+            hasNonDigit |= character is < '0' or > '9';
         }
 
-        return true;
+        return hasNonDigit;
     }
 
     public static bool IsAllowedText(string? value)
@@ -80,13 +85,6 @@ public static class ComputerNameRules
         }
 
         return true;
-    }
-
-    public static string GetValidationMessage(string? value)
-    {
-        return IsValid(value)
-            ? string.Empty
-            : ValidationMessage;
     }
 
     public static bool IsAllowedCharacter(char character)

--- a/src/Foundry.Deploy.Tests/DeploymentLaunchPreparationServiceTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentLaunchPreparationServiceTests.cs
@@ -12,6 +12,22 @@ namespace Foundry.Deploy.Tests;
 
 public sealed class DeploymentLaunchPreparationServiceTests
 {
+    [Theory]
+    [InlineData("123456789012345")]
+    [InlineData(" 123_456 ")]
+    public void Prepare_WhenComputerNameContainsOnlyDigits_FailsBeforeConfirmation(string computerName)
+    {
+        var shell = new FakeApplicationShellService();
+        var service = new DeploymentLaunchPreparationService(shell);
+
+        DeploymentLaunchPreparationResult result = service.Prepare(
+            CreateRequest(selectedTargetDisk: CreateDisk(), targetComputerName: computerName));
+
+        Assert.False(result.IsReadyToStart);
+        Assert.Null(result.Context);
+        Assert.Equal(0, shell.ConfirmationCallCount);
+    }
+
     [Fact]
     public void Prepare_WhenDryRunAndTargetDiskMissing_UsesDebugVirtualDisk()
     {

--- a/src/Foundry.Deploy.Tests/ProvisionAutopilotStepTests.cs
+++ b/src/Foundry.Deploy.Tests/ProvisionAutopilotStepTests.cs
@@ -416,7 +416,8 @@ public sealed class ProvisionAutopilotStepTests
 
         public Task SaveStateAsync<TState>(DeploymentLogSession session, TState state, CancellationToken cancellationToken = default)
         {
-            return File.WriteAllTextAsync(session.StateFilePath, "{}", cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
         }
 
     }

--- a/src/Foundry.Localization.Tests/ResourceKeyParityTests.cs
+++ b/src/Foundry.Localization.Tests/ResourceKeyParityTests.cs
@@ -154,30 +154,6 @@ public sealed class ResourceKeyParityTests
         Assert.Empty(expectedKeys.Except(enUsKeys, StringComparer.Ordinal));
     }
 
-    [Fact]
-    public void FoundryXamlResources_ResolveApplicationDefinedReferences()
-    {
-        string foundryRoot = Path.Combine(FindSourceRoot(), "Foundry");
-        string[] xamlPaths = Directory
-            .EnumerateFiles(foundryRoot, "*.xaml", SearchOption.AllDirectories)
-            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase))
-            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase))
-            .ToArray();
-        HashSet<string> definedKeys = xamlPaths
-            .SelectMany(path => Regex.Matches(File.ReadAllText(path), "x:Key=\"(Foundry[A-Za-z0-9.]+)\"")
-                .Select(match => match.Groups[1].Value))
-            .ToHashSet(StringComparer.Ordinal);
-        string[] missingKeys = xamlPaths
-            .SelectMany(path => Regex.Matches(File.ReadAllText(path), @"\{(?:Theme|Static)Resource\s+(Foundry[A-Za-z0-9.]+)\}")
-                .Select(match => match.Groups[1].Value))
-            .Distinct(StringComparer.Ordinal)
-            .Except(definedKeys, StringComparer.Ordinal)
-            .Order(StringComparer.Ordinal)
-            .ToArray();
-
-        Assert.Empty(missingKeys);
-    }
-
     [Theory]
     [MemberData(nameof(ResourceSets))]
     public void LocalizedResourceFiles_MatchEnUsKeys(string projectName, string extension)


### PR DESCRIPTION
## Summary
Reject numeric-only computer names before deployment and remove a small set of obsolete helpers and low-value tests.

## Reason
Serial-number composition can produce a name such as `123456789012345`, which Windows Setup rejects. The previous validator accepted it and allowed deployment to proceed.

## Main changes
- Enforce the shared name rule after composition and normalization, before destructive confirmation.
- Add regression coverage, correct numeric-only success fixtures, and move Core validator tests into Core.Tests.
- Remove the unused validation-message helper, a constant-alias assertion, and a WinUI XAML structure test; retain migration and localization-contract coverage.
- Remove unnecessary asynchronous state-file writes from an Autopilot test fake to prevent temporary-directory cleanup races.
- Document numeric serial naming guidance. No schema version change is required.

## Testing
- Regression tests reproduced the bug before the validator fix.
- x64 Release solution build with warnings treated as errors: passed, zero warnings/errors.
- All six x64 test projects: 1,718 passed.
- Repository formatting check: passed (scripts/Test-FoundryFormat.ps1).
- Real WinPE/Windows OOBE deployment was not run.

Kept as separate commits for review. No merge or squash performed.

