### PR TITLE
feat(telemetry): capture bootstrap failures and diagnostics

### DIFF
--- a/src/Foundry.Bootstrap.Tests/BootstrapCoordinatorTests.cs
+++ b/src/Foundry.Bootstrap.Tests/BootstrapCoordinatorTests.cs
@@ -14,6 +14,25 @@ namespace Foundry.Bootstrap.Tests;
 public sealed class BootstrapCoordinatorTests
 {
     [Theory]
+    [InlineData(0)]
+    [InlineData(20)]
+    [InlineData(7)]
+    public async Task DiagnosticsObserveOneTerminalOutcomeAndDeliveryFollowsSystemPreparation(int exitCode)
+    {
+        using var fixture = new Fixture { ConnectExit = exitCode, ObserveDiagnostics = true };
+        BootstrapResult result = await fixture.RunAsync();
+        Assert.Equal(exitCode == 0 ? BootstrapOutcome.Succeeded : exitCode == 20 ? BootstrapOutcome.Cancelled : BootstrapOutcome.Failed, result.Outcome);
+        Assert.Single(fixture.Outcomes);
+        Assert.Equal(result, fixture.Outcomes[0]);
+        if (exitCode == 0)
+        {
+            Assert.True(fixture.Calls.IndexOf("system") < fixture.Calls.IndexOf("delivery"));
+            Assert.True(fixture.Calls.IndexOf("delivery") < fixture.Calls.IndexOf("deploy"));
+        }
+        else { Assert.DoesNotContain("delivery", fixture.Calls); }
+    }
+
+    [Theory]
     [InlineData(20, true)]
     [InlineData(21, false)]
     [InlineData(22, false)]
@@ -118,9 +137,13 @@ public sealed class BootstrapCoordinatorTests
         internal bool CancelConnect { get; init; }
         internal bool DeployFails { get; init; }
         internal bool ConnectTimeout { get; init; }
+        internal bool ObserveDiagnostics { get; init; }
+        internal List<BootstrapResult> Outcomes { get; } = [];
 
         internal Task<BootstrapResult> RunAsync() => new BootstrapCoordinator(Context, this, this, this, this,
-            logger, Progress.Add).RunAsync(cancellation.Token);
+            logger, Progress.Add,
+            ObserveDiagnostics ? () => Calls.Add("delivery") : null,
+            ObserveDiagnostics ? (result, _) => Outcomes.Add(result) : null).RunAsync(cancellation.Token);
 
         public Task<string> ResolveAsync(string applicationName, bool skipReleaseLookup, CancellationToken cancellationToken)
         {

--- a/src/Foundry.Bootstrap.Tests/Diagnostics/BootstrapTelemetryConsentTests.cs
+++ b/src/Foundry.Bootstrap.Tests/Diagnostics/BootstrapTelemetryConsentTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Bootstrap.Diagnostics;
+using Xunit;
+
+namespace Foundry.Bootstrap.Tests.Diagnostics;
+
+public sealed class BootstrapTelemetryConsentTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("invalid")]
+    [InlineData("{}")]
+    [InlineData("{\"schemaVersion\":1,\"telemetry\":{}}")]
+    [InlineData("{\"schemaVersion\":2,\"telemetry\":{\"isEnabled\":true,\"isRemoteDiagnosticsEnabled\":true}}")]
+    public void MissingOrInvalidBootstrapPreferencesNeverAuthorizeSending(string? json)
+    {
+        Assert.Null(BootstrapTelemetryConsent.ReadBootstrap(json));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void PreferencesRemainIndependentBeforeSecretsAreDecrypted(bool usage, bool diagnostics)
+    {
+        string json = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            schemaVersion = 1,
+            telemetry = new { isEnabled = usage, isRemoteDiagnosticsEnabled = diagnostics },
+            protection = new { unreadableSecret = "not-decrypted" }
+        });
+        var settings = BootstrapTelemetryConsent.ReadBootstrap(json);
+        Assert.NotNull(settings);
+        Assert.Equal(usage, settings.IsEnabled);
+        Assert.Equal(diagnostics, settings.IsRemoteDiagnosticsEnabled);
+        Assert.Equal((usage, diagnostics), BootstrapTelemetryConsent.RestrictChild(json, true, true, true));
+        Assert.Equal((false, false), BootstrapTelemetryConsent.RestrictChild(json, true, false, false));
+    }
+
+    [Fact]
+    public void UnknownOverrideAndMalformedPreferencesRestrictDelivery()
+    {
+        Assert.Equal((false, false), BootstrapTelemetryConsent.RestrictChild(null, true, true, true));
+        Assert.Equal((false, false), BootstrapTelemetryConsent.RestrictChild("invalid", false, true, true));
+        Assert.Equal((true, false), BootstrapTelemetryConsent.RestrictChild(null, false, true, false));
+        Assert.Equal((false, true), BootstrapTelemetryConsent.RestrictChild("{\"Telemetry\":{\"IsEnabled\":false}}", true, true, true));
+    }
+
+    [Theory]
+    [InlineData("{\"telemetry\":{\"isEnabled\":true,\"IsEnabled\":false}}")]
+    [InlineData("{\"telemetry\":{\"isRemoteDiagnosticsEnabled\":true,\"isRemoteDiagnosticsEnabled\":false}}")]
+    [InlineData("{\"telemetry\":{\"isEnabled\":true},\"Telemetry\":{\"isEnabled\":false}}")]
+    public void AmbiguousConsentFailsClosed(string json)
+    {
+        Assert.Equal((false, false), BootstrapTelemetryConsent.RestrictChild(json, true, true, true));
+    }
+}

--- a/src/Foundry.Bootstrap.Tests/SystemPreparation/WinPeSystemPreparationTests.cs
+++ b/src/Foundry.Bootstrap.Tests/SystemPreparation/WinPeSystemPreparationTests.cs
@@ -116,6 +116,7 @@ public sealed class WinPeSystemPreparationTests : IDisposable
         await preparation.PrepareSystemAsync(CancellationToken.None);
 
         Assert.Equal(expectedUpdate ? 1 : 0, platform.AppliedUtcTimes.Count);
+        Assert.True(preparation.IsClockUsable);
     }
 
     [Fact]
@@ -134,6 +135,7 @@ public sealed class WinPeSystemPreparationTests : IDisposable
         await preparation.PrepareSystemAsync(CancellationToken.None);
 
         Assert.Empty(platform.AppliedUtcTimes);
+        Assert.False(preparation.IsClockUsable);
     }
 
     [Fact]

--- a/src/Foundry.Bootstrap/BootstrapCoordinator.cs
+++ b/src/Foundry.Bootstrap/BootstrapCoordinator.cs
@@ -14,7 +14,8 @@ namespace Foundry.Bootstrap;
 /// <summary>Runs the finite, ordered WinPE boot workflow.</summary>
 internal sealed class BootstrapCoordinator(BootstrapContext context, IRuntimeResolver runtime,
     ISystemPreparation preparation, IApplicationLauncher launcher, IBootstrapLogPersistence persistence,
-    ILogger logger, Action<BootstrapProgress> progress)
+    ILogger logger, Action<BootstrapProgress> progress, Action? deliveryReady = null,
+    Action<BootstrapResult, TimeSpan>? completed = null)
 {
     private BootstrapStage stage = BootstrapStage.Environment;
 
@@ -54,8 +55,10 @@ internal sealed class BootstrapCoordinator(BootstrapContext context, IRuntimeRes
                 _ => "This boot stage could not be completed. Check the session log for details."
             };
             Report(status, message);
-            logger.Information("Bootstrap finished with {Outcome} at {Stage}; child exit {ExitCode}; elapsed {ElapsedMilliseconds} ms",
+            logger.ForContext("RemoteDiagnostic", true).Information("Bootstrap finished with {Outcome} at {Stage}; child exit {ExitCode}; elapsed {DurationMilliseconds} ms",
                 result.Outcome, result.Stage, result.ChildExitCode, Stopwatch.GetElapsedTime(started).TotalMilliseconds);
+            try { completed?.Invoke(result, Stopwatch.GetElapsedTime(started)); }
+            catch { }
         }
         finally
         {
@@ -104,6 +107,8 @@ internal sealed class BootstrapCoordinator(BootstrapContext context, IRuntimeRes
         await BestEffortAsync(() => preparation.PrepareSystemAsync(cancellationToken),
             "Some system preparation was unavailable. Continuing.").ConfigureAwait(false);
         Report(BootstrapStatus.Completed, "System preparation completed");
+        try { deliveryReady?.Invoke(); }
+        catch { }
 
         stage = BootstrapStage.DeploymentPreparation;
         Report(BootstrapStatus.Running, "Preparing the deployment application");
@@ -133,5 +138,12 @@ internal sealed class BootstrapCoordinator(BootstrapContext context, IRuntimeRes
         }
     }
 
-    private void Report(BootstrapStatus status, string message) => progress(new BootstrapProgress(stage, status, message));
+    private void Report(BootstrapStatus status, string message)
+    {
+        if (status == BootstrapStatus.Completed)
+        {
+            logger.ForContext("RemoteDiagnostic", true).Information("Bootstrap stage {Stage} completed", stage);
+        }
+        progress(new BootstrapProgress(stage, status, message));
+    }
 }

--- a/src/Foundry.Bootstrap/Diagnostics/BootstrapTelemetry.cs
+++ b/src/Foundry.Bootstrap/Diagnostics/BootstrapTelemetry.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Foundry.Telemetry;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Foundry.Bootstrap.Diagnostics;
+
+/// <summary>Adapts boot outcomes and consent to the shared, best-effort telemetry pipeline.</summary>
+internal sealed class BootstrapTelemetry : ILogEventSink
+{
+    private BootstrapTelemetryPipeline? pipeline;
+    private string root = string.Empty;
+    private TelemetrySettings? settings;
+
+    /// <summary>Enables capture only after valid media preferences; no transport starts here.</summary>
+    internal void Configure(string winPeRoot, string? cacheRoot)
+    {
+        try
+        {
+            root = winPeRoot;
+            settings = BootstrapTelemetryConsent.ReadBootstrap(ReadFile(Path.Combine(root, "Config", "foundry.bootstrap.config.json")));
+            if (settings is null) { return; }
+            string version = typeof(BootstrapTelemetry).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown";
+            var context = TelemetryContextFactory.Create(TelemetryApps.FoundryBootstrap, version, TelemetryBuildConfiguration.Current,
+                "winpe", settings.RuntimePayloadSource, cacheRoot is null ? "iso" : "usb",
+                RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant(), CultureInfo.CurrentUICulture.Name);
+            pipeline = new BootstrapTelemetryPipeline(
+                new(settings.IsEnabled, settings.HostUrl, settings.ProjectToken, settings.InstallId), context,
+                new(settings.IsRemoteDiagnosticsEnabled, settings.HostUrl, settings.ProjectToken, settings.InstallId),
+                TelemetryContextFactory.CreateRemoteDiagnosticsContext(context),
+                cacheRoot is null ? null : Path.Combine(cacheRoot, "Diagnostics", "Bootstrap", "pending.jsonl"));
+            RestrictChildConsent();
+        }
+        catch { }
+    }
+
+    public void Emit(LogEvent logEvent)
+    {
+        try { pipeline?.Emit(logEvent); }
+        catch { }
+    }
+
+    /// <summary>Rechecks child opt-outs before the coordinator permits background delivery.</summary>
+    internal void StartDelivery(bool clockUsable)
+    {
+        try { RestrictChildConsent(); pipeline?.StartDelivery(clockUsable); }
+        catch { }
+    }
+
+    /// <summary>Maps only terminal failures to product events; diagnostics use their own consent.</summary>
+    internal void Complete(BootstrapResult result, TimeSpan elapsed)
+    {
+        if (result.Outcome != BootstrapOutcome.Failed) { return; }
+        try
+        {
+            RestrictChildConsent();
+            pipeline?.CaptureTerminalFailure(new Dictionary<string, object?>
+            {
+                ["failure_category"] = result.ChildExitCode.HasValue ? "child_exit" : "stage_failed",
+                ["last_stage"] = result.Stage.ToString().ToLowerInvariant(),
+                ["elapsed_seconds"] = elapsed.TotalSeconds,
+                ["child_application"] = result.Stage == BootstrapStage.Connect ? "foundry_connect" : result.Stage == BootstrapStage.Deploy ? "foundry_deploy" : "none",
+                ["child_exit_code"] = result.ChildExitCode,
+                ["payload_source"] = settings?.RuntimePayloadSource,
+                ["architecture"] = RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant()
+            });
+        }
+        catch { }
+    }
+
+    internal async Task ShutdownAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            RestrictChildConsent();
+            if (pipeline is not null) { await pipeline.ShutdownAsync(cancellationToken).ConfigureAwait(false); }
+        }
+        catch { }
+    }
+
+    private void RestrictChildConsent()
+    {
+        if (settings is null || pipeline is null) { return; }
+        string? connectOverride = Environment.GetEnvironmentVariable("FOUNDRY_CONNECT_CONFIG");
+        bool required = !string.IsNullOrWhiteSpace(connectOverride);
+        // Connect resolves relative overrides under its executable directory, which differs from Bootstrap.
+        string? connectJson = required && !Path.IsPathFullyQualified(connectOverride!) ? "invalid" :
+            ReadFile(required ? connectOverride! : Path.Combine(root, "Config", "foundry.connect.config.json"));
+        var consent = BootstrapTelemetryConsent.RestrictChild(connectJson,
+            required, settings.IsEnabled, settings.IsRemoteDiagnosticsEnabled);
+        consent = BootstrapTelemetryConsent.RestrictChild(ReadFile(Path.Combine(root, "Config", "foundry.deploy.config.json")), false, consent.Usage, consent.Diagnostics);
+        pipeline.RestrictConsent(consent.Usage, consent.Diagnostics);
+    }
+
+    private static string? ReadFile(string path)
+    {
+        try
+        {
+            using var file = File.OpenRead(path);
+            if (file.Length > 1024 * 1024) { return "invalid"; }
+            using var reader = new StreamReader(file);
+            return reader.ReadToEnd();
+        }
+        catch (FileNotFoundException) { return null; }
+        catch (DirectoryNotFoundException) { return null; }
+        catch { return "invalid"; }
+    }
+}

