### PR TITLE
feat(logging): align local and PostHog logs across Foundry applications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ Logging rules:
 - Use `FoundryLogConfiguration` for application file sinks so Foundry.OSD, Foundry.Bootstrap, Foundry.Connect, and Foundry.Deploy share the same structured text contract
 - Emit UTC timestamps with milliseconds and the Application, Session, and Component context on every application log event
 - Keep one stable active log filename with 10 MB size-based rolling and bounded retention
-- Use Verbose as the shared application file and PostHog Logs threshold for Foundry.OSD, Bootstrap, Connect, and Deploy; developer mode must not lower this threshold
+- Use Verbose as the shared application file and PostHog Logs threshold for Foundry.OSD, Bootstrap, Connect, and Deploy
 - Use one normal structured log call for local and remote output; preserve original timestamps, event identifiers, process order, and ordinary diagnostic context, with targeted authentication-secret masking before both outputs
 - Keep Product Analytics and Error Tracking consent, privacy filtering, and exception deduplication separate from the all-level Logs stream; never add remote-only eligibility markers or per-message rate limiting
 - Keep verbose console output opt-in; pending remote logs must not block the application's primary operation or shutdown indefinitely

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,8 +126,10 @@ Logging rules:
 - Use `FoundryLogConfiguration` for application file sinks so Foundry.OSD, Foundry.Bootstrap, Foundry.Connect, and Foundry.Deploy share the same structured text contract
 - Emit UTC timestamps with milliseconds and the Application, Session, and Component context on every application log event
 - Keep one stable active log filename with 10 MB size-based rolling and bounded retention
-- Use Information as the Foundry.OSD default level, with Debug enabled by developer mode
-- Use Debug as the default file level for WinPE Bootstrap, Foundry.Connect, and Foundry.Deploy; keep verbose console output opt-in
+- Use Verbose as the shared application file and PostHog Logs threshold for Foundry.OSD, Bootstrap, Connect, and Deploy; developer mode must not lower this threshold
+- Use one normal structured log call for local and remote output; preserve original timestamps, event identifiers, process order, and ordinary diagnostic context, with targeted authentication-secret masking before both outputs
+- Keep Product Analytics and Error Tracking consent, privacy filtering, and exception deduplication separate from the all-level Logs stream; never add remote-only eligibility markers or per-message rate limiting
+- Keep verbose console output opt-in; pending remote logs must not block the application's primary operation or shutdown indefinitely
 - Write logs only when they add operational or diagnostic value
 - Use the log levels already defined by the project
 - Use Debug for detailed troubleshooting; keep meaningful operation outcomes at Information or above

--- a/src/Foundry.Bootstrap.Tests/BootstrapCoordinatorTests.cs
+++ b/src/Foundry.Bootstrap.Tests/BootstrapCoordinatorTests.cs
@@ -14,6 +14,18 @@ namespace Foundry.Bootstrap.Tests;
 public sealed class BootstrapCoordinatorTests
 {
     [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task EarlyClockFailureDoesNotPreventConnectOrThePostConnectRetry(bool fails)
+    {
+        using var fixture = new Fixture { EarlyClockFails = fails };
+        Assert.Equal(BootstrapOutcome.Succeeded, (await fixture.RunAsync()).Outcome);
+        Assert.True(fixture.Calls.IndexOf("clock") > fixture.Calls.IndexOf("network"));
+        Assert.True(fixture.Calls.IndexOf("clock") < fixture.Calls.IndexOf("connect"));
+        Assert.True(fixture.Calls.IndexOf("system") > fixture.Calls.IndexOf("connect"));
+    }
+
+    [Theory]
     [InlineData(0)]
     [InlineData(20)]
     [InlineData(7)]
@@ -55,7 +67,7 @@ public sealed class BootstrapCoordinatorTests
         using var fixture = new Fixture();
         BootstrapResult result = await fixture.RunAsync();
         Assert.Equal(BootstrapOutcome.Succeeded, result.Outcome);
-        Assert.Equal(["network", "Foundry.Connect:True", "connect", "system", "Foundry.Connect:False",
+        Assert.Equal(["network", "clock", "Foundry.Connect:True", "connect", "system", "Foundry.Connect:False",
             "Foundry.Deploy:False", "deploy", "persist"], fixture.Calls);
     }
 
@@ -140,6 +152,7 @@ public sealed class BootstrapCoordinatorTests
         internal bool DeployFails { get; init; }
         internal bool ConnectTimeout { get; init; }
         internal bool ObserveDiagnostics { get; init; }
+        internal bool EarlyClockFails { get; init; }
         internal List<BootstrapResult> Outcomes { get; } = [];
 
         internal Task<BootstrapResult> RunAsync() => new BootstrapCoordinator(Context, this, this, this, this,
@@ -158,6 +171,11 @@ public sealed class BootstrapCoordinatorTests
         }
 
         public Task PrepareNetworkAsync(CancellationToken cancellationToken) { Calls.Add("network"); return Task.CompletedTask; }
+        public Task PrepareClockAsync(CancellationToken cancellationToken)
+        {
+            Calls.Add("clock");
+            return EarlyClockFails ? Task.FromException(new HttpRequestException("Offline")) : Task.CompletedTask;
+        }
         public Task PrepareSystemAsync(CancellationToken cancellationToken)
         {
             Calls.Add("system");

--- a/src/Foundry.Bootstrap.Tests/SystemPreparation/WinPeSystemPreparationTests.cs
+++ b/src/Foundry.Bootstrap.Tests/SystemPreparation/WinPeSystemPreparationTests.cs
@@ -149,16 +149,19 @@ public sealed class WinPeSystemPreparationTests : IDisposable
     }
 
     [Theory]
-    [InlineData(5, false)]
-    [InlineData(6, true)]
-    public async Task PrepareSystemAsync_UpdatesClockOnlyAboveFiveMinuteSkew(int skewMinutes, bool expectedUpdate)
+    [InlineData(0, false)]
+    [InlineData(1, false)]
+    [InlineData(2, true)]
+    [InlineData(-36000, true)]
+    [InlineData(36000, true)]
+    public async Task PrepareSystemAsync_UpdatesClockAboveOneSecondSkew(int skewSeconds, bool expectedUpdate)
     {
         DateTimeOffset now = new(2026, 9, 10, 10, 0, 0, TimeSpan.Zero);
         var platform = new RecordingPlatform { UtcNow = now, ValidTimeZoneIds = ["UTC"] };
         var handler = new StubHttpHandler(request =>
         {
             var response = new HttpResponseMessage(HttpStatusCode.OK);
-            response.Headers.Date = now.AddMinutes(skewMinutes);
+            response.Headers.Date = now.AddSeconds(skewSeconds);
             return response;
         });
         var preparation = CreatePreparation(platform, handler);
@@ -269,6 +272,75 @@ public sealed class WinPeSystemPreparationTests : IDisposable
 
         Assert.Contains("dot3svc", platform.StartedServices);
         Assert.Equal(expectedWlanStart, platform.StartedServices.Contains("WlanSvc"));
+    }
+
+    [Fact]
+    public async Task PrepareClockAsync_RetriesAfterConnectWhenInitiallyOffline()
+    {
+        var platform = new RecordingPlatform { ValidTimeZoneIds = ["UTC"] };
+        bool online = false;
+        var handler = new StubHttpHandler(_ =>
+        {
+            if (!online) throw new HttpRequestException("Offline");
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.Headers.Date = platform.UtcNow.AddHours(-10);
+            return response;
+        });
+        var preparation = CreatePreparation(platform, handler);
+
+        await preparation.PrepareClockAsync(CancellationToken.None);
+        Assert.False(preparation.IsClockUsable);
+        Assert.Empty(platform.AppliedTimeZoneIds);
+        online = true;
+        await preparation.PrepareSystemAsync(CancellationToken.None);
+
+        Assert.True(preparation.IsClockUsable);
+        Assert.Single(platform.AppliedUtcTimes);
+    }
+
+    [Fact]
+    public async Task PrepareClockAsync_DoesNotRepeatSuccessfulProbeOrConfigureTimeZoneEarly()
+    {
+        var platform = new RecordingPlatform { EnvironmentTimeZoneId = "UTC", ValidTimeZoneIds = ["UTC"] };
+        var handler = new StubHttpHandler(_ =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.Headers.Date = platform.UtcNow;
+            return response;
+        });
+        var preparation = CreatePreparation(platform, handler);
+
+        await preparation.PrepareClockAsync(CancellationToken.None);
+        Assert.True(preparation.IsClockUsable);
+        Assert.Empty(platform.AppliedTimeZoneIds);
+        await preparation.PrepareSystemAsync(CancellationToken.None);
+
+        Assert.Equal(1, handler.RequestCount);
+        Assert.Single(platform.AppliedTimeZoneIds);
+    }
+
+    [Fact]
+    public async Task PrepareClockAsync_ContinuesAfterItsBudgetButPropagatesOperatorCancellation()
+    {
+        using var httpClient = new HttpClient(new StalledHttpHandler());
+        var preparation = new WinPeSystemPreparation(_root, httpClient, Logger.None,
+            new RecordingPlatform(), TimeSpan.FromSeconds(30));
+        await preparation.PrepareClockAsync(TestContext.Current.CancellationToken)
+            .WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.False(preparation.IsClockUsable);
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => preparation.PrepareClockAsync(cancellation.Token));
+    }
+
+    private sealed class StalledHttpHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new InvalidOperationException("The request must be cancelled.");
+        }
     }
 
     public void Dispose()

--- a/src/Foundry.Bootstrap/BootstrapContext.cs
+++ b/src/Foundry.Bootstrap/BootstrapContext.cs
@@ -18,6 +18,7 @@ internal sealed record BootstrapContext(string WinPeRoot, string RuntimeRoot, st
     internal IReadOnlyDictionary<string, string?> ChildEnvironment => new Dictionary<string, string?>
     {
         [DiagnosticSessionContext.EnvironmentVariableName] = SessionId,
+        [DiagnosticClock.EnvironmentVariableName] = DiagnosticClock.Current.IsSynchronized == true ? "true" : "false",
         [DiagnosticSessionContext.PersistenceDirectoryEnvironmentVariableName] = PersistenceDirectory,
         ["FOUNDRY_DEPLOYMENT_MODE"] = IsUsb ? "Usb" : "Iso"
     };

--- a/src/Foundry.Bootstrap/BootstrapCoordinator.cs
+++ b/src/Foundry.Bootstrap/BootstrapCoordinator.cs
@@ -59,7 +59,7 @@ internal sealed class BootstrapCoordinator(BootstrapContext context, IRuntimeRes
                 _ => "This boot stage could not be completed. Check the session log for details."
             };
             Report(status, message);
-            logger.ForContext("RemoteDiagnostic", true).Information("Bootstrap finished with {Outcome} at {Stage}; child exit {ExitCode}; elapsed {DurationMilliseconds} ms",
+            logger.Information("Bootstrap finished with {Outcome} at {Stage}; child exit {ExitCode}; elapsed {DurationMilliseconds} ms",
                 result.Outcome, result.Stage, result.ChildExitCode, Stopwatch.GetElapsedTime(started).TotalMilliseconds);
             try { completed?.Invoke(result, Stopwatch.GetElapsedTime(started)); }
             catch { }
@@ -153,7 +153,7 @@ internal sealed class BootstrapCoordinator(BootstrapContext context, IRuntimeRes
         }
         if (status == BootstrapStatus.Completed)
         {
-            logger.ForContext("RemoteDiagnostic", true).Information("Bootstrap stage {Stage} completed in {DurationMilliseconds:F0} ms",
+            logger.Information("Bootstrap stage {Stage} completed in {DurationMilliseconds:F0} ms",
                 stage, Stopwatch.GetElapsedTime(stageStarted).TotalMilliseconds);
         }
         progress(new BootstrapProgress(stage, status, message));

--- a/src/Foundry.Bootstrap/BootstrapCoordinator.cs
+++ b/src/Foundry.Bootstrap/BootstrapCoordinator.cs
@@ -81,6 +81,9 @@ internal sealed class BootstrapCoordinator(BootstrapContext context, IRuntimeRes
             "Some network preparation was unavailable. Continuing.").ConfigureAwait(false);
         Report(BootstrapStatus.Completed, "Environment prepared");
 
+        await BestEffortAsync(() => preparation.PrepareClockAsync(cancellationToken),
+            "Early clock synchronization was unavailable. Continuing to Foundry Connect.").ConfigureAwait(false);
+
         stage = BootstrapStage.Connect;
         Report(BootstrapStatus.Running, "Preparing Foundry Connect");
         string connect;

--- a/src/Foundry.Bootstrap/Processes/ApplicationLauncher.cs
+++ b/src/Foundry.Bootstrap/Processes/ApplicationLauncher.cs
@@ -89,7 +89,7 @@ internal sealed class ApplicationLauncher(ILogger logger, string? sessionDirecto
                 cancellationToken.ThrowIfCancellationRequested();
                 if (process.HasExited) { result = result with { ExitCode = process.ExitCode }; }
             }
-            logger.ForContext("RemoteDiagnostic", true).Information(
+            logger.Information(
                 "Application startup observed for {Component}: {Outcome}; stage {Stage}; exit {ExitCode}; reason {FailureReason}; duration {DurationMilliseconds:F0} ms",
                 application, result.Succeeded ? "Succeeded" : "Stopped", result.LastStage, result.ExitCode, result.FailureCategory,
                 Stopwatch.GetElapsedTime(launched).TotalMilliseconds);

--- a/src/Foundry.Bootstrap/Program.cs
+++ b/src/Foundry.Bootstrap/Program.cs
@@ -37,6 +37,7 @@ internal static class Program
             return arguments is ["--help"] ? 0 : 1;
         }
 
+        DiagnosticClock.Current.InitializeRuntime(null);
         string sessionId = DiagnosticSessionContext.CurrentSessionId;
         string? logPath = null;
         BootstrapLogPersistence? persistence = null;

--- a/src/Foundry.Bootstrap/Program.cs
+++ b/src/Foundry.Bootstrap/Program.cs
@@ -10,6 +10,7 @@ using Foundry.Bootstrap.Diagnostics;
 using Foundry.Bootstrap.Processes;
 using Foundry.Bootstrap.Runtime;
 using Foundry.Bootstrap.SystemPreparation;
+using Foundry.Telemetry;
 using Foundry.Utilities.Diagnostics;
 using Foundry.Utilities.IO;
 using Foundry.Utilities.Runtime;
@@ -52,13 +53,14 @@ internal static class Program
             {
                 logPath = WritableFilePathResolver.Resolve([Path.Combine(WinPeRoot, "Logs"),
                     Path.Combine(Path.GetTempPath(), "Foundry", "Logs")], "FoundryBootstrap.log");
+                RemoteDiagnosticsSink.SetLogDirectory(Path.Combine(Path.GetDirectoryName(logPath)!, "PendingLogs"));
                 Log.Logger = FoundryLogConfiguration.CreateFileLogger(logPath, "Foundry.Bootstrap", sessionId,
-                    LogEventLevel.Debug, 5, additionalSink: telemetry);
+                    LogEventLevel.Verbose, 5, additionalSink: telemetry);
             }
             catch
             {
                 logPath = null;
-                Log.Logger = FoundryLogConfiguration.CreateDebugLogger("Foundry.Bootstrap", sessionId, LogEventLevel.Debug, additionalSink: telemetry);
+                Log.Logger = FoundryLogConfiguration.CreateDebugLogger("Foundry.Bootstrap", sessionId, LogEventLevel.Verbose, additionalSink: telemetry);
             }
 
             if (!WinPeRuntimeDetector.IsWinPeRuntime())

--- a/src/Foundry.Bootstrap/SystemPreparation/ISystemPreparation.cs
+++ b/src/Foundry.Bootstrap/SystemPreparation/ISystemPreparation.cs
@@ -14,6 +14,9 @@ public interface ISystemPreparation
     /// </summary>
     Task PrepareNetworkAsync(CancellationToken cancellationToken);
 
+    /// <summary>Attempts clock synchronization within a short budget before Connect establishes connectivity.</summary>
+    Task PrepareClockAsync(CancellationToken cancellationToken);
+
     /// <summary>
     /// Corrects material clock skew and selects the best available timezone.
     /// </summary>

--- a/src/Foundry.Bootstrap/SystemPreparation/WinPeSystemPreparation.cs
+++ b/src/Foundry.Bootstrap/SystemPreparation/WinPeSystemPreparation.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Text.Json;
+using Foundry.Utilities.Diagnostics;
 using Serilog;
 
 namespace Foundry.Bootstrap.SystemPreparation;
@@ -12,7 +13,7 @@ namespace Foundry.Bootstrap.SystemPreparation;
 /// </summary>
 public sealed class WinPeSystemPreparation : ISystemPreparation
 {
-    private static readonly TimeSpan ClockSkewThreshold = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan ClockSkewThreshold = TimeSpan.FromSeconds(1);
     private static readonly Uri[] ClockProbeUris =
     [
         new("http://www.msftconnecttest.com/connecttest.txt"),
@@ -97,6 +98,19 @@ public sealed class WinPeSystemPreparation : ISystemPreparation
             cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task PrepareClockAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!_platform.IsWinPeSystemDrive || IsClockUsable) return;
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(2));
+        try { await SynchronizeClockAsync(timeout.Token).ConfigureAwait(false); }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.Debug("Early clock synchronization timed out. Continuing to Foundry Connect.");
+        }
+    }
+
     public async Task PrepareSystemAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -106,7 +120,7 @@ public sealed class WinPeSystemPreparation : ISystemPreparation
             return;
         }
 
-        await SynchronizeClockAsync(cancellationToken).ConfigureAwait(false);
+        if (!IsClockUsable) await SynchronizeClockAsync(cancellationToken).ConfigureAwait(false);
         cancellationToken.ThrowIfCancellationRequested();
         await ConfigureTimeZoneAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -147,6 +161,7 @@ public sealed class WinPeSystemPreparation : ISystemPreparation
         if (clockSkew.Duration() <= ClockSkewThreshold)
         {
             IsClockUsable = true;
+            DiagnosticClock.Current.MarkSynchronized();
             _logger.Information("System clock is within the allowed internet time threshold. ClockSkewSeconds={ClockSkewSeconds:F0}", clockSkew.TotalSeconds);
             return;
         }
@@ -157,6 +172,7 @@ public sealed class WinPeSystemPreparation : ISystemPreparation
             {
                 await _platform.SetSystemTimeAsync(internetTime.Value.ToUniversalTime(), token).ConfigureAwait(false);
                 IsClockUsable = true;
+                DiagnosticClock.Current.MarkSynchronized();
                 _logger.Information("System clock synchronized successfully. CorrectionSeconds={ClockSkewSeconds:F0}", clockSkew.TotalSeconds);
             },
             cancellationToken).ConfigureAwait(false);

--- a/src/Foundry.Connect.Tests/MainWindowViewModelTests.cs
+++ b/src/Foundry.Connect.Tests/MainWindowViewModelTests.cs
@@ -143,11 +143,10 @@ public sealed class MainWindowViewModelTests
         Assert.Equal("network", entry.Properties["FailureKind"]);
         Assert.Equal("http_status", entry.Properties["FailureReason"]);
         Assert.Equal("502", entry.Properties["FailureCode"]);
-        Assert.Equal(true, entry.Properties["RemoteDiagnostic"]);
     }
 
     [Fact]
-    public async Task InitializeAsync_WhenProvisionedSettingsReturnHandledFailure_LogsStructuredRemoteDiagnosticOnce()
+    public async Task InitializeAsync_WhenProvisionedSettingsReturnHandledFailure_LogsStructuredFailureOnce()
     {
         var telemetry = new RecordingTelemetryService();
         var logger = new RecordingLogger<MainWindowViewModel>();
@@ -170,12 +169,11 @@ public sealed class MainWindowViewModelTests
         Assert.Equal("network", entry.Properties["FailureKind"]);
         Assert.Equal("profile_import_failed", entry.Properties["FailureReason"]);
         Assert.Equal("wifi_profile_import_failed", entry.Properties["FailureCode"]);
-        Assert.Equal(true, entry.Properties["RemoteDiagnostic"]);
-        Assert.Single(logger.Entries, item => item.Properties.ContainsKey("RemoteDiagnostic"));
+        Assert.Single(logger.Entries, item => item.Properties.ContainsKey("FailureKind"));
     }
 
     [Fact]
-    public async Task ConnectConfiguredWifiAsync_WhenHandledFailureIsReturned_LogsStructuredRemoteDiagnosticOnce()
+    public async Task ConnectConfiguredWifiAsync_WhenHandledFailureIsReturned_LogsStructuredFailureOnce()
     {
         var telemetry = new RecordingTelemetryService();
         var logger = new RecordingLogger<MainWindowViewModel>();
@@ -200,12 +198,11 @@ public sealed class MainWindowViewModelTests
         Assert.Equal("network", entry.Properties["FailureKind"]);
         Assert.Equal("connect_request_failed", entry.Properties["FailureReason"]);
         Assert.Equal("wifi_connect_request_failed", entry.Properties["FailureCode"]);
-        Assert.Equal(true, entry.Properties["RemoteDiagnostic"]);
-        Assert.Single(logger.Entries, item => item.Properties.ContainsKey("RemoteDiagnostic"));
+        Assert.Single(logger.Entries, item => item.Properties.ContainsKey("FailureKind"));
     }
 
     [Fact]
-    public async Task InitializeAsync_WhenProvisionedSettingsReturnWiredHandledFailure_LogsStructuredWiredRemoteDiagnostic()
+    public async Task InitializeAsync_WhenProvisionedSettingsReturnWiredHandledFailure_LogsStructuredWiredFailure()
     {
         var telemetry = new RecordingTelemetryService();
         var logger = new RecordingLogger<MainWindowViewModel>();
@@ -220,14 +217,14 @@ public sealed class MainWindowViewModelTests
         await viewModel.InitializeAsync();
         viewModel.Dispose();
 
-        LogEntry entry = Assert.Single(logger.Entries, item => item.Properties.ContainsKey("RemoteDiagnostic"));
+        LogEntry entry = Assert.Single(logger.Entries, item => item.Properties.ContainsKey("FailureKind"));
         Assert.Equal("network.apply_provisioned_settings", entry.Properties["NetworkOperation"]);
         Assert.Equal("profile_unavailable", entry.Properties["FailureReason"]);
         Assert.Equal("wired_profile_template_missing", entry.Properties["FailureCode"]);
     }
 
     [Fact]
-    public async Task InitializeAsync_WhenProvisionedSettingsReturnMixedHandledFailures_LogsOneRemoteDiagnosticPerFailure()
+    public async Task InitializeAsync_WhenProvisionedSettingsReturnMixedHandledFailures_LogsOneStructuredEventPerFailure()
     {
         var telemetry = new RecordingTelemetryService();
         var logger = new RecordingLogger<MainWindowViewModel>();
@@ -246,7 +243,7 @@ public sealed class MainWindowViewModelTests
         viewModel.Dispose();
 
         LogEntry[] entries = logger.Entries
-            .Where(item => item.Properties.ContainsKey("RemoteDiagnostic"))
+            .Where(item => item.Properties.ContainsKey("FailureKind"))
             .ToArray();
         Assert.Equal(2, entries.Length);
         Assert.All(entries, entry => Assert.Equal("network.apply_provisioned_settings", entry.Properties["NetworkOperation"]));
@@ -257,7 +254,7 @@ public sealed class MainWindowViewModelTests
     }
 
     [Fact]
-    public async Task InitializeAsync_WhenProvisionedSettingsAreCancelled_DoesNotLogRemoteDiagnosticFailure()
+    public async Task InitializeAsync_WhenProvisionedSettingsAreCancelled_DoesNotLogStructuredFailure()
     {
         var telemetry = new RecordingTelemetryService();
         var logger = new RecordingLogger<MainWindowViewModel>();
@@ -270,11 +267,11 @@ public sealed class MainWindowViewModelTests
         await viewModel.InitializeAsync();
         viewModel.Dispose();
 
-        Assert.DoesNotContain(logger.Entries, item => item.Properties.ContainsKey("RemoteDiagnostic"));
+        Assert.DoesNotContain(logger.Entries, item => item.Properties.ContainsKey("FailureKind"));
     }
 
     [Fact]
-    public async Task InitializeAsync_WhenHandledFailuresAlsoLogLocalServiceDetails_ExportsOneRemoteEligibleWarningPerFailure()
+    public async Task InitializeAsync_WhenHandledFailuresAlsoLogLocalServiceDetails_ForwardsAllLocalDiagnosticEvents()
     {
         using var temporaryDirectory = new TemporaryDirectory();
         string certificatePath = temporaryDirectory.CreateFile("invalid.cer", "not-a-certificate");
@@ -327,13 +324,13 @@ public sealed class MainWindowViewModelTests
             RemoteDiagnosticsSink.Clear();
         }
 
+        Assert.Equal(localSink.Events, remoteDiagnostics.Events);
         Assert.Equal(2, remoteDiagnostics.ExportEligibleWarnings.Count);
         Assert.All(
             remoteDiagnostics.ExportEligibleWarnings,
             warning =>
             {
                 Assert.Equal(LogEventLevel.Warning, warning.Level);
-                Assert.True(HasTrueScalar(warning, "RemoteDiagnostic"));
                 Assert.False(string.IsNullOrWhiteSpace(GetScalarText(warning, "FailureCode")));
             });
         Assert.Contains(
@@ -670,6 +667,7 @@ public sealed class MainWindowViewModelTests
     private sealed class RecordingRemoteDiagnosticsService : IRemoteDiagnosticsService
     {
         public List<LogEvent> ExportEligibleWarnings { get; } = [];
+        public List<LogEvent> Events { get; } = [];
 
         public void Configure(RemoteDiagnosticsOptions options, RemoteDiagnosticsContext context)
         {
@@ -681,6 +679,7 @@ public sealed class MainWindowViewModelTests
 
         public void Emit(LogEvent logEvent)
         {
+            Events.Add(logEvent);
             if (logEvent.Level == LogEventLevel.Warning && !HasTrueScalar(logEvent, "RemoteDiagnosticsInternal"))
             {
                 ExportEligibleWarnings.Add(logEvent);

--- a/src/Foundry.Connect.Tests/RuntimeStartupDiagnosticsTests.cs
+++ b/src/Foundry.Connect.Tests/RuntimeStartupDiagnosticsTests.cs
@@ -5,6 +5,7 @@
 using Foundry.Connect.Services.Runtime;
 using Foundry.Core.Models.Runtime;
 using Foundry.Telemetry;
+using Foundry.Utilities.Diagnostics;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
@@ -188,15 +189,29 @@ public sealed class RuntimeStartupDiagnosticsTests
     public void StartupFailureExchangeAndLocalLogShareOriginalEventIdentityAndContent()
     {
         var sink = new RecordingLogSink();
-        using var logger = new LoggerConfiguration().WriteTo.Sink(sink).CreateLogger();
+        using var logger = (Logger)FoundryLogConfiguration.CreateDebugLogger("Foundry.Connect",
+            DiagnosticSessionContext.CurrentSessionId, LogEventLevel.Verbose, additionalSink: sink);
         LogEvent? captured = null;
+        Dictionary<string, LogEventPropertyValue>? capturedProperties = null;
         var startup = new RuntimeStartupDiagnostics((_, _, _) => { },
-            (_, entry, _) => { captured = entry; return Guid.NewGuid(); }, logger);
+            (_, entry, _) =>
+            {
+                captured = entry;
+                capturedProperties = entry.Properties.ToDictionary();
+                return Guid.NewGuid();
+            }, logger);
 
         startup.ReportFailure(new InvalidOperationException("startup failure detail"), "configuration");
 
         LogEvent local = Assert.Single(sink.Events);
         Assert.NotNull(captured);
+        Assert.NotNull(capturedProperties);
+        foreach ((string name, LogEventPropertyValue value) in local.Properties)
+        {
+            if (name == "RemoteDiagnosticsInternal") continue;
+            Assert.True(capturedProperties.TryGetValue(name, out LogEventPropertyValue? capturedValue), name);
+            Assert.Equal(value.ToString(), capturedValue.ToString());
+        }
         Assert.Equal(captured.Properties["diagnostics.record_id"], local.Properties["diagnostics.record_id"]);
         Assert.Equal(captured.Properties["diagnostics.sequence"], local.Properties["diagnostics.sequence"]);
         Assert.Equal(captured.Timestamp, local.Timestamp);

--- a/src/Foundry.Connect.Tests/RuntimeStartupDiagnosticsTests.cs
+++ b/src/Foundry.Connect.Tests/RuntimeStartupDiagnosticsTests.cs
@@ -4,13 +4,36 @@
 
 using Foundry.Connect.Services.Runtime;
 using Foundry.Core.Models.Runtime;
+using Foundry.Telemetry;
 using Serilog;
 using Serilog.Core;
+using Serilog.Events;
 
 namespace Foundry.Connect.Tests;
 
+[Collection(ConnectRemoteDiagnosticsCollection.Name)]
 public sealed class RuntimeStartupDiagnosticsTests
 {
+    [Fact]
+    public void FailureNormalizationErrorStillPublishesFailedStatus()
+    {
+        string? stage = null;
+        string? recordId = "unset";
+        var startup = new RuntimeStartupDiagnostics(
+            (value, _, id) => { stage = value; recordId = id; },
+            (_, _, _) => throw new InvalidOperationException("Capture must not run after normalization fails"), Logger.None);
+
+        startup.ReportFailure(new UnrenderableException(), "configuration");
+
+        Assert.Equal(StartupStage.StartupFailed, stage);
+        Assert.Null(recordId);
+    }
+
+    private sealed class UnrenderableException : Exception
+    {
+        public override string ToString() => throw new InvalidOperationException("Exception formatting failed");
+    }
+
     [Fact]
     public void FailureCaptureErrorStillPublishesFailedStatusWithoutRecordId()
     {
@@ -18,7 +41,7 @@ public sealed class RuntimeStartupDiagnosticsTests
         string? recordId = "unset";
         var startup = new RuntimeStartupDiagnostics(
             (value, _, id) => { stage = value; recordId = id; },
-            (_, _) => throw new IOException("unavailable storage"), Logger.None);
+            (_, _, _) => throw new IOException("unavailable storage"), Logger.None);
 
         startup.ReportFailure(new InvalidOperationException(), "configuration");
 
@@ -35,7 +58,7 @@ public sealed class RuntimeStartupDiagnosticsTests
         Exception? captured = null;
         var startup = new RuntimeStartupDiagnostics(
             (stage, category, id) => calls.Add(stage + ":" + id),
-            (error, category) => { captured = error; calls.Add("persist"); return recordId; },
+            (error, _, category) => { captured = error; calls.Add("persist"); return recordId; },
             Logger.None);
 
         startup.ReportFailure(exception, "configuration");
@@ -53,7 +76,7 @@ public sealed class RuntimeStartupDiagnosticsTests
         int captures = 0;
         var startup = new RuntimeStartupDiagnostics(
             (stage, category, id) => stages.Add(stage),
-            (_, _) => { captures++; return Guid.NewGuid(); },
+            (_, _, _) => { captures++; return Guid.NewGuid(); },
             Logger.None);
 
         startup.ReportUiReady();
@@ -70,7 +93,7 @@ public sealed class RuntimeStartupDiagnosticsTests
         var rendered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var stages = new List<string>();
         var startup = new RuntimeStartupDiagnostics(
-            (stage, _, _) => stages.Add(stage), (_, _) => null, Logger.None);
+            (stage, _, _) => stages.Add(stage), (_, _, _) => null, Logger.None);
 
         Task observation = startup.ObserveInitializationAsync(() => initialized.Task, () => rendered.Task, () => true);
         Assert.Empty(stages);
@@ -87,10 +110,122 @@ public sealed class RuntimeStartupDiagnosticsTests
     {
         var stages = new List<string>();
         var startup = new RuntimeStartupDiagnostics(
-            (stage, _, _) => stages.Add(stage), (_, _) => null, Logger.None);
+            (stage, _, _) => stages.Add(stage), (_, _, _) => null, Logger.None);
 
         await startup.ObserveInitializationAsync(() => Task.CompletedTask, () => Task.CompletedTask, () => false);
 
         Assert.Empty(stages);
+    }
+
+    [Fact]
+    public void MissingEarlyConsentDoesNotConfigureRemoteService()
+    {
+        var startup = new RuntimeStartupDiagnostics(reporter: null, settings: null);
+        var service = new RecordingDiagnosticsService();
+
+        startup.InitializeRemoteDiagnostics(service);
+
+        Assert.Empty(service.Configurations);
+    }
+
+    [Fact]
+    public void EarlyOptOutPassesDestinationForPendingRecordPurgeAndStopsForwarding()
+    {
+        TelemetrySettings settings = CreateSettings() with { IsRemoteDiagnosticsEnabled = false };
+        var startup = new RuntimeStartupDiagnostics(reporter: null, settings);
+        var service = new RecordingDiagnosticsService();
+        RemoteDiagnosticsSink.Clear();
+        RemoteDiagnosticsSink.SetService(service);
+        try
+        {
+            startup.InitializeRemoteDiagnostics(service);
+            using var logger = new LoggerConfiguration().WriteTo.Sink(RemoteDiagnosticsSink.Instance).CreateLogger();
+            logger.Information("Consent is disabled");
+
+            var configuration = Assert.Single(service.Configurations);
+            Assert.False(configuration.Options.IsEnabled);
+            Assert.Equal(settings.InstallId, configuration.Options.InstallId);
+            Assert.Equal(settings.HostUrl, configuration.Options.HostUrl);
+            Assert.Equal(settings.ProjectToken, configuration.Options.ProjectToken);
+            Assert.Empty(service.Events);
+        }
+        finally
+        {
+            RemoteDiagnosticsSink.Clear();
+        }
+    }
+
+    [Fact]
+    public void RuntimeInitializationKeepsUsingTheEarlyStartupService()
+    {
+        TelemetrySettings settings = CreateSettings();
+        var startup = new RuntimeStartupDiagnostics(reporter: null, settings);
+        var service = new RecordingDiagnosticsService();
+        RemoteDiagnosticsSink.Clear();
+        try
+        {
+            startup.InitializeRemoteDiagnostics(service);
+            RemoteDiagnosticsContext context = Assert.Single(service.Configurations).Context;
+            using var logger = new LoggerConfiguration().WriteTo.Sink(RemoteDiagnosticsSink.Instance).CreateLogger();
+            logger.Information("Before configuration loaded");
+            RemoteDiagnosticsLifecycle.Initialize(service, settings, new TelemetryContext(
+                context.App, context.AppVersion, context.BuildConfiguration, context.Runtime,
+                TelemetryRuntimePayloadSources.Unknown, TelemetryBootMediaTargets.None,
+                context.RuntimeArchitecture, context.Locale, context.SessionId));
+            logger.Information("After configuration loaded");
+
+            Assert.Equal(2, service.Configurations.Count);
+            Assert.Equal(["Before configuration loaded", "After configuration loaded"],
+                service.Events.Select(entry => entry.RenderMessage()));
+        }
+        finally
+        {
+            RemoteDiagnosticsSink.Clear();
+        }
+    }
+
+    [Fact]
+    public void StartupFailureExchangeAndLocalLogShareOriginalEventIdentityAndContent()
+    {
+        var sink = new RecordingLogSink();
+        using var logger = new LoggerConfiguration().WriteTo.Sink(sink).CreateLogger();
+        LogEvent? captured = null;
+        var startup = new RuntimeStartupDiagnostics((_, _, _) => { },
+            (_, entry, _) => { captured = entry; return Guid.NewGuid(); }, logger);
+
+        startup.ReportFailure(new InvalidOperationException("startup failure detail"), "configuration");
+
+        LogEvent local = Assert.Single(sink.Events);
+        Assert.NotNull(captured);
+        Assert.Equal(captured.Properties["diagnostics.record_id"], local.Properties["diagnostics.record_id"]);
+        Assert.Equal(captured.Properties["diagnostics.sequence"], local.Properties["diagnostics.sequence"]);
+        Assert.Equal(captured.Timestamp, local.Timestamp);
+        Assert.Equal(captured.RenderMessage(), local.RenderMessage());
+        Assert.Equal(captured.Exception?.ToString(), local.Exception?.ToString());
+    }
+
+    private sealed class RecordingLogSink : ILogEventSink
+    {
+        public List<LogEvent> Events { get; } = [];
+        public void Emit(LogEvent logEvent) => Events.Add(logEvent);
+    }
+
+    private static TelemetrySettings CreateSettings() => new()
+    {
+        IsRemoteDiagnosticsEnabled = true,
+        HostUrl = "https://posthog.example",
+        ProjectToken = "test-project-token",
+        InstallId = "test-install"
+    };
+
+    private sealed class RecordingDiagnosticsService : IRemoteDiagnosticsService
+    {
+        public List<(RemoteDiagnosticsOptions Options, RemoteDiagnosticsContext Context)> Configurations { get; } = [];
+        public List<LogEvent> Events { get; } = [];
+        public void Configure(RemoteDiagnosticsOptions options, RemoteDiagnosticsContext context) => Configurations.Add((options, context));
+        public void Disable() { }
+        public void Emit(LogEvent logEvent) => Events.Add(logEvent);
+        public Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/src/Foundry.Connect/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Connect/DependencyInjection/ServiceCollectionExtensions.cs
@@ -39,7 +39,6 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(sp => sp.GetRequiredService<IConnectConfigurationService>().Load());
         services.AddSingleton(CreateTelemetryOptions);
         services.AddSingleton(CreateTelemetryContext);
-        services.AddSingleton<IRemoteDiagnosticsService>(_ => new PostHogRemoteDiagnosticsSink());
         services.AddSingleton<ITelemetryService>(sp =>
         {
             TelemetryOptions options = sp.GetRequiredService<TelemetryOptions>();

--- a/src/Foundry.Connect/Program.cs
+++ b/src/Foundry.Connect/Program.cs
@@ -54,10 +54,12 @@ public static class Program
                 startupLogFilePath = "<unavailable>";
                 Log.Logger = FoundryLogConfiguration.CreateDebugLogger(
                     "Foundry.Connect", DiagnosticSessionContext.CurrentSessionId,
-                    Serilog.Events.LogEventLevel.Debug, additionalSink: RemoteDiagnosticsSink.Instance);
+                    Serilog.Events.LogEventLevel.Verbose, additionalSink: RemoteDiagnosticsSink.Instance);
                 Log.ForContext(typeof(Program)).Error(exception, "File logging initialization failed. Falling back to debugger output.");
             }
 
+            remoteDiagnosticsService = new PostHogRemoteDiagnosticsSink();
+            startup.InitializeRemoteDiagnostics(remoteDiagnosticsService);
             programLogger = Log.ForContext(typeof(Program));
             programLogger.Information(
                 "Foundry.Connect bootstrap started. Version={Version}, SessionId={SessionId}, LogFilePath={LogFilePath}",
@@ -67,12 +69,11 @@ public static class Program
 
             ConfigureRuntimeCompatibility();
             stage = "configuration";
-            host = BuildHost(args, startup);
+            host = BuildHost(args, startup, remoteDiagnosticsService);
             _ = host.Services.GetRequiredService<FoundryConnectConfiguration>();
             startup.ReportConfigurationLoaded();
             stage = "services";
             telemetryService = host.Services.GetRequiredService<ITelemetryService>();
-            remoteDiagnosticsService = host.Services.GetRequiredService<IRemoteDiagnosticsService>();
             InitializeRemoteDiagnostics(host.Services, remoteDiagnosticsService);
 
             stage = "ui_startup";
@@ -101,9 +102,10 @@ public static class Program
         }
         finally
         {
-            ShutdownDiagnostics(telemetryService, remoteDiagnosticsService);
             try { host?.Dispose(); }
             catch (Exception exception) { programLogger.Warning(exception, "Application service disposal failed."); }
+            programLogger.Information("Foundry.Connect application shutdown completed. Closing diagnostics.");
+            ShutdownDiagnostics(telemetryService, remoteDiagnosticsService);
             try { Task.Run(() => Log.CloseAndFlushAsync().AsTask()).WaitAsync(DiagnosticsShutdownTimeout).GetAwaiter().GetResult(); }
             catch { }
         }
@@ -166,13 +168,15 @@ public static class Program
         };
     }
 
-    private static IHost BuildHost(string[] args, RuntimeStartupDiagnostics startup)
+    private static IHost BuildHost(string[] args, RuntimeStartupDiagnostics startup, IRemoteDiagnosticsService remoteDiagnosticsService)
     {
         HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
         builder.Logging.ClearProviders();
+        builder.Logging.SetMinimumLevel(LogLevel.Trace);
         builder.Logging.AddSerilog(dispose: false);
         builder.Services.AddSingleton(startup);
         builder.Services.AddFoundryConnectApplicationServices(args);
+        builder.Services.AddSingleton(remoteDiagnosticsService);
         return builder.Build();
     }
 
@@ -185,6 +189,8 @@ public static class Program
 
     private static void ShutdownDiagnostics(ITelemetryService? telemetry, IRemoteDiagnosticsService? diagnostics)
     {
+        Serilog.ILogger transportLogger = Log.ForContext(typeof(Program)).ForContext("PostHogTransportInternal", true);
+        transportLogger.Debug("Flushing remote diagnostics.");
         try
         {
             Task.Run(async () =>
@@ -198,8 +204,12 @@ public static class Program
                 if (diagnostics is not null)
                     await RemoteDiagnosticsLifecycle.ShutdownAsync(diagnostics, timeout.Token).ConfigureAwait(false);
             }).WaitAsync(DiagnosticsShutdownTimeout).GetAwaiter().GetResult();
+            transportLogger.Debug("Remote diagnostics shutdown completed.");
         }
-        catch { }
+        catch (Exception exception)
+        {
+            transportLogger.Warning(exception, "Remote diagnostics shutdown did not complete within the shutdown budget.");
+        }
     }
 
     private static void RegisterGlobalExceptionHandlers(RuntimeStartupDiagnostics startup)

--- a/src/Foundry.Connect/Program.cs
+++ b/src/Foundry.Connect/Program.cs
@@ -31,6 +31,7 @@ public static class Program
     [STAThread]
     public static int Main(string[] args)
     {
+        DiagnosticClock.Current.InitializeRuntime(Environment.GetEnvironmentVariable(DiagnosticClock.EnvironmentVariableName));
         string startupLogFilePath = "<unavailable>";
         IHost? host = null;
         ITelemetryService? telemetryService = null;

--- a/src/Foundry.Connect/Services/Logging/FoundryConnectLogging.cs
+++ b/src/Foundry.Connect/Services/Logging/FoundryConnectLogging.cs
@@ -30,11 +30,12 @@ internal static class FoundryConnectLogging
     public static ILogger CreateLogger(string logFilePath)
     {
         string normalizedLogFilePath = Path.GetFullPath(logFilePath);
+        RemoteDiagnosticsSink.SetLogDirectory(Path.Combine(Path.GetDirectoryName(normalizedLogFilePath)!, "PendingLogs"));
         ILogger logger = FoundryLogConfiguration.CreateFileLogger(
             logFilePath,
             "Foundry.Connect",
             DiagnosticSessionContext.CurrentSessionId,
-            LogEventLevel.Debug,
+            LogEventLevel.Verbose,
             RetainedLogFileCount,
             additionalSink: RemoteDiagnosticsSink.Instance);
 

--- a/src/Foundry.Connect/Services/Runtime/RuntimeStartupDiagnostics.cs
+++ b/src/Foundry.Connect/Services/Runtime/RuntimeStartupDiagnostics.cs
@@ -103,10 +103,11 @@ public sealed class RuntimeStartupDiagnostics
         Guid? recordId = null;
         try
         {
-            var entry = LogEventNormalizer.Normalize(new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Fatal, exception,
+            var entry = FoundryLogConfiguration.PrepareEvent(new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Fatal, exception,
                 new MessageTemplateParser().Parse("Application failed at {FailureReason}."),
                 [new LogEventProperty("FailureReason", new ScalarValue(category)),
-                 new LogEventProperty("SourceContext", new ScalarValue(typeof(RuntimeStartupDiagnostics).FullName))]));
+                 new LogEventProperty("SourceContext", new ScalarValue(typeof(RuntimeStartupDiagnostics).FullName))]),
+                "Foundry.Connect", DiagnosticSessionContext.CurrentSessionId);
             try
             {
                 if (Volatile.Read(ref _ready) == 0) recordId = _capture(exception, entry, category);

--- a/src/Foundry.Connect/Services/Runtime/RuntimeStartupDiagnostics.cs
+++ b/src/Foundry.Connect/Services/Runtime/RuntimeStartupDiagnostics.cs
@@ -19,21 +19,23 @@ namespace Foundry.Connect.Services.Runtime;
 public sealed class RuntimeStartupDiagnostics
 {
     private readonly Action<string, string?, string?> _report;
-    private readonly Func<Exception, string, Guid?> _capture;
+    private readonly Func<Exception, LogEvent, string, Guid?> _capture;
     private readonly Func<ILogger> _logger;
+    private readonly TelemetrySettings? _earlySettings;
+    private readonly RemoteDiagnosticsContext? _earlyContext;
     private string? _emergencyPath;
     private int _failed;
     private int _ready;
 
     internal RuntimeStartupDiagnostics(Action<string, string?, string?> report,
-        Func<Exception, string, Guid?> capture, ILogger logger)
+        Func<Exception, LogEvent, string, Guid?> capture, ILogger logger)
     {
         _report = report;
         _capture = capture;
         _logger = () => logger;
     }
 
-    private RuntimeStartupDiagnostics(RuntimeStartupReporter? reporter, TelemetrySettings? settings)
+    internal RuntimeStartupDiagnostics(RuntimeStartupReporter? reporter, TelemetrySettings? settings)
     {
         _report = (stage, category, id) => reporter?.Report(stage, category, id);
         _logger = () => Log.ForContext<RuntimeStartupDiagnostics>();
@@ -43,14 +45,13 @@ public sealed class RuntimeStartupDiagnostics
             RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant(), CultureInfo.CurrentUICulture.Name,
             reporter?.SessionId ?? DiagnosticSessionContext.CurrentSessionId,
             TelemetryApps.FoundryConnect + "@" + FoundryConnectApplicationInfo.Version);
-        _capture = (exception, category) =>
+        _earlySettings = settings;
+        _earlyContext = context;
+        _capture = (exception, entry, category) =>
         {
             if (reporter is null || settings is null) return null;
             var options = new RemoteDiagnosticsOptions(settings.IsRemoteDiagnosticsEnabled,
                 settings.HostUrl, settings.ProjectToken, settings.InstallId);
-            var entry = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Fatal, exception,
-                new MessageTemplateParser().Parse("Application startup failed at {FailureReason}."),
-                [new LogEventProperty("FailureReason", new ScalarValue(category))]);
             return ChildStartupFailureExchange.TryCapture(Path.GetDirectoryName(reporter.StatusPath)!,
                 Guid.Parse(reporter.LaunchId), options, context, entry);
         };
@@ -64,6 +65,16 @@ public sealed class RuntimeStartupDiagnostics
         TelemetrySettings? settings = reporter is null ? null : RuntimeTelemetryConsent.ReadSettings(
             @"X:\Foundry\Config\foundry.bootstrap.config.json", childConfigurationPath, configurationRequired);
         return new RuntimeStartupDiagnostics(reporter, settings);
+    }
+
+    /// <summary>Starts the process service with verified managed-startup consent before full configuration loading.</summary>
+    internal void InitializeRemoteDiagnostics(IRemoteDiagnosticsService service)
+    {
+        if (_earlySettings is null || _earlyContext is null) return;
+        var context = new TelemetryContext(_earlyContext.App, _earlyContext.AppVersion,
+            _earlyContext.BuildConfiguration, _earlyContext.Runtime, _earlySettings.RuntimePayloadSource,
+            TelemetryBootMediaTargets.None, _earlyContext.RuntimeArchitecture, _earlyContext.Locale, _earlyContext.SessionId);
+        RemoteDiagnosticsLifecycle.Initialize(service, _earlySettings, context);
     }
 
     /// <summary>Publishes successful configuration loading before the UI is constructed.</summary>
@@ -92,16 +103,26 @@ public sealed class RuntimeStartupDiagnostics
         Guid? recordId = null;
         try
         {
-            if (Volatile.Read(ref _ready) == 0) recordId = _capture(exception, category);
+            var entry = LogEventNormalizer.Normalize(new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Fatal, exception,
+                new MessageTemplateParser().Parse("Application failed at {FailureReason}."),
+                [new LogEventProperty("FailureReason", new ScalarValue(category)),
+                 new LogEventProperty("SourceContext", new ScalarValue(typeof(RuntimeStartupDiagnostics).FullName))]));
+            try
+            {
+                if (Volatile.Read(ref _ready) == 0) recordId = _capture(exception, entry, category);
+            }
+            catch { }
+            try
+            {
+                _logger().ForContext("RemoteDiagnosticsInternal", recordId.HasValue).Write(entry);
+            }
+            catch { }
         }
         catch { }
-        try
+        finally
         {
-            _logger().ForContext("RemoteDiagnosticsInternal", recordId.HasValue)
-                .Fatal(exception, "Application failed at {FailureReason}.", category);
+            Report(StartupStage.StartupFailed, category, recordId?.ToString("N"));
         }
-        catch { }
-        Report(StartupStage.StartupFailed, category, recordId?.ToString("N"));
     }
 
     private void Report(string stage, string? category = null, string? recordId = null)

--- a/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
+++ b/src/Foundry.Connect/ViewModels/MainWindowViewModel.cs
@@ -1689,14 +1689,13 @@ public partial class MainWindowViewModel : LocalizedViewModelBase
             level,
             eventId: default,
             exception,
-            "Network operation failed. Workflow={Workflow}, OperationId={OperationId}, NetworkOperation={NetworkOperation}, FailureKind={FailureKind}, FailureReason={FailureReason}, FailureCode={FailureCode}, RemoteDiagnostic={RemoteDiagnostic}",
+            "Network operation failed. Workflow={Workflow}, OperationId={OperationId}, NetworkOperation={NetworkOperation}, FailureKind={FailureKind}, FailureReason={FailureReason}, FailureCode={FailureCode}",
             "connect",
             operationId,
             networkOperation,
             failure.Kind,
             failure.Reason,
-            failure.Code,
-            true);
+            failure.Code);
     }
 
     private IDisposable? BeginNetworkOperationScope(string operationId, string networkOperation) =>

--- a/src/Foundry.Deploy.Tests/DeploymentOrchestratorTests.cs
+++ b/src/Foundry.Deploy.Tests/DeploymentOrchestratorTests.cs
@@ -320,15 +320,11 @@ public sealed class DeploymentOrchestratorTests
         Assert.Equal("failed", terminalLog.Properties["Outcome"]);
         Assert.Equal(DeploymentOperationNames.ValidateTargetDisk, terminalLog.Properties["FailedOperationName"]);
         Assert.Equal("missing_target_partition", terminalLog.Properties["FailureCode"]);
-        Assert.Equal(true, terminalLog.Properties["RemoteDiagnostic"]);
-        Assert.Equal(true, terminalLog.Properties["RemoteDiagnosticTerminal"]);
         Assert.Contains(logger.Entries, entry =>
-            entry.Properties.TryGetValue("RemoteDiagnostic", out object? remote) && Equals(remote, true) &&
             entry.Properties.ContainsKey("Mode") && !entry.Properties.ContainsKey("Outcome"));
         Assert.Contains(logger.Entries, entry =>
-            entry.Properties.TryGetValue("RemoteDiagnostic", out object? remote) && Equals(remote, true) &&
             entry.Properties.TryGetValue("StepName", out object? step) && Equals(step, DeploymentStepNames.ValidateTargetConfiguration));
-        Assert.All(logger.Entries.Where(entry => Equals(entry.Properties.GetValueOrDefault("RemoteDiagnostic"), true)),
+        Assert.All(logger.Entries.Where(entry => entry.Properties.ContainsKey("OperationId")),
             entry => Assert.Equal(operationId, entry.Properties["OperationId"]));
     }
 

--- a/src/Foundry.Deploy.Tests/RuntimeStartupDiagnosticsTests.cs
+++ b/src/Foundry.Deploy.Tests/RuntimeStartupDiagnosticsTests.cs
@@ -5,6 +5,7 @@
 using Foundry.Deploy.Services.Runtime;
 using Foundry.Core.Models.Runtime;
 using Foundry.Telemetry;
+using Foundry.Utilities.Diagnostics;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
@@ -188,15 +189,29 @@ public sealed class RuntimeStartupDiagnosticsTests
     public void StartupFailureExchangeAndLocalLogShareOriginalEventIdentityAndContent()
     {
         var sink = new RecordingLogSink();
-        using var logger = new LoggerConfiguration().WriteTo.Sink(sink).CreateLogger();
+        using var logger = (Logger)FoundryLogConfiguration.CreateDebugLogger("Foundry.Deploy",
+            DiagnosticSessionContext.CurrentSessionId, LogEventLevel.Verbose, additionalSink: sink);
         LogEvent? captured = null;
+        Dictionary<string, LogEventPropertyValue>? capturedProperties = null;
         var startup = new RuntimeStartupDiagnostics((_, _, _) => { },
-            (_, entry, _) => { captured = entry; return Guid.NewGuid(); }, logger);
+            (_, entry, _) =>
+            {
+                captured = entry;
+                capturedProperties = entry.Properties.ToDictionary();
+                return Guid.NewGuid();
+            }, logger);
 
         startup.ReportFailure(new InvalidOperationException("startup failure detail"), "configuration");
 
         LogEvent local = Assert.Single(sink.Events);
         Assert.NotNull(captured);
+        Assert.NotNull(capturedProperties);
+        foreach ((string name, LogEventPropertyValue value) in local.Properties)
+        {
+            if (name == "RemoteDiagnosticsInternal") continue;
+            Assert.True(capturedProperties.TryGetValue(name, out LogEventPropertyValue? capturedValue), name);
+            Assert.Equal(value.ToString(), capturedValue.ToString());
+        }
         Assert.Equal(captured.Properties["diagnostics.record_id"], local.Properties["diagnostics.record_id"]);
         Assert.Equal(captured.Properties["diagnostics.sequence"], local.Properties["diagnostics.sequence"]);
         Assert.Equal(captured.Timestamp, local.Timestamp);

--- a/src/Foundry.Deploy.Tests/RuntimeStartupDiagnosticsTests.cs
+++ b/src/Foundry.Deploy.Tests/RuntimeStartupDiagnosticsTests.cs
@@ -4,13 +4,36 @@
 
 using Foundry.Deploy.Services.Runtime;
 using Foundry.Core.Models.Runtime;
+using Foundry.Telemetry;
 using Serilog;
 using Serilog.Core;
+using Serilog.Events;
 
 namespace Foundry.Deploy.Tests;
 
+[Collection(nameof(SerilogCollection))]
 public sealed class RuntimeStartupDiagnosticsTests
 {
+    [Fact]
+    public void FailureNormalizationErrorStillPublishesFailedStatus()
+    {
+        string? stage = null;
+        string? recordId = "unset";
+        var startup = new RuntimeStartupDiagnostics(
+            (value, _, id) => { stage = value; recordId = id; },
+            (_, _, _) => throw new InvalidOperationException("Capture must not run after normalization fails"), Logger.None);
+
+        startup.ReportFailure(new UnrenderableException(), "configuration");
+
+        Assert.Equal(StartupStage.StartupFailed, stage);
+        Assert.Null(recordId);
+    }
+
+    private sealed class UnrenderableException : Exception
+    {
+        public override string ToString() => throw new InvalidOperationException("Exception formatting failed");
+    }
+
     [Fact]
     public void FailureCaptureErrorStillPublishesFailedStatusWithoutRecordId()
     {
@@ -18,7 +41,7 @@ public sealed class RuntimeStartupDiagnosticsTests
         string? recordId = "unset";
         var startup = new RuntimeStartupDiagnostics(
             (value, _, id) => { stage = value; recordId = id; },
-            (_, _) => throw new IOException("unavailable storage"), Logger.None);
+            (_, _, _) => throw new IOException("unavailable storage"), Logger.None);
 
         startup.ReportFailure(new InvalidOperationException(), "configuration");
 
@@ -35,7 +58,7 @@ public sealed class RuntimeStartupDiagnosticsTests
         Exception? captured = null;
         var startup = new RuntimeStartupDiagnostics(
             (stage, category, id) => calls.Add(stage + ":" + id),
-            (error, category) => { captured = error; calls.Add("persist"); return recordId; },
+            (error, _, category) => { captured = error; calls.Add("persist"); return recordId; },
             Logger.None);
 
         startup.ReportFailure(exception, "configuration");
@@ -53,7 +76,7 @@ public sealed class RuntimeStartupDiagnosticsTests
         int captures = 0;
         var startup = new RuntimeStartupDiagnostics(
             (stage, category, id) => stages.Add(stage),
-            (_, _) => { captures++; return Guid.NewGuid(); },
+            (_, _, _) => { captures++; return Guid.NewGuid(); },
             Logger.None);
 
         startup.ReportUiReady();
@@ -70,7 +93,7 @@ public sealed class RuntimeStartupDiagnosticsTests
         var rendered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var stages = new List<string>();
         var startup = new RuntimeStartupDiagnostics(
-            (stage, _, _) => stages.Add(stage), (_, _) => null, Logger.None);
+            (stage, _, _) => stages.Add(stage), (_, _, _) => null, Logger.None);
 
         Task observation = startup.ObserveInitializationAsync(() => initialized.Task, () => rendered.Task, () => true);
         Assert.Empty(stages);
@@ -87,10 +110,122 @@ public sealed class RuntimeStartupDiagnosticsTests
     {
         var stages = new List<string>();
         var startup = new RuntimeStartupDiagnostics(
-            (stage, _, _) => stages.Add(stage), (_, _) => null, Logger.None);
+            (stage, _, _) => stages.Add(stage), (_, _, _) => null, Logger.None);
 
         await startup.ObserveInitializationAsync(() => Task.CompletedTask, () => Task.CompletedTask, () => false);
 
         Assert.Empty(stages);
+    }
+
+    [Fact]
+    public void MissingEarlyConsentDoesNotConfigureRemoteService()
+    {
+        var startup = new RuntimeStartupDiagnostics(reporter: null, settings: null);
+        var service = new RecordingDiagnosticsService();
+
+        startup.InitializeRemoteDiagnostics(service);
+
+        Assert.Empty(service.Configurations);
+    }
+
+    [Fact]
+    public void EarlyOptOutPassesDestinationForPendingRecordPurgeAndStopsForwarding()
+    {
+        TelemetrySettings settings = CreateSettings() with { IsRemoteDiagnosticsEnabled = false };
+        var startup = new RuntimeStartupDiagnostics(reporter: null, settings);
+        var service = new RecordingDiagnosticsService();
+        RemoteDiagnosticsSink.Clear();
+        RemoteDiagnosticsSink.SetService(service);
+        try
+        {
+            startup.InitializeRemoteDiagnostics(service);
+            using var logger = new LoggerConfiguration().WriteTo.Sink(RemoteDiagnosticsSink.Instance).CreateLogger();
+            logger.Information("Consent is disabled");
+
+            var configuration = Assert.Single(service.Configurations);
+            Assert.False(configuration.Options.IsEnabled);
+            Assert.Equal(settings.InstallId, configuration.Options.InstallId);
+            Assert.Equal(settings.HostUrl, configuration.Options.HostUrl);
+            Assert.Equal(settings.ProjectToken, configuration.Options.ProjectToken);
+            Assert.Empty(service.Events);
+        }
+        finally
+        {
+            RemoteDiagnosticsSink.Clear();
+        }
+    }
+
+    [Fact]
+    public void RuntimeInitializationKeepsUsingTheEarlyStartupService()
+    {
+        TelemetrySettings settings = CreateSettings();
+        var startup = new RuntimeStartupDiagnostics(reporter: null, settings);
+        var service = new RecordingDiagnosticsService();
+        RemoteDiagnosticsSink.Clear();
+        try
+        {
+            startup.InitializeRemoteDiagnostics(service);
+            RemoteDiagnosticsContext context = Assert.Single(service.Configurations).Context;
+            using var logger = new LoggerConfiguration().WriteTo.Sink(RemoteDiagnosticsSink.Instance).CreateLogger();
+            logger.Information("Before configuration loaded");
+            RemoteDiagnosticsLifecycle.Initialize(service, settings, new TelemetryContext(
+                context.App, context.AppVersion, context.BuildConfiguration, context.Runtime,
+                TelemetryRuntimePayloadSources.Unknown, TelemetryBootMediaTargets.None,
+                context.RuntimeArchitecture, context.Locale, context.SessionId));
+            logger.Information("After configuration loaded");
+
+            Assert.Equal(2, service.Configurations.Count);
+            Assert.Equal(["Before configuration loaded", "After configuration loaded"],
+                service.Events.Select(entry => entry.RenderMessage()));
+        }
+        finally
+        {
+            RemoteDiagnosticsSink.Clear();
+        }
+    }
+
+    [Fact]
+    public void StartupFailureExchangeAndLocalLogShareOriginalEventIdentityAndContent()
+    {
+        var sink = new RecordingLogSink();
+        using var logger = new LoggerConfiguration().WriteTo.Sink(sink).CreateLogger();
+        LogEvent? captured = null;
+        var startup = new RuntimeStartupDiagnostics((_, _, _) => { },
+            (_, entry, _) => { captured = entry; return Guid.NewGuid(); }, logger);
+
+        startup.ReportFailure(new InvalidOperationException("startup failure detail"), "configuration");
+
+        LogEvent local = Assert.Single(sink.Events);
+        Assert.NotNull(captured);
+        Assert.Equal(captured.Properties["diagnostics.record_id"], local.Properties["diagnostics.record_id"]);
+        Assert.Equal(captured.Properties["diagnostics.sequence"], local.Properties["diagnostics.sequence"]);
+        Assert.Equal(captured.Timestamp, local.Timestamp);
+        Assert.Equal(captured.RenderMessage(), local.RenderMessage());
+        Assert.Equal(captured.Exception?.ToString(), local.Exception?.ToString());
+    }
+
+    private sealed class RecordingLogSink : ILogEventSink
+    {
+        public List<LogEvent> Events { get; } = [];
+        public void Emit(LogEvent logEvent) => Events.Add(logEvent);
+    }
+
+    private static TelemetrySettings CreateSettings() => new()
+    {
+        IsRemoteDiagnosticsEnabled = true,
+        HostUrl = "https://posthog.example",
+        ProjectToken = "test-project-token",
+        InstallId = "test-install"
+    };
+
+    private sealed class RecordingDiagnosticsService : IRemoteDiagnosticsService
+    {
+        public List<(RemoteDiagnosticsOptions Options, RemoteDiagnosticsContext Context)> Configurations { get; } = [];
+        public List<LogEvent> Events { get; } = [];
+        public void Configure(RemoteDiagnosticsOptions options, RemoteDiagnosticsContext context) => Configurations.Add((options, context));
+        public void Disable() { }
+        public void Emit(LogEvent logEvent) => Events.Add(logEvent);
+        public Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry.Deploy/DependencyInjection/ServiceCollectionExtensions.cs
@@ -68,7 +68,6 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(LoadTelemetrySettings);
         services.AddSingleton(CreateTelemetryOptions);
         services.AddSingleton(CreateTelemetryContext);
-        services.AddSingleton<IRemoteDiagnosticsService>(_ => new PostHogRemoteDiagnosticsSink());
         services.AddSingleton<ITelemetryService>(sp =>
         {
             TelemetryOptions options = sp.GetRequiredService<TelemetryOptions>();

--- a/src/Foundry.Deploy/Program.cs
+++ b/src/Foundry.Deploy/Program.cs
@@ -30,6 +30,7 @@ public static class Program
     [STAThread]
     public static int Main(string[] args)
     {
+        DiagnosticClock.Current.InitializeRuntime(Environment.GetEnvironmentVariable(DiagnosticClock.EnvironmentVariableName));
         string startupLogFilePath = "<unavailable>";
         IHost? host = null;
         ITelemetryService? telemetryService = null;

--- a/src/Foundry.Deploy/Program.cs
+++ b/src/Foundry.Deploy/Program.cs
@@ -52,10 +52,12 @@ public static class Program
                 startupLogFilePath = "<unavailable>";
                 Log.Logger = FoundryLogConfiguration.CreateDebugLogger(
                     "Foundry.Deploy", DiagnosticSessionContext.CurrentSessionId,
-                    Serilog.Events.LogEventLevel.Debug, additionalSink: RemoteDiagnosticsSink.Instance);
+                    Serilog.Events.LogEventLevel.Verbose, additionalSink: RemoteDiagnosticsSink.Instance);
                 Log.ForContext(typeof(Program)).Error(exception, "File logging initialization failed. Falling back to debugger output.");
             }
 
+            remoteDiagnosticsService = new PostHogRemoteDiagnosticsSink();
+            startup.InitializeRemoteDiagnostics(remoteDiagnosticsService);
             programLogger = Log.ForContext(typeof(Program));
             programLogger.Information(
                 "Foundry.Deploy bootstrap started. Version={Version}, SessionId={SessionId}, LogFilePath={LogFilePath}",
@@ -65,7 +67,7 @@ public static class Program
 
             ConfigureRuntimeCompatibility();
             stage = "configuration";
-            host = BuildHost(args, startup);
+            host = BuildHost(args, startup, remoteDiagnosticsService);
             DeployConfigurationLoadResult configuration = host.Services.GetRequiredService<IDeployConfigurationService>().LoadOptional();
             if (startup.ProtocolEnabled && configuration.Exists && configuration.Document is null)
             {
@@ -75,7 +77,6 @@ public static class Program
             startup.ReportConfigurationLoaded();
             stage = "services";
             telemetryService = host.Services.GetRequiredService<ITelemetryService>();
-            remoteDiagnosticsService = host.Services.GetRequiredService<IRemoteDiagnosticsService>();
             InitializeRemoteDiagnostics(host.Services, remoteDiagnosticsService);
 
             stage = "ui_startup";
@@ -99,9 +100,10 @@ public static class Program
         }
         finally
         {
-            ShutdownDiagnostics(telemetryService, remoteDiagnosticsService);
             try { host?.Dispose(); }
             catch (Exception exception) { programLogger.Warning(exception, "Application service disposal failed."); }
+            programLogger.Information("Foundry.Deploy application shutdown completed. Closing diagnostics.");
+            ShutdownDiagnostics(telemetryService, remoteDiagnosticsService);
             try { Task.Run(() => Log.CloseAndFlushAsync().AsTask()).WaitAsync(DiagnosticsShutdownTimeout).GetAwaiter().GetResult(); }
             catch { }
             try { FoundryDeployLogging.PersistCurrentLogs(); }
@@ -165,13 +167,15 @@ public static class Program
         };
     }
 
-    private static IHost BuildHost(string[] args, RuntimeStartupDiagnostics startup)
+    private static IHost BuildHost(string[] args, RuntimeStartupDiagnostics startup, IRemoteDiagnosticsService remoteDiagnosticsService)
     {
         HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
         builder.Logging.ClearProviders();
+        builder.Logging.SetMinimumLevel(LogLevel.Trace);
         builder.Logging.AddSerilog(dispose: false);
         builder.Services.AddSingleton(startup);
         builder.Services.AddFoundryDeployApplicationServices();
+        builder.Services.AddSingleton(remoteDiagnosticsService);
         return builder.Build();
     }
 
@@ -184,6 +188,8 @@ public static class Program
 
     private static void ShutdownDiagnostics(ITelemetryService? telemetry, IRemoteDiagnosticsService? diagnostics)
     {
+        Serilog.ILogger transportLogger = Log.ForContext(typeof(Program)).ForContext("PostHogTransportInternal", true);
+        transportLogger.Debug("Flushing remote diagnostics.");
         try
         {
             Task.Run(async () =>
@@ -197,8 +203,12 @@ public static class Program
                 if (diagnostics is not null)
                     await RemoteDiagnosticsLifecycle.ShutdownAsync(diagnostics, timeout.Token).ConfigureAwait(false);
             }).WaitAsync(DiagnosticsShutdownTimeout).GetAwaiter().GetResult();
+            transportLogger.Debug("Remote diagnostics shutdown completed.");
         }
-        catch { }
+        catch (Exception exception)
+        {
+            transportLogger.Warning(exception, "Remote diagnostics shutdown did not complete within the shutdown budget.");
+        }
     }
 
     private static void RegisterGlobalExceptionHandlers(RuntimeStartupDiagnostics startup)

--- a/src/Foundry.Deploy/Services/Deployment/DeploymentOrchestrator.cs
+++ b/src/Foundry.Deploy/Services/Deployment/DeploymentOrchestrator.cs
@@ -96,14 +96,13 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
             ["Workflow"] = "deployment"
         });
         _logger.LogInformation(
-            "Starting deployment orchestration. Mode={Mode}, IsDryRun={IsDryRun}, TargetDiskNumber={TargetDiskNumber}, HasTargetComputerName={HasTargetComputerName}, DriverPackSelectionKind={DriverPackSelectionKind}, ApplyFirmwareUpdates={ApplyFirmwareUpdates}, RemoteDiagnostic={RemoteDiagnostic}",
+            "Starting deployment orchestration. Mode={Mode}, IsDryRun={IsDryRun}, TargetDiskNumber={TargetDiskNumber}, HasTargetComputerName={HasTargetComputerName}, DriverPackSelectionKind={DriverPackSelectionKind}, ApplyFirmwareUpdates={ApplyFirmwareUpdates}",
             context.Mode,
             context.IsDryRun,
             context.TargetDiskNumber,
             !string.IsNullOrWhiteSpace(context.TargetComputerName),
             context.DriverPackSelectionKind,
-            context.ApplyFirmwareUpdates,
-            true);
+            context.ApplyFirmwareUpdates);
 
         if (!_operationProgressService.TryStart(OperationKind.Deploy, "Starting Foundry.Deploy orchestration.", 0))
         {
@@ -204,11 +203,10 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
                 await executionContext.TrySaveRuntimeStateAsync(cancellationToken).ConfigureAwait(false);
 
                 _logger.LogInformation(
-                    "Executing deployment step {StepIndex}/{StepCount}: {StepName}. RemoteDiagnostic={RemoteDiagnostic}",
+                    "Executing deployment step {StepIndex}/{StepCount}: {StepName}.",
                     i + 1,
                     _steps.Count,
-                    step.Name,
-                    true);
+                    step.Name);
 
                 executionContext.EmitCurrentStep(
                     DeploymentStepState.Running,
@@ -217,11 +215,10 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
                     stepSubProgressLabel: $"Starting {step.Name}...");
                 DeploymentStepResult result = await step.ExecuteAsync(executionContext, cancellationToken).ConfigureAwait(false);
                 _logger.LogInformation(
-                    "Deployment step finished. StepName={StepName}, StepState={StepState}, CurrentOperation={CurrentOperation}, RemoteDiagnostic={RemoteDiagnostic}",
+                    "Deployment step finished. StepName={StepName}, StepState={StepState}, CurrentOperation={CurrentOperation}",
                     step.Name,
                     result.State,
-                    runtimeState.CurrentOperation,
-                    true);
+                    runtimeState.CurrentOperation);
 
                 _operationProgressService.Report(CalculateOverallProgressPercent(i + 1), result.Message);
                 executionContext.EmitCurrentStep(
@@ -476,7 +473,7 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
             level,
             eventId: default,
             exception,
-            "Deployment operation finished. OperationId={OperationId}, Outcome={Outcome}, DurationMs={DurationMs}, CompletedStepCount={CompletedStepCount}, FailedStepName={FailedStepName}, FailedOperationName={FailedOperationName}, FailureKind={FailureKind}, FailureReason={FailureReason}, FailureCode={FailureCode}, Mode={Mode}, IsDryRun={IsDryRun}, Cancelled={Cancelled}, RemoteDiagnostic={RemoteDiagnostic}, RemoteDiagnosticTerminal={RemoteDiagnosticTerminal}",
+            "Deployment operation finished. OperationId={OperationId}, Outcome={Outcome}, DurationMs={DurationMs}, CompletedStepCount={CompletedStepCount}, FailedStepName={FailedStepName}, FailedOperationName={FailedOperationName}, FailureKind={FailureKind}, FailureReason={FailureReason}, FailureCode={FailureCode}, Mode={Mode}, IsDryRun={IsDryRun}, Cancelled={Cancelled}",
             operationId,
             outcome,
             Math.Round(duration.TotalMilliseconds, 0),
@@ -488,9 +485,7 @@ public sealed class DeploymentOrchestrator : IDeploymentOrchestrator
             failure?.Code,
             context.Mode,
             context.IsDryRun,
-            cancelled,
-            true,
-            true);
+            cancelled);
     }
 
     private static string ResolveFailedStepName(DeploymentRuntimeState runtimeState)

--- a/src/Foundry.Deploy/Services/Logging/FoundryDeployLogging.cs
+++ b/src/Foundry.Deploy/Services/Logging/FoundryDeployLogging.cs
@@ -37,11 +37,12 @@ internal static class FoundryDeployLogging
     public static ILogger CreateLogger(string logFilePath)
     {
         string normalizedLogFilePath = Path.GetFullPath(logFilePath);
+        RemoteDiagnosticsSink.SetLogDirectory(Path.Combine(Path.GetDirectoryName(normalizedLogFilePath)!, "PendingLogs"));
         ILogger logger = FoundryLogConfiguration.CreateFileLogger(
             logFilePath,
             "Foundry.Deploy",
             DiagnosticSessionContext.CurrentSessionId,
-            LogEventLevel.Debug,
+            LogEventLevel.Verbose,
             RetainedLogFileCount,
             additionalSink: RemoteDiagnosticsSink.Instance);
 

--- a/src/Foundry.Deploy/Services/Runtime/RuntimeStartupDiagnostics.cs
+++ b/src/Foundry.Deploy/Services/Runtime/RuntimeStartupDiagnostics.cs
@@ -19,21 +19,23 @@ namespace Foundry.Deploy.Services.Runtime;
 public sealed class RuntimeStartupDiagnostics
 {
     private readonly Action<string, string?, string?> _report;
-    private readonly Func<Exception, string, Guid?> _capture;
+    private readonly Func<Exception, LogEvent, string, Guid?> _capture;
     private readonly Func<ILogger> _logger;
+    private readonly TelemetrySettings? _earlySettings;
+    private readonly RemoteDiagnosticsContext? _earlyContext;
     private string? _emergencyPath;
     private int _failed;
     private int _ready;
 
     internal RuntimeStartupDiagnostics(Action<string, string?, string?> report,
-        Func<Exception, string, Guid?> capture, ILogger logger)
+        Func<Exception, LogEvent, string, Guid?> capture, ILogger logger)
     {
         _report = report;
         _capture = capture;
         _logger = () => logger;
     }
 
-    private RuntimeStartupDiagnostics(RuntimeStartupReporter? reporter, TelemetrySettings? settings)
+    internal RuntimeStartupDiagnostics(RuntimeStartupReporter? reporter, TelemetrySettings? settings)
     {
         ProtocolEnabled = reporter is not null;
         _report = (stage, category, id) => reporter?.Report(stage, category, id);
@@ -44,14 +46,13 @@ public sealed class RuntimeStartupDiagnostics
             RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant(), CultureInfo.CurrentUICulture.Name,
             reporter?.SessionId ?? DiagnosticSessionContext.CurrentSessionId,
             TelemetryApps.FoundryDeploy + "@" + FoundryDeployApplicationInfo.Version);
-        _capture = (exception, category) =>
+        _earlySettings = settings;
+        _earlyContext = context;
+        _capture = (exception, entry, category) =>
         {
             if (reporter is null || settings is null) return null;
             var options = new RemoteDiagnosticsOptions(settings.IsRemoteDiagnosticsEnabled,
                 settings.HostUrl, settings.ProjectToken, settings.InstallId);
-            var entry = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Fatal, exception,
-                new MessageTemplateParser().Parse("Application startup failed at {FailureReason}."),
-                [new LogEventProperty("FailureReason", new ScalarValue(category))]);
             return ChildStartupFailureExchange.TryCapture(Path.GetDirectoryName(reporter.StatusPath)!,
                 Guid.Parse(reporter.LaunchId), options, context, entry);
         };
@@ -68,6 +69,16 @@ public sealed class RuntimeStartupDiagnostics
         TelemetrySettings? settings = reporter is null ? null : RuntimeTelemetryConsent.ReadSettings(
             @"X:\Foundry\Config\foundry.bootstrap.config.json", childConfigurationPath, configurationRequired);
         return new RuntimeStartupDiagnostics(reporter, settings);
+    }
+
+    /// <summary>Starts the process service with verified managed-startup consent before full configuration loading.</summary>
+    internal void InitializeRemoteDiagnostics(IRemoteDiagnosticsService service)
+    {
+        if (_earlySettings is null || _earlyContext is null) return;
+        var context = new TelemetryContext(_earlyContext.App, _earlyContext.AppVersion,
+            _earlyContext.BuildConfiguration, _earlyContext.Runtime, _earlySettings.RuntimePayloadSource,
+            TelemetryBootMediaTargets.None, _earlyContext.RuntimeArchitecture, _earlyContext.Locale, _earlyContext.SessionId);
+        RemoteDiagnosticsLifecycle.Initialize(service, _earlySettings, context);
     }
 
     /// <summary>Publishes successful configuration loading before the UI is constructed.</summary>
@@ -96,16 +107,26 @@ public sealed class RuntimeStartupDiagnostics
         Guid? recordId = null;
         try
         {
-            if (Volatile.Read(ref _ready) == 0) recordId = _capture(exception, category);
+            var entry = LogEventNormalizer.Normalize(new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Fatal, exception,
+                new MessageTemplateParser().Parse("Application failed at {FailureReason}."),
+                [new LogEventProperty("FailureReason", new ScalarValue(category)),
+                 new LogEventProperty("SourceContext", new ScalarValue(typeof(RuntimeStartupDiagnostics).FullName))]));
+            try
+            {
+                if (Volatile.Read(ref _ready) == 0) recordId = _capture(exception, entry, category);
+            }
+            catch { }
+            try
+            {
+                _logger().ForContext("RemoteDiagnosticsInternal", recordId.HasValue).Write(entry);
+            }
+            catch { }
         }
         catch { }
-        try
+        finally
         {
-            _logger().ForContext("RemoteDiagnosticsInternal", recordId.HasValue)
-                .Fatal(exception, "Application failed at {FailureReason}.", category);
+            Report(StartupStage.StartupFailed, category, recordId?.ToString("N"));
         }
-        catch { }
-        Report(StartupStage.StartupFailed, category, recordId?.ToString("N"));
     }
 
     private void Report(string stage, string? category = null, string? recordId = null)

--- a/src/Foundry.Deploy/Services/Runtime/RuntimeStartupDiagnostics.cs
+++ b/src/Foundry.Deploy/Services/Runtime/RuntimeStartupDiagnostics.cs
@@ -107,10 +107,11 @@ public sealed class RuntimeStartupDiagnostics
         Guid? recordId = null;
         try
         {
-            var entry = LogEventNormalizer.Normalize(new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Fatal, exception,
+            var entry = FoundryLogConfiguration.PrepareEvent(new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Fatal, exception,
                 new MessageTemplateParser().Parse("Application failed at {FailureReason}."),
                 [new LogEventProperty("FailureReason", new ScalarValue(category)),
-                 new LogEventProperty("SourceContext", new ScalarValue(typeof(RuntimeStartupDiagnostics).FullName))]));
+                 new LogEventProperty("SourceContext", new ScalarValue(typeof(RuntimeStartupDiagnostics).FullName))]),
+                "Foundry.Deploy", DiagnosticSessionContext.CurrentSessionId);
             try
             {
                 if (Volatile.Read(ref _ready) == 0) recordId = _capture(exception, entry, category);

--- a/src/Foundry.Telemetry.Tests/BootstrapTelemetryPipelineTests.cs
+++ b/src/Foundry.Telemetry.Tests/BootstrapTelemetryPipelineTests.cs
@@ -36,16 +36,15 @@ public sealed class BootstrapTelemetryPipelineTests
     }
 
     [Fact]
-    public async Task Logs_KeepFilterRateLimitAndExceptionDedupe()
+    public async Task Logs_PreserveAllLevelsAndRepetitionsWhileExceptionsRemainDeduplicated()
     {
         var transport = new RecordingTransport();
         await using var pipeline = Create(transport);
-        pipeline.Emit(Event(LogEventLevel.Debug));
-        pipeline.Emit(Event(LogEventLevel.Information));
-        pipeline.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Information, "Milestone", null, ("RemoteDiagnostic", true)));
+        foreach (LogEventLevel level in Enum.GetValues<LogEventLevel>()) pipeline.Emit(Event(level));
+        pipeline.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Information, "Milestone"));
         var exception = new IOException("password=secret");
         for (int index = 0; index < 20; index++) pipeline.Emit(Event(LogEventLevel.Error, exception));
-        Assert.Equal(6, pipeline.PendingRecords.Count(record => record.Destination == BootstrapTelemetryDestination.Log));
+        Assert.Equal(27, pipeline.PendingRecords.Count(record => record.Destination == BootstrapTelemetryDestination.Log));
         Assert.Single(pipeline.PendingRecords, record => record.Destination == BootstrapTelemetryDestination.Exception);
         Assert.DoesNotContain(pipeline.PendingRecords, record => record.Destination == BootstrapTelemetryDestination.Analytics);
     }
@@ -53,7 +52,7 @@ public sealed class BootstrapTelemetryPipelineTests
     [Fact]
     public async Task Delivery_DrainsBeforePreparationRecordsAndContinuesAcceptingNewRecords()
     {
-        var transport = new RecordingTransport();
+        var transport = new RecordingTransport { Acknowledge = _ => true };
         await using var pipeline = Create(transport);
         pipeline.Emit(Event(LogEventLevel.Warning));
         Assert.Empty(transport.Records);
@@ -63,7 +62,7 @@ public sealed class BootstrapTelemetryPipelineTests
         await transport.WaitForCountAsync(2);
         Assert.Equal(0, transport.FlushCount);
         await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
-        Assert.Equal(1, transport.FlushCount);
+        Assert.Equal(0, transport.FlushCount);
     }
 
     [Fact]
@@ -76,7 +75,7 @@ public sealed class BootstrapTelemetryPipelineTests
     }
 
     [Fact]
-    public async Task Journal_RetainsIdentityTimestampAndCapsUnacknowledgedHandoffsAcrossBoots()
+    public async Task Logs_RetainIdentityAndTimestampAndContinueRetryingAfterThreeBoots()
     {
         using var folder = new TestFolder();
         Guid identity;
@@ -88,7 +87,7 @@ public sealed class BootstrapTelemetryPipelineTests
             identity = pipeline.PendingRecords[0].Id;
             timestamp = pipeline.PendingRecords[0].Timestamp;
             await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
-            Assert.Equal(BootstrapDeliveryState.HandedToTransport, pipeline.PendingRecords[0].State);
+            Assert.Equal(BootstrapDeliveryState.Pending, pipeline.PendingRecords[0].State);
         }
         for (int boot = 2; boot <= 4; boot++)
         {
@@ -96,11 +95,76 @@ public sealed class BootstrapTelemetryPipelineTests
             await using var pipeline = Create(transport, folder.Path);
             pipeline.StartDelivery(true);
             await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
-            Assert.Equal(boot <= 3 ? 1 : 0, transport.Records.Count);
+            Assert.Single(transport.Records);
             Assert.Equal(identity, pipeline.PendingRecords[0].Id);
             Assert.Equal(timestamp, pipeline.PendingRecords[0].Timestamp);
-            Assert.Equal(Math.Min(boot, 3), pipeline.PendingRecords[0].Attempts);
+            Assert.Equal(0, pipeline.PendingRecords[0].Attempts);
         }
+    }
+
+    [Fact]
+    public async Task Logs_PreserveLargeMessagesAndStructuredValuesAcrossRestart()
+    {
+        using var folder = new TestFolder();
+        string message = "Driver C:\\Drivers\\network.inf " + new string('x', 300_000);
+        Guid id;
+        DateTimeOffset timestamp;
+        await using (var pipeline = Create(new RecordingTransport(), folder.Path))
+        {
+            pipeline.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Debug, message, null,
+                ("TechnicalValue", "tenant-name"), ("password", "private-secret")));
+            BootstrapPendingRecord pending = Assert.Single(pipeline.PendingRecords);
+            id = pending.Id;
+            timestamp = pending.Timestamp;
+        }
+        var transport = new RecordingTransport { Acknowledge = _ => true };
+        await using var replay = Create(transport, folder.Path);
+        Assert.Empty(transport.Records);
+        await replay.ShutdownAsync(TestContext.Current.CancellationToken);
+        BootstrapPendingRecord sent = Assert.Single(transport.Records);
+        Assert.Equal(id, sent.Id);
+        Assert.Equal(timestamp, sent.Timestamp);
+        Assert.Equal(message, sent.Diagnostic!.Body);
+        Assert.Equal("tenant-name", sent.Diagnostic.Attributes["TechnicalValue"]);
+        Assert.DoesNotContain("private-secret", JsonSerializer.Serialize(sent), StringComparison.Ordinal);
+        Assert.Empty(replay.PendingRecords);
+    }
+
+    [Fact]
+    public async Task LegacyLogs_TransferToSharedQueueWithOriginalIdentityDespiteOldAttemptCap()
+    {
+        using var folder = new TestFolder();
+        Guid id = Guid.NewGuid();
+        RemoteDiagnosticRecord log = LogRecordFactory.Create(Event(LogEventLevel.Verbose),
+            TelemetryContextFactory.CreateRemoteDiagnosticsContext(Context));
+        var journal = new BootstrapTelemetryJournal(folder.Path);
+        journal.Add(new BootstrapPendingRecord(id,
+            BootstrapTelemetryJournal.Scope("https://example.test", "public", "install"),
+            BootstrapTelemetryDestination.Log, log.Timestamp, null, log, Attempts: 3));
+        var transport = new RecordingTransport { Acknowledge = _ => true };
+        await using (var pipeline = Create(transport, folder.Path))
+        {
+            Assert.Empty(File.ReadAllLines(folder.Path));
+            Assert.Equal(id, Assert.Single(pipeline.PendingRecords).Id);
+            await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(id, Assert.Single(transport.Records).Id);
+        }
+        await using var next = Create(new RecordingTransport(), folder.Path);
+        Assert.Empty(next.PendingRecords);
+    }
+
+    [Fact]
+    public async Task DisabledConsentOnRestart_PurgesPersistedLogsBeforeFutureOptIn()
+    {
+        using var folder = new TestFolder();
+        await using (var first = Create(new RecordingTransport(), folder.Path))
+            first.Emit(Event(LogEventLevel.Debug));
+        await using (var disabled = Create(new RecordingTransport(), folder.Path, diagnostics: false))
+            Assert.Empty(disabled.PendingRecords);
+        var transport = new RecordingTransport();
+        await using var enabled = Create(transport, folder.Path);
+        await enabled.ShutdownAsync(TestContext.Current.CancellationToken);
+        Assert.Empty(transport.Records);
     }
 
     [Fact]
@@ -141,7 +205,7 @@ public sealed class BootstrapTelemetryPipelineTests
         pipeline.StartDelivery(true);
         await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
         Assert.Equal(expected, transport.Records.Count);
-        Assert.Equal(expected, File.ReadAllLines(folder.Path).Length);
+        Assert.Equal(expected, pipeline.PendingRecords.Count);
     }
 
     [Fact]
@@ -202,7 +266,7 @@ public sealed class BootstrapTelemetryPipelineTests
     }
 
     [Fact]
-    public async Task Replay_IsLimitedToOneHundredRecordsPerBoot()
+    public async Task Logs_ReplayAllPendingRecordsAcrossMultipleAcknowledgedBatches()
     {
         using var folder = new TestFolder();
         await using (var first = Create(new RecordingTransport(), folder.Path))
@@ -210,12 +274,12 @@ public sealed class BootstrapTelemetryPipelineTests
             for (int index = 0; index < 110; index++)
                 first.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Warning, "Warning " + index));
         }
-        var transport = new RecordingTransport();
+        var transport = new RecordingTransport { Acknowledge = _ => true };
         await using var replay = Create(transport, folder.Path, time: new TestClock());
         replay.StartDelivery(clockUsable: false);
-        await transport.WaitForCountAsync(100, TimeSpan.FromSeconds(30));
+        await transport.WaitForCountAsync(110, TimeSpan.FromSeconds(30));
         await replay.ShutdownAsync(TestContext.Current.CancellationToken);
-        Assert.Equal(100, transport.Records.Count);
+        Assert.Equal(110, transport.Records.Count);
     }
 
     [Fact]
@@ -225,7 +289,7 @@ public sealed class BootstrapTelemetryPipelineTests
         var clock = new TestClock();
         await using (var first = Create(new RecordingTransport(), folder.Path, time: clock))
         {
-            first.Emit(Event(LogEventLevel.Warning));
+            first.Emit(Event(LogEventLevel.Error, new IOException("Failed")));
             first.CaptureTerminalFailure(Failure());
         }
         var transport = new RecordingTransport
@@ -234,7 +298,7 @@ public sealed class BootstrapTelemetryPipelineTests
         };
         await using var replay = Create(transport, folder.Path, time: clock);
         await replay.ShutdownAsync(TestContext.Current.CancellationToken);
-        Assert.Single(transport.Records);
+        Assert.Single(transport.Records, record => record.Destination != BootstrapTelemetryDestination.Log);
     }
 
     [Fact]
@@ -256,7 +320,7 @@ public sealed class BootstrapTelemetryPipelineTests
         await using (var first = Create(new RecordingTransport(), folder.Path))
         {
             first.CaptureTerminalFailure(Failure());
-            first.Emit(Event(LogEventLevel.Warning));
+            first.Emit(Event(LogEventLevel.Error, new IOException("Failed")));
         }
         string[] lines = File.ReadAllLines(folder.Path);
         var record = JsonSerializer.Deserialize<BootstrapPendingRecord>(lines[0])!;
@@ -269,7 +333,7 @@ public sealed class BootstrapTelemetryPipelineTests
         string content = File.ReadAllText(folder.Path);
         Assert.DoesNotContain("private-secret", content, StringComparison.Ordinal);
         Assert.DoesNotContain("not json", content, StringComparison.Ordinal);
-        Assert.Equal(2, transport.Records.Count);
+        Assert.Equal(2, transport.Records.Count(record => record.Destination != BootstrapTelemetryDestination.Log));
     }
 
     [Fact]
@@ -279,7 +343,7 @@ public sealed class BootstrapTelemetryPipelineTests
         await using (var first = Create(new RecordingTransport(), folder.Path))
         {
             first.CaptureTerminalFailure(Failure());
-            first.Emit(Event(LogEventLevel.Warning));
+            first.Emit(Event(LogEventLevel.Error, new IOException("Failed")));
         }
         string[] lines = File.ReadAllLines(folder.Path);
         string invalid = lines[1].Replace("\"Attributes\":{", "\"Attributes\":{\"duration.ms\":1e999,", StringComparison.Ordinal);
@@ -287,7 +351,8 @@ public sealed class BootstrapTelemetryPipelineTests
         var transport = new RecordingTransport();
         await using var replay = Create(transport, folder.Path);
         await replay.ShutdownAsync(TestContext.Current.CancellationToken);
-        Assert.Equal(BootstrapTelemetryDestination.Analytics, Assert.Single(transport.Records).Destination);
+        Assert.Equal(BootstrapTelemetryDestination.Analytics,
+            Assert.Single(transport.Records, record => record.Destination != BootstrapTelemetryDestination.Log).Destination);
     }
 
     [Fact]
@@ -343,7 +408,7 @@ public sealed class BootstrapTelemetryPipelineTests
         bool usage = true, bool diagnostics = true, string installation = "install", TimeProvider? time = null) =>
         new(new TelemetryOptions(usage, "https://example.test", "public", installation), Context,
             new RemoteDiagnosticsOptions(diagnostics, "https://example.test", "public", installation),
-            TelemetryContextFactory.CreateRemoteDiagnosticsContext(Context), path, () => transport, time ?? TimeProvider.System);
+            TelemetryContextFactory.CreateRemoteDiagnosticsContext(Context), path, () => transport, time ?? TimeProvider.System, transport);
 
     private static LogEvent Event(LogEventLevel level, Exception? exception = null) =>
         RemoteDiagnosticsTestData.LogEvent(level, "Bootstrap operation failed", exception);
@@ -358,7 +423,7 @@ public sealed class BootstrapTelemetryPipelineTests
         ["password"] = "private-secret"
     };
 
-    private sealed class RecordingTransport : IBootstrapTelemetryTransport
+    private sealed class RecordingTransport : IBootstrapTelemetryTransport, ILogBatchTransport
     {
         internal ConcurrentQueue<BootstrapPendingRecord> Records { get; } = new();
         internal Func<BootstrapPendingRecord, bool> Acknowledge { get; init; } = _ => false;
@@ -373,6 +438,18 @@ public sealed class BootstrapTelemetryPipelineTests
         }
         public Task FlushAsync(CancellationToken cancellationToken) { FlushCount++; return Task.CompletedTask; }
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public void Dispose() { }
+        public async Task<LogBatchResult> SendAsync(IReadOnlyList<RemoteDiagnosticRecord> records, CancellationToken cancellationToken)
+        {
+            bool accepted = true;
+            foreach (RemoteDiagnosticRecord record in records)
+            {
+                var pending = new BootstrapPendingRecord(Guid.Parse(record.Attributes["diagnostics.record_id"].ToString()!),
+                    string.Empty, BootstrapTelemetryDestination.Log, record.Timestamp, null, record);
+                accepted &= await DeliverAsync(pending, cancellationToken);
+            }
+            return new LogBatchResult(accepted ? LogBatchDisposition.Accepted : LogBatchDisposition.Retry);
+        }
         internal async Task WaitForCountAsync(int count, TimeSpan? waitTimeout = null)
         {
             using var timeout = new CancellationTokenSource(waitTimeout ?? TimeSpan.FromSeconds(3));

--- a/src/Foundry.Telemetry.Tests/ChildStartupFailureExchangeTests.cs
+++ b/src/Foundry.Telemetry.Tests/ChildStartupFailureExchangeTests.cs
@@ -35,15 +35,41 @@ public sealed class ChildStartupFailureExchangeTests
     }
 
     [Fact]
-    public void Capture_RequiresResolvedConsentAndBoundsTheFailureFile()
+    public void Capture_RequiresResolvedConsentAndPreservesFailureLargerThanLegacyLimit()
     {
         using var folder = new TestFolder();
         Assert.Null(ChildStartupFailureExchange.TryCapture(folder.Directory, folder.Launch, Options with { IsEnabled = false },
             ChildContext, Failure(new IOException("Failed"))));
         Assert.False(File.Exists(folder.Exchange));
         var largeFailure = new AggregateException(Enumerable.Range(0, 200).Select(_ => new IOException(new string('x', 2048))));
-        Assert.Null(Capture(folder, largeFailure));
-        Assert.False(File.Exists(folder.Exchange));
+        Assert.NotNull(Capture(folder, largeFailure));
+        Assert.True(new FileInfo(folder.Exchange).Length > 256 * 1024);
+        Assert.True(new FileInfo(folder.Exchange).Length <= ChildStartupFailureExchange.MaximumBytes);
+    }
+
+    [Fact]
+    public async Task Import_PreservesFullChildLogSeparatelyFromConservativeErrorTracking()
+    {
+        using var folder = new TestFolder();
+        string message = "Failed to load C:\\Drivers\\network.inf for {Tenant}";
+        LogEvent source = RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, message, CreateException(),
+            ("Tenant", "ExampleTenant"), ("password", "private-secret"), ("UnrestrictedDetail", new string('x', 5000)));
+        Guid? id = ChildStartupFailureExchange.TryCapture(folder.Directory, folder.Launch, Options, ChildContext, source);
+        Assert.NotNull(id);
+        ChildStartupFailureRecord stored = ChildStartupFailureExchange.Read(folder.Directory, folder.Launch, ChildContext.App)!;
+        Assert.NotNull(stored.Log);
+        Assert.Contains("C:\\Drivers\\network.inf", stored.Log.Body, StringComparison.Ordinal);
+        Assert.Contains("ExampleTenant", stored.Log.Body, StringComparison.Ordinal);
+        Assert.Equal(5000, stored.Log.Attributes["UnrestrictedDetail"].ToString()!.Length);
+        Assert.DoesNotContain("private-secret", JsonSerializer.Serialize(stored), StringComparison.Ordinal);
+        Assert.False(stored.Diagnostic.Attributes.ContainsKey("UnrestrictedDetail"));
+        var transport = new RecordingTransport { AcknowledgeLogs = true };
+        await using var pipeline = Create(transport, folder.Journal);
+        Assert.True(pipeline.ImportChildStartupFailure(folder.Directory, folder.Launch, ChildContext.App, true, id));
+        await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
+        BootstrapPendingRecord sent = Assert.Single(transport.Records, record => record.Destination == BootstrapTelemetryDestination.Log);
+        Assert.Equal(stored.LogRecordId, sent.Id);
+        Assert.Equal(stored.Log.Body, sent.Diagnostic!.Body);
     }
 
     [Theory]
@@ -85,7 +111,7 @@ public sealed class ChildStartupFailureExchangeTests
     }
 
     [Fact]
-    public async Task Reimport_PreservesPartialReceiptsAndThreeAttemptLimitAcrossBoots()
+    public async Task Reimport_PreservesExceptionAttemptLimitAndStableLogIdentityAcrossBoots()
     {
         using var folder = new TestFolder();
         Guid id = Capture(folder, CreateException())!.Value;
@@ -97,12 +123,13 @@ public sealed class ChildStartupFailureExchangeTests
             await using var pipeline = Create(transport, folder.Journal);
             Assert.True(pipeline.ImportChildStartupFailure(folder.Directory, folder.Launch, ChildContext.App, true));
             await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
-            Assert.Equal(boot == 1 ? 2 : boot <= 3 ? 1 : 0, transport.Records.Count);
+            Assert.Equal(boot <= 3 ? 2 : 1, transport.Records.Count);
             BootstrapPendingRecord exception = Assert.Single(pipeline.PendingRecords, record => record.Destination == BootstrapTelemetryDestination.Exception);
             Assert.Equal(id, exception.Id);
             Assert.Equal(Math.Min(boot, 3), exception.Attempts);
-            Assert.Equal(BootstrapDeliveryState.Acknowledged,
-                Assert.Single(pipeline.PendingRecords, record => record.Destination == BootstrapTelemetryDestination.Log).State);
+            Assert.DoesNotContain(pipeline.PendingRecords, record => record.Destination == BootstrapTelemetryDestination.Log);
+            Assert.Equal(JsonSerializer.Deserialize<ChildStartupFailureRecord>(exchange)!.LogRecordId,
+                Assert.Single(transport.Records, record => record.Destination == BootstrapTelemetryDestination.Log).Id);
         }
     }
 
@@ -179,8 +206,10 @@ public sealed class ChildStartupFailureExchangeTests
         Assert.Equal(2, transport.Records.Count);
     }
 
-    [Fact]
-    public async Task Recovery_ExpiresPriorBootRecordsOnlyWithUsableClock()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Recovery_ExpiresOldExceptionsButPreservesLogTimestamp(bool startBeforeImport)
     {
         using var folder = new TestFolder();
         var oldContext = ChildContext with { SessionId = "earlier-boot" };
@@ -190,11 +219,14 @@ public sealed class ChildStartupFailureExchangeTests
         Assert.NotNull(ChildStartupFailureExchange.TryCapture(folder.Directory, folder.Launch, Options, oldContext, failure));
         var transport = new RecordingTransport();
         await using var pipeline = Create(transport, folder.Journal);
+        if (startBeforeImport) pipeline.StartDelivery(true);
         Assert.True(pipeline.ImportChildStartupFailure(folder.Directory, folder.Launch, ChildContext.App, true));
-        Assert.Equal(2, pipeline.PendingRecords.Count);
+        Assert.Equal(startBeforeImport ? 1 : 2, pipeline.PendingRecords.Count);
         pipeline.StartDelivery(true);
         await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
-        Assert.Empty(transport.Records);
+        BootstrapPendingRecord replayed = Assert.Single(transport.Records);
+        Assert.Equal(BootstrapTelemetryDestination.Log, replayed.Destination);
+        Assert.Equal(failure.Timestamp, replayed.Timestamp);
     }
 
     [Fact]
@@ -222,11 +254,11 @@ public sealed class ChildStartupFailureExchangeTests
     }
 
     [Fact]
-    public async Task ImportedDestinations_ShareOneHundredRecordReplayLimit()
+    public async Task ImportedLogs_DoNotConsumeExceptionReplayBudget()
     {
         using var folder = new TestFolder();
-        var transport = new RecordingTransport();
-        await using var pipeline = Create(transport, time: new TestClock());
+        var transport = new RecordingTransport { AcknowledgeLogs = true };
+        await using var pipeline = Create(transport, folder.Journal, time: new TestClock());
         for (int index = 0; index < 60; index++)
         {
             Guid launch = Guid.NewGuid();
@@ -237,9 +269,9 @@ public sealed class ChildStartupFailureExchangeTests
         pipeline.StartDelivery(clockUsable: false);
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.CancelAfter(TimeSpan.FromSeconds(30));
-        while (transport.Records.Count < 100) await Task.Delay(10, cancellation.Token);
+        while (transport.Records.Count < 120) await Task.Delay(10, cancellation.Token);
         await pipeline.ShutdownAsync(TestContext.Current.CancellationToken);
-        Assert.Equal(100, transport.Records.Count);
+        Assert.Equal(120, transport.Records.Count);
     }
 
     private static Guid? Capture(TestFolder folder, Exception exception) => ChildStartupFailureExchange.TryCapture(
@@ -258,9 +290,9 @@ public sealed class ChildStartupFailureExchangeTests
         RemoteDiagnosticsOptions? options = null, TimeProvider? time = null) => new(
             new TelemetryOptions(false, Options.HostUrl, Options.ProjectToken, Options.InstallId), ParentContext,
             options ?? Options, TelemetryContextFactory.CreateRemoteDiagnosticsContext(ParentContext), path,
-            () => transport, time ?? TimeProvider.System);
+            () => transport, time ?? TimeProvider.System, transport);
 
-    private sealed class RecordingTransport : IBootstrapTelemetryTransport
+    private sealed class RecordingTransport : IBootstrapTelemetryTransport, ILogBatchTransport
     {
         internal ConcurrentQueue<BootstrapPendingRecord> Records { get; } = new();
         internal bool AcknowledgeLogs { get; init; }
@@ -272,6 +304,14 @@ public sealed class ChildStartupFailureExchangeTests
         }
         public Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public void Dispose() { }
+        public async Task<LogBatchResult> SendAsync(IReadOnlyList<RemoteDiagnosticRecord> records, CancellationToken cancellationToken)
+        {
+            foreach (RemoteDiagnosticRecord record in records)
+                await DeliverAsync(new BootstrapPendingRecord(Guid.Parse(record.Attributes["diagnostics.record_id"].ToString()!),
+                    string.Empty, BootstrapTelemetryDestination.Log, record.Timestamp, null, record), cancellationToken);
+            return new LogBatchResult(AcknowledgeLogs ? LogBatchDisposition.Accepted : LogBatchDisposition.Retry);
+        }
     }
 
     private sealed class TestClock : TimeProvider

--- a/src/Foundry.Telemetry.Tests/ChildStartupFailureExchangeTests.cs
+++ b/src/Foundry.Telemetry.Tests/ChildStartupFailureExchangeTests.cs
@@ -103,11 +103,10 @@ public sealed class ChildStartupFailureExchangeTests
         Assert.Equal(id, exception.Id);
         Assert.Equal(ChildContext.App, exception.Diagnostic!.Attributes["service.name"]);
         Assert.Equal(ChildContext.SessionId, exception.Diagnostic.Attributes["session.id"]);
-        RemoteDiagnosticsContext resource = BootstrapTelemetryTransport.GetResourceContext(exception.Diagnostic,
-            TelemetryContextFactory.CreateRemoteDiagnosticsContext(ParentContext));
-        Assert.Equal(ChildContext.App, resource.App);
-        Assert.Equal(ChildContext.AppVersion, resource.AppVersion);
-        Assert.Equal(ChildContext.Release, resource.Release);
+        Assert.Equal(ChildContext.AppVersion, exception.Diagnostic.Attributes["service.version"]);
+        Assert.Equal(ChildContext.Runtime, exception.Diagnostic.Attributes["runtime.name"]);
+        Assert.Equal(ChildContext.RuntimeArchitecture, exception.Diagnostic.Attributes["runtime.architecture"]);
+        Assert.Equal(ChildContext.Release, exception.Diagnostic.Attributes["service.release"]);
     }
 
     [Fact]

--- a/src/Foundry.Telemetry.Tests/DurableLogQueueTests.cs
+++ b/src/Foundry.Telemetry.Tests/DurableLogQueueTests.cs
@@ -1,0 +1,194 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Serilog.Events;
+
+namespace Foundry.Telemetry.Tests;
+
+public sealed class DurableLogQueueTests : IDisposable
+{
+    private readonly string directory = Path.Combine(Path.GetTempPath(), "foundry-log-tests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void Restart_RetainsOriginalRecordAndAcknowledgementRemovesIt()
+    {
+        RemoteDiagnosticRecord record = CreateRecord("original");
+        using (var queue = new DurableLogQueue(directory))
+        {
+            Assert.True(queue.Add(record));
+        }
+        using (var recovered = new DurableLogQueue(directory))
+        {
+            RemoteDiagnosticRecord replay = Assert.Single(recovered.Take(100));
+            Assert.Equal(record.Timestamp, replay.Timestamp);
+            Assert.Equal(record.Body, replay.Body);
+            Assert.Equal(record.Attributes["diagnostics.record_id"].ToString(), replay.Attributes["diagnostics.record_id"].ToString());
+            recovered.Remove([replay]);
+        }
+        using var empty = new DurableLogQueue(directory);
+        Assert.Empty(empty.Take(100));
+    }
+
+    [Fact]
+    public void ActiveProcessRecords_AreNotReplayedByAnotherProcess()
+    {
+        using var first = new DurableLogQueue(directory);
+        first.Add(CreateRecord("first"));
+        using var second = new DurableLogQueue(directory);
+        Assert.Empty(second.Take(100));
+        second.Add(CreateRecord("second"));
+        Assert.Equal("first", Assert.Single(first.Take(100)).Body);
+    }
+
+    [Fact]
+    public void Capacity_IsBoundedAndLossIsCounted()
+    {
+        using var queue = new DurableLogQueue(directory, maximumRecords: 2);
+        queue.Add(CreateRecord("one"));
+        queue.Add(CreateRecord("two"));
+        queue.Add(CreateRecord("three"));
+        Assert.Equal(["two", "three"], queue.Take(100).Select(record => record.Body));
+        Assert.Equal(1, queue.DroppedCount);
+    }
+
+    [Fact]
+    public void Revocation_RemovesPersistedPendingRecords()
+    {
+        using (var queue = new DurableLogQueue(directory))
+        {
+            queue.Add(CreateRecord("pending"));
+            queue.Clear();
+        }
+        using var recovered = new DurableLogQueue(directory);
+        Assert.Empty(recovered.Take(100));
+    }
+
+    [Fact]
+    public void Revocation_WhenARecordCannotBeDeleted_DoesNotReplayItLater()
+    {
+        using (var queue = new DurableLogQueue(directory))
+        {
+            queue.Add(CreateRecord("revoked"));
+            string path = Assert.Single(Directory.GetFiles(directory, "*.json", SearchOption.AllDirectories));
+            File.SetAttributes(path, FileAttributes.ReadOnly);
+            queue.Clear();
+            Assert.True(queue.StorageFailureCount > 0);
+            File.SetAttributes(path, FileAttributes.Normal);
+            queue.Add(CreateRecord("after opt-in"));
+        }
+        using var recovered = new DurableLogQueue(directory);
+        Assert.Equal("after opt-in", Assert.Single(recovered.Take(100)).Body);
+    }
+
+    [Fact]
+    public void FailedPersistentStorage_DoesNotAcknowledgeImportedEvidence()
+    {
+        using var memory = new DurableLogQueue(null);
+        Assert.False(memory.Add(CreateRecord("source must remain"), requireDurable: true));
+        Assert.Single(memory.Take(100));
+    }
+
+    [Theory]
+    [InlineData("acknowledge")]
+    [InlineData("trim")]
+    [InlineData("revoke")]
+    public void UndeletablePayload_StillConsumesDiskBudget(string removal)
+    {
+        RemoteDiagnosticRecord original = CreateRecord("original");
+        int budget = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(original).Length;
+        using var queue = new DurableLogQueue(directory, maximumRecords: 1, maximumBytes: budget);
+        Assert.True(queue.Add(original));
+        string path = Assert.Single(Directory.GetFiles(directory, "*.json", SearchOption.AllDirectories));
+        using (var locked = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            if (removal == "acknowledge") queue.Remove([original]);
+            else if (removal == "revoke") queue.Clear();
+            for (int index = 0; index < 3; index++)
+            {
+                Assert.False(queue.Add(CreateRecord("fallback"), requireDurable: true));
+                Assert.Single(queue.Take(100));
+                Assert.Equal(budget, PayloadBytes());
+            }
+            Assert.True(queue.StorageFailureCount > 0);
+        }
+        queue.Remove(queue.Take(100));
+        Assert.True(queue.Add(CreateRecord("restored"), requireDurable: true));
+        Assert.True(PayloadBytes() <= budget);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Recovery_ChargesUndeletableTemporaryFilesToDiskBudget(bool revoked)
+    {
+        string processDirectory = Path.Combine(directory, "abandoned");
+        Directory.CreateDirectory(processDirectory);
+        RemoteDiagnosticRecord record = CreateRecord("fallback");
+        int budget = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(record).Length;
+        string temporary = Path.Combine(processDirectory, "0000000000000000001-" + Guid.NewGuid().ToString("N") + ".json.tmp");
+        File.WriteAllText(temporary, new string('{', budget));
+        if (revoked) File.WriteAllText(Path.Combine(processDirectory, ".revoked"), "");
+        using (var locked = new FileStream(temporary, FileMode.Open, FileAccess.Read, FileShare.Read))
+        using (var queue = new DurableLogQueue(directory, maximumBytes: budget))
+        {
+            Assert.False(queue.Add(record, requireDurable: true));
+            Assert.Single(queue.Take(100));
+            Assert.Equal(budget, PayloadBytes());
+        }
+    }
+
+    private long PayloadBytes() => Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories)
+        .Where(path => path.EndsWith(".json", StringComparison.Ordinal) || path.EndsWith(".json.tmp", StringComparison.Ordinal))
+        .Sum(path => new FileInfo(path).Length);
+
+    [Fact]
+    public void Recovery_UndeletablePayloadStillConsumesRecordLimit()
+    {
+        using (var original = new DurableLogQueue(directory)) original.Add(CreateRecord("original"));
+        string path = Assert.Single(Directory.GetFiles(directory, "*.json", SearchOption.AllDirectories));
+        using var locked = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        using var recovered = new DurableLogQueue(directory, maximumRecords: 1);
+        Assert.Equal("original", Assert.Single(recovered.Take(100)).Body);
+        Assert.False(recovered.Add(CreateRecord("fallback"), requireDurable: true));
+        Assert.Equal("fallback", Assert.Single(recovered.Take(100)).Body);
+        Assert.Single(Directory.GetFiles(directory, "*.json", SearchOption.AllDirectories));
+    }
+
+    [Fact]
+    public void EmptyProcessDirectories_AreRemovedOnDisposal()
+    {
+        using (var queue = new DurableLogQueue(directory))
+        {
+            var record = CreateRecord("accepted");
+            queue.Add(record);
+            queue.Remove([record]);
+        }
+        Assert.Empty(Directory.EnumerateDirectories(directory));
+    }
+
+    [Fact]
+    public void InterruptedAtomicWrite_RecoversCompleteRecordAndDiscardsPartialRecord()
+    {
+        string processDirectory = Path.Combine(directory, "abandoned");
+        Directory.CreateDirectory(processDirectory);
+        RemoteDiagnosticRecord record = CreateRecord("complete");
+        string id = Guid.Parse(record.Attributes["diagnostics.record_id"].ToString()!).ToString("N");
+        File.WriteAllText(Path.Combine(processDirectory, "0000000000000000001-" + id + ".json.tmp"),
+            System.Text.Json.JsonSerializer.Serialize(record));
+        File.WriteAllText(Path.Combine(processDirectory, "0000000000000000002-" + Guid.NewGuid().ToString("N") + ".json.tmp"), "{");
+        using var recovered = new DurableLogQueue(directory);
+        Assert.Equal("complete", Assert.Single(recovered.Take(100)).Body);
+        Assert.Equal(1, recovered.DroppedCount);
+        Assert.Empty(Directory.EnumerateFiles(processDirectory, "*.tmp"));
+    }
+
+    private static RemoteDiagnosticRecord CreateRecord(string body) => new(
+        new DateTimeOffset(2026, 9, 11, 10, 0, 0, TimeSpan.Zero), LogEventLevel.Debug, body,
+        new Dictionary<string, object> { ["diagnostics.record_id"] = Guid.NewGuid().ToString(), ["service.name"] = "test" }, null);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(directory)) Directory.Delete(directory, true);
+    }
+}

--- a/src/Foundry.Telemetry.Tests/LogRecordFactoryTests.cs
+++ b/src/Foundry.Telemetry.Tests/LogRecordFactoryTests.cs
@@ -11,6 +11,24 @@ namespace Foundry.Telemetry.Tests;
 
 public sealed class LogRecordFactoryTests
 {
+    [Fact]
+    public void Create_PreservesDictionaryValuesWhenDifferentKeyTypesRenderIdentically()
+    {
+        var dictionary = new DictionaryValue([
+            new(new ScalarValue(1), new ScalarValue("numeric")),
+            new(new ScalarValue("1"), new ScalarValue("text")),
+            new(new ScalarValue("1 [2]"), new ScalarValue("existing suffix"))]);
+        var source = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Debug, null,
+            new MessageTemplateParser().Parse("Values {@Values}"), [new("Values", dictionary)]);
+
+        RemoteDiagnosticRecord record = LogRecordFactory.Create(source, RemoteDiagnosticsTestData.Context());
+
+        using JsonDocument result = JsonDocument.Parse(JsonSerializer.Serialize(record.Attributes["Values"]));
+        Assert.Equal(3, result.RootElement.EnumerateObject().Count());
+        Assert.Equal(["numeric", "text", "existing suffix"],
+            result.RootElement.EnumerateObject().Select(property => property.Value.GetString()).ToArray());
+    }
+
     [Theory]
     [InlineData("Type")]
     [InlineData("Message")]

--- a/src/Foundry.Telemetry.Tests/LogRecordFactoryTests.cs
+++ b/src/Foundry.Telemetry.Tests/LogRecordFactoryTests.cs
@@ -1,0 +1,165 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using Foundry.Utilities.Diagnostics;
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace Foundry.Telemetry.Tests;
+
+public sealed class LogRecordFactoryTests
+{
+    [Theory]
+    [InlineData("Type")]
+    [InlineData("Message")]
+    [InlineData("InnerExceptions")]
+    public void SanitizePersistedRecord_RejectsMalformedExceptionFieldsAsInvalidJson(string field)
+    {
+        var exception = new RemoteDiagnosticException("System.Exception", "failed", null, []);
+        exception = field switch
+        {
+            "Type" => exception with { Type = null! },
+            "Message" => exception with { Message = null! },
+            _ => exception with { InnerExceptions = null! }
+        };
+        var record = new RemoteDiagnosticRecord(DateTimeOffset.UtcNow, LogEventLevel.Error, "failed",
+            new Dictionary<string, object>(), exception);
+
+        Assert.Throws<JsonException>(() => LogRecordFactory.SanitizePersistedRecord(record));
+    }
+
+    [Fact]
+    public void SanitizePersistedRecord_MasksDictionaryKeysWithoutLosingCollidingValues()
+    {
+        var record = new RemoteDiagnosticRecord(DateTimeOffset.UtcNow, LogEventLevel.Debug, "results",
+            new Dictionary<string, object>
+            {
+                ["Results"] = new Dictionary<string, object>
+                {
+                    ["https://example.test?sig=first-secret"] = 42,
+                    ["https://example.test?sig=second-secret"] = 43
+                }
+            }, null);
+
+        RemoteDiagnosticRecord result = LogRecordFactory.SanitizePersistedRecord(record);
+
+        string json = JsonSerializer.Serialize(result);
+        Assert.DoesNotContain("first-secret", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("second-secret", json, StringComparison.Ordinal);
+        using JsonDocument nested = JsonDocument.Parse(JsonSerializer.Serialize(result.Attributes["Results"]));
+        Assert.Equal([42, 43], nested.RootElement.EnumerateObject().Select(property => property.Value.GetInt32()).ToArray());
+    }
+
+    [Fact]
+    public void SanitizePersistedRecord_MasksSecretsWithoutLosingJsonStructureOrOriginalIdentity()
+    {
+        var original = new RemoteDiagnosticRecord(DateTimeOffset.UtcNow, LogEventLevel.Debug,
+            "Reading C:\\boot.wim; password=body-secret", new Dictionary<string, object>
+            {
+                ["diagnostics.record_id"] = "record-42",
+                ["Nested"] = new Dictionary<string, object>
+                {
+                    ["TenantId"] = "tenant-42",
+                    ["AccessToken"] = "token-secret",
+                    ["Count"] = 42,
+                    ["Rows"] = new object?[] { null, "https://example.test?sig=signature-secret&version=42" }
+                }
+            }, new RemoteDiagnosticException("System.Exception", "password=exception-secret",
+                "at Reading C:\\boot.cs:42", []));
+        RemoteDiagnosticRecord loaded = JsonSerializer.Deserialize<RemoteDiagnosticRecord>(JsonSerializer.Serialize(original))!;
+
+        RemoteDiagnosticRecord sanitized = LogRecordFactory.SanitizePersistedRecord(loaded);
+
+        string json = JsonSerializer.Serialize(sanitized);
+        Assert.DoesNotContain("body-secret", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("token-secret", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("signature-secret", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("exception-secret", json, StringComparison.Ordinal);
+        Assert.Equal(original.Timestamp, sanitized.Timestamp);
+        Assert.Equal("record-42", sanitized.Attributes["diagnostics.record_id"]);
+        Assert.Contains("tenant-42", json, StringComparison.Ordinal);
+        Assert.Equal("at Reading C:\\boot.cs:42", sanitized.Exception!.StackTrace);
+        using JsonDocument nested = JsonDocument.Parse(JsonSerializer.Serialize(sanitized.Attributes["Nested"]));
+        Assert.Equal(42, nested.RootElement.GetProperty("Count").GetInt32());
+        Assert.Equal(JsonValueKind.Null, nested.RootElement.GetProperty("Rows")[0].ValueKind);
+    }
+
+    [Fact]
+    public void Create_PreservesFullMessageNestedPropertiesAndOriginalTime()
+    {
+        string detail = new('x', 9000);
+        var time = new DateTimeOffset(2026, 9, 10, 12, 34, 56, TimeSpan.FromHours(2));
+        var source = new LogEvent(time, LogEventLevel.Verbose, null,
+            new MessageTemplateParser().Parse("Reading {Path}: {Detail}"),
+            [new("Path", new ScalarValue(@"C:\Users\alice\boot.wim")), new("Detail", new ScalarValue(detail)),
+             new("Nested", new StructureValue([new("TenantId", new ScalarValue("tenant-42")),
+                 new("Rows", new SequenceValue([new ScalarValue(42), new ScalarValue(null)])),
+                 new("AccessToken", new ScalarValue("never-export"))]))]);
+
+        RemoteDiagnosticRecord record = LogRecordFactory.Create(source, Context);
+
+        Assert.Equal(time, record.Timestamp);
+        Assert.Equal(LogEventLevel.Verbose, record.Level);
+        Assert.Contains(detail, record.Body, StringComparison.Ordinal);
+        Assert.Contains("alice", record.Body, StringComparison.Ordinal);
+        Assert.StartsWith(@"Reading C:\Users\alice\boot.wim: ", record.Body, StringComparison.Ordinal);
+        Assert.Equal(@"C:\Users\alice\boot.wim", record.Attributes["Path"]);
+        Assert.Equal("foundry_deploy", record.Attributes["service.name"]);
+        using JsonDocument nested = JsonDocument.Parse(JsonSerializer.Serialize(record.Attributes["Nested"]));
+        Assert.Equal("tenant-42", nested.RootElement.GetProperty("TenantId").GetString());
+        Assert.Equal(42, nested.RootElement.GetProperty("Rows")[0].GetInt32());
+        Assert.Equal(JsonValueKind.Null, nested.RootElement.GetProperty("Rows")[1].ValueKind);
+        Assert.Equal("<redacted>", nested.RootElement.GetProperty("AccessToken").GetString());
+        Assert.Equal("Reading {Path}: {Detail}", record.Attributes["message_template.text"]);
+        Assert.False(record.ShouldTrackException);
+    }
+
+    [Fact]
+    public void Create_PreservesSafeExceptionStackTypeAndIdentityAcrossRepeatedNormalization()
+    {
+        Exception exception;
+        try
+        {
+            throw new InvalidOperationException("Reading C:\\boot.wim failed; password=exception-secret");
+        }
+        catch (InvalidOperationException caught)
+        {
+            exception = caught;
+        }
+        LogEvent source = LogEventNormalizer.Normalize(new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Error,
+            exception, new MessageTemplateParser().Parse("Read failed"), []));
+
+        RemoteDiagnosticRecord first = LogRecordFactory.Create(source, Context);
+        RemoteDiagnosticRecord second = LogRecordFactory.Create(source, Context);
+
+        Assert.Equal(first.Attributes["diagnostics.record_id"], second.Attributes["diagnostics.record_id"]);
+        Assert.Equal(first.Attributes["diagnostics.sequence"], second.Attributes["diagnostics.sequence"]);
+        Assert.NotNull(first.Exception);
+        Assert.Equal("System.InvalidOperationException", first.Exception.Type);
+        Assert.Contains("C:\\boot.wim", first.Exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("exception-secret", first.Exception.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(Create_PreservesSafeExceptionStackTypeAndIdentityAcrossRepeatedNormalization), first.Exception.StackTrace, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StrictExceptionPolicy_PreservesOriginalTypesAndAggregateChildrenAfterNormalization()
+    {
+        var exception = new AggregateException("password=root-secret",
+            new InvalidOperationException("password=first-secret"), new TimeoutException("password=second-secret"));
+        LogEvent source = LogEventNormalizer.Normalize(new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Error,
+            exception, new MessageTemplateParser().Parse("Read failed"), []));
+
+        RemoteDiagnosticRecord record = RemoteDiagnosticPropertyPolicy.CreateSanitizedRecord(source, Context);
+
+        Assert.NotNull(record.Exception);
+        Assert.Equal("System.AggregateException", record.Exception.Type);
+        Assert.Equal(2, record.Exception.InnerExceptions.Count);
+        Assert.Equal("System.InvalidOperationException", record.Exception.InnerExceptions[0].Type);
+        Assert.Equal("System.TimeoutException", record.Exception.InnerExceptions[1].Type);
+        Assert.DoesNotContain("secret", JsonSerializer.Serialize(record), StringComparison.Ordinal);
+    }
+
+    private static readonly RemoteDiagnosticsContext Context = new("foundry_deploy", "1.2.3", "release", "winpe", "x64", "en-US", "session-1", "foundry_deploy@1.2.3");
+}

--- a/src/Foundry.Telemetry.Tests/OtlpLogTransportTests.cs
+++ b/src/Foundry.Telemetry.Tests/OtlpLogTransportTests.cs
@@ -1,0 +1,306 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Google.Protobuf;
+using Serilog.Events;
+
+namespace Foundry.Telemetry.Tests;
+
+public sealed class OtlpLogTransportTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SendAsync_PreservesAllSeveritiesOriginalTimeStructuredValuesAndLiteralBody(bool replayFromJson)
+    {
+        using var handler = new RecordingHandler(HttpStatusCode.OK);
+        using var transport = CreateTransport(handler);
+        RemoteDiagnosticRecord[] records = Enum.GetValues<LogEventLevel>()
+            .Select(level => CreateRecord(level)).ToArray();
+        if (replayFromJson)
+        {
+            records = JsonSerializer.Deserialize<RemoteDiagnosticRecord[]>(JsonSerializer.Serialize(records))!;
+        }
+
+        LogBatchResult result = await transport.SendAsync(records, CancellationToken.None);
+
+        Assert.Equal(LogBatchDisposition.Accepted, result.Disposition);
+        Assert.Equal(new Uri("https://eu.i.posthog.com/i/v1/logs"), handler.RequestUri);
+        Assert.Equal("Bearer phc_test", handler.Authorization);
+        Assert.Equal("application/x-protobuf", handler.ContentType);
+        List<byte[]> resourceLogs = ReadMessages(handler.Body, 1);
+        Assert.Equal(6, resourceLogs.Count);
+        List<byte[]> logs = resourceLogs.SelectMany(resource => ReadMessages(resource, 2))
+            .SelectMany(scope => ReadMessages(scope, 2)).ToList();
+        Assert.Equal(new ulong[] { 1, 5, 9, 13, 17, 21 }, logs.Select(log => ReadNumber(log, 2)));
+        foreach (byte[] log in logs)
+        {
+            Assert.Equal(1_700_000_000_123_456_700UL, ReadNumber(log, 1));
+            Assert.Equal("Driver {original} C:\\Drivers\\net.inf", ReadString(Assert.Single(ReadMessages(log, 5)), 1));
+            Dictionary<string, byte[]> attributes = ReadAttributes(log, 6);
+            Assert.Equal("Session with full context", ReadString(attributes["session.id"], 1));
+            Assert.Equal("System.InvalidOperationException", ReadString(attributes["exception.type"], 1));
+            Assert.Equal("at Install() in C:\\Source\\Install.cs:line 42", ReadString(attributes["exception.stacktrace"], 1));
+            byte[] nestedMap = Assert.Single(ReadMessages(attributes["details"], 6));
+            Dictionary<string, byte[]> nested = ReadAttributes(nestedMap, 1);
+            Assert.Equal(12UL, ReadNumber(nested["count"], 3));
+            Assert.Equal("net.inf", ReadString(nested["file"], 1));
+            Assert.Equal("empty key", ReadString(nested[""], 1));
+            byte[] array = Assert.Single(ReadMessages(attributes["codes"], 5));
+            Assert.Equal(new ulong[] { 3, 7 }, ReadMessages(array, 1).Select(value => ReadNumber(value, 3)));
+        }
+        Dictionary<string, byte[]> resourceAttributes = ReadAttributes(Assert.Single(ReadMessages(resourceLogs[0], 1)), 1);
+        Assert.Equal("foundry.bootstrap", ReadString(resourceAttributes["service.name"], 1));
+        Assert.Equal("old-version", ReadString(resourceAttributes["service.version"], 1));
+    }
+
+    [Theory]
+    [InlineData(429, (int)LogBatchDisposition.Retry)]
+    [InlineData(500, (int)LogBatchDisposition.Retry)]
+    [InlineData(503, (int)LogBatchDisposition.Retry)]
+    [InlineData(408, (int)LogBatchDisposition.Retry)]
+    [InlineData(400, (int)LogBatchDisposition.Rejected)]
+    [InlineData(401, (int)LogBatchDisposition.Rejected)]
+    [InlineData(403, (int)LogBatchDisposition.Rejected)]
+    [InlineData(302, (int)LogBatchDisposition.Rejected)]
+    public async Task SendAsync_ClassifiesHttpFailuresAndHonorsRetryAfter(int status, int expectedValue)
+    {
+        using var handler = new RecordingHandler((HttpStatusCode)status, retryAfter: TimeSpan.FromSeconds(19));
+        using var transport = CreateTransport(handler);
+
+        LogBatchResult result = await transport.SendAsync([CreateRecord()], CancellationToken.None);
+
+        var expected = (LogBatchDisposition)expectedValue;
+        Assert.Equal(expected, result.Disposition);
+        if (expected == LogBatchDisposition.Retry)
+        {
+            Assert.Equal(TimeSpan.FromSeconds(19), result.RetryAfter);
+        }
+        else
+        {
+            Assert.Equal(1, result.RejectedRecordCount);
+        }
+    }
+
+    [Fact]
+    public async Task SendAsync_PartialSuccessIsTerminalAndReportsOnlyRejectedCount()
+    {
+        // ExportLogsServiceResponse.partial_success.rejected_log_records = 1.
+        using var handler = new RecordingHandler(HttpStatusCode.OK, [0x0a, 0x02, 0x08, 0x01]);
+        using var transport = CreateTransport(handler);
+
+        LogBatchResult result = await transport.SendAsync([CreateRecord(), CreateRecord()], CancellationToken.None);
+
+        Assert.Equal(LogBatchDisposition.Rejected, result.Disposition);
+        Assert.Equal(1, result.RejectedRecordCount);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task SendAsync_PartialSuccessWarningWithoutRejectionIsAccepted()
+    {
+        using var handler = new RecordingHandler(HttpStatusCode.OK, [0x0a, 0x03, 0x12, 0x01, 0x78]);
+        using var transport = CreateTransport(handler);
+
+        LogBatchResult result = await transport.SendAsync([CreateRecord()], CancellationToken.None);
+
+        Assert.Equal(LogBatchDisposition.Accepted, result.Disposition);
+    }
+
+    [Theory]
+    [InlineData(" { }\n", 0)]
+    [InlineData("{\"partialSuccess\":{\"rejectedLogRecords\":\"1\",\"errorMessage\":\"invalid row\"}}", 1)]
+    [InlineData("{\"partial_success\":{\"rejected_log_records\":1}}", 1)]
+    [InlineData("{\"partialSuccess\":{\"errorMessage\":\"warning only\"}}", 0)]
+    public async Task SendAsync_HandlesPostHogJsonAcknowledgments(string response, int rejected)
+    {
+        using var handler = new RecordingHandler(HttpStatusCode.OK, Encoding.UTF8.GetBytes(response), responseContentType: "application/json");
+        using var transport = CreateTransport(handler);
+
+        LogBatchResult result = await transport.SendAsync([CreateRecord(), CreateRecord()], CancellationToken.None);
+
+        Assert.Equal(rejected == 0 ? LogBatchDisposition.Accepted : LogBatchDisposition.Rejected, result.Disposition);
+        Assert.Equal(rejected, result.RejectedRecordCount);
+    }
+
+    [Fact]
+    public async Task SendAsync_OversizedBatchRequestsSplitWithoutAcknowledgingRecords()
+    {
+        using var handler = new RecordingHandler(HttpStatusCode.RequestEntityTooLarge);
+        using var transport = CreateTransport(handler);
+
+        LogBatchResult result = await transport.SendAsync([CreateRecord(), CreateRecord()], CancellationToken.None);
+
+        Assert.Equal(LogBatchDisposition.Split, result.Disposition);
+        Assert.Equal(0, result.RejectedRecordCount);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task SendAsync_OversizedSingleRecordIsExplicitlyRejected()
+    {
+        using var handler = new RecordingHandler(HttpStatusCode.RequestEntityTooLarge);
+        using var transport = CreateTransport(handler);
+
+        LogBatchResult result = await transport.SendAsync([CreateRecord()], CancellationToken.None);
+
+        Assert.Equal(LogBatchDisposition.Rejected, result.Disposition);
+        Assert.Equal(1, result.RejectedRecordCount);
+    }
+
+    [Fact]
+    public async Task SendAsync_MalformedSuccessResponseIsNotAcknowledged()
+    {
+        using var handler = new RecordingHandler(HttpStatusCode.OK, [0x0a, 0xff]);
+        using var transport = CreateTransport(handler);
+
+        LogBatchResult result = await transport.SendAsync([CreateRecord()], CancellationToken.None);
+
+        Assert.Equal(LogBatchDisposition.Retry, result.Disposition);
+    }
+
+    [Fact]
+    public async Task SendAsync_NetworkFailureRetainsBatchForRetry()
+    {
+        using var handler = new RecordingHandler(HttpStatusCode.OK, failure: new HttpRequestException("offline"));
+        using var transport = CreateTransport(handler);
+
+        LogBatchResult result = await transport.SendAsync([CreateRecord()], CancellationToken.None);
+
+        Assert.Equal(LogBatchDisposition.Retry, result.Disposition);
+    }
+
+    [Fact]
+    public async Task SendAsync_CancellationIsPropagatedWithoutAcknowledgment()
+    {
+        using var handler = new RecordingHandler(HttpStatusCode.OK);
+        using var transport = CreateTransport(handler);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => transport.SendAsync([CreateRecord()], cancellation.Token));
+
+        Assert.Equal(0, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task SendAsync_DoesNotTruncateLongBodyOrExceptionStack()
+    {
+        using var handler = new RecordingHandler(HttpStatusCode.OK);
+        using var transport = CreateTransport(handler);
+        string body = new('b', 30_000);
+        string stack = new('s', 40_000);
+        RemoteDiagnosticRecord record = CreateRecord() with
+        {
+            Body = body,
+            Exception = new RemoteDiagnosticException("Exception", "details", stack, [])
+        };
+
+        await transport.SendAsync([record], CancellationToken.None);
+
+        byte[] resource = Assert.Single(ReadMessages(handler.Body, 1));
+        byte[] scope = Assert.Single(ReadMessages(resource, 2));
+        byte[] log = Assert.Single(ReadMessages(scope, 2));
+        Assert.Equal(body, ReadString(Assert.Single(ReadMessages(log, 5)), 1));
+        Assert.Equal(stack, ReadString(ReadAttributes(log, 6)["exception.stacktrace"], 1));
+    }
+
+    private static OtlpLogTransport CreateTransport(HttpMessageHandler handler) => new(
+        RemoteDiagnosticsTestData.EnabledOptions(), RemoteDiagnosticsTestData.Context(), handler);
+
+    private static RemoteDiagnosticRecord CreateRecord(LogEventLevel level = LogEventLevel.Information) => new(
+        DateTimeOffset.UnixEpoch.AddTicks(17_000_000_001_234_567), level,
+        "Driver {original} C:\\Drivers\\net.inf",
+        new Dictionary<string, object>
+        {
+            ["service.name"] = "foundry.bootstrap",
+            ["service.version"] = "old-version",
+            ["session.id"] = "Session with full context",
+            ["details"] = new Dictionary<string, object> { ["count"] = 12, ["file"] = "net.inf", [""] = "empty key" },
+            ["codes"] = new[] { 3, 7 }
+        },
+        new RemoteDiagnosticException("System.InvalidOperationException", "failure",
+            "at Install() in C:\\Source\\Install.cs:line 42", []));
+
+    private static Dictionary<string, byte[]> ReadAttributes(byte[] data, int field) =>
+        ReadMessages(data, field).ToDictionary(attribute => ReadString(attribute, 1), attribute => Assert.Single(ReadMessages(attribute, 2)));
+
+    private static string ReadString(byte[] data, int field)
+    {
+        List<byte[]> values = ReadMessages(data, field);
+        return values.Count == 0 ? string.Empty : Encoding.UTF8.GetString(Assert.Single(values));
+    }
+
+    private static List<byte[]> ReadMessages(byte[] data, int field)
+    {
+        var result = new List<byte[]>();
+        using var input = new CodedInputStream(data);
+        uint tag;
+        while ((tag = input.ReadTag()) != 0)
+        {
+            if (tag == (uint)((field << 3) | 2))
+            {
+                result.Add(input.ReadBytes().ToByteArray());
+            }
+            else
+            {
+                input.SkipLastField();
+            }
+        }
+        return result;
+    }
+
+    private static ulong ReadNumber(byte[] data, int field)
+    {
+        using var input = new CodedInputStream(data);
+        uint tag;
+        while ((tag = input.ReadTag()) != 0)
+        {
+            if (tag == (uint)(field << 3))
+            {
+                return input.ReadUInt64();
+            }
+            if (tag == (uint)((field << 3) | 1))
+            {
+                return input.ReadFixed64();
+            }
+            input.SkipLastField();
+        }
+        throw new InvalidDataException($"Missing numeric field {field}.");
+    }
+
+    private sealed class RecordingHandler(HttpStatusCode status, byte[]? response = null, TimeSpan? retryAfter = null,
+        Exception? failure = null, string responseContentType = "application/x-protobuf") : HttpMessageHandler
+    {
+        public Uri? RequestUri { get; private set; }
+        public string? Authorization { get; private set; }
+        public string? ContentType { get; private set; }
+        public byte[] Body { get; private set; } = [];
+        public int RequestCount { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            RequestUri = request.RequestUri;
+            Authorization = request.Headers.Authorization?.ToString();
+            ContentType = request.Content?.Headers.ContentType?.MediaType;
+            Body = await request.Content!.ReadAsByteArrayAsync(cancellationToken);
+            if (failure is not null)
+            {
+                throw failure;
+            }
+            var message = new HttpResponseMessage(status) { Content = new ByteArrayContent(response ?? []) };
+            message.Content.Headers.ContentType = new MediaTypeHeaderValue(responseContentType);
+            if (retryAfter is not null)
+            {
+                message.Headers.RetryAfter = new RetryConditionHeaderValue(retryAfter.Value);
+            }
+            return message;
+        }
+    }
+}

--- a/src/Foundry.Telemetry.Tests/OtlpLogTransportTests.cs
+++ b/src/Foundry.Telemetry.Tests/OtlpLogTransportTests.cs
@@ -14,6 +14,34 @@ namespace Foundry.Telemetry.Tests;
 public sealed class OtlpLogTransportTests
 {
     [Theory]
+    [InlineData(-10, false)]
+    [InlineData(10, false)]
+    [InlineData(-10, true)]
+    [InlineData(10, true)]
+    public async Task SendAsync_UsesIngestionTimeForUnsynchronizedEventsIncludingReplay(int skewHours, bool replay)
+    {
+        using var handler = new RecordingHandler(HttpStatusCode.OK);
+        using var transport = CreateTransport(handler);
+        RemoteDiagnosticRecord record = CreateRecord() with
+        {
+            Timestamp = DateTimeOffset.UtcNow.AddHours(skewHours),
+            Attributes = new Dictionary<string, object> { ["diagnostics.clock_synchronized"] = false }
+        };
+        if (replay) record = JsonSerializer.Deserialize<RemoteDiagnosticRecord>(JsonSerializer.Serialize(record))!;
+
+        await transport.SendAsync([record], CancellationToken.None);
+
+        byte[] resource = Assert.Single(ReadMessages(handler.Body, 1));
+        byte[] scope = Assert.Single(ReadMessages(resource, 2));
+        byte[] log = Assert.Single(ReadMessages(scope, 2));
+        Assert.Equal(0UL, ReadNumber(log, 1, defaultValue: 0));
+        Dictionary<string, byte[]> attributes = ReadAttributes(log, 6);
+        Assert.Equal(record.Timestamp.ToString("O", System.Globalization.CultureInfo.InvariantCulture),
+            ReadString(attributes["diagnostics.original_timestamp"], 1));
+        Assert.Equal("ingestion", ReadString(attributes["diagnostics.timestamp_source"], 1));
+    }
+
+    [Theory]
     [InlineData(false)]
     [InlineData(true)]
     public async Task SendAsync_PreservesAllSeveritiesOriginalTimeStructuredValuesAndLiteralBody(bool replayFromJson)
@@ -255,7 +283,7 @@ public sealed class OtlpLogTransportTests
         return result;
     }
 
-    private static ulong ReadNumber(byte[] data, int field)
+    private static ulong ReadNumber(byte[] data, int field, ulong? defaultValue = null)
     {
         using var input = new CodedInputStream(data);
         uint tag;
@@ -271,7 +299,7 @@ public sealed class OtlpLogTransportTests
             }
             input.SkipLastField();
         }
-        throw new InvalidDataException($"Missing numeric field {field}.");
+        return defaultValue ?? throw new InvalidDataException($"Missing numeric field {field}.");
     }
 
     private sealed class RecordingHandler(HttpStatusCode status, byte[]? response = null, TimeSpan? retryAfter = null,

--- a/src/Foundry.Telemetry.Tests/PostHogRemoteDiagnosticsSinkTests.cs
+++ b/src/Foundry.Telemetry.Tests/PostHogRemoteDiagnosticsSinkTests.cs
@@ -10,25 +10,72 @@ namespace Foundry.Telemetry.Tests;
 public sealed class PostHogRemoteDiagnosticsSinkTests
 {
     [Fact]
-    public async Task Emit_FiltersLevelsAndAllowsExplicitInformationBoundaries()
+    public async Task Configure_NewDestinationRetiresOldExporterAndUsesNewRecordContext()
     {
-        var exporter = new RecordingExporter();
-        await using var service = CreateService(exporter);
-        service.Configure(RemoteDiagnosticsTestData.EnabledOptions(), RemoteDiagnosticsTestData.Context());
+        var original = new RecordingExporter();
+        var replacement = new RecordingExporter();
+        var configured = new List<RemoteDiagnosticsOptions>();
+        await using var service = new PostHogRemoteDiagnosticsSink((options, _) =>
+        {
+            configured.Add(options);
+            return configured.Count == 1 ? original : replacement;
+        });
+        RemoteDiagnosticsOptions firstOptions = RemoteDiagnosticsTestData.EnabledOptions();
+        service.Configure(firstOptions, RemoteDiagnosticsTestData.Context());
+        service.Configure(firstOptions with { ProjectToken = "phc_replacement" },
+            RemoteDiagnosticsTestData.Context() with { SessionId = "session-2" });
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "new destination", new InvalidOperationException("failed")));
+        await service.FlushAsync(TestContext.Current.CancellationToken);
+        await service.DisposeAsync();
 
-        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Debug, "debug"));
-        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Information, "ordinary info"));
-        service.Emit(RemoteDiagnosticsTestData.LogEvent(
-            LogEventLevel.Information,
-            "workflow boundary",
-            properties: ("RemoteDiagnostic", true)));
-        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Warning, "warning"));
-        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "error"));
+        Assert.Equal(2, configured.Count);
+        Assert.True(original.IsDisposed);
+        Assert.Empty(original.Records);
+        Assert.Equal("session-2", Assert.Single(replacement.Records).Attributes["session.id"]);
+        Assert.Equal("phc_replacement", configured[1].ProjectToken);
+    }
+
+    [Fact]
+    public async Task Configure_ContextChangePreservesPendingRecordsAndExistingDestination()
+    {
+        var exporter = new BlockingExporter();
+        int factoryCalls = 0;
+        await using var service = new PostHogRemoteDiagnosticsSink((_, _) => { factoryCalls++; return exporter; });
+        RemoteDiagnosticsOptions options = RemoteDiagnosticsTestData.EnabledOptions();
+        service.Configure(options, RemoteDiagnosticsTestData.Context());
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "first", new InvalidOperationException("failed")));
+        Assert.True(exporter.Started.Wait(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken));
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "pending", new InvalidOperationException("failed")));
+        service.Configure(options, RemoteDiagnosticsTestData.Context() with { SessionId = "session-2" });
+        exporter.Release.Set();
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "updated", new InvalidOperationException("failed")));
         await service.FlushAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(
-            [LogEventLevel.Information, LogEventLevel.Warning, LogEventLevel.Error],
-            exporter.Records.Select(static record => record.Level).ToArray());
+        Assert.Equal(1, factoryCalls);
+        Assert.Equal(["first", "pending", "updated"], exporter.Records.Select(record => record.Body).ToArray());
+        Assert.Equal("session-1", exporter.Records[1].Attributes["session.id"]);
+        Assert.Equal("session-2", exporter.Records[2].Attributes["session.id"]);
+    }
+
+    [Fact]
+    public async Task Emit_CapturesAllSixLogLevelsAndReservesStrictChannelForErrorExceptions()
+    {
+        var exporter = new RecordingExporter();
+        var logs = new List<RemoteDiagnosticRecord>();
+        await using var service = new PostHogRemoteDiagnosticsSink((_, _) => exporter, logCapture: logs.Add);
+        service.Configure(RemoteDiagnosticsTestData.EnabledOptions(), RemoteDiagnosticsTestData.Context());
+
+        foreach (LogEventLevel level in Enum.GetValues<LogEventLevel>())
+        {
+            service.Emit(RemoteDiagnosticsTestData.LogEvent(level, "ordinary log"));
+            service.Emit(RemoteDiagnosticsTestData.LogEvent(level, "exception log", new InvalidOperationException("failed")));
+        }
+        await service.FlushAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(12, logs.Count);
+        Assert.All(Enum.GetValues<LogEventLevel>(), level => Assert.Equal(2, logs.Count(record => record.Level == level)));
+        Assert.Equal([LogEventLevel.Error, LogEventLevel.Fatal], exporter.Records.Select(record => record.Level).ToArray());
+        Assert.Equal(2, exporter.ExceptionEvents.Count);
     }
 
     [Fact]
@@ -43,7 +90,7 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
             });
 
         service.Configure(RemoteDiagnosticsTestData.EnabledOptions() with { IsEnabled = false }, RemoteDiagnosticsTestData.Context());
-        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "failed"));
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "failed", new InvalidOperationException("failed")));
         await service.FlushAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(0, factoryCalls);
@@ -57,9 +104,9 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
         service.Configure(RemoteDiagnosticsTestData.EnabledOptions(), RemoteDiagnosticsTestData.Context());
 
         service.Disable();
-        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "disabled"));
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "disabled", new InvalidOperationException("failed")));
         service.Configure(RemoteDiagnosticsTestData.EnabledOptions(), RemoteDiagnosticsTestData.Context());
-        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "re-enabled"));
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "re-enabled", new InvalidOperationException("failed")));
         await service.FlushAsync(TestContext.Current.CancellationToken);
 
         RemoteDiagnosticRecord record = Assert.Single(exporter.Records);
@@ -72,14 +119,14 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
         var exporter = new BlockingExporter();
         await using var service = CreateService(exporter);
         service.Configure(RemoteDiagnosticsTestData.EnabledOptions(), RemoteDiagnosticsTestData.Context());
-        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "in-flight"));
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "in-flight", new InvalidOperationException("failed")));
         Assert.True(exporter.Started.Wait(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken));
-        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "buffered"));
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "buffered", new InvalidOperationException("failed")));
 
         service.Disable();
         exporter.Release.Set();
         service.Configure(RemoteDiagnosticsTestData.EnabledOptions(), RemoteDiagnosticsTestData.Context());
-        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "after-reenable"));
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "after-reenable", new InvalidOperationException("failed")));
         await service.FlushAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(["in-flight", "after-reenable"], exporter.Records.Select(static record => record.Body).ToArray());
@@ -124,8 +171,8 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
 
         Exception? exception = Record.Exception(() =>
         {
-            service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "first"));
-            service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "second"));
+            service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "first", new InvalidOperationException("failed")));
+            service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "second", new InvalidOperationException("failed")));
         });
         await service.FlushAsync(TestContext.Current.CancellationToken);
 
@@ -192,7 +239,7 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
         service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "failed", exception));
         await service.FlushAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(2, exporter.Records.Count);
+        Assert.Single(exporter.Records);
         Assert.Single(exporter.ExceptionEvents);
     }
 
@@ -219,20 +266,22 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
     }
 
     [Fact]
-    public async Task Emit_RateLimitsRepeatedFingerprint()
+    public async Task Emit_RepeatedWarningsAreAllCapturedWithoutEnteringErrorTracking()
     {
         var exporter = new RecordingExporter();
-        await using var service = CreateService(exporter);
+        var logs = new List<RemoteDiagnosticRecord>();
+        await using var service = new PostHogRemoteDiagnosticsSink((_, _) => exporter, logCapture: logs.Add);
         service.Configure(RemoteDiagnosticsTestData.EnabledOptions(), RemoteDiagnosticsTestData.Context());
 
-        for (int index = 0; index < 8; index++)
+        for (int index = 0; index < 20; index++)
         {
             service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Warning, "same warning"));
         }
 
         await service.FlushAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(5, exporter.Records.Count);
+        Assert.Equal(20, logs.Count);
+        Assert.Empty(exporter.Records);
     }
 
     [Theory]
@@ -249,7 +298,7 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
         for (int index = 0; index < 8; index++)
         {
             service.Emit(RemoteDiagnosticsTestData.LogEvent(
-                LogEventLevel.Warning, "same warning", properties: (propertyName, $"value-{index}")));
+                LogEventLevel.Error, "same failure", new InvalidOperationException("failed"), (propertyName, $"value-{index}")));
         }
 
         await service.FlushAsync(TestContext.Current.CancellationToken);
@@ -258,48 +307,52 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
     }
 
     [Fact]
-    public async Task Emit_PreservesDistinctStepsAndLimitsRepeatedStep()
+    public async Task Emit_PreservesEveryInformationStepIncludingRepetitions()
     {
         var exporter = new RecordingExporter();
-        await using var service = CreateService(exporter);
+        var logs = new List<RemoteDiagnosticRecord>();
+        await using var service = new PostHogRemoteDiagnosticsSink((_, _) => exporter, logCapture: logs.Add);
         service.Configure(RemoteDiagnosticsTestData.EnabledOptions(), RemoteDiagnosticsTestData.Context());
         for (int index = 0; index < 8; index++)
         {
             service.Emit(RemoteDiagnosticsTestData.LogEvent(
                 LogEventLevel.Information, "Step starting",
-                properties: [("RemoteDiagnostic", true), ("OperationId", "deployment-1"), ("StepName", $"step-{index}")]));
+                properties: [("OperationId", "deployment-1"), ("StepName", $"step-{index}")]));
         }
 
         for (int index = 0; index < 8; index++)
         {
             service.Emit(RemoteDiagnosticsTestData.LogEvent(
                 LogEventLevel.Information, "Step starting",
-                properties: [("RemoteDiagnostic", true), ("OperationId", "deployment-1"), ("StepName", "step-0")]));
+                properties: [("OperationId", "deployment-1"), ("StepName", "step-0")]));
         }
 
         await service.FlushAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(12, exporter.Records.Count);
-        Assert.Equal(8, exporter.Records.Select(record => record.Attributes["workflow.step"]).Distinct().Count());
-        Assert.Equal(5, exporter.Records.Count(record => Equals(record.Attributes["workflow.step"], "step-0")));
+        Assert.Equal(16, logs.Count);
+        Assert.Equal(8, logs.Select(record => record.Attributes["StepName"]).Distinct().Count());
+        Assert.Equal(9, logs.Count(record => Equals(record.Attributes["StepName"], "step-0")));
+        Assert.Empty(exporter.Records);
     }
 
     [Fact]
-    public async Task Emit_TerminalEventBypassesThrottleAndReportsDroppedRecords()
+    public async Task Emit_ReportsErrorTrackingThrottleLossWithoutDroppingLogs()
     {
         var exporter = new RecordingExporter();
-        await using var service = CreateService(exporter);
+        var logs = new List<RemoteDiagnosticRecord>();
+        await using var service = new PostHogRemoteDiagnosticsSink((_, _) => exporter, logCapture: logs.Add);
         service.Configure(RemoteDiagnosticsTestData.EnabledOptions(), RemoteDiagnosticsTestData.Context());
         for (int index = 0; index < 8; index++)
         {
-            service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "failed"));
+            service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "failed", new InvalidOperationException("failed")));
         }
 
         service.Emit(RemoteDiagnosticsTestData.LogEvent(
-            LogEventLevel.Error, "failed", properties: ("RemoteDiagnosticTerminal", true)));
+            LogEventLevel.Error, "another failure", new InvalidOperationException("failed")));
         await service.FlushAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(6, exporter.Records.Count);
+        Assert.Equal(9, logs.Count);
         Assert.Equal(3L, exporter.Records[^1].Attributes["diagnostics.dropped_record_count"]);
     }
 
@@ -309,11 +362,11 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
         var exporter = new BlockingExporter();
         await using var service = CreateService(exporter, queueCapacity: 1);
         service.Configure(RemoteDiagnosticsTestData.EnabledOptions(), RemoteDiagnosticsTestData.Context());
-        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "first"));
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "first", new InvalidOperationException("failed")));
         Assert.True(exporter.Started.Wait(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken));
 
-        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "second"));
-        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "third"));
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "second", new InvalidOperationException("failed")));
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "third", new InvalidOperationException("failed")));
 
         Assert.Equal(1, service.DroppedRecordCount);
         exporter.Release.Set();
@@ -326,7 +379,7 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
         var exporter = new BlockingExporter();
         await using var service = CreateService(exporter);
         service.Configure(RemoteDiagnosticsTestData.EnabledOptions(), RemoteDiagnosticsTestData.Context());
-        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "failed"));
+        service.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "failed", new InvalidOperationException("failed")));
         Assert.True(exporter.Started.Wait(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken));
         using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
 
@@ -335,8 +388,10 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
         exporter.Release.Set();
     }
 
-    [Fact]
-    public async Task Emit_InternalExporterEvent_IsExcluded()
+    [Theory]
+    [InlineData("RemoteDiagnosticsInternal")]
+    [InlineData("PostHogTransportInternal")]
+    public async Task Emit_InternalExporterEvent_IsExcludedFromErrorTracking(string internalProperty)
     {
         var exporter = new RecordingExporter();
         await using var service = CreateService(exporter);
@@ -345,64 +400,11 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
         service.Emit(RemoteDiagnosticsTestData.LogEvent(
             LogEventLevel.Error,
             "exporter failure",
-            properties: ("RemoteDiagnosticsInternal", true)));
+            new InvalidOperationException("failed"),
+            properties: (internalProperty, true)));
         await service.FlushAsync(TestContext.Current.CancellationToken);
 
         Assert.Empty(exporter.Records);
-    }
-
-    [Fact]
-    public void CreateLogEvent_DoesNotDuplicateResourceAttributes()
-    {
-        var record = new RemoteDiagnosticRecord(
-            DateTimeOffset.UtcNow,
-            LogEventLevel.Error,
-            "Deployment failed for {Path}",
-            new Dictionary<string, object>
-            {
-                ["service.name"] = "foundry.deploy",
-                ["service.version"] = "1.2.3",
-                ["service.release"] = "foundry.deploy@1.2.3",
-                ["runtime.name"] = "winpe",
-                ["runtime.architecture"] = "x64",
-                ["operation.id"] = "operation-1",
-                ["failure.operation"] = "windows_optional_features.validate"
-            },
-            new RemoteDiagnosticException("System.InvalidOperationException", "redacted", "at Foundry.Run()", []));
-
-        LogEvent logEvent = PostHogDiagnosticsExporter.CreateLogEvent(record);
-
-        Assert.Null(logEvent.Exception);
-        Assert.Equal("Deployment failed for {Path}", logEvent.RenderMessage());
-        Assert.DoesNotContain("DiagnosticBody", logEvent.Properties.Keys, StringComparer.Ordinal);
-        Assert.DoesNotContain("service.name", logEvent.Properties.Keys, StringComparer.Ordinal);
-        Assert.DoesNotContain("service.version", logEvent.Properties.Keys, StringComparer.Ordinal);
-        Assert.DoesNotContain("service.release", logEvent.Properties.Keys, StringComparer.Ordinal);
-        Assert.DoesNotContain("runtime.name", logEvent.Properties.Keys, StringComparer.Ordinal);
-        Assert.DoesNotContain("runtime.architecture", logEvent.Properties.Keys, StringComparer.Ordinal);
-        Assert.Equal("operation-1", Assert.IsType<ScalarValue>(logEvent.Properties["operation.id"]).Value);
-        Assert.Equal(
-            "windows_optional_features.validate",
-            Assert.IsType<ScalarValue>(logEvent.Properties["failure.operation"]).Value);
-        Assert.Equal("redacted", Assert.IsType<ScalarValue>(logEvent.Properties["exception.message"]).Value);
-    }
-
-    [Fact]
-    public void CreateLogEvent_WhenExceptionMessageMatchesBody_DoesNotDuplicateMessage()
-    {
-        LogEvent source = RemoteDiagnosticsTestData.LogEvent(
-            LogEventLevel.Error,
-            "Deployment failed",
-            new InvalidOperationException("private detail"));
-        RemoteDiagnosticRecord record = RemoteDiagnosticPropertyPolicy.CreateSanitizedRecord(
-            source,
-            RemoteDiagnosticsTestData.Context());
-
-        LogEvent logEvent = PostHogDiagnosticsExporter.CreateLogEvent(record);
-
-        Assert.Equal("Deployment failed", logEvent.RenderMessage());
-        Assert.DoesNotContain("exception.message", logEvent.Properties.Keys, StringComparer.Ordinal);
-        Assert.Contains("exception.type", logEvent.Properties.Keys, StringComparer.Ordinal);
     }
 
     private static PostHogRemoteDiagnosticsSink CreateService(
@@ -422,6 +424,8 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
 
         public bool ThrowOnExport { get; init; }
 
+        public bool IsDisposed { get; private set; }
+
         public virtual ValueTask ExportAsync(RemoteDiagnosticRecord record, CancellationToken cancellationToken)
         {
             ExportAttempts++;
@@ -437,7 +441,11 @@ public sealed class PostHogRemoteDiagnosticsSinkTests
 
         public virtual Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
-        public virtual ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public virtual ValueTask DisposeAsync()
+        {
+            IsDisposed = true;
+            return ValueTask.CompletedTask;
+        }
     }
 
     private sealed class RecordingEventClient : IPostHogEventClient

--- a/src/Foundry.Telemetry.Tests/PostHogTelemetryServiceTests.cs
+++ b/src/Foundry.Telemetry.Tests/PostHogTelemetryServiceTests.cs
@@ -64,7 +64,8 @@ public sealed class PostHogTelemetryServiceTests
 
             RemoteDiagnosticsSink.Instance.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "Failed"));
 
-            Assert.Equal(0, service.ConfigureCallCount);
+            Assert.Equal(1, service.ConfigureCallCount);
+            Assert.False(Assert.Single(service.Configurations).CanSend);
             Assert.Equal(1, service.DisableCallCount);
             Assert.Equal(0, service.EmitCallCount);
         }
@@ -110,7 +111,8 @@ public sealed class PostHogTelemetryServiceTests
             RemoteDiagnosticsLifecycle.Initialize(service, settings, telemetryContext);
             RemoteDiagnosticsSink.Instance.Emit(RemoteDiagnosticsTestData.LogEvent(LogEventLevel.Error, "Re-enabled"));
 
-            Assert.Equal(2, service.ConfigureCallCount);
+            Assert.Equal(3, service.ConfigureCallCount);
+            Assert.Equal(new[] { true, false, true }, service.Configurations.Select(options => options.CanSend));
             Assert.Equal(1, service.DisableCallCount);
             Assert.Equal(2, service.EmitCallCount);
         }
@@ -377,6 +379,8 @@ public sealed class PostHogTelemetryServiceTests
 
     private class RecordingRemoteDiagnosticsService : IRemoteDiagnosticsService
     {
+        public List<RemoteDiagnosticsOptions> Configurations { get; } = [];
+
         public int ConfigureCallCount { get; private set; }
 
         public int EmitCallCount { get; private set; }
@@ -388,6 +392,7 @@ public sealed class PostHogTelemetryServiceTests
         public void Configure(RemoteDiagnosticsOptions options, RemoteDiagnosticsContext context)
         {
             ConfigureCallCount++;
+            Configurations.Add(options);
         }
 
         public void Emit(LogEvent logEvent)

--- a/src/Foundry.Telemetry.Tests/ReliableLogPipelineTests.cs
+++ b/src/Foundry.Telemetry.Tests/ReliableLogPipelineTests.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using Serilog.Events;
+
+namespace Foundry.Telemetry.Tests;
+
+public sealed class ReliableLogPipelineTests : IDisposable
+{
+    private readonly string directory = Path.Combine(Path.GetTempPath(), "foundry-delivery-tests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task OfflineRestart_ReplaysAllLevelsWithOriginalIdsAndTimes()
+    {
+        var offline = new Transport(_ => new(LogBatchDisposition.Retry));
+        var records = Enum.GetValues<LogEventLevel>().Select(level => Record(level)).ToArray();
+        await using (var first = new ReliableLogPipeline(offline, directory, startDelivery: false))
+        {
+            foreach (var record in records) first.Emit(record);
+            await first.FlushAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(6, first.PendingCount);
+        }
+        var online = new Transport(_ => new(LogBatchDisposition.Accepted));
+        await using (var replay = new ReliableLogPipeline(online, directory, startDelivery: false))
+        {
+            await replay.FlushAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(0, replay.PendingCount);
+        }
+        RemoteDiagnosticRecord[] delivered = Assert.Single(online.Batches).ToArray();
+        Assert.Equal(records.Select(r => r.Level), delivered.Select(r => r.Level));
+        Assert.Equal(records.Select(r => r.Timestamp), delivered.Select(r => r.Timestamp));
+        Assert.Equal(records.Select(Id), delivered.Select(Id));
+    }
+
+    [Fact]
+    public async Task TransientFailure_RetriesTheSameRecordWithoutRestart()
+    {
+        var accepted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int attempts = 0;
+        var transport = new Transport(_ =>
+        {
+            if (Interlocked.Increment(ref attempts) == 1)
+                return new(LogBatchDisposition.Retry, RetryAfter: TimeSpan.FromMilliseconds(100));
+            accepted.TrySetResult();
+            return new(LogBatchDisposition.Accepted);
+        });
+        await using var pipeline = new ReliableLogPipeline(transport, directory, interval: TimeSpan.FromMilliseconds(5));
+        RemoteDiagnosticRecord record = Record(LogEventLevel.Debug);
+        pipeline.Emit(record);
+        await accepted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await pipeline.FlushAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(0, pipeline.PendingCount);
+        Assert.Equal(2, transport.Batches.Count);
+        Assert.All(transport.Batches, batch => Assert.Equal(Id(record), Id(Assert.Single(batch))));
+    }
+
+    [Fact]
+    public async Task ShutdownDeadline_CancelsTransportAndPreservesPendingRecord()
+    {
+        var transport = new BlockingTransport();
+        string id;
+        await using (var pipeline = new ReliableLogPipeline(transport, directory, interval: TimeSpan.FromMilliseconds(5)))
+        {
+            RemoteDiagnosticRecord record = Record(LogEventLevel.Fatal);
+            id = Id(record);
+            pipeline.Emit(record);
+            await transport.Started.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            using var deadline = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pipeline.FlushAsync(deadline.Token));
+            await transport.Cancelled.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        }
+        using var recovered = new DurableLogQueue(directory);
+        Assert.Equal(id, Id(Assert.Single(recovered.Take(10))));
+    }
+
+    [Fact]
+    public async Task RepeatedMessages_AreNotSampledAndOversizedBatchesAreSplit()
+    {
+        var transport = new Transport(batch => batch.Count > 3 ? new(LogBatchDisposition.Split) : new(LogBatchDisposition.Accepted));
+        await using var pipeline = new ReliableLogPipeline(transport, directory, startDelivery: false);
+        for (int i = 0; i < 20; i++) pipeline.Emit(Record(LogEventLevel.Information));
+        await pipeline.FlushAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(0, pipeline.PendingCount);
+        Assert.Equal(20, transport.Batches.Where(batch => batch.Count <= 3).Sum(batch => batch.Count));
+    }
+
+    [Fact]
+    public async Task Disable_CancelsInFlightRequestAndPurgesUnsentRecords()
+    {
+        var transport = new BlockingTransport();
+        await using (var pipeline = new ReliableLogPipeline(transport, directory, interval: TimeSpan.FromMilliseconds(5)))
+        {
+            pipeline.Emit(Record(LogEventLevel.Debug));
+            await transport.Started.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            pipeline.Disable();
+            await transport.Cancelled.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            Assert.Equal(0, pipeline.PendingCount);
+        }
+        using var queue = new DurableLogQueue(directory);
+        Assert.Empty(queue.Take(100));
+    }
+
+    [Fact]
+    public async Task PartialRejection_DoesNotReplayTheAcceptedSubset()
+    {
+        var transport = new Transport(_ => new(LogBatchDisposition.Rejected, 1));
+        await using var pipeline = new ReliableLogPipeline(transport, directory, startDelivery: false);
+        pipeline.Emit(Record(LogEventLevel.Warning));
+        pipeline.Emit(Record(LogEventLevel.Error));
+        await pipeline.FlushAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(0, pipeline.PendingCount);
+        Assert.Single(transport.Batches);
+    }
+
+    private static string Id(RemoteDiagnosticRecord record) => record.Attributes["diagnostics.record_id"].ToString()!;
+    private static RemoteDiagnosticRecord Record(LogEventLevel level) => new(
+        new DateTimeOffset(2026, 9, 11, 10, 0, 0, TimeSpan.Zero), level, "Repeated operation",
+        new Dictionary<string, object> { ["diagnostics.record_id"] = Guid.NewGuid().ToString(), ["service.name"] = "test" }, null);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(directory)) Directory.Delete(directory, true);
+    }
+
+    private sealed class Transport(Func<IReadOnlyList<RemoteDiagnosticRecord>, LogBatchResult> respond) : ILogBatchTransport
+    {
+        internal ConcurrentQueue<IReadOnlyList<RemoteDiagnosticRecord>> Batches { get; } = new();
+        public Task<LogBatchResult> SendAsync(IReadOnlyList<RemoteDiagnosticRecord> records, CancellationToken token)
+        {
+            Batches.Enqueue(records);
+            return Task.FromResult(respond(records));
+        }
+        public void Dispose() { }
+    }
+
+    private sealed class BlockingTransport : ILogBatchTransport
+    {
+        internal TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal TaskCompletionSource Cancelled { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public async Task<LogBatchResult> SendAsync(IReadOnlyList<RemoteDiagnosticRecord> records, CancellationToken token)
+        {
+            Started.TrySetResult();
+            try { await Task.Delay(Timeout.Infinite, token); }
+            catch (OperationCanceledException) { Cancelled.TrySetResult(); throw; }
+            return new(LogBatchDisposition.Accepted);
+        }
+        public void Dispose() { }
+    }
+}

--- a/src/Foundry.Telemetry.Tests/RemoteDiagnosticPropertyPolicyTests.cs
+++ b/src/Foundry.Telemetry.Tests/RemoteDiagnosticPropertyPolicyTests.cs
@@ -270,15 +270,15 @@ public sealed class RemoteDiagnosticPropertyPolicyTests
     }
 
     [Fact]
-    public void CreateSanitizedRecord_RendersInternalMarkersWithoutExportingAttributes()
+    public void CreateSanitizedRecord_RedactsUnreviewedBooleanProperties()
     {
         LogEvent source = CreateLogEvent(LogEventLevel.Information,
-            "Finished. RemoteDiagnostic={RemoteDiagnostic}", null, ("RemoteDiagnostic", true));
+            "Finished. PrivateFlag={PrivateFlag}", null, ("PrivateFlag", true));
 
         RemoteDiagnosticRecord result = RemoteDiagnosticPropertyPolicy.CreateSanitizedRecord(source, CreateContext());
 
-        Assert.DoesNotContain("<redacted>", result.Body);
-        Assert.DoesNotContain("RemoteDiagnostic", result.Attributes.Keys);
+        Assert.Contains("<redacted>", result.Body);
+        Assert.DoesNotContain("PrivateFlag", result.Attributes.Keys);
     }
 
     [Fact]

--- a/src/Foundry.Telemetry.Tests/RemoteLogStorageTests.cs
+++ b/src/Foundry.Telemetry.Tests/RemoteLogStorageTests.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Telemetry.Tests;
+
+public sealed class RemoteLogStorageTests
+{
+    [Fact]
+    public void MatchingBootstrapCache_IsStableAcrossBootSessions()
+    {
+        RemoteDiagnosticsContext context = RemoteDiagnosticsTestData.Context();
+        string first = RemoteLogStorage.ResolveRoot(@"X:\Logs\PendingLogs", context, @"R:\Logs\session-1");
+        string second = RemoteLogStorage.ResolveRoot(@"X:\Logs\PendingLogs", context with { SessionId = "session-2" }, @"R:\Logs\session-2");
+        Assert.Equal(@"R:\Logs\PendingLogs", first);
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void UnrelatedInheritedCache_DoesNotRedirectTheOutbox()
+    {
+        Assert.Equal(@"X:\Logs\PendingLogs", RemoteLogStorage.ResolveRoot(@"X:\Logs\PendingLogs",
+            RemoteDiagnosticsTestData.Context(), @"R:\Logs\another-session"));
+    }
+}

--- a/src/Foundry.Telemetry/BootstrapTelemetryJournal.cs
+++ b/src/Foundry.Telemetry/BootstrapTelemetryJournal.cs
@@ -8,7 +8,7 @@ using System.Text.Json;
 
 namespace Foundry.Telemetry;
 
-/// <summary>Independent destinations retain their own handoff state when another destination fails.</summary>
+/// <summary>Analytics and exceptions retain independent handoff state; Log is retained for legacy journal migration.</summary>
 internal enum BootstrapTelemetryDestination { Analytics, Log, Exception }
 
 /// <summary>Buffered SDK handoff is deliberately distinct from an HTTP receipt.</summary>
@@ -110,7 +110,7 @@ internal sealed class BootstrapTelemetryJournal
                         Enum.IsDefined(record.Destination) && Enum.IsDefined(record.State) && record.Attempts >= 0 &&
                         (record.State != BootstrapDeliveryState.Acknowledged || record.RetainAcknowledgement) &&
                         (record.Destination == BootstrapTelemetryDestination.Analytics ? record.Properties is not null :
-                            record.Diagnostic is { Attributes: not null, Body: not null } diagnostic && Enum.IsDefined(diagnostic.Level) && diagnostic.Level >= Serilog.Events.LogEventLevel.Information &&
+                            record.Diagnostic is { Attributes: not null, Body: not null } diagnostic && Enum.IsDefined(diagnostic.Level) &&
                             (record.Destination != BootstrapTelemetryDestination.Exception ||
                                 diagnostic is { Exception: not null, Level: >= Serilog.Events.LogEventLevel.Error })) &&
                         !_records.Any(candidate => candidate.Id == record.Id))
@@ -129,6 +129,8 @@ internal sealed class BootstrapTelemetryJournal
 
     private static BootstrapPendingRecord Revalidate(BootstrapPendingRecord record)
     {
+        if (record.Destination == BootstrapTelemetryDestination.Log)
+            return record with { Diagnostic = LogRecordFactory.SanitizePersistedRecord(record.Diagnostic!) };
         if (record.Destination != BootstrapTelemetryDestination.Analytics)
         {
             return record with { Diagnostic = RemoteDiagnosticPropertyPolicy.SanitizePersistedRecord(record.Diagnostic!) };
@@ -159,7 +161,7 @@ internal sealed class BootstrapTelemetryJournal
     private static BootstrapPendingRecord Normalize(BootstrapPendingRecord record) => record with
     {
         Properties = record.Properties?.ToDictionary(pair => pair.Key, pair => Scalar(pair.Value), StringComparer.Ordinal),
-        Diagnostic = record.Diagnostic is { } diagnostic ? diagnostic with
+        Diagnostic = record.Destination == BootstrapTelemetryDestination.Log ? record.Diagnostic : record.Diagnostic is { } diagnostic ? diagnostic with
         {
             Attributes = diagnostic.Attributes.ToDictionary(pair => pair.Key, pair => Scalar(pair.Value), StringComparer.Ordinal)
         } : null

--- a/src/Foundry.Telemetry/BootstrapTelemetryPipeline.cs
+++ b/src/Foundry.Telemetry/BootstrapTelemetryPipeline.cs
@@ -41,7 +41,7 @@ public sealed class BootstrapTelemetryPipeline : ILogEventSink, IAsyncDisposable
     public BootstrapTelemetryPipeline(TelemetryOptions usage, TelemetryContext context,
         RemoteDiagnosticsOptions diagnostics, RemoteDiagnosticsContext diagnosticContext, string? journalPath)
         : this(usage, context, diagnostics, diagnosticContext, journalPath,
-            () => new BootstrapTelemetryTransport(usage, context, diagnostics, diagnosticContext), TimeProvider.System)
+            () => new BootstrapTelemetryTransport(usage, context, diagnostics), TimeProvider.System)
     {
     }
 

--- a/src/Foundry.Telemetry/BootstrapTelemetryPipeline.cs
+++ b/src/Foundry.Telemetry/BootstrapTelemetryPipeline.cs
@@ -8,7 +8,7 @@ using Serilog.Events;
 namespace Foundry.Telemetry;
 
 /// <summary>
-/// Captures sanitized Bootstrap records before connectivity, then drains in the background after preparation.
+/// Captures Bootstrap records before connectivity, then drains in the background after preparation.
 /// A persistent journal is optional; a RAM-backed path does not survive a reboot.
 /// </summary>
 public sealed class BootstrapTelemetryPipeline : ILogEventSink, IAsyncDisposable
@@ -16,6 +16,7 @@ public sealed class BootstrapTelemetryPipeline : ILogEventSink, IAsyncDisposable
     private readonly object _gate = new();
     private readonly BootstrapTelemetryJournal _journal;
     private readonly PostHogRemoteDiagnosticsSink _capture;
+    private readonly ReliableLogPipeline? _logs;
     private readonly TelemetryContext _context;
     private readonly string _usageScope;
     private readonly string _diagnosticScope;
@@ -46,7 +47,7 @@ public sealed class BootstrapTelemetryPipeline : ILogEventSink, IAsyncDisposable
 
     internal BootstrapTelemetryPipeline(TelemetryOptions usage, TelemetryContext context,
         RemoteDiagnosticsOptions diagnostics, RemoteDiagnosticsContext diagnosticContext, string? journalPath,
-        Func<IBootstrapTelemetryTransport> transportFactory, TimeProvider timeProvider)
+        Func<IBootstrapTelemetryTransport> transportFactory, TimeProvider timeProvider, ILogBatchTransport? logTransport = null)
     {
         _context = context;
         _transportFactory = transportFactory;
@@ -57,10 +58,22 @@ public sealed class BootstrapTelemetryPipeline : ILogEventSink, IAsyncDisposable
         _diagnosticScope = BootstrapTelemetryJournal.Scope(diagnostics.HostUrl, diagnostics.ProjectToken, diagnostics.InstallId);
         _journal = new BootstrapTelemetryJournal(journalPath);
         PurgeDisallowed();
+        string? logDirectory = journalPath is null ? null : Path.Combine(journalPath + ".logs", _diagnosticScope);
+        if (_diagnosticsEnabled)
+        {
+            _logs = new ReliableLogPipeline(logTransport ?? new OtlpLogTransport(diagnostics, diagnosticContext),
+                logDirectory, startDelivery: false);
+            TransferLegacyLogs();
+        }
+        else if (logDirectory is not null)
+        {
+            using var revoked = new DurableLogQueue(logDirectory);
+            revoked.Clear();
+        }
         _replayIds = _journal.Records.Select(record => record.Id).ToHashSet();
         _previousBootIds = new HashSet<Guid>(_replayIds);
         _capture = new PostHogRemoteDiagnosticsSink(static (_, _) => new CaptureOnlyExporter(),
-            timeProvider: timeProvider, capture: CaptureDiagnostic);
+            timeProvider: timeProvider, capture: CaptureDiagnostic, logCapture: CaptureLog);
         _capture.Configure(diagnostics, diagnosticContext);
     }
 
@@ -71,6 +84,7 @@ public sealed class BootstrapTelemetryPipeline : ILogEventSink, IAsyncDisposable
         {
             _usageEnabled &= usageEnabled;
             _diagnosticsEnabled &= diagnosticsEnabled;
+            if (!_diagnosticsEnabled) _logs?.Disable();
             PurgeDisallowed();
         }
         // Do not acquire the capture sink lock while holding the journal lock.
@@ -115,18 +129,20 @@ public sealed class BootstrapTelemetryPipeline : ILogEventSink, IAsyncDisposable
             }
             RemoteDiagnosticRecord diagnostic = failure.Diagnostic;
             bool priorBoot = !diagnostic.Attributes.TryGetValue("session.id", out object? session) || !Equals(session, _context.SessionId);
-            if (priorBoot && _clockUsable && _time.GetUtcNow() - diagnostic.Timestamp > TimeSpan.FromDays(7))
-            {
-                ChildStartupFailureExchange.Retire(launchDirectory);
-                return false;
-            }
-            var records = new List<BootstrapPendingRecord>
-            {
-                ImportedRecord(failure.LogRecordId, BootstrapTelemetryDestination.Log, diagnostic)
-            };
-            if (diagnostic.Exception is not null)
+            bool expiredException = priorBoot && _clockUsable && _time.GetUtcNow() - diagnostic.Timestamp > TimeSpan.FromDays(7);
+            var records = new List<BootstrapPendingRecord>();
+            if (diagnostic.Exception is not null && !expiredException)
                 records.Add(ImportedRecord(failure.RecordId, BootstrapTelemetryDestination.Exception, diagnostic));
-            if (!_journal.Import(records)) return false;
+            if (records.Count > 0 && !_journal.Import(records)) return false;
+            RemoteDiagnosticRecord log = (failure.Log ?? diagnostic) with
+            {
+                Attributes = new Dictionary<string, object>((failure.Log ?? diagnostic).Attributes, StringComparer.Ordinal)
+                {
+                    ["diagnostics.record_id"] = failure.LogRecordId.ToString("N")
+                },
+                ShouldTrackException = false
+            };
+            if (_logs?.TryImport(log) != true) return false;
             foreach (BootstrapPendingRecord record in records)
             {
                 _replayIds.Add(record.Id);
@@ -156,6 +172,7 @@ public sealed class BootstrapTelemetryPipeline : ILogEventSink, IAsyncDisposable
             if (_stopping) return;
             _clockUsable |= clockUsable;
             Expire();
+            _logs?.StartDelivery();
             StartWorker();
         }
     }
@@ -177,7 +194,13 @@ public sealed class BootstrapTelemetryPipeline : ILogEventSink, IAsyncDisposable
 
     internal IReadOnlyList<BootstrapPendingRecord> PendingRecords
     {
-        get { lock (_gate) return _journal.Records.ToArray(); }
+        get
+        {
+            lock (_gate)
+                return _journal.Records.Concat((_logs?.PendingRecords ?? []).Select(record =>
+                    new BootstrapPendingRecord(Guid.Parse(record.Attributes["diagnostics.record_id"].ToString()!),
+                        _diagnosticScope, BootstrapTelemetryDestination.Log, record.Timestamp, null, record))).ToArray();
+        }
     }
 
     private void CaptureDiagnostic(RemoteDiagnosticRecord diagnostic)
@@ -185,25 +208,56 @@ public sealed class BootstrapTelemetryPipeline : ILogEventSink, IAsyncDisposable
         lock (_gate)
         {
             if (!_diagnosticsEnabled || _stopping) return;
-            AddDiagnostic(diagnostic, BootstrapTelemetryDestination.Log);
             if (diagnostic.ShouldTrackException && diagnostic.Exception is not null && diagnostic.Level >= LogEventLevel.Error)
-                AddDiagnostic(diagnostic, BootstrapTelemetryDestination.Exception);
+                AddExceptionDiagnostic(diagnostic);
             Signal();
         }
     }
 
-    private void AddDiagnostic(RemoteDiagnosticRecord diagnostic, BootstrapTelemetryDestination destination)
+    private void AddExceptionDiagnostic(RemoteDiagnosticRecord diagnostic)
     {
         Guid id = Guid.NewGuid();
         var attributes = new Dictionary<string, object>(diagnostic.Attributes, StringComparer.Ordinal)
         {
             ["diagnostics.record_id"] = id.ToString()
         };
-        _journal.Add(new BootstrapPendingRecord(id, _diagnosticScope, destination, diagnostic.Timestamp,
+        _journal.Add(new BootstrapPendingRecord(id, _diagnosticScope, BootstrapTelemetryDestination.Exception, diagnostic.Timestamp,
             null, diagnostic with { Attributes = attributes }));
     }
 
+    private void CaptureLog(RemoteDiagnosticRecord diagnostic)
+    {
+        lock (_gate)
+        {
+            if (!_diagnosticsEnabled || _stopping) return;
+            _logs?.Emit(diagnostic);
+        }
+    }
+
     private void PurgeDisallowed() => _journal.Purge(record => !Allowed(record));
+
+    private void TransferLegacyLogs()
+    {
+        foreach (BootstrapPendingRecord record in _journal.Records.Where(record =>
+            record.Destination == BootstrapTelemetryDestination.Log).ToArray())
+        {
+            if (record.State == BootstrapDeliveryState.Acknowledged)
+            {
+                _journal.Purge(candidate => candidate.Id == record.Id);
+                continue;
+            }
+            RemoteDiagnosticRecord log = record.Diagnostic! with
+            {
+                Attributes = new Dictionary<string, object>(record.Diagnostic!.Attributes, StringComparer.Ordinal)
+                {
+                    ["diagnostics.record_id"] = record.Id.ToString("N")
+                },
+                ShouldTrackException = false
+            };
+            if (_logs?.TryImport(log) == true)
+                _journal.Purge(candidate => candidate.Id == record.Id);
+        }
+    }
 
     private bool Allowed(BootstrapPendingRecord record) => record.Destination == BootstrapTelemetryDestination.Analytics
         ? _usageEnabled && record.Scope == _usageScope
@@ -230,10 +284,15 @@ public sealed class BootstrapTelemetryPipeline : ILogEventSink, IAsyncDisposable
         }
         try
         {
-            await Task.WhenAll(_worker!, _capture.FlushAsync(_deliveryCancellation.Token))
+            await Task.WhenAll(_worker!, _capture.FlushAsync(_deliveryCancellation.Token),
+                    _logs?.FlushAsync(_deliveryCancellation.Token) ?? Task.CompletedTask)
                 .WaitAsync(_deliveryCancellation.Token).ConfigureAwait(false);
         }
         catch (OperationCanceledException) { }
+        finally
+        {
+            if (_logs is not null) await _logs.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     private void Signal()
@@ -324,7 +383,7 @@ public sealed class BootstrapTelemetryPipeline : ILogEventSink, IAsyncDisposable
     {
         foreach (BootstrapPendingRecord record in _journal.Records)
         {
-            if (record.State == BootstrapDeliveryState.Acknowledged || !Allowed(record) || (record.Destination != BootstrapTelemetryDestination.Analytics && record.Attempts >= 3) || _attempted.Contains(record.Id)) continue;
+            if (record.Destination == BootstrapTelemetryDestination.Log || record.State == BootstrapDeliveryState.Acknowledged || !Allowed(record) || (record.Destination != BootstrapTelemetryDestination.Analytics && record.Attempts >= 3) || _attempted.Contains(record.Id)) continue;
             if (_replayIds.Contains(record.Id))
             {
                 if (_replayed >= 100 || _replayElapsed >= TimeSpan.FromSeconds(5)) continue;

--- a/src/Foundry.Telemetry/BootstrapTelemetryTransport.cs
+++ b/src/Foundry.Telemetry/BootstrapTelemetryTransport.cs
@@ -37,15 +37,16 @@ internal sealed class BootstrapTelemetryTransport : IBootstrapTelemetryTransport
                 .ConfigureAwait(false);
         }
 
+        if (record.Destination != BootstrapTelemetryDestination.Exception)
+            throw new ArgumentException("Bootstrap Logs use the shared reliable log pipeline.", nameof(record));
         RemoteDiagnosticsContext context = GetResourceContext(record.Diagnostic!, _context);
         if (!_diagnostics.TryGetValue(context, out PostHogDiagnosticsExporter? exporter))
         {
             exporter = new PostHogDiagnosticsExporter(_options, context);
             _diagnostics.Add(context, exporter);
         }
-        if (record.Destination == BootstrapTelemetryDestination.Log) exporter.ExportLog(record.Diagnostic!);
-        else exporter.ExportException(record.Diagnostic!);
-        // Both SDK APIs only enqueue. Their flush methods do not expose per-record receipts.
+        exporter.ExportException(record.Diagnostic!);
+        // The exception SDK only enqueues; its flush method does not expose per-record receipts.
         return false;
     }
 

--- a/src/Foundry.Telemetry/BootstrapTelemetryTransport.cs
+++ b/src/Foundry.Telemetry/BootstrapTelemetryTransport.cs
@@ -17,15 +17,13 @@ internal sealed class BootstrapTelemetryTransport : IBootstrapTelemetryTransport
     private readonly HttpClient _httpClient = new();
     private readonly PostHogTelemetryService _analytics;
     private readonly RemoteDiagnosticsOptions _options;
-    private readonly RemoteDiagnosticsContext _context;
-    private readonly Dictionary<RemoteDiagnosticsContext, PostHogDiagnosticsExporter> _diagnostics = [];
+    private PostHogDiagnosticsExporter? _diagnostics;
 
     internal BootstrapTelemetryTransport(TelemetryOptions usage, TelemetryContext context,
-        RemoteDiagnosticsOptions diagnostics, RemoteDiagnosticsContext diagnosticContext)
+        RemoteDiagnosticsOptions diagnostics)
     {
         _analytics = new PostHogTelemetryService(_httpClient, usage, context);
         _options = diagnostics;
-        _context = diagnosticContext;
     }
 
     public async Task<bool> DeliverAsync(BootstrapPendingRecord record, CancellationToken cancellationToken)
@@ -39,33 +37,19 @@ internal sealed class BootstrapTelemetryTransport : IBootstrapTelemetryTransport
 
         if (record.Destination != BootstrapTelemetryDestination.Exception)
             throw new ArgumentException("Bootstrap Logs use the shared reliable log pipeline.", nameof(record));
-        RemoteDiagnosticsContext context = GetResourceContext(record.Diagnostic!, _context);
-        if (!_diagnostics.TryGetValue(context, out PostHogDiagnosticsExporter? exporter))
-        {
-            exporter = new PostHogDiagnosticsExporter(_options, context);
-            _diagnostics.Add(context, exporter);
-        }
-        exporter.ExportException(record.Diagnostic!);
+        _diagnostics ??= new PostHogDiagnosticsExporter(_options);
+        _diagnostics.ExportException(record.Diagnostic!);
         // The exception SDK only enqueues; its flush method does not expose per-record receipts.
         return false;
     }
 
-    internal static RemoteDiagnosticsContext GetResourceContext(RemoteDiagnosticRecord record, RemoteDiagnosticsContext fallback)
-    {
-        string Attribute(string name, string defaultValue) => record.Attributes.TryGetValue(name, out object? value) && value is string text
-            ? text : defaultValue;
-        return new RemoteDiagnosticsContext(Attribute("service.name", fallback.App), Attribute("service.version", fallback.AppVersion),
-            string.Empty, Attribute("runtime.name", fallback.Runtime), Attribute("runtime.architecture", fallback.RuntimeArchitecture),
-            string.Empty, string.Empty, Attribute("service.release", fallback.Release));
-    }
-
     public Task FlushAsync(CancellationToken cancellationToken) =>
-        Task.WhenAll(_diagnostics.Values.Select(exporter => exporter.FlushAsync(cancellationToken)));
+        _diagnostics?.FlushAsync(cancellationToken) ?? Task.CompletedTask;
 
     public async ValueTask DisposeAsync()
     {
         _httpClient.Dispose();
-        foreach (PostHogDiagnosticsExporter exporter in _diagnostics.Values)
-            await exporter.DisposeAsync().ConfigureAwait(false);
+        if (_diagnostics is not null)
+            await _diagnostics.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/src/Foundry.Telemetry/ChildStartupFailureExchange.cs
+++ b/src/Foundry.Telemetry/ChildStartupFailureExchange.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Text.Json;
+using Foundry.Utilities.Diagnostics;
 using Serilog.Events;
 
 namespace Foundry.Telemetry;
@@ -12,7 +13,7 @@ public static class ChildStartupFailureExchange
 {
     /// <summary>The bounded record resides beside the launch status, never at a path read from its contents.</summary>
     public const string FileName = "startup-failure.json";
-    internal const int MaximumBytes = 256 * 1024;
+    internal const int MaximumBytes = (int)DurableLogQueue.DefaultMaximumBytes;
     private static readonly object CaptureGate = new();
 
     /// <summary>
@@ -37,9 +38,12 @@ public static class ChildStartupFailureExchange
             string scope = BootstrapTelemetryJournal.Scope(options.HostUrl, options.ProjectToken, options.InstallId);
             ChildStartupFailureRecord? previous = Read(launchDirectory, launchId, context.App);
             if (previous is not null && previous.Scope == scope) return previous.RecordId;
-            Guid id = Guid.NewGuid();
-            var record = new ChildStartupFailureRecord(1, launchId, id, logEvent.Exception is null ? id : Guid.NewGuid(), scope,
-                RemoteDiagnosticPropertyPolicy.CreateSanitizedRecord(logEvent, context));
+            LogEvent normalized = LogEventNormalizer.Normalize(logEvent);
+            RemoteDiagnosticRecord log = LogRecordFactory.Create(normalized, context);
+            Guid logId = Guid.Parse(log.Attributes["diagnostics.record_id"].ToString()!);
+            Guid id = logEvent.Exception is null ? logId : Guid.NewGuid();
+            var record = new ChildStartupFailureRecord(1, launchId, id, logId, scope,
+                RemoteDiagnosticPropertyPolicy.CreateSanitizedRecord(logEvent, context), log);
             byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(record);
             if (bytes.Length > MaximumBytes) return null;
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
@@ -83,7 +87,22 @@ public static class ChildStartupFailureExchange
             RemoteDiagnosticRecord diagnostic = BootstrapTelemetryJournal.RevalidateDiagnostic(record.Diagnostic);
             if (application is not (TelemetryApps.FoundryConnect or TelemetryApps.FoundryDeploy) ||
                 !diagnostic.Attributes.TryGetValue("service.name", out object? app) || !Equals(app, application)) return null;
-            return record with { Diagnostic = diagnostic };
+            RemoteDiagnosticRecord? log = record.Log;
+            if (log is not null)
+            {
+                if (log.Attributes is null || log.Body is null ||
+                    log.Level is not (LogEventLevel.Error or LogEventLevel.Fatal)) return null;
+                log = LogRecordFactory.SanitizePersistedRecord(log);
+                if (!log.Attributes.TryGetValue("service.name", out object? logApp) || !Equals(logApp, application)) return null;
+                log = log with
+                {
+                    Attributes = new Dictionary<string, object>(log.Attributes, StringComparer.Ordinal)
+                    {
+                        ["diagnostics.record_id"] = record.LogRecordId.ToString("N")
+                    }
+                };
+            }
+            return record with { Diagnostic = diagnostic, Log = log };
         }
 #pragma warning disable CA1031 // Corrupt or inaccessible exchange files are ignored without affecting startup.
         catch (Exception) { return null; }
@@ -119,4 +138,4 @@ public static class ChildStartupFailureExchange
 
 /// <summary>Credentials are replaced by a destination/installation digest; IDs survive transfer and replay.</summary>
 internal sealed record ChildStartupFailureRecord(int Version, Guid LaunchId, Guid RecordId, Guid LogRecordId,
-    string Scope, RemoteDiagnosticRecord Diagnostic);
+    string Scope, RemoteDiagnosticRecord Diagnostic, RemoteDiagnosticRecord? Log = null);

--- a/src/Foundry.Telemetry/DurableLogQueue.cs
+++ b/src/Foundry.Telemetry/DurableLogQueue.cs
@@ -1,0 +1,332 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+
+namespace Foundry.Telemetry;
+
+/// <summary>
+/// Stores pending logs before transport. Each process leases its own directory; only abandoned
+/// directories are recovered. Callers serialize access. A null directory provides bounded RAM storage.
+/// </summary>
+internal sealed class DurableLogQueue : IDisposable
+{
+    internal const int DefaultMaximumRecords = 4096;
+    internal const long DefaultMaximumBytes = 50 * 1024 * 1024;
+    private readonly int maximumRecords;
+    private readonly long maximumBytes;
+    private readonly List<Entry> entries = [];
+    private readonly List<FileStream> leases = [];
+    private readonly Dictionary<string, long> payloadFiles = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> retiredFiles = new(StringComparer.OrdinalIgnoreCase);
+    private string? writerDirectory;
+    private readonly string? rootDirectory;
+    private long bytes;
+    private long sequence;
+
+    internal DurableLogQueue(string? directory, int maximumRecords = DefaultMaximumRecords,
+        long maximumBytes = DefaultMaximumBytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maximumRecords, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maximumBytes, 1);
+        this.maximumRecords = maximumRecords;
+        this.maximumBytes = maximumBytes;
+        rootDirectory = directory;
+        if (directory is null) return;
+        try
+        {
+            Directory.CreateDirectory(directory);
+            RejectLinks(directory);
+            foreach (string candidate in Directory.EnumerateDirectories(directory).Order(StringComparer.Ordinal))
+            {
+                if (!TryLease(candidate)) continue;
+                foreach (string path in Directory.EnumerateFiles(candidate).Where(IsPayloadFile))
+                    AccountExistingFile(path);
+                if (File.Exists(Path.Combine(candidate, ".revoked")))
+                {
+                    foreach (string revoked in Directory.EnumerateFiles(candidate, "*.json")) Delete(revoked);
+                    foreach (string revoked in Directory.EnumerateFiles(candidate, "*.json.tmp")) Delete(revoked);
+                    continue;
+                }
+                RecoverTemporaryRecords(candidate);
+                foreach (string path in Directory.EnumerateFiles(candidate, "*.json").Order(StringComparer.Ordinal))
+                {
+                    try
+                    {
+                        RejectLinks(path);
+                        long size = new FileInfo(path).Length;
+                        if (size > maximumBytes) { DropFile(path); continue; }
+                        RemoteDiagnosticRecord? record = JsonSerializer.Deserialize<RemoteDiagnosticRecord>(File.ReadAllBytes(path));
+                        if (record is null || record.Body is null || record.Attributes is null ||
+                            !Enum.IsDefined(record.Level) || !TryId(record, out _))
+                        {
+                            DropFile(path);
+                            continue;
+                        }
+                        entries.Add(new Entry(LogRecordFactory.SanitizePersistedRecord(record), path, size));
+                        bytes += size;
+                        Trim();
+                    }
+                    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or ArgumentException)
+                    {
+                        DropFile(path);
+                    }
+                }
+            }
+            CreateWriter();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            StorageFailureCount++;
+            writerDirectory = null;
+        }
+    }
+
+    internal long DroppedCount { get; private set; }
+    internal long StorageFailureCount { get; private set; }
+    internal int Count => entries.Count;
+
+    /// <summary>Atomically persists the exact event snapshot, retaining a bounded RAM copy if storage fails.</summary>
+    internal bool Add(RemoteDiagnosticRecord record, bool requireDurable = false)
+    {
+        if (!TryId(record, out Guid id)) throw new ArgumentException("A log requires a stable record ID.", nameof(record));
+        Entry? existing = entries.Find(entry => Id(entry.Record) == id);
+        if (existing is not null) return existing.Path is not null || (!requireDurable && rootDirectory is null);
+        byte[] content = JsonSerializer.SerializeToUtf8Bytes(record);
+        if (content.Length > maximumBytes) { DroppedCount++; return false; }
+        // Reclaim the oldest pending record before creating the temporary file, so an atomic write
+        // cannot exceed the physical budget even briefly. Failed deletes retain their disk charge.
+        Trim(1, content.Length);
+        string? path = null;
+        if (writerDirectory is not null && CanPersist(content.Length))
+        {
+            path = Path.Combine(writerDirectory, (++sequence).ToString("D19", System.Globalization.CultureInfo.InvariantCulture) + "-" + id.ToString("N") + ".json");
+            string temporary = path + ".tmp";
+            payloadFiles.Add(temporary, content.Length);
+            try
+            {
+                RejectLinks(writerDirectory);
+                using (var stream = new FileStream(temporary, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                {
+                    stream.Write(content);
+                    stream.Flush(flushToDisk: true);
+                }
+                File.Move(temporary, path);
+                payloadFiles.Remove(temporary);
+                payloadFiles.Add(path, content.Length);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                StorageFailureCount++;
+                path = null;
+            }
+            finally
+            {
+                Delete(temporary);
+            }
+        }
+        entries.Add(new Entry(record, path, content.Length));
+        bytes += content.Length;
+        return path is not null || (!requireDurable && rootDirectory is null);
+    }
+
+    internal IReadOnlyList<RemoteDiagnosticRecord> Take(int count) => entries.Take(count).Select(entry => entry.Record).ToArray();
+
+    /// <summary>Retires acknowledged or explicitly rejected records; a failed delete remains replayable.</summary>
+    internal void Remove(IReadOnlyList<RemoteDiagnosticRecord> records)
+    {
+        var ids = records.Select(Id).ToHashSet();
+        for (int index = entries.Count - 1; index >= 0; index--)
+        {
+            if (!ids.Contains(Id(entries[index].Record))) continue;
+            Delete(entries[index].Path);
+            bytes -= entries[index].Bytes;
+            entries.RemoveAt(index);
+        }
+    }
+
+    /// <summary>Revocation deletes queued payloads, including recovered records.</summary>
+    internal void Clear()
+    {
+        foreach (FileStream lease in leases)
+        {
+            try
+            {
+                string marker = Path.Combine(Path.GetDirectoryName(lease.Name)!, ".revoked");
+                RejectLinks(marker);
+                using var stream = new FileStream(marker, FileMode.Create, FileAccess.Write, FileShare.Read);
+                stream.Flush(flushToDisk: true);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { StorageFailureCount++; }
+        }
+        Remove(Take(int.MaxValue));
+        foreach (string path in retiredFiles.ToArray()) Delete(path);
+        writerDirectory = null;
+        try { CreateWriter(); }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { StorageFailureCount++; }
+    }
+
+    private void CreateWriter()
+    {
+        if (rootDirectory is null) return;
+        string candidate = Path.Combine(rootDirectory, DateTime.UtcNow.Ticks.ToString("D19",
+            System.Globalization.CultureInfo.InvariantCulture) + "-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(candidate);
+        if (!TryLease(candidate)) throw new IOException("Cannot lease the log journal.");
+        writerDirectory = candidate;
+    }
+
+    private void RecoverTemporaryRecords(string directory)
+    {
+        foreach (string temporary in Directory.EnumerateFiles(directory, "*.json.tmp"))
+        {
+            string name = Path.GetFileName(temporary);
+            if (name.Length != 61 || name[19] != '-' || !name[..19].All(char.IsAsciiDigit) ||
+                !Guid.TryParseExact(name.Substring(20, 32), "N", out Guid expectedId)) continue;
+            try
+            {
+                RejectLinks(temporary);
+                if (new FileInfo(temporary).Length > maximumBytes) { DropFile(temporary); continue; }
+                RemoteDiagnosticRecord? record = JsonSerializer.Deserialize<RemoteDiagnosticRecord>(File.ReadAllBytes(temporary));
+                if (record is null || record.Body is null || record.Attributes is null ||
+                    !TryId(record, out Guid id) || id != expectedId) { DropFile(temporary); continue; }
+                _ = LogRecordFactory.SanitizePersistedRecord(record);
+                string target = temporary[..^4];
+                if (File.Exists(target)) Delete(temporary);
+                else
+                {
+                    File.Move(temporary, target);
+                    long size = payloadFiles[temporary];
+                    payloadFiles.Remove(temporary);
+                    payloadFiles.Add(target, size);
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or ArgumentException)
+            {
+                DropFile(temporary);
+            }
+        }
+    }
+
+    private void Trim(int incomingRecords = 0, long incomingBytes = 0)
+    {
+        while (entries.Count > maximumRecords - incomingRecords || bytes > maximumBytes - incomingBytes)
+        {
+            Entry entry = entries[0];
+            Delete(entry.Path);
+            bytes -= entry.Bytes;
+            entries.RemoveAt(0);
+            DroppedCount++;
+        }
+    }
+
+    private void DropFile(string path) { Delete(path); DroppedCount++; }
+
+    private void Delete(string? path)
+    {
+        if (path is null) return;
+        try
+        {
+            RejectLinks(path);
+            File.Delete(path);
+            payloadFiles.Remove(path);
+            retiredFiles.Remove(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            retiredFiles.Add(path);
+            StorageFailureCount++;
+        }
+    }
+
+    /// <summary>Charges inaccessible and abandoned payloads until their deletion actually succeeds.</summary>
+    private void AccountExistingFile(string path)
+    {
+        try
+        {
+            RejectLinks(path);
+            payloadFiles[path] = new FileInfo(path).Length;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Unknown size must not create apparent free space for more persistent writes.
+            payloadFiles[path] = maximumBytes;
+            StorageFailureCount++;
+        }
+    }
+
+    private bool CanPersist(int incomingBytes)
+    {
+        foreach (string path in retiredFiles.ToArray()) Delete(path);
+        long available = maximumBytes;
+        foreach (long size in payloadFiles.Values)
+        {
+            available -= Math.Min(available, size);
+        }
+        if (payloadFiles.Count < maximumRecords && available >= incomingBytes) return true;
+        StorageFailureCount++;
+        return false;
+    }
+
+    private static bool IsPayloadFile(string path) => path.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
+        || path.EndsWith(".json.tmp", StringComparison.OrdinalIgnoreCase);
+
+    private bool TryLease(string directory)
+    {
+        try
+        {
+            RejectLinks(directory);
+            string leasePath = Path.Combine(directory, ".lease");
+            RejectLinks(leasePath);
+            leases.Add(new FileStream(leasePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None));
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { return false; }
+    }
+
+    private static void RejectLinks(string path)
+    {
+        for (string? current = Path.GetFullPath(path); current is not null; current = Path.GetDirectoryName(current))
+        {
+            try
+            {
+                if ((File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
+                    throw new IOException("Log journal paths cannot contain links.");
+            }
+            catch (FileNotFoundException) { }
+            catch (DirectoryNotFoundException) { }
+        }
+    }
+
+    private static Guid Id(RemoteDiagnosticRecord record) => Guid.Parse(record.Attributes["diagnostics.record_id"].ToString()!);
+    private static bool TryId(RemoteDiagnosticRecord record, out Guid id)
+    {
+        id = Guid.Empty;
+        return record.Attributes.TryGetValue("diagnostics.record_id", out object? value) &&
+            Guid.TryParse(value?.ToString(), out id) && id != Guid.Empty;
+    }
+
+    public void Dispose()
+    {
+        foreach (FileStream lease in leases)
+        {
+            string directory = Path.GetDirectoryName(lease.Name)!;
+            lease.Dispose();
+            try
+            {
+                if (!Directory.EnumerateFiles(directory).Any(IsPayloadFile))
+                {
+                    File.Delete(Path.Combine(directory, ".lease"));
+                    File.Delete(Path.Combine(directory, ".revoked"));
+                    // Nonrecursive: never remove unexpected files or another process's new records.
+                    Directory.Delete(directory);
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { }
+        }
+        leases.Clear();
+    }
+
+    private sealed record Entry(RemoteDiagnosticRecord Record, string? Path, long Bytes);
+}

--- a/src/Foundry.Telemetry/IRemoteDiagnosticsService.cs
+++ b/src/Foundry.Telemetry/IRemoteDiagnosticsService.cs
@@ -22,7 +22,7 @@ public interface IRemoteDiagnosticsService : IAsyncDisposable
     void Disable();
 
     /// <summary>
-    /// Attempts to accept a log event without blocking the caller.
+    /// Captures a log locally for background delivery without waiting for network I/O.
     /// </summary>
     void Emit(LogEvent logEvent);
 

--- a/src/Foundry.Telemetry/LogRecordFactory.cs
+++ b/src/Foundry.Telemetry/LogRecordFactory.cs
@@ -1,0 +1,189 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+using Foundry.Utilities.Diagnostics;
+using Serilog.Events;
+using Serilog.Formatting.Display;
+
+namespace Foundry.Telemetry;
+
+/// <summary>Converts common log events into the full-fidelity Logs contract.</summary>
+public static class LogRecordFactory
+{
+    private static readonly MessageTemplateTextFormatter MessageFormatter = new("{Message:lj}", CultureInfo.InvariantCulture);
+
+    /// <summary>Revalidates persisted Logs without applying the separate Error Tracking whitelist.</summary>
+    public static RemoteDiagnosticRecord SanitizePersistedRecord(RemoteDiagnosticRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+        return record with
+        {
+            Body = LogSecretMasker.Mask(record.Body),
+            Attributes = MaskPersistedObject(record.Attributes.Select(entry =>
+                new KeyValuePair<string, JsonElement>(entry.Key, JsonSerializer.SerializeToElement(entry.Value)))),
+            Exception = MaskPersistedException(record.Exception),
+            ShouldTrackException = false
+        };
+    }
+
+    private static object? MaskPersistedValue(string name, JsonElement value)
+    {
+        if (LogSecretMasker.IsSecretName(name))
+        {
+            return LogSecretMasker.Redacted;
+        }
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.Object => MaskPersistedObject(value.EnumerateObject().Select(property =>
+                new KeyValuePair<string, JsonElement>(property.Name, property.Value))),
+            JsonValueKind.Array => value.EnumerateArray().Select(item => MaskPersistedValue(string.Empty, item)).ToArray(),
+            JsonValueKind.String => LogSecretMasker.Mask(value.GetString()!),
+            JsonValueKind.Number when value.TryGetInt64(out long number) => number,
+            JsonValueKind.Number when value.TryGetDecimal(out decimal number) => number,
+            JsonValueKind.Number => ConvertScalar(value.GetDouble()),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => null
+        };
+    }
+
+    private static RemoteDiagnosticException? MaskPersistedException(RemoteDiagnosticException? exception)
+    {
+        if (exception is null)
+        {
+            return null;
+        }
+        if (exception.Type is null || exception.Message is null || exception.InnerExceptions is null ||
+            exception.InnerExceptions.Any(child => child is null))
+        {
+            throw new JsonException("A persisted exception requires a type, message and valid child collection.");
+        }
+        return exception with
+        {
+            Type = LogSecretMasker.Mask(exception.Type),
+            Message = LogSecretMasker.Mask(exception.Message),
+            StackTrace = exception.StackTrace is { } stack ? LogSecretMasker.Mask(stack) : null,
+            InnerExceptions = exception.InnerExceptions.Select(child => MaskPersistedException(child)!).ToArray()
+        };
+    }
+
+    private static Dictionary<string, object> MaskPersistedObject(IEnumerable<KeyValuePair<string, JsonElement>> source)
+    {
+        var result = new Dictionary<string, object>(StringComparer.Ordinal);
+        foreach ((string name, JsonElement value) in source)
+        {
+            string masked = LogSecretMasker.Mask(name);
+            string key = masked;
+            int occurrence = 1;
+            while (result.ContainsKey(key))
+            {
+                key = masked + " [" + (++occurrence).ToString(CultureInfo.InvariantCulture) + "]";
+            }
+            result.Add(key, MaskPersistedValue(name, value)!);
+        }
+        return result;
+    }
+
+    /// <summary>Preserves original time, severity and structured properties for Logs export.</summary>
+    public static RemoteDiagnosticRecord Create(LogEvent logEvent, RemoteDiagnosticsContext context)
+    {
+        ArgumentNullException.ThrowIfNull(logEvent);
+        ArgumentNullException.ThrowIfNull(context);
+        LogEvent source = LogEventNormalizer.Normalize(logEvent);
+        var attributes = source.Properties.ToDictionary(property => property.Key,
+            property => ConvertValue(property.Value)!, StringComparer.Ordinal);
+        attributes["service.name"] = LogSecretMasker.Mask(context.App);
+        attributes["service.version"] = LogSecretMasker.Mask(context.AppVersion);
+        attributes["build.configuration"] = LogSecretMasker.Mask(context.BuildConfiguration);
+        attributes["runtime.name"] = LogSecretMasker.Mask(context.Runtime);
+        attributes["runtime.architecture"] = LogSecretMasker.Mask(context.RuntimeArchitecture);
+        attributes["locale"] = LogSecretMasker.Mask(context.Locale);
+        attributes["session.id"] = LogSecretMasker.Mask(context.SessionId);
+        attributes["service.release"] = LogSecretMasker.Mask(context.Release);
+        attributes["message_template.text"] = source.MessageTemplate.Text;
+        AddAlias(attributes, "SourceContext", "code.namespace");
+        AddAlias(attributes, "Component", "component");
+        AddAlias(attributes, "OperationId", "operation.id");
+        AddAlias(attributes, "ProcessStdout", "process.stdout");
+        AddAlias(attributes, "ProcessStderr", "process.stderr");
+        if (source.TraceId is { } traceId)
+        {
+            attributes["trace.id"] = traceId.ToString();
+        }
+        if (source.SpanId is { } spanId)
+        {
+            attributes["span.id"] = spanId.ToString();
+        }
+
+        using var message = new StringWriter(CultureInfo.InvariantCulture);
+        MessageFormatter.Format(source, message);
+        return new RemoteDiagnosticRecord(source.Timestamp, source.Level,
+            message.ToString(), attributes, ConvertException(source.Exception))
+        {
+            // Logs and Error Tracking have separate privacy and duplicate-suppression contracts.
+            ShouldTrackException = false
+        };
+    }
+
+    private static void AddAlias(Dictionary<string, object> attributes, string source, string destination)
+    {
+        if (attributes.TryGetValue(source, out object? value))
+        {
+            attributes[destination] = value;
+        }
+    }
+
+    private static object? ConvertValue(LogEventPropertyValue value)
+    {
+        return value switch
+        {
+            ScalarValue scalar => ConvertScalar(scalar.Value),
+            SequenceValue sequence => sequence.Elements.Select(ConvertValue).ToArray(),
+            StructureValue structure => structure.Properties.ToDictionary(property => property.Name,
+                property => ConvertValue(property.Value), StringComparer.Ordinal),
+            DictionaryValue dictionary => dictionary.Elements.ToDictionary(entry =>
+                Convert.ToString(entry.Key.Value, CultureInfo.InvariantCulture) ?? "null",
+                entry => ConvertValue(entry.Value), StringComparer.Ordinal),
+            _ => LogSecretMasker.Mask(value.ToString())
+        };
+    }
+
+    private static object? ConvertScalar(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            string or bool or byte or sbyte or short or ushort or int or uint or long or ulong or decimal => value,
+            float number when float.IsFinite(number) => number,
+            double number when double.IsFinite(number) => number,
+            DateTime time => time.ToString("O", CultureInfo.InvariantCulture),
+            DateTimeOffset time => time.ToString("O", CultureInfo.InvariantCulture),
+            byte[] bytes => Convert.ToBase64String(bytes),
+            _ => LogSecretMasker.Mask(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty)
+        };
+    }
+
+    private static RemoteDiagnosticException? ConvertException(Exception? exception)
+    {
+        if (exception is null)
+        {
+            return null;
+        }
+
+        IEnumerable<Exception> children = exception switch
+        {
+            LogExceptionSnapshot snapshot => snapshot.InnerExceptions,
+            AggregateException aggregate => aggregate.InnerExceptions,
+            { InnerException: { } inner } => [inner],
+            _ => []
+        };
+        return new RemoteDiagnosticException(
+            exception is LogExceptionSnapshot safe ? safe.OriginalType : exception.GetType().FullName ?? exception.GetType().Name,
+            exception.Message, exception.StackTrace, children.Select(child => ConvertException(child)!).ToArray());
+    }
+}

--- a/src/Foundry.Telemetry/LogRecordFactory.cs
+++ b/src/Foundry.Telemetry/LogRecordFactory.cs
@@ -146,11 +146,25 @@ public static class LogRecordFactory
             SequenceValue sequence => sequence.Elements.Select(ConvertValue).ToArray(),
             StructureValue structure => structure.Properties.ToDictionary(property => property.Name,
                 property => ConvertValue(property.Value), StringComparer.Ordinal),
-            DictionaryValue dictionary => dictionary.Elements.ToDictionary(entry =>
-                Convert.ToString(entry.Key.Value, CultureInfo.InvariantCulture) ?? "null",
-                entry => ConvertValue(entry.Value), StringComparer.Ordinal),
+            DictionaryValue dictionary => ConvertDictionary(dictionary),
             _ => LogSecretMasker.Mask(value.ToString())
         };
+    }
+
+    private static Dictionary<string, object?> ConvertDictionary(DictionaryValue dictionary)
+    {
+        var result = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach ((ScalarValue key, LogEventPropertyValue value) in dictionary.Elements)
+        {
+            string name = Convert.ToString(key.Value, CultureInfo.InvariantCulture) ?? "null";
+            string uniqueName = name;
+            int occurrence = 1;
+            // OTLP/JSON map keys are strings; distinct scalar keys can have the same text.
+            while (result.ContainsKey(uniqueName))
+                uniqueName = name + " [" + (++occurrence).ToString(CultureInfo.InvariantCulture) + "]";
+            result.Add(uniqueName, ConvertValue(value));
+        }
+        return result;
     }
 
     private static object? ConvertScalar(object? value)

--- a/src/Foundry.Telemetry/OtlpLogTransport.cs
+++ b/src/Foundry.Telemetry/OtlpLogTransport.cs
@@ -1,0 +1,321 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Google.Protobuf;
+using Serilog;
+using Serilog.Events;
+using Serilog.Parsing;
+using Serilog.Sinks.OpenTelemetry;
+
+namespace Foundry.Telemetry;
+
+/// <summary>
+/// Distinguishes terminal acknowledgments from requests that must remain in durable storage.
+/// </summary>
+internal enum LogBatchDisposition
+{
+    Accepted,
+    Retry,
+    Rejected,
+    /// <summary>
+    /// No records were accepted; retry fewer records to fit the collector's request size limit.
+    /// </summary>
+    Split
+}
+
+/// <summary>
+/// A rejected result retires the entire batch: OTLP does not identify individual rejected records.
+/// </summary>
+internal sealed record LogBatchResult(
+    LogBatchDisposition Disposition,
+    long RejectedRecordCount = 0,
+    TimeSpan? RetryAfter = null);
+
+/// <summary>
+/// Sends an already persisted batch and reports the collector's response, without hidden retries or queues.
+/// </summary>
+internal interface ILogBatchTransport : IDisposable
+{
+    /// <summary>
+    /// Returns only after the server responds; cancellation never acknowledges the batch.
+    /// </summary>
+    Task<LogBatchResult> SendAsync(IReadOnlyList<RemoteDiagnosticRecord> records, CancellationToken token);
+}
+
+/// <summary>
+/// Uses Serilog's OTLP serializer with an acknowledged HTTP transport controlled by the durable queue.
+/// </summary>
+internal sealed class OtlpLogTransport : ILogBatchTransport
+{
+    private static readonly string[] ResourceAttributeNames =
+    [
+        "service.name", "service.version", "service.release", "runtime.name", "runtime.architecture"
+    ];
+
+    private readonly HttpClient _client;
+    private readonly Uri _endpoint;
+    private readonly RemoteDiagnosticsContext _context;
+
+    /// <summary>
+    /// Creates a bounded HTTP client; redirects are disabled to keep credentials on the configured host.
+    /// </summary>
+    internal OtlpLogTransport(RemoteDiagnosticsOptions options, RemoteDiagnosticsContext context, HttpMessageHandler? handler = null)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(context);
+        if (!options.CanSend)
+        {
+            throw new ArgumentException("Enabled diagnostics and a valid HTTPS endpoint are required.", nameof(options));
+        }
+        _endpoint = new Uri(options.HostUrl.TrimEnd('/') + "/i/v1/logs", UriKind.Absolute);
+        _context = context;
+        _client = new HttpClient(handler ?? new SocketsHttpHandler { AllowAutoRedirect = false })
+        {
+            Timeout = TimeSpan.FromSeconds(15),
+            MaxResponseContentBufferSize = 64 * 1024
+        };
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", options.ProjectToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<LogBatchResult> SendAsync(IReadOnlyList<RemoteDiagnosticRecord> records, CancellationToken token)
+    {
+        ArgumentNullException.ThrowIfNull(records);
+        token.ThrowIfCancellationRequested();
+        if (records.Count == 0)
+        {
+            return new LogBatchResult(LogBatchDisposition.Accepted);
+        }
+
+        byte[] payload = Serialize(records, token);
+        using var request = new HttpRequestMessage(HttpMethod.Post, _endpoint)
+        {
+            Content = new ByteArrayContent(payload)
+        };
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/x-protobuf");
+        try
+        {
+            using HttpResponseMessage response = await _client.SendAsync(request, token).ConfigureAwait(false);
+            if (response.StatusCode == HttpStatusCode.RequestEntityTooLarge && records.Count > 1)
+            {
+                return new LogBatchResult(LogBatchDisposition.Split);
+            }
+            if (response.StatusCode == HttpStatusCode.RequestTimeout ||
+                response.StatusCode == HttpStatusCode.TooManyRequests || (int)response.StatusCode >= 500)
+            {
+                return new LogBatchResult(LogBatchDisposition.Retry, RetryAfter: GetRetryAfter(response));
+            }
+            if (!response.IsSuccessStatusCode)
+            {
+                return new LogBatchResult(LogBatchDisposition.Rejected, records.Count);
+            }
+
+            byte[] body = await response.Content.ReadAsByteArrayAsync(token).ConfigureAwait(false);
+            // PostHog currently returns application/json, even for protobuf requests. Other OTLP
+            // collectors return protobuf; support both without mistaking malformed responses for receipts.
+            long rejected = string.Equals(response.Content.Headers.ContentType?.MediaType, "application/json", StringComparison.OrdinalIgnoreCase)
+                ? ReadJsonRejectedCount(body) : ReadRejectedCount(body);
+            if (rejected < 0 || rejected > records.Count)
+            {
+                return new LogBatchResult(LogBatchDisposition.Retry);
+            }
+            return rejected == 0
+                ? new LogBatchResult(LogBatchDisposition.Accepted)
+                : new LogBatchResult(LogBatchDisposition.Rejected, rejected);
+        }
+        catch (HttpRequestException)
+        {
+            return new LogBatchResult(LogBatchDisposition.Retry);
+        }
+        catch (OperationCanceledException) when (!token.IsCancellationRequested)
+        {
+            return new LogBatchResult(LogBatchDisposition.Retry);
+        }
+        catch (InvalidProtocolBufferException)
+        {
+            // A malformed response cannot prove acceptance. Stable event IDs identify possible replay duplicates.
+            return new LogBatchResult(LogBatchDisposition.Retry);
+        }
+        catch (JsonException)
+        {
+            return new LogBatchResult(LogBatchDisposition.Retry);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => _client.Dispose();
+
+    private byte[] Serialize(IReadOnlyList<RemoteDiagnosticRecord> records, CancellationToken token)
+    {
+        using var batch = new MemoryStream();
+        foreach (RemoteDiagnosticRecord record in records)
+        {
+            token.ThrowIfCancellationRequested();
+            using var capture = new SerializationHandler(batch);
+            using Serilog.Core.Logger serializer = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .AuditTo.OpenTelemetry(options =>
+                {
+                    options.LogsEndpoint = _endpoint.ToString();
+                    options.Protocol = OtlpProtocol.HttpProtobuf;
+                    options.HttpMessageHandler = capture;
+                    options.ResourceAttributes = CreateResourceAttributes(record);
+                    options.IncludedData = IncludedData.SpecRequiredResourceAttributes;
+                })
+                .CreateLogger();
+            serializer.Write(CreateLogEvent(record));
+        }
+        // ExportLogsServiceRequest contains only repeated resource_logs (field 1). Protobuf concatenation
+        // merges repeated fields, preserving the package's encoding and each record's original resource.
+        return batch.ToArray();
+    }
+
+    private Dictionary<string, object> CreateResourceAttributes(RemoteDiagnosticRecord record)
+    {
+        var attributes = new Dictionary<string, object>(StringComparer.Ordinal)
+        {
+            ["service.name"] = _context.App,
+            ["service.version"] = _context.AppVersion,
+            ["service.release"] = _context.Release,
+            ["runtime.name"] = _context.Runtime,
+            ["runtime.architecture"] = _context.RuntimeArchitecture
+        };
+        foreach (string name in ResourceAttributeNames)
+        {
+            if (record.Attributes.TryGetValue(name, out object? value))
+            {
+                attributes[name] = value is JsonElement json ? json.ToString() : value;
+            }
+        }
+        return attributes;
+    }
+
+    private static LogEvent CreateLogEvent(RemoteDiagnosticRecord record)
+    {
+        var properties = record.Attributes
+            .Where(attribute => !ResourceAttributeNames.Contains(attribute.Key, StringComparer.Ordinal))
+            .Select(attribute => new LogEventProperty(attribute.Key, ConvertValue(attribute.Value)))
+            .ToDictionary(property => property.Name, StringComparer.Ordinal);
+        if (record.Exception is not null)
+        {
+            properties["exception.type"] = new LogEventProperty("exception.type", new ScalarValue(record.Exception.Type));
+            properties["exception.message"] = new LogEventProperty("exception.message", new ScalarValue(record.Exception.Message));
+            if (!string.IsNullOrEmpty(record.Exception.StackTrace))
+            {
+                properties["exception.stacktrace"] = new LogEventProperty("exception.stacktrace", new ScalarValue(record.Exception.StackTrace));
+            }
+            if (record.Exception.InnerExceptions.Count > 0)
+            {
+                properties["exception.inner_exceptions"] = new LogEventProperty("exception.inner_exceptions",
+                    ConvertValue(JsonSerializer.SerializeToElement(record.Exception.InnerExceptions)));
+            }
+        }
+        var template = new MessageTemplateParser().Parse(record.Body
+            .Replace("{", "{{", StringComparison.Ordinal).Replace("}", "}}", StringComparison.Ordinal));
+        return new LogEvent(record.Timestamp, record.Level, null, template, properties.Values);
+    }
+
+    private static LogEventPropertyValue ConvertValue(object? value) => value switch
+    {
+        JsonElement json => ConvertJson(json),
+        LogEventPropertyValue property => property,
+        IReadOnlyDictionary<string, object> dictionary => new DictionaryValue(dictionary.Select(pair =>
+            new KeyValuePair<ScalarValue, LogEventPropertyValue>(new ScalarValue(pair.Key), ConvertValue(pair.Value)))),
+        IDictionary dictionary => new DictionaryValue(dictionary.Cast<DictionaryEntry>().Select(pair =>
+            new KeyValuePair<ScalarValue, LogEventPropertyValue>(new ScalarValue(pair.Key), ConvertValue(pair.Value)))),
+        string => new ScalarValue(value),
+        IEnumerable sequence => new SequenceValue(sequence.Cast<object?>().Select(ConvertValue)),
+        _ => new ScalarValue(value)
+    };
+
+    private static LogEventPropertyValue ConvertJson(JsonElement value) => value.ValueKind switch
+    {
+        JsonValueKind.Object => new DictionaryValue(value.EnumerateObject().Select(property =>
+            new KeyValuePair<ScalarValue, LogEventPropertyValue>(new ScalarValue(property.Name), ConvertJson(property.Value)))),
+        JsonValueKind.Array => new SequenceValue(value.EnumerateArray().Select(ConvertJson)),
+        JsonValueKind.String => new ScalarValue(value.GetString()),
+        JsonValueKind.Number => value.TryGetInt64(out long integer) ? new ScalarValue(integer) : new ScalarValue(value.GetDouble()),
+        JsonValueKind.True => new ScalarValue(true),
+        JsonValueKind.False => new ScalarValue(false),
+        _ => new ScalarValue(null)
+    };
+
+    private static TimeSpan? GetRetryAfter(HttpResponseMessage response)
+    {
+        RetryConditionHeaderValue? retry = response.Headers.RetryAfter;
+        TimeSpan? delay = retry?.Delta ?? (retry?.Date is { } date ? date - DateTimeOffset.UtcNow : null);
+        return delay is { } value && value < TimeSpan.Zero ? TimeSpan.Zero : delay;
+    }
+
+    private static long ReadRejectedCount(byte[] body)
+    {
+        using var input = new CodedInputStream(body);
+        long rejected = 0;
+        uint tag;
+        while ((tag = input.ReadTag()) != 0)
+        {
+            if (tag != 10)
+            {
+                input.SkipLastField();
+                continue;
+            }
+            // ExportLogsServiceResponse.partial_success (field 1), rejected_log_records (field 1).
+            using var partial = new CodedInputStream(input.ReadBytes().ToByteArray());
+            uint partialTag;
+            while ((partialTag = partial.ReadTag()) != 0)
+            {
+                if (partialTag == 8)
+                {
+                    rejected = partial.ReadInt64();
+                }
+                else
+                {
+                    partial.SkipLastField();
+                }
+            }
+        }
+        return rejected;
+    }
+
+    private static long ReadJsonRejectedCount(byte[] body)
+    {
+        using JsonDocument document = JsonDocument.Parse(body);
+        JsonElement root = document.RootElement;
+        if (root.ValueKind != JsonValueKind.Object || root.TryGetProperty("error", out _))
+            throw new JsonException("The response is not an OTLP acknowledgment.");
+        if (!root.TryGetProperty("partialSuccess", out JsonElement partial) &&
+            !root.TryGetProperty("partial_success", out partial)) return 0;
+        if (partial.ValueKind != JsonValueKind.Object)
+            throw new JsonException("The response has an invalid partial-success object.");
+        if (!partial.TryGetProperty("rejectedLogRecords", out JsonElement rejected) &&
+            !partial.TryGetProperty("rejected_log_records", out rejected)) return 0;
+        if (rejected.ValueKind == JsonValueKind.Number && rejected.TryGetInt64(out long count)) return count;
+        if (rejected.ValueKind == JsonValueKind.String &&
+            long.TryParse(rejected.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out count)) return count;
+        throw new JsonException("The response has an invalid rejected-log count.");
+    }
+
+    /// <summary>
+    /// Captures the sink's supported synchronous audit serialization without performing network I/O.
+    /// </summary>
+    private sealed class SerializationHandler(Stream destination) : HttpMessageHandler
+    {
+        protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            using (request)
+            {
+                request.Content!.CopyTo(destination, null, cancellationToken);
+            }
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(Send(request, cancellationToken));
+    }
+}

--- a/src/Foundry.Telemetry/OtlpLogTransport.cs
+++ b/src/Foundry.Telemetry/OtlpLogTransport.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using Google.Protobuf;
+using Foundry.Utilities.Diagnostics;
 using Serilog;
 using Serilog.Events;
 using Serilog.Parsing;
@@ -218,7 +219,19 @@ internal sealed class OtlpLogTransport : ILogBatchTransport
         }
         var template = new MessageTemplateParser().Parse(record.Body
             .Replace("{", "{{", StringComparison.Ordinal).Replace("}", "}}", StringComparison.Ordinal));
-        return new LogEvent(record.Timestamp, record.Level, null, template, properties.Values);
+        bool useIngestionTime = properties.TryGetValue(DiagnosticClock.SynchronizedProperty, out LogEventProperty? clock) &&
+            clock.Value is ScalarValue { Value: false };
+        if (useIngestionTime)
+        {
+            properties.TryAdd(DiagnosticClock.OriginalTimestampProperty, new LogEventProperty(
+                DiagnosticClock.OriginalTimestampProperty, new ScalarValue(record.Timestamp.ToString("O", CultureInfo.InvariantCulture))));
+            properties[DiagnosticClock.TimestampSourceProperty] = new LogEventProperty(
+                DiagnosticClock.TimestampSourceProperty, new ScalarValue("ingestion"));
+        }
+        // UnixEpoch serializes as OTLP time_unix_nano=0: PostHog assigns its receipt time.
+        // The durable record and local event retain the original time and captured clock state.
+        return new LogEvent(useIngestionTime ? DateTimeOffset.UnixEpoch : record.Timestamp,
+            record.Level, null, template, properties.Values);
     }
 
     private static LogEventPropertyValue ConvertValue(object? value) => value switch

--- a/src/Foundry.Telemetry/PostHogRemoteDiagnosticsSink.cs
+++ b/src/Foundry.Telemetry/PostHogRemoteDiagnosticsSink.cs
@@ -47,7 +47,7 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
     /// Initializes a production PostHog diagnostics service.
     /// </summary>
     public PostHogRemoteDiagnosticsSink()
-        : this(static (options, context) => new PostHogDiagnosticsExporter(options, context), DefaultQueueCapacity)
+        : this(static (options, _) => new PostHogDiagnosticsExporter(options), DefaultQueueCapacity)
     {
         _productionLogs = true;
     }
@@ -423,7 +423,7 @@ internal sealed class PostHogDiagnosticsExporter : IRemoteDiagnosticsExporter
     private readonly PostHogExceptionTracker _exceptionTracker;
     private int _disposed;
 
-    public PostHogDiagnosticsExporter(RemoteDiagnosticsOptions options, RemoteDiagnosticsContext context)
+    public PostHogDiagnosticsExporter(RemoteDiagnosticsOptions options)
     {
         var client = new PostHogClient(Options.Create(new PostHogOptions
         {

--- a/src/Foundry.Telemetry/PostHogRemoteDiagnosticsSink.cs
+++ b/src/Foundry.Telemetry/PostHogRemoteDiagnosticsSink.cs
@@ -5,17 +5,15 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
+using Foundry.Utilities.Diagnostics;
 using Microsoft.Extensions.Options;
 using PostHog;
-using Serilog;
 using Serilog.Events;
-using Serilog.Parsing;
-using Serilog.Sinks.OpenTelemetry;
 
 namespace Foundry.Telemetry;
 
 /// <summary>
-/// Sanitizes and queues eligible log events for best-effort PostHog delivery.
+/// Captures complete Logs independently from the conservative, rate-limited Error Tracking channel.
 /// </summary>
 public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, IDisposable
 {
@@ -27,6 +25,11 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
     private readonly Func<RemoteDiagnosticsOptions, RemoteDiagnosticsContext, IRemoteDiagnosticsExporter> _exporterFactory;
     private readonly int _queueCapacity;
     private readonly Action<RemoteDiagnosticRecord>? _capture;
+    private readonly Action<RemoteDiagnosticRecord>? _logCapture;
+    private readonly bool _productionLogs;
+    private ReliableLogPipeline? _logs;
+    private RemoteDiagnosticsOptions? _configuredOptions;
+    private readonly List<Task> _retired = [];
     private readonly TimeProvider _timeProvider;
     private ConditionalWeakTable<Exception, ExceptionDedupeState> _seenExceptions = new();
     private readonly Dictionary<string, FingerprintWindowState> _fingerprints = new(StringComparer.Ordinal);
@@ -46,18 +49,21 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
     public PostHogRemoteDiagnosticsSink()
         : this(static (options, context) => new PostHogDiagnosticsExporter(options, context), DefaultQueueCapacity)
     {
+        _productionLogs = true;
     }
 
     internal PostHogRemoteDiagnosticsSink(
         Func<RemoteDiagnosticsOptions, RemoteDiagnosticsContext, IRemoteDiagnosticsExporter> exporterFactory,
         int queueCapacity = DefaultQueueCapacity,
         TimeProvider? timeProvider = null,
-        Action<RemoteDiagnosticRecord>? capture = null)
+        Action<RemoteDiagnosticRecord>? capture = null,
+        Action<RemoteDiagnosticRecord>? logCapture = null)
     {
         ArgumentNullException.ThrowIfNull(exporterFactory);
         ArgumentOutOfRangeException.ThrowIfLessThan(queueCapacity, 1);
         _exporterFactory = exporterFactory;
         _capture = capture;
+        _logCapture = logCapture;
         _queueCapacity = queueCapacity;
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
@@ -69,8 +75,14 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(context);
+        options = options with { LogDirectory = options.LogDirectory ?? RemoteDiagnosticsSink.LogDirectory };
         if (!options.CanSend || Volatile.Read(ref _stopping) != 0)
         {
+            if (_productionLogs && _logs is null && !options.IsEnabled)
+            {
+                using var pending = new DurableLogQueue(RemoteLogStorage.Resolve(options, context));
+                pending.Clear();
+            }
             Disable();
             return;
         }
@@ -84,14 +96,27 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
 
             if (_exporter is not null)
             {
-                Volatile.Write(ref _accepting, 1);
-                return;
+                if (_configuredOptions == options)
+                {
+                    _context = context;
+                    _logs?.Enable();
+                    Volatile.Write(ref _accepting, 1);
+                    return;
+                }
+                Disable();
+                _channel?.Writer.TryComplete();
+                _retired.Add(RetireAsync(_worker, _logs, _exporter));
+                _logs = null;
+                _exporter = null;
             }
 
             try
             {
                 _exporter = _exporterFactory(options, context);
                 _context = context;
+                _configuredOptions = options;
+                if (_productionLogs)
+                    _logs = new ReliableLogPipeline(new OtlpLogTransport(options, context), RemoteLogStorage.Resolve(options, context));
                 _channel = Channel.CreateBounded<QueuedRemoteDiagnosticRecord>(new BoundedChannelOptions(_queueCapacity)
                 {
                     FullMode = BoundedChannelFullMode.Wait,
@@ -124,6 +149,7 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
             Interlocked.Increment(ref _consentGeneration);
             _fingerprints.Clear();
             _seenExceptions = new ConditionalWeakTable<Exception, ExceptionDedupeState>();
+            _logs?.Disable();
         }
     }
 
@@ -131,6 +157,23 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
     public void Emit(LogEvent logEvent)
     {
         ArgumentNullException.ThrowIfNull(logEvent);
+        if (Volatile.Read(ref _stopping) != 0 || HasTrueScalar(logEvent, "PostHogTransportInternal")) return;
+        try
+        {
+            lock (_gate)
+            {
+                if (!HasTrueScalar(logEvent, "RemoteDiagnosticsInternal") &&
+                    Volatile.Read(ref _accepting) != 0 && _context is not null && (_logs is not null || _logCapture is not null))
+                {
+                    RemoteDiagnosticRecord log = LogRecordFactory.Create(logEvent, _context);
+                    _logs?.Emit(log);
+                    _logCapture?.Invoke(log);
+                }
+            }
+        }
+#pragma warning disable CA1031 // Local storage/serialization failures must not suppress independent error tracking.
+        catch (Exception ex) { Debug.WriteLine($"Log capture failed: {ex.GetType().Name}"); }
+#pragma warning restore CA1031
         if (Volatile.Read(ref _stopping) != 0 || !ShouldExport(logEvent))
         {
             return;
@@ -217,6 +260,8 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
             _channel?.Writer.TryComplete();
         }
 
+        if (_logs is not null) await _logs.FlushAsync(cancellationToken).ConfigureAwait(false);
+
         await _worker.WaitAsync(cancellationToken).ConfigureAwait(false);
         if (_exporter is not null)
         {
@@ -254,6 +299,8 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
                 Debug.WriteLine($"Remote diagnostics disposal failed: {ex.GetType().Name}");
             }
         }
+        if (_logs is not null) await _logs.DisposeAsync().ConfigureAwait(false);
+        await Task.WhenAll(_retired).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -261,19 +308,24 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
     /// </summary>
     public void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();
 
+    private static async Task RetireAsync(Task worker, ReliableLogPipeline? logs, IRemoteDiagnosticsExporter exporter)
+    {
+        try
+        {
+            if (logs is not null) await logs.DisposeAsync().ConfigureAwait(false);
+            await worker.ConfigureAwait(false);
+            await exporter.DisposeAsync().ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Superseded diagnostics cannot interrupt settings changes.
+        catch (Exception ex) { Debug.WriteLine($"Retired diagnostics disposal failed: {ex.GetType().Name}"); }
+#pragma warning restore CA1031
+    }
+
     private static bool ShouldExport(LogEvent logEvent)
     {
-        if (HasTrueScalar(logEvent, "RemoteDiagnosticsInternal"))
-        {
-            return false;
-        }
-
-        return logEvent.Level switch
-        {
-            LogEventLevel.Fatal or LogEventLevel.Error or LogEventLevel.Warning => true,
-            LogEventLevel.Information => HasTrueScalar(logEvent, "RemoteDiagnostic"),
-            _ => false
-        };
+        return logEvent.Exception is not null && logEvent.Level >= LogEventLevel.Error
+            && !HasTrueScalar(logEvent, "RemoteDiagnosticsInternal")
+            && !HasTrueScalar(logEvent, "PostHogTransportInternal");
     }
 
     private static bool HasTrueScalar(LogEvent logEvent, string propertyName) =>
@@ -282,12 +334,8 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
 
     private bool TryAcquireFingerprint(LogEvent logEvent)
     {
-        if (HasTrueScalar(logEvent, "RemoteDiagnosticTerminal"))
-        {
-            return true;
-        }
-
-        string exceptionType = logEvent.Exception?.GetType().FullName ?? string.Empty;
+        string exceptionType = logEvent.Exception is LogExceptionSnapshot snapshot
+            ? snapshot.OriginalType : logEvent.Exception?.GetType().FullName ?? string.Empty;
         string failureCode = GetScalarText(logEvent, "FailureCode");
         if (string.IsNullOrEmpty(failureCode))
         {
@@ -368,51 +416,16 @@ public sealed class PostHogRemoteDiagnosticsSink : IRemoteDiagnosticsService, ID
     }
 }
 
+/// <summary>Exports the conservative Error Tracking contract; Logs use acknowledged OTLP delivery.</summary>
 internal sealed class PostHogDiagnosticsExporter : IRemoteDiagnosticsExporter
 {
-    private static readonly HashSet<string> ResourceAttributeNames = new(StringComparer.Ordinal)
-    {
-        "service.name",
-        "service.version",
-        "service.release",
-        "runtime.name",
-        "runtime.architecture"
-    };
-
-    private readonly Serilog.ILogger _logExporter;
     private readonly IPostHogEventClient _eventClient;
     private readonly PostHogExceptionTracker _exceptionTracker;
-    private int _logExporterDisposed;
     private int _disposed;
 
     public PostHogDiagnosticsExporter(RemoteDiagnosticsOptions options, RemoteDiagnosticsContext context)
     {
-        string logsEndpoint = options.HostUrl.TrimEnd('/') + "/i/v1/logs";
-        _logExporter = new LoggerConfiguration()
-            .WriteTo.OpenTelemetry(configuration =>
-            {
-                configuration.LogsEndpoint = logsEndpoint;
-                configuration.Protocol = OtlpProtocol.HttpProtobuf;
-                configuration.Headers = new Dictionary<string, string>(StringComparer.Ordinal)
-                {
-                    ["Authorization"] = $"Bearer {options.ProjectToken}"
-                };
-                configuration.ResourceAttributes = new Dictionary<string, object>(StringComparer.Ordinal)
-                {
-                    ["service.name"] = RemoteDiagnosticPropertyPolicy.SanitizeResourceValue(context.App),
-                    ["service.version"] = RemoteDiagnosticPropertyPolicy.SanitizeResourceValue(context.AppVersion),
-                    ["service.release"] = RemoteDiagnosticPropertyPolicy.SanitizeResourceValue(context.Release),
-                    ["runtime.name"] = RemoteDiagnosticPropertyPolicy.SanitizeResourceValue(context.Runtime),
-                    ["runtime.architecture"] = RemoteDiagnosticPropertyPolicy.SanitizeResourceValue(context.RuntimeArchitecture)
-                };
-                configuration.IncludedData = IncludedData.SpecRequiredResourceAttributes;
-                configuration.BatchingOptions.BatchSizeLimit = 50;
-                configuration.BatchingOptions.QueueLimit = 256;
-                configuration.BatchingOptions.BufferingTimeLimit = TimeSpan.FromSeconds(2);
-            }, ignoreEnvironment: true)
-            .CreateLogger();
-
-        var postHogClient = new PostHogClient(Options.Create(new PostHogOptions
+        var client = new PostHogClient(Options.Create(new PostHogOptions
         {
             ProjectToken = options.ProjectToken,
             HostUrl = new Uri(options.HostUrl, UriKind.Absolute),
@@ -422,79 +435,24 @@ internal sealed class PostHogDiagnosticsExporter : IRemoteDiagnosticsExporter
             FlushAt = 20,
             FlushInterval = TimeSpan.FromSeconds(5)
         }));
-        _eventClient = new PostHogEventClient(postHogClient);
+        _eventClient = new PostHogEventClient(client);
         _exceptionTracker = new PostHogExceptionTracker(_eventClient, options.InstallId);
     }
 
     public ValueTask ExportAsync(RemoteDiagnosticRecord record, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        ExportLog(record);
         ExportException(record);
         return ValueTask.CompletedTask;
     }
 
-    internal void ExportLog(RemoteDiagnosticRecord record) => _logExporter.Write(CreateLogEvent(record));
-
     internal void ExportException(RemoteDiagnosticRecord record) => _exceptionTracker.Track(record);
 
-    internal static LogEvent CreateLogEvent(RemoteDiagnosticRecord record)
-    {
-        var properties = new List<LogEventProperty>(record.Attributes.Count + 3);
-        properties.AddRange(record.Attributes
-            .Where(static attribute => !ResourceAttributeNames.Contains(attribute.Key))
-            .Select(static attribute =>
-                new LogEventProperty(attribute.Key, new ScalarValue(attribute.Value))));
-        if (record.Exception is not null)
-        {
-            properties.Add(new LogEventProperty("exception.type", new ScalarValue(record.Exception.Type)));
-            if (!string.Equals(record.Exception.Message, record.Body, StringComparison.Ordinal))
-            {
-                properties.Add(new LogEventProperty("exception.message", new ScalarValue(record.Exception.Message)));
-            }
-
-            if (!string.IsNullOrWhiteSpace(record.Exception.StackTrace))
-            {
-                properties.Add(new LogEventProperty("exception.stacktrace", new ScalarValue(record.Exception.StackTrace)));
-            }
-        }
-
-        return new LogEvent(
-            record.Timestamp,
-            record.Level,
-            exception: null,
-            CreateLiteralMessageTemplate(record.Body),
-            properties);
-    }
-
-    private static MessageTemplate CreateLiteralMessageTemplate(string message) =>
-        new MessageTemplateParser().Parse(
-            message
-                .Replace("{", "{{", StringComparison.Ordinal)
-                .Replace("}", "}}", StringComparison.Ordinal));
-
-    public async Task FlushAsync(CancellationToken cancellationToken)
-    {
-        await Task.Run(DisposeLogExporter).WaitAsync(cancellationToken).ConfigureAwait(false);
-        await _eventClient.FlushAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task FlushAsync(CancellationToken cancellationToken) => _eventClient.FlushAsync().WaitAsync(cancellationToken);
 
     public async ValueTask DisposeAsync()
     {
-        if (Interlocked.Exchange(ref _disposed, 1) != 0)
-        {
-            return;
-        }
-
-        DisposeLogExporter();
-        await _eventClient.DisposeAsync().ConfigureAwait(false);
-    }
-
-    private void DisposeLogExporter()
-    {
-        if (Interlocked.Exchange(ref _logExporterDisposed, 1) == 0 && _logExporter is IDisposable disposable)
-        {
-            disposable.Dispose();
-        }
+        if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            await _eventClient.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/src/Foundry.Telemetry/ReliableLogPipeline.cs
+++ b/src/Foundry.Telemetry/ReliableLogPipeline.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Serilog;
+
+namespace Foundry.Telemetry;
+
+/// <summary>
+/// Persists logs before background delivery and retires them only after a terminal transport result.
+/// Consent revocation discards pending data. Network operations never run on the logging thread.
+/// </summary>
+internal sealed class ReliableLogPipeline : IAsyncDisposable
+{
+    private readonly object gate = new();
+    private readonly DurableLogQueue queue;
+    private readonly ILogBatchTransport transport;
+    private readonly CancellationTokenSource lifetime = new();
+    private readonly SemaphoreSlim signal = new(0, 1);
+    private readonly TimeSpan interval;
+    private Task? worker;
+    private bool enabled = true;
+    private bool stopping;
+    private bool disposed;
+    private CancellationTokenSource? activeRequest;
+    private int consentGeneration;
+    private long rejected;
+    private long reportedLosses;
+    private long reportedStorageFailures;
+
+    internal ReliableLogPipeline(ILogBatchTransport transport, string? directory, bool startDelivery = true,
+        TimeSpan? interval = null)
+    {
+        this.transport = transport;
+        queue = new DurableLogQueue(directory);
+        this.interval = interval ?? TimeSpan.FromSeconds(2);
+        if (startDelivery) StartDelivery();
+    }
+
+    internal int PendingCount { get { lock (gate) return queue.Count; } }
+    internal IReadOnlyList<RemoteDiagnosticRecord> PendingRecords { get { lock (gate) return queue.Take(int.MaxValue); } }
+
+    internal void Emit(RemoteDiagnosticRecord record)
+    {
+        lock (gate)
+        {
+            if (!enabled || stopping) return;
+            queue.Add(record);
+        }
+    }
+
+    /// <summary>Transfers recovered evidence only when it is safely accepted by this journal.</summary>
+    internal bool TryImport(RemoteDiagnosticRecord record, bool requireDurable = true)
+    {
+        lock (gate) return enabled && !stopping && queue.Add(record, requireDurable);
+    }
+
+    internal void StartDelivery()
+    {
+        lock (gate) worker ??= Task.Run(DeliverAsync);
+    }
+
+    internal void Disable()
+    {
+        lock (gate)
+        {
+            enabled = false;
+            consentGeneration++;
+            activeRequest?.Cancel();
+            queue.Clear();
+        }
+    }
+
+    internal void Enable() { lock (gate) enabled = true; }
+
+    private async Task DeliverAsync()
+    {
+        TimeSpan delay = interval;
+        int failures = 0;
+        int batchSize = 100;
+        try
+        {
+            while (!lifetime.IsCancellationRequested)
+            {
+                await signal.WaitAsync(delay, lifetime.Token).ConfigureAwait(false);
+                IReadOnlyList<RemoteDiagnosticRecord> batch;
+                int generation;
+                lock (gate)
+                {
+                    generation = consentGeneration;
+                    batch = enabled ? queue.Take(batchSize) : [];
+                    if (stopping && batch.Count == 0) break;
+                }
+                ReportLosses();
+                if (batch.Count == 0) { delay = interval; continue; }
+                LogBatchResult result;
+                CancellationTokenSource? request = null;
+                try
+                {
+                    Task<LogBatchResult> send;
+                    lock (gate)
+                    {
+                        if (!enabled || generation != consentGeneration) continue;
+                        request = CancellationTokenSource.CreateLinkedTokenSource(lifetime.Token);
+                        activeRequest = request;
+                        request.CancelAfter(TimeSpan.FromSeconds(10));
+                        send = transport.SendAsync(batch, request.Token);
+                    }
+                    result = await send.WaitAsync(request.Token).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is HttpRequestException or IOException or OperationCanceledException)
+                {
+                    result = new LogBatchResult(LogBatchDisposition.Retry);
+                }
+#pragma warning disable CA1031 // An invalid log must not permanently stop unrelated records from being delivered.
+                catch (Exception)
+#pragma warning restore CA1031
+                {
+                    result = new LogBatchResult(batch.Count > 1 ? LogBatchDisposition.Split : LogBatchDisposition.Rejected, batch.Count);
+                }
+                finally
+                {
+                    lock (gate) activeRequest = null;
+                    request?.Dispose();
+                }
+                lock (gate)
+                {
+                    if (result.Disposition is LogBatchDisposition.Accepted or LogBatchDisposition.Rejected)
+                    {
+                        queue.Remove(batch);
+                        if (result.Disposition == LogBatchDisposition.Rejected)
+                            rejected += Math.Clamp(result.RejectedRecordCount, 1, batch.Count);
+                    }
+                }
+                if (result.Disposition == LogBatchDisposition.Split)
+                {
+                    batchSize = Math.Max(1, batch.Count / 2);
+                    delay = TimeSpan.Zero;
+                }
+                else if (result.Disposition == LogBatchDisposition.Retry)
+                {
+                    failures = Math.Min(failures + 1, 6);
+                    delay = result.RetryAfter ?? TimeSpan.FromSeconds(Math.Min(60, Math.Pow(2, failures)));
+                    delay = TimeSpan.FromMilliseconds(Math.Clamp(delay.TotalMilliseconds, 100, int.MaxValue));
+                }
+                else
+                {
+                    failures = 0;
+                    delay = PendingCount >= 100 || stopping ? TimeSpan.Zero : interval;
+                }
+                ReportLosses();
+                if (stopping && result.Disposition == LogBatchDisposition.Retry) break;
+            }
+        }
+        catch (OperationCanceledException) when (lifetime.IsCancellationRequested) { }
+    }
+
+    private void ReportLosses()
+    {
+        long losses;
+        long storageFailures;
+        lock (gate)
+        {
+            losses = queue.DroppedCount + rejected;
+            storageFailures = queue.StorageFailureCount;
+        }
+        // Transport health is local-only: exporting an exporter failure would recursively generate logs.
+        if (losses != reportedLosses || storageFailures != reportedStorageFailures)
+        {
+            Log.ForContext("PostHogTransportInternal", true).Warning(
+                "PostHog log delivery discarded pending records or encountered storage failures. DiscardedRecords={DiscardedRecords}, StorageFailures={StorageFailures}",
+                losses, storageFailures);
+            reportedLosses = losses;
+            reportedStorageFailures = storageFailures;
+        }
+    }
+
+    internal async Task FlushAsync(CancellationToken cancellationToken)
+    {
+        lock (gate)
+        {
+            stopping = true;
+            worker ??= Task.Run(DeliverAsync);
+            if (signal.CurrentCount == 0) signal.Release();
+        }
+        try { await worker.WaitAsync(cancellationToken).ConfigureAwait(false); }
+        catch (OperationCanceledException)
+        {
+            await lifetime.CancelAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        lock (gate)
+        {
+            if (disposed) return;
+            disposed = true;
+            stopping = true;
+        }
+        await lifetime.CancelAsync().ConfigureAwait(false);
+        if (worker is not null) await worker.ConfigureAwait(false);
+        transport.Dispose();
+        queue.Dispose();
+        signal.Dispose();
+        lifetime.Dispose();
+    }
+}

--- a/src/Foundry.Telemetry/RemoteDiagnosticPropertyPolicy.cs
+++ b/src/Foundry.Telemetry/RemoteDiagnosticPropertyPolicy.cs
@@ -262,8 +262,6 @@ public static partial class RemoteDiagnosticPropertyPolicy
     private static string SanitizeAttribute(string? value) =>
         RemoteDiagnosticText.Sanitize(value, MaximumAttributeLength);
 
-    internal static string SanitizeResourceValue(string? value) => SanitizeAttribute(value);
-
     private static string SanitizeStackTrace(string stackTrace)
     {
         string withoutSourcePaths = StackSourcePathPattern().Replace(stackTrace, " in <redacted:path>");

--- a/src/Foundry.Telemetry/RemoteDiagnosticPropertyPolicy.cs
+++ b/src/Foundry.Telemetry/RemoteDiagnosticPropertyPolicy.cs
@@ -150,8 +150,7 @@ public static partial class RemoteDiagnosticPropertyPolicy
         var safeProperties = new List<LogEventProperty>(logEvent.Properties.Count);
         foreach ((string name, LogEventPropertyValue propertyValue) in logEvent.Properties)
         {
-            object safeValue = (AllowedPropertyNames.ContainsKey(name) ||
-                                name is "RemoteDiagnostic" or "RemoteDiagnosticTerminal") &&
+            object safeValue = AllowedPropertyNames.ContainsKey(name) &&
                                TryConvertScalar(propertyValue, out object scalarValue)
                 ? scalarValue
                 : "<redacted>";
@@ -224,11 +223,17 @@ public static partial class RemoteDiagnosticPropertyPolicy
         string? stackTrace = exception.StackTrace is null
             ? null
             : SanitizeStackTrace(exception.StackTrace);
+        string exceptionType = exception is LogExceptionSnapshot snapshot
+            ? snapshot.OriginalType
+            : exception.GetType().FullName ?? exception.GetType().Name;
+        IEnumerable<Exception> children = exception is LogExceptionSnapshot sanitized
+            ? sanitized.InnerExceptions
+            : GetInnerExceptions(exception);
         return new RemoteDiagnosticException(
-            exception.GetType().FullName ?? exception.GetType().Name,
-            GetExceptionMessage(exception, depth == 0 ? safeRootMessage : exception.GetType().FullName ?? exception.GetType().Name),
+            exceptionType,
+            GetExceptionMessage(exception, depth == 0 ? safeRootMessage : exceptionType),
             stackTrace,
-            GetInnerExceptions(exception)
+            children
                 .Select(innerException => CreateException(innerException, safeRootMessage, depth + 1))
                 .OfType<RemoteDiagnosticException>()
                 .ToArray());

--- a/src/Foundry.Telemetry/RemoteDiagnosticRecord.cs
+++ b/src/Foundry.Telemetry/RemoteDiagnosticRecord.cs
@@ -7,7 +7,7 @@ using Serilog.Events;
 namespace Foundry.Telemetry;
 
 /// <summary>
-/// Represents a privacy-filtered log record that is safe to enqueue for remote delivery.
+/// Represents a prepared remote record; Logs and Error Tracking apply their own content policies.
 /// </summary>
 public sealed record RemoteDiagnosticRecord(
     DateTimeOffset Timestamp,

--- a/src/Foundry.Telemetry/RemoteDiagnosticsLifecycle.cs
+++ b/src/Foundry.Telemetry/RemoteDiagnosticsLifecycle.cs
@@ -25,12 +25,14 @@ public static class RemoteDiagnosticsLifecycle
             settings.IsRemoteDiagnosticsEnabled,
             settings.HostUrl,
             settings.ProjectToken,
-            settings.InstallId);
+            settings.InstallId)
+        { LogDirectory = RemoteDiagnosticsSink.LogDirectory };
 
         if (!options.CanSend)
         {
             RemoteDiagnosticsSink.Clear();
             service.Disable();
+            service.Configure(options, TelemetryContextFactory.CreateRemoteDiagnosticsContext(telemetryContext));
             return;
         }
 

--- a/src/Foundry.Telemetry/RemoteDiagnosticsOptions.cs
+++ b/src/Foundry.Telemetry/RemoteDiagnosticsOptions.cs
@@ -5,7 +5,7 @@
 namespace Foundry.Telemetry;
 
 /// <summary>
-/// Describes runtime configuration for privacy-filtered remote diagnostics.
+/// Describes runtime configuration for remote Logs and Error Tracking.
 /// </summary>
 /// <param name="IsEnabled">Whether remote diagnostics are enabled.</param>
 /// <param name="HostUrl">PostHog ingestion host.</param>
@@ -17,6 +17,9 @@ public sealed record RemoteDiagnosticsOptions(
     string ProjectToken,
     string InstallId)
 {
+    /// <summary>Optional process-local outbox root; this is not part of generated runtime configuration.</summary>
+    public string? LogDirectory { get; init; }
+
     /// <summary>
     /// Gets whether the exporter has complete configuration and diagnostics are enabled.
     /// </summary>

--- a/src/Foundry.Telemetry/RemoteDiagnosticsSink.cs
+++ b/src/Foundry.Telemetry/RemoteDiagnosticsSink.cs
@@ -14,6 +14,14 @@ namespace Foundry.Telemetry;
 public sealed class RemoteDiagnosticsSink : ILogEventSink
 {
     private static IRemoteDiagnosticsService? _service;
+    private static readonly object Gate = new();
+    private static readonly Queue<LogEvent> Startup = new();
+    private static bool _bufferStartup = true;
+    private static long _startupDropped;
+    internal static string? LogDirectory { get; private set; }
+
+    /// <summary>Sets the process-local outbox root beside the selected local logs, before diagnostics initialization.</summary>
+    public static void SetLogDirectory(string? root) => LogDirectory = root;
 
     private RemoteDiagnosticsSink()
     {
@@ -30,20 +38,50 @@ public sealed class RemoteDiagnosticsSink : ILogEventSink
     public static void SetService(IRemoteDiagnosticsService service)
     {
         ArgumentNullException.ThrowIfNull(service);
-        Volatile.Write(ref _service, service);
+        lock (Gate)
+        {
+            Volatile.Write(ref _service, service);
+            while (Startup.TryDequeue(out LogEvent? logEvent)) service.Emit(logEvent);
+            _bufferStartup = false;
+        }
+        long dropped = Interlocked.Exchange(ref _startupDropped, 0);
+        if (dropped > 0)
+            Serilog.Log.ForContext("PostHogTransportInternal", true).Warning(
+                "Startup log buffer overflowed before diagnostic settings were available. LostRecords={LostRecords}", dropped);
     }
 
     /// <summary>
     /// Removes the registered service. Intended for orderly shutdown and isolated tests.
     /// </summary>
-    public static void Clear() => Volatile.Write(ref _service, null);
+    public static void Clear()
+    {
+        lock (Gate)
+        {
+            Volatile.Write(ref _service, null);
+            Startup.Clear();
+            _startupDropped = 0;
+            _bufferStartup = false;
+        }
+    }
 
     /// <inheritdoc />
     public void Emit(LogEvent logEvent)
     {
         try
         {
-            Volatile.Read(ref _service)?.Emit(logEvent);
+            lock (Gate)
+            {
+                if (_service is not null) _service.Emit(logEvent);
+                else if (_bufferStartup)
+                {
+                    if (Startup.Count == DurableLogQueue.DefaultMaximumRecords)
+                    {
+                        Startup.Dequeue();
+                        _startupDropped++;
+                    }
+                    Startup.Enqueue(logEvent);
+                }
+            }
         }
 #pragma warning disable CA1031 // The delegating sink must never affect application logging.
         catch (Exception ex)

--- a/src/Foundry.Telemetry/RemoteLogStorage.cs
+++ b/src/Foundry.Telemetry/RemoteLogStorage.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Telemetry;
+
+/// <summary>Resolves a separate outbox for each application and destination without storing credentials.</summary>
+internal static class RemoteLogStorage
+{
+    internal static string Resolve(RemoteDiagnosticsOptions options, RemoteDiagnosticsContext context)
+    {
+        string root = options.LogDirectory ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Foundry", "Diagnostics", "PendingLogs");
+        root = ResolveRoot(root, context, Environment.GetEnvironmentVariable(
+            Foundry.Utilities.Diagnostics.DiagnosticSessionContext.PersistenceDirectoryEnvironmentVariableName));
+        string application = string.Concat(context.App.Select(character => char.IsAsciiLetterOrDigit(character) || character is '_' or '-' ? character : '_'));
+        return Path.Combine(root, application,
+            BootstrapTelemetryJournal.Scope(options.HostUrl, options.ProjectToken, options.InstallId));
+    }
+
+    /// <summary>Uses Bootstrap's persistent cache across boot sessions when its inherited session path matches.</summary>
+    internal static string ResolveRoot(string fallback, RemoteDiagnosticsContext context, string? persistenceDirectory)
+    {
+        if (context.Runtime != TelemetryRuntimeModes.WinPe || string.IsNullOrWhiteSpace(persistenceDirectory)) return fallback;
+        try
+        {
+            if (!Path.IsPathFullyQualified(persistenceDirectory) || persistenceDirectory.StartsWith(@"\\", StringComparison.Ordinal)) return fallback;
+            string path = Path.GetFullPath(persistenceDirectory).TrimEnd(Path.DirectorySeparatorChar);
+            if (!string.Equals(Path.GetFileName(path), context.SessionId, StringComparison.OrdinalIgnoreCase)) return fallback;
+            string? parent = Path.GetDirectoryName(path);
+            return parent is null ? fallback : Path.Combine(parent, "PendingLogs");
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or IOException) { return fallback; }
+    }
+}

--- a/src/Foundry.Telemetry/TelemetrySettings.cs
+++ b/src/Foundry.Telemetry/TelemetrySettings.cs
@@ -15,7 +15,7 @@ public sealed record TelemetrySettings
     public bool IsEnabled { get; init; } = true;
 
     /// <summary>
-    /// Gets whether privacy-filtered remote diagnostics are enabled for the current runtime.
+    /// Gets whether remote Logs and Error Tracking are enabled for the current runtime.
     /// </summary>
     public bool IsRemoteDiagnosticsEnabled { get; init; } = true;
 

--- a/src/Foundry.Utilities.Tests/Diagnostics/DiagnosticClockTests.cs
+++ b/src/Foundry.Utilities.Tests/Diagnostics/DiagnosticClockTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Utilities.Diagnostics;
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace Foundry.Utilities.Tests.Diagnostics;
+
+public sealed class DiagnosticClockTests
+{
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("false", false)]
+    [InlineData("invalid", false)]
+    [InlineData("true", true)]
+    public void RuntimeUsesOnlyExplicitInheritedSynchronization(string? inherited, bool expected)
+    {
+        var clock = new DiagnosticClock();
+        clock.InitializeRuntime(inherited);
+        LogEvent entry = CreateEvent();
+        clock.Enrich(entry);
+        Assert.Equal(expected, ((ScalarValue)entry.Properties[DiagnosticClock.SynchronizedProperty]).Value);
+        Assert.Equal(expected ? "event" : "ingestion", ((ScalarValue)entry.Properties[DiagnosticClock.TimestampSourceProperty]).Value);
+    }
+
+    [Fact]
+    public void LaterSynchronizationCannotReclassifyAnEarlierEvent()
+    {
+        var clock = new DiagnosticClock();
+        clock.InitializeRuntime(null);
+        LogEvent earlier = CreateEvent();
+        DateTimeOffset originalTime = earlier.Timestamp;
+        clock.Enrich(earlier);
+        clock.MarkSynchronized();
+        clock.Enrich(earlier);
+        LogEvent normalized = LogEventNormalizer.Normalize(earlier);
+        LogEvent later = CreateEvent();
+        clock.Enrich(later);
+
+        Assert.Equal(originalTime, normalized.Timestamp);
+        Assert.Equal(false, ((ScalarValue)normalized.Properties[DiagnosticClock.SynchronizedProperty]).Value);
+        Assert.Equal(originalTime.ToString("O", System.Globalization.CultureInfo.InvariantCulture),
+            ((ScalarValue)normalized.Properties[DiagnosticClock.OriginalTimestampProperty]).Value);
+        Assert.Equal(true, ((ScalarValue)later.Properties[DiagnosticClock.SynchronizedProperty]).Value);
+    }
+
+    [Fact]
+    public void DesktopDefaultDoesNotOverrideEventTimestampPolicy()
+    {
+        var clock = new DiagnosticClock();
+        LogEvent entry = CreateEvent();
+        clock.Enrich(entry);
+        Assert.Null(clock.IsSynchronized);
+        Assert.DoesNotContain(DiagnosticClock.SynchronizedProperty, entry.Properties.Keys);
+    }
+
+    private static LogEvent CreateEvent() => new(DateTimeOffset.UtcNow.AddHours(10), LogEventLevel.Debug, null,
+        new MessageTemplateParser().Parse("Connecting"), []);
+}

--- a/src/Foundry.Utilities.Tests/Diagnostics/FoundryLogConfigurationTests.cs
+++ b/src/Foundry.Utilities.Tests/Diagnostics/FoundryLogConfigurationTests.cs
@@ -13,6 +13,34 @@ namespace Foundry.Utilities.Tests.Diagnostics;
 public sealed class FoundryLogConfigurationTests
 {
     [Fact]
+    public void PrepareEvent_EnrichesAndMasksHandoffWithoutChangingSubsequentLogIdentity()
+    {
+        var sink = new CollectingSink();
+        using var logger = (Logger)FoundryLogConfiguration.CreateDebugLogger("Foundry.Test", "SESSION01",
+            LogEventLevel.Verbose, additionalSink: sink);
+        using IDisposable context = Serilog.Context.LogContext.PushProperty("OperationId", "operation-1");
+        using IDisposable secret = Serilog.Context.LogContext.PushProperty("Password", "private-secret");
+        var source = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Fatal, new IOException("password=private-secret"),
+            new Serilog.Parsing.MessageTemplateParser().Parse("Startup failed"),
+            [new LogEventProperty("SourceContext", new ScalarValue("Foundry.Test.Startup"))]);
+
+        LogEvent prepared = FoundryLogConfiguration.PrepareEvent(source, "Foundry.Test", "SESSION01");
+        Assert.Empty(sink.Events);
+        var properties = prepared.Properties.ToDictionary();
+        logger.Write(prepared);
+
+        LogEvent logged = Assert.Single(sink.Events);
+        Assert.Equal(prepared.Timestamp, logged.Timestamp);
+        Assert.Equal(properties.Keys.Order(), logged.Properties.Keys.Order());
+        foreach ((string name, LogEventPropertyValue value) in properties)
+            Assert.Equal(value.ToString(), logged.Properties[name].ToString());
+        Assert.Equal("Startup", ((ScalarValue)properties["Component"]).Value);
+        Assert.Equal("operation-1", ((ScalarValue)properties["OperationId"]).Value);
+        Assert.DoesNotContain("private-secret", properties["Password"].ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("private-secret", prepared.Exception!.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CreateFileLogger_UsesInvariantMessageFormattingUnderFrenchCulture()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/src/Foundry.Utilities.Tests/Diagnostics/FoundryLogConfigurationTests.cs
+++ b/src/Foundry.Utilities.Tests/Diagnostics/FoundryLogConfigurationTests.cs
@@ -13,6 +13,94 @@ namespace Foundry.Utilities.Tests.Diagnostics;
 public sealed class FoundryLogConfigurationTests
 {
     [Fact]
+    public void CreateFileLogger_UsesInvariantMessageFormattingUnderFrenchCulture()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        string path = Path.Combine(tempDirectory.Path, "Foundry.log");
+        System.Globalization.CultureInfo original = System.Globalization.CultureInfo.CurrentCulture;
+        try
+        {
+            System.Globalization.CultureInfo.CurrentCulture = System.Globalization.CultureInfo.GetCultureInfo("fr-FR");
+            ILogger logger = FoundryLogConfiguration.CreateFileLogger(path, "Foundry.Test", "SESSION01",
+                LogEventLevel.Verbose, 2);
+            try { logger.Information("Duration {Duration:F2}", 1.25); }
+            finally { (logger as IDisposable)?.Dispose(); }
+        }
+        finally { System.Globalization.CultureInfo.CurrentCulture = original; }
+
+        Assert.Contains("Duration 1.25", File.ReadAllText(path), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateFileLogger_MasksSecretsBeforeBothOutputsAndPreservesTechnicalContext()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        string path = Path.Combine(tempDirectory.Path, "Foundry.log");
+        var sink = new CollectingSink();
+        ILogger logger = FoundryLogConfiguration.CreateFileLogger(path, "Foundry.Test", "SESSION01",
+            LogEventLevel.Verbose, 2, additionalSink: sink);
+        try
+        {
+            logger.Information("Reading {Path} using {Password}; {@Context}", @"C:\Users\alice\boot.wim",
+                "password-value", new { TenantId = "tenant-42", AccessToken = "token-value", Count = 3 });
+            logger.Error(new InvalidOperationException("Request failed: Authorization: Bearer bearer-value\npassword=exception-value"),
+                "GET https://storage.example/image.wim?version=42&sig=signature-value");
+        }
+        finally
+        {
+            (logger as IDisposable)?.Dispose();
+        }
+
+        string local = File.ReadAllText(path);
+        string remote = string.Join("\n", sink.Events.Select(e => e.RenderMessage() + e.Exception));
+        foreach (string output in new[] { local, remote })
+        {
+            Assert.DoesNotContain("password-value", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("token-value", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("bearer-value", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("exception-value", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("signature-value", output, StringComparison.Ordinal);
+            Assert.Contains("alice", output, StringComparison.Ordinal);
+            Assert.Contains("tenant-42", output, StringComparison.Ordinal);
+            Assert.Contains("version=42", output, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void CreateFileLogger_PreservesAllLevelsAndStableIdentityAcrossFanout()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        string path = Path.Combine(tempDirectory.Path, "Foundry.log");
+        var sink = new CollectingSink();
+        ILogger logger = FoundryLogConfiguration.CreateFileLogger(path, "Foundry.Test", "SESSION01",
+            LogEventLevel.Verbose, 2, additionalSink: sink);
+        var timestamp = new DateTimeOffset(2026, 9, 10, 12, 34, 56, TimeSpan.Zero);
+        try
+        {
+            foreach (LogEventLevel level in Enum.GetValues<LogEventLevel>())
+            {
+                logger.Write(new LogEvent(timestamp, level, null,
+                    new Serilog.Parsing.MessageTemplateParser().Parse("Repeated diagnostic"), []));
+            }
+        }
+        finally
+        {
+            (logger as IDisposable)?.Dispose();
+        }
+
+        Assert.Equal(6, sink.Events.Count);
+        Assert.All(sink.Events, e => Assert.Equal(timestamp, e.Timestamp));
+        string local = File.ReadAllText(path);
+        Assert.Equal(6, sink.Events.Select(e => e.Properties["diagnostics.record_id"].ToString()).Distinct().Count());
+        foreach (LogEvent entry in sink.Events)
+        {
+            Assert.Contains(((ScalarValue)entry.Properties["diagnostics.record_id"]).Value!.ToString()!, local, StringComparison.Ordinal);
+        }
+        long[] sequences = sink.Events.Select(e => (long)((ScalarValue)e.Properties["diagnostics.sequence"]).Value!).ToArray();
+        Assert.True(sequences.Zip(sequences.Skip(1), (left, right) => left < right).All(value => value));
+    }
+
+    [Fact]
     public void CreateFileLogger_ForwardsEventsToAdditionalSink()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/src/Foundry.Utilities.Tests/Diagnostics/LogEventNormalizerTests.cs
+++ b/src/Foundry.Utilities.Tests/Diagnostics/LogEventNormalizerTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Utilities.Diagnostics;
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace Foundry.Utilities.Tests.Diagnostics;
+
+public sealed class LogEventNormalizerTests
+{
+    [Fact]
+    public void Normalize_MasksSignedUrlsUsedAsDictionaryKeysWithoutDroppingCollidingEntries()
+    {
+        var source = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Debug, null,
+            new MessageTemplateParser().Parse("Results {@Results}"), [new("Results", new DictionaryValue([
+                new(new ScalarValue("https://example.test?sig=first-secret"), new ScalarValue(42)),
+                new(new ScalarValue("https://example.test?sig=second-secret"), new ScalarValue(43))]))]);
+
+        LogEvent result = LogEventNormalizer.Normalize(source);
+
+        Assert.DoesNotContain("first-secret", result.RenderMessage(), StringComparison.Ordinal);
+        Assert.DoesNotContain("second-secret", result.RenderMessage(), StringComparison.Ordinal);
+        DictionaryValue values = Assert.IsType<DictionaryValue>(result.Properties["Results"]);
+        Assert.Equal(2, values.Elements.Count);
+        Assert.Contains(values.Elements.Values, value => Equals(((ScalarValue)value).Value, 42));
+        Assert.Contains(values.Elements.Values, value => Equals(((ScalarValue)value).Value, 43));
+    }
+
+    [Theory]
+    [InlineData("Password: {Value}")]
+    [InlineData("Running tool --password {Value}")]
+    [InlineData("URL https://example.test?sig={Value}")]
+    public void Normalize_RecognizesCredentialsFromTemplateEvenWhenPropertyNameIsGeneric(string template)
+    {
+        var source = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Debug, null,
+            new MessageTemplateParser().Parse(template), [new("Value", new ScalarValue("never-export"))]);
+
+        LogEvent result = LogEventNormalizer.Normalize(source);
+
+        Assert.DoesNotContain("never-export", result.RenderMessage(), StringComparison.Ordinal);
+        Assert.Equal("<redacted>", ((ScalarValue)result.Properties["Value"]).Value);
+    }
+
+    [Fact]
+    public void Normalize_PreservesExceptionIdentityForIndependentErrorTrackingDeduplication()
+    {
+        var exception = new InvalidOperationException("password=never-export");
+        var source = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Error, exception,
+            new MessageTemplateParser().Parse("Failed"), []);
+
+        LogEvent first = LogEventNormalizer.Normalize(source);
+        LogEvent second = LogEventNormalizer.Normalize(source);
+
+        Assert.Same(first.Exception, second.Exception);
+        Assert.DoesNotContain("never-export", first.Exception!.ToString(), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("--password \"never-export\"", "never-export")]
+    [InlineData("Cookie: session=never-export; other=also-private", "never-export")]
+    [InlineData("Cookie: session=never-export; other=also-private", "also-private")]
+    [InlineData("-----BEGIN RSA PRIVATE KEY-----\nnever-export\n-----END RSA PRIVATE KEY-----", "never-export")]
+    [InlineData("https://example.test/file?X-Amz-Signature=never-export&version=42", "never-export")]
+    [InlineData("https://user:never-export@example.test/file", "never-export")]
+    public void Normalize_MasksEmbeddedAuthenticationSecrets(string text, string secret)
+    {
+        var source = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Debug, null,
+            new MessageTemplateParser().Parse("Output: {Output}"), [new("Output", new ScalarValue(text))]);
+
+        LogEvent result = LogEventNormalizer.Normalize(source);
+
+        Assert.DoesNotContain(secret, result.RenderMessage(), StringComparison.Ordinal);
+        Assert.Contains("<redacted>", result.RenderMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Normalize_MasksCredentialNamesInsideDictionariesAndPreservesNonSecrets()
+    {
+        var source = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Information, null,
+            new MessageTemplateParser().Parse("Settings {@Settings}"),
+            [new("Settings", new DictionaryValue([
+                new(new ScalarValue("NetworkPassword"), new ScalarValue("never-export")),
+                new(new ScalarValue("TokenCount"), new ScalarValue(42)),
+                new(new ScalarValue("TenantId"), new ScalarValue("tenant-42"))]))]);
+
+        LogEvent result = LogEventNormalizer.Normalize(source);
+
+        Assert.DoesNotContain("never-export", result.RenderMessage(), StringComparison.Ordinal);
+        Assert.Contains("tenant-42", result.RenderMessage(), StringComparison.Ordinal);
+        Assert.Contains("42", result.RenderMessage(), StringComparison.Ordinal);
+    }
+}

--- a/src/Foundry.Utilities/Diagnostics/DiagnosticClock.cs
+++ b/src/Foundry.Utilities/Diagnostics/DiagnosticClock.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using Serilog.Events;
+
+namespace Foundry.Utilities.Diagnostics;
+
+/// <summary>Captures boot-clock reliability on events without rewriting their original timestamps.</summary>
+public sealed class DiagnosticClock
+{
+    public const string EnvironmentVariableName = "FOUNDRY_DIAGNOSTIC_CLOCK_SYNCHRONIZED";
+    public const string SynchronizedProperty = "diagnostics.clock_synchronized";
+    public const string OriginalTimestampProperty = "diagnostics.original_timestamp";
+    public const string TimestampSourceProperty = "diagnostics.timestamp_source";
+    private int _state;
+
+    /// <summary>The clock policy for this process; desktop logging keeps its usual timestamps by default.</summary>
+    public static DiagnosticClock Current { get; } = new();
+
+    /// <summary>Null outside managed boot logging, otherwise the current verified clock state.</summary>
+    public bool? IsSynchronized => Volatile.Read(ref _state) switch { 0 => null, 2 => true, _ => false };
+
+    /// <summary>Starts boot logging, accepting only an explicit synchronized state inherited from Bootstrap.</summary>
+    public void InitializeRuntime(string? inheritedState) =>
+        Volatile.Write(ref _state, string.Equals(inheritedState, "true", StringComparison.OrdinalIgnoreCase) ? 2 : 1);
+
+    /// <summary>Marks subsequent events after successful UTC verification or correction.</summary>
+    public void MarkSynchronized() => Volatile.Write(ref _state, 2);
+
+    /// <summary>Snapshots reliability once, preserving prior state when events are normalized again.</summary>
+    public void Enrich(LogEvent logEvent)
+    {
+        ArgumentNullException.ThrowIfNull(logEvent);
+        if (IsSynchronized is bool synchronized)
+            logEvent.AddPropertyIfAbsent(new LogEventProperty(SynchronizedProperty, new ScalarValue(synchronized)));
+        if (logEvent.Properties.TryGetValue(SynchronizedProperty, out LogEventPropertyValue? value) &&
+            value is ScalarValue { Value: bool capturedState })
+        {
+            logEvent.AddPropertyIfAbsent(new LogEventProperty(TimestampSourceProperty,
+                new ScalarValue(capturedState ? "event" : "ingestion")));
+            if (!capturedState)
+                logEvent.AddPropertyIfAbsent(new LogEventProperty(OriginalTimestampProperty,
+                    new ScalarValue(logEvent.Timestamp.ToString("O", CultureInfo.InvariantCulture))));
+        }
+    }
+}

--- a/src/Foundry.Utilities/Diagnostics/FoundryLogConfiguration.cs
+++ b/src/Foundry.Utilities/Diagnostics/FoundryLogConfiguration.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
@@ -16,7 +17,7 @@ public static class FoundryLogConfiguration
     public const long DefaultFileSizeLimitBytes = 10 * 1024 * 1024;
 
     public const string OutputTemplate =
-        "{UtcTimestamp:yyyy-MM-ddTHH:mm:ss.fff'Z'} [{Level:u3}] [{Application}] [Session:{SessionId}] [{Component}] {Message:lj}{NewLine}{Exception}";
+        "{UtcTimestamp:yyyy-MM-ddTHH:mm:ss.fff'Z'} [{Level:u3}] [{Application}] [Session:{SessionId}] [{Component}] {Message:lj} {Properties:j}{NewLine}{Exception}";
 
     /// <summary>
     /// Creates a logger with a stable active filename, size-based rolling, and bounded retention.
@@ -39,18 +40,21 @@ public static class FoundryLogConfiguration
         ConfigureMinimumLevel(configuration, minimumLevel, levelSwitch);
 
         ConfigureEnrichment(configuration, applicationName, sessionId);
-        ConfigureAdditionalSink(configuration, additionalSink);
-        return configuration
+        var destinations = new LoggerConfiguration().MinimumLevel.Verbose();
+        ConfigureAdditionalSink(destinations, additionalSink);
+        Logger output = destinations
             .WriteTo.File(
                 logFilePath,
                 outputTemplate: OutputTemplate,
+                formatProvider: CultureInfo.InvariantCulture,
                 fileSizeLimitBytes: DefaultFileSizeLimitBytes,
                 rollOnFileSizeLimit: true,
                 retainedFileCountLimit: retainedFileCountLimit,
                 shared: true,
                 flushToDiskInterval: TimeSpan.FromSeconds(1))
-            .WriteTo.Debug(outputTemplate: OutputTemplate)
+            .WriteTo.Debug(outputTemplate: OutputTemplate, formatProvider: CultureInfo.InvariantCulture)
             .CreateLogger();
+        return configuration.WriteTo.Sink(new NormalizingLogSink(output)).CreateLogger();
     }
 
     /// <summary>
@@ -69,10 +73,12 @@ public static class FoundryLogConfiguration
         var configuration = new LoggerConfiguration();
         ConfigureMinimumLevel(configuration, minimumLevel, levelSwitch);
         ConfigureEnrichment(configuration, applicationName, sessionId);
-        ConfigureAdditionalSink(configuration, additionalSink);
-        return configuration
-            .WriteTo.Debug(outputTemplate: OutputTemplate)
+        var destinations = new LoggerConfiguration().MinimumLevel.Verbose();
+        ConfigureAdditionalSink(destinations, additionalSink);
+        Logger output = destinations
+            .WriteTo.Debug(outputTemplate: OutputTemplate, formatProvider: CultureInfo.InvariantCulture)
             .CreateLogger();
+        return configuration.WriteTo.Sink(new NormalizingLogSink(output)).CreateLogger();
     }
 
     private static void ConfigureMinimumLevel(

--- a/src/Foundry.Utilities/Diagnostics/FoundryLogConfiguration.cs
+++ b/src/Foundry.Utilities/Diagnostics/FoundryLogConfiguration.cs
@@ -20,6 +20,24 @@ public static class FoundryLogConfiguration
         "{UtcTimestamp:yyyy-MM-ddTHH:mm:ss.fff'Z'} [{Level:u3}] [{Application}] [Session:{SessionId}] [{Component}] {Message:lj} {Properties:j}{NewLine}{Exception}";
 
     /// <summary>
+    /// Prepares an event for durable handoff with the same context and masking as local logging,
+    /// without writing to any output. Subsequent logging preserves its identity and timestamp.
+    /// </summary>
+    public static LogEvent PrepareEvent(LogEvent logEvent, string applicationName, string sessionId)
+    {
+        ArgumentNullException.ThrowIfNull(logEvent);
+        ArgumentException.ThrowIfNullOrWhiteSpace(applicationName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+
+        var configuration = new LoggerConfiguration().MinimumLevel.Verbose();
+        ConfigureEnrichment(configuration, applicationName, sessionId);
+        var sink = new PreparedEventSink();
+        using Logger logger = configuration.WriteTo.Sink(sink).CreateLogger();
+        logger.Write(logEvent);
+        return LogEventNormalizer.Normalize(sink.Event ?? logEvent);
+    }
+
+    /// <summary>
     /// Creates a logger with a stable active filename, size-based rolling, and bounded retention.
     /// </summary>
     public static ILogger CreateFileLogger(
@@ -115,5 +133,11 @@ public static class FoundryLogConfiguration
         {
             configuration.WriteTo.Sink(additionalSink);
         }
+    }
+
+    private sealed class PreparedEventSink : ILogEventSink
+    {
+        public LogEvent? Event { get; private set; }
+        public void Emit(LogEvent logEvent) => Event = logEvent;
     }
 }

--- a/src/Foundry.Utilities/Diagnostics/FoundryLogConfiguration.cs
+++ b/src/Foundry.Utilities/Diagnostics/FoundryLogConfiguration.cs
@@ -46,7 +46,6 @@ public static class FoundryLogConfiguration
         string sessionId,
         LogEventLevel minimumLevel,
         int retainedFileCountLimit,
-        LoggingLevelSwitch? levelSwitch = null,
         ILogEventSink? additionalSink = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(logFilePath);
@@ -54,8 +53,7 @@ public static class FoundryLogConfiguration
         ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(retainedFileCountLimit);
 
-        var configuration = new LoggerConfiguration();
-        ConfigureMinimumLevel(configuration, minimumLevel, levelSwitch);
+        var configuration = new LoggerConfiguration().MinimumLevel.Is(minimumLevel);
 
         ConfigureEnrichment(configuration, applicationName, sessionId);
         var destinations = new LoggerConfiguration().MinimumLevel.Verbose();
@@ -82,14 +80,12 @@ public static class FoundryLogConfiguration
         string applicationName,
         string sessionId,
         LogEventLevel minimumLevel,
-        LoggingLevelSwitch? levelSwitch = null,
         ILogEventSink? additionalSink = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(applicationName);
         ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
 
-        var configuration = new LoggerConfiguration();
-        ConfigureMinimumLevel(configuration, minimumLevel, levelSwitch);
+        var configuration = new LoggerConfiguration().MinimumLevel.Is(minimumLevel);
         ConfigureEnrichment(configuration, applicationName, sessionId);
         var destinations = new LoggerConfiguration().MinimumLevel.Verbose();
         ConfigureAdditionalSink(destinations, additionalSink);
@@ -97,21 +93,6 @@ public static class FoundryLogConfiguration
             .WriteTo.Debug(outputTemplate: OutputTemplate, formatProvider: CultureInfo.InvariantCulture)
             .CreateLogger();
         return configuration.WriteTo.Sink(new NormalizingLogSink(output)).CreateLogger();
-    }
-
-    private static void ConfigureMinimumLevel(
-        LoggerConfiguration configuration,
-        LogEventLevel minimumLevel,
-        LoggingLevelSwitch? levelSwitch)
-    {
-        if (levelSwitch is null)
-        {
-            configuration.MinimumLevel.Is(minimumLevel);
-        }
-        else
-        {
-            configuration.MinimumLevel.ControlledBy(levelSwitch);
-        }
     }
 
     private static void ConfigureEnrichment(

--- a/src/Foundry.Utilities/Diagnostics/LogEventNormalizer.cs
+++ b/src/Foundry.Utilities/Diagnostics/LogEventNormalizer.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace Foundry.Utilities.Diagnostics;
+
+/// <summary>Produces the common secret-masked event before local and remote sinks receive it.</summary>
+public static class LogEventNormalizer
+{
+    private static readonly string ProcessId = Guid.NewGuid().ToString("N");
+    private static long _sequence;
+
+    /// <summary>Preserves event time, trace context, structure and identity across repeated normalization.</summary>
+    public static LogEvent Normalize(LogEvent source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        HashSet<string> credentialProperties = LogSecretMasker.GetSecretTemplateProperties(source.MessageTemplate.Text);
+        var properties = source.Properties.Select(property => new LogEventProperty(property.Key,
+            credentialProperties.Contains(property.Key) ? new ScalarValue(LogSecretMasker.Redacted)
+                : MaskProperty(property.Key, property.Value))).ToList();
+        string template = LogSecretMasker.Mask(source.MessageTemplate.Text);
+        var result = new LogEvent(source.Timestamp, source.Level, LogExceptionSnapshot.Create(source.Exception),
+            template == source.MessageTemplate.Text ? source.MessageTemplate : new MessageTemplateParser().Parse(template),
+            properties, source.TraceId ?? default, source.SpanId ?? default);
+        result.AddPropertyIfAbsent(new LogEventProperty("diagnostics.record_id", new ScalarValue(Guid.NewGuid().ToString("N"))));
+        result.AddPropertyIfAbsent(new LogEventProperty("diagnostics.process_id", new ScalarValue(ProcessId)));
+        result.AddPropertyIfAbsent(new LogEventProperty("diagnostics.sequence", new ScalarValue(Interlocked.Increment(ref _sequence))));
+        return result;
+    }
+
+    private static LogEventPropertyValue MaskProperty(string name, LogEventPropertyValue value)
+    {
+        if (LogSecretMasker.IsSecretName(name))
+        {
+            return new ScalarValue(LogSecretMasker.Redacted);
+        }
+
+        return value switch
+        {
+            ScalarValue { Value: string text } => new ScalarValue(LogSecretMasker.Mask(text)),
+            ScalarValue { Value: Uri uri } => new ScalarValue(LogSecretMasker.Mask(uri.ToString())),
+            SequenceValue sequence => new SequenceValue(sequence.Elements.Select(element => MaskProperty(string.Empty, element))),
+            StructureValue structure => new StructureValue(structure.Properties.Select(property =>
+                new LogEventProperty(property.Name, MaskProperty(property.Name, property.Value))), structure.TypeTag),
+            DictionaryValue dictionary => MaskDictionary(dictionary),
+            _ => value
+        };
+    }
+
+    private static DictionaryValue MaskDictionary(DictionaryValue dictionary)
+    {
+        var entries = new Dictionary<ScalarValue, LogEventPropertyValue>();
+        foreach ((ScalarValue key, LogEventPropertyValue value) in dictionary.Elements)
+        {
+            string original = key.Value?.ToString() ?? string.Empty;
+            string masked = LogSecretMasker.Mask(original);
+            ScalarValue safeKey = masked == original ? key : new ScalarValue(masked);
+            int occurrence = 1;
+            while (entries.ContainsKey(safeKey))
+            {
+                safeKey = new ScalarValue(masked + " [" + (++occurrence).ToString(System.Globalization.CultureInfo.InvariantCulture) + "]");
+            }
+            entries.Add(safeKey, MaskProperty(original, value));
+        }
+        return new DictionaryValue(entries);
+    }
+}

--- a/src/Foundry.Utilities/Diagnostics/LogEventNormalizer.cs
+++ b/src/Foundry.Utilities/Diagnostics/LogEventNormalizer.cs
@@ -28,6 +28,7 @@ public static class LogEventNormalizer
         result.AddPropertyIfAbsent(new LogEventProperty("diagnostics.record_id", new ScalarValue(Guid.NewGuid().ToString("N"))));
         result.AddPropertyIfAbsent(new LogEventProperty("diagnostics.process_id", new ScalarValue(ProcessId)));
         result.AddPropertyIfAbsent(new LogEventProperty("diagnostics.sequence", new ScalarValue(Interlocked.Increment(ref _sequence))));
+        DiagnosticClock.Current.Enrich(result);
         return result;
     }
 

--- a/src/Foundry.Utilities/Diagnostics/LogExceptionSnapshot.cs
+++ b/src/Foundry.Utilities/Diagnostics/LogExceptionSnapshot.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace Foundry.Utilities.Diagnostics;
+
+/// <summary>Retains an exception's original diagnostic identity and stack after secret removal.</summary>
+public sealed class LogExceptionSnapshot : Exception
+{
+    private static readonly ConditionalWeakTable<Exception, LogExceptionSnapshot> Snapshots = new();
+    private readonly string _text;
+
+    private LogExceptionSnapshot(Exception source, IReadOnlyList<Exception> innerExceptions)
+        : base(LogSecretMasker.Mask(source.Message), innerExceptions.FirstOrDefault())
+    {
+        OriginalType = source is LogExceptionSnapshot snapshot ? snapshot.OriginalType : source.GetType().FullName ?? source.GetType().Name;
+        StackTrace = source.StackTrace is { } stack ? LogSecretMasker.Mask(stack) : null;
+        InnerExceptions = innerExceptions;
+        HResult = source.HResult;
+        _text = LogSecretMasker.Mask(source.ToString());
+    }
+
+    public string OriginalType { get; }
+    public IReadOnlyList<Exception> InnerExceptions { get; }
+    public override string? StackTrace { get; }
+
+    public override string ToString()
+    {
+        return _text;
+    }
+
+    /// <summary>Leaves unaffected exceptions intact; snapshots only chains containing secrets.</summary>
+    internal static Exception? Create(Exception? source)
+    {
+        if (source is null || source is LogExceptionSnapshot)
+        {
+            return source;
+        }
+
+        string original = source.ToString();
+        if (string.Equals(original, LogSecretMasker.Mask(original), StringComparison.Ordinal))
+        {
+            return source;
+        }
+
+        return Snapshots.GetValue(source, static exception =>
+        {
+            IEnumerable<Exception> children = exception is AggregateException aggregate ? aggregate.InnerExceptions
+                : exception.InnerException is { } inner ? [inner] : [];
+            return new LogExceptionSnapshot(exception, children.Select(child => Create(child)!).ToArray());
+        });
+    }
+}

--- a/src/Foundry.Utilities/Diagnostics/LogSecretMasker.cs
+++ b/src/Foundry.Utilities/Diagnostics/LogSecretMasker.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.RegularExpressions;
+
+namespace Foundry.Utilities.Diagnostics;
+
+/// <summary>Masks authentication secrets while retaining ordinary diagnostic values and paths.</summary>
+public static partial class LogSecretMasker
+{
+    public const string Redacted = "<redacted>";
+
+    /// <summary>Recognizes credential property names, including common HTTP and signed URL keys.</summary>
+    public static bool IsSecretName(string name)
+    {
+        if (name.IndexOfAny([':', '/', '?', '=', '&']) >= 0)
+        {
+            return false;
+        }
+        string normalized = string.Concat(name.Where(char.IsLetterOrDigit)).ToLowerInvariant();
+        return normalized.EndsWith("password", StringComparison.Ordinal) || normalized.EndsWith("token", StringComparison.Ordinal)
+            || normalized.EndsWith("secret", StringComparison.Ordinal) || normalized.EndsWith("apikey", StringComparison.Ordinal)
+            || normalized.EndsWith("privatekey", StringComparison.Ordinal)
+            || normalized is "password" or "passwd" or "pwd" or "token" or "accesstoken" or "refreshtoken"
+            or "idtoken" or "authorization" or "proxyauthorization" or "clientsecret" or "secret"
+            or "apikey" or "privatekey" or "accountkey" or "sharedaccesssignature" or "sig" or "signature"
+            or "xamzsignature" or "xamzcredential" or "xamzsecuritytoken" or "xgoogsignature"
+            or "xgoogcredential" or "cookie" or "setcookie" or "sas" or "sastoken";
+    }
+
+    /// <summary>Removes explicit credentials embedded in free text without truncating diagnostic content.</summary>
+    public static string Mask(string text)
+    {
+        string result = PrivateKey().Replace(text, Redacted);
+        result = CookieHeader().Replace(result, "$1" + Redacted);
+        result = CredentialArgument().Replace(result, "$1" + Redacted);
+        result = Authorization().Replace(result, "$1" + Redacted);
+        result = CredentialAssignment().Replace(result, "$1" + Redacted);
+        return UrlCredentials().Replace(result, "$1" + Redacted + "@");
+    }
+
+    /// <summary>Recognizes placeholders whose surrounding template labels their value as a credential.</summary>
+    internal static HashSet<string> GetSecretTemplateProperties(string template)
+    {
+        return CredentialPlaceholder().Matches(template).Cast<Match>()
+            .Where(match => IsSecretName(match.Groups["label"].Value))
+            .Select(match => match.Groups["property"].Value).ToHashSet(StringComparer.Ordinal);
+    }
+
+    [GeneratedRegex("(?i)(?:(?<label>[a-z][a-z0-9_-]*)[\\\"']?\\s*[:=]\\s*|[-/]{1,2}(?<label>[a-z][a-z0-9_-]*)\\s+)\\{[@$]?(?<property>[a-z_][a-z0-9_]*)(?:[^}]*)\\}", RegexOptions.CultureInvariant)]
+    private static partial Regex CredentialPlaceholder();
+
+    [GeneratedRegex(@"-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----", RegexOptions.CultureInvariant)]
+    private static partial Regex PrivateKey();
+
+    [GeneratedRegex(@"(?i)(\b(?:Bearer|Basic)\s+)[A-Za-z0-9+/=_\-.~]+", RegexOptions.CultureInvariant)]
+    private static partial Regex Authorization();
+
+    [GeneratedRegex(@"(?im)(\b(?:set-cookie|cookie)\s*:\s*)[^\r\n]+", RegexOptions.CultureInvariant)]
+    private static partial Regex CookieHeader();
+
+    [GeneratedRegex("(?i)((?<![a-z0-9])[-/]{1,2}(?:password|passwd|pwd|(?:access[_-]?|refresh[_-]?|sas[_-]?)?token|client[_-]?secret|api[_-]?key)\\s+)(?:\\\"[^\\\"]*\\\"|'[^']*'|(?!\\{)[^\\s<>]+)", RegexOptions.CultureInvariant)]
+    private static partial Regex CredentialArgument();
+
+    [GeneratedRegex("(?i)((?<![a-z0-9_])(?:password|passwd|pwd|(?:access[_-]?|refresh[_-]?|id[_-]?|sas[_-]?)?token|client[_-]?secret|secret|api[_-]?key|account[_-]?key|private[_-]?key|authorization|proxy-authorization|sharedaccesssignature|sig|signature|x-amz-(?:signature|credential|security-token)|x-goog-(?:signature|credential)|cookie|set-cookie)[\\\"']?\\s*[:=]\\s*)(?:\\\"[^\\\"]*\\\"|'[^']*'|(?!\\{)[^\\s&;,\\\"'<>}]+)", RegexOptions.CultureInvariant)]
+    private static partial Regex CredentialAssignment();
+
+    [GeneratedRegex(@"(?i)(https?://)[^\s/@]+:[^\s/@]+@", RegexOptions.CultureInvariant)]
+    private static partial Regex UrlCredentials();
+}

--- a/src/Foundry.Utilities/Diagnostics/NormalizingLogSink.cs
+++ b/src/Foundry.Utilities/Diagnostics/NormalizingLogSink.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Foundry.Utilities.Diagnostics;
+
+/// <summary>Owns the sink logger and applies normalization once before its fan-out.</summary>
+internal sealed class NormalizingLogSink(Logger output) : ILogEventSink, IDisposable
+{
+    public void Emit(LogEvent logEvent)
+    {
+        output.Write(LogEventNormalizer.Normalize(logEvent));
+    }
+
+    public void Dispose()
+    {
+        output.Dispose();
+    }
+}

--- a/src/Foundry/App.xaml.cs
+++ b/src/Foundry/App.xaml.cs
@@ -79,11 +79,9 @@ namespace Foundry
         {
             Host = FoundryHost.Create();
             _ = Host.Services.GetRequiredService<IApplicationProxyService>();
-            IAppSettingsService appSettingsService = Host.Services.GetRequiredService<IAppSettingsService>();
-            SetDeveloperModeEnabled(appSettingsService.Current.Diagnostics.DeveloperMode);
+            InitializeRemoteDiagnostics(Host.Services.GetRequiredService<TelemetrySettings>());
             _ = Host.Services.GetRequiredService<IFoundryConfigurationStateService>();
             Host.Services.GetRequiredService<IApplicationLocalizationService>().InitializeAsync().GetAwaiter().GetResult();
-            InitializeRemoteDiagnostics(Host.Services.GetRequiredService<TelemetrySettings>());
             RegisterWinUiExceptionHandler();
 
             AppLogger.Information("Foundry WinUI host initialized.");
@@ -175,9 +173,9 @@ namespace Foundry
             AppLogger.Debug("Flushing Foundry telemetry events.");
             GetService<ITelemetryService>().FlushAsync().GetAwaiter().GetResult();
             AppLogger.Debug("Foundry telemetry flush completed.");
+            AppLogger.Information("Foundry WinUI application work completed. Closing diagnostics and services.");
             ShutdownRemoteDiagnostics();
             Host.Dispose();
-            AppLogger.Information("Foundry WinUI shutdown completed.");
             Log.CloseAndFlush();
         }
 
@@ -191,24 +189,25 @@ namespace Foundry
 
         private void ShutdownRemoteDiagnostics()
         {
-            AppLogger.Debug("Flushing Foundry remote diagnostics.");
+            ILogger transportLogger = AppLogger.ForContext("PostHogTransportInternal", true);
+            transportLogger.Debug("Flushing Foundry remote diagnostics.");
             using var cancellation = new CancellationTokenSource(RemoteDiagnosticsShutdownTimeout);
             try
             {
                 RemoteDiagnosticsLifecycle.ShutdownAsync(
                     GetService<IRemoteDiagnosticsService>(),
                     cancellation.Token).GetAwaiter().GetResult();
-                AppLogger.Debug("Foundry remote diagnostics flush completed.");
+                transportLogger.Debug("Foundry remote diagnostics flush completed.");
             }
             catch (OperationCanceledException)
             {
-                AppLogger.Warning(
+                transportLogger.Warning(
                     "Foundry remote diagnostics flush timed out after {TimeoutSeconds} seconds.",
                     RemoteDiagnosticsShutdownTimeout.TotalSeconds);
             }
             catch (Exception ex)
             {
-                AppLogger.Warning(ex, "Foundry remote diagnostics shutdown failed.");
+                transportLogger.Warning(ex, "Foundry remote diagnostics shutdown failed.");
             }
         }
 

--- a/src/Foundry/Common/LoggerSetup.cs
+++ b/src/Foundry/Common/LoggerSetup.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Serilog;
-using Serilog.Core;
 using Serilog.Events;
 using Foundry.Telemetry;
 using Foundry.Utilities.Diagnostics;
@@ -16,7 +15,6 @@ namespace Foundry.Common
     /// </summary>
     public static partial class LoggerSetup
     {
-        private static readonly LoggingLevelSwitch MinimumLevelSwitch = new(LogEventLevel.Information);
         private static bool globalExceptionHandlersRegistered;
         private const int RetainedLogFileCount = 10;
 
@@ -42,6 +40,7 @@ namespace Foundry.Common
                     AppContext.BaseDirectory
                 ],
                 Path.GetFileName(Constants.LogFilePath));
+            RemoteDiagnosticsSink.SetLogDirectory(Path.Combine(Path.GetDirectoryName(LogFilePath)!, "PendingLogs"));
 
             try
             {
@@ -49,10 +48,9 @@ namespace Foundry.Common
                     LogFilePath,
                     "Foundry.OSD",
                     DiagnosticSessionContext.CurrentSessionId,
-                    LogEventLevel.Information,
+                    LogEventLevel.Verbose,
                     RetainedLogFileCount,
-                    MinimumLevelSwitch,
-                    RemoteDiagnosticsSink.Instance);
+                    additionalSink: RemoteDiagnosticsSink.Instance);
             }
             catch (Exception ex)
             {
@@ -61,9 +59,8 @@ namespace Foundry.Common
                 Logger = FoundryLogConfiguration.CreateDebugLogger(
                     "Foundry.OSD",
                     DiagnosticSessionContext.CurrentSessionId,
-                    LogEventLevel.Information,
-                    MinimumLevelSwitch,
-                    RemoteDiagnosticsSink.Instance);
+                    LogEventLevel.Verbose,
+                    additionalSink: RemoteDiagnosticsSink.Instance);
             }
 
             Log.Logger = Logger;
@@ -71,22 +68,6 @@ namespace Foundry.Common
             {
                 SetupLogger.Error(initializationException, "File logging initialization failed. Falling back to debugger output.");
             }
-        }
-
-        /// <summary>
-        /// Updates the minimum logging level used by runtime diagnostics.
-        /// </summary>
-        /// <param name="isEnabled">Whether developer diagnostics should enable debug logging.</param>
-        public static void SetDeveloperModeEnabled(bool isEnabled)
-        {
-            LogEventLevel targetLevel = isEnabled ? LogEventLevel.Debug : LogEventLevel.Information;
-            if (MinimumLevelSwitch.MinimumLevel == targetLevel)
-            {
-                return;
-            }
-
-            MinimumLevelSwitch.MinimumLevel = targetLevel;
-            SetupLogger.Information("Developer diagnostics logging level changed. DeveloperMode={DeveloperMode}, MinimumLevel={MinimumLevel}", isEnabled, targetLevel);
         }
 
         /// <summary>

--- a/src/Foundry/DependencyInjection/FoundryHost.cs
+++ b/src/Foundry/DependencyInjection/FoundryHost.cs
@@ -21,6 +21,7 @@ public static class FoundryHost
     {
         HostApplicationBuilder builder = Host.CreateApplicationBuilder();
         builder.Logging.ClearProviders();
+        builder.Logging.SetMinimumLevel(LogLevel.Trace);
         builder.Logging.AddSerilog(dispose: false);
         builder.Services.AddFoundryApplicationServices();
         return builder.Build();

--- a/src/Foundry/Services/Localization/ApplicationLocalizationService.cs
+++ b/src/Foundry/Services/Localization/ApplicationLocalizationService.cs
@@ -123,16 +123,11 @@ internal sealed class ApplicationLocalizationService(
         }
         catch (Exception ex)
         {
-            if (appSettingsService.Current.Diagnostics.DeveloperMode)
-            {
-                logger.Warning(ex, "Localized resource lookup failed. Key={Key}, Language={Language}", key, currentLanguage);
-            }
+            logger.Warning(ex, "Localized resource lookup failed. Key={Key}, Language={Language}", key, currentLanguage);
+            return key;
         }
 
-        if (appSettingsService.Current.Diagnostics.DeveloperMode)
-        {
-            logger.Warning("Localized resource key was not found. Key={Key}, Language={Language}", key, currentLanguage);
-        }
+        logger.Warning("Localized resource key was not found. Key={Key}, Language={Language}", key, currentLanguage);
 
         return key;
     }

--- a/src/Foundry/Services/Settings/FoundryAppSettings.cs
+++ b/src/Foundry/Services/Settings/FoundryAppSettings.cs
@@ -34,11 +34,6 @@ public sealed class FoundryAppSettings
     public UpdateSettings Updates { get; set; } = new();
 
     /// <summary>
-    /// Gets or sets diagnostic and developer-mode preferences.
-    /// </summary>
-    public DiagnosticsSettings Diagnostics { get; set; } = new();
-
-    /// <summary>
     /// Gets or sets anonymous telemetry preferences and identity.
     /// </summary>
     public TelemetryAppSettings Telemetry { get; set; } = new();
@@ -205,17 +200,6 @@ public sealed class UpdateSettings
     /// Gets or sets the last time an update check completed.
     /// </summary>
     public DateTimeOffset? LastCheckedAt { get; set; }
-}
-
-/// <summary>
-/// Stores diagnostic preferences that affect logging and developer-only UI behavior.
-/// </summary>
-public sealed class DiagnosticsSettings
-{
-    /// <summary>
-    /// Gets or sets a value indicating whether developer diagnostics are enabled.
-    /// </summary>
-    public bool DeveloperMode { get; set; }
 }
 
 /// <summary>

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>إنشاء الوسائط</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>الإبلاغ عن مفاتيح الترجمة المفقودة وإخفاقات البحث عن الموارد. تظل جميع مستويات سجلات التطبيق مفعّلة.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>تشخيصات المطور</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>قم بتغيير لغة التطبيق دون إعادة تشغيل Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>إنشاء الوسائط</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>تمكين تسجيل التطبيق على مستوى تصحيح الأخطاء.</value>
+    <value>الإبلاغ عن مفاتيح الترجمة المفقودة وإخفاقات البحث عن الموارد. تظل جميع مستويات سجلات التطبيق مفعّلة.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>تشخيصات المطور</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>أرسل السجلات المنقّحة وتفاصيل الاستثناءات للمساعدة في تشخيص حالات الفشل. تُستبعد الأسرار والمُعرّفات المباشرة.</value>
+    <value>إرسال جميع مستويات السجلات والسياق التقني إلى PostHog مع إخفاء أسرار المصادقة، بالإضافة إلى تقارير استثناءات منفصلة. تُحذف السجلات تلقائيًا بعد 7 أيام.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>تمكين التشخيص عن بُعد</value>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Създаване на носител</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Активиране на регистрирането на приложението на ниво „Отстраняване на грешки“.</value>
+    <value>Съобщаване за липсващи ключове за превод и грешки при търсене на ресурси. Всички нива на регистриране остават включени.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Диагностика за разработчици</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Изпращайте обезличени регистрационни файлове и подробности за изключенията, за да помогнете при диагностицирането на неизправности. Тайните данни и преките идентификатори се изключват.</value>
+    <value>Изпращане до PostHog на всички нива на регистрационни записи и техническия контекст със скрити тайни за удостоверяване, както и отделни отчети за изключения. Записите се изтриват автоматично след 7 дни.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Активиране на отдалечената диагностика</value>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Създаване на носител</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Съобщаване за липсващи ключове за превод и грешки при търсене на ресурси. Всички нива на регистриране остават включени.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Диагностика за разработчици</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Променете езика на приложението, без да рестартирате Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Vytvoření média</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Hlásit chybějící překladové klíče a chyby vyhledávání prostředků. Všechny úrovně protokolování zůstávají zapnuté.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Diagnostika pro vývojáře</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Změňte jazyk aplikace bez restartování Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Vytvoření média</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Povolit protokolování aplikace na úrovni ladění.</value>
+    <value>Hlásit chybějící překladové klíče a chyby vyhledávání prostředků. Všechny úrovně protokolování zůstávají zapnuté.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Diagnostika pro vývojáře</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Odesílejte očištěné protokoly a podrobnosti o výjimkách, které pomohou diagnostikovat selhání. Tajné údaje a přímé identifikátory jsou vyloučeny.</value>
+    <value>Odesílat do PostHog všechny úrovně protokolů a technický kontext s maskovanými ověřovacími tajnými údaji a samostatná hlášení výjimek. Protokoly se automaticky odstraní po 7 dnech.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Povolit vzdálenou diagnostiku</value>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Medieoprettelse</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Rapportér manglende oversættelsesnøgler og fejl ved ressourcesøgning. Alle logniveauer forbliver aktiveret.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Udviklerdiagnosticering</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Skift applikationssproget uden at genstarte Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Medieoprettelse</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Aktivér programlogføring på fejlfindingsniveau.</value>
+    <value>Rapportér manglende oversættelsesnøgler og fejl ved ressourcesøgning. Alle logniveauer forbliver aktiveret.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Udviklerdiagnosticering</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Send rensede logfiler og oplysninger om undtagelser for at hjælpe med at diagnosticere fejl. Hemmeligheder og direkte identifikatorer udelades.</value>
+    <value>Send alle logniveauer og teknisk kontekst til PostHog med maskerede godkendelseshemmeligheder samt separate undtagelsesrapporter. Logfiler slettes automatisk efter 7 dage.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Aktivér fjerndiagnosticering</value>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Medienerstellung</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Fehlende Übersetzungsschlüssel und Fehler bei der Ressourcensuche melden. Alle Anwendungsprotokollstufen bleiben aktiviert.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Entwicklerdiagnose</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Ändern Sie die Anwendungssprache, ohne Foundry OSD neu zu starten.</value>
   </data>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Medienerstellung</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Protokollierung der Anwendung auf Debug-Ebene aktivieren.</value>
+    <value>Fehlende Übersetzungsschlüssel und Fehler bei der Ressourcensuche melden. Alle Anwendungsprotokollstufen bleiben aktiviert.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Entwicklerdiagnose</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Senden Sie bereinigte Protokolle und Ausnahmedetails, um Fehler zu diagnostizieren. Geheimnisse und direkte Identifikatoren werden ausgeschlossen.</value>
+    <value>Alle Protokollstufen und technischen Kontext mit maskierten Authentifizierungsgeheimnissen sowie separate Ausnahmeberichte an PostHog senden. Protokolle werden nach 7 Tagen automatisch gelöscht.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Ferndiagnose aktivieren</value>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Δημιουργία μέσων</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Αναφορά κλειδιών μετάφρασης που λείπουν και αποτυχιών αναζήτησης πόρων. Όλα τα επίπεδα καταγραφής παραμένουν ενεργά.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Διαγνωστικά για προγραμματιστές</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Αλλάξτε τη γλώσσα της εφαρμογής χωρίς επανεκκίνηση του Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Δημιουργία μέσων</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Ενεργοποίηση καταγραφής εφαρμογής σε επίπεδο εντοπισμού σφαλμάτων.</value>
+    <value>Αναφορά κλειδιών μετάφρασης που λείπουν και αποτυχιών αναζήτησης πόρων. Όλα τα επίπεδα καταγραφής παραμένουν ενεργά.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Διαγνωστικά για προγραμματιστές</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Στείλτε καθαρισμένα αρχεία καταγραφής και λεπτομέρειες εξαιρέσεων για να βοηθήσετε στη διάγνωση αποτυχιών. Τα μυστικά και τα άμεσα αναγνωριστικά εξαιρούνται.</value>
+    <value>Αποστολή όλων των επιπέδων καταγραφής και του τεχνικού πλαισίου στο PostHog με απόκρυψη μυστικών ελέγχου ταυτότητας, καθώς και ξεχωριστών αναφορών εξαιρέσεων. Τα αρχεία καταγραφής διαγράφονται αυτόματα μετά από 7 ημέρες.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Ενεργοποίηση απομακρυσμένων διαγνωστικών</value>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Media creation</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Enable Debug-level application logging.</value>
+    <value>Report missing localisation keys and resource lookup failures. All application log levels remain enabled.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Developer diagnostics</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Send sanitised logs and exception details to help diagnose failures. Secrets and direct identifiers are excluded.</value>
+    <value>Send all log levels and technical context to PostHog, with authentication secrets masked, plus separate exception reports. Logs are automatically deleted after 7 days.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Enable remote diagnostics</value>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Media creation</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Report missing localisation keys and resource lookup failures. All application log levels remain enabled.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Developer diagnostics</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Change the application language without restarting Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Media creation</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Report missing localization keys and resource lookup failures. All application log levels remain enabled.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Developer diagnostics</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Change the application language without restarting Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Media creation</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Enable Debug-level application logging.</value>
+    <value>Report missing localization keys and resource lookup failures. All application log levels remain enabled.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Developer diagnostics</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Send sanitized logs and exception details to help diagnose failures. Secrets and direct identifiers are excluded.</value>
+    <value>Send all log levels and technical context to PostHog, with authentication secrets masked, plus separate exception reports. Logs are automatically deleted after 7 days.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Enable remote diagnostics</value>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Creación de medios</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Habilitar el registro de la aplicación en el nivel de depuración.</value>
+    <value>Notificar claves de traducción ausentes y errores de búsqueda de recursos. Todos los niveles de registro permanecen activados.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Diagnósticos para desarrolladores</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Envíe registros saneados y detalles de excepciones para ayudar a diagnosticar errores. Se excluyen los secretos y los identificadores directos.</value>
+    <value>Enviar a PostHog todos los niveles de registro y el contexto técnico, con los secretos de autenticación ocultos, además de informes de excepciones independientes. Los registros se eliminan automáticamente después de 7 días.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Activar diagnósticos remotos</value>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Creación de medios</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Notificar claves de traducción ausentes y errores de búsqueda de recursos. Todos los niveles de registro permanecen activados.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Diagnósticos para desarrolladores</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Cambie el idioma de la aplicación sin reiniciar Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Creación de medios</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Habilitar el registro de la aplicación en el nivel de depuración.</value>
+    <value>Notificar claves de traducción ausentes y errores de búsqueda de recursos. Todos los niveles de registro permanecen activados.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Diagnósticos para desarrolladores</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Envíe registros saneados y detalles de excepciones para ayudar a diagnosticar errores. Se excluyen los secretos y los identificadores directos.</value>
+    <value>Enviar a PostHog todos los niveles de registro y el contexto técnico, con los secretos de autenticación ocultos, además de informes de excepciones independientes. Los registros se eliminan automáticamente después de 7 días.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Activar diagnósticos remotos</value>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Creación de medios</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Notificar claves de traducción ausentes y errores de búsqueda de recursos. Todos los niveles de registro permanecen activados.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Diagnósticos para desarrolladores</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Cambie el idioma de la aplicación sin reiniciar Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Meediumi loomine</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Luba rakenduse silumistaseme logimine.</value>
+    <value>Teavita puuduvatest tõlkevõtmetest ja ressursiotsingu tõrgetest. Kõik logitasemed jäävad lubatuks.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Arendaja diagnostika</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Saatke tõrgete diagnoosimiseks puhastatud logid ja erandite üksikasjad. Saladused ja otsesed identifikaatorid jäetakse välja.</value>
+    <value>Saada PostHogi kõigi tasemete logid ja tehniline kontekst koos varjatud autentimissaladustega ning eraldi erandiaruanded. Logid kustutatakse automaatselt 7 päeva pärast.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Luba kaugdiagnostika</value>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Meediumi loomine</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Teavita puuduvatest tõlkevõtmetest ja ressursiotsingu tõrgetest. Kõik logitasemed jäävad lubatuks.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Arendaja diagnostika</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Muutke rakenduse keelt ilma Foundry OSD taaskäivitamata.</value>
   </data>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Median luonti</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Ilmoita puuttuvista käännösavaimista ja resurssihaun virheistä. Kaikki lokitasot pysyvät käytössä.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Kehittäjän diagnostiikka</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Vaihda sovelluksen kieli käynnistämättä uudelleen Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Median luonti</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Ota sovelluksen virheenkorjaustason lokikirjaus käyttöön.</value>
+    <value>Ilmoita puuttuvista käännösavaimista ja resurssihaun virheistä. Kaikki lokitasot pysyvät käytössä.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Kehittäjän diagnostiikka</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Lähetä puhdistetut lokitiedot ja poikkeusten tiedot, jotta virheiden diagnosointi olisi helpompaa. Salaisuudet ja suorat tunnisteet jätetään pois.</value>
+    <value>Lähetä PostHogiin kaikkien tasojen lokit ja tekninen konteksti todennussalaisuudet peitettyinä sekä erilliset poikkeusraportit. Lokit poistetaan automaattisesti 7 päivän kuluttua.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Ota etädiagnostiikka käyttöön</value>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Création du média</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Signaler les clés de traduction manquantes et les échecs de recherche de ressources. Tous les niveaux de journaux restent activés.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Diagnostics pour les développeurs</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Changez la langue de l'application sans redémarrer Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Création du média</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Activer la journalisation de l’application au niveau débogage.</value>
+    <value>Signaler les clés de traduction manquantes et les échecs de recherche de ressources. Tous les niveaux de journaux restent activés.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Diagnostics pour les développeurs</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Envoyez des journaux assainis et les détails sur les exceptions afin de faciliter le diagnostic des défaillances. Les secrets et les identifiants directs sont exclus.</value>
+    <value>Envoyer à PostHog tous les niveaux de journaux et le contexte technique, avec masquage des secrets d’authentification, ainsi que des rapports d’exception distincts. Les journaux sont supprimés automatiquement après 7 jours.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Activer les diagnostics à distance</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Création du média</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Activer la journalisation de l’application au niveau débogage.</value>
+    <value>Signaler les clés de traduction manquantes et les échecs de recherche de ressources. Tous les niveaux de journaux restent activés.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Diagnostics pour les développeurs</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Envoyez des journaux assainis et les détails des exceptions afin de faciliter le diagnostic des défaillances. Les secrets et les identifiants directs sont exclus.</value>
+    <value>Envoyer à PostHog tous les niveaux de journaux et le contexte technique, avec masquage des secrets d’authentification, ainsi que des rapports d’exception distincts. Les journaux sont supprimés automatiquement après 7 jours.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Activer les diagnostics à distance</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Création du média</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Signaler les clés de traduction manquantes et les échecs de recherche de ressources. Tous les niveaux de journaux restent activés.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Diagnostics pour les développeurs</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Changer la langue de l'application sans redémarrer Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>יצירת מדיה</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>הפעלת רישום יישום ברמת איתור באגים.</value>
+    <value>דיווח על מפתחות תרגום חסרים ועל כשלים בחיפוש משאבים. כל רמות היומן של היישום נשארות פעילות.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>אבחון למפתחים</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>שלח יומנים מנוקים ופרטי חריגות כדי לסייע באבחון תקלות. סודות ומזהים ישירים אינם נכללים.</value>
+    <value>שליחת כל רמות היומן וההקשר הטכני ל-PostHog, תוך מיסוך סודות אימות, וכן דוחות חריגות נפרדים. היומנים נמחקים אוטומטית לאחר 7 ימים.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>הפעלת אבחון מרחוק</value>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>יצירת מדיה</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>דיווח על מפתחות תרגום חסרים ועל כשלים בחיפוש משאבים. כל רמות היומן של היישום נשארות פעילות.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>אבחון למפתחים</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>שנה את שפת היישום מבלי להפעיל מחדש את Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Stvaranje medija</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Omogući zapisivanje aplikacije na razini otklanjanja pogrešaka.</value>
+    <value>Prijavite nedostajuće prijevodne ključeve i pogreške pretraživanja resursa. Sve razine zapisivanja ostaju omogućene.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Dijagnostika za razvojne inženjere</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Šaljite pročišćene zapisnike i pojedinosti o iznimkama radi lakšeg dijagnosticiranja kvarova. Tajni podaci i izravni identifikatori isključeni su.</value>
+    <value>Šaljite sve razine zapisnika i tehnički kontekst u PostHog uz maskirane autentifikacijske tajne te zasebna izvješća o iznimkama. Zapisnici se automatski brišu nakon 7 dana.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Omogući udaljenu dijagnostiku</value>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Stvaranje medija</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Prijavite nedostajuće prijevodne ključeve i pogreške pretraživanja resursa. Sve razine zapisivanja ostaju omogućene.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Dijagnostika za razvojne inženjere</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Promijenite jezik aplikacije bez ponovnog pokretanja Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Adathordozó létrehozása</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Az alkalmazás hibakeresési szintű naplózásának engedélyezése.</value>
+    <value>Hiányzó fordítási kulcsok és erőforrás-keresési hibák jelentése. Minden naplózási szint engedélyezve marad.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Fejlesztői diagnosztika</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Küldjön megtisztított naplókat és kivételadatokat a hibák diagnosztizálásának elősegítéséhez. A titkos adatok és a közvetlen azonosítók kimaradnak.</value>
+    <value>Minden naplózási szint és technikai környezet elküldése a PostHog számára, a hitelesítési titkok maszkolásával és külön kivételjelentésekkel. A naplók 7 nap után automatikusan törlődnek.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Távoli diagnosztika engedélyezése</value>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Adathordozó létrehozása</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Hiányzó fordítási kulcsok és erőforrás-keresési hibák jelentése. Minden naplózási szint engedélyezve marad.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Fejlesztői diagnosztika</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Változtassa meg az alkalmazás nyelvét a Foundry OSD újraindítása nélkül.</value>
   </data>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Creazione supporti</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Segnalare chiavi di traduzione mancanti ed errori nella ricerca delle risorse. Tutti i livelli di log restano attivi.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Diagnostica per sviluppatori</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Modificare la lingua dell'applicazione senza riavviare Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Creazione supporti</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Abilita la registrazione dell'applicazione a livello di debug.</value>
+    <value>Segnalare chiavi di traduzione mancanti ed errori nella ricerca delle risorse. Tutti i livelli di log restano attivi.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Diagnostica per sviluppatori</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Invia log ripuliti e dettagli sulle eccezioni per facilitare la diagnosi degli errori. I dati segreti e gli identificatori diretti sono esclusi.</value>
+    <value>Inviare a PostHog tutti i livelli di log e il contesto tecnico, con i segreti di autenticazione mascherati, oltre a rapporti separati sulle eccezioni. I log vengono eliminati automaticamente dopo 7 giorni.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Abilita diagnostica remota</value>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>メディアの作成</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>アプリケーションのデバッグレベルのログ記録を有効にします。</value>
+    <value>不足している翻訳キーとリソース検索の失敗を報告します。すべてのアプリケーションログレベルは有効のままです。</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>開発者向け診断</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>障害の診断に役立てるため、機密情報を除去したログと例外の詳細を送信します。機密情報と直接識別子は除外されます。</value>
+    <value>認証情報の秘密をマスクし、すべてのログレベルと技術的なコンテキスト、および個別の例外レポートを PostHog に送信します。ログは 7 日後に自動削除されます。</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>リモート診断を有効にする</value>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>メディアの作成</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>不足している翻訳キーとリソース検索の失敗を報告します。すべてのアプリケーションログレベルは有効のままです。</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>開発者向け診断</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Foundry OSD を再起動せずにアプリケーション言語を変更します。</value>
   </data>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>미디어 만들기</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>누락된 번역 키와 리소스 조회 실패를 보고합니다. 모든 애플리케이션 로그 수준은 계속 활성화됩니다.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>개발자 진단</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Foundry OSD을 다시 시작하지 않고 애플리케이션 언어를 변경하세요.</value>
   </data>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>미디어 만들기</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>디버그 수준 애플리케이션 로깅을 사용합니다.</value>
+    <value>누락된 번역 키와 리소스 조회 실패를 보고합니다. 모든 애플리케이션 로그 수준은 계속 활성화됩니다.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>개발자 진단</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>오류 진단에 도움이 되도록 민감한 정보를 제거한 로그와 예외 세부 정보를 보냅니다. 비밀 정보와 직접 식별자는 제외됩니다.</value>
+    <value>인증 비밀을 마스킹한 모든 수준의 로그와 기술적 컨텍스트 및 별도의 예외 보고서를 PostHog로 보냅니다. 로그는 7일 후 자동으로 삭제됩니다.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>원격 진단 활성화</value>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Laikmenos kūrimas</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Įjungti programos žurnalų registravimą derinimo lygiu.</value>
+    <value>Pranešti apie trūkstamus vertimo raktus ir išteklių paieškos klaidas. Visi žurnalų lygiai lieka įjungti.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Kūrėjo diagnostika</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Siųskite išvalytus žurnalus ir išsamią išimčių informaciją, kad būtų lengviau diagnozuoti triktis. Slapti duomenys ir tiesioginiai identifikatoriai neįtraukiami.</value>
+    <value>Siųsti į PostHog visų lygių žurnalus ir techninį kontekstą su užmaskuotomis autentifikavimo paslaptimis bei atskiras išimčių ataskaitas. Žurnalai automatiškai ištrinami po 7 dienų.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Įjungti nuotolinę diagnostiką</value>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Laikmenos kūrimas</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Pranešti apie trūkstamus vertimo raktus ir išteklių paieškos klaidas. Visi žurnalų lygiai lieka įjungti.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Kūrėjo diagnostika</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Pakeiskite programos kalbą iš naujo nepaleidę Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Datu nesēja izveide</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Ziņot par trūkstošām tulkojumu atslēgām un resursu meklēšanas kļūmēm. Visi žurnālu līmeņi paliek iespējoti.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Izstrādātāja diagnostika</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Mainiet lietojumprogrammas valodu, nerestartējot Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Datu nesēja izveide</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Iespējot lietojumprogrammas atkļūdošanas līmeņa žurnalēšanu.</value>
+    <value>Ziņot par trūkstošām tulkojumu atslēgām un resursu meklēšanas kļūmēm. Visi žurnālu līmeņi paliek iespējoti.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Izstrādātāja diagnostika</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Nosūtiet attīrītus žurnālus un detalizētu informāciju par izņēmumiem, lai palīdzētu diagnosticēt kļūmes. Noslēpumi un tiešie identifikatori netiek iekļauti.</value>
+    <value>Sūtīt uz PostHog visu līmeņu žurnālus un tehnisko kontekstu ar maskētiem autentifikācijas noslēpumiem, kā arī atsevišķus izņēmumu pārskatus. Žurnāli tiek automātiski dzēsti pēc 7 dienām.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Iespējot attālo diagnostiku</value>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Medieoppretting</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Rapporter manglende oversettelsesnøkler og feil ved ressurssøk. Alle loggnivåer forblir aktivert.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Utviklerdiagnostikk</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Endre applikasjonsspråket uten å starte Foundry OSD på nytt.</value>
   </data>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Medieoppretting</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Aktiver programlogging på feilsøkingsnivå.</value>
+    <value>Rapporter manglende oversettelsesnøkler og feil ved ressurssøk. Alle loggnivåer forblir aktivert.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Utviklerdiagnostikk</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Send rensede logger og unntaksdetaljer for å gjøre det enklere å diagnostisere feil. Hemmeligheter og direkte identifikatorer utelates.</value>
+    <value>Send alle loggnivåer og teknisk kontekst til PostHog med maskerte autentiseringshemmeligheter samt separate unntaksrapporter. Logger slettes automatisk etter 7 dager.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Aktiver fjerndiagnostikk</value>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Media maken</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Ontbrekende vertaalsleutels en fouten bij het zoeken naar resources melden. Alle logniveaus blijven ingeschakeld.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Diagnostiek voor ontwikkelaars</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Wijzig de applicatietaal zonder Foundry OSD opnieuw te starten.</value>
   </data>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Media maken</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Logboekregistratie voor de toepassing op debugniveau inschakelen.</value>
+    <value>Ontbrekende vertaalsleutels en fouten bij het zoeken naar resources melden. Alle logniveaus blijven ingeschakeld.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Diagnostiek voor ontwikkelaars</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Verzend opgeschoonde logboeken en details over uitzonderingen om fouten te helpen diagnosticeren. Geheimen en directe identificatoren worden uitgesloten.</value>
+    <value>Alle logniveaus en technische context met afgeschermde authenticatiegeheimen en afzonderlijke uitzonderingsrapporten naar PostHog verzenden. Logs worden na 7 dagen automatisch verwijderd.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Diagnostiek op afstand inschakelen</value>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Tworzenie nośnika</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Zgłaszaj brakujące klucze tłumaczeń i błędy wyszukiwania zasobów. Wszystkie poziomy logowania pozostają włączone.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Diagnostyka deweloperska</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Zmień język aplikacji bez ponownego uruchamiania Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Tworzenie nośnika</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Włącz rejestrowanie zdarzeń aplikacji na poziomie debugowania.</value>
+    <value>Zgłaszaj brakujące klucze tłumaczeń i błędy wyszukiwania zasobów. Wszystkie poziomy logowania pozostają włączone.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Diagnostyka deweloperska</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Wysyłaj oczyszczone dzienniki i szczegóły wyjątków, aby ułatwić diagnozowanie awarii. Dane poufne i bezpośrednie identyfikatory są wykluczane.</value>
+    <value>Wysyłaj do PostHog logi wszystkich poziomów i kontekst techniczny z zamaskowanymi sekretami uwierzytelniania oraz osobne raporty wyjątków. Logi są automatycznie usuwane po 7 dniach.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Włącz diagnostykę zdalną</value>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Criação de mídia</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Relatar chaves de tradução ausentes e falhas na busca de recursos. Todos os níveis de log permanecem ativos.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Diagnóstico do desenvolvedor</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Altere o idioma do aplicativo sem reiniciar Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Criação de mídia</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Habilite o registro em log do aplicativo no nível de depuração.</value>
+    <value>Relatar chaves de tradução ausentes e falhas na busca de recursos. Todos os níveis de log permanecem ativos.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Diagnóstico do desenvolvedor</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Envie logs tratados e detalhes de exceções para ajudar a diagnosticar falhas. Segredos e identificadores diretos são excluídos.</value>
+    <value>Enviar ao PostHog todos os níveis de log e o contexto técnico, com os segredos de autenticação ocultos, além de relatórios de exceções separados. Os logs são excluídos automaticamente após 7 dias.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Habilitar diagnóstico remoto</value>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Criação de suporte</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Ativar o registo da aplicação ao nível de depuração.</value>
+    <value>Comunicar chaves de tradução em falta e falhas na pesquisa de recursos. Todos os níveis de registo permanecem ativos.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Diagnóstico de programador</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Envie registos expurgados e detalhes das exceções para ajudar a diagnosticar falhas. Os segredos e os identificadores diretos são excluídos.</value>
+    <value>Enviar para o PostHog todos os níveis de registo e o contexto técnico, com os segredos de autenticação ocultos, além de relatórios de exceções separados. Os registos são eliminados automaticamente após 7 dias.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Ativar diagnóstico remoto</value>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Criação de suporte</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Comunicar chaves de tradução em falta e falhas na pesquisa de recursos. Todos os níveis de registo permanecem ativos.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Diagnóstico de programador</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Altere o idioma do aplicativo sem reiniciar Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Crearea suportului</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Activați jurnalizarea aplicației la nivel de depanare.</value>
+    <value>Raportează cheile de traducere lipsă și erorile de căutare a resurselor. Toate nivelurile de jurnal rămân activate.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Diagnosticare pentru dezvoltatori</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Trimiteți jurnale curățate și detalii despre excepții pentru a ajuta la diagnosticarea erorilor. Se exclud secretele și identificatorii direcți.</value>
+    <value>Trimite către PostHog toate nivelurile de jurnal și contextul tehnic, cu secretele de autentificare mascate, plus rapoarte separate de excepții. Jurnalele sunt șterse automat după 7 zile.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Activați diagnosticarea la distanță</value>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Crearea suportului</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Raportează cheile de traducere lipsă și erorile de căutare a resurselor. Toate nivelurile de jurnal rămân activate.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Diagnosticare pentru dezvoltatori</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Schimbați limba aplicației fără a reporni Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Создание носителя</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Сообщать об отсутствующих ключах перевода и ошибках поиска ресурсов. Все уровни журналирования остаются включёнными.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Диагностика для разработчиков</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Измените язык приложения без перезапуска Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Создание носителя</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Включить ведение журнала приложения на уровне отладки.</value>
+    <value>Сообщать об отсутствующих ключах перевода и ошибках поиска ресурсов. Все уровни журналирования остаются включёнными.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Диагностика для разработчиков</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Отправляйте очищенные журналы и сведения об исключениях, чтобы помочь диагностировать сбои. Секретные данные и прямые идентификаторы исключаются.</value>
+    <value>Отправлять в PostHog журналы всех уровней и технический контекст с маскированием секретов аутентификации, а также отдельные отчёты об исключениях. Журналы автоматически удаляются через 7 дней.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Включить удалённую диагностику</value>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Vytvorenie média</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Hlásiť chýbajúce prekladové kľúče a chyby vyhľadávania prostriedkov. Všetky úrovne protokolovania zostávajú zapnuté.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Diagnostika pre vývojárov</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Zmeňte jazyk aplikácie bez reštartovania Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Vytvorenie média</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Povoliť zapisovanie aplikácie do denníka na úrovni ladenia.</value>
+    <value>Hlásiť chýbajúce prekladové kľúče a chyby vyhľadávania prostriedkov. Všetky úrovne protokolovania zostávajú zapnuté.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Diagnostika pre vývojárov</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Odosielajte vyčistené denníky a podrobnosti o výnimkách, ktoré pomôžu diagnostikovať zlyhania. Tajné údaje a priame identifikátory sú vylúčené.</value>
+    <value>Odosielať do PostHog všetky úrovne protokolov a technický kontext s maskovanými overovacími tajnými údajmi a samostatné hlásenia výnimiek. Protokoly sa automaticky odstránia po 7 dňoch.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Povoliť vzdialenú diagnostiku</value>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Ustvarjanje medija</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Omogoči beleženje dnevnika programa na ravni razhroščevanja.</value>
+    <value>Poročajte o manjkajočih prevodnih ključih in napakah pri iskanju virov. Vse ravni beleženja ostanejo omogočene.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Diagnostika za razvijalce</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Pošiljajte prečiščene dnevnike in podrobnosti o izjemah za lažje diagnosticiranje napak. Skrivnosti in neposredni identifikatorji so izključeni.</value>
+    <value>Pošiljajte vse ravni dnevnikov in tehnični kontekst v PostHog z zakritimi skrivnostmi za preverjanje pristnosti ter ločena poročila o izjemah. Dnevniki se samodejno izbrišejo po 7 dneh.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Omogoči oddaljeno diagnostiko</value>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Ustvarjanje medija</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Poročajte o manjkajočih prevodnih ključih in napakah pri iskanju virov. Vse ravni beleženja ostanejo omogočene.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Diagnostika za razvijalce</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Spremenite jezik aplikacije brez ponovnega zagona Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Kreiranje medija</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Omogući evidentiranje aplikacije na nivou otklanjanja grešaka.</value>
+    <value>Prijavljujte nedostajuće ključeve prevoda i greške pri pretrazi resursa. Svi nivoi evidentiranja ostaju omogućeni.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Dijagnostika za programere</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Šaljite prečišćene evidencije i detalje o izuzecima radi lakšeg dijagnostikovanja grešaka. Tajni podaci i direktni identifikatori su isključeni.</value>
+    <value>Šaljite sve nivoe evidencije i tehnički kontekst u PostHog uz maskirane tajne za autentifikaciju i zasebne izveštaje o izuzecima. Evidencije se automatski brišu posle 7 dana.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Omogući udaljenu dijagnostiku</value>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Kreiranje medija</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Prijavljujte nedostajuće ključeve prevoda i greške pri pretrazi resursa. Svi nivoi evidentiranja ostaju omogućeni.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Dijagnostika za programere</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Promenite jezik aplikacije bez ponovnog pokretanja Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Skapa media</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Aktivera programloggning på felsökningsnivå.</value>
+    <value>Rapportera saknade översättningsnycklar och fel vid resurssökning. Alla loggnivåer förblir aktiverade.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Utvecklardiagnostik</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Skicka rensade loggar och undantagsinformation för att underlätta diagnostisering av fel. Hemligheter och direkta identifierare utesluts.</value>
+    <value>Skicka alla loggnivåer och teknisk kontext till PostHog med maskerade autentiseringshemligheter samt separata undantagsrapporter. Loggar raderas automatiskt efter 7 dagar.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Aktivera fjärrdiagnostik</value>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Skapa media</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Rapportera saknade översättningsnycklar och fel vid resurssökning. Alla loggnivåer förblir aktiverade.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Utvecklardiagnostik</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Ändra applikationsspråk utan att starta om Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>การสร้างสื่อ</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>เปิดใช้งานการบันทึกของแอปพลิเคชันระดับดีบัก</value>
+    <value>รายงานคีย์คำแปลที่ขาดหายและข้อผิดพลาดในการค้นหาทรัพยากร บันทึกของแอปพลิเคชันทุกระดับยังคงเปิดใช้งานอยู่</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>การวินิจฉัยสำหรับนักพัฒนา</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>ส่งบันทึกที่ผ่านการลบข้อมูลละเอียดอ่อนและรายละเอียดข้อยกเว้นเพื่อช่วยวินิจฉัยความล้มเหลว โดยจะไม่รวมข้อมูลลับและตัวระบุโดยตรง</value>
+    <value>ส่งบันทึกทุกระดับและบริบททางเทคนิคไปยัง PostHog โดยปกปิดข้อมูลลับสำหรับการยืนยันตัวตน พร้อมรายงานข้อยกเว้นแยกต่างหาก บันทึกจะถูกลบโดยอัตโนมัติหลังจาก 7 วัน</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>เปิดใช้งานการวินิจฉัยระยะไกล</value>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>การสร้างสื่อ</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>รายงานคีย์คำแปลที่ขาดหายและข้อผิดพลาดในการค้นหาทรัพยากร บันทึกของแอปพลิเคชันทุกระดับยังคงเปิดใช้งานอยู่</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>การวินิจฉัยสำหรับนักพัฒนา</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>เปลี่ยนภาษาของแอปพลิเคชันโดยไม่ต้องรีสตาร์ท Foundry OSD</value>
   </data>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Medya oluşturma</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Eksik çeviri anahtarlarını ve kaynak arama hatalarını bildirin. Tüm günlük düzeyleri etkin kalır.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Geliştirici tanılaması</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Foundry OSD'yi yeniden başlatmadan uygulama dilini değiştirin.</value>
   </data>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Medya oluşturma</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Uygulama günlüklerinin hata ayıklama düzeyinde kaydedilmesini etkinleştirin.</value>
+    <value>Eksik çeviri anahtarlarını ve kaynak arama hatalarını bildirin. Tüm günlük düzeyleri etkin kalır.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Geliştirici tanılaması</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Hataları tanılamaya yardımcı olmak için hassas bilgilerden arındırılmış günlükleri ve özel durum ayrıntılarını gönderin. Gizli bilgiler ve doğrudan tanımlayıcılar hariç tutulur.</value>
+    <value>Tüm günlük düzeylerini ve teknik bağlamı, kimlik doğrulama sırları maskelenmiş olarak, ayrı özel durum raporlarıyla birlikte PostHog’a gönderin. Günlükler 7 gün sonra otomatik olarak silinir.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Uzaktan tanılamayı etkinleştir</value>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>Створення носія</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Увімкнути журналювання програми на рівні налагодження.</value>
+    <value>Повідомляти про відсутні ключі перекладу та помилки пошуку ресурсів. Усі рівні журналювання залишаються ввімкненими.</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>Діагностика для розробників</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>Надсилайте очищені журнали та відомості про винятки, щоб допомогти діагностувати збої. Секретні дані та прямі ідентифікатори виключаються.</value>
+    <value>Надсилати до PostHog журнали всіх рівнів і технічний контекст із маскуванням секретів автентифікації, а також окремі звіти про винятки. Журнали автоматично видаляються через 7 днів.</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>Увімкнути віддалену діагностику</value>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>Створення носія</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>Повідомляти про відсутні ключі перекладу та помилки пошуку ресурсів. Усі рівні журналювання залишаються ввімкненими.</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>Діагностика для розробників</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>Змініть мову програми без перезапуску Foundry OSD.</value>
   </data>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>创建媒体</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>启用调试级应用日志记录。</value>
+    <value>报告缺失的翻译键和资源查找失败。所有应用程序日志级别均保持启用。</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>开发人员诊断</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>发送已清理敏感信息的日志和异常详细信息，以帮助诊断故障。不会包含机密信息和直接标识符。</value>
+    <value>向 PostHog 发送所有级别的日志、技术上下文以及单独的异常报告，并对身份验证机密进行掩码处理。日志会在 7 天后自动删除。</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>启用远程诊断</value>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>创建媒体</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>报告缺失的翻译键和资源查找失败。所有应用程序日志级别均保持启用。</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>开发人员诊断</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>更改应用程序语言而无需重新启动Foundry OSD。</value>
   </data>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -1743,12 +1743,6 @@
   <data name="GeneralConfiguration_CreateMedia.Header" xml:space="preserve">
     <value>建立媒體</value>
   </data>
-  <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>回報遺失的翻譯索引鍵與資源查詢失敗。所有應用程式記錄層級均保持啟用。</value>
-  </data>
-  <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
-    <value>開發人員診斷</value>
-  </data>
   <data name="GeneralSetting_LanguageCard.Description" xml:space="preserve">
     <value>更改應用程式語言而無需重新啟動Foundry OSD。</value>
   </data>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -1744,7 +1744,7 @@
     <value>建立媒體</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Description" xml:space="preserve">
-    <value>啟用偵錯層級的應用程式記錄。</value>
+    <value>回報遺失的翻譯索引鍵與資源查詢失敗。所有應用程式記錄層級均保持啟用。</value>
   </data>
   <data name="GeneralSetting_DiagnosticsCard.Header" xml:space="preserve">
     <value>開發人員診斷</value>
@@ -2338,7 +2338,7 @@
     <value>Proxy</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Description" xml:space="preserve">
-    <value>傳送已清除敏感資訊的記錄和例外狀況詳細資料，以協助診斷失敗。系統不會包含機密資訊和直接識別碼。</value>
+    <value>將所有層級的記錄、技術內容及獨立的例外狀況報告傳送至 PostHog，並遮蔽驗證機密。記錄會在 7 天後自動刪除。</value>
   </data>
   <data name="SettingsPage_RemoteDiagnosticsCard.Header" xml:space="preserve">
     <value>啟用遠端診斷</value>

--- a/src/Foundry/ViewModels/Settings/GeneralSettingViewModel.cs
+++ b/src/Foundry/ViewModels/Settings/GeneralSettingViewModel.cs
@@ -62,7 +62,6 @@ namespace Foundry.ViewModels
         {
             appSettingsService.Current.Diagnostics.DeveloperMode = value;
             appSettingsService.Save();
-            SetDeveloperModeEnabled(value);
         }
 
         [RelayCommand]

--- a/src/Foundry/ViewModels/Settings/GeneralSettingViewModel.cs
+++ b/src/Foundry/ViewModels/Settings/GeneralSettingViewModel.cs
@@ -8,7 +8,6 @@ using Foundry.Localization;
 using Foundry.Core.Services.Application;
 using Foundry.Services.Application;
 using Foundry.Services.Localization;
-using Foundry.Services.Settings;
 using Foundry.Utilities.Diagnostics;
 using Microsoft.UI.Xaml.Controls;
 using Serilog;
@@ -17,22 +16,18 @@ namespace Foundry.ViewModels
 {
     public sealed partial class GeneralSettingViewModel : ObservableObject
     {
-        private readonly IAppSettingsService appSettingsService;
         private readonly IExternalProcessLauncher externalProcessLauncher;
         private readonly IApplicationLocalizationService localizationService;
         private readonly IFilePickerService filePickerService;
 
         public GeneralSettingViewModel(
-            IAppSettingsService appSettingsService,
             IExternalProcessLauncher externalProcessLauncher,
             IApplicationLocalizationService localizationService,
             IFilePickerService filePickerService)
         {
-            this.appSettingsService = appSettingsService;
             this.externalProcessLauncher = externalProcessLauncher;
             this.localizationService = localizationService;
             this.filePickerService = filePickerService;
-            IsDeveloperMode = appSettingsService.Current.Diagnostics.DeveloperMode;
             RefreshSupportedLanguages();
         }
 
@@ -41,9 +36,6 @@ namespace Foundry.ViewModels
         public string LogDirectoryPath => LoggerSetup.LogFilePath == "<unavailable>"
             ? LoggerSetup.LogFilePath
             : Path.GetDirectoryName(LoggerSetup.LogFilePath) ?? Constants.LogDirectoryPath;
-
-        [ObservableProperty]
-        public partial bool IsDeveloperMode { get; set; }
 
         [ObservableProperty]
         public partial SupportedCultureOption? SelectedLanguage { get; set; }
@@ -56,12 +48,6 @@ namespace Foundry.ViewModels
             }
 
             await localizationService.SetLanguageAsync(selectedLanguage.Code);
-        }
-
-        partial void OnIsDeveloperModeChanged(bool value)
-        {
-            appSettingsService.Current.Diagnostics.DeveloperMode = value;
-            appSettingsService.Save();
         }
 
         [RelayCommand]

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -593,7 +593,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             operationProgressService.Report(100, terminalStatus);
             logger.Error(
                 ex,
-                "Final boot media operation failed. FailedStepName={FailedStepName}, DurationMs={DurationMs}, FailureKind={FailureKind}, FailureReason={FailureReason}, FailureCode={FailureCode}, ToolName={ToolName}, ExitCode={ExitCode}, RetryCount={RetryCount}, FailureSummary={FailureSummary}, RemoteDiagnostic={RemoteDiagnostic}",
+                "Final boot media operation failed. FailedStepName={FailedStepName}, DurationMs={DurationMs}, FailureKind={FailureKind}, FailureReason={FailureReason}, FailureCode={FailureCode}, ToolName={ToolName}, ExitCode={ExitCode}, RetryCount={RetryCount}, FailureSummary={FailureSummary}",
                 failedStepName,
                 stopwatch.ElapsedMilliseconds,
                 failureDiagnostic.FailureKind,
@@ -602,8 +602,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 failureDiagnostic.ToolName,
                 failureDiagnostic.ExitCode,
                 failureDiagnostic.RetryCount,
-                failureDiagnostic.Message,
-                true);
+                failureDiagnostic.Message);
         }
         catch (OperationCanceledException ex)
         {
@@ -617,14 +616,13 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 exception: ex);
             logger.Warning(
                 ex,
-                "Final boot media operation cancelled. FailedStepName={FailedStepName}, DurationMs={DurationMs}, FailureKind={FailureKind}, FailureReason={FailureReason}, FailureCode={FailureCode}, RetryCount={RetryCount}, RemoteDiagnostic={RemoteDiagnostic}",
+                "Final boot media operation cancelled. FailedStepName={FailedStepName}, DurationMs={DurationMs}, FailureKind={FailureKind}, FailureReason={FailureReason}, FailureCode={FailureCode}, RetryCount={RetryCount}",
                 telemetryProgressTracker.CurrentStepName,
                 stopwatch.ElapsedMilliseconds,
                 failureDiagnostic.FailureKind,
                 failureDiagnostic.FailureReason,
                 failureDiagnostic.Code,
-                failureDiagnostic.RetryCount,
-                true);
+                failureDiagnostic.RetryCount);
             throw;
         }
         finally

--- a/src/Foundry/Views/Settings/GeneralSettingPage.xaml
+++ b/src/Foundry/Views/Settings/GeneralSettingPage.xaml
@@ -43,16 +43,6 @@
                 </ComboBox>
             </wct:SettingsCard>
 
-            <wct:SettingsCard x:Name="DeveloperDiagnosticsCard"
-                x:Uid="GeneralSetting_DiagnosticsCard">
-                <wct:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xEC7A;" />
-                </wct:SettingsCard.HeaderIcon>
-                <ToggleSwitch
-                    behaviors:LocalizedToggleSwitch.UseLocalizedStateContent="True"
-                    IsOn="{x:Bind ViewModel.IsDeveloperMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-            </wct:SettingsCard>
-
             <wct:SettingsCard x:Name="ExportDiagnosticsCard">
                 <wct:SettingsCard.HeaderIcon>
                     <FontIcon Glyph="&#xE74E;" />

--- a/src/Foundry/Views/Settings/GeneralSettingPage.xaml.cs
+++ b/src/Foundry/Views/Settings/GeneralSettingPage.xaml.cs
@@ -111,8 +111,6 @@ public sealed partial class GeneralSettingPage : Page
         StartupCard.Description = localizationService.GetString("GeneralSetting_StartupCard.Description");
         LanguageCard.Header = localizationService.GetString("GeneralSetting_LanguageCard.Header");
         LanguageCard.Description = localizationService.GetString("GeneralSetting_LanguageCard.Description");
-        DeveloperDiagnosticsCard.Header = localizationService.GetString("GeneralSetting_DiagnosticsCard.Header");
-        DeveloperDiagnosticsCard.Description = localizationService.GetString("GeneralSetting_DiagnosticsCard.Description");
         ExportDiagnosticsCard.Header = localizationService.GetString("Diagnostics.ExportCardHeader");
         ExportDiagnosticsCard.Description = localizationService.GetString("Diagnostics.ExportCardDescription");
         ExportDiagnosticsButton.Content = localizationService.GetString("Diagnostics.ExportButton");

--- a/src/Foundry/Views/SettingsPage.xaml.cs
+++ b/src/Foundry/Views/SettingsPage.xaml.cs
@@ -51,6 +51,8 @@ namespace Foundry.Views
         {
             TelemetryCard.Header = localizationService.GetString("SettingsPage_TelemetryCard.Header");
             TelemetryCard.Description = localizationService.GetString("SettingsPage_TelemetryCard.Description");
+            RemoteDiagnosticsCard.Header = localizationService.GetString("SettingsPage_RemoteDiagnosticsCard.Header");
+            RemoteDiagnosticsCard.Description = localizationService.GetString("SettingsPage_RemoteDiagnosticsCard.Description");
             ApplyNavigationGuardState();
         }
 


### PR DESCRIPTION
## Summary

A single Serilog call writes the same normalized event to the local file and PostHog Logs across Foundry OSD, Bootstrap, Connect and Deploy. All six log levels are enabled, with technical context and original timestamps retained.

## Reason

Local files and PostHog previously exposed different detail and filtering, making remote investigations difficult to reconcile. An incorrect WinPE boot clock also placed early Connect logs outside the incident's time range.

## Main changes

- Share event normalization, stable identifiers, UTC timestamps and targeted authentication-secret masking.
- Deliver Logs through a bounded durable queue with acknowledgements, retries, payload splitting and recovery. Disabling remote diagnostics stops delivery and invalidates pending records.
- Preserve startup-failure events and their context during Bootstrap handoff. Keep transport diagnostics local to avoid feedback loops.
- Attempt clock synchronization before Connect within two seconds, continue offline, and retry afterward if needed. Snapshot clock reliability on each event: unverified events use PostHog receipt-time indexing and retain their raw original time; synchronized events use creation time.
- Keep product telemetry and strict Error Tracking separate. Remove the developer diagnostics setting and update the remaining descriptions in all 38 languages.
- Remove obsolete log eligibility markers, unused dynamic level switching, and redundant Error Tracking clients partitioned by an unused context. Keep compatibility paths needed to recover older pending records.
- Document behavior and seven-day PostHog Logs retention in [GitBook PR #20](https://github.com/foundry-osd/GitBook/pull/20).

## Testing

- Full x64 Release solution build with continuous-integration settings: zero warnings or errors.
- All 2,119 tests pass after cleanup: Utilities 221, Telemetry 248, Bootstrap 115, Core 705, Connect 119, Deploy 649 and Localization 62.
- `scripts/Test-FoundryFormat.ps1` passes. All 1,126 C# headers are valid; all 38 resource files have unique keys and one value per entry.
- Independent transport and runtime reviews found no blocking defect; the cleanup received a final integration review.
- Live OSD ISO creation succeeded: 201 remotely eligible events matched local records without duplicates; two transport-flush diagnostics remained local.
- Full WinPE run succeeded: 230 distinct records reached PostHog (Bootstrap 33, Connect 25, Deploy 172), with no warnings or errors. Connect exited with code 0; deployment completed with 17 successful and 6 skipped steps.
- The WinPE run exercised an early clock timeout followed by successful correction of approximately ten hours of skew. All 42 pre-synchronization events used receipt time and retained their raw timestamp; the other 188 used event time.

## Additional information

No configuration schema change. Plans and local audit artifacts are excluded from commits.

Sustained network interruption and durable-queue recovery across a WinPE restart remain covered by automated tests rather than a complete manual scenario. The WinPE audit verifies the remote stream; full local/remote parity for that run requires its local files. Delivery may replay records after an interrupted acknowledgement.
