### PR TITLE
feat(credentials): centralize Windows Credential Manager storage

### DIFF
--- a/src/Foundry.Utilities.Tests/Security/WindowsCredentialStoreTests.cs
+++ b/src/Foundry.Utilities.Tests/Security/WindowsCredentialStoreTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using Foundry.Utilities.Security;
+
+namespace Foundry.Utilities.Tests.Security;
+
+public sealed class WindowsCredentialStoreTests
+{
+    [Fact]
+    public void CredentialDispose_ErasesOwnedSecretBuffer()
+    {
+        byte[] secret = [0x11, 0xFF, 0xA3];
+        var credential = new WindowsCredential(secret);
+
+        credential.Dispose();
+        credential.Dispose();
+
+        Assert.Equal(new byte[3], secret);
+    }
+
+    [Fact]
+    public void WriteRead_WithBinarySecret_PreservesBytesAndUsernameAcrossStoreInstances()
+    {
+        var store = new WindowsCredentialStore();
+        string target = CreateTarget();
+        byte[] secret = [0x00, 0xFF, 0x41, 0x00, 0xFE];
+        try
+        {
+            store.Write(target, secret, @"EXAMPLE\operator");
+            using WindowsCredential? result = new WindowsCredentialStore().Read(target);
+
+            Assert.NotNull(result);
+            Assert.Equal(new byte[] { 0x00, 0xFF, 0x41, 0x00, 0xFE }, result.Secret);
+            Assert.Equal(@"EXAMPLE\operator", result.UserName);
+            Assert.Equal(new byte[] { 0x00, 0xFF, 0x41, 0x00, 0xFE }, secret);
+        }
+        finally
+        {
+            store.Delete(target);
+        }
+    }
+
+    [Fact]
+    public void Write_WithMaximumSizeAndOversizedReplacement_PreservesStoredSecret()
+    {
+        var store = new WindowsCredentialStore();
+        string target = CreateTarget();
+        byte[] secret = Enumerable.Range(0, 2560).Select(value => (byte)value).ToArray();
+        try
+        {
+            store.Write(target, secret);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => store.Write(target, new byte[2561]));
+            using WindowsCredential? result = store.Read(target);
+            Assert.NotNull(result);
+            Assert.Equal(secret, result.Secret);
+        }
+        finally
+        {
+            store.Delete(target);
+        }
+    }
+
+    [Fact]
+    public void Delete_WithTwoTargets_RemovesOnlyRequestedCredentialAndDistinguishesEmptyFromMissing()
+    {
+        var store = new WindowsCredentialStore();
+        string firstTarget = CreateTarget();
+        string secondTarget = CreateTarget();
+        try
+        {
+            Assert.Null(store.Read(firstTarget));
+            store.Write(firstTarget, [0x19]);
+            store.Write(secondTarget, []);
+
+            store.Delete(firstTarget);
+            store.Delete(firstTarget);
+
+            Assert.Null(store.Read(firstTarget));
+            using WindowsCredential? second = store.Read(secondTarget);
+            Assert.NotNull(second);
+            Assert.Empty(second.Secret);
+        }
+        finally
+        {
+            store.Delete(firstTarget);
+            store.Delete(secondTarget);
+        }
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("target\0suffix")]
+    public void Operations_WithInvalidTarget_RejectBeforeNativeAccess(string target)
+    {
+        var store = new WindowsCredentialStore();
+
+        Assert.Throws<ArgumentException>(() => store.Read(target));
+        Assert.Throws<ArgumentException>(() => store.Write(target, []));
+        Assert.Throws<ArgumentException>(() => store.Delete(target));
+    }
+
+    [Fact]
+    public void Write_WhenWindowsRejectsUsername_ReportsNativeErrorAndPreservesExistingValue()
+    {
+        var store = new WindowsCredentialStore();
+        string target = CreateTarget();
+        try
+        {
+            store.Write(target, [0x31]);
+
+            Win32Exception error = Assert.Throws<Win32Exception>(() =>
+                store.Write(target, [0x42], new string('x', 514)));
+
+            Assert.NotEqual(0, error.NativeErrorCode);
+            using WindowsCredential? result = store.Read(target);
+            Assert.NotNull(result);
+            Assert.Equal(new byte[] { 0x31 }, result.Secret);
+        }
+        finally
+        {
+            store.Delete(target);
+        }
+    }
+
+    private static string CreateTarget() => $"Foundry.Utilities.Tests/{Guid.NewGuid():N}";
+}