--- a/src/Foundry.Bootstrap/Diagnostics/BootstrapTelemetryConsent.cs
+++ b/src/Foundry.Bootstrap/Diagnostics/BootstrapTelemetryConsent.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using Foundry.Telemetry;
+
+namespace Foundry.Bootstrap.Diagnostics;
+
+/// <summary>Reads only diagnostic preferences, without loading or decrypting child secrets.</summary>
+internal static class BootstrapTelemetryConsent
+{
+    private static readonly JsonSerializerOptions Options = new() { PropertyNameCaseInsensitive = true };
+
+    internal static TelemetrySettings? ReadBootstrap(string? json)
+    {
+        try
+        {
+            if (json is null) { return null; }
+            using JsonDocument document = JsonDocument.Parse(json);
+            JsonElement root = document.RootElement;
+            if (!TryProperty(root, "schemaVersion", out var version) || !version.TryGetInt32(out int schema) || schema != 1 ||
+                !TryProperty(root, "telemetry", out var settings) ||
+                !TryBoolean(settings, "isEnabled", out _) || !TryBoolean(settings, "isRemoteDiagnosticsEnabled", out _))
+            {
+                return null;
+            }
+            return settings.Deserialize<TelemetrySettings>(Options);
+        }
+        catch (Exception exception) when (exception is JsonException or InvalidOperationException) { return null; }
+    }
+
+    internal static (bool Usage, bool Diagnostics) RestrictChild(string? json, bool required,
+        bool usage, bool diagnostics)
+    {
+        if (json is null) { return required ? (false, false) : (usage, diagnostics); }
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(json, new JsonDocumentOptions { CommentHandling = JsonCommentHandling.Skip });
+            if (document.RootElement.ValueKind != JsonValueKind.Object) { return (false, false); }
+            if (!TryProperty(document.RootElement, "telemetry", out var settings)) { return (usage, diagnostics); }
+            if (settings.ValueKind != JsonValueKind.Object) { return (false, false); }
+            if (TryProperty(settings, "isEnabled", out var enabled))
+            {
+                usage &= enabled.ValueKind == JsonValueKind.True;
+            }
+            if (TryProperty(settings, "isRemoteDiagnosticsEnabled", out var remote))
+            {
+                diagnostics &= remote.ValueKind == JsonValueKind.True;
+            }
+            return (usage, diagnostics);
+        }
+        catch (Exception exception) when (exception is JsonException or InvalidOperationException) { return (false, false); }
+    }
+
+    private static bool TryBoolean(JsonElement element, string name, out bool value)
+    {
+        value = false;
+        if (!TryProperty(element, name, out var property) || property.ValueKind is not (JsonValueKind.True or JsonValueKind.False)) { return false; }
+        value = property.GetBoolean();
+        return true;
+    }
+
+    private static bool TryProperty(JsonElement element, string name, out JsonElement property)
+    {
+        property = default;
+        bool found = false;
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var candidate in element.EnumerateObject())
+            {
+                if (!candidate.Name.Equals(name, StringComparison.OrdinalIgnoreCase)) { continue; }
+                if (found) { throw new JsonException("Duplicate telemetry configuration property."); }
+                property = candidate.Value;
+                found = true;
+            }
+        }
+        return found;
+    }
+}

--- a/src/Foundry.Bootstrap/Foundry.Bootstrap.csproj
+++ b/src/Foundry.Bootstrap/Foundry.Bootstrap.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Foundry.Telemetry\Foundry.Telemetry.csproj" />
     <ProjectReference Include="..\Foundry.Utilities\Foundry.Utilities.csproj" />
     <InternalsVisibleTo Include="Foundry.Bootstrap.Tests" />
   </ItemGroup>

--- a/src/Foundry.Bootstrap/Program.cs
+++ b/src/Foundry.Bootstrap/Program.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Foundry.Bootstrap.Console;
 using Foundry.Bootstrap.Diagnostics;
@@ -39,6 +40,8 @@ internal static class Program
         string? logPath = null;
         BootstrapLogPersistence? persistence = null;
         bool coordinatorStarted = false;
+        long started = Stopwatch.GetTimestamp();
+        var telemetry = new BootstrapTelemetry();
         using var presenter = new BootstrapConsole();
         using var cancellation = new CancellationTokenSource();
         ConsoleCancelEventHandler cancel = (_, args) => { args.Cancel = true; cancellation.Cancel(); };
@@ -50,12 +53,12 @@ internal static class Program
                 logPath = WritableFilePathResolver.Resolve([Path.Combine(WinPeRoot, "Logs"),
                     Path.Combine(Path.GetTempPath(), "Foundry", "Logs")], "FoundryBootstrap.log");
                 Log.Logger = FoundryLogConfiguration.CreateFileLogger(logPath, "Foundry.Bootstrap", sessionId,
-                    LogEventLevel.Debug, 5);
+                    LogEventLevel.Debug, 5, additionalSink: telemetry);
             }
             catch
             {
                 logPath = null;
-                Log.Logger = FoundryLogConfiguration.CreateDebugLogger("Foundry.Bootstrap", sessionId, LogEventLevel.Debug);
+                Log.Logger = FoundryLogConfiguration.CreateDebugLogger("Foundry.Bootstrap", sessionId, LogEventLevel.Debug, additionalSink: telemetry);
             }
 
             if (!WinPeRuntimeDetector.IsWinPeRuntime())
@@ -70,6 +73,7 @@ internal static class Program
             BootstrapVolume[] volumes = BootstrapEnvironment.EnumerateVolumes().ToArray();
             BootstrapVolume? cache = volumes.FirstOrDefault(volume => volume.IsReady &&
                 string.Equals(volume.Label, "Foundry Cache", StringComparison.OrdinalIgnoreCase));
+            telemetry.Configure(WinPeRoot, cache?.Root);
             persistence = new BootstrapLogPersistence(Path.GetDirectoryName(logPath) ?? Path.Combine(WinPeRoot, "Logs"),
                 cache is null ? null : Path.Combine(cache.Root, "Logs", sessionId),
                 Log.ForContext<BootstrapLogPersistence>());
@@ -85,7 +89,8 @@ internal static class Program
                 Log.ForContext<WinPeSystemPreparation>(), presenter.ReportWarning);
             var launcher = new ApplicationLauncher(Log.ForContext<ApplicationLauncher>());
             var coordinator = new BootstrapCoordinator(context, runtime, preparation, launcher, persistence,
-                Log.ForContext<BootstrapCoordinator>(), presenter.Report);
+                Log.ForContext<BootstrapCoordinator>(), presenter.Report,
+                () => telemetry.StartDelivery(preparation.IsClockUsable), telemetry.Complete);
             coordinatorStarted = true;
             BootstrapResult result = await coordinator.RunAsync(cancellation.Token).ConfigureAwait(false);
             if (result.Outcome != BootstrapOutcome.Succeeded) { presenter.ShowDiagnostics(sessionId, logPath); }
@@ -94,6 +99,7 @@ internal static class Program
         catch (Exception exception)
         {
             Log.Fatal(exception, "Bootstrap could not initialize");
+            telemetry.Complete(new BootstrapResult(BootstrapOutcome.Failed, BootstrapStage.Environment), Stopwatch.GetElapsedTime(started));
             presenter.Report(new BootstrapProgress(BootstrapStage.Environment, BootstrapStatus.Failed,
                 "The boot environment could not be initialized."));
             presenter.ShowDiagnostics(sessionId, logPath);
@@ -107,7 +113,13 @@ internal static class Program
                 try { await persistence.PersistAsync(CancellationToken.None).ConfigureAwait(false); }
                 catch { }
             }
