### PR TITLE
feat(profiles): persist local revisions with Windows credentials

### DIFF
--- a/src/Foundry.Core.Tests/Profiles/LocalDeploymentProfileRepositoryTests.cs
+++ b/src/Foundry.Core.Tests/Profiles/LocalDeploymentProfileRepositoryTests.cs
@@ -1,0 +1,373 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Nodes;
+using Foundry.Core.Models.Profiles;
+using Foundry.Core.Services.Profiles;
+using Foundry.Utilities.Security;
+
+namespace Foundry.Core.Tests.Profiles;
+
+public sealed class LocalDeploymentProfileRepositoryTests : IDisposable
+{
+    private readonly string root = Path.Combine(Path.GetTempPath(), "Foundry.LocalProfiles.Tests", Guid.NewGuid().ToString("N"));
+    private readonly FakeCredentials credentials = new();
+    private readonly Guid localId = Guid.NewGuid();
+
+    [Fact]
+    public void SaveRead_EncryptsOwnedSecretsAndKeepsLocalAndSharedIdentitiesSeparate()
+    {
+        var repository = CreateRepository();
+        DeploymentProfileDocument profile = CreateProfile();
+
+        LocalProfileDescriptor descriptor = repository.Save(localId, profile, true, null);
+        using LocalProfileSnapshot read = CreateRepository().Read(localId);
+
+        Assert.Equal(localId, descriptor.LocalId);
+        Assert.Equal(profile.ProfileId, descriptor.ProfileId);
+        Assert.NotEqual(descriptor.LocalId, descriptor.ProfileId);
+        Assert.Equal("synthetic-secret-keep-exact", Encoding.UTF8.GetString(Assert.Single(read.Profile.Secrets.Entries).Value!));
+        Assert.Equal(descriptor.Revision, read.Descriptor.Revision);
+        foreach (string file in Directory.GetFiles(root, "*", SearchOption.AllDirectories))
+        {
+            Assert.DoesNotContain("synthetic-secret-keep-exact", Encoding.UTF8.GetString(File.ReadAllBytes(file)));
+        }
+        Assert.Single(credentials.Values);
+    }
+
+    [Fact]
+    public void Save_WithoutRemembering_OmitsSecretAndAssetBytesButPreservesLocalSourcePathsAndBlankState()
+    {
+        var repository = CreateRepository();
+        DeploymentProfileDocument profile = CreateProfile();
+        byte[] content = [1, 2, 3];
+        profile = profile with
+        {
+            Configuration = profile.Configuration with { Network = new() { Wifi = new() { CertificatePath = "C:/synthetic/certificate.pfx" } } },
+            Secrets = new() { Entries = [.. profile.Secrets.Entries, new() { Purpose = ProfileSecretPurpose.AdministratorPassword, Identity = "administrator", State = ProfileValueState.Blank }] },
+            Assets = [new() { Id = "certificate", Kind = ProfileAssetKind.WifiCertificate, RelativePath = "wifi/certificate.pfx", State = ProfileValueState.Present, Content = content, Sha256 = Convert.ToHexString(SHA256.HashData(content)) }]
+        };
+
+        repository.Save(localId, profile, false, null);
+        using LocalProfileSnapshot read = repository.Read(localId);
+
+        Assert.Equal(ProfileValueState.Omitted, read.Profile.Secrets.Entries[0].State);
+        Assert.Null(read.Profile.Secrets.Entries[0].Value);
+        Assert.Equal(ProfileValueState.Blank, read.Profile.Secrets.Entries[1].State);
+        Assert.Equal(ProfileValueState.Omitted, Assert.Single(read.Profile.Assets).State);
+        Assert.Null(read.Profile.Assets[0].Content);
+        Assert.Equal("C:/synthetic/certificate.pfx", read.Profile.Configuration.Network.Wifi.CertificatePath);
+        Assert.NotNull(profile.Secrets.Entries[0].Value);
+        Assert.Equal(content, profile.Assets[0].Content);
+    }
+
+    [Fact]
+    public void Save_WithStaleExpectedRevision_PreservesConcurrentWriter()
+    {
+        var first = CreateRepository();
+        var second = CreateRepository();
+        DeploymentProfileDocument profile = CreateProfile();
+        LocalProfileDescriptor original = first.Save(localId, profile, true, null);
+        LocalProfileDescriptor updated = second.Save(localId, profile with { DisplayName = "Newer" }, true, original.Revision);
+
+        LocalProfileConflictException conflict = Assert.Throws<LocalProfileConflictException>(() =>
+            first.Save(localId, profile with { DisplayName = "Stale" }, true, original.Revision));
+
+        Assert.Equal(updated.Revision, conflict.CurrentRevision);
+        using LocalProfileSnapshot read = first.Read(localId);
+        Assert.Equal("Newer", read.Profile.DisplayName);
+        Assert.Single(credentials.Values);
+    }
+
+    [Fact]
+    public void MissingKey_LocksReadAndSaveWithoutReplacingCommittedProfile()
+    {
+        var repository = CreateRepository();
+        DeploymentProfileDocument profile = CreateProfile();
+        LocalProfileDescriptor descriptor = repository.Save(localId, profile, true, null);
+        credentials.Clear();
+
+        Assert.Throws<LocalProfileLockedException>(() => repository.Read(localId));
+        Assert.Throws<LocalProfileLockedException>(() => repository.Save(localId, profile, true, descriptor.Revision));
+
+        Assert.Equal(descriptor.Revision, Assert.Single(repository.List()).Revision);
+        Assert.Empty(credentials.Values);
+    }
+
+    [Fact]
+    public void FailedCredentialWrite_PreservesPreviousRevisionAndCleansAmbiguousCandidate()
+    {
+        var repository = CreateRepository();
+        DeploymentProfileDocument profile = CreateProfile();
+        LocalProfileDescriptor descriptor = repository.Save(localId, profile, true, null);
+        credentials.ThrowAfterNextWrite = true;
+
+        Assert.Throws<Win32Exception>(() => repository.Save(localId, profile with { DisplayName = "Failed" }, true, descriptor.Revision));
+
+        using LocalProfileSnapshot read = repository.Read(localId);
+        Assert.Equal(descriptor.Revision, read.Descriptor.Revision);
+        Assert.Equal("Synthetic profile", read.Profile.DisplayName);
+        Assert.Single(credentials.Values);
+    }
+
+    [Fact]
+    public void FailedHeadPublication_PreservesPreviousRevisionAndRetiresCandidateKey()
+    {
+        var repository = CreateRepository();
+        DeploymentProfileDocument profile = CreateProfile();
+        LocalProfileDescriptor descriptor = repository.Save(localId, profile, true, null);
+        FileStream? lockedHead = null;
+        credentials.AfterWrite = () => lockedHead = new FileStream(HeadPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        try
+        {
+            Exception? failure = Record.Exception(() => repository.Save(localId, profile with { DisplayName = "Failed" }, true, descriptor.Revision));
+            Assert.True(failure is IOException or UnauthorizedAccessException);
+        }
+        finally
+        {
+            lockedHead?.Dispose();
+            credentials.AfterWrite = null;
+        }
+
+        using LocalProfileSnapshot read = repository.Read(localId);
+        Assert.Equal(descriptor.Revision, read.Descriptor.Revision);
+        Assert.Single(credentials.Values);
+    }
+
+    [Fact]
+    public void Forget_CommitsSettingsOnlyDisablesEnrollmentAndRetiresAllOldKeys()
+    {
+        var repository = CreateRepository();
+        DeploymentProfileDocument profile = CreateProfile();
+        LocalProfileEnrollment enrollment = CreateEnrollment(profile.ProfileId);
+        LocalProfileDescriptor original = repository.Save(localId, profile, true, null, enrollment, new byte[32]);
+        string[] priorTargets = credentials.Values.Keys.ToArray();
+
+        LocalProfileDescriptor forgotten = repository.Forget(localId, original.Revision);
+
+        Assert.False(forgotten.RememberSecrets);
+        Assert.False(forgotten.Enrollment!.IsEnabled);
+        Assert.False(forgotten.Enrollment.RememberSharedKey);
+        Assert.Null(repository.ReadSharedKey(localId));
+        Assert.All(priorTargets, target => Assert.False(credentials.Values.ContainsKey(target)));
+        Assert.Single(credentials.Values);
+        using LocalProfileSnapshot read = CreateRepository().Read(localId);
+        Assert.Null(Assert.Single(read.Profile.Secrets.Entries).Value);
+    }
+
+    [Fact]
+    public void InterruptedCleanup_ReportsPendingAndRecoversWithoutLosingCommittedRevision()
+    {
+        var repository = CreateRepository();
+        DeploymentProfileDocument profile = CreateProfile();
+        LocalProfileDescriptor original = repository.Save(localId, profile, true, null);
+        credentials.FailDelete = true;
+
+        LocalProfileDescriptor forgotten = repository.Forget(localId, original.Revision);
+
+        Assert.True(forgotten.CleanupPending);
+        Assert.NotEqual(original.Revision, forgotten.Revision);
+        credentials.FailDelete = false;
+        LocalProfileDescriptor recovered = Assert.Single(CreateRepository().List());
+        Assert.Equal(forgotten.Revision, recovered.Revision);
+        Assert.False(recovered.CleanupPending);
+        Assert.Single(credentials.Values);
+    }
+
+    [Fact]
+    public void EnrollmentKey_PreservesMatchingTupleAndRequiresNewKeyForChangedEpoch()
+    {
+        var repository = CreateRepository();
+        DeploymentProfileDocument profile = CreateProfile();
+        LocalProfileEnrollment enrollment = CreateEnrollment(profile.ProfileId);
+        byte[] key = Enumerable.Repeat((byte)0x73, 32).ToArray();
+        LocalProfileDescriptor first = repository.Save(localId, profile, false, null, enrollment, key);
+        LocalProfileDescriptor second = repository.Save(localId, profile, false, first.Revision, enrollment);
+        using WindowsCredential? read = repository.ReadSharedKey(localId);
+        Assert.NotNull(read);
+        Assert.Equal(key, read.Secret);
+
+        Assert.Throws<ArgumentException>(() => repository.Save(localId, profile, false, second.Revision, enrollment with { KeyEpoch = 2 }));
+        Assert.Equal(second.Revision, Assert.Single(repository.List()).Revision);
+    }
+
+    [Fact]
+    public void Delete_UpdatesActiveSelectionAndLeavesOtherProfilesUntouched()
+    {
+        var repository = CreateRepository();
+        LocalProfileDescriptor first = repository.Save(localId, CreateProfile(), true, null);
+        Guid otherId = Guid.NewGuid();
+        LocalProfileDescriptor other = repository.Save(otherId, CreateProfile(), false, null);
+        repository.SetActive(localId);
+
+        Assert.False(repository.Delete(localId, first.Revision));
+
+        Assert.Null(repository.GetActive());
+        Assert.Equal(otherId, Assert.Single(repository.List()).LocalId);
+        using LocalProfileSnapshot read = repository.Read(otherId);
+        Assert.Equal(other.Revision, read.Descriptor.Revision);
+    }
+
+    [Fact]
+    public void FutureHeadVersion_IsNotOverwrittenOrRemoved()
+    {
+        var repository = CreateRepository();
+        DeploymentProfileDocument profile = CreateProfile();
+        LocalProfileDescriptor descriptor = repository.Save(localId, profile, true, null);
+        JsonObject head = JsonNode.Parse(File.ReadAllText(HeadPath))!.AsObject();
+        head["version"] = 999;
+        File.WriteAllText(HeadPath, head.ToJsonString());
+        byte[] before = File.ReadAllBytes(HeadPath);
+
+        Assert.Throws<InvalidDataException>(() => repository.Save(localId, profile, true, descriptor.Revision));
+        Assert.Throws<InvalidDataException>(() => repository.Delete(localId, descriptor.Revision));
+        Assert.Equal(before, File.ReadAllBytes(HeadPath));
+    }
+
+    [Fact]
+    public void ModifiedEnrollment_FailsAuthenticationBeforeItCanBeSaved()
+    {
+        var repository = CreateRepository();
+        DeploymentProfileDocument profile = CreateProfile();
+        LocalProfileEnrollment enrollment = CreateEnrollment(profile.ProfileId);
+        LocalProfileDescriptor descriptor = repository.Save(localId, profile, true, null, enrollment, new byte[32]);
+        JsonObject head = JsonNode.Parse(File.ReadAllText(HeadPath))!.AsObject();
+        head["enrollment"]!["rootPath"] = "C:/other-share";
+        File.WriteAllText(HeadPath, head.ToJsonString());
+
+        Assert.ThrowsAny<CryptographicException>(() => repository.Read(localId));
+        Assert.ThrowsAny<CryptographicException>(() => repository.Save(localId, profile, true, descriptor.Revision, enrollment));
+        Assert.Equal(2, credentials.Values.Count);
+    }
+
+    [Fact]
+    public void MissingSharedKey_IsLockedWhileNativeReadFailureRemainsDistinct()
+    {
+        var repository = CreateRepository();
+        DeploymentProfileDocument profile = CreateProfile();
+        repository.Save(localId, profile, true, null, CreateEnrollment(profile.ProfileId), new byte[32]);
+        credentials.Delete(Assert.Single(credentials.Values.Keys, target => target.Contains("/Shared/", StringComparison.Ordinal)));
+
+        using LocalProfileSnapshot readable = repository.Read(localId);
+        Assert.Throws<LocalProfileLockedException>(() => repository.ReadSharedKey(localId));
+        credentials.FailRead = true;
+        Assert.Throws<Win32Exception>(() => repository.Read(localId));
+    }
+
+    [Fact]
+    public void FailedFirstSave_RecoversOrphanKeyBeforeLaterCreation()
+    {
+        var repository = CreateRepository();
+        DeploymentProfileDocument profile = CreateProfile();
+        credentials.ThrowAfterNextWrite = true;
+        credentials.FailDelete = true;
+
+        Assert.Throws<Win32Exception>(() => repository.Save(localId, profile, true, null));
+        Assert.Single(credentials.Values);
+        Assert.Throws<IOException>(() => repository.Save(localId, profile, true, null));
+        credentials.FailDelete = false;
+        Assert.Empty(CreateRepository().List());
+        Assert.Empty(credentials.Values);
+        LocalProfileDescriptor created = repository.Save(localId, profile, true, null);
+        using LocalProfileSnapshot read = repository.Read(localId);
+        Assert.Equal(created.Revision, read.Descriptor.Revision);
+    }
+
+    [Fact]
+    public void MismatchedRecoveryKeyReference_CannotRetireTheCommittedSharedKey()
+    {
+        var repository = CreateRepository();
+        DeploymentProfileDocument profile = CreateProfile();
+        LocalProfileEnrollment enrollment = CreateEnrollment(profile.ProfileId);
+        LocalProfileDescriptor original = repository.Save(localId, profile, true, null, enrollment, new byte[32]);
+        credentials.ThrowAfterNextWrite = true;
+        credentials.FailDelete = true;
+        Assert.Throws<Win32Exception>(() => repository.Save(localId, profile, true, original.Revision, enrollment));
+        string journalPath = Path.Combine(Path.GetDirectoryName(HeadPath)!, "journal.json");
+        JsonObject journal = JsonNode.Parse(File.ReadAllText(journalPath))!.AsObject();
+        journal["previousSharedKeyRevision"] = Guid.NewGuid().ToString();
+        File.WriteAllText(journalPath, journal.ToJsonString());
+        credentials.FailDelete = false;
+        int count = credentials.Values.Count;
+
+        Assert.Throws<InvalidDataException>(() => repository.List());
+        Assert.Equal(count, credentials.Values.Count);
+    }
+
+    private string HeadPath => Path.Combine(root, "profiles", localId.ToString("N"), "head.json");
+    private LocalDeploymentProfileRepository CreateRepository() => new(root, credentials, new DeploymentProfilePackageService());
+    private static DeploymentProfileDocument CreateProfile() => new()
+    {
+        ProfileId = Guid.NewGuid(),
+        DisplayName = "Synthetic profile",
+        Secrets = new() { Entries = [new() { Purpose = ProfileSecretPurpose.WifiPassphrase, Identity = "wifi", State = ProfileValueState.Present, Value = Encoding.UTF8.GetBytes("synthetic-secret-keep-exact") }] }
+    };
+    private static LocalProfileEnrollment CreateEnrollment(Guid profileId) => new()
+    {
+        RootPath = "C:/synthetic-share",
+        RepositoryId = Guid.NewGuid(),
+        ProfileId = profileId,
+        KeyEpoch = 1,
+        IsEnabled = true,
+        RememberSharedKey = true
+    };
+
+    public void Dispose()
+    {
+        credentials.Clear();
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private sealed class FakeCredentials : IWindowsCredentialStore
+    {
+        public Dictionary<string, byte[]> Values { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public bool ThrowAfterNextWrite { get; set; }
+        public bool FailDelete { get; set; }
+        public bool FailRead { get; set; }
+        public Action? AfterWrite { get; set; }
+        public WindowsCredential? Read(string target)
+        {
+            if (FailRead)
+            {
+                throw new Win32Exception(5);
+            }
+            return Values.TryGetValue(target, out byte[]? value) ? new(value.ToArray()) : null;
+        }
+        public void Write(string target, ReadOnlySpan<byte> secret, string? userName = null)
+        {
+            Values[target] = secret.ToArray();
+            AfterWrite?.Invoke();
+            if (ThrowAfterNextWrite)
+            {
+                ThrowAfterNextWrite = false;
+                throw new Win32Exception(5);
+            }
+        }
+        public void Delete(string target)
+        {
+            if (FailDelete)
+            {
+                throw new Win32Exception(5);
+            }
+            if (Values.Remove(target, out byte[]? value))
+            {
+                CryptographicOperations.ZeroMemory(value);
+            }
+        }
+        public void Clear()
+        {
+            foreach (byte[] value in Values.Values)
+            {
+                CryptographicOperations.ZeroMemory(value);
+            }
+            Values.Clear();
+        }
+    }
+}

--- a/src/Foundry.Core/Services/Profiles/LocalDeploymentProfileRepository.cs
+++ b/src/Foundry.Core/Services/Profiles/LocalDeploymentProfileRepository.cs
@@ -1,0 +1,495 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Foundry.Core.Models.Profiles;
+using Foundry.Utilities.Security;
+
+namespace Foundry.Core.Services.Profiles;
+
+/// <summary>Publishes encrypted local profile revisions beneath a caller-selected per-user directory.</summary>
+public sealed class LocalDeploymentProfileRepository
+{
+    private readonly string root;
+    private readonly string credentialScope;
+    private readonly IWindowsCredentialStore credentials;
+    private readonly IDeploymentProfilePackageService packages;
+
+    public LocalDeploymentProfileRepository(string rootDirectory, IWindowsCredentialStore credentials, IDeploymentProfilePackageService packages)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(rootDirectory);
+        this.credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
+        this.packages = packages ?? throw new ArgumentNullException(nameof(packages));
+        root = Path.TrimEndingDirectorySeparator(Path.GetFullPath(rootDirectory));
+        credentialScope = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(root.ToUpperInvariant())))[..24];
+    }
+
+    /// <summary>Lists committed metadata. Unsupported or malformed metadata fails closed instead of resetting a profile.</summary>
+    public IReadOnlyList<LocalProfileDescriptor> List()
+    {
+        using FileStream lease = AcquireLock();
+        var descriptors = new List<LocalProfileDescriptor>();
+        string directory = ManagedPath("profiles");
+        if (!Directory.Exists(directory))
+        {
+            return descriptors;
+        }
+        foreach (string path in Directory.GetDirectories(directory))
+        {
+            if (!Guid.TryParseExact(Path.GetFileName(path), "N", out Guid id) || id == Guid.Empty)
+            {
+                continue;
+            }
+            bool recovered = Recover(id);
+            LocalProfileDescriptor? descriptor = ReadHead(id);
+            if (descriptor is not null)
+            {
+                descriptors.Add(descriptor with { CleanupPending = !recovered });
+            }
+        }
+        return descriptors.OrderBy(profile => profile.DisplayName, StringComparer.OrdinalIgnoreCase).ThenBy(profile => profile.LocalId).ToArray();
+    }
+
+    /// <summary>Reads one fixed committed revision and transfers ownership of decrypted buffers to the caller.</summary>
+    public LocalProfileSnapshot Read(Guid localId)
+    {
+        ValidateId(localId);
+        using FileStream lease = AcquireLock();
+        bool recovered = Recover(localId);
+        return ReadSnapshot(RequireHead(localId) with { CleanupPending = !recovered });
+    }
+
+    /// <summary>Returns an owned remembered enrollment key. No remembered policy returns null; a missing requested key is locked.</summary>
+    public WindowsCredential? ReadSharedKey(Guid localId)
+    {
+        ValidateId(localId);
+        using FileStream lease = AcquireLock();
+        _ = Recover(localId);
+        LocalProfileDescriptor descriptor = RequireHead(localId);
+        using LocalProfileSnapshot snapshot = ReadSnapshot(descriptor);
+        return descriptor.Enrollment?.RememberSharedKey == true
+            ? ReadKey(localId, descriptor.SharedKeyRevision!.Value, shared: true)
+            : null;
+    }
+
+    /// <summary>Publishes a new revision only when the current revision matches. Null expected revision means create only.</summary>
+    public LocalProfileDescriptor Save(Guid localId, DeploymentProfileDocument profile, bool rememberSecrets, Guid? expectedRevision,
+        LocalProfileEnrollment? enrollment = null, byte[]? sharedKey = null)
+    {
+        ValidateId(localId);
+        ArgumentNullException.ThrowIfNull(profile);
+        ValidateEnrollment(enrollment, profile.ProfileId);
+        using FileStream lease = AcquireLock();
+        EnsureRecovered(localId);
+        LocalProfileDescriptor? previous = ReadHead(localId);
+        CheckRevision(previous, expectedRevision);
+        if (previous is not null)
+        {
+            using LocalProfileSnapshot snapshot = ReadSnapshot(previous);
+            if (previous.ProfileId != profile.ProfileId)
+            {
+                throw new ArgumentException("Create a new local identity for an independent profile copy.", nameof(profile));
+            }
+        }
+        return SaveRevision(localId, profile, rememberSecrets, previous, enrollment, sharedKey);
+    }
+
+    /// <summary>Commits settings without secret/asset bytes, disables automatic shared access, then retires earlier keys.</summary>
+    public LocalProfileDescriptor Forget(Guid localId, Guid expectedRevision)
+    {
+        ValidateId(localId);
+        using FileStream lease = AcquireLock();
+        EnsureRecovered(localId);
+        LocalProfileDescriptor previous = RequireHead(localId);
+        CheckRevision(previous, expectedRevision);
+        using LocalProfileSnapshot snapshot = ReadSnapshot(previous);
+        LocalProfileEnrollment? enrollment = previous.Enrollment is null ? null : previous.Enrollment with
+        {
+            RememberSharedKey = false,
+            IsEnabled = false
+        };
+        return SaveRevision(localId, snapshot.Profile, false, previous, enrollment, null);
+    }
+
+    /// <summary>Deletes a committed local profile. Returns true if committed deletion still has journaled cleanup pending.</summary>
+    public bool Delete(Guid localId, Guid expectedRevision)
+    {
+        ValidateId(localId);
+        using FileStream lease = AcquireLock();
+        EnsureRecovered(localId);
+        LocalProfileDescriptor previous = RequireHead(localId);
+        CheckRevision(previous, expectedRevision);
+        var journal = new LocalProfileJournal
+        {
+            LocalId = localId,
+            IsDelete = true,
+            PreviousRevision = previous.Revision,
+            PreviousSharedKeyRevision = previous.SharedKeyRevision
+        };
+        PublishJournal(journal);
+        if (ReadActive() == localId)
+        {
+            PublishActive(null);
+        }
+        File.Delete(HeadPath(localId));
+        return !Recover(localId);
+    }
+
+    /// <summary>Changes only the active local selection after verifying the selected revision is readable.</summary>
+    public void SetActive(Guid? localId)
+    {
+        if (localId is { } id)
+        {
+            ValidateId(id);
+        }
+        using FileStream lease = AcquireLock();
+        _ = ReadActive();
+        if (localId is { } selected)
+        {
+            _ = Recover(selected);
+            using LocalProfileSnapshot snapshot = ReadSnapshot(RequireHead(selected));
+        }
+        PublishActive(localId);
+    }
+
+    public Guid? GetActive()
+    {
+        using FileStream lease = AcquireLock();
+        Guid? id = ReadActive();
+        return id is { } localId && ReadHead(localId) is not null ? id : null;
+    }
+
+    private LocalProfileDescriptor SaveRevision(Guid localId, DeploymentProfileDocument profile, bool rememberSecrets,
+        LocalProfileDescriptor? previous, LocalProfileEnrollment? enrollment, byte[]? sharedKey)
+    {
+        Guid? sharedRevision = ResolveSharedKeyRevision(localId, previous, enrollment, sharedKey);
+        var descriptor = new LocalProfileDescriptor
+        {
+            LocalId = localId,
+            ProfileId = profile.ProfileId,
+            Revision = Guid.NewGuid(),
+            DisplayName = profile.DisplayName,
+            RememberSecrets = rememberSecrets,
+            Enrollment = enrollment,
+            SharedKeyRevision = sharedRevision
+        };
+        ValidateDescriptor(descriptor, localId);
+        byte[] key = RandomNumberGenerator.GetBytes(32);
+        try
+        {
+            DeploymentProfileDocument stored = rememberSecrets ? profile : OmitSecretBytes(profile);
+            byte[] ciphertext = packages.Encrypt(stored, key, ProfilePackagePurpose.LocalStorage, DescriptorContext(descriptor));
+            EnsureProfileDirectory(localId);
+            PublishJournal(new LocalProfileJournal
+            {
+                LocalId = localId,
+                PreviousRevision = previous?.Revision,
+                NextRevision = descriptor.Revision,
+                PreviousSharedKeyRevision = previous?.SharedKeyRevision,
+                NextSharedKeyRevision = sharedRevision
+            });
+            return PublishRevision(descriptor, key, sharedKey, ciphertext, previous);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(key);
+        }
+    }
+
+    private LocalProfileDescriptor PublishRevision(LocalProfileDescriptor descriptor, byte[] key, byte[]? sharedKey,
+        byte[] ciphertext, LocalProfileDescriptor? previous)
+    {
+        try
+        {
+            WriteVerifiedKey(descriptor.LocalId, descriptor.Revision, key, shared: false);
+            if (descriptor.SharedKeyRevision is { } sharedRevision && sharedRevision != previous?.SharedKeyRevision)
+            {
+                WriteVerifiedKey(descriptor.LocalId, sharedRevision, sharedKey!, shared: true);
+            }
+            LocalProfileStorage.WriteNew(RevisionPath(descriptor.LocalId, descriptor.Revision), ciphertext);
+            using (LocalProfileSnapshot verified = ReadSnapshot(descriptor))
+            {
+            }
+            LocalProfileStorage.PublishJson(HeadPath(descriptor.LocalId), descriptor);
+        }
+        catch
+        {
+            _ = TryRecover(descriptor.LocalId);
+            throw;
+        }
+        return descriptor with { CleanupPending = !Recover(descriptor.LocalId) };
+    }
+
+    private Guid? ResolveSharedKeyRevision(Guid localId, LocalProfileDescriptor? previous, LocalProfileEnrollment? enrollment, byte[]? sharedKey)
+    {
+        if (enrollment?.RememberSharedKey != true)
+        {
+            if (sharedKey is not null)
+            {
+                throw new ArgumentException("Remembering the shared key requires explicit enrollment policy.", nameof(sharedKey));
+            }
+            return null;
+        }
+        if (sharedKey is not null)
+        {
+            if (sharedKey.Length != 32)
+            {
+                throw new ArgumentException("The shared profile key must contain 32 bytes.", nameof(sharedKey));
+            }
+            return Guid.NewGuid();
+        }
+        if (previous?.SharedKeyRevision is not { } revision || previous.Enrollment is not { } old
+            || old.RepositoryId != enrollment.RepositoryId || old.ProfileId != enrollment.ProfileId || old.KeyEpoch != enrollment.KeyEpoch)
+        {
+            throw new ArgumentException("A new shared enrollment requires its matching key.", nameof(sharedKey));
+        }
+        using WindowsCredential key = ReadKey(localId, revision, shared: true);
+        return revision;
+    }
+
+    private LocalProfileSnapshot ReadSnapshot(LocalProfileDescriptor descriptor)
+    {
+        using WindowsCredential key = ReadKey(descriptor.LocalId, descriptor.Revision, shared: false);
+        byte[] ciphertext = LocalProfileStorage.ReadBytes(RevisionPath(descriptor.LocalId, descriptor.Revision), 17 * 1024 * 1024);
+        DeploymentProfileDocument profile = packages.Decrypt(ciphertext, key.Secret, ProfilePackagePurpose.LocalStorage, DescriptorContext(descriptor));
+        var snapshot = new LocalProfileSnapshot(descriptor, profile);
+        if (profile.ProfileId != descriptor.ProfileId || !string.Equals(profile.DisplayName, descriptor.DisplayName, StringComparison.Ordinal))
+        {
+            snapshot.Dispose();
+            throw new InvalidDataException("The local profile identity does not match its committed metadata.");
+        }
+        return snapshot;
+    }
+
+    private WindowsCredential ReadKey(Guid localId, Guid revision, bool shared)
+    {
+        WindowsCredential key = credentials.Read(CredentialTarget(localId, revision, shared)) ?? throw new LocalProfileLockedException(localId);
+        if (key.Secret.Length != 32)
+        {
+            key.Dispose();
+            throw new InvalidDataException("The stored local profile key is invalid.");
+        }
+        return key;
+    }
+
+    private void WriteVerifiedKey(Guid localId, Guid revision, byte[] key, bool shared)
+    {
+        credentials.Write(CredentialTarget(localId, revision, shared), key);
+        using WindowsCredential readback = ReadKey(localId, revision, shared);
+        if (!CryptographicOperations.FixedTimeEquals(key, readback.Secret))
+        {
+            throw new IOException("The stored local profile key could not be verified.");
+        }
+    }
+
+    private bool Recover(Guid localId)
+    {
+        string path = JournalPath(localId);
+        if (!File.Exists(path))
+        {
+            return true;
+        }
+        LocalProfileJournal journal = LocalProfileStorage.ReadJson<LocalProfileJournal>(path);
+        ValidateJournal(journal, localId);
+        LocalProfileDescriptor? head = ReadHead(localId);
+        if (journal.IsDelete)
+        {
+            if (head is not null && head.Revision != journal.PreviousRevision)
+            {
+                throw new InvalidDataException("The local deletion journal does not match the committed revision.");
+            }
+        }
+        else if (head?.Revision != journal.PreviousRevision && head?.Revision != journal.NextRevision)
+        {
+            throw new InvalidDataException("The local save journal does not match the committed revision.");
+        }
+        bool committed = journal.IsDelete ? head is null : head?.Revision == journal.NextRevision;
+        Guid? keepShared = committed ? journal.NextSharedKeyRevision : journal.PreviousSharedKeyRevision;
+        if (head?.SharedKeyRevision != keepShared)
+        {
+            throw new InvalidDataException("The local operation journal does not match the committed enrollment key.");
+        }
+        try
+        {
+            RetireRevision(localId, committed ? journal.PreviousRevision : journal.NextRevision);
+            Guid? retireShared = committed ? journal.PreviousSharedKeyRevision : journal.NextSharedKeyRevision;
+            if (retireShared is { } shared && retireShared != keepShared)
+            {
+                credentials.Delete(CredentialTarget(localId, shared, shared: true));
+            }
+            File.Delete(path);
+            return true;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or Win32Exception)
+        {
+            return false;
+        }
+    }
+
+    private bool TryRecover(Guid localId)
+    {
+        try
+        {
+            return Recover(localId);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or Win32Exception)
+        {
+            return false;
+        }
+    }
+
+    private void EnsureRecovered(Guid localId)
+    {
+        if (!Recover(localId))
+        {
+            throw new IOException("A previous local profile operation still requires cleanup. Retry when its storage is available.");
+        }
+    }
+
+    private void RetireRevision(Guid localId, Guid? revision)
+    {
+        if (revision is not { } id)
+        {
+            return;
+        }
+        credentials.Delete(CredentialTarget(localId, id, shared: false));
+        File.Delete(RevisionPath(localId, id));
+    }
+
+    private LocalProfileDescriptor? ReadHead(Guid localId)
+    {
+        string path = HeadPath(localId);
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+        LocalProfileDescriptor descriptor = LocalProfileStorage.ReadJson<LocalProfileDescriptor>(path);
+        ValidateDescriptor(descriptor, localId);
+        return descriptor;
+    }
+
+    private LocalProfileDescriptor RequireHead(Guid localId) => ReadHead(localId) ?? throw new FileNotFoundException("The local profile does not exist.");
+
+    private Guid? ReadActive()
+    {
+        string path = ManagedPath("active.json");
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+        LocalProfileActivePointer pointer = LocalProfileStorage.ReadJson<LocalProfileActivePointer>(path);
+        if (pointer.LocalId == Guid.Empty)
+        {
+            throw new InvalidDataException("The active local profile identity is invalid.");
+        }
+        return pointer.LocalId;
+    }
+
+    private void PublishActive(Guid? localId) => LocalProfileStorage.PublishJson(ManagedPath("active.json"), new LocalProfileActivePointer { LocalId = localId });
+    private void PublishJournal(LocalProfileJournal journal) => LocalProfileStorage.PublishJson(JournalPath(journal.LocalId), journal);
+    private static byte[] DescriptorContext(LocalProfileDescriptor descriptor) => JsonSerializer.SerializeToUtf8Bytes(descriptor, LocalProfileStorage.JsonOptions);
+
+    private FileStream AcquireLock()
+    {
+        _ = ManagedPath();
+        Directory.CreateDirectory(root);
+        return new FileStream(ManagedPath(".repository.lock"), FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+    }
+
+    private void EnsureProfileDirectory(Guid localId)
+    {
+        Directory.CreateDirectory(ManagedPath("profiles", localId.ToString("N"), "revisions"));
+    }
+
+    private string HeadPath(Guid localId) => ManagedPath("profiles", localId.ToString("N"), "head.json");
+    private string JournalPath(Guid localId) => ManagedPath("profiles", localId.ToString("N"), "journal.json");
+    private string RevisionPath(Guid localId, Guid revision) => ManagedPath("profiles", localId.ToString("N"), "revisions", revision.ToString("N") + ".profile");
+    private string CredentialTarget(Guid localId, Guid revision, bool shared) => $"FoundryOSD/Profiles/{credentialScope}/{localId:N}/{(shared ? "Shared" : "Revision")}/{revision:N}";
+
+    private string ManagedPath(params string[] segments)
+    {
+        string path = Path.GetFullPath(Path.Combine([root, .. segments]));
+        string prefix = root + Path.DirectorySeparatorChar;
+        if (!string.Equals(path, root, StringComparison.OrdinalIgnoreCase) && !path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException("The local profile path is outside its managed directory.");
+        }
+        for (string? current = path; current is not null; current = Path.GetDirectoryName(current))
+        {
+            if ((File.Exists(current) || Directory.Exists(current)) && (File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
+            {
+                throw new IOException("Local profile storage cannot use redirected files or directories.");
+            }
+            if (string.Equals(current, root, StringComparison.OrdinalIgnoreCase))
+            {
+                break;
+            }
+        }
+        return path;
+    }
+
+    private static void ValidateDescriptor(LocalProfileDescriptor descriptor, Guid localId)
+    {
+        if (descriptor.Version != 1 || descriptor.LocalId != localId || descriptor.LocalId == Guid.Empty || descriptor.ProfileId == Guid.Empty
+            || descriptor.Revision == Guid.Empty || string.IsNullOrWhiteSpace(descriptor.DisplayName) || descriptor.DisplayName.Length > 128
+            || descriptor.DisplayName.Any(char.IsControl) || descriptor.SharedKeyRevision == Guid.Empty
+            || (descriptor.Enrollment?.RememberSharedKey == true) != descriptor.SharedKeyRevision.HasValue)
+        {
+            throw new InvalidDataException("The committed local profile metadata is invalid.");
+        }
+        ValidateEnrollment(descriptor.Enrollment, descriptor.ProfileId);
+    }
+
+    private static void ValidateEnrollment(LocalProfileEnrollment? enrollment, Guid profileId)
+    {
+        if (enrollment is not null && (string.IsNullOrWhiteSpace(enrollment.RootPath) || enrollment.RootPath.Length > 4096
+            || enrollment.RootPath.Any(char.IsControl) || enrollment.RepositoryId == Guid.Empty || enrollment.ProfileId != profileId
+            || enrollment.KeyEpoch <= 0 || enrollment.KnownRevisionId == Guid.Empty || enrollment.PendingOperationId == Guid.Empty))
+        {
+            throw new InvalidDataException("The local profile enrollment is invalid.");
+        }
+    }
+
+    private static void ValidateJournal(LocalProfileJournal journal, Guid localId)
+    {
+        if (journal.LocalId != localId || journal.LocalId == Guid.Empty || journal.PreviousRevision == Guid.Empty
+            || journal.NextRevision == Guid.Empty || journal.PreviousSharedKeyRevision == Guid.Empty || journal.NextSharedKeyRevision == Guid.Empty
+            || (journal.PreviousRevision is null && journal.PreviousSharedKeyRevision is not null)
+            || (journal.IsDelete ? journal.PreviousRevision is null || journal.NextRevision is not null || journal.NextSharedKeyRevision is not null
+                : journal.NextRevision is null || journal.NextRevision == journal.PreviousRevision))
+        {
+            throw new InvalidDataException("The local profile operation journal is invalid.");
+        }
+    }
+
+    private static void ValidateId(Guid id)
+    {
+        if (id == Guid.Empty)
+        {
+            throw new ArgumentException("A nonempty local profile identity is required.", nameof(id));
+        }
+    }
+
+    private static void CheckRevision(LocalProfileDescriptor? current, Guid? expected)
+    {
+        if (current?.Revision != expected)
+        {
+            throw new LocalProfileConflictException(current?.Revision);
+        }
+    }
+
+    private static DeploymentProfileDocument OmitSecretBytes(DeploymentProfileDocument profile) => profile with
+    {
+        Secrets = new()
+        {
+            Entries = profile.Secrets.Entries.Select(secret => secret.State == ProfileValueState.Present
+                ? secret with { State = ProfileValueState.Omitted, Value = null } : secret).ToArray()
+        },
+        Assets = profile.Assets.Select(asset => asset.State == ProfileValueState.Present
+            ? asset with { State = ProfileValueState.Omitted, Content = null } : asset).ToArray()
+    };
+}

--- a/src/Foundry.Core/Services/Profiles/LocalProfileDescriptor.cs
+++ b/src/Foundry.Core/Services/Profiles/LocalProfileDescriptor.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using System.Text.Json.Serialization;
+using Foundry.Core.Models.Profiles;
+
+namespace Foundry.Core.Services.Profiles;
+
+/// <summary>Identifies one committed local revision; the local identity is independent from its shared profile identity.</summary>
+public sealed record LocalProfileDescriptor
+{
+    public int Version { get; init; } = 1;
+    public Guid LocalId { get; init; }
+    public Guid ProfileId { get; init; }
+    public Guid Revision { get; init; }
+    public string DisplayName { get; init; } = string.Empty;
+    public bool RememberSecrets { get; init; }
+    public LocalProfileEnrollment? Enrollment { get; init; }
+    /// <summary>Repository-controlled local credential identity, never a native target supplied by a profile package.</summary>
+    public Guid? SharedKeyRevision { get; init; }
+    /// <summary>The committed revision is usable, but an earlier key or file still requires cleanup.</summary>
+    [JsonIgnore]
+    public bool CleanupPending { get; init; }
+}
+
+/// <summary>Local synchronization enrollment. Keys and encrypted outbox bodies are managed separately.</summary>
+public sealed record LocalProfileEnrollment
+{
+    public string RootPath { get; init; } = string.Empty;
+    public Guid RepositoryId { get; init; }
+    public Guid ProfileId { get; init; }
+    public int KeyEpoch { get; init; }
+    public Guid? KnownRevisionId { get; init; }
+    public Guid? PendingOperationId { get; init; }
+    public bool IsDirty { get; init; }
+    public bool IsEnabled { get; init; }
+    public bool RememberSharedKey { get; init; }
+    public bool IncludeSecrets { get; init; }
+}
+
+/// <summary>Owns decrypted profile secret and asset buffers for one committed revision.</summary>
+public sealed record LocalProfileSnapshot(LocalProfileDescriptor Descriptor, DeploymentProfileDocument Profile) : IDisposable
+{
+    public void Dispose()
+    {
+        foreach (DeploymentProfileSecret secret in Profile.Secrets.Entries)
+        {
+            if (secret.Value is { } value)
+            {
+                CryptographicOperations.ZeroMemory(value);
+            }
+        }
+        foreach (DeploymentProfileAsset asset in Profile.Assets)
+        {
+            if (asset.Content is { } content)
+            {
+                CryptographicOperations.ZeroMemory(content);
+            }
+        }
+    }
+}
+
+/// <summary>A committed profile or enrollment key is unavailable for the current Windows identity.</summary>
+public sealed class LocalProfileLockedException(Guid localId) : IOException("The local profile key is unavailable for this Windows user.")
+{
+    public Guid LocalId { get; } = localId;
+}
+
+/// <summary>A local writer attempted to replace a revision that has changed since it was read.</summary>
+public sealed class LocalProfileConflictException(Guid? currentRevision) : IOException("The local profile changed. Reload it before saving.")
+{
+    public Guid? CurrentRevision { get; } = currentRevision;
+}

--- a/src/Foundry.Core/Services/Profiles/LocalProfileStorage.cs
+++ b/src/Foundry.Core/Services/Profiles/LocalProfileStorage.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Foundry.Core.Services.Profiles;
+
+/// <summary>Bounded metadata and durable file publication for a dedicated local profile directory.</summary>
+internal static class LocalProfileStorage
+{
+    internal static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+        MaxDepth = 16
+    };
+
+    internal static T ReadJson<T>(string path)
+    {
+        byte[] bytes = ReadBytes(path, 64 * 1024);
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(bytes, new() { MaxDepth = 16 });
+            ValidateProperties(document.RootElement);
+            if (document.RootElement.GetProperty("version").GetInt32() != 1)
+            {
+                throw new InvalidDataException("The local profile metadata version is unsupported.");
+            }
+            return JsonSerializer.Deserialize<T>(bytes, JsonOptions)
+                ?? throw new InvalidDataException("The local profile metadata is missing.");
+        }
+        catch (Exception exception) when (exception is JsonException or InvalidOperationException or KeyNotFoundException or FormatException)
+        {
+            throw new InvalidDataException("The local profile metadata is invalid.", exception);
+        }
+    }
+
+    internal static byte[] ReadBytes(string path, int maximumLength)
+    {
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        if (stream.Length is <= 0 || stream.Length > maximumLength)
+        {
+            throw new InvalidDataException("The local profile file size is invalid.");
+        }
+        byte[] bytes = new byte[(int)stream.Length];
+        stream.ReadExactly(bytes);
+        return bytes;
+    }
+
+    internal static void WriteNew(string path, ReadOnlySpan<byte> bytes)
+    {
+        using var stream = new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+        stream.Write(bytes);
+        stream.Flush(flushToDisk: true);
+    }
+
+    internal static void PublishJson<T>(string path, T value)
+    {
+        byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(value, JsonOptions);
+        string temporary = path + ".pending";
+        try
+        {
+            File.Delete(temporary);
+            using (var stream = new FileStream(temporary, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            {
+                stream.Write(bytes);
+                stream.Flush(flushToDisk: true);
+            }
+            File.Move(temporary, path, overwrite: true);
+        }
+        finally
+        {
+            File.Delete(temporary);
+        }
+    }
+
+    private static void ValidateProperties(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (JsonProperty property in element.EnumerateObject())
+            {
+                if (!names.Add(property.Name))
+                {
+                    throw new InvalidDataException("Duplicate local profile metadata properties are not allowed.");
+                }
+                ValidateProperties(property.Value);
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement item in element.EnumerateArray())
+            {
+                ValidateProperties(item);
+            }
+        }
+    }
+}
+
+/// <summary>Contains only local operation identities needed to retire a committed revision or roll back an unpublished candidate.</summary>
+internal sealed record LocalProfileJournal
+{
+    public int Version { get; init; } = 1;
+    public Guid LocalId { get; init; }
+    public bool IsDelete { get; init; }
+    public Guid? PreviousRevision { get; init; }
+    public Guid? NextRevision { get; init; }
+    public Guid? PreviousSharedKeyRevision { get; init; }
+    public Guid? NextSharedKeyRevision { get; init; }
+}
+
+internal sealed record LocalProfileActivePointer
+{
+    public int Version { get; init; } = 1;
+    public Guid? LocalId { get; init; }
+}


### PR DESCRIPTION
## Summary

Adds local deployment-profile persistence for #339 and parent #345. Profile revisions are encrypted using versioned Windows Credential Manager keys for the current Windows account.

## Main changes

- Verify new credential keys and encrypted revisions before atomically publishing the local pointer.
- Recover interrupted operations through journals containing only local identifiers; report committed cleanup failures without losing the usable revision.
- Reject stale local writers, missing credentials, altered enrollment metadata, and unsupported formats.
- Explicitly remember or forget secret and asset bytes, with independent shared-key policy. Forget disables automatic shared access.

## Testing

- Core executable suite: 768 passed, including 15 local-persistence regressions.
- Credential write failures, denied head replacement, cleanup retries, missing keys, enrollment tampering, and stale revisions covered.
- `scripts/Test-FoundryFormat.ps1` and `git diff --check`: passed.
- Required x64 and ARM64 CI must pass before squash merging into the integration branch.

Part of foundry-osd/foundry#339. Parent #345 remains open for maintainer merge.