--- a/src/Foundry.Utilities/Security/IWindowsCredentialStore.cs
+++ b/src/Foundry.Utilities/Security/IWindowsCredentialStore.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Utilities.Security;
+
+/// <summary>
+/// Stores generic credentials for the executing Windows user on the current computer.
+/// Callers own case-insensitive target identity and policy; native failures are never treated as missing secrets.
+/// </summary>
+public interface IWindowsCredentialStore
+{
+    /// <summary>
+    /// Reads an owned secret buffer, or returns null only when the target does not exist.
+    /// The caller must dispose the returned credential.
+    /// </summary>
+    WindowsCredential? Read(string target);
+
+    /// <summary>
+    /// Copies and persists an opaque secret, preserving empty values and optional username metadata.
+    /// </summary>
+    void Write(string target, ReadOnlySpan<byte> secret, string? userName = null);
+
+    /// <summary>
+    /// Deletes the target. A missing target is already deleted; other native failures are reported.
+    /// </summary>
+    void Delete(string target);
+}

--- a/src/Foundry.Utilities/Security/WindowsCredential.cs
+++ b/src/Foundry.Utilities/Security/WindowsCredential.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+
+namespace Foundry.Utilities.Security;
+
+/// <summary>
+/// Owns credential bytes returned by a store and erases them when disposed.
+/// </summary>
+/// <param name="secret">Buffer whose ownership is transferred to this credential without copying.</param>
+/// <param name="userName">Optional account metadata associated with the secret.</param>
+public sealed class WindowsCredential(byte[] secret, string? userName = null) : IDisposable
+{
+    /// <summary>
+    /// Gets the owned secret buffer. Do not retain or use it after disposing this credential.
+    /// </summary>
+    public byte[] Secret { get; } = secret ?? throw new ArgumentNullException(nameof(secret));
+
+    public string? UserName { get; } = userName;
+
+    /// <summary>
+    /// Erases the owned bytes; repeated disposal is harmless.
+    /// </summary>
+    public void Dispose() => CryptographicOperations.ZeroMemory(Secret);
+}

