### PR TITLE
fix(storage): handle paths without physical partitions

### DIFF
--- a/src/Foundry.Utilities.Tests/Storage/WindowsDiskInspectorTests.cs
+++ b/src/Foundry.Utilities.Tests/Storage/WindowsDiskInspectorTests.cs
@@ -171,6 +171,55 @@ public sealed class WindowsDiskInspectorTests
         Assert.Null(diskNumber);
     }
 
+    [Theory]
+    [InlineData("X:\\Foundry")]
+    [InlineData("R:\\Foundry")]
+    public async Task ResolveDiskNumberForPathAsync_WhenPowerShellReportsNoMatchingPartition_ReturnsNull(string path)
+    {
+        var inspector = CreatePowerShellInspector("""
+            $PSCmdlet.WriteError([System.Management.Automation.ErrorRecord]::new(
+                [System.Exception]::new('No matching partition.'),
+                'CmdletizationQuery_NotFound_DriveLetter',
+                [System.Management.Automation.ErrorCategory]::ObjectNotFound,
+                $DriveLetter))
+            """);
+
+        int? diskNumber = await inspector.ResolveDiskNumberForPathAsync(
+            path,
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(diskNumber);
+    }
+
+    [Fact]
+    public async Task ResolveDiskNumberForPathAsync_WhenPowerShellCannotAccessPartitions_ThrowsInvalidDataException()
+    {
+        var inspector = CreatePowerShellInspector("""
+            $PSCmdlet.WriteError([System.Management.Automation.ErrorRecord]::new(
+                [System.UnauthorizedAccessException]::new('Access denied.'),
+                'StorageWMI 40001',
+                [System.Management.Automation.ErrorCategory]::PermissionDenied,
+                $DriveLetter))
+            """);
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => inspector.ResolveDiskNumberForPathAsync(
+                "C:\\Foundry",
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ResolveDiskNumberForPathAsync_WhenPowerShellFindsPartition_ReturnsDiskNumber()
+    {
+        var inspector = CreatePowerShellInspector("[pscustomobject]@{ DiskNumber = 3 }");
+
+        int? diskNumber = await inspector.ResolveDiskNumberForPathAsync(
+            "C:\\Foundry",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, diskNumber);
+    }
+
     [Fact]
     public async Task ResolveDiskNumberForPathAsync_WhenPayloadIsMalformed_ThrowsInvalidDataException()
     {
@@ -225,6 +274,28 @@ public sealed class WindowsDiskInspectorTests
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => inspector.GetDisksAsync(cancellationSource.Token));
+    }
+
+    private static WindowsDiskInspector CreatePowerShellInspector(string partitionQueryBody)
+    {
+        return new WindowsDiskInspector((request, cancellationToken) =>
+        {
+            string[] arguments = request.ArgumentList!.ToArray();
+            int encodedCommandIndex = Array.IndexOf(arguments, "-EncodedCommand") + 1;
+            string script = Encoding.Unicode.GetString(Convert.FromBase64String(arguments[encodedCommandIndex]));
+            string stub = $$"""
+                function Get-Partition {
+                    [CmdletBinding()]
+                    param([char]$DriveLetter)
+                    {{partitionQueryBody}}
+                }
+                """;
+            arguments[encodedCommandIndex] = Convert.ToBase64String(Encoding.Unicode.GetBytes(stub + "\n" + script));
+
+            return new ProcessRunner().RunAsync(
+                new ProcessExecutionRequest(request.FileName, arguments, request.WorkingDirectory),
+                cancellationToken);
+        });
     }
 
     private static WindowsDiskInspector CreateInspector(string json)

--- a/src/Foundry.Utilities/Storage/IWindowsDiskInspector.cs
+++ b/src/Foundry.Utilities/Storage/IWindowsDiskInspector.cs
@@ -17,6 +17,7 @@ public interface IWindowsDiskInspector
     /// <summary>
     /// Resolves the physical disk number that contains a path.
     /// </summary>
+    /// <returns>The disk number, or null when the path has no matching physical partition, such as a WinPE RAM drive.</returns>
     Task<int?> ResolveDiskNumberForPathAsync(
         string path,
         CancellationToken cancellationToken = default);

--- a/src/Foundry.Utilities/Storage/WindowsDiskInspector.cs
+++ b/src/Foundry.Utilities/Storage/WindowsDiskInspector.cs
@@ -96,9 +96,16 @@ public sealed class WindowsDiskInspector : IWindowsDiskInspector
         string driveLetter = char.ToUpperInvariant(root[0]).ToString(CultureInfo.InvariantCulture);
 
         string script = $@"
-$partition = Get-Partition -DriveLetter '{EscapeForSingleQuote(driveLetter)}' -ErrorAction SilentlyContinue
+try {{
+    $partition = Get-Partition -DriveLetter '{EscapeForSingleQuote(driveLetter)}' -ErrorAction Stop
+}} catch {{
+    if ($_.FullyQualifiedErrorId -eq 'CmdletizationQuery_NotFound_DriveLetter,Get-Partition') {{
+        exit 0
+    }}
+    throw
+}}
 if ($null -eq $partition) {{
-    return
+    exit 0
 }}
 
 [pscustomobject]@{{


### PR DESCRIPTION
## Summary
Fix false disk lookup errors when a cache path has no matching physical partition, such as the WinPE RAM drive.

## Reason
The missing-partition query could leave powershell.exe with exit code 1 despite SilentlyContinue. Foundry then logged InvalidDataException to PostHog even though deployment continued successfully.

## Main changes
- Handle only Get-Partition's specific missing-drive-partition error and exit successfully with no disk number.
- Preserve access failures and other unexpected query errors; do not special-case a drive letter.
- Document the nullable result and add regression tests that execute the generated script in Windows PowerShell.

## Testing
- Regression tests failed before the fix for missing partitions on X: and R: and passed afterward.
- Foundry.Utilities.Tests: 199 passed (Release x64).
- Foundry.Deploy.Tests: 637 passed (Release x64).
- Independent code review: no actionable findings.
- Repository formatting check and git diff --check passed.
