### PR TITLE
feat(profiles): add authenticated portable profile packages

### DIFF
--- a/src/Foundry.Core.Tests/Profiles/DeploymentProfilePackageServiceTests.cs
+++ b/src/Foundry.Core.Tests/Profiles/DeploymentProfilePackageServiceTests.cs
@@ -1,0 +1,325 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using System.Text;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Models.Profiles;
+using Foundry.Core.Services.Profiles;
+using Foundry.Telemetry;
+
+namespace Foundry.Core.Tests.Profiles;
+
+public sealed class DeploymentProfilePackageServiceTests
+{
+    private readonly DeploymentProfilePackageService _service = new();
+
+    [Fact]
+    public void ExportImport_PreservesSelectedSecretsAndExactAssetBytes()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("<?xml version=\"1.0\"?>\r\n<unattend />\r\n");
+        DeploymentProfileDocument profile = CreateProfile() with
+        {
+            Assets = [new() { Id = "answer", Kind = ProfileAssetKind.Unattend, RelativePath = "unattend/answer.xml", State = ProfileValueState.Present, Content = content, Sha256 = Convert.ToHexString(SHA256.HashData(content)) }],
+            Secrets = new() { Entries = [new() { Purpose = ProfileSecretPurpose.WifiPassphrase, Identity = "wifi-1", State = ProfileValueState.Present, Value = Encoding.UTF8.GetBytes("confidential-wifi") }] }
+        };
+
+        byte[] package = _service.Export(profile, "a long export passphrase");
+        DeploymentProfileDocument imported = _service.Import(package, "a long export passphrase");
+
+        Assert.Equal(profile.ProfileId, imported.ProfileId);
+        Assert.Equal(content, Assert.Single(imported.Assets).Content);
+        Assert.Equal("confidential-wifi", Encoding.UTF8.GetString(Assert.Single(imported.Secrets.Entries).Value!));
+        Assert.DoesNotContain("confidential-wifi", Encoding.UTF8.GetString(package));
+        Assert.NotEqual(package, _service.Export(profile, "a long export passphrase"));
+    }
+
+    [Fact]
+    public void ExportImport_DropsMachinePathsAndInlineSecretsWithoutMutatingSource()
+    {
+        DeploymentProfileDocument profile = CreateProfile() with
+        {
+            Configuration = new()
+            {
+                General = new() { IsoOutputPath = "C:/private.iso", CustomDriverDirectoryPath = "C:/drivers", IncludeDellDrivers = true },
+                Network = new() { Wifi = new() { Ssid = "office", Passphrase = "private", CertificatePath = "C:/cert.pfx", EnterpriseProfileTemplatePath = "C:/wifi.xml" } },
+                Telemetry = new() { InstallId = "private-install", ProjectToken = "private-token" }
+            }
+        };
+
+        DeploymentProfileDocument imported = _service.Import(_service.Export(profile, "password"), "password");
+
+        Assert.Null(imported.Configuration.General.IsoOutputPath);
+        Assert.Null(imported.Configuration.General.CustomDriverDirectoryPath);
+        Assert.True(imported.Configuration.General.IncludeDellDrivers);
+        Assert.Equal("office", imported.Configuration.Network.Wifi.Ssid);
+        Assert.Null(imported.Configuration.Network.Wifi.Passphrase);
+        Assert.Null(imported.Configuration.Network.Wifi.CertificatePath);
+        Assert.Null(imported.Configuration.Network.Wifi.EnterpriseProfileTemplatePath);
+        Assert.Empty(imported.Configuration.Telemetry.InstallId);
+        Assert.Equal("private", profile.Configuration.Network.Wifi.Passphrase);
+    }
+
+    [Fact]
+    public void Import_RejectsWrongPasswordTamperingAndTruncation()
+    {
+        byte[] package = _service.Export(CreateProfile(), "password");
+        Assert.ThrowsAny<CryptographicException>(() => _service.Import(package, "wrong"));
+        package[^1] ^= 1;
+        Assert.ThrowsAny<CryptographicException>(() => _service.Import(package, "password"));
+        Assert.Throws<InvalidDataException>(() => _service.Import(package.AsSpan(0, 20), "password"));
+    }
+
+    [Fact]
+    public void Encrypt_RequiresCorrectStoragePurposeAndKey()
+    {
+        byte[] key = RandomNumberGenerator.GetBytes(32);
+        byte[] package = _service.Encrypt(CreateProfile(), key, ProfilePackagePurpose.LocalStorage);
+        Assert.Equal("Office", _service.Decrypt(package, key, ProfilePackagePurpose.LocalStorage).DisplayName);
+        Assert.Throws<InvalidDataException>(() => _service.Decrypt(package, key, ProfilePackagePurpose.SharedRevision));
+        Assert.ThrowsAny<CryptographicException>(() => _service.Decrypt(package, RandomNumberGenerator.GetBytes(32), ProfilePackagePurpose.LocalStorage));
+    }
+
+    [Theory]
+    [InlineData(ProfileValueState.Omitted)]
+    [InlineData(ProfileValueState.Unavailable)]
+    [InlineData(ProfileValueState.Deleted)]
+    [InlineData(ProfileValueState.Blank)]
+    public void EncryptDecrypt_PreservesExplicitSecretStates(ProfileValueState state)
+    {
+        byte[] key = new byte[32];
+        DeploymentProfileDocument profile = CreateProfile() with { Secrets = new() { Entries = [new() { Purpose = ProfileSecretPurpose.AdministratorPassword, Identity = "administrator", State = state }] } };
+        Assert.Equal(state, Assert.Single(_service.Decrypt(_service.Encrypt(profile, key, ProfilePackagePurpose.LocalStorage), key, ProfilePackagePurpose.LocalStorage).Secrets.Entries).State);
+    }
+
+    [Theory]
+    [InlineData("../answer.xml")]
+    [InlineData("C:/answer.xml")]
+    [InlineData("folder/../answer.xml")]
+    [InlineData("folder\\answer.xml")]
+    [InlineData("folder/CON.xml")]
+    public void Export_RejectsUnsafeAssetPaths(string path)
+    {
+        DeploymentProfileDocument profile = CreateProfile() with { Assets = [new() { Id = "asset", Kind = ProfileAssetKind.Unattend, RelativePath = path }] };
+        Assert.Throws<InvalidDataException>(() => _service.Export(profile, "password"));
+    }
+
+    [Fact]
+    public void Export_RejectsFutureSchemaAndAssetDigestMismatch()
+    {
+        Assert.Throws<InvalidDataException>(() => _service.Export(CreateProfile() with { Configuration = new() { SchemaVersion = int.MaxValue } }, "password"));
+        Assert.Throws<InvalidDataException>(() => _service.Export(CreateProfile() with { FormatVersion = 2 }, "password"));
+        DeploymentProfileDocument profile = CreateProfile() with { Assets = [new() { Id = "asset", Kind = ProfileAssetKind.Unattend, RelativePath = "answer.xml", State = ProfileValueState.Present, Content = [1, 2], Sha256 = new string('0', 64) }] };
+        Assert.Throws<InvalidDataException>(() => _service.Export(profile, "password"));
+    }
+
+    [Fact]
+    public void EncryptDecrypt_AuthenticatesExternalRevisionContext()
+    {
+        byte[] key = new byte[32];
+        byte[] package = _service.Encrypt(CreateProfile(), key, ProfilePackagePurpose.SharedRevision, "revision-a"u8);
+        Assert.Equal("Office", _service.Decrypt(package, key, ProfilePackagePurpose.SharedRevision, "revision-a"u8).DisplayName);
+        Assert.ThrowsAny<CryptographicException>(() => _service.Decrypt(package, key, ProfilePackagePurpose.SharedRevision, "revision-b"u8));
+    }
+
+    [Fact]
+    public void LocalStorage_RetainsHostSettingsWhileSharedRevisionRemovesThem()
+    {
+        byte[] key = new byte[32];
+        DeploymentProfileDocument profile = CreateProfile() with
+        {
+            Configuration = new()
+            {
+                General = new() { IsoOutputPath = "C:/media.iso", CustomDriverDirectoryPath = "C:/drivers" },
+                Network = new() { Dot1x = new() { CertificatePath = "C:/certificate.pfx" } },
+                Telemetry = new() { InstallId = "local-install", IsEnabled = true }
+            }
+        };
+        DeploymentProfileDocument local = _service.Decrypt(_service.Encrypt(profile, key, ProfilePackagePurpose.LocalStorage), key, ProfilePackagePurpose.LocalStorage);
+        DeploymentProfileDocument shared = _service.Decrypt(_service.Encrypt(profile, key, ProfilePackagePurpose.SharedRevision), key, ProfilePackagePurpose.SharedRevision);
+        Assert.Equal("C:/media.iso", local.Configuration.General.IsoOutputPath);
+        Assert.Equal("C:/drivers", local.Configuration.General.CustomDriverDirectoryPath);
+        Assert.Equal("C:/certificate.pfx", local.Configuration.Network.Dot1x.CertificatePath);
+        Assert.Equal("local-install", local.Configuration.Telemetry.InstallId);
+        Assert.Null(shared.Configuration.General.IsoOutputPath);
+        Assert.Null(shared.Configuration.Network.Dot1x.CertificatePath);
+        Assert.Empty(shared.Configuration.Telemetry.InstallId);
+    }
+
+    [Theory]
+    [InlineData(8)]
+    [InlineData(9)]
+    [InlineData(10)]
+    [InlineData(13)]
+    public void Import_RejectsChangedFormatPurposeAndKdfCostBeforeDerivation(int offset)
+    {
+        byte[] package = _service.Export(CreateProfile(), "password");
+        package[offset] ^= 0x7f;
+        Assert.Throws<InvalidDataException>(() => _service.Import(package, "password"));
+    }
+
+    [Theory]
+    [InlineData(14)]
+    [InlineData(30)]
+    [InlineData(42)]
+    [InlineData(58)]
+    [InlineData(90)]
+    [InlineData(102)]
+    public void Decrypt_AuthenticatesSaltNoncesWrappedKeyAndTags(int offset)
+    {
+        byte[] key = new byte[32];
+        byte[] package = _service.Encrypt(CreateProfile(), key, ProfilePackagePurpose.LocalStorage);
+        package[offset] ^= 1;
+        Assert.ThrowsAny<CryptographicException>(() => _service.Decrypt(package, key, ProfilePackagePurpose.LocalStorage));
+    }
+
+    [Theory]
+    [InlineData("duplicate")]
+    [InlineData("future-schema")]
+    [InlineData("unknown-property")]
+    [InlineData("missing-state")]
+    [InlineData("invalid-state")]
+    [InlineData("credential-target")]
+    public void Decrypt_RejectsAuthenticatedMalformedPayload(string mutation)
+    {
+        byte[] key = new byte[32];
+        DeploymentProfileDocument profile = CreateProfile() with { Secrets = new() { Entries = [new() { Identity = "identity", State = ProfileValueState.Omitted }] } };
+        byte[] package = _service.Encrypt(profile, key, ProfilePackagePurpose.LocalStorage);
+        byte[] invalid = RewriteAuthenticatedPayload(package, key, json => mutation switch
+        {
+            "duplicate" => json.Replace("\"formatVersion\":1", "\"formatVersion\":1,\"FormatVersion\":1", StringComparison.Ordinal),
+            "future-schema" => json.Replace($"\"schemaVersion\":{FoundryConfigurationDocument.CurrentSchemaVersion}", "\"schemaVersion\":2147483647", StringComparison.Ordinal),
+            "unknown-property" => json.Replace("\"displayName\":", "\"nativeTarget\":\"arbitrary\",\"displayName\":", StringComparison.Ordinal),
+            "missing-state" => json.Replace("\"state\":0,", string.Empty, StringComparison.Ordinal),
+            "invalid-state" => json.Replace("\"state\":0", "\"state\":999", StringComparison.Ordinal),
+            "credential-target" => json.Replace("\"identity\":\"identity\"", "\"identity\":\"FoundryOSD/Proxy\"", StringComparison.Ordinal),
+            _ => throw new InvalidOperationException()
+        });
+        Assert.Throws<InvalidDataException>(() => _service.Decrypt(invalid, key, ProfilePackagePurpose.LocalStorage));
+    }
+
+    [Fact]
+    public void Export_RejectsAmbiguousAssetPathsAndSecretStates()
+    {
+        DeploymentProfileAsset asset = new() { Id = "a", RelativePath = "assets/a.xml", Kind = ProfileAssetKind.Unattend };
+        Assert.Throws<InvalidDataException>(() => _service.Export(CreateProfile() with { Assets = [asset, asset with { Id = "b", RelativePath = "ASSETS/A.XML" }] }, "password"));
+        DeploymentProfileSecret secret = new() { Identity = "a", State = ProfileValueState.Unavailable, Value = [1] };
+        Assert.Throws<InvalidDataException>(() => _service.Export(CreateProfile() with { Secrets = new() { Entries = [secret] } }, "password"));
+    }
+
+    [Fact]
+    public void ImportExport_RejectsOversizedPackagesAssetsAndSecretCollections()
+    {
+        Assert.Throws<InvalidDataException>(() => _service.Import(new byte[(16 * 1024 * 1024) + 119], "password"));
+        byte[] bytes = new byte[(4 * 1024 * 1024) + 1];
+        DeploymentProfileAsset asset = new() { Id = "a", RelativePath = "a.xml", State = ProfileValueState.Present, Content = bytes, Sha256 = Convert.ToHexString(SHA256.HashData(bytes)) };
+        Assert.Throws<InvalidDataException>(() => _service.Export(CreateProfile() with { Assets = [asset] }, "password"));
+        DeploymentProfileSecret[] secrets = Enumerable.Range(0, 129).Select(index => new DeploymentProfileSecret { Identity = $"identity-{index}" }).ToArray();
+        Assert.Throws<InvalidDataException>(() => _service.Export(CreateProfile() with { Secrets = new() { Entries = secrets } }, "password"));
+    }
+
+    [Fact]
+    public void Export_RejectsAssetWhoseDigestDisagreesWithAuthoringSource()
+    {
+        byte[] content = [1, 2, 3];
+        string id = Guid.NewGuid().ToString("N");
+        DeploymentProfileDocument profile = CreateProfile() with
+        {
+            Configuration = new() { Unattend = new() { Files = [new() { Id = id, DisplayName = "Answer", ContentHash = new string('0', 64) }] } },
+            Assets = [new() { Id = id, Kind = ProfileAssetKind.Unattend, RelativePath = "answer.xml", State = ProfileValueState.Present, Content = content, Sha256 = Convert.ToHexString(SHA256.HashData(content)) }]
+        };
+        Assert.Throws<InvalidDataException>(() => _service.Export(profile, "password"));
+    }
+
+    [Fact]
+    public void Export_RejectsNullRequiredConfigurationSections()
+    {
+        DeploymentProfileDocument profile = CreateProfile() with { Configuration = new() { Customization = new() { MachineNaming = null! } } };
+        Assert.Throws<InvalidDataException>(() => _service.Export(profile, "password"));
+    }
+    [Theory]
+    [InlineData("naming-components")]
+    [InlineData("naming-entry")]
+    [InlineData("appx-packages")]
+    [InlineData("appx-entry")]
+    [InlineData("autopilot-entry")]
+    public void Export_RejectsConfigurationCollectionsThatCannotBeActivated(string section)
+    {
+        FoundryConfigurationDocument configuration = section switch
+        {
+            "naming-components" => new() { Customization = new() { MachineNaming = new() { Components = null! } } },
+            "naming-entry" => new() { Customization = new() { MachineNaming = new() { Components = [null!] } } },
+            "appx-packages" => new() { Customization = new() { AppxRemoval = new() { PackageNames = null! } } },
+            "appx-entry" => new() { Customization = new() { AppxRemoval = new() { PackageNames = [null!] } } },
+            "autopilot-entry" => new() { Autopilot = new() { Profiles = [null!] } },
+            _ => throw new InvalidOperationException()
+        };
+        Assert.Throws<InvalidDataException>(() => _service.Export(CreateProfile() with { Configuration = configuration }, "password"));
+    }
+
+    [Fact]
+    public void Export_RejectsCollidingAutopilotFolders()
+    {
+        AutopilotProfileSettings first = CreateAutopilotProfile();
+        DeploymentProfileDocument profile = CreateProfile() with { Configuration = new() { Autopilot = new() { Profiles = [first, first with { Id = "second", FolderName = "AUTOPILOT" }] } } };
+        Assert.Throws<InvalidDataException>(() => _service.Export(profile, "password"));
+    }
+
+    [Theory]
+    [InlineData("../Autopilot")]
+    [InlineData("folder/Autopilot")]
+    [InlineData("CON.txt")]
+    [InlineData("Autopilot.")]
+    public void Export_RejectsUnsafeInlineAutopilotFolder(string folder)
+    {
+        DeploymentProfileDocument profile = CreateProfile() with { Configuration = new() { Autopilot = new() { Profiles = [CreateAutopilotProfile() with { FolderName = folder }] } } };
+        Assert.Throws<InvalidDataException>(() => _service.Export(profile, "password"));
+    }
+
+    [Fact]
+    public void ExportImport_PreservesSafeUnicodeAutopilotFolderAndInlineJson()
+    {
+        AutopilotProfileSettings autopilot = CreateAutopilotProfile() with { FolderName = "Équipe_Paris" };
+        DeploymentProfileDocument profile = CreateProfile() with { Configuration = new() { Autopilot = new() { Profiles = [autopilot] } } };
+        AutopilotProfileSettings imported = Assert.Single(_service.Import(_service.Export(profile, "password"), "password").Configuration.Autopilot.Profiles);
+        Assert.Equal(autopilot.FolderName, imported.FolderName);
+        Assert.Equal(autopilot.JsonContent, imported.JsonContent);
+    }
+
+    [Fact]
+    public void Export_RejectsInvalidUtf8SecretBytes()
+    {
+        DeploymentProfileSecret secret = new() { Identity = "identity", State = ProfileValueState.Present, Value = [0xff] };
+        Assert.Throws<InvalidDataException>(() => _service.Export(CreateProfile() with { Secrets = new() { Entries = [secret] } }, "password"));
+    }
+
+    private static AutopilotProfileSettings CreateAutopilotProfile() => new()
+    {
+        Id = "first",
+        DisplayName = "Autopilot",
+        FolderName = "Autopilot",
+        Source = "Imported",
+        ImportedAtUtc = DateTimeOffset.UnixEpoch,
+        JsonContent = "{\"CloudAssignedTenantId\":\"test-tenant\"}"
+    };
+    private static byte[] RewriteAuthenticatedPayload(byte[] package, byte[] wrappingKey, Func<string, string> mutate)
+    {
+        byte[] dataKey = new byte[32];
+        byte[] plaintext = new byte[package.Length - 118];
+        using var wrapping = new AesGcm(wrappingKey, 16);
+        wrapping.Decrypt(package.AsSpan(30, 12), package.AsSpan(58, 32), package.AsSpan(42, 16), dataKey, package.AsSpan(0, 30));
+        using var data = new AesGcm(dataKey, 16);
+        data.Decrypt(package.AsSpan(90, 12), package.AsSpan(118), package.AsSpan(102, 16), plaintext, package.AsSpan(0, 90));
+        byte[] changed = Encoding.UTF8.GetBytes(mutate(Encoding.UTF8.GetString(plaintext)));
+        byte[] result = new byte[118 + changed.Length];
+        package.AsSpan(0, 118).CopyTo(result);
+        RandomNumberGenerator.Fill(result.AsSpan(90, 12));
+        data.Encrypt(result.AsSpan(90, 12), changed, result.AsSpan(118), result.AsSpan(102, 16), result.AsSpan(0, 90));
+        CryptographicOperations.ZeroMemory(dataKey);
+        CryptographicOperations.ZeroMemory(plaintext);
+        CryptographicOperations.ZeroMemory(changed);
+        return result;
+    }
+    private static DeploymentProfileDocument CreateProfile() => new() { ProfileId = Guid.NewGuid(), DisplayName = "Office" };
+}

