### PR TITLE
fix(oobe): prevent crash when expanding Accounts

### DIFF
--- a/src/Foundry/Views/OobePage.xaml
+++ b/src/Foundry/Views/OobePage.xaml
@@ -62,7 +62,7 @@
                                     Text="{x:Bind ViewModel.OobeAccountsNeedsAttentionText, Mode=OneWay}" />
                             </StackPanel>
                         </Border>
-                        <wct:SettingsExpander.Items>
+                        <wct:SettingsExpander.ItemsHeader>
                             <Border
                                 Padding="{ThemeResource FoundryDefaultContentPadding}"
                                 Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
@@ -320,7 +320,7 @@
                                     </ContentControl>
                                 </StackPanel>
                             </Border>
-                        </wct:SettingsExpander.Items>
+                        </wct:SettingsExpander.ItemsHeader>
                     </wct:SettingsExpander>
 
                     <wct:SettingsCard


### PR DESCRIPTION
## Summary
Fix the Accounts expander crash reported in #332.

## Reason
The panel puts a Border in SettingsExpander.Items. The toolkit applies its default SettingsCard style to that Border when preparing the expanded content, causing a runtime style target mismatch.

## Main changes
Move the existing panel to SettingsExpander.ItemsHeader, which accepts arbitrary UIElement content. Preserve all account controls, bindings, and layout, following the existing Start page pattern.

## Testing
- Release x64 Foundry build with warnings as errors: passed, zero warnings/errors.
- Foundry.Core.Tests: 622 passed on the unchanged baseline; no business logic changed.
- Targeted XAML compatibility check: identifies the incompatible item before the fix and none after it.
- git diff --check: passed.
- scripts/Test-FoundryFormat.ps1: passed, including all 69 XAML files.
- Interactive Accounts validation was not completed: an isolated WinUI probe terminated during resource initialization before reaching the test, with both container variants.

Fixes #332.