-            await BootstrapLogShutdown.FlushAsync().ConfigureAwait(false);
+            using var shutdown = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            try
+            {
+                await Task.WhenAll(telemetry.ShutdownAsync(shutdown.Token), BootstrapLogShutdown.FlushAsync())
+                    .WaitAsync(shutdown.Token).ConfigureAwait(false);
+            }
+            catch { }
         }
     }
 }

--- a/src/Foundry.Bootstrap/SystemPreparation/WinPeSystemPreparation.cs
+++ b/src/Foundry.Bootstrap/SystemPreparation/WinPeSystemPreparation.cs
@@ -33,6 +33,9 @@ public sealed class WinPeSystemPreparation : ISystemPreparation
     private readonly TimeSpan _requestTimeout;
     private readonly Action<string>? _warningCallback;
 
+    /// <summary>Indicates that system UTC was verified or corrected against an internet clock response.</summary>
+    public bool IsClockUsable { get; private set; }
+
     public WinPeSystemPreparation(
         string winPeRoot,
         HttpClient httpClient,
@@ -142,13 +145,18 @@ public sealed class WinPeSystemPreparation : ISystemPreparation
 
         if ((internetTime.Value - _platform.UtcNow).Duration() <= ClockSkewThreshold)
         {
+            IsClockUsable = true;
             _logger.Information("System clock is within the allowed internet time threshold.");
             return;
         }
 
         await TryActionAsync(
             "System clock could not be corrected. Boot will continue.",
-            token => _platform.SetSystemTimeAsync(internetTime.Value.ToUniversalTime(), token),
+            async token =>
+            {
+                await _platform.SetSystemTimeAsync(internetTime.Value.ToUniversalTime(), token).ConfigureAwait(false);
+                IsClockUsable = true;
+            },
             cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeMountedImageAssetProvisioningServiceTests.cs
@@ -11,11 +11,62 @@ using Foundry.Core.Models.Configuration;
 using Foundry.Core.Services.Autopilot;
 using Foundry.Core.Services.Configuration;
 using Foundry.Core.Services.WinPe;
+using Foundry.Telemetry;
 
 namespace Foundry.Core.Tests.WinPe;
 
 public sealed class WinPeMountedImageAssetProvisioningServiceTests
 {
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ProvisionAsync_WritesIsolatedBootstrapTelemetryConfiguration(bool provideConfiguration)
+    {
+        using TempMountedImage image = TempMountedImage.Create();
+        string curlSource = Path.Combine(image.RootPath, "curl.exe");
+        File.WriteAllText(curlSource, "curl");
+        var configuration = new FoundryBootstrapConfigurationDocument
+        {
+            Telemetry = new TelemetrySettings
+            {
+                IsEnabled = true,
+                IsRemoteDiagnosticsEnabled = false,
+                InstallId = "anonymous-install",
+                RuntimePayloadSource = TelemetryRuntimePayloadSources.Release
+            }
+        };
+
+        WinPeResult result = await new WinPeMountedImageAssetProvisioningService().ProvisionAsync(
+            new WinPeMountedImageAssetProvisioningOptions
+            {
+                MountedImagePath = image.MountedImagePath,
+                CurlExecutableSourcePath = curlSource,
+                IanaWindowsTimeZoneMapJson = "{}",
+                FoundryBootstrapConfiguration = provideConfiguration ? configuration : null,
+                FoundryConnectConfigurationJson = "{\"network\":{\"secret\":\"network-secret\"}}",
+                DeployConfigurationJson = "{\"deploymentSecret\":\"deployment-secret\"}"
+            }, TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsSuccess, result.Error?.Details);
+        string json = await File.ReadAllTextAsync(
+            Path.Combine(image.MountedImagePath, "Foundry", "Config", "foundry.bootstrap.config.json"),
+            TestContext.Current.CancellationToken);
+        var written = JsonSerializer.Deserialize<FoundryBootstrapConfigurationDocument>(json, ConfigurationJsonDefaults.SerializerOptions);
+        Assert.NotNull(written);
+        Assert.Equal(1, written.SchemaVersion);
+        Assert.Equal(provideConfiguration, written.Telemetry.IsEnabled);
+        Assert.False(written.Telemetry.IsRemoteDiagnosticsEnabled);
+        if (provideConfiguration)
+        {
+            Assert.Equal(configuration.Telemetry, written.Telemetry);
+        }
+
+        using JsonDocument document = JsonDocument.Parse(json);
+        Assert.Equal(["schemaVersion", "telemetry"], document.RootElement.EnumerateObject().Select(property => property.Name).Order());
+        Assert.DoesNotContain("network-secret", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("deployment-secret", json, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task Launcher_WhenExecutableCannotStart_RecordsAttemptAndPropagatesFailure()
     {

--- a/src/Foundry.Core/Models/Configuration/FoundryBootstrapConfigurationDocument.cs
+++ b/src/Foundry.Core/Models/Configuration/FoundryBootstrapConfigurationDocument.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Telemetry;
+
+namespace Foundry.Core.Models.Configuration;
+
+/// <summary>
+/// Contains only the telemetry policy consumed by the boot orchestrator.
+/// </summary>
+public sealed record FoundryBootstrapConfigurationDocument
+{
+    /// <summary>
+    /// Defines the independently versioned Bootstrap configuration contract.
+    /// </summary>
+    public const int CurrentSchemaVersion = 1;
+
+    /// <summary>
+    /// Gets the schema version of this configuration document.
+    /// </summary>
+    public int SchemaVersion { get; init; } = CurrentSchemaVersion;
+
+    /// <summary>
+    /// Gets telemetry settings, disabled unless authoring explicitly supplies consent.
+    /// </summary>
+    public TelemetrySettings Telemetry { get; init; } = new()
+    {
+        IsEnabled = false,
+        IsRemoteDiagnosticsEnabled = false
+    };
+}

--- a/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningOptions.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningOptions.cs
@@ -13,6 +13,7 @@ public sealed record WinPeMountedImageAssetProvisioningOptions
     public string CurlExecutableSourcePath { get; init; } = string.Empty;
     public string SevenZipSourceDirectoryPath { get; init; } = string.Empty;
     public string IanaWindowsTimeZoneMapJson { get; init; } = string.Empty;
+    public FoundryBootstrapConfigurationDocument? FoundryBootstrapConfiguration { get; init; }
     public string FoundryConnectConfigurationJson { get; init; } = string.Empty;
     public string DeployConfigurationJson { get; init; } = string.Empty;
     public byte[]? NetworkSecretsKey { get; init; }

--- a/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningService.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeMountedImageAssetProvisioningService.cs
@@ -120,6 +120,16 @@ public sealed class WinPeMountedImageAssetProvisioningService : IWinPeMountedIma
         WinPeMountedImageAssetProvisioningOptions options,
         CancellationToken cancellationToken)
     {
+        string bootstrapConfigurationJson = JsonSerializer.Serialize(
+            options.FoundryBootstrapConfiguration ?? new FoundryBootstrapConfigurationDocument(),
+            ConfigurationJsonDefaults.SerializerOptions);
+
+        await File.WriteAllTextAsync(
+            Path.Combine(foundryConfigPath, "foundry.bootstrap.config.json"),
+            bootstrapConfigurationJson,
+            Utf8NoBom,
+            cancellationToken).ConfigureAwait(false);
+
         string connectConfigurationJson = string.IsNullOrWhiteSpace(options.FoundryConnectConfigurationJson)
             ? CreateFallbackFoundryConnectConfigurationJson()
             : options.FoundryConnectConfigurationJson;

--- a/src/Foundry.Telemetry.Tests/BootstrapTelemetryPipelineTests.cs
+++ b/src/Foundry.Telemetry.Tests/BootstrapTelemetryPipelineTests.cs
@@ -1,0 +1,407 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Net;
+using System.Text.Json;
+using Foundry.Telemetry;
+using Serilog.Events;
+
+namespace Foundry.Telemetry.Tests;
+
+public sealed class BootstrapTelemetryPipelineTests
+{
+    private static readonly TelemetryContext Context = new(TelemetryApps.FoundryBootstrap, "1.2.3", "release", "winpe",
+        "release", "usb", "x64", "en-US", "boot-session");
+
+    [Theory]
+    [InlineData(false, false, 0, 0)]
+    [InlineData(false, true, 0, 2)]
+    [InlineData(true, false, 1, 0)]
+    [InlineData(true, true, 1, 2)]
+    public async Task Capture_RespectsIndependentConsent(bool usage, bool diagnostics, int analyticsCount, int diagnosticCount)
+    {
+        var transport = new RecordingTransport();
+        await using var pipeline = Create(transport, usage: usage, diagnostics: diagnostics);
+        pipeline.Emit(Event(LogEventLevel.Error, new InvalidOperationException("password=secret")));
+        pipeline.CaptureTerminalFailure(Failure());
+        pipeline.CaptureTerminalFailure(Failure());
+        Assert.Empty(transport.Records);
+        Assert.Equal(analyticsCount, pipeline.PendingRecords.Count(record => record.Destination == BootstrapTelemetryDestination.Analytics));
+        Assert.Equal(diagnosticCount, pipeline.PendingRecords.Count(record => record.Destination != BootstrapTelemetryDestination.Analytics));
+        await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(analyticsCount + diagnosticCount, transport.Records.Count);
+    }
+
+    [Fact]
+    public async Task Logs_KeepFilterRateLimitAndExceptionDedupe()
+    {
+        var transport = new RecordingTransport();
+        await using var pipeline = Create(transport);
+        pipeline.Emit(Event(LogEventLevel.Debug));
+        pipeline.Emit(Event(LogEventLevel.Information));
+        pipeline.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Information, "Milestone", null, ("RemoteDiagnostic", true)));
+        var exception = new IOException("password=secret");
+        for (int index = 0; index < 20; index++) pipeline.Emit(Event(LogEventLevel.Error, exception));
+        Assert.Equal(6, pipeline.PendingRecords.Count(record => record.Destination == BootstrapTelemetryDestination.Log));
+        Assert.Single(pipeline.PendingRecords, record => record.Destination == BootstrapTelemetryDestination.Exception);
+        Assert.DoesNotContain(pipeline.PendingRecords, record => record.Destination == BootstrapTelemetryDestination.Analytics);
+    }
+
+    [Fact]
+    public async Task Delivery_DrainsBeforePreparationRecordsAndContinuesAcceptingNewRecords()
+    {
+        var transport = new RecordingTransport();
+        await using var pipeline = Create(transport);
+        pipeline.Emit(Event(LogEventLevel.Warning));
+        Assert.Empty(transport.Records);
+        pipeline.StartDelivery(true);
+        await transport.WaitForCountAsync(1);
+        pipeline.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Warning, "Later warning"));
+        await transport.WaitForCountAsync(2);
+        Assert.Equal(0, transport.FlushCount);
+        await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(1, transport.FlushCount);
+    }
+
+    [Fact]
+    public async Task ProcessExitObservation_DoesNotManufactureAnException()
+    {
+        await using var pipeline = Create(new RecordingTransport());
+        pipeline.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "Child exited", null, ("ExitCode", 22)));
+        Assert.Single(pipeline.PendingRecords);
+        Assert.Null(pipeline.PendingRecords[0].Diagnostic!.Exception);
+    }
+
+    [Fact]
+    public async Task Journal_RetainsIdentityTimestampAndCapsUnacknowledgedHandoffsAcrossBoots()
+    {
+        using var folder = new TestFolder();
+        Guid identity;
+        DateTimeOffset timestamp;
+        var first = new RecordingTransport();
+        await using (var pipeline = Create(first, folder.Path))
+        {
+            pipeline.Emit(Event(LogEventLevel.Warning));
+            identity = pipeline.PendingRecords[0].Id;
+            timestamp = pipeline.PendingRecords[0].Timestamp;
+            await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(BootstrapDeliveryState.HandedToTransport, pipeline.PendingRecords[0].State);
+        }
+        for (int boot = 2; boot <= 4; boot++)
+        {
+            var transport = new RecordingTransport();
+            await using var pipeline = Create(transport, folder.Path);
+            pipeline.StartDelivery(true);
+            await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(boot <= 3 ? 1 : 0, transport.Records.Count);
+            Assert.Equal(identity, pipeline.PendingRecords[0].Id);
+            Assert.Equal(timestamp, pipeline.PendingRecords[0].Timestamp);
+            Assert.Equal(Math.Min(boot, 3), pipeline.PendingRecords[0].Attempts);
+        }
+    }
+
+    [Fact]
+    public async Task PartialReceipt_RemovesOnlyAcknowledgedDestination()
+    {
+        using var folder = new TestFolder();
+        var transport = new RecordingTransport { Acknowledge = record => record.Destination == BootstrapTelemetryDestination.Log };
+        await using (var pipeline = Create(transport, folder.Path))
+        {
+            pipeline.Emit(Event(LogEventLevel.Error, new IOException("Failed")));
+            await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(BootstrapTelemetryDestination.Exception, Assert.Single(pipeline.PendingRecords).Destination);
+        }
+        var next = new RecordingTransport();
+        await using var replay = Create(next, folder.Path);
+        await replay.ShutdownAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(BootstrapTelemetryDestination.Exception, Assert.Single(next.Records).Destination);
+    }
+
+    [Theory]
+    [InlineData(false, false, 0)]
+    [InlineData(true, false, 1)]
+    [InlineData(false, true, 2)]
+    [InlineData(true, true, 3)]
+    public async Task RestrictionBeforeReplay_PurgesEachCategoryIndependently(bool usage, bool diagnostics, int expected)
+    {
+        using var folder = new TestFolder();
+        await using (var first = Create(new RecordingTransport(), folder.Path))
+        {
+            first.CaptureTerminalFailure(Failure());
+            first.Emit(Event(LogEventLevel.Error, new IOException("Failed")));
+            await first.ShutdownAsync(new CancellationToken(true));
+        }
+        var transport = new RecordingTransport();
+        await using var pipeline = Create(transport, folder.Path);
+        pipeline.RestrictConsent(usage, diagnostics);
+        Assert.Equal(expected, pipeline.PendingRecords.Count);
+        pipeline.StartDelivery(true);
+        await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(expected, transport.Records.Count);
+        Assert.Equal(expected, File.ReadAllLines(folder.Path).Length);
+    }
+
+    [Fact]
+    public async Task ChangedInstallationOrDestination_DoesNotReplayOldRecords()
+    {
+        using var folder = new TestFolder();
+        await using (var first = Create(new RecordingTransport(), folder.Path))
+        {
+            first.CaptureTerminalFailure(Failure());
+            first.Emit(Event(LogEventLevel.Warning));
+        }
+        var transport = new RecordingTransport();
+        await using var changed = Create(transport, folder.Path, installation: "another-installation");
+        await changed.ShutdownAsync(TestContext.Current.CancellationToken);
+        Assert.Empty(transport.Records);
+        Assert.Empty(changed.PendingRecords);
+    }
+
+    [Fact]
+    public async Task ClockGate_ExpiresOldRecordsOnlyAfterUsableClock()
+    {
+        using var folder = new TestFolder();
+        var clock = new TestClock();
+        await using (var first = Create(new RecordingTransport(), folder.Path, time: clock))
+            first.CaptureTerminalFailure(Failure());
+        clock.UtcNow += TimeSpan.FromDays(8);
+        await using var replay = Create(new RecordingTransport(), folder.Path, time: clock);
+        Assert.Single(replay.PendingRecords);
+        replay.StartDelivery(true);
+        Assert.Empty(replay.PendingRecords);
+    }
+
+    [Fact]
+    public async Task ClockCorrection_DoesNotExpireRecordsCapturedDuringCurrentBoot()
+    {
+        var clock = new TestClock();
+        var transport = new RecordingTransport();
+        await using var pipeline = Create(transport, time: clock);
+        pipeline.CaptureTerminalFailure(Failure());
+        DateTimeOffset original = pipeline.PendingRecords[0].Timestamp;
+        clock.UtcNow += TimeSpan.FromDays(365);
+        pipeline.StartDelivery(true);
+        await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(original, Assert.Single(transport.Records).Timestamp);
+    }
+
+    [Fact]
+    public async Task DurableAttemptWriteFailure_DoesNotSubmitUnrecordedAttempts()
+    {
+        using var folder = new TestFolder();
+        Directory.CreateDirectory(folder.Path);
+        var transport = new RecordingTransport();
+        await using var pipeline = Create(transport, folder.Path);
+        pipeline.CaptureTerminalFailure(Failure());
+        await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
+        Assert.Empty(transport.Records);
+        Assert.Single(pipeline.PendingRecords);
+    }
+
+    [Fact]
+    public async Task Replay_IsLimitedToOneHundredRecordsPerBoot()
+    {
+        using var folder = new TestFolder();
+        await using (var first = Create(new RecordingTransport(), folder.Path))
+        {
+            for (int index = 0; index < 110; index++)
+                first.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Warning, "Warning " + index));
+        }
+        var transport = new RecordingTransport();
+        await using var replay = Create(transport, folder.Path);
+        await replay.ShutdownAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(100, transport.Records.Count);
+    }
+
+    [Fact]
+    public async Task Replay_UsesSharedMonotonicFiveSecondBudget()
+    {
+        using var folder = new TestFolder();
+        var clock = new TestClock();
+        await using (var first = Create(new RecordingTransport(), folder.Path, time: clock))
+        {
+            first.Emit(Event(LogEventLevel.Warning));
+            first.CaptureTerminalFailure(Failure());
+        }
+        var transport = new RecordingTransport
+        {
+            Acknowledge = _ => { clock.Timestamp += 6 * clock.TimestampFrequency; return false; }
+        };
+        await using var replay = Create(transport, folder.Path, time: clock);
+        await replay.ShutdownAsync(TestContext.Current.CancellationToken);
+        Assert.Single(transport.Records);
+    }
+
+    [Fact]
+    public async Task Shutdown_OutageSharesTwoSecondBudget()
+    {
+        var transport = new RecordingTransport { Block = true };
+        await using var pipeline = Create(transport);
+        pipeline.CaptureTerminalFailure(Failure());
+        var elapsed = Stopwatch.StartNew();
+        await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
+        Assert.True(elapsed.Elapsed < TimeSpan.FromSeconds(3));
+        Assert.Single(pipeline.PendingRecords);
+    }
+
+    [Fact]
+    public async Task CorruptAndUntrustedJournal_IsBoundedAndResanitized()
+    {
+        using var folder = new TestFolder();
+        await using (var first = Create(new RecordingTransport(), folder.Path))
+        {
+            first.CaptureTerminalFailure(Failure());
+            first.Emit(Event(LogEventLevel.Warning));
+        }
+        string[] lines = File.ReadAllLines(folder.Path);
+        var record = JsonSerializer.Deserialize<BootstrapPendingRecord>(lines[0])!;
+        record.Properties!["password"] = "private-secret";
+        record.Properties["last_stage"] = "password=private-secret";
+        File.WriteAllLines(folder.Path, ["not json", JsonSerializer.Serialize(record), lines[1]]);
+        var transport = new RecordingTransport();
+        await using var replay = Create(transport, folder.Path);
+        await replay.ShutdownAsync(TestContext.Current.CancellationToken);
+        string content = File.ReadAllText(folder.Path);
+        Assert.DoesNotContain("private-secret", content, StringComparison.Ordinal);
+        Assert.DoesNotContain("not json", content, StringComparison.Ordinal);
+        Assert.Equal(2, transport.Records.Count);
+    }
+
+    [Fact]
+    public async Task InvalidJournalNumber_DoesNotDiscardOtherValidRecords()
+    {
+        using var folder = new TestFolder();
+        await using (var first = Create(new RecordingTransport(), folder.Path))
+        {
+            first.CaptureTerminalFailure(Failure());
+            first.Emit(Event(LogEventLevel.Warning));
+        }
+        string[] lines = File.ReadAllLines(folder.Path);
+        string invalid = lines[1].Replace("\"Attributes\":{", "\"Attributes\":{\"duration.ms\":1e999,", StringComparison.Ordinal);
+        File.WriteAllLines(folder.Path, [invalid, lines[0]]);
+        var transport = new RecordingTransport();
+        await using var replay = Create(transport, folder.Path);
+        await replay.ShutdownAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(BootstrapTelemetryDestination.Analytics, Assert.Single(transport.Records).Destination);
+    }
+
+    [Fact]
+    public void Journal_EnforcesByteLimitWithoutClock()
+    {
+        using var folder = new TestFolder();
+        var journal = new BootstrapTelemetryJournal(folder.Path);
+        for (int index = 0; index < 30; index++)
+            journal.Add(new BootstrapPendingRecord(Guid.NewGuid(), new string('a', 64), BootstrapTelemetryDestination.Analytics,
+                DateTimeOffset.MinValue, new Dictionary<string, object> { ["data"] = new string('a', 200000) }, null));
+        Assert.True(new FileInfo(folder.Path).Length <= BootstrapTelemetryJournal.MaximumBytes);
+        Assert.True(journal.Records.Count < 30);
+    }
+
+    [Fact]
+    public void FailureProperties_RejectUnknownCategoriesAndUnboundedValues()
+    {
+        var properties = new Dictionary<string, object?>
+        {
+            ["failure_category"] = "private-name",
+            ["last_stage"] = "private-name",
+            ["child_application"] = "private-name",
+            ["payload_source"] = "private-name",
+            ["architecture"] = "private-name",
+            ["payload_version"] = "private-name",
+            ["elapsed_seconds"] = double.PositiveInfinity
+        };
+        Assert.Empty(TelemetryEventPropertyPolicy.Sanitize(TelemetryEvents.BootstrapFailed, properties));
+        var valid = TelemetryEventPropertyPolicy.Sanitize(TelemetryEvents.BootstrapFailed, Failure());
+        Assert.Equal("foundry_connect", valid["child_application"]);
+        Assert.Equal("child_exit", valid["failure_category"]);
+    }
+
+    [Fact]
+    public async Task AnalyticsTransport_UsesOriginalUuidAndTimestampAndRequiresHttpAcceptance()
+    {
+        var handler = new CaptureHandler();
+        using var client = new HttpClient(handler);
+        var service = new PostHogTelemetryService(client, new TelemetryOptions(true, "https://example.test", "public", "install"), Context);
+        Guid id = Guid.NewGuid();
+        DateTimeOffset timestamp = DateTimeOffset.Parse("2026-01-01T00:00:00Z", System.Globalization.CultureInfo.InvariantCulture);
+        var properties = PostHogTelemetryService.BuildProperties(Context, TelemetryEvents.BootstrapFailed, Failure());
+        Assert.False(await service.SendDurableAsync(id, timestamp, properties, CancellationToken.None));
+        handler.Status = HttpStatusCode.OK;
+        Assert.True(await service.SendDurableAsync(id, timestamp, properties, CancellationToken.None));
+        Assert.Equal(handler.Payloads[0], handler.Payloads[1]);
+        using var payload = JsonDocument.Parse(handler.Payloads[0]);
+        Assert.Equal(id, payload.RootElement.GetProperty("uuid").GetGuid());
+        Assert.Equal(timestamp, payload.RootElement.GetProperty("timestamp").GetDateTimeOffset());
+    }
+
+    private static BootstrapTelemetryPipeline Create(RecordingTransport transport, string? path = null,
+        bool usage = true, bool diagnostics = true, string installation = "install", TimeProvider? time = null) =>
+        new(new TelemetryOptions(usage, "https://example.test", "public", installation), Context,
+            new RemoteDiagnosticsOptions(diagnostics, "https://example.test", "public", installation),
+            TelemetryContextFactory.CreateRemoteDiagnosticsContext(Context), path, () => transport, time ?? TimeProvider.System);
+
+    private static LogEvent Event(LogEventLevel level, Exception? exception = null) =>
+        RemoteDiagnosticsTestData.LogEvent(level, "Bootstrap operation failed", exception);
+
+    private static Dictionary<string, object?> Failure() => new()
+    {
+        ["failure_category"] = "child_exit",
+        ["last_stage"] = "connect",
+        ["elapsed_seconds"] = 1.5,
+        ["child_application"] = "foundry_connect",
+        ["child_exit_code"] = 22,
+        ["password"] = "private-secret"
+    };
+
+    private sealed class RecordingTransport : IBootstrapTelemetryTransport
+    {
+        internal ConcurrentQueue<BootstrapPendingRecord> Records { get; } = new();
+        internal Func<BootstrapPendingRecord, bool> Acknowledge { get; init; } = _ => false;
+        internal bool Block { get; init; }
+        internal int FlushCount { get; private set; }
+        public async Task<bool> DeliverAsync(BootstrapPendingRecord record, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Records.Enqueue(record);
+            if (Block) await Task.Delay(Timeout.Infinite, cancellationToken);
+            return Acknowledge(record);
+        }
+        public Task FlushAsync(CancellationToken cancellationToken) { FlushCount++; return Task.CompletedTask; }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        internal async Task WaitForCountAsync(int count)
+        {
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+            while (Records.Count < count) await Task.Delay(10, timeout.Token);
+        }
+    }
+
+    private sealed class TestClock : TimeProvider
+    {
+        internal DateTimeOffset UtcNow { get; set; } = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        internal long Timestamp { get; set; }
+        public override DateTimeOffset GetUtcNow() => UtcNow;
+        public override long GetTimestamp() => Timestamp;
+    }
+
+    private sealed class TestFolder : IDisposable
+    {
+        private readonly string _directory = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        internal TestFolder() => Directory.CreateDirectory(_directory);
+        internal string Path => System.IO.Path.Combine(_directory, "pending.jsonl");
+        public void Dispose() => Directory.Delete(_directory, recursive: true);
+    }
+
+    private sealed class CaptureHandler : HttpMessageHandler
+    {
+        internal HttpStatusCode Status { get; set; } = HttpStatusCode.ServiceUnavailable;
+        internal List<string> Payloads { get; } = [];
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Payloads.Add(await request.Content!.ReadAsStringAsync(cancellationToken));
+            return new HttpResponseMessage(Status);
+        }
+    }
+}