--- a/src/Foundry.Core/Models/Profiles/DeploymentProfileDocument.cs
+++ b/src/Foundry.Core/Models/Profiles/DeploymentProfileDocument.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Core.Models.Configuration;
+
+namespace Foundry.Core.Models.Profiles;
+
+/// <summary>A portable authoring revision. Included secret and asset buffers belong to its owner and must be cleared after use.</summary>
+public sealed record DeploymentProfileDocument
+{
+    public const int CurrentFormatVersion = 1;
+    public int FormatVersion { get; init; } = CurrentFormatVersion;
+    /// <summary>Shared identity preserved when joining; independent copies must allocate a new identity.</summary>
+    public Guid ProfileId { get; init; }
+    public string DisplayName { get; init; } = string.Empty;
+    public FoundryConfigurationDocument Configuration { get; init; } = new();
+    public DeploymentProfileSecrets Secrets { get; init; } = new();
+    public IReadOnlyList<DeploymentProfileAsset> Assets { get; init; } = [];
+}
+
+/// <summary>Logical secret records; native credential target names are never portable.</summary>
+public sealed record DeploymentProfileSecrets
+{
+    public IReadOnlyList<DeploymentProfileSecret> Entries { get; init; } = [];
+}
+
+/// <summary>A secret bound to a product purpose and stable context identity, encoded as UTF-8 by the caller.</summary>
+public sealed record DeploymentProfileSecret
+{
+    public ProfileSecretPurpose Purpose { get; init; }
+    /// <summary>A context identifier of 1 to 128 ASCII letters, digits, hyphens, underscores or dots.</summary>
+    public string Identity { get; init; } = string.Empty;
+    public ProfileValueState State { get; init; }
+    /// <summary>Owned secret bytes, required only for Present. Blank and all absent states use null.</summary>
+    public byte[]? Value { get; init; }
+}
+
+/// <summary>An exact source file with a verified digest and managed relative destination, never an imported host path.</summary>
+public sealed record DeploymentProfileAsset
+{
+    public string Id { get; init; } = string.Empty;
+    public ProfileAssetKind Kind { get; init; }
+    /// <summary>Case-insensitively unique portable destination with safe ASCII path segments and forward slashes.</summary>
+    public string RelativePath { get; init; } = string.Empty;
+    public ProfileValueState State { get; init; }
+    /// <summary>SHA-256 hexadecimal source digest, mandatory for present bytes and verified before activation.</summary>
+    public string? Sha256 { get; init; }
+    public byte[]? Content { get; init; }
+}
+
+/// <summary>Omission and failed lookup never imply deletion or an intentionally empty password.</summary>
+public enum ProfileValueState { Omitted, Unavailable, Deleted, Blank, Present }
+
+/// <summary>Allowlisted password families, independent of operating-system credential storage names.</summary>
+public enum ProfileSecretPurpose { DeploymentPassword, WifiPassphrase, AdministratorPassword, AdditionalAccountPassword, WiredCertificatePassword, WifiCertificatePassword, AutopilotCertificatePassword }
+
+/// <summary>Allowlisted portable inputs. Opaque files are included only when the caller explicitly supplies their bytes.</summary>
+public enum ProfileAssetKind { Unattend, WiredProfile, WifiProfile, WiredCertificate, WifiCertificate, AutopilotProfile, AutopilotCertificate }
+
+/// <summary>Distinct authenticated domains prevent a local ciphertext being accepted as a shared revision.</summary>
+public enum ProfilePackagePurpose { LocalStorage = 2, SharedRevision = 3 }

--- a/src/Foundry.Core/Services/Profiles/DeploymentProfilePackageService.cs
+++ b/src/Foundry.Core/Services/Profiles/DeploymentProfilePackageService.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using Foundry.Core.Models.Profiles;
+using Foundry.Utilities.Security;
+
+namespace Foundry.Core.Services.Profiles;
+
+/// <summary>Encrypts bounded profile revisions; callers own plaintext buffers inside imported documents.</summary>
+public interface IDeploymentProfilePackageService
+{
+    byte[] Export(DeploymentProfileDocument profile, ReadOnlySpan<char> passphrase);
+    DeploymentProfileDocument Import(ReadOnlySpan<byte> package, ReadOnlySpan<char> passphrase);
+    byte[] Encrypt(DeploymentProfileDocument profile, ReadOnlySpan<byte> wrappingKey, ProfilePackagePurpose purpose, ReadOnlySpan<byte> associatedData = default);
+    DeploymentProfileDocument Decrypt(ReadOnlySpan<byte> package, ReadOnlySpan<byte> wrappingKey, ProfilePackagePurpose purpose, ReadOnlySpan<byte> associatedData = default);
+}
+
+/// <summary>Uses fresh data keys and nonces, authenticated purpose/header/context, and bounded PBKDF2-SHA256 key wrapping.</summary>
+public sealed class DeploymentProfilePackageService : IDeploymentProfilePackageService
+{
+    private const int HeaderSize = 30;
+    private const int WrappedKeySize = 60;
+    private const int PayloadOffset = HeaderSize + WrappedKeySize;
+    private const int EncryptionOverhead = 28;
+    private const int PassphraseMode = 1;
+    private const int Iterations = 600_000;
+    private static ReadOnlySpan<byte> Magic => "FNDRYPRF"u8;
+
+    /// <summary>Creates an encrypted portable export. Only explicitly supplied logical secrets and assets are included.</summary>
+    public byte[] Export(DeploymentProfileDocument profile, ReadOnlySpan<char> passphrase)
+    {
+        ValidatePassphrase(passphrase);
+        byte[] header = CreateHeader(PassphraseMode);
+        byte[] key = PasswordKeyDerivation.DeriveKey(passphrase, header.AsSpan(14, 16), Iterations, 32);
+        try
+        {
+            return EncryptPayload(profile, key, header, [], true);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(key);
+        }
+    }
+
+    /// <summary>Authenticates and validates the complete portable export before returning its owned plaintext records.</summary>
+    public DeploymentProfileDocument Import(ReadOnlySpan<byte> package, ReadOnlySpan<char> passphrase)
+    {
+        ValidatePassphrase(passphrase);
+        ValidateEnvelope(package, PassphraseMode);
+        byte[] key = PasswordKeyDerivation.DeriveKey(passphrase, package.Slice(14, 16), Iterations, 32);
+        try
+        {
+            return DecryptPayload(package, key, [], true);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(key);
+        }
+    }
+
+    /// <summary>Protects a revision under a caller-owned 32-byte key. Local storage retains local paths; shared revisions are portable.</summary>
+    public byte[] Encrypt(DeploymentProfileDocument profile, ReadOnlySpan<byte> wrappingKey, ProfilePackagePurpose purpose, ReadOnlySpan<byte> associatedData = default)
+    {
+        ValidateKeyAndContext(wrappingKey, purpose, associatedData);
+        return EncryptPayload(profile, wrappingKey, CreateHeader((int)purpose), associatedData, purpose != ProfilePackagePurpose.LocalStorage);
+    }
+
+    /// <summary>Requires the original purpose and external revision context, protecting metadata kept outside the ciphertext.</summary>
+    public DeploymentProfileDocument Decrypt(ReadOnlySpan<byte> package, ReadOnlySpan<byte> wrappingKey, ProfilePackagePurpose purpose, ReadOnlySpan<byte> associatedData = default)
+    {
+        ValidateKeyAndContext(wrappingKey, purpose, associatedData);
+        ValidateEnvelope(package, (int)purpose);
+        return DecryptPayload(package, wrappingKey, associatedData, purpose != ProfilePackagePurpose.LocalStorage);
+    }
+
+    private static byte[] EncryptPayload(DeploymentProfileDocument profile, ReadOnlySpan<byte> wrappingKey, byte[] header, ReadOnlySpan<byte> context, bool portable)
+    {
+        byte[] plaintext = DeploymentProfilePayload.Serialize(profile, portable);
+        byte[] dataKey = RandomNumberGenerator.GetBytes(32);
+        try
+        {
+            byte[] package = new byte[PayloadOffset + EncryptionOverhead + plaintext.Length];
+            header.CopyTo(package, 0);
+            byte[] wrappingAad = CreateAssociatedData(header, context);
+            EncryptBlock(dataKey, wrappingKey, package.AsSpan(HeaderSize, WrappedKeySize), wrappingAad);
+            byte[] payloadAad = CreateAssociatedData(package.AsSpan(0, PayloadOffset), context);
+            EncryptBlock(plaintext, dataKey, package.AsSpan(PayloadOffset), payloadAad);
+            return package;
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(dataKey);
+            CryptographicOperations.ZeroMemory(plaintext);
+        }
+    }
+
+    private static DeploymentProfileDocument DecryptPayload(ReadOnlySpan<byte> package, ReadOnlySpan<byte> wrappingKey, ReadOnlySpan<byte> context, bool portable)
+    {
+        byte[] dataKey = new byte[32];
+        byte[] plaintext = new byte[package.Length - PayloadOffset - EncryptionOverhead];
+        try
+        {
+            byte[] wrappingAad = CreateAssociatedData(package[..HeaderSize], context);
+            DecryptBlock(package.Slice(HeaderSize, WrappedKeySize), wrappingKey, dataKey, wrappingAad);
+            byte[] payloadAad = CreateAssociatedData(package[..PayloadOffset], context);
+            DecryptBlock(package[PayloadOffset..], dataKey, plaintext, payloadAad);
+            return DeploymentProfilePayload.Deserialize(plaintext, portable);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(dataKey);
+            CryptographicOperations.ZeroMemory(plaintext);
+        }
+    }
+
+    private static void EncryptBlock(ReadOnlySpan<byte> plaintext, ReadOnlySpan<byte> key, Span<byte> destination, ReadOnlySpan<byte> aad)
+    {
+        RandomNumberGenerator.Fill(destination[..12]);
+        using AesGcm aes = new(key, 16);
+        aes.Encrypt(destination[..12], plaintext, destination[28..], destination.Slice(12, 16), aad);
+    }
+
+    private static void DecryptBlock(ReadOnlySpan<byte> source, ReadOnlySpan<byte> key, Span<byte> plaintext, ReadOnlySpan<byte> aad)
+    {
+        using AesGcm aes = new(key, 16);
+        aes.Decrypt(source[..12], source[28..], source.Slice(12, 16), plaintext, aad);
+    }
+
+    private static byte[] CreateHeader(int mode)
+    {
+        byte[] header = new byte[HeaderSize];
+        Magic.CopyTo(header);
+        header[8] = DeploymentProfileDocument.CurrentFormatVersion;
+        header[9] = (byte)mode;
+        BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(10, 4), mode == PassphraseMode ? Iterations : 0);
+        RandomNumberGenerator.Fill(header.AsSpan(14, 16));
+        return header;
+    }
+
+    private static byte[] CreateAssociatedData(ReadOnlySpan<byte> prefix, ReadOnlySpan<byte> context)
+    {
+        byte[] aad = new byte[prefix.Length + context.Length];
+        prefix.CopyTo(aad);
+        context.CopyTo(aad.AsSpan(prefix.Length));
+        return aad;
+    }
+
+    private static void ValidateEnvelope(ReadOnlySpan<byte> package, int mode)
+    {
+        if (package.Length <= PayloadOffset + EncryptionOverhead || package.Length > DeploymentProfilePayload.MaximumPayloadBytes + PayloadOffset + EncryptionOverhead
+            || !package[..8].SequenceEqual(Magic) || package[8] != DeploymentProfileDocument.CurrentFormatVersion || package[9] != mode
+            || BinaryPrimitives.ReadInt32LittleEndian(package.Slice(10, 4)) != (mode == PassphraseMode ? Iterations : 0))
+        {
+            throw new InvalidDataException("The encrypted profile format, purpose, size or key derivation parameters are invalid.");
+        }
+    }
+
+    private static void ValidatePassphrase(ReadOnlySpan<char> passphrase)
+    {
+        if (passphrase.Length is < 1 or > 1024)
+        {
+            throw new ArgumentException("The profile passphrase must contain 1 to 1024 characters.", nameof(passphrase));
+        }
+    }
+
+    private static void ValidateKeyAndContext(ReadOnlySpan<byte> wrappingKey, ProfilePackagePurpose purpose, ReadOnlySpan<byte> context)
+    {
+        if (wrappingKey.Length != 32 || !Enum.IsDefined(purpose) || context.Length > 16 * 1024)
+        {
+            throw new ArgumentException("The profile key, purpose or associated context is invalid.");
+        }
+    }
+}

--- a/src/Foundry.Core/Services/Profiles/DeploymentProfilePayload.cs
+++ b/src/Foundry.Core/Services/Profiles/DeploymentProfilePayload.cs
@@ -1,0 +1,348 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Models.Profiles;
+
+namespace Foundry.Core.Services.Profiles;
+
+/// <summary>Validates the entire bounded payload before it can be activated or persisted.</summary>
+internal static class DeploymentProfilePayload
+{
+    internal const int MaximumPayloadBytes = 16 * 1024 * 1024;
+    private const int MaximumAssetBytes = 4 * 1024 * 1024;
+    private const int MaximumTotalAssetBytes = 8 * 1024 * 1024;
+    private static readonly UTF8Encoding SecretEncoding = new(false, true);
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+        MaxDepth = 32
+    };
+
+    internal static byte[] Serialize(DeploymentProfileDocument profile, bool portable)
+    {
+        Validate(profile);
+        DeploymentProfileDocument projected = profile with { Configuration = ProjectConfiguration(profile.Configuration, portable) };
+        using var buffer = new BoundedPayloadStream();
+        try
+        {
+            JsonSerializer.Serialize(buffer, projected, Options);
+            return buffer.ToArray();
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(buffer.GetBuffer());
+        }
+    }
+    internal static DeploymentProfileDocument Deserialize(byte[] bytes, bool portable)
+    {
+        DeploymentProfileDocument? profile = null;
+        try
+        {
+            using JsonDocument json = JsonDocument.Parse(bytes, new() { MaxDepth = 32 });
+            ValidateJson(json.RootElement);
+            RequireProperties(json.RootElement, "formatVersion", "profileId", "displayName", "configuration", "secrets", "assets");
+            if (json.RootElement.GetProperty("formatVersion").GetInt32() != DeploymentProfileDocument.CurrentFormatVersion)
+            {
+                throw new InvalidDataException("The profile payload format is unsupported.");
+            }
+            JsonElement configuration = json.RootElement.GetProperty("configuration");
+            RequireProperties(configuration, "schemaVersion");
+            int schema = configuration.GetProperty("schemaVersion").GetInt32();
+            if (schema < 1 || schema > FoundryConfigurationDocument.CurrentSchemaVersion)
+            {
+                throw new InvalidDataException("The profile authoring schema is unsupported.");
+            }
+            foreach (JsonElement secret in json.RootElement.GetProperty("secrets").GetProperty("entries").EnumerateArray())
+            {
+                RequireProperties(secret, "purpose", "identity", "state");
+            }
+            foreach (JsonElement asset in json.RootElement.GetProperty("assets").EnumerateArray())
+            {
+                RequireProperties(asset, "id", "kind", "relativePath", "state");
+            }
+            profile = JsonSerializer.Deserialize<DeploymentProfileDocument>(bytes, Options)
+                ?? throw new InvalidDataException("The profile payload is missing.");
+            Validate(profile);
+            return profile with { Configuration = ProjectConfiguration(profile.Configuration, portable) };
+        }
+        catch (Exception exception) when (exception is JsonException or InvalidOperationException or FormatException or KeyNotFoundException or ArgumentException)
+        {
+            ClearBuffers(profile);
+            throw new InvalidDataException("The profile payload is invalid.", exception);
+        }
+        catch
+        {
+            ClearBuffers(profile);
+            throw;
+        }
+    }
+
+    private static FoundryConfigurationDocument ProjectConfiguration(FoundryConfigurationDocument configuration, bool portable)
+    {
+        FoundryConfigurationDocument projected = DeploymentProfileProjection.CreatePortable(configuration);
+        return portable ? projected : projected with
+        {
+            General = configuration.General,
+            Network = projected.Network with
+            {
+                Wifi = projected.Network.Wifi with { CertificatePath = configuration.Network.Wifi.CertificatePath, EnterpriseProfileTemplatePath = configuration.Network.Wifi.EnterpriseProfileTemplatePath },
+                Dot1x = projected.Network.Dot1x with { CertificatePath = configuration.Network.Dot1x.CertificatePath, ProfileTemplatePath = configuration.Network.Dot1x.ProfileTemplatePath }
+            },
+            Unattend = configuration.Unattend,
+            Telemetry = configuration.Telemetry
+        };
+    }
+    private static void Validate(DeploymentProfileDocument profile)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+        if (profile.FormatVersion != DeploymentProfileDocument.CurrentFormatVersion || profile.ProfileId == Guid.Empty
+            || string.IsNullOrWhiteSpace(profile.DisplayName) || profile.DisplayName.Length > 128 || profile.DisplayName.Any(char.IsControl)
+            || profile.Configuration is null || profile.Secrets?.Entries is null || profile.Assets is null
+            || profile.Secrets.Entries.Count > 128 || profile.Assets.Count > 64)
+        {
+            throw new InvalidDataException("The profile metadata is invalid or unsupported.");
+        }
+        _ = DeploymentProfileProjection.CreatePortable(profile.Configuration);
+        ValidateConfigurationCollections(profile.Configuration);
+        var identities = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (DeploymentProfileSecret secret in profile.Secrets.Entries)
+        {
+            if (secret is null || !Enum.IsDefined(secret.Purpose) || !Enum.IsDefined(secret.State) || !IsIdentity(secret.Identity)
+                || !identities.Add($"{(int)secret.Purpose}:{secret.Identity}")
+                || (secret.State == ProfileValueState.Present ? !IsValidSecret(secret.Value) : secret.Value is not null))
+            {
+                throw new InvalidDataException("The profile secret record is invalid.");
+            }
+        }
+        identities.Clear();
+        var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        long totalBytes = 0;
+        foreach (DeploymentProfileAsset asset in profile.Assets)
+        {
+            if (asset is null || !Enum.IsDefined(asset.Kind) || !Enum.IsDefined(asset.State) || asset.State == ProfileValueState.Blank
+                || !IsIdentity(asset.Id) || !identities.Add(asset.Id) || !IsSafePath(asset.RelativePath) || !paths.Add(asset.RelativePath))
+            {
+                throw new InvalidDataException("The profile asset record is invalid.");
+            }
+            if (asset.State == ProfileValueState.Present)
+            {
+                if (asset.Content is not { Length: <= MaximumAssetBytes } || !IsDigest(asset.Sha256)
+                    || !string.Equals(Convert.ToHexString(SHA256.HashData(asset.Content)), asset.Sha256, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidDataException("The profile asset content or digest is invalid.");
+                }
+                totalBytes += asset.Content.Length;
+            }
+            else if (asset.Content is not null || (asset.Sha256 is not null && !IsDigest(asset.Sha256)))
+            {
+                throw new InvalidDataException("An absent asset cannot contain bytes or an invalid digest.");
+            }
+        }
+        if (totalBytes > MaximumTotalAssetBytes)
+        {
+            throw new InvalidDataException("The profile assets exceed the total size limit.");
+        }
+        ValidateSourceAssets(profile);
+        identities.Clear();
+        foreach (OobeAdditionalAccountSettings account in profile.Configuration.Customization.Oobe.AdditionalAccounts)
+        {
+            if (account is null || !IsIdentity(account.Id) || !identities.Add(account.Id))
+            {
+                throw new InvalidDataException("The profile account identity is invalid or duplicated.");
+            }
+        }
+    }
+
+    private static bool IsValidSecret(byte[]? value)
+    {
+        if (value is not { Length: > 0 and <= 2560 })
+        {
+            return false;
+        }
+        try
+        {
+            _ = SecretEncoding.GetCharCount(value);
+            return true;
+        }
+        catch (DecoderFallbackException)
+        {
+            return false;
+        }
+    }
+
+    private static void ValidateConfigurationCollections(FoundryConfigurationDocument configuration)
+    {
+        ValidateList(configuration.Customization.MachineNaming.Components);
+        ValidateList(configuration.Customization.Oobe.AdditionalAccounts);
+        ValidateList(configuration.Customization.AppxRemoval.PackageNames);
+        ValidateList(configuration.Customization.WindowsOptionalFeatures.EnabledFeatureIds);
+        ValidateList(configuration.Customization.WindowsOptionalFeatures.DisabledFeatureIds);
+        ValidateList(configuration.OperatingSystemSelection.AllowedLanguageCodes);
+        ValidateList(configuration.OperatingSystemSelection.AllowedReleaseIds);
+        ValidateList(configuration.OperatingSystemSelection.AllowedLicenseChannels);
+        ValidateList(configuration.OperatingSystemSelection.AllowedEditions);
+        ValidateList(configuration.Autopilot.HardwareHashUpload.KnownGroupTags);
+        ValidateList(configuration.Autopilot.Profiles);
+        ValidateList(configuration.Unattend.Files);
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var folders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (AutopilotProfileSettings autopilot in configuration.Autopilot.Profiles)
+        {
+            if (!IsIdentity(autopilot.Id) || !ids.Add(autopilot.Id) || !IsSafeFolder(autopilot.FolderName) || !folders.Add(autopilot.FolderName)
+                || string.IsNullOrWhiteSpace(autopilot.DisplayName) || string.IsNullOrWhiteSpace(autopilot.Source) || string.IsNullOrWhiteSpace(autopilot.JsonContent))
+            {
+                throw new InvalidDataException("The Autopilot profile metadata is invalid or duplicated.");
+            }
+        }
+    }
+
+    private static void ValidateList<T>(IReadOnlyList<T>? values) where T : class
+    {
+        if (values is null || values.Count > 1024 || values.Any(value => value is null))
+        {
+            throw new InvalidDataException("The profile configuration collection is invalid or too large.");
+        }
+    }
+
+    private static bool IsSafeFolder(string? folder)
+    {
+        if (folder is not { Length: > 0 and <= 200 } || folder is "." or ".." || folder.EndsWith('.') || folder.EndsWith(' ')
+            || folder.Any(character => char.IsControl(character) || "<>:\"/\\|?*".Contains(character)))
+        {
+            return false;
+        }
+        string name = folder.Split('.')[0].TrimEnd(' ').ToUpperInvariant();
+        return name is not ("CON" or "PRN" or "AUX" or "NUL")
+            && !(name.Length == 4 && (name.StartsWith("COM", StringComparison.Ordinal) || name.StartsWith("LPT", StringComparison.Ordinal)) && name[3] is >= '0' and <= '9');
+    }
+    private static void ValidateSourceAssets(DeploymentProfileDocument profile)
+    {
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var hashes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (UnattendFileSettings file in profile.Configuration.Unattend.Files)
+        {
+            if (file.Id is not { Length: 32 } || !file.Id.All(char.IsAsciiHexDigit) || !ids.Add(file.Id)
+                || !IsDigest(file.ContentHash) || !hashes.Add(file.ContentHash)
+                || string.IsNullOrWhiteSpace(file.DisplayName) || file.DisplayName.Length > 200 || file.DisplayName.Any(char.IsControl))
+            {
+                throw new InvalidDataException("The answer-file source metadata is invalid or duplicated.");
+            }
+            DeploymentProfileAsset? asset = profile.Assets.FirstOrDefault(candidate => candidate.Kind == ProfileAssetKind.Unattend
+                && string.Equals(candidate.Id, file.Id, StringComparison.OrdinalIgnoreCase));
+            if (asset?.State == ProfileValueState.Present && !string.Equals(file.ContentHash, asset.Sha256, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidDataException("The answer-file asset does not match its recorded source digest.");
+            }
+        }
+    }
+    private static bool IsIdentity(string? identity) => identity is { Length: > 0 and <= 128 } and not "." and not ".."
+        && identity.All(character => char.IsAsciiLetterOrDigit(character) || character is '-' or '_' or '.');
+
+    private static bool IsDigest(string? digest) => digest is { Length: 64 } && digest.All(char.IsAsciiHexDigit);
+
+    private static bool IsSafePath(string? path)
+    {
+        if (path is not { Length: > 0 and <= 200 } || path.Contains('\\'))
+        {
+            return false;
+        }
+        foreach (string segment in path.Split('/'))
+        {
+            if (!IsIdentity(segment) || segment is "." or ".." || segment.EndsWith('.'))
+            {
+                return false;
+            }
+            string name = segment.Split('.')[0].ToUpperInvariant();
+            if (name is "CON" or "PRN" or "AUX" or "NUL"
+                || (name.Length == 4 && (name.StartsWith("COM", StringComparison.Ordinal) || name.StartsWith("LPT", StringComparison.Ordinal)) && name[3] is >= '0' and <= '9'))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void RequireProperties(JsonElement element, params string[] names)
+    {
+        if (element.ValueKind != JsonValueKind.Object || names.Any(name => !element.TryGetProperty(name, out _)))
+        {
+            throw new InvalidDataException("Required profile properties are missing.");
+        }
+    }
+
+    private static void ValidateJson(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (JsonProperty property in element.EnumerateObject())
+            {
+                if (!names.Add(property.Name))
+                {
+                    throw new InvalidDataException("Duplicate profile properties are not allowed.");
+                }
+                ValidateJson(property.Value);
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement item in element.EnumerateArray())
+            {
+                ValidateJson(item);
+            }
+        }
+    }
+
+    private sealed class BoundedPayloadStream : MemoryStream
+    {
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            EnsureCapacityLimit(count);
+            base.Write(buffer, offset, count);
+        }
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            EnsureCapacityLimit(buffer.Length);
+            base.Write(buffer);
+        }
+
+        private void EnsureCapacityLimit(int count)
+        {
+            if (Position + count > MaximumPayloadBytes)
+            {
+                throw new InvalidDataException("The profile payload exceeds the size limit.");
+            }
+        }
+    }
+    private static void ClearBuffers(DeploymentProfileDocument? profile)
+    {
+        if (profile?.Secrets?.Entries is { } secrets)
+        {
+            foreach (DeploymentProfileSecret secret in secrets)
+            {
+                if (secret?.Value is { } value)
+                {
+                    CryptographicOperations.ZeroMemory(value);
+                }
+            }
+        }
+        if (profile?.Assets is { } assets)
+        {
+            foreach (DeploymentProfileAsset asset in assets)
+            {
+                if (asset?.Content is { } content)
+                {
+                    CryptographicOperations.ZeroMemory(content);
+                }
+            }
+        }
+    }
+}

--- a/src/Foundry.Core/Services/Profiles/DeploymentProfileProjection.cs
+++ b/src/Foundry.Core/Services/Profiles/DeploymentProfileProjection.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Services.Configuration;
+using Foundry.Telemetry;
+
+namespace Foundry.Core.Services.Profiles;
+
+/// <summary>Removes host paths, session secrets, runtime envelopes and local telemetry before transfer or activation.</summary>
+public static class DeploymentProfileProjection
+{
+    public static FoundryConfigurationDocument CreatePortable(FoundryConfigurationDocument configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        if (configuration.SchemaVersion < 1 || configuration.SchemaVersion > FoundryConfigurationDocument.CurrentSchemaVersion)
+        {
+            throw new InvalidDataException("The profile authoring schema is unsupported.");
+        }
+
+        if (configuration.General is null || configuration.Network?.Wifi is null || configuration.Network.Dot1x is null
+            || configuration.Customization?.Oobe?.AdditionalAccounts is null || configuration.Unattend?.Files is null
+            || configuration.Autopilot?.HardwareHashUpload is null || configuration.Autopilot.Profiles is null
+            || configuration.OperatingSystemSelection is null || configuration.Localization is null || configuration.General.DeploymentProtection is null
+            || configuration.Customization.MachineNaming is null || configuration.Customization.AppxRemoval is null
+            || configuration.Customization.WindowsOptionalFeatures is null || configuration.Customization.AiComponentRemoval is null
+            || configuration.Autopilot.HardwareHashUpload.Tenant is null)
+        {
+            throw new InvalidDataException("The profile configuration is incomplete.");
+        }
+
+        FoundryConfigurationDocument portable = configuration with
+        {
+            General = configuration.General with { IsoOutputPath = null, CustomDriverDirectoryPath = null },
+            Network = configuration.Network with
+            {
+                Wifi = configuration.Network.Wifi with
+                {
+                    Passphrase = null,
+                    PassphraseSecret = null,
+                    CertificatePfxPassword = null,
+                    CertificatePfxPasswordSecret = null,
+                    CertificatePath = null,
+                    EnterpriseProfileTemplatePath = null
+                },
+                Dot1x = configuration.Network.Dot1x with
+                {
+                    CertificatePfxPassword = null,
+                    CertificatePfxPasswordSecret = null,
+                    CertificatePath = null,
+                    ProfileTemplatePath = null
+                }
+            },
+            Unattend = configuration.Unattend with
+            {
+                Files = configuration.Unattend.Files.Select(file => file is null
+                    ? throw new InvalidDataException("The profile contains an invalid answer file.")
+                    : file with { SourcePath = string.Empty }).ToArray()
+            },
+            Autopilot = configuration.Autopilot with
+            {
+                HardwareHashUpload = configuration.Autopilot.HardwareHashUpload with { BootMediaCertificate = new() }
+            },
+            Telemetry = new TelemetrySettings { IsEnabled = false, IsRemoteDiagnosticsEnabled = false, InstallId = string.Empty, HostUrl = string.Empty, ProjectToken = string.Empty }
+        };
+        return FoundryConfigurationMigration.ApplySchemaMigrations(portable);
+    }
+}


### PR DESCRIPTION
## Summary

Adds encrypted deployment-profile packages for foundry-osd/foundry#339, including selected secrets and source files. The format separates portable settings from machine-specific authoring state.

## Main changes

- Fresh AES-GCM data keys and nonces, PBKDF2-SHA256 passphrase wrapping, and authenticated purpose/header/revision context.
- Explicit omitted, unavailable, deleted, blank, and present secret states; bounded, digest-verified dependencies.
- Strict JSON, schema, identity, path, UTF-8, and nested configuration validation before returning a profile.
- Independent review regressions cover malformed nested collections and duplicate Autopilot destinations.

## Testing

- Core executable suite: 753 passed, including 48 new package cases.
- `scripts/Test-FoundryFormat.ps1`: passed; `git diff --check`: passed.
- Independent package review completed and reproduced findings corrected.
- x64 and ARM64 CI remain required before squash merging into the integration branch.

Part of foundry-osd/foundry#339; child PR targeting `feat/deployment-profiles`.