--- a/src/Foundry.Utilities/Security/WindowsCredentialStore.cs
+++ b/src/Foundry.Utilities/Security/WindowsCredentialStore.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace Foundry.Utilities.Security;
+
+/// <summary>
+/// Stores bounded opaque values in Windows Credential Manager without a plaintext fallback.
+/// </summary>
+public sealed class WindowsCredentialStore : IWindowsCredentialStore
+{
+    /// <summary>
+    /// Maximum encoded blob length accepted by WinCred (CRED_MAX_CREDENTIAL_BLOB_SIZE).
+    /// </summary>
+    public const int MaximumSecretSize = 2560;
+
+    private const int CredentialTypeGeneric = 1;
+    private const int CredentialPersistLocalMachine = 2;
+    private const int ErrorNotFound = 1168;
+
+    /// <inheritdoc />
+    public WindowsCredential? Read(string target)
+    {
+        ValidateTarget(target);
+        if (!CredRead(target, CredentialTypeGeneric, 0, out nint credentialPointer))
+        {
+            int error = Marshal.GetLastWin32Error();
+            return error == ErrorNotFound ? null : throw new Win32Exception(error);
+        }
+
+        NativeCredential nativeCredential = default;
+        try
+        {
+            nativeCredential = Marshal.PtrToStructure<NativeCredential>(credentialPointer);
+            if (nativeCredential.CredentialBlobSize > MaximumSecretSize ||
+                (nativeCredential.CredentialBlobSize > 0 && nativeCredential.CredentialBlob == 0))
+            {
+                throw new InvalidDataException("Windows returned an invalid credential blob.");
+            }
+
+            byte[] secret = new byte[(int)nativeCredential.CredentialBlobSize];
+            try
+            {
+                if (secret.Length > 0)
+                {
+                    Marshal.Copy(nativeCredential.CredentialBlob, secret, 0, secret.Length);
+                }
+
+                return new WindowsCredential(secret, nativeCredential.UserName);
+            }
+            catch
+            {
+                CryptographicOperations.ZeroMemory(secret);
+                throw;
+            }
+        }
+        finally
+        {
+            try
+            {
+                if (nativeCredential.CredentialBlob != 0 && nativeCredential.CredentialBlobSize <= MaximumSecretSize)
+                {
+                    for (int index = 0; index < nativeCredential.CredentialBlobSize; index++)
+                    {
+                        Marshal.WriteByte(nativeCredential.CredentialBlob, index, 0);
+                    }
+                }
+            }
+            finally
+            {
+                CredFree(credentialPointer);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void Write(string target, ReadOnlySpan<byte> secret, string? userName = null)
+    {
+        ValidateTarget(target);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(secret.Length, MaximumSecretSize, nameof(secret));
+        if (userName?.Contains('\0') == true)
+        {
+            throw new ArgumentException("Credential usernames cannot contain null characters.", nameof(userName));
+        }
+
+        byte[] secretCopy = secret.ToArray();
+        GCHandle pinnedSecret = default;
+        try
+        {
+            pinnedSecret = GCHandle.Alloc(secretCopy, GCHandleType.Pinned);
+            var credential = new NativeCredential
+            {
+                Type = CredentialTypeGeneric,
+                TargetName = target,
+                CredentialBlobSize = (uint)secretCopy.Length,
+                CredentialBlob = secretCopy.Length == 0 ? 0 : pinnedSecret.AddrOfPinnedObject(),
+                Persist = CredentialPersistLocalMachine,
+                UserName = userName
+            };
+
+            if (!CredWrite(ref credential, 0))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(secretCopy);
+            if (pinnedSecret.IsAllocated)
+            {
+                pinnedSecret.Free();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void Delete(string target)
+    {
+        ValidateTarget(target);
+        if (CredDelete(target, CredentialTypeGeneric, 0))
+        {
+            return;
+        }
+
+        int error = Marshal.GetLastWin32Error();
+        if (error != ErrorNotFound)
+        {
+            throw new Win32Exception(error);
+        }
+    }
+
+    private static void ValidateTarget(string target)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(target);
+        if (target.Contains('\0'))
+        {
+            throw new ArgumentException("Credential targets cannot contain null characters.", nameof(target));
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct NativeCredential
+    {
+        public uint Flags;
+        public int Type;
+        public string? TargetName;
+        public string? Comment;
+        public long LastWritten;
+        public uint CredentialBlobSize;
+        public nint CredentialBlob;
+        public int Persist;
+        public uint AttributeCount;
+        public nint Attributes;
+        public string? TargetAlias;
+        public string? UserName;
+    }
+
+    [DllImport("advapi32.dll", EntryPoint = "CredReadW", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CredRead(string target, int type, int flags, out nint credential);
+
+    [DllImport("advapi32.dll", EntryPoint = "CredWriteW", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CredWrite(ref NativeCredential credential, int flags);
+
+    [DllImport("advapi32.dll", EntryPoint = "CredDeleteW", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CredDelete(string target, int type, int flags);
+
+    [DllImport("advapi32.dll")]
+    private static extern void CredFree(nint buffer);
+}

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -45,6 +45,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<MainWindow>();
 
         services.AddSingleton<IAppSettingsService, JsonAppSettingsService>();
+        services.AddSingleton<Foundry.Utilities.Security.IWindowsCredentialStore, Foundry.Utilities.Security.WindowsCredentialStore>();
         services.AddSingleton<IProxyCredentialStore, ProxyCredentialStore>();
         services.AddSingleton<IApplicationProxyService, ApplicationProxyService>();
         services.AddSingleton(sp =>

--- a/src/Foundry/Services/Networking/ProxyCredentialStore.cs
+++ b/src/Foundry/Services/Networking/ProxyCredentialStore.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
-using System.ComponentModel;
 using System.Runtime.InteropServices;
+using Foundry.Utilities.Security;
 
 namespace Foundry.Services.Networking;
 
@@ -32,35 +32,26 @@ public interface IProxyCredentialStore
     void Delete();
 }
 
-internal sealed class ProxyCredentialStore : IProxyCredentialStore
+internal sealed class ProxyCredentialStore(IWindowsCredentialStore credentialStore) : IProxyCredentialStore
 {
     private const string TargetName = "FoundryOSD/Proxy";
-    private const int CredentialTypeGeneric = 1;
-    private const int CredentialPersistLocalMachine = 2;
-    private const int ErrorNotFound = 1168;
 
     public ProxyCredential? Read()
     {
-        if (!CredRead(TargetName, CredentialTypeGeneric, 0, out nint credentialPointer))
+        using WindowsCredential? credential = credentialStore.Read(TargetName);
+        if (credential is null)
         {
-            int error = Marshal.GetLastWin32Error();
-            return error == ErrorNotFound ? null : throw new Win32Exception(error);
+            return null;
         }
 
-        try
+        if (credential.Secret.Length % sizeof(char) != 0)
         {
-            NativeCredential credential = Marshal.PtrToStructure<NativeCredential>(credentialPointer);
-            string username = credential.UserName ?? string.Empty;
-            string password = credential.CredentialBlobSize == 0
-                ? string.Empty
-                : Marshal.PtrToStringUni(credential.CredentialBlob, credential.CredentialBlobSize / sizeof(char)) ?? string.Empty;
-            (string domain, string user) = SplitUsername(username);
-            return new ProxyCredential(user, domain, password);
+            throw new InvalidDataException("The stored proxy credential has an invalid password encoding.");
         }
-        finally
-        {
-            CredFree(credentialPointer);
-        }
+
+        string password = new(MemoryMarshal.Cast<byte, char>(credential.Secret));
+        (string domain, string user) = SplitUsername(credential.UserName ?? string.Empty);
+        return new ProxyCredential(user, domain, password);
     }
 
     public void Save(ProxyCredential credential)
@@ -69,42 +60,12 @@ internal sealed class ProxyCredentialStore : IProxyCredentialStore
         string username = string.IsNullOrWhiteSpace(credential.Domain)
             ? credential.Username
             : $"{credential.Domain}\\{credential.Username}";
-        nint passwordPointer = Marshal.StringToCoTaskMemUni(credential.Password);
-        try
-        {
-            var nativeCredential = new NativeCredential
-            {
-                Type = CredentialTypeGeneric,
-                TargetName = TargetName,
-                CredentialBlobSize = credential.Password.Length * sizeof(char),
-                CredentialBlob = passwordPointer,
-                Persist = CredentialPersistLocalMachine,
-                UserName = username
-            };
-
-            if (!CredWrite(ref nativeCredential, 0))
-            {
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-        }
-        finally
-        {
-            Marshal.ZeroFreeCoTaskMemUnicode(passwordPointer);
-        }
+        credentialStore.Write(TargetName, MemoryMarshal.AsBytes(credential.Password.AsSpan()), username);
     }
 
     public void Delete()
     {
-        if (CredDelete(TargetName, CredentialTypeGeneric, 0))
-        {
-            return;
-        }
-
-        int error = Marshal.GetLastWin32Error();
-        if (error != ErrorNotFound)
-        {
-            throw new Win32Exception(error);
-        }
+        credentialStore.Delete(TargetName);
     }
 
     private static (string Domain, string Username) SplitUsername(string value)
@@ -114,36 +75,4 @@ internal sealed class ProxyCredentialStore : IProxyCredentialStore
             ? (value[..separator], value[(separator + 1)..])
             : (string.Empty, value);
     }
-
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-    private struct NativeCredential
-    {
-        public int Flags;
-        public int Type;
-        public string TargetName;
-        public string? Comment;
-        public long LastWritten;
-        public int CredentialBlobSize;
-        public nint CredentialBlob;
-        public int Persist;
-        public int AttributeCount;
-        public nint Attributes;
-        public string? TargetAlias;
-        public string UserName;
-    }
-
-    [DllImport("advapi32.dll", EntryPoint = "CredReadW", CharSet = CharSet.Unicode, SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool CredRead(string target, int type, int flags, out nint credential);
-
-    [DllImport("advapi32.dll", EntryPoint = "CredWriteW", CharSet = CharSet.Unicode, SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool CredWrite(ref NativeCredential credential, int flags);
-
-    [DllImport("advapi32.dll", EntryPoint = "CredDeleteW", CharSet = CharSet.Unicode, SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool CredDelete(string target, int type, int flags);
-
-    [DllImport("advapi32.dll")]
-    private static extern void CredFree(nint buffer);
 }


### PR DESCRIPTION
## Summary

Centralizes Windows Credential Manager access and moves proxy credentials onto the reusable adapter. This provides the native storage foundation for deployment profiles in #339.

## Main changes

- Preserve the existing proxy target, account identity, and UTF-16 password bytes.
- Distinguish missing credentials from native failures, enforce the 2,560-byte blob limit, and clear owned secret buffers.
- Register the adapter in the desktop composition root and remove duplicate WinCred interop.

## Testing

- Utilities executable suite: 228 passed, including real Windows credential round trips, deletion, limits, and native error handling using disposable synthetic targets.
- Desktop Release x64 build: passed with zero warnings/errors.
- `scripts/Test-FoundryFormat.ps1` and `git diff --check`: passed.
- x64 and ARM64 CI checks must pass before squash merging into `feat/deployment-profiles`.

Part of foundry-osd/foundry#339. This child targets the integration branch; the parent PR remains for maintainer merge.
