### PR TITLE
feat(profiles): add authenticated multiwriter shared repository

### DIFF
--- a/src/Foundry.Core.Tests/Profiles/SharedProfileRepositoryTests.cs
+++ b/src/Foundry.Core.Tests/Profiles/SharedProfileRepositoryTests.cs
@@ -1,0 +1,369 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Foundry.Core.Services.Profiles;
+
+namespace Foundry.Core.Tests.Profiles;
+
+public sealed class SharedProfileRepositoryTests
+{
+    private static CancellationToken Cancellation => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task Publish_CompetingWritersCannotReplaceOneAnother()
+    {
+        using var fixture = new RepositoryFixture();
+        using var first = fixture.Open();
+        using var second = fixture.Open();
+        Assert.Equal(SharedProfileRepositoryStatus.Success, (await first.InitializeAsync(Cancellation)).Status);
+        SharedProfileRepositoryResult initial = await first.PublishAsync([1], null, Guid.NewGuid(), Cancellation);
+        Guid baseId = Assert.IsType<SharedProfileSnapshot>(initial.Snapshot).Head.RevisionId;
+
+        SharedProfileRepositoryResult[] results = await Task.WhenAll(
+            first.PublishAsync([2], baseId, Guid.NewGuid(), Cancellation),
+            second.PublishAsync([3], baseId, Guid.NewGuid(), Cancellation));
+
+        Assert.Single(results, result => result.Status == SharedProfileRepositoryStatus.Success);
+        Assert.Single(results, result => result.Status is SharedProfileRepositoryStatus.Conflict or SharedProfileRepositoryStatus.Busy);
+        SharedProfileSnapshot winner = Assert.IsType<SharedProfileSnapshot>((await first.LoadAsync(baseId, Cancellation)).Snapshot);
+        Assert.Equal(baseId, winner.Head.ParentRevisionId);
+        Assert.Contains(winner.EncryptedPayload[0], new byte[] { 2, 3 });
+        Assert.Equal(SharedProfileRepositoryStatus.Conflict,
+            (await second.PublishAsync([4], baseId, Guid.NewGuid(), Cancellation)).Status);
+    }
+
+    [Fact]
+    public async Task Retry_RecognizesCommittedOperationAfterAnotherWriterAdvancesHead()
+    {
+        using var fixture = new RepositoryFixture();
+        using var repository = fixture.Open();
+        await repository.InitializeAsync(Cancellation);
+        Guid operation = Guid.NewGuid();
+        SharedProfileSnapshot initial = Assert.IsType<SharedProfileSnapshot>(
+            (await repository.PublishAsync([4, 5], null, operation, Cancellation)).Snapshot);
+        SharedProfileSnapshot current = Assert.IsType<SharedProfileSnapshot>(
+            (await repository.PublishAsync([6], initial.Head.RevisionId, Guid.NewGuid(), Cancellation)).Snapshot);
+
+        SharedProfileRepositoryResult retry = await repository.PublishAsync([4, 5], null, operation, Cancellation);
+
+        Assert.Equal(SharedProfileRepositoryStatus.Success, retry.Status);
+        Assert.Equal(initial.Head.RevisionId, retry.CommittedRevisionId);
+        Assert.Equal(current.Head.RevisionId, retry.Snapshot!.Head.RevisionId);
+        Assert.Equal(initial.Head.RevisionId, (await repository.ReconcileAsync(operation, cancellationToken: Cancellation)).CommittedRevisionId);
+        Assert.Equal(SharedProfileRepositoryStatus.InvalidData, (await repository.PublishAsync([7], null, operation, Cancellation)).Status);
+    }
+
+    [Fact]
+    public async Task Load_RejectsWrongKeyAndAlteredPayload()
+    {
+        using var fixture = new RepositoryFixture();
+        using var repository = fixture.Open();
+        await repository.InitializeAsync(Cancellation);
+        Assert.Equal(SharedProfileRepositoryStatus.Success, (await repository.PublishAsync([1, 2, 3], null, Guid.NewGuid(), Cancellation)).Status);
+        using var wrongKey = fixture.Open(key: RandomNumberGenerator.GetBytes(32));
+        Assert.Equal(SharedProfileRepositoryStatus.InvalidData, (await wrongKey.LoadAsync(cancellationToken: Cancellation)).Status);
+
+        string payload = Assert.Single(Directory.GetFiles(fixture.Root, "*.payload", SearchOption.AllDirectories));
+        await File.WriteAllBytesAsync(payload, [3, 2, 1], Cancellation);
+
+        Assert.Equal(SharedProfileRepositoryStatus.InvalidData, (await repository.LoadAsync(cancellationToken: Cancellation)).Status);
+    }
+
+    [Fact]
+    public async Task Publish_RejectsRollbackAndDoesNotResurrectDeletedHead()
+    {
+        using var fixture = new RepositoryFixture();
+        using var repository = fixture.Open();
+        await repository.InitializeAsync(Cancellation);
+        SharedProfileSnapshot first = (await repository.PublishAsync([1], null, Guid.NewGuid(), Cancellation)).Snapshot!;
+        byte[] oldHead = await File.ReadAllBytesAsync(fixture.HeadPath, Cancellation);
+        SharedProfileSnapshot second = (await repository.PublishAsync([2], first.Head.RevisionId, Guid.NewGuid(), Cancellation)).Snapshot!;
+        await File.WriteAllBytesAsync(fixture.HeadPath, oldHead, Cancellation);
+
+        Assert.Equal(SharedProfileRepositoryStatus.RollbackDetected, (await repository.LoadAsync(second.Head.RevisionId, Cancellation)).Status);
+        Assert.Equal(SharedProfileRepositoryStatus.RollbackDetected,
+            (await repository.PublishAsync([3], second.Head.RevisionId, Guid.NewGuid(), Cancellation)).Status);
+
+        File.Delete(fixture.HeadPath);
+        Assert.Equal(SharedProfileRepositoryStatus.Unavailable,
+            (await repository.PublishAsync([3], second.Head.RevisionId, Guid.NewGuid(), Cancellation)).Status);
+    }
+
+    [Fact]
+    public async Task Tombstone_PreservesHistoryAndRejectsEditAndNullBaseResurrection()
+    {
+        using var fixture = new RepositoryFixture();
+        using var repository = fixture.Open();
+        await repository.InitializeAsync(Cancellation);
+        Guid initialOperation = Guid.NewGuid();
+        SharedProfileSnapshot first = (await repository.PublishAsync([1], null, initialOperation, Cancellation)).Snapshot!;
+        Guid deleteOperation = Guid.NewGuid();
+        SharedProfileRepositoryResult deletion = await repository.TombstoneAsync(first.Head.RevisionId, deleteOperation, Cancellation);
+
+        Assert.True(deletion.Snapshot!.Head.IsTombstone);
+        Assert.Empty(deletion.Snapshot.EncryptedPayload);
+        Assert.Equal(SharedProfileRepositoryStatus.Success,
+            (await repository.TombstoneAsync(first.Head.RevisionId, deleteOperation, Cancellation)).Status);
+        Assert.Equal(SharedProfileRepositoryStatus.Success, (await repository.ReconcileAsync(initialOperation, first.Head.RevisionId, Cancellation)).Status);
+        Assert.Equal(SharedProfileRepositoryStatus.Conflict, (await repository.PublishAsync([2], null, Guid.NewGuid(), Cancellation)).Status);
+        Assert.Equal(SharedProfileRepositoryStatus.Conflict, (await repository.PublishAsync([2], deletion.Snapshot.Head.RevisionId, Guid.NewGuid(), Cancellation)).Status);
+    }
+
+    [Fact]
+    public async Task Reconcile_IncompleteCommitTailDoesNotTreatOrphanAsCommitted()
+    {
+        using var fixture = new RepositoryFixture();
+        using var repository = fixture.Open();
+        await repository.InitializeAsync(Cancellation);
+        SharedProfileSnapshot initial = (await repository.PublishAsync([1], null, Guid.NewGuid(), Cancellation)).Snapshot!;
+        Guid operation = Guid.NewGuid();
+        SharedProfileSnapshot interrupted = (await repository.PublishAsync([2], initial.Head.RevisionId, operation, Cancellation)).Snapshot!;
+        using (var journal = new FileStream(fixture.HeadPath, FileMode.Open, FileAccess.Write, FileShare.None))
+            journal.SetLength(journal.Length - 1);
+
+        Assert.Equal(2, Directory.GetFiles(fixture.Root, "*.payload", SearchOption.AllDirectories).Length);
+        Assert.Equal(SharedProfileRepositoryStatus.RollbackDetected,
+            (await repository.LoadAsync(interrupted.Head.RevisionId, Cancellation)).Status);
+        Assert.Equal(SharedProfileRepositoryStatus.NotCommitted, (await repository.ReconcileAsync(operation, initial.Head.RevisionId, Cancellation)).Status);
+        SharedProfileRepositoryResult retry = await repository.PublishAsync([2], initial.Head.RevisionId, operation, Cancellation);
+        Assert.Equal(SharedProfileRepositoryStatus.Success, retry.Status);
+        Assert.Equal(retry.Snapshot!.Head.RevisionId, (await repository.ReconcileAsync(operation, initial.Head.RevisionId, Cancellation)).CommittedRevisionId);
+    }
+
+    [Fact]
+    public async Task StableLock_ReturnsBusyAndRemainsUsableAfterHandleCloses()
+    {
+        using var fixture = new RepositoryFixture();
+        using var repository = fixture.Open();
+        await repository.InitializeAsync(Cancellation);
+        string lockPath = fixture.HeadPath;
+        using (var held = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
+        {
+            Assert.Equal(SharedProfileRepositoryStatus.Busy,
+                (await repository.PublishAsync([1], null, Guid.NewGuid(), Cancellation)).Status);
+            Assert.Equal(SharedProfileRepositoryStatus.Busy, (await repository.LoadAsync(cancellationToken: Cancellation)).Status);
+        }
+        Assert.True(File.Exists(lockPath));
+        Assert.Equal(SharedProfileRepositoryStatus.Success,
+            (await repository.PublishAsync([1], null, Guid.NewGuid(), Cancellation)).Status);
+    }
+
+    [Fact]
+    public async Task BoundedHistory_RefusesNewPublicationWithoutDeletingCommittedHistory()
+    {
+        using var fixture = new RepositoryFixture();
+        using var repository = fixture.Open(new() { MaximumHistoryCount = 2 });
+        await repository.InitializeAsync(Cancellation);
+        SharedProfileSnapshot first = (await repository.PublishAsync([1], null, Guid.NewGuid(), Cancellation)).Snapshot!;
+        SharedProfileSnapshot second = (await repository.PublishAsync([2], first.Head.RevisionId, Guid.NewGuid(), Cancellation)).Snapshot!;
+
+        Assert.Equal(SharedProfileRepositoryStatus.HistoryLimitExceeded,
+            (await repository.PublishAsync([3], second.Head.RevisionId, Guid.NewGuid(), Cancellation)).Status);
+        Assert.Equal(second.Head.RevisionId, (await repository.LoadAsync(first.Head.RevisionId, Cancellation)).Snapshot!.Head.RevisionId);
+        using var constrainedReader = fixture.Open(new() { MaximumHistoryCount = 1 });
+        Assert.Equal(SharedProfileRepositoryStatus.HistoryLimitExceeded,
+            (await constrainedReader.ReconcileAsync(Guid.NewGuid(), cancellationToken: Cancellation)).Status);
+    }
+
+    [Fact]
+    public async Task MissingStorage_NeverReinitializesDuringOrdinaryOperationsOrExistingSession()
+    {
+        using var fixture = new RepositoryFixture();
+        using var repository = fixture.Open();
+        Assert.Equal(SharedProfileRepositoryStatus.Unavailable, (await repository.LoadAsync(cancellationToken: Cancellation)).Status);
+        Assert.False(Directory.Exists(fixture.Root));
+        await repository.InitializeAsync(Cancellation);
+        Directory.Delete(fixture.Root, recursive: true);
+
+        Assert.Equal(SharedProfileRepositoryStatus.Unavailable,
+            (await repository.PublishAsync([1], null, Guid.NewGuid(), Cancellation)).Status);
+        Assert.Equal(SharedProfileRepositoryStatus.Unavailable, (await repository.InitializeAsync(Cancellation)).Status);
+        Assert.False(Directory.Exists(fixture.Root));
+    }
+
+    [Theory]
+    [InlineData("formatVersion", 2, SharedProfileRepositoryStatus.UnsupportedFormat)]
+    [InlineData("keyEpoch", 2, SharedProfileRepositoryStatus.InvalidData)]
+    public async Task AuthenticatedManifest_RejectsUnsupportedFormatAndMismatchedEnrollment(string field, int value, SharedProfileRepositoryStatus status)
+    {
+        using var fixture = new RepositoryFixture();
+        using var repository = fixture.Open();
+        await repository.InitializeAsync(Cancellation);
+        string path = Path.Combine(fixture.Root, "repository.json");
+        fixture.RewriteSignedRecord(path, "repository", json => json[field] = value);
+
+        Assert.Equal(status, (await repository.LoadAsync(cancellationToken: Cancellation)).Status);
+    }
+
+    [Fact]
+    public async Task AuthenticatedRevision_RejectsIdentitySubstitutionAndBrokenAncestry()
+    {
+        using var fixture = new RepositoryFixture();
+        using var repository = fixture.Open();
+        await repository.InitializeAsync(Cancellation);
+        SharedProfileSnapshot first = (await repository.PublishAsync([1], null, Guid.NewGuid(), Cancellation)).Snapshot!;
+        string path = Path.Combine(fixture.ProfilePath, "revisions", first.Head.RevisionId.ToString("N") + ".json");
+        byte[] original = await File.ReadAllBytesAsync(path, Cancellation);
+        fixture.RewriteSignedRecord(path, "revision", json => json["revision"]!["profileId"] = Guid.NewGuid());
+        Assert.Equal(SharedProfileRepositoryStatus.InvalidData, (await repository.LoadAsync(cancellationToken: Cancellation)).Status);
+        await File.WriteAllBytesAsync(path, original, Cancellation);
+        fixture.RewriteSignedRecord(path, "revision", json => json["revision"]!["sequence"] = 2);
+        Assert.Equal(SharedProfileRepositoryStatus.InvalidData, (await repository.LoadAsync(cancellationToken: Cancellation)).Status);
+    }
+
+    [Fact]
+    public async Task MissingHead_CannotBeMistakenForANewProfile()
+    {
+        using var fixture = new RepositoryFixture();
+        using var repository = fixture.Open();
+        await repository.InitializeAsync(Cancellation);
+        Assert.Null((await repository.LoadAsync(cancellationToken: Cancellation)).Snapshot);
+        File.Delete(fixture.HeadPath);
+
+        Assert.Equal(SharedProfileRepositoryStatus.Unavailable, (await repository.LoadAsync(cancellationToken: Cancellation)).Status);
+        Assert.Equal(SharedProfileRepositoryStatus.Unavailable,
+            (await repository.PublishAsync([1], null, Guid.NewGuid(), Cancellation)).Status);
+    }
+
+    [Fact]
+    public async Task Load_RejectsOversizedAndDuplicateMetadataBeforeAcceptingState()
+    {
+        using var fixture = new RepositoryFixture();
+        using var repository = fixture.Open();
+        await repository.InitializeAsync(Cancellation);
+        await repository.PublishAsync([1], null, Guid.NewGuid(), Cancellation);
+        byte[] original = await File.ReadAllBytesAsync(fixture.HeadPath, Cancellation);
+        byte[] oversized = new byte[70_000];
+        BinaryPrimitives.WriteInt32LittleEndian(oversized.AsSpan(0, 4), 70_000);
+        await File.WriteAllBytesAsync(fixture.HeadPath, oversized, Cancellation);
+        Assert.Equal(SharedProfileRepositoryStatus.InvalidData, (await repository.LoadAsync(cancellationToken: Cancellation)).Status);
+
+        await File.WriteAllBytesAsync(fixture.HeadPath, original, Cancellation);
+        fixture.RewriteLastJournalRecord(body => Encoding.UTF8.GetBytes("{\"content\":\"\"," + Encoding.UTF8.GetString(body)[1..]));
+        Assert.Equal(SharedProfileRepositoryStatus.InvalidData, (await repository.LoadAsync(cancellationToken: Cancellation)).Status);
+    }
+
+    [Fact]
+    public async Task Journal_CompleteUnauthenticatedCommitFailsClosedInsteadOfFallingBack()
+    {
+        using var fixture = new RepositoryFixture();
+        using var repository = fixture.Open();
+        await repository.InitializeAsync(Cancellation);
+        SharedProfileSnapshot first = (await repository.PublishAsync([1], null, Guid.NewGuid(), Cancellation)).Snapshot!;
+        await repository.PublishAsync([2], first.Head.RevisionId, Guid.NewGuid(), Cancellation);
+        fixture.RewriteLastJournalRecord(body =>
+        {
+            JsonNode record = JsonNode.Parse(body)!;
+            record["authenticationTag"] = Convert.ToBase64String(new byte[32]);
+            return Encoding.UTF8.GetBytes(record.ToJsonString());
+        });
+
+        Assert.Equal(SharedProfileRepositoryStatus.InvalidData, (await repository.LoadAsync(first.Head.RevisionId, Cancellation)).Status);
+        Assert.Equal(SharedProfileRepositoryStatus.InvalidData,
+            (await repository.PublishAsync([3], first.Head.RevisionId, Guid.NewGuid(), Cancellation)).Status);
+    }
+
+    [Fact]
+    public async Task Journal_LostHandleCannotOverwriteACommitMadeByANewOwner()
+    {
+        using var fixture = new RepositoryFixture();
+        using var repository = fixture.Open();
+        await repository.InitializeAsync(Cancellation);
+        SharedProfileSnapshot first = (await repository.PublishAsync([1], null, Guid.NewGuid(), Cancellation)).Snapshot!;
+        var files = new SharedProfileRepositoryFiles(fixture.Key);
+        using FileStream staleHandle = files.OpenJournal(fixture.HeadPath);
+        SharedProfileJournal<JsonElement> observed = files.ReadJournal<JsonElement>(staleHandle, 10, Cancellation);
+        staleHandle.Dispose();
+        SharedProfileSnapshot second = (await repository.PublishAsync([2], first.Head.RevisionId, Guid.NewGuid(), Cancellation)).Snapshot!;
+
+        Assert.Throws<ObjectDisposedException>(() => files.AppendJournal(staleHandle, observed.CommittedLength, observed.Records[^1]));
+        Assert.Equal(second.Head.RevisionId, (await repository.LoadAsync(second.Head.RevisionId, Cancellation)).Snapshot!.Head.RevisionId);
+    }
+
+    [Fact]
+    public async Task Publish_CopiesInputAndEnforcesPayloadLimit()
+    {
+        using var fixture = new RepositoryFixture();
+        using var repository = fixture.Open(new() { MaximumPayloadBytes = 3 });
+        await repository.InitializeAsync(Cancellation);
+        byte[] payload = [1, 2, 3];
+        Task<SharedProfileRepositoryResult> publication = repository.PublishAsync(payload, null, Guid.NewGuid(), Cancellation);
+        payload[0] = 99;
+        SharedProfileSnapshot snapshot = (await publication).Snapshot!;
+        Assert.Equal(new byte[] { 1, 2, 3 }, snapshot.EncryptedPayload);
+        snapshot.EncryptedPayload[1] = 99;
+        Assert.Equal(new byte[] { 1, 2, 3 }, (await repository.LoadAsync(cancellationToken: Cancellation)).Snapshot!.EncryptedPayload);
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => repository.PublishAsync([1, 2, 3, 4], snapshot.Head.RevisionId, Guid.NewGuid(), Cancellation));
+    }
+
+    [Fact]
+    public async Task Cancellation_StopsPublicationBeforeAnySharedWrite()
+    {
+        using var fixture = new RepositoryFixture();
+        using var repository = fixture.Open();
+        await repository.InitializeAsync(Cancellation);
+        using var canceled = new CancellationTokenSource();
+        await canceled.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => repository.PublishAsync([1], null, Guid.NewGuid(), canceled.Token));
+        Assert.Null((await repository.LoadAsync(cancellationToken: Cancellation)).Snapshot);
+    }
+
+    private sealed class RepositoryFixture : IDisposable
+    {
+        public string Root { get; } = Path.Combine(Path.GetTempPath(), "FoundrySharedProfileTests", Guid.NewGuid().ToString("N"));
+        public Guid RepositoryId { get; } = Guid.NewGuid();
+        public Guid ProfileId { get; } = Guid.NewGuid();
+        public byte[] Key { get; } = RandomNumberGenerator.GetBytes(32);
+        public string ProfilePath => Path.Combine(Root, "profiles", ProfileId.ToString("N"));
+        public string HeadPath => Path.Combine(ProfilePath, "head.journal");
+
+        public SharedProfileRepository Open(SharedProfileRepositoryOptions? options = null, byte[]? key = null) =>
+            new(Root, RepositoryId, ProfileId, 1, key ?? Key, options);
+
+        public void RewriteSignedRecord(string path, string purpose, Action<JsonNode> change)
+        {
+            JsonNode envelope = JsonNode.Parse(File.ReadAllText(path))!;
+            JsonNode content = JsonNode.Parse(Convert.FromBase64String(envelope["content"]!.GetValue<string>()))!;
+            change(content);
+            byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(content);
+            byte[] prefix = Encoding.UTF8.GetBytes("Foundry.SharedProfiles.v1/" + purpose + "\0");
+            envelope["content"] = Convert.ToBase64String(bytes);
+            envelope["authenticationTag"] = Convert.ToBase64String(HMACSHA256.HashData(Key.AsSpan(), [.. prefix, .. bytes]));
+            File.WriteAllText(path, envelope.ToJsonString());
+        }
+
+        public void RewriteLastJournalRecord(Func<byte[], byte[]> rewrite)
+        {
+            byte[] journal = File.ReadAllBytes(HeadPath);
+            int offset = 0;
+            int last = 0;
+            while (offset < journal.Length)
+            {
+                last = offset;
+                int length = BinaryPrimitives.ReadInt32LittleEndian(journal.AsSpan(offset, 4));
+                offset += length + 8;
+            }
+            int oldLength = BinaryPrimitives.ReadInt32LittleEndian(journal.AsSpan(last, 4));
+            byte[] record = rewrite(journal.AsSpan(last + 4, oldLength).ToArray());
+            byte[] rewritten = new byte[last + record.Length + 8];
+            journal.AsSpan(0, last).CopyTo(rewritten);
+            BinaryPrimitives.WriteInt32LittleEndian(rewritten.AsSpan(last, 4), record.Length);
+            record.CopyTo(rewritten, last + 4);
+            BinaryPrimitives.WriteInt32LittleEndian(rewritten.AsSpan(last + 4 + record.Length, 4), record.Length);
+            File.WriteAllBytes(HeadPath, rewritten);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Root)) Directory.Delete(Root, recursive: true);
+            CryptographicOperations.ZeroMemory(Key);
+        }
+    }
+}

