### PR TITLE
fix(winpe): avoid warnings for expected process exit codes

### DIFF
--- a/src/Foundry.Core.Tests/WinPe/WinPeProcessLoggingTests.cs
+++ b/src/Foundry.Core.Tests/WinPe/WinPeProcessLoggingTests.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Core.Services.WinPe;
+using Foundry.Core.Tests.TestUtilities;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Foundry.Core.Tests.WinPe;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class WinPeProcessLoggingCollection
+{
+    public const string Name = "WinPeProcessLogging";
+}
+
+[Collection(WinPeProcessLoggingCollection.Name)]
+public sealed class WinPeProcessLoggingTests : IDisposable
+{
+    private readonly ILogger _previousLogger = Log.Logger;
+    private readonly CapturingSink _sink = new();
+    private readonly Logger _logger;
+
+    public WinPeProcessLoggingTests()
+    {
+        _logger = new LoggerConfiguration().MinimumLevel.Debug().WriteTo.Sink(_sink).CreateLogger();
+        Log.Logger = _logger;
+    }
+
+    [Theory]
+    [InlineData(false, 1)]
+    [InlineData(true, 3)]
+    public async Task RunAsync_RobocopySuccessfulCopy_LogsDebug(bool extraFile, int expectedExitCode)
+    {
+        using var workspace = new TemporaryDirectory();
+        string source = Directory.CreateDirectory(Path.Combine(workspace.Path, "source")).FullName;
+        string destination = Directory.CreateDirectory(Path.Combine(workspace.Path, "destination")).FullName;
+        await File.WriteAllTextAsync(Path.Combine(source, "source.txt"), "copy me", TestContext.Current.CancellationToken);
+        if (extraFile)
+        {
+            await File.WriteAllTextAsync(Path.Combine(destination, "extra.txt"), "keep me", TestContext.Current.CancellationToken);
+        }
+
+        WinPeProcessExecution result = await new WinPeProcessRunner().RunAsync(
+            Path.Combine(Environment.SystemDirectory, "robocopy.exe"),
+            $"\"{source}\" \"{destination}\" /E /R:0 /W:0 /NFL /NDL /NJH /NJS /NP",
+            workspace.Path,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(expectedExitCode, result.ExitCode);
+        Assert.Equal("copy me", await File.ReadAllTextAsync(Path.Combine(destination, "source.txt"), TestContext.Current.CancellationToken));
+        AssertExitLog(LogEventLevel.Debug, expectedExitCode);
+    }
+
+    [Fact]
+    public async Task RunAsync_RobocopyMissingSource_StillLogsWarning()
+    {
+        using var workspace = new TemporaryDirectory();
+        WinPeProcessExecution result = await new WinPeProcessRunner().RunAsync(
+            Path.Combine(Environment.SystemDirectory, "robocopy.exe"),
+            $"\"{Path.Combine(workspace.Path, "missing")}\" \"{Path.Combine(workspace.Path, "destination")}\" /R:0 /W:0",
+            workspace.Path,
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.ExitCode >= 8);
+        AssertExitLog(LogEventLevel.Warning, result.ExitCode);
+    }
+
+    [Theory]
+    [InlineData("MakeWinPEMedia.cmd", "/?", 1, "echo /bootex", LogEventLevel.Debug)]
+    [InlineData("MakeWinPEMedia.cmd", "/?", 1, "echo /bootex 1>&2", LogEventLevel.Debug)]
+    [InlineData("MakeWinPEMedia.cmd", "/?", 1, "echo unavailable", LogEventLevel.Warning)]
+    [InlineData("MakeWinPEMedia.cmd", "/?", 2, "echo /bootex", LogEventLevel.Warning)]
+    [InlineData("MakeWinPEMedia.cmd", "/ISO", 1, "echo /bootex", LogEventLevel.Warning)]
+    [InlineData("other.cmd", "/?", 1, "echo /bootex", LogEventLevel.Warning)]
+    public async Task RunCmdScriptDirectAsync_OnlySupportedHelpProbeIsDebug(
+        string scriptName, string arguments, int exitCode, string outputCommand, LogEventLevel expectedLevel)
+    {
+        using var workspace = new TemporaryDirectory();
+        string script = Path.Combine(workspace.Path, scriptName);
+        await File.WriteAllTextAsync(script, $"@echo off\r\n{outputCommand}\r\nexit /b {exitCode}\r\n", TestContext.Current.CancellationToken);
+
+        WinPeProcessExecution result = await new WinPeProcessRunner().RunCmdScriptDirectAsync(
+            script, arguments, workspace.Path, TestContext.Current.CancellationToken);
+
+        Assert.Equal(exitCode, result.ExitCode);
+        AssertExitLog(expectedLevel, exitCode);
+    }
+
+    [Fact]
+    public async Task RunAsync_OrdinaryCommandFailure_StillLogsWarning()
+    {
+        using var workspace = new TemporaryDirectory();
+        WinPeProcessExecution result = await new WinPeProcessRunner().RunAsync(
+            Path.Combine(Environment.SystemDirectory, "cmd.exe"), "/d /c exit /b 1", workspace.Path, TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, result.ExitCode);
+        AssertExitLog(LogEventLevel.Warning, 1);
+    }
+
+    private void AssertExitLog(LogEventLevel expectedLevel, int exitCode)
+    {
+        LogEvent logEvent = Assert.Single(_sink.Events);
+        Assert.Equal(expectedLevel, logEvent.Level);
+        Assert.Equal(exitCode, Assert.IsType<ScalarValue>(logEvent.Properties["ExitCode"]).Value);
+        Assert.Equal(true, Assert.IsType<ScalarValue>(logEvent.Properties["ProcessOutputOmitted"]).Value);
+        Assert.False(logEvent.Properties.ContainsKey("ProcessStdout"));
+        Assert.False(logEvent.Properties.ContainsKey("ProcessStderr"));
+    }
+
+    public void Dispose()
+    {
+        Log.Logger = _previousLogger;
+        _logger.Dispose();
+    }
+
+    private sealed class CapturingSink : ILogEventSink
+    {
+        public List<LogEvent> Events { get; } = [];
+
+        public void Emit(LogEvent logEvent) => Events.Add(logEvent);
+    }
+}

--- a/src/Foundry.Core/Services/WinPe/WinPeProcessRunner.cs
+++ b/src/Foundry.Core/Services/WinPe/WinPeProcessRunner.cs
@@ -8,6 +8,7 @@ using System.Runtime.ExceptionServices;
 using Foundry.Telemetry;
 using Foundry.Utilities.Processes;
 using Serilog;
+using Serilog.Events;
 using UtilityProcessRunner = Foundry.Utilities.Processes.ProcessRunner;
 
 namespace Foundry.Core.Services.WinPe;
@@ -34,7 +35,7 @@ public sealed class WinPeProcessRunner : IWinPeProcessOutputRunner
             environmentOverrides).ConfigureAwait(false);
     }
 