--- a/src/Foundry.Telemetry/BootstrapTelemetryJournal.cs
+++ b/src/Foundry.Telemetry/BootstrapTelemetryJournal.cs
@@ -1,0 +1,187 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Foundry.Telemetry;
+
+/// <summary>Independent destinations retain their own handoff state when another destination fails.</summary>
+internal enum BootstrapTelemetryDestination { Analytics, Log, Exception }
+
+/// <summary>Buffered SDK handoff is deliberately distinct from an HTTP receipt.</summary>
+internal enum BootstrapDeliveryState { Pending, HandedToTransport, Acknowledged }
+
+/// <summary>A sanitized durable envelope; credentials are never stored in the journal.</summary>
+internal sealed record BootstrapPendingRecord(
+    Guid Id,
+    string Scope,
+    BootstrapTelemetryDestination Destination,
+    DateTimeOffset Timestamp,
+    Dictionary<string, object>? Properties,
+    RemoteDiagnosticRecord? Diagnostic,
+    int Attempts = 0,
+    BootstrapDeliveryState State = BootstrapDeliveryState.Pending);
+
+/// <summary>Bounds both RAM and disk; callers serialize access and apply consent before replay.</summary>
+internal sealed class BootstrapTelemetryJournal
+{
+    internal const int MaximumBytes = 5 * 1024 * 1024;
+    private const int MaximumRecordBytes = 256 * 1024;
+    private readonly string? _path;
+    private readonly List<BootstrapPendingRecord> _records = [];
+
+    internal BootstrapTelemetryJournal(string? path)
+    {
+        _path = path;
+        Load();
+    }
+
+    internal IReadOnlyList<BootstrapPendingRecord> Records => _records;
+
+    internal static string Scope(string host, string token, string installation) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(
+            string.Join('\n', host.TrimEnd('/').ToLowerInvariant(), token, installation))));
+
+    internal void Add(BootstrapPendingRecord record)
+    {
+        if (JsonSerializer.SerializeToUtf8Bytes(record).Length <= MaximumRecordBytes)
+        {
+            _records.Add(record);
+            Save();
+        }
+    }
+
+    internal bool Update(BootstrapPendingRecord record)
+    {
+        int index = _records.FindIndex(candidate => candidate.Id == record.Id);
+        if (index >= 0)
+        {
+            if (record.State == BootstrapDeliveryState.Acknowledged) _records.RemoveAt(index);
+            else _records[index] = record;
+            return Save();
+        }
+        return false;
+    }
+
+    internal void Purge(Func<BootstrapPendingRecord, bool> predicate)
+    {
+        _records.RemoveAll(record => predicate(record));
+        Save();
+    }
+
+    private void Load()
+    {
+        if (_path is null) return;
+        try
+        {
+            if (!File.Exists(_path)) return;
+            // Reject oversized input before allocating; the next save replaces it with a bounded journal.
+            if (new FileInfo(_path).Length > MaximumBytes) return;
+            foreach (string line in File.ReadLines(_path))
+            {
+                if (Encoding.UTF8.GetByteCount(line) > MaximumRecordBytes) continue;
+                try
+                {
+                    BootstrapPendingRecord? record = JsonSerializer.Deserialize<BootstrapPendingRecord>(line);
+                    if (record is not null && record.Id != Guid.Empty && record.Scope is { Length: 64 } &&
+                        Enum.IsDefined(record.Destination) && Enum.IsDefined(record.State) && record.Attempts >= 0 &&
+                        record.State != BootstrapDeliveryState.Acknowledged &&
+                        (record.Destination == BootstrapTelemetryDestination.Analytics ? record.Properties is not null :
+                            record.Diagnostic is { Attributes: not null, Body: not null } diagnostic && Enum.IsDefined(diagnostic.Level) && diagnostic.Level >= Serilog.Events.LogEventLevel.Information &&
+                            (record.Destination != BootstrapTelemetryDestination.Exception ||
+                                diagnostic is { Exception: not null, Level: >= Serilog.Events.LogEventLevel.Error })) &&
+                        !_records.Any(candidate => candidate.Id == record.Id))
+                    {
+                        _records.Add(Revalidate(Normalize(record)));
+                    }
+                }
+                catch (Exception exception) when (exception is JsonException or ArgumentException or InvalidOperationException or FormatException or OverflowException) { }
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            System.Diagnostics.Debug.WriteLine("Bootstrap telemetry journal could not be read.");
+        }
+    }
+
+    private static BootstrapPendingRecord Revalidate(BootstrapPendingRecord record)
+    {
+        if (record.Destination != BootstrapTelemetryDestination.Analytics)
+        {
+            return record with { Diagnostic = RemoteDiagnosticPropertyPolicy.SanitizePersistedRecord(record.Diagnostic!) };
+        }
+        var candidates = record.Properties!.ToDictionary(pair => pair.Key, pair => (object?)pair.Value, StringComparer.Ordinal);
+        if (candidates.GetValueOrDefault("elapsed_seconds") is long seconds) candidates["elapsed_seconds"] = (double)seconds;
+        if (candidates.GetValueOrDefault("child_exit_code") is long code && code is >= int.MinValue and <= int.MaxValue)
+            candidates["child_exit_code"] = (int)code;
+        var properties = TelemetryEventPropertyPolicy.Sanitize(TelemetryEvents.BootstrapFailed, candidates)
+            .Where(pair => pair.Value is not null).ToDictionary(pair => pair.Key, pair => pair.Value!, StringComparer.Ordinal);
+        foreach (string name in new[] { "app_version", "build_configuration", "app_runtime", "app_runtime_architecture", "app_locale", "session_id" })
+        {
+            if (candidates.GetValueOrDefault(name) is string value) properties[name] = RemoteDiagnosticText.Sanitize(value, 128);
+        }
+        properties["app"] = TelemetryApps.FoundryBootstrap;
+        properties["telemetry_schema_version"] = TelemetryDefaults.SchemaVersion;
+        properties["$process_person_profile"] = false;
+        properties["$geoip_disable"] = false;
+        return record with { Properties = properties };
+    }
+
+    private static BootstrapPendingRecord Normalize(BootstrapPendingRecord record) => record with
+    {
+        Properties = record.Properties?.ToDictionary(pair => pair.Key, pair => Scalar(pair.Value), StringComparer.Ordinal),
+        Diagnostic = record.Diagnostic is { } diagnostic ? diagnostic with
+        {
+            Attributes = diagnostic.Attributes.ToDictionary(pair => pair.Key, pair => Scalar(pair.Value), StringComparer.Ordinal)
+        } : null
+    };
+
+    private static object Scalar(object value) => value is JsonElement element ? element.ValueKind switch
+    {
+        JsonValueKind.String => element.GetString() ?? string.Empty,
+        JsonValueKind.True => true,
+        JsonValueKind.False => false,
+        JsonValueKind.Number when element.TryGetInt64(out long integer) => integer,
+        JsonValueKind.Number when double.IsFinite(element.GetDouble()) => element.GetDouble(),
+        JsonValueKind.Number => throw new FormatException("Non-finite journal number."),
+        _ => string.Empty
+    } : value;
+
+    private bool Save()
+    {
+        var lines = _records.Select(record => JsonSerializer.Serialize(record)).ToList();
+        long bytes = lines.Sum(line => (long)Encoding.UTF8.GetByteCount(line) + 1);
+        while (bytes > MaximumBytes && lines.Count > 0)
+        {
+            bytes -= Encoding.UTF8.GetByteCount(lines[0]) + 1;
+            lines.RemoveAt(0);
+            _records.RemoveAt(0);
+        }
+        if (_path is null) return true;
+        try
+        {
+            string? directory = Path.GetDirectoryName(_path);
+            if (!string.IsNullOrEmpty(directory)) Directory.CreateDirectory(directory);
+            string temporary = _path + ".tmp";
+            using (var stream = new FileStream(temporary, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                using (var writer = new StreamWriter(stream, new UTF8Encoding(false), leaveOpen: true))
+                {
+                    writer.NewLine = "\n";
+                    foreach (string line in lines) writer.WriteLine(line);
+                }
+                stream.Flush(flushToDisk: true);
+            }
+            File.Move(temporary, _path, overwrite: true);
+            return true;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            System.Diagnostics.Debug.WriteLine("Bootstrap telemetry remains in memory because its journal could not be written.");
+            return false;
+        }
+    }
+}

--- a/src/Foundry.Telemetry/BootstrapTelemetryPipeline.cs
+++ b/src/Foundry.Telemetry/BootstrapTelemetryPipeline.cs
@@ -1,0 +1,285 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Foundry.Telemetry;
+
+/// <summary>
+/// Captures sanitized Bootstrap records before connectivity, then drains in the background after preparation.
+/// A persistent journal is optional; a RAM-backed path does not survive a reboot.
+/// </summary>
+public sealed class BootstrapTelemetryPipeline : ILogEventSink, IAsyncDisposable
+{
+    private readonly object _gate = new();
+    private readonly BootstrapTelemetryJournal _journal;
+    private readonly PostHogRemoteDiagnosticsSink _capture;
+    private readonly TelemetryContext _context;
+    private readonly string _usageScope;
+    private readonly string _diagnosticScope;
+    private readonly Func<IBootstrapTelemetryTransport> _transportFactory;
+    private readonly TimeProvider _time;
+    private readonly HashSet<Guid> _replayIds;
+    private readonly HashSet<Guid> _attempted = [];
+    private readonly SemaphoreSlim _signal = new(0, 1);
+    private readonly CancellationTokenSource _deliveryCancellation = new();
+    private bool _usageEnabled;
+    private bool _diagnosticsEnabled;
+    private bool _terminalCaptured;
+    private bool _clockUsable;
+    private bool _stopping;
+    private Task? _worker;
+    private Task? _shutdown;
+    private int _replayed;
+    private long _replayStarted;
+
+    /// <summary>Creates capture without opening a remote connection. Null journalPath retains records only in memory.</summary>
+    public BootstrapTelemetryPipeline(TelemetryOptions usage, TelemetryContext context,
+        RemoteDiagnosticsOptions diagnostics, RemoteDiagnosticsContext diagnosticContext, string? journalPath)
+        : this(usage, context, diagnostics, diagnosticContext, journalPath,
+            () => new BootstrapTelemetryTransport(usage, context, diagnostics, diagnosticContext), TimeProvider.System)
+    {
+    }
+
+    internal BootstrapTelemetryPipeline(TelemetryOptions usage, TelemetryContext context,
+        RemoteDiagnosticsOptions diagnostics, RemoteDiagnosticsContext diagnosticContext, string? journalPath,
+        Func<IBootstrapTelemetryTransport> transportFactory, TimeProvider timeProvider)
+    {
+        _context = context;
+        _transportFactory = transportFactory;
+        _time = timeProvider;
+        _usageEnabled = usage.CanSend && Uri.TryCreate(usage.HostUrl, UriKind.Absolute, out Uri? host) && host.Scheme == "https";
+        _diagnosticsEnabled = diagnostics.CanSend;
+        _usageScope = BootstrapTelemetryJournal.Scope(usage.HostUrl, usage.ProjectToken, usage.InstallId);
+        _diagnosticScope = BootstrapTelemetryJournal.Scope(diagnostics.HostUrl, diagnostics.ProjectToken, diagnostics.InstallId);
+        _journal = new BootstrapTelemetryJournal(journalPath);
+        PurgeDisallowed();
+        _replayIds = _journal.Records.Select(record => record.Id).ToHashSet();
+        _capture = new PostHogRemoteDiagnosticsSink(static (_, _) => new CaptureOnlyExporter(),
+            timeProvider: timeProvider, capture: CaptureDiagnostic);
+        _capture.Configure(diagnostics, diagnosticContext);
+    }
+
+    /// <summary>Restrictions are monotonic and immediately purge the affected category, including durable records.</summary>
+    public void RestrictConsent(bool usageEnabled, bool diagnosticsEnabled)
+    {
+        lock (_gate)
+        {
+            _usageEnabled &= usageEnabled;
+            _diagnosticsEnabled &= diagnosticsEnabled;
+            PurgeDisallowed();
+        }
+        // Do not acquire the capture sink lock while holding the journal lock.
+        if (!diagnosticsEnabled) _capture.Disable();
+    }
+
+    /// <inheritdoc />
+    public void Emit(LogEvent logEvent) => _capture.Emit(logEvent);
+
+    /// <summary>Records the single terminal failure event; warnings, cancellation and success never call this method.</summary>
+    public void CaptureTerminalFailure(IReadOnlyDictionary<string, object?> properties)
+    {
+        lock (_gate)
+        {
+            if (_stopping || _terminalCaptured) return;
+            _terminalCaptured = true;
+            if (!_usageEnabled) return;
+            Dictionary<string, object> envelope = PostHogTelemetryService.BuildProperties(
+                _context, TelemetryEvents.BootstrapFailed, properties);
+            _journal.Add(new BootstrapPendingRecord(Guid.NewGuid(), _usageScope,
+                BootstrapTelemetryDestination.Analytics, _time.GetUtcNow(), envelope, null));
+            Signal();
+        }
+    }
+
+    /// <summary>Enables nonterminal delivery after Connect and clock preparation; false defers age-based expiry.</summary>
+    public void StartDelivery(bool clockUsable)
+    {
+        lock (_gate)
+        {
+            if (_stopping) return;
+            _clockUsable |= clockUsable;
+            Expire();
+            StartWorker();
+        }
+    }
+
+    /// <summary>Stops capture and shares a maximum two-second deadline across drain, flush and disposal.</summary>
+    public Task ShutdownAsync(CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (_shutdown is not null) return _shutdown;
+            _stopping = true;
+            _deliveryCancellation.CancelAfter(TimeSpan.FromSeconds(2));
+            return _shutdown = Task.Run(() => ShutdownCoreAsync(cancellationToken), CancellationToken.None);
+        }
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync() => new(ShutdownAsync());
+
+    internal IReadOnlyList<BootstrapPendingRecord> PendingRecords
+    {
+        get { lock (_gate) return _journal.Records.ToArray(); }
+    }
+
+    private void CaptureDiagnostic(RemoteDiagnosticRecord diagnostic)
+    {
+        lock (_gate)
+        {
+            if (!_diagnosticsEnabled || _stopping) return;
+            AddDiagnostic(diagnostic, BootstrapTelemetryDestination.Log);
+            if (diagnostic.ShouldTrackException && diagnostic.Exception is not null && diagnostic.Level >= LogEventLevel.Error)
+                AddDiagnostic(diagnostic, BootstrapTelemetryDestination.Exception);
+            Signal();
+        }
+    }
+
+    private void AddDiagnostic(RemoteDiagnosticRecord diagnostic, BootstrapTelemetryDestination destination)
+    {
+        Guid id = Guid.NewGuid();
+        var attributes = new Dictionary<string, object>(diagnostic.Attributes, StringComparer.Ordinal)
+        {
+            ["diagnostics.record_id"] = id.ToString()
+        };
+        _journal.Add(new BootstrapPendingRecord(id, _diagnosticScope, destination, diagnostic.Timestamp,
+            null, diagnostic with { Attributes = attributes }));
+    }
+
+    private void PurgeDisallowed() => _journal.Purge(record => !Allowed(record));
+
+    private bool Allowed(BootstrapPendingRecord record) => record.Destination == BootstrapTelemetryDestination.Analytics
+        ? _usageEnabled && record.Scope == _usageScope
+        : _diagnosticsEnabled && record.Scope == _diagnosticScope;
+
+    private void Expire()
+    {
+        if (_clockUsable) _journal.Purge(record => _replayIds.Contains(record.Id) && _time.GetUtcNow() - record.Timestamp > TimeSpan.FromDays(7));
+    }
+
+    private void StartWorker()
+    {
+        if (_worker is not null) return;
+        _replayStarted = _time.GetTimestamp();
+        _worker = Task.Run(DeliverAsync);
+    }
+
+    private async Task ShutdownCoreAsync(CancellationToken cancellationToken)
+    {
+        using CancellationTokenRegistration registration = cancellationToken.Register(_deliveryCancellation.Cancel);
+        lock (_gate)
+        {
+            StartWorker();
+            Signal();
+        }
+        try
+        {
+            await Task.WhenAll(_worker!, _capture.FlushAsync(_deliveryCancellation.Token))
+                .WaitAsync(_deliveryCancellation.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    private void Signal()
+    {
+        if (_signal.CurrentCount == 0) _signal.Release();
+    }
+
+    private async Task DeliverAsync()
+    {
+        IBootstrapTelemetryTransport? transport = null;
+        try
+        {
+            while (true)
+            {
+                BootstrapPendingRecord? record;
+                bool stopping;
+                lock (_gate)
+                {
+                    record = NextRecord();
+                    stopping = _stopping;
+                }
+                if (record is null)
+                {
+                    if (stopping) break;
+                    await _signal.WaitAsync(_deliveryCancellation.Token).ConfigureAwait(false);
+                    continue;
+                }
+                using var budget = CancellationTokenSource.CreateLinkedTokenSource(_deliveryCancellation.Token);
+                if (_replayIds.Contains(record.Id))
+                {
+                    TimeSpan remaining = TimeSpan.FromSeconds(5) - _time.GetElapsedTime(_replayStarted);
+                    if (remaining <= TimeSpan.Zero) continue;
+                    budget.CancelAfter(remaining);
+                }
+                else budget.CancelAfter(TimeSpan.FromSeconds(5));
+                try
+                {
+                    Task<bool> delivery;
+                    lock (_gate)
+                    {
+                        if (!Allowed(record)) continue;
+                        transport ??= _transportFactory();
+                        // Persist the attempt before enqueue: a crash cannot reset the replay cap.
+                        record = record with { Attempts = Math.Min(record.Attempts, int.MaxValue - 1) + 1, State = BootstrapDeliveryState.HandedToTransport };
+                        if (!_journal.Update(record)) continue;
+                        delivery = transport.DeliverAsync(record, budget.Token);
+                    }
+                    bool acknowledged = await delivery.WaitAsync(budget.Token).ConfigureAwait(false);
+                    if (acknowledged)
+                    {
+                        lock (_gate) _journal.Update(record with { State = BootstrapDeliveryState.Acknowledged });
+                    }
+                }
+#pragma warning disable CA1031 // Telemetry failures cannot change the boot outcome.
+                catch (Exception) { }
+#pragma warning restore CA1031
+                _deliveryCancellation.Token.ThrowIfCancellationRequested();
+            }
+            if (transport is not null)
+                await transport.FlushAsync(_deliveryCancellation.Token).WaitAsync(_deliveryCancellation.Token).ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Network and exporter failures are best effort.
+        catch (Exception) { }
+#pragma warning restore CA1031
+        finally
+        {
+            if (transport is not null)
+            {
+                try
+                {
+                    await transport.DisposeAsync().AsTask().WaitAsync(_deliveryCancellation.Token).ConfigureAwait(false);
+                }
+#pragma warning disable CA1031 // Disposal shares the terminal budget.
+                catch (Exception) { }
+#pragma warning restore CA1031
+            }
+        }
+    }
+
+    private BootstrapPendingRecord? NextRecord()
+    {
+        foreach (BootstrapPendingRecord record in _journal.Records)
+        {
+            if (!Allowed(record) || (record.Destination != BootstrapTelemetryDestination.Analytics && record.Attempts >= 3) || _attempted.Contains(record.Id)) continue;
+            if (_replayIds.Contains(record.Id))
+            {
+                if (_replayed >= 100 || _time.GetElapsedTime(_replayStarted) >= TimeSpan.FromSeconds(5)) continue;
+                _replayed++;
+            }
+            _attempted.Add(record.Id);
+            return record;
+        }
+        return null;
+    }
+
+    private sealed class CaptureOnlyExporter : IRemoteDiagnosticsExporter
+    {
+        public ValueTask ExportAsync(RemoteDiagnosticRecord record, CancellationToken cancellationToken) => ValueTask.CompletedTask;
+        public Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/src/Foundry.Telemetry/BootstrapTelemetryTransport.cs
+++ b/src/Foundry.Telemetry/BootstrapTelemetryTransport.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Telemetry;
+
+/// <summary>Only an actual transport receipt may acknowledge a durable destination.</summary>
+internal interface IBootstrapTelemetryTransport : IAsyncDisposable
+{
+    Task<bool> DeliverAsync(BootstrapPendingRecord record, CancellationToken cancellationToken);
+    Task FlushAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>Reuses the existing HTTP analytics and buffered diagnostics clients without treating enqueue as receipt.</summary>
+internal sealed class BootstrapTelemetryTransport : IBootstrapTelemetryTransport
+{
+    private readonly HttpClient _httpClient = new();
+    private readonly PostHogTelemetryService _analytics;
+    private readonly RemoteDiagnosticsOptions _options;
+    private readonly RemoteDiagnosticsContext _context;
+    private PostHogDiagnosticsExporter? _diagnostics;
+
+    internal BootstrapTelemetryTransport(TelemetryOptions usage, TelemetryContext context,
+        RemoteDiagnosticsOptions diagnostics, RemoteDiagnosticsContext diagnosticContext)
+    {
+        _analytics = new PostHogTelemetryService(_httpClient, usage, context);
+        _options = diagnostics;
+        _context = diagnosticContext;
+    }
+
+    public async Task<bool> DeliverAsync(BootstrapPendingRecord record, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (record.Destination == BootstrapTelemetryDestination.Analytics)
+        {
+            return await _analytics.SendDurableAsync(record.Id, record.Timestamp, record.Properties!, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        _diagnostics ??= new PostHogDiagnosticsExporter(_options, _context);
+        if (record.Destination == BootstrapTelemetryDestination.Log) _diagnostics.ExportLog(record.Diagnostic!);
+        else _diagnostics.ExportException(record.Diagnostic!);
+        // Both SDK APIs only enqueue. Their flush methods do not expose per-record receipts.
+        return false;
+    }
+
+    public Task FlushAsync(CancellationToken cancellationToken) =>
+        _diagnostics?.FlushAsync(cancellationToken) ?? Task.CompletedTask;
+
+    public async ValueTask DisposeAsync()
+    {
+        _httpClient.Dispose();
+        if (_diagnostics is not null) await _diagnostics.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/Foundry.Telemetry/PostHogRemoteDiagnosticsSink.cs
+++ b/src/Foundry.Telemetry/PostHogRemoteDiagnosticsSink.cs
@@ -26,6 +26,7 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
     private readonly object _gate = new();
     private readonly Func<RemoteDiagnosticsOptions, RemoteDiagnosticsContext, IRemoteDiagnosticsExporter> _exporterFactory;
     private readonly int _queueCapacity;
+    private readonly Action<RemoteDiagnosticRecord>? _capture;
     private readonly TimeProvider _timeProvider;
     private ConditionalWeakTable<Exception, ExceptionDedupeState> _seenExceptions = new();
     private readonly Dictionary<string, FingerprintWindowState> _fingerprints = new(StringComparer.Ordinal);
@@ -50,11 +51,13 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
     internal PostHogRemoteDiagnosticsSink(
         Func<RemoteDiagnosticsOptions, RemoteDiagnosticsContext, IRemoteDiagnosticsExporter> exporterFactory,
         int queueCapacity = DefaultQueueCapacity,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        Action<RemoteDiagnosticRecord>? capture = null)
     {
         ArgumentNullException.ThrowIfNull(exporterFactory);
         ArgumentOutOfRangeException.ThrowIfLessThan(queueCapacity, 1);
         _exporterFactory = exporterFactory;
+        _capture = capture;
         _queueCapacity = queueCapacity;
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
@@ -172,6 +175,17 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
                 var queuedRecord = new QueuedRemoteDiagnosticRecord(
                     Volatile.Read(ref _consentGeneration),
                     record);
+                if (_capture is not null)
+                {
+                    _capture(record);
+                    if (record.ShouldTrackException)
+                    {
+                        _seenExceptions.GetValue(logEvent.Exception!, static _ => new ExceptionDedupeState())
+                            .OperationIds.Add(GetScalarText(logEvent, "OperationId"));
+                    }
+                    return;
+                }
+
                 if (!channel.Writer.TryWrite(queuedRecord))
                 {
                     Interlocked.Increment(ref _droppedRecordCount);
@@ -284,7 +298,7 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
             GetScalarText(logEvent, "OperationId"), GetScalarText(logEvent, "FailedOperationName"),
             GetScalarText(logEvent, "CurrentOperation"), GetScalarText(logEvent, "ProcessOperation"),
             GetScalarText(logEvent, "StepName"), GetScalarText(logEvent, "ToolName"));
-        DateTimeOffset now = _timeProvider.GetUtcNow();
+        long now = _timeProvider.GetTimestamp();
         lock (_gate)
         {
             if (_fingerprints.Count >= MaximumFingerprintEntries && !_fingerprints.ContainsKey(fingerprint))
@@ -292,7 +306,7 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
                 _fingerprints.Clear();
             }
 
-            if (!_fingerprints.TryGetValue(fingerprint, out FingerprintWindowState? state) || now - state.StartedAt >= FingerprintWindow)
+            if (!_fingerprints.TryGetValue(fingerprint, out FingerprintWindowState? state) || _timeProvider.GetElapsedTime(state.StartedAt, now) >= FingerprintWindow)
             {
                 _fingerprints[fingerprint] = new FingerprintWindowState(now, 1);
                 return true;
@@ -342,7 +356,7 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
         }
     }
 
-    private sealed record FingerprintWindowState(DateTimeOffset StartedAt, int Count);
+    private sealed record FingerprintWindowState(long StartedAt, int Count);
 
     private sealed record QueuedRemoteDiagnosticRecord(
         int ConsentGeneration,
@@ -415,10 +429,14 @@ internal sealed class PostHogDiagnosticsExporter : IRemoteDiagnosticsExporter
     public ValueTask ExportAsync(RemoteDiagnosticRecord record, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        _logExporter.Write(CreateLogEvent(record));
-        _exceptionTracker.Track(record);
+        ExportLog(record);
+        ExportException(record);
         return ValueTask.CompletedTask;
     }
+
+    internal void ExportLog(RemoteDiagnosticRecord record) => _logExporter.Write(CreateLogEvent(record));
+
+    internal void ExportException(RemoteDiagnosticRecord record) => _exceptionTracker.Track(record);
 
     internal static LogEvent CreateLogEvent(RemoteDiagnosticRecord record)
     {

--- a/src/Foundry.Telemetry/PostHogTelemetryService.cs
+++ b/src/Foundry.Telemetry/PostHogTelemetryService.cs
@@ -63,7 +63,7 @@ public sealed class PostHogTelemetryService : ITelemetryService
 
         try
         {
-            Dictionary<string, object> finalProperties = BuildProperties(eventName, properties);
+            Dictionary<string, object> finalProperties = BuildProperties(context, eventName, properties);
             var payload = new PostHogCapturePayload(
                 options.ProjectToken,
                 eventName,
@@ -115,13 +115,32 @@ public sealed class PostHogTelemetryService : ITelemetryService
         return Task.CompletedTask;
     }
 
+    /// <summary>Returns HTTP acceptance for durable events, retaining the original identity and timestamp.</summary>
+    internal async Task<bool> SendDurableAsync(
+        Guid id, DateTimeOffset timestamp, IReadOnlyDictionary<string, object> properties,
+        CancellationToken cancellationToken)
+    {
+        var payload = new
+        {
+            api_key = options.ProjectToken,
+            @event = TelemetryEvents.BootstrapFailed,
+            distinct_id = options.InstallId,
+            uuid = id,
+            timestamp,
+            properties
+        };
+        using HttpResponseMessage response = await httpClient.PostAsJsonAsync(
+            BuildCaptureEndpoint(options.HostUrl), payload, JsonOptions, cancellationToken).ConfigureAwait(false);
+        return response.IsSuccessStatusCode;
+    }
+
     private static Uri BuildCaptureEndpoint(string hostUrl)
     {
         var baseUri = new Uri(hostUrl.EndsWith("/", StringComparison.Ordinal) ? hostUrl : hostUrl + "/");
         return new Uri(baseUri, "i/v0/e/");
     }
 
-    private Dictionary<string, object> BuildProperties(string eventName, IReadOnlyDictionary<string, object?> properties)
+    internal static Dictionary<string, object> BuildProperties(TelemetryContext context, string eventName, IReadOnlyDictionary<string, object?> properties)
     {
         Dictionary<string, object> finalProperties = new(StringComparer.Ordinal)
         {
@@ -145,12 +164,12 @@ public sealed class PostHogTelemetryService : ITelemetryService
             }
         }
 
-        AddEventContext(eventName, finalProperties);
+        AddEventContext(context, eventName, finalProperties);
 
         return finalProperties;
     }
 
-    private void AddEventContext(string eventName, IDictionary<string, object> finalProperties)
+    private static void AddEventContext(TelemetryContext context, string eventName, IDictionary<string, object> finalProperties)
     {
         if (eventName == TelemetryEvents.ConnectSessionReady)
         {

--- a/src/Foundry.Telemetry/RemoteDiagnosticPropertyPolicy.cs
+++ b/src/Foundry.Telemetry/RemoteDiagnosticPropertyPolicy.cs
@@ -111,6 +111,40 @@ public static partial class RemoteDiagnosticPropertyPolicy
         return new RemoteDiagnosticRecord(logEvent.Timestamp, logEvent.Level, body, attributes, exception);
     }
 
+    /// <summary>Revalidates on-disk records without manufacturing exception objects or losing their original stacks.</summary>
+    internal static RemoteDiagnosticRecord SanitizePersistedRecord(RemoteDiagnosticRecord record)
+    {
+        var allowed = new HashSet<string>(AllowedPropertyNames.Values, StringComparer.Ordinal)
+        {
+            "service.name", "service.version", "service.release", "build.configuration", "runtime.name",
+            "runtime.architecture", "locale", "session.id", "diagnostics.record_id", "diagnostics.dropped_record_count"
+        };
+        var attributes = new Dictionary<string, object>(StringComparer.Ordinal);
+        foreach ((string name, object value) in record.Attributes)
+        {
+            if (allowed.Contains(name) && TryConvertScalar(new ScalarValue(value), out object sanitized))
+                attributes[name] = sanitized;
+            else if (name is "process.stdout" or "process.stderr" && value is string output)
+                attributes[name] = RemoteDiagnosticText.SanitizeOutput(output);
+        }
+        return record with
+        {
+            Body = RemoteDiagnosticText.Sanitize(record.Body, MaximumMessageLength),
+            Attributes = attributes,
+            Exception = SanitizePersistedException(record.Exception, 0)
+        };
+    }
+
+    private static RemoteDiagnosticException? SanitizePersistedException(RemoteDiagnosticException? exception, int depth)
+    {
+        if (exception is null || depth >= MaximumExceptionDepth) return null;
+        return new RemoteDiagnosticException(SanitizeAttribute(exception.Type),
+            RemoteDiagnosticText.Sanitize(exception.Message, MaximumMessageLength),
+            exception.StackTrace is null ? null : SanitizeStackTrace(exception.StackTrace),
+            (exception.InnerExceptions ?? []).Take(16)
+                .Select(inner => SanitizePersistedException(inner, depth + 1)).OfType<RemoteDiagnosticException>().ToArray());
+    }
+
     private static string RenderSafeMessage(LogEvent logEvent)
     {
         var safeProperties = new List<LogEventProperty>(logEvent.Properties.Count);

--- a/src/Foundry.Telemetry/TelemetryApps.cs
+++ b/src/Foundry.Telemetry/TelemetryApps.cs
@@ -9,6 +9,7 @@ namespace Foundry.Telemetry;
 /// </summary>
 public static class TelemetryApps
 {
+    public const string FoundryBootstrap = "foundry_bootstrap";
     public const string FoundryOsd = "foundry_osd";
     public const string FoundryConnect = "foundry_connect";
     public const string FoundryDeploy = "foundry_deploy";

--- a/src/Foundry.Telemetry/TelemetryEventPropertyPolicy.cs
+++ b/src/Foundry.Telemetry/TelemetryEventPropertyPolicy.cs
@@ -46,6 +46,11 @@ public static class TelemetryEventPropertyPolicy
     private static readonly IReadOnlyDictionary<string, HashSet<string>> AllowedPropertiesByEvent =
         new Dictionary<string, HashSet<string>>(StringComparer.Ordinal)
         {
+            [TelemetryEvents.BootstrapFailed] = new(StringComparer.Ordinal)
+            {
+                "failure_category", "last_stage", "elapsed_seconds", "child_application",
+                "child_exit_code", "payload_source", "payload_version", "architecture"
+            },
             [TelemetryEvents.AppDailyActive] = new(StringComparer.Ordinal)
             {
                 "proxy_method",
@@ -234,11 +239,43 @@ public static class TelemetryEventPropertyPolicy
                 continue;
             }
 
+            if (eventName == TelemetryEvents.BootstrapFailed)
+            {
+                if (key == "elapsed_seconds")
+                {
+                    if (value is double seconds && double.IsFinite(seconds) && seconds >= 0)
+                    {
+                        sanitized[key] = Math.Min(seconds, 604800);
+                    }
+                }
+                else if (key == "child_exit_code")
+                {
+                    if (value is int) sanitized[key] = value;
+                }
+                else if (value is string text && IsAllowedBootstrapValue(key, text))
+                {
+                    sanitized[key] = text;
+                }
+                continue;
+            }
+
             sanitized[key] = value;
         }
 
         return sanitized;
     }
+
+    private static bool IsAllowedBootstrapValue(string key, string value) => key switch
+    {
+        "failure_category" => value is "child_exit" or "stage_failed",
+        "last_stage" => value is "environment" or "connect" or "system" or "deploymentpreparation" or "deploy",
+        "child_application" => value is TelemetryApps.FoundryConnect or TelemetryApps.FoundryDeploy or "none",
+        "payload_source" => value is TelemetryRuntimePayloadSources.None or TelemetryRuntimePayloadSources.Debug or
+            TelemetryRuntimePayloadSources.Release or TelemetryRuntimePayloadSources.Unknown,
+        "architecture" => value is "x64" or "arm64",
+        "payload_version" => value.Length <= 64 && Version.TryParse(value, out _),
+        _ => false
+    };
 
     private static bool IsAllowedUnattendValue(string key, object? value) => key switch
     {

--- a/src/Foundry.Telemetry/TelemetryEvents.cs
+++ b/src/Foundry.Telemetry/TelemetryEvents.cs
@@ -9,6 +9,7 @@ namespace Foundry.Telemetry;
 /// </summary>
 public static class TelemetryEvents
 {
+    public const string BootstrapFailed = "bootstrap:failed";
     public const string AppDailyActive = "app:daily_active";
     public const string OsdBootMediaFinished = "osd:boot_media_finished";
     public const string ConnectSessionReady = "connect:session_ready";

--- a/src/Foundry.Telemetry/TelemetryRuntimePayloadSources.cs
+++ b/src/Foundry.Telemetry/TelemetryRuntimePayloadSources.cs
@@ -5,7 +5,7 @@
 namespace Foundry.Telemetry;
 
 /// <summary>
-/// Defines stable categories for the Connect and Deploy runtime payload source.
+/// Defines stable categories for the Bootstrap, Connect, and Deploy runtime payload source.
 /// </summary>
 public static class TelemetryRuntimePayloadSources
 {

--- a/src/Foundry.Telemetry/TelemetrySettings.cs
+++ b/src/Foundry.Telemetry/TelemetrySettings.cs
@@ -35,7 +35,7 @@ public sealed record TelemetrySettings
     public string ProjectToken { get; init; } = TelemetryDefaults.ProjectToken;
 
     /// <summary>
-    /// Gets the source of the generated Connect or Deploy runtime payload.
+    /// Gets the source of the generated Bootstrap, Connect, or Deploy runtime payload.
     /// </summary>
     public string RuntimePayloadSource { get; init; } = TelemetryRuntimePayloadSources.Unknown;
 }

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -1013,6 +1013,10 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             CurlExecutableSourcePath = ResolveCurlExecutablePath(),
             SevenZipSourceDirectoryPath = embeddedAssetService.GetSevenZipSourceDirectoryPath(),
             IanaWindowsTimeZoneMapJson = embeddedAssetService.GetIanaWindowsTimeZoneMapJson(),
+            FoundryBootstrapConfiguration = new FoundryBootstrapConfigurationDocument
+            {
+                Telemetry = CreateRuntimeTelemetrySettings(ResolveRuntimePayloadSource(runtimePayloadProvisioning.Bootstrap))
+            },
             FoundryConnectConfigurationJson = connectBundle.ConfigurationJson,
             DeployConfigurationJson = foundryConfigurationStateService.GenerateDeployConfigurationJson(
                 deployTelemetrySettings,


### PR DESCRIPTION
## Summary

Add Bootstrap failure reporting and sanitized remote diagnostics with independent telemetry and diagnostics preferences.

## Reason

Preserve startup evidence before networking is ready while avoiding product events for successful or cancelled boots.

## Main changes

- Generate a minimal Bootstrap configuration and apply child opt-outs before delivery, without decrypting child secrets.
- Emit one `bootstrap:failed` event for terminal failure; reuse Serilog filtering, sanitization, and exception handling for remote diagnostics.
- Start background delivery after Connect and clock preparation. Bound the cache journal to 5 MB and seven days, replay to 100 records/five seconds, and shutdown to two seconds.
- Preserve event identity and separate log/exception delivery state. Buffered diagnostic submissions are capped at three attempts; delivery remains best effort.
- Cover consent, boot sequencing, clock changes, replay, corruption, privacy, and transport acceptance with focused tests.

## Testing

- [x] `.\scripts\Test-FoundryFormat.ps1`
- [x] x64 Release solution build: zero warnings or errors.
- [x] ARM64 Release solution build: zero warnings or errors.
- [x] 1,634 x64 tests passed: Bootstrap 79, Core 651, Telemetry 157, Connect 109, Deploy 638.
- [x] `git diff --check` and review for obsolete or unrelated changes.
- [ ] Manual validation.

Validation not run and reason: full WinPE integration and live PostHog validation are deferred until all four PRs are implemented, as agreed.

## Additional information

- Bootstrap configuration starts at schema 1. Existing authoring, Connect, and Deploy schemas are unchanged.
- Companion documentation: https://github.com/foundry-osd/GitBook/pull/19.
- PR 3 of 4. PR 4 adds the Connect/Deploy startup observation protocol and early child failure reporting.