--- a/src/Foundry.Core/Services/Profiles/SharedProfileRepository.cs
+++ b/src/Foundry.Core/Services/Profiles/SharedProfileRepository.cs
@@ -1,0 +1,314 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+
+namespace Foundry.Core.Services.Profiles;
+
+/// <summary>Publishes opaque encrypted revisions through a stable, exclusively opened commit journal.</summary>
+public sealed class SharedProfileRepository : IDisposable
+{
+    private readonly string rootPath;
+    private readonly string profilePath;
+    private readonly string journalPath;
+    private readonly Guid repositoryId;
+    private readonly Guid profileId;
+    private readonly int keyEpoch;
+    private readonly byte[] sharedKey;
+    private readonly SharedProfileRepositoryOptions options;
+    private readonly object keyLock = new();
+    private bool disposed;
+    private int initialized;
+
+    /// <summary>Copies the enrollment key; the caller must pin these identities outside the shared directory.</summary>
+    public SharedProfileRepository(string rootPath, Guid repositoryId, Guid profileId, int keyEpoch,
+        ReadOnlySpan<byte> sharedKey, SharedProfileRepositoryOptions? options = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(rootPath);
+        if (!Path.IsPathFullyQualified(rootPath)) throw new ArgumentException("An absolute repository path is required.", nameof(rootPath));
+        if (repositoryId == Guid.Empty || profileId == Guid.Empty) throw new ArgumentException("Repository identities must be nonempty.");
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(keyEpoch);
+        if (sharedKey.Length != 32) throw new ArgumentException("A 32-byte enrollment key is required.", nameof(sharedKey));
+        this.options = options ?? new();
+        if (this.options.MaximumPayloadBytes is < 1 or > 256 * 1024 * 1024 ||
+            this.options.MaximumHistoryCount is < 1 or > 4096)
+            throw new ArgumentOutOfRangeException(nameof(options));
+        this.rootPath = Path.GetFullPath(rootPath);
+        this.profilePath = Path.Combine(this.rootPath, "profiles", profileId.ToString("N"));
+        this.journalPath = Path.Combine(profilePath, "head.journal");
+        this.repositoryId = repositoryId;
+        this.profileId = profileId;
+        this.keyEpoch = keyEpoch;
+        this.sharedKey = sharedKey.ToArray();
+    }
+
+    /// <summary>Explicitly creates a new repository or validates an existing enrollment; ordinary operations never initialize storage.</summary>
+    public Task<SharedProfileRepositoryResult> InitializeAsync(CancellationToken cancellationToken = default) =>
+        ExecuteAsync((files, token) =>
+        {
+            if (Volatile.Read(ref initialized) != 0)
+            {
+                using FileStream existingJournal = files.OpenJournal(journalPath);
+                _ = ReadHistory(files, existingJournal, token, out _);
+                return new(SharedProfileRepositoryStatus.Success);
+            }
+            SharedProfileRepositoryFiles.ValidatePath(rootPath);
+            Directory.CreateDirectory(rootPath);
+            using FileStream repositoryLock = files.AcquireLock(Path.Combine(rootPath, "repository.lock"));
+            string manifestPath = Path.Combine(rootPath, "repository.json");
+            if (files.Exists(manifestPath))
+            {
+                ValidateManifest(files);
+            }
+            else
+            {
+                // Missing metadata in nonempty storage must not turn an old repository into a fresh one.
+                if (Directory.EnumerateFileSystemEntries(rootPath).Any(path =>
+                    !string.Equals(Path.GetFileName(path), "repository.lock", StringComparison.Ordinal)))
+                    throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+                files.WriteSigned(manifestPath, "repository", new RepositoryManifest(1, repositoryId, keyEpoch));
+            }
+            token.ThrowIfCancellationRequested();
+            bool profileExisted = Directory.Exists(profilePath);
+            Directory.CreateDirectory(profilePath);
+            Directory.CreateDirectory(Path.Combine(profilePath, "revisions"));
+            using FileStream journal = files.OpenJournal(journalPath, create: !profileExisted);
+            if (!profileExisted) files.AppendJournal(journal, 0, CreateHead(null));
+            _ = ReadHistory(files, journal, token, out _);
+            Volatile.Write(ref initialized, 1);
+            return new(SharedProfileRepositoryStatus.Success);
+        }, cancellationToken);
+
+    /// <summary>Authenticates committed ancestry and rejects a head that no longer descends from a locally pinned revision.</summary>
+    public Task<SharedProfileRepositoryResult> LoadAsync(Guid? knownRevisionId = null, CancellationToken cancellationToken = default) =>
+        ExecuteAsync((files, token) =>
+        {
+            using FileStream journal = files.OpenJournal(journalPath);
+            List<RevisionMetadata> history = ReadHistory(files, journal, token, out _);
+            EnsureKnownRevision(history, knownRevisionId);
+            return new(SharedProfileRepositoryStatus.Success, ReadSnapshot(files, history));
+        }, cancellationToken);
+
+    /// <summary>Copies encrypted input immediately, then publishes only if the locked head still equals the expected base.</summary>
+    public Task<SharedProfileRepositoryResult> PublishAsync(byte[] encryptedPayload, Guid? expectedRevisionId,
+        Guid operationId, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(encryptedPayload);
+        if (encryptedPayload.Length == 0 || encryptedPayload.Length > options.MaximumPayloadBytes)
+            throw new ArgumentOutOfRangeException(nameof(encryptedPayload));
+        return PublishCoreAsync(encryptedPayload.ToArray(), expectedRevisionId, operationId, false, cancellationToken);
+    }
+
+    /// <summary>Publishes a deletion revision conditionally; no files or committed ancestry are removed.</summary>
+    public Task<SharedProfileRepositoryResult> TombstoneAsync(Guid expectedRevisionId, Guid operationId,
+        CancellationToken cancellationToken = default) =>
+        PublishCoreAsync([], expectedRevisionId, operationId, true, cancellationToken);
+
+    /// <summary>Only authenticated committed ancestry proves success; orphan files never count as a committed operation.</summary>
+    public Task<SharedProfileRepositoryResult> ReconcileAsync(Guid operationId, Guid? knownRevisionId = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (operationId == Guid.Empty) throw new ArgumentException("An operation identity is required.", nameof(operationId));
+        return ExecuteAsync((files, token) =>
+        {
+            using FileStream journal = files.OpenJournal(journalPath);
+            List<RevisionMetadata> history = ReadHistory(files, journal, token, out _);
+            EnsureKnownRevision(history, knownRevisionId);
+            RevisionMetadata? committed = history.Find(revision => revision.Revision.OperationId == operationId);
+            return new(committed is null ? SharedProfileRepositoryStatus.NotCommitted : SharedProfileRepositoryStatus.Success,
+                ReadSnapshot(files, history), committed?.Revision.RevisionId);
+        }, cancellationToken);
+    }
+
+    /// <summary>Clears the owned enrollment key; already started operations own separate bounded-lifetime copies.</summary>
+    public void Dispose()
+    {
+        lock (keyLock)
+        {
+            disposed = true;
+            CryptographicOperations.ZeroMemory(sharedKey);
+        }
+    }
+
+    private async Task<SharedProfileRepositoryResult> PublishCoreAsync(byte[] payload, Guid? expectedRevisionId,
+        Guid operationId, bool tombstone, CancellationToken cancellationToken)
+    {
+        if (operationId == Guid.Empty || expectedRevisionId == Guid.Empty)
+            throw new ArgumentException("Operation and revision identities must be nonempty.");
+        try
+        {
+            return await ExecuteAsync((files, token) =>
+            {
+                ValidateManifest(files);
+                using FileStream journal = files.OpenJournal(journalPath);
+                List<RevisionMetadata> history = ReadHistory(files, journal, token, out long committedLength);
+                string hash = Convert.ToHexString(SHA256.HashData(payload));
+                RevisionMetadata? previous = history.Find(revision => revision.Revision.OperationId == operationId);
+                if (previous is not null)
+                {
+                    if (previous.Revision.ParentRevisionId != expectedRevisionId || previous.Revision.IsTombstone != tombstone ||
+                        previous.PayloadLength != payload.Length || previous.PayloadHash != hash)
+                        throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+                    return new(SharedProfileRepositoryStatus.Success, ReadSnapshot(files, history), previous.Revision.RevisionId);
+                }
+
+                EnsureKnownRevision(history, expectedRevisionId);
+                SharedProfileSnapshot? current = ReadSnapshot(files, history);
+                if (current?.Head.RevisionId != expectedRevisionId || current?.Head.IsTombstone == true)
+                    return new(SharedProfileRepositoryStatus.Conflict, current);
+                if (history.Count >= options.MaximumHistoryCount)
+                    throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.HistoryLimitExceeded);
+
+                var revision = new SharedProfileRevision(repositoryId, profileId, Guid.NewGuid(), expectedRevisionId,
+                    operationId, (current?.Head.Sequence ?? 0) + 1, keyEpoch, tombstone);
+                var metadata = new RevisionMetadata(1, revision, hash, payload.Length);
+                token.ThrowIfCancellationRequested();
+                if (!tombstone) files.WriteBytes(RevisionPath(revision.RevisionId, ".payload"), payload);
+                files.WriteSigned(RevisionPath(revision.RevisionId, ".json"), "revision", metadata);
+                token.ThrowIfCancellationRequested();
+                files.AppendJournal(journal, committedLength, CreateHead(revision));
+                return new(SharedProfileRepositoryStatus.Success, new(revision, payload.ToArray()), revision.RevisionId);
+            }, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(payload);
+        }
+    }
+
+    private List<RevisionMetadata> ReadHistory(SharedProfileRepositoryFiles files, FileStream journal,
+        CancellationToken token, out long committedLength)
+    {
+        ValidateManifest(files);
+        SharedProfileJournal<HeadMetadata> commits = files.ReadJournal<HeadMetadata>(journal, options.MaximumHistoryCount + 1, token);
+        committedLength = commits.CommittedLength;
+        ValidateCommits(commits.Records);
+        HeadMetadata head = commits.Records[^1];
+        if (head.Revision is null) return [];
+        var history = new List<RevisionMetadata>();
+        var revisions = new HashSet<Guid>();
+        var operations = new HashSet<Guid>();
+        Guid? next = head.Revision.RevisionId;
+        long sequence = head.Revision.Sequence;
+        while (next is Guid id)
+        {
+            token.ThrowIfCancellationRequested();
+            if (history.Count >= options.MaximumHistoryCount)
+                throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.HistoryLimitExceeded);
+            RevisionMetadata item = files.ReadSigned<RevisionMetadata>(RevisionPath(id, ".json"), "revision");
+            ValidateVersion(item.FormatVersion);
+            ValidateRevision(item.Revision);
+            if (item.Revision.RevisionId != id || item.Revision.Sequence != sequence || !revisions.Add(id) ||
+                !operations.Add(item.Revision.OperationId) || item.PayloadLength < 0 || item.PayloadLength > options.MaximumPayloadBytes ||
+                item.PayloadHash is not { Length: 64 } || !item.PayloadHash.All(Uri.IsHexDigit) ||
+                item.Revision.IsTombstone != (item.PayloadLength == 0) ||
+                item.Revision != commits.Records[commits.Records.Count - 1 - history.Count].Revision ||
+                history.Count > 0 && item.Revision.IsTombstone)
+                throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+            history.Add(item);
+            next = item.Revision.ParentRevisionId;
+            sequence--;
+        }
+        if (sequence != 0 || history.Count != commits.Records.Count - 1)
+            throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+        return history;
+    }
+
+    private void ValidateCommits(IReadOnlyList<HeadMetadata> commits)
+    {
+        SharedProfileRevision? previous = null;
+        for (int index = 0; index < commits.Count; index++)
+        {
+            HeadMetadata commit = commits[index];
+            ValidateVersion(commit.FormatVersion);
+            if (commit.RepositoryId != repositoryId || commit.ProfileId != profileId || commit.KeyEpoch != keyEpoch)
+                throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+            if (index == 0)
+            {
+                if (commit.Revision is not null) throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+                continue;
+            }
+            ValidateRevision(commit.Revision);
+            if (commit.Revision!.Sequence != index || commit.Revision.ParentRevisionId != previous?.RevisionId || previous?.IsTombstone == true)
+                throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+            previous = commit.Revision;
+        }
+    }
+
+    private SharedProfileSnapshot? ReadSnapshot(SharedProfileRepositoryFiles files, List<RevisionMetadata> history)
+    {
+        if (history.Count == 0) return null;
+        RevisionMetadata head = history[0];
+        byte[] payload = head.Revision.IsTombstone ? [] : files.ReadBytes(RevisionPath(head.Revision.RevisionId, ".payload"), options.MaximumPayloadBytes);
+        if (payload.Length != head.PayloadLength || !string.Equals(Convert.ToHexString(SHA256.HashData(payload)), head.PayloadHash, StringComparison.Ordinal))
+            throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+        return new(head.Revision, payload);
+    }
+
+    private void ValidateManifest(SharedProfileRepositoryFiles files)
+    {
+        RepositoryManifest manifest = files.ReadSigned<RepositoryManifest>(Path.Combine(rootPath, "repository.json"), "repository");
+        ValidateVersion(manifest.FormatVersion);
+        if (manifest.RepositoryId != repositoryId || manifest.KeyEpoch != keyEpoch)
+            throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+        SharedProfileRepositoryFiles.ValidatePath(profilePath);
+    }
+
+    private void ValidateRevision(SharedProfileRevision? revision)
+    {
+        if (revision is null || revision.RepositoryId != repositoryId || revision.ProfileId != profileId ||
+            revision.KeyEpoch != keyEpoch || revision.RevisionId == Guid.Empty || revision.OperationId == Guid.Empty ||
+            revision.ParentRevisionId == Guid.Empty || revision.Sequence <= 0 ||
+            (revision.ParentRevisionId is null) != (revision.Sequence == 1))
+            throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+    }
+
+    private static void ValidateVersion(int version)
+    {
+        if (version != 1) throw new SharedProfileRepositoryException(
+            version > 1 ? SharedProfileRepositoryStatus.UnsupportedFormat : SharedProfileRepositoryStatus.InvalidData);
+    }
+
+    private static void EnsureKnownRevision(List<RevisionMetadata> history, Guid? knownRevisionId)
+    {
+        if (knownRevisionId is not null && !history.Any(item => item.Revision.RevisionId == knownRevisionId))
+            throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.RollbackDetected);
+    }
+
+    private string RevisionPath(Guid revisionId, string extension) =>
+        Path.Combine(profilePath, "revisions", revisionId.ToString("N") + extension);
+
+    private HeadMetadata CreateHead(SharedProfileRevision? revision) => new(1, repositoryId, profileId, keyEpoch, revision);
+
+    private Task<SharedProfileRepositoryResult> ExecuteAsync(
+        Func<SharedProfileRepositoryFiles, CancellationToken, SharedProfileRepositoryResult> action, CancellationToken cancellationToken)
+    {
+        byte[] operationKey;
+        lock (keyLock)
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            operationKey = sharedKey.ToArray();
+        }
+        // Native UNC opens can block despite cancellation. They never execute on the caller's UI thread.
+        return Task.Run(() =>
+        {
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return action(new SharedProfileRepositoryFiles(operationKey), cancellationToken);
+            }
+            catch (SharedProfileRepositoryException exception) { return new(exception.Status); }
+            catch (System.Text.Json.JsonException) { return new(SharedProfileRepositoryStatus.InvalidData); }
+            catch (CryptographicException) { return new(SharedProfileRepositoryStatus.InvalidData); }
+            catch (FormatException) { return new(SharedProfileRepositoryStatus.InvalidData); }
+            catch (IOException) { return new(SharedProfileRepositoryStatus.Unavailable); }
+            catch (UnauthorizedAccessException) { return new(SharedProfileRepositoryStatus.Unavailable); }
+            finally { CryptographicOperations.ZeroMemory(operationKey); }
+        });
+    }
+
+    private sealed record RepositoryManifest(int FormatVersion, Guid RepositoryId, int KeyEpoch);
+    private sealed record HeadMetadata(int FormatVersion, Guid RepositoryId, Guid ProfileId, int KeyEpoch, SharedProfileRevision? Revision);
+    private sealed record RevisionMetadata(int FormatVersion, SharedProfileRevision Revision, string PayloadHash, int PayloadLength);
+}

--- a/src/Foundry.Core/Services/Profiles/SharedProfileRepositoryContracts.cs
+++ b/src/Foundry.Core/Services/Profiles/SharedProfileRepositoryContracts.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+namespace Foundry.Core.Services.Profiles;
+
+/// <summary>Classifies repository outcomes without exposing remote paths or confidential payloads.</summary>
+public enum SharedProfileRepositoryStatus
+{
+    Success,
+    Conflict,
+    Busy,
+    Unavailable,
+    InvalidData,
+    UnsupportedFormat,
+    RollbackDetected,
+    HistoryLimitExceeded,
+    NotCommitted
+}
+
+/// <summary>Bounds untrusted payloads and authenticated ancestry; exhausted history requires explicit maintenance.</summary>
+public sealed record SharedProfileRepositoryOptions
+{
+    public int MaximumPayloadBytes { get; init; } = 64 * 1024 * 1024;
+    public int MaximumHistoryCount { get; init; } = 512;
+}
+
+/// <summary>Identifies one authenticated immutable revision, including deletion tombstones.</summary>
+public sealed record SharedProfileRevision(
+    Guid RepositoryId,
+    Guid ProfileId,
+    Guid RevisionId,
+    Guid? ParentRevisionId,
+    Guid OperationId,
+    long Sequence,
+    int KeyEpoch,
+    bool IsTombstone);
+
+/// <summary>Contains caller-owned encrypted bytes bound to the authenticated revision.</summary>
+public sealed record SharedProfileSnapshot(SharedProfileRevision Head, byte[] EncryptedPayload);
+
+/// <summary>A missing snapshot on success means a new profile has no committed head.</summary>
+/// <param name="CommittedRevisionId">The original committed revision when an operation was reconciled or retried.</param>
+public sealed record SharedProfileRepositoryResult(
+    SharedProfileRepositoryStatus Status,
+    SharedProfileSnapshot? Snapshot = null,
+    Guid? CommittedRevisionId = null);

--- a/src/Foundry.Core/Services/Profiles/SharedProfileRepositoryFiles.cs
+++ b/src/Foundry.Core/Services/Profiles/SharedProfileRepositoryFiles.cs
@@ -1,0 +1,235 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Foundry.Core.Services.Profiles;
+
+/// <summary>Bounds and authenticates repository records. The shared directory must enforce trusted-writer ACLs.</summary>
+internal sealed class SharedProfileRepositoryFiles(byte[] key)
+{
+    private const int MaximumMetadataBytes = 64 * 1024;
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+        RespectRequiredConstructorParameters = true,
+        MaxDepth = 16
+    };
+
+    internal FileStream AcquireLock(string path)
+    {
+        ValidatePath(path);
+        try
+        {
+            // This file remains in place permanently. Ownership is the OS handle, never file existence.
+            return new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+        }
+        catch (IOException exception) when ((exception.HResult & 0xffff) is 32 or 33)
+        {
+            throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.Busy);
+        }
+    }
+
+    /// <summary>The stable journal handle is both the exclusive lock and the only route for committing a head.</summary>
+    internal FileStream OpenJournal(string path, bool create = false)
+    {
+        ValidatePath(path);
+        try
+        {
+            return new FileStream(path, create ? FileMode.CreateNew : FileMode.Open,
+                FileAccess.ReadWrite, FileShare.None, bufferSize: 1, FileOptions.WriteThrough);
+        }
+        catch (IOException exception) when ((exception.HResult & 0xffff) is 32 or 33)
+        {
+            throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.Busy);
+        }
+    }
+
+    /// <summary>Only an incomplete final frame is recoverable; complete malformed or unauthenticated records fail closed.</summary>
+    internal SharedProfileJournal<T> ReadJournal<T>(FileStream journal, int maximumRecords, CancellationToken token)
+    {
+        if (journal.Length > (long)maximumRecords * (MaximumMetadataBytes + 8))
+            throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.HistoryLimitExceeded);
+        journal.Position = 0;
+        var records = new List<T>();
+        long committedLength = 0;
+        Span<byte> framing = stackalloc byte[4];
+        while (journal.Position < journal.Length)
+        {
+            token.ThrowIfCancellationRequested();
+            if (journal.Length - journal.Position < framing.Length) break;
+            journal.ReadExactly(framing);
+            int length = BinaryPrimitives.ReadInt32LittleEndian(framing);
+            if (length is <= 0 or > MaximumMetadataBytes)
+                throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+            if (journal.Length - journal.Position < length + framing.Length) break;
+            if (records.Count >= maximumRecords)
+                throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.HistoryLimitExceeded);
+            byte[] content = new byte[length];
+            journal.ReadExactly(content);
+            journal.ReadExactly(framing);
+            if (BinaryPrimitives.ReadInt32LittleEndian(framing) != length)
+                throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+            records.Add(DeserializeSigned<T>(content, "head"));
+            committedLength = journal.Position;
+        }
+        if (records.Count == 0) throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+        return new(records, committedLength);
+    }
+
+    /// <summary>Writes and flushes through the already locked handle, including after a durable SMB reconnect.</summary>
+    internal void AppendJournal<T>(FileStream journal, long committedLength, T value)
+    {
+        byte[] bytes = SerializeSigned("head", value);
+        byte[] frame = new byte[bytes.Length + 8];
+        BinaryPrimitives.WriteInt32LittleEndian(frame.AsSpan(0, 4), bytes.Length);
+        bytes.CopyTo(frame, 4);
+        BinaryPrimitives.WriteInt32LittleEndian(frame.AsSpan(bytes.Length + 4, 4), bytes.Length);
+        // Truncate only the incomplete tail previously identified while holding this same exclusive handle.
+        if (journal.Length != committedLength) journal.SetLength(committedLength);
+        journal.Position = committedLength;
+        journal.Write(frame);
+        journal.Flush(flushToDisk: true);
+    }
+
+    internal bool Exists(string path)
+    {
+        ValidatePath(path);
+        try { return (File.GetAttributes(path) & FileAttributes.Directory) == 0; }
+        catch (FileNotFoundException) { return false; }
+        catch (DirectoryNotFoundException) { return false; }
+    }
+
+    internal T ReadSigned<T>(string path, string purpose)
+    {
+        byte[] envelopeBytes = ReadBytes(path, MaximumMetadataBytes);
+        return DeserializeSigned<T>(envelopeBytes, purpose);
+    }
+
+    private T DeserializeSigned<T>(byte[] envelopeBytes, string purpose)
+    {
+        ValidateJson(envelopeBytes);
+        SignedRecord envelope = JsonSerializer.Deserialize<SignedRecord>(envelopeBytes, JsonOptions)
+            ?? throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+        if (envelope.Content is null || envelope.AuthenticationTag is not { Length: 32 })
+            throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+        byte[] expectedTag = Authenticate(purpose, envelope.Content);
+        if (!CryptographicOperations.FixedTimeEquals(envelope.AuthenticationTag, expectedTag))
+            throw new CryptographicException("Repository record authentication failed.");
+        ValidateJson(envelope.Content);
+        return JsonSerializer.Deserialize<T>(envelope.Content, JsonOptions)
+            ?? throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+    }
+
+    internal void WriteSigned<T>(string path, string purpose, T value)
+    {
+        WriteBytes(path, SerializeSigned(purpose, value));
+    }
+
+    private byte[] SerializeSigned<T>(string purpose, T value)
+    {
+        byte[] content = JsonSerializer.SerializeToUtf8Bytes(value, JsonOptions);
+        byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(new SignedRecord(content, Authenticate(purpose, content)), JsonOptions);
+        if (bytes.Length > MaximumMetadataBytes) throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+        return bytes;
+    }
+
+    internal byte[] ReadBytes(string path, int maximumBytes)
+    {
+        ValidatePath(path);
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete);
+        if (stream.Length > maximumBytes) throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+        int length = checked((int)stream.Length);
+        byte[] bytes = new byte[length];
+        stream.ReadExactly(bytes);
+        if (stream.ReadByte() != -1) throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+        return bytes;
+    }
+
+    internal void WriteBytes(string path, byte[] bytes)
+    {
+        ValidatePath(path);
+        string temporary = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
+        try
+        {
+            using (var stream = new FileStream(temporary, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            {
+                stream.Write(bytes);
+                stream.Flush(flushToDisk: true);
+            }
+            ValidatePath(path);
+            File.Move(temporary, path);
+        }
+        finally
+        {
+            try { File.Delete(temporary); }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+
+    internal static void ValidatePath(string path)
+    {
+        string? current = Path.GetFullPath(path);
+        while (current is not null)
+        {
+            try
+            {
+                if ((File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
+                    throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+            }
+            catch (FileNotFoundException) { }
+            catch (DirectoryNotFoundException) { }
+            current = Path.GetDirectoryName(current);
+        }
+    }
+
+    private byte[] Authenticate(string purpose, byte[] content)
+    {
+        byte[] prefix = Encoding.UTF8.GetBytes("Foundry.SharedProfiles.v1/" + purpose + "\0");
+        using IncrementalHash hmac = IncrementalHash.CreateHMAC(HashAlgorithmName.SHA256, key);
+        hmac.AppendData(prefix);
+        hmac.AppendData(content);
+        return hmac.GetHashAndReset();
+    }
+
+    private static void ValidateJson(byte[] bytes)
+    {
+        using JsonDocument json = JsonDocument.Parse(bytes, new JsonDocumentOptions { MaxDepth = 16 });
+        ValidateElement(json.RootElement);
+    }
+
+    private static void ValidateElement(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (JsonProperty property in element.EnumerateObject())
+            {
+                if (!names.Add(property.Name)) throw new SharedProfileRepositoryException(SharedProfileRepositoryStatus.InvalidData);
+                ValidateElement(property.Value);
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement item in element.EnumerateArray()) ValidateElement(item);
+        }
+    }
+
+    private sealed record SignedRecord(byte[] Content, byte[] AuthenticationTag);
+}
+
+/// <summary>Internal classified failure; only its status crosses the repository boundary.</summary>
+internal sealed class SharedProfileRepositoryException(SharedProfileRepositoryStatus status) : Exception
+{
+    internal SharedProfileRepositoryStatus Status { get; } = status;
+}
+
+/// <summary>Authenticated frames and the end of the last complete frame, observed under an exclusive journal handle.</summary>
+internal sealed record SharedProfileJournal<T>(IReadOnlyList<T> Records, long CommittedLength);


### PR DESCRIPTION
## Summary

Adds the authenticated shared-profile repository for #339 and parent #345. Multiple installations publish conditionally against a known revision and retain conflicting local work.

## Main changes

- Immutable encrypted payloads and authenticated repository, revision, and committed ancestry metadata.
- One stable exclusive journal handle performs the comparison and durable head append, preventing publication through a separate path after losing an SMB lock.
- Explicit conflicts, rollback detection, tombstones, bounded history, and retry reconciliation using committed operation IDs.
- Interrupted final journal frames recover without accepting complete tampered records or orphan payloads as commits.

## Testing

- Core executable suite: 723 passed, including 18 shared-repository cases.
- Concurrent publication, invalidated handles, partial writes, tampering, stale writers, tombstones, and retries covered on the local Windows filesystem.
- `scripts/Test-FoundryFormat.ps1` and `git diff --check`: passed.
- Real SMB failover remains a manual acceptance check. Required x64 and ARM64 CI must pass before squash merge.

Part of foundry-osd/foundry#339. Targets the parent integration branch; final main merge remains with the maintainer.