-    public async Task<WinPeProcessExecution> RunWithOutputAsync(
+    public Task<WinPeProcessExecution> RunWithOutputAsync(
         string fileName,
         string arguments,
         string workingDirectory,
@@ -42,6 +43,20 @@ public sealed class WinPeProcessRunner : IWinPeProcessOutputRunner
         Action<string>? onErrorData,
         CancellationToken cancellationToken,
         IReadOnlyDictionary<string, string>? environmentOverrides = null)
+    {
+        return RunWithOutputCoreAsync(fileName, arguments, workingDirectory, onOutputData, onErrorData,
+            cancellationToken, environmentOverrides, isMakeWinPeMediaHelp: false);
+    }
+
+    private async Task<WinPeProcessExecution> RunWithOutputCoreAsync(
+        string fileName,
+        string arguments,
+        string workingDirectory,
+        Action<string>? onOutputData,
+        Action<string>? onErrorData,
+        CancellationToken cancellationToken,
+        IReadOnlyDictionary<string, string>? environmentOverrides,
+        bool isMakeWinPeMediaHelp)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
         ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
@@ -69,7 +84,10 @@ public sealed class WinPeProcessRunner : IWinPeProcessOutputRunner
                 {
                     logger = logger.ForContext(name, value);
                 }
-                logger.Warning("External process returned a nonzero exit code. ToolName={ToolName}, ExitCode={ExitCode}",
+                LogEventLevel level = IsExpectedNonzeroExit(result, isMakeWinPeMediaHelp)
+                    ? LogEventLevel.Debug
+                    : LogEventLevel.Warning;
+                logger.Write(level, "External process returned a nonzero exit code. ToolName={ToolName}, ExitCode={ExitCode}",
                     Path.GetFileName(result.FileName), result.ExitCode);
             }
             return WinPeProcessExecution.FromProcessExecutionResult(result);
@@ -156,7 +174,26 @@ public sealed class WinPeProcessRunner : IWinPeProcessOutputRunner
 
         string switchS = useCommandExtensionsStripQuoteRules ? " /s" : string.Empty;
         string arguments = $"/d{switchS} /c \"{command}\"";
-        return RunAsync(GetCommandProcessorPath(), arguments, workingDirectory, cancellationToken, environmentOverrides);
+        bool isMakeWinPeMediaHelp = Path.GetFileName(scriptPath).Equals("MakeWinPEMedia.cmd", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(scriptArguments?.Trim(), "/?", StringComparison.Ordinal);
+        return RunWithOutputCoreAsync(GetCommandProcessorPath(), arguments, workingDirectory, null, null,
+            cancellationToken, environmentOverrides, isMakeWinPeMediaHelp);
+    }
+
+    /// <summary>
+    /// Classifies known nonzero outcomes for logging only; callers retain the raw exit code and output.
+    /// </summary>
+    private static bool IsExpectedNonzeroExit(ProcessExecutionResult result, bool isMakeWinPeMediaHelp)
+    {
+        if (Path.GetFileName(result.FileName).Equals("robocopy.exe", StringComparison.OrdinalIgnoreCase))
+        {
+            return WinPeUsbMediaService.IsRobocopySuccessExitCode(result.ExitCode);
+        }
+
+        // MakeWinPEMedia help can exit with 1 even when the capability probe has usable output.
+        return isMakeWinPeMediaHelp && result.ExitCode == 1 &&
+            (result.StandardOutput.Contains("/bootex", StringComparison.OrdinalIgnoreCase) ||
+             result.StandardError.Contains("/bootex", StringComparison.OrdinalIgnoreCase));
     }
 
     private static string GetCommandProcessorPath()


### PR DESCRIPTION
## Summary
Fix false process warnings during WinPE USB updates. Successful Robocopy copies and supported MakeWinPEMedia help probes now log at Debug instead of Warning.

## Reason and changes
The process runner previously treated every nonzero exit code as a warning before callers interpreted tool-specific results.

- Reuse the existing Robocopy success policy (codes 0–7).
- Downgrade MakeWinPEMedia /? exit code 1 only when stdout or stderr confirms /bootex support.
- Preserve raw execution results, structured diagnostics, output redaction, and warnings for unexpected exits and start failures.
- Add regression tests using real Robocopy operations and controlled command scripts.

## Testing
- Confirmed four regression cases fail before the fix and pass afterward.
- All 705 Foundry.Core.Tests pass on Release x64.
- scripts/Test-FoundryFormat.ps1 passes.
- git diff --check passes.
- Independent code review: no findings.
- CI x64 and ARM64 checks are pending.