### PR TITLE
feat(profiles): integrate settings workflows and immutable media snapshots

### DIFF
--- a/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/ConfigurationSchemaVersionsTests.cs
@@ -19,7 +19,7 @@ public sealed class ConfigurationSchemaVersionsTests
     [Fact]
     public void CurrentSchemaVersions_MatchNextPublishedContractVersions()
     {
-        Assert.Equal(14, ConfigurationSchemaVersions.FoundryCurrent);
+        Assert.Equal(15, ConfigurationSchemaVersions.FoundryCurrent);
         Assert.Equal(12, ConfigurationSchemaVersions.DeployCurrent);
         Assert.Equal(4, ConfigurationSchemaVersions.ConnectCurrent);
     }

--- a/src/Foundry.Core.Tests/Configuration/FoundryConfigurationServiceTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/FoundryConfigurationServiceTests.cs
@@ -271,7 +271,7 @@ public sealed class FoundryConfigurationServiceTests
         Assert.Equal(MachineNameSeparator.None, naming.Separator);
         Assert.Equal(MachineNameCasing.Preserve, naming.Casing);
         Assert.False(naming.AllowEditingDuringDeployment);
-        Assert.Equal(14, loaded.SchemaVersion);
+        Assert.Equal(15, loaded.SchemaVersion);
 
         string serialized = service.Serialize(loaded);
         Assert.DoesNotContain("prefix", serialized, StringComparison.OrdinalIgnoreCase);

--- a/src/Foundry.Core.Tests/Configuration/NetworkSecretStateTests.cs
+++ b/src/Foundry.Core.Tests/Configuration/NetworkSecretStateTests.cs
@@ -15,6 +15,16 @@ public sealed class NetworkSecretStateTests
         NetworkSecretState state = new();
 
         state.Update(CreatePersonalWifiSettings("ValidPassphrase123"));
+        state.Update(CreatePersonalWifiSettings(null));
+
+        Assert.Equal("ValidPassphrase123", state.PersonalWifiPassphrase);
+    }
+
+    [Fact]
+    public void Update_WhenSsidChanges_DoesNotReuseAnotherNetworksPassword()
+    {
+        NetworkSecretState state = new();
+        state.Update(CreatePersonalWifiSettings("ValidPassphrase123"));
         state.Update(CreatePersonalWifiSettings(null) with
         {
             Wifi = CreatePersonalWifiSettings(null).Wifi with
@@ -23,7 +33,25 @@ public sealed class NetworkSecretStateTests
             }
         });
 
-        Assert.Equal("ValidPassphrase123", state.PersonalWifiPassphrase);
+        Assert.Null(state.PersonalWifiPassphrase);
+    }
+
+    [Fact]
+    public void CertificatePassword_PreservesBlankButClearsWhenCertificateChanges()
+    {
+        NetworkSecretState state = new();
+        NetworkSettings settings = new()
+        {
+            Dot1x = new Dot1xSettings { IsEnabled = true, RequiresCertificate = true, CertificatePath = "first.pfx", CertificatePfxPassword = string.Empty }
+        };
+        state.Update(settings);
+        settings = NetworkConfigurationValidator.SanitizeForPersistence(settings);
+        state.Update(settings);
+        Assert.Equal(string.Empty, state.ApplyRequiredSecrets(settings).Dot1x.CertificatePfxPassword);
+
+        settings = settings with { Dot1x = settings.Dot1x with { CertificatePath = "second.pfx" } };
+        state.Update(settings);
+        Assert.Null(state.ApplyRequiredSecrets(settings).Dot1x.CertificatePfxPassword);
     }
 
     [Fact]

--- a/src/Foundry.Core.Tests/Networking/MutableApplicationProxyAuthenticationTests.cs
+++ b/src/Foundry.Core.Tests/Networking/MutableApplicationProxyAuthenticationTests.cs
@@ -107,7 +107,6 @@ public sealed class MutableApplicationProxyAuthenticationTests
         public async ValueTask DisposeAsync()
         {
             await shutdown.CancelAsync();
-            listener.Stop();
             try
             {
                 await serverTask;
@@ -117,6 +116,7 @@ public sealed class MutableApplicationProxyAuthenticationTests
             }
             finally
             {
+                listener.Stop();
                 shutdown.Dispose();
             }
         }

--- a/src/Foundry.Core.Tests/Profiles/DeploymentBuildSnapshotTests.cs
+++ b/src/Foundry.Core.Tests/Profiles/DeploymentBuildSnapshotTests.cs
@@ -1,0 +1,206 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Models.Configuration.Deploy;
+using Foundry.Core.Services.Autopilot;
+using Foundry.Core.Services.Configuration;
+using Foundry.Core.Services.Profiles;
+
+namespace Foundry.Core.Tests.Profiles;
+
+public sealed class DeploymentBuildSnapshotTests : IDisposable
+{
+    private readonly string root = Path.Combine(Path.GetTempPath(), "FoundrySnapshotTests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task CaptureAsync_FreezesMutableCollectionsBeforeReturningTask()
+    {
+        var packages = new List<string> { "Original.Package" };
+        var document = new FoundryConfigurationDocument { Customization = new() { AppxRemoval = new() { IsEnabled = true, PackageNames = packages } } };
+        using var secrets = new OobeAccountSecretState();
+        Task<DeploymentBuildSnapshot> capture = DeploymentBuildSnapshot.CaptureAsync(document, secrets, [], root, TestContext.Current.CancellationToken);
+        packages[0] = "Changed.Package";
+        using DeploymentBuildSnapshot snapshot = await capture;
+        Assert.Equal("Original.Package", Assert.Single(snapshot.Configuration.Customization.AppxRemoval.PackageNames));
+        IList<string> exposed = (IList<string>)snapshot.Configuration.Customization.AppxRemoval.PackageNames;
+        exposed[0] = "External.Change";
+        Assert.Equal("Original.Package", Assert.Single(snapshot.Configuration.Customization.AppxRemoval.PackageNames));
+    }
+
+    [Fact]
+    public async Task CaptureAsync_FreezesSecretsAcrossSourceChanges()
+    {
+        using var secrets = new OobeAccountSecretState();
+        secrets.SetAdministratorPassword("AdminPassword123!");
+        secrets.SetAdministratorConfirmation("AdminPassword123!");
+        char[] mediaPassword = "MediaPassword123!".ToCharArray();
+        var document = new FoundryConfigurationDocument
+        {
+            General = new() { DeploymentProtection = new() { IsEnabled = true } },
+            Network = new() { WifiProvisioned = true, Wifi = new() { IsEnabled = true, Ssid = "Office", SecurityType = "WPA2/WPA3-Personal", Passphrase = "OriginalWifiPassword" } },
+            Customization = new() { Oobe = new() { IsEnabled = true, EnableAdministratorAccount = true, UseAdministratorPassword = true } }
+        };
+        Task<DeploymentBuildSnapshot> capture = DeploymentBuildSnapshot.CaptureAsync(document, secrets, mediaPassword, root, TestContext.Current.CancellationToken);
+        secrets.Clear();
+        Array.Clear(mediaPassword);
+        using DeploymentBuildSnapshot snapshot = await capture;
+        using var protection = snapshot.CreateDeploymentProtectionMaterial();
+        FoundryConnectProvisioningBundle connect = snapshot.CreateConnectProvisioningBundle(Path.Combine(root, "connect"));
+        try
+        {
+            Assert.Equal("OriginalWifiPassword", MediaSecretEnvelopeProtector.DecryptString(connect.Configuration.Wifi.PassphraseSecret!, connect.MediaSecretsKey!));
+            string json = snapshot.GenerateDeployConfigurationJson(deploymentSecretsKey: protection.DeploymentKey, protectionSettings: protection.Settings);
+            FoundryDeployConfigurationDocument deploy = JsonSerializer.Deserialize<FoundryDeployConfigurationDocument>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+            Assert.Equal("AdminPassword123!", MediaSecretEnvelopeProtector.DecryptString(deploy.Customization.Oobe.AdministratorPasswordSecret!, protection.DeploymentKey, MediaSecretEnvelopeProtector.DeploymentKeyId));
+            Assert.Null(snapshot.Configuration.Network.Wifi.Passphrase);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(connect.MediaSecretsKey!);
+        }
+    }
+
+    [Fact]
+    public async Task CaptureAsync_PinsUnattendAndDriverBytesThenRemovesPrivateFiles()
+    {
+        Directory.CreateDirectory(root);
+        string answer = Path.Combine(root, "answer.xml");
+        byte[] content = Encoding.UTF8.GetBytes("<?xml version=\"1.0\"?>\r\n<unattend />\r\n");
+        File.WriteAllBytes(answer, content);
+        string drivers = Path.Combine(root, "drivers");
+        Directory.CreateDirectory(drivers);
+        File.WriteAllText(Path.Combine(drivers, "original.inf"), "driver-before");
+        var document = new FoundryConfigurationDocument
+        {
+            General = new() { CustomDriverDirectoryPath = drivers },
+            Unattend = new() { IsEnabled = true, Files = [new() { Id = Guid.NewGuid().ToString("N"), DisplayName = "Answer", SourcePath = answer, ContentHash = Convert.ToHexString(SHA256.HashData(content)) }] }
+        };
+        using var secrets = new OobeAccountSecretState();
+        DeploymentBuildSnapshot snapshot = await DeploymentBuildSnapshot.CaptureAsync(document, secrets, [], root, TestContext.Current.CancellationToken);
+        string capturedAnswer = Assert.Single(snapshot.Configuration.Unattend.Files).SourcePath;
+        string capturedDrivers = snapshot.Configuration.General.CustomDriverDirectoryPath!;
+        File.WriteAllText(answer, "changed");
+        File.WriteAllText(Path.Combine(drivers, "original.inf"), "driver-after");
+        Assert.Equal(content, File.ReadAllBytes(capturedAnswer));
+        Assert.Equal("driver-before", File.ReadAllText(Path.Combine(capturedDrivers, "original.inf")));
+        snapshot.Dispose();
+        Assert.False(File.Exists(capturedAnswer));
+        Assert.False(Directory.Exists(capturedDrivers));
+        Assert.Throws<ObjectDisposedException>(() => snapshot.CreateDeploymentProtectionMaterial());
+    }
+
+    [Fact]
+    public async Task CaptureAsync_IgnoresDisabledStaleDependenciesAndPreservesTelemetry()
+    {
+        using var secrets = new OobeAccountSecretState();
+        var document = new FoundryConfigurationDocument
+        {
+            Network = new() { Dot1x = new() { IsEnabled = false, ProfileTemplatePath = "Z:/missing.xml" } },
+            Telemetry = new() { IsEnabled = true, InstallId = "captured-install" },
+            General = new() { IsoOutputPath = "C:/local-output.iso" }
+        };
+        using DeploymentBuildSnapshot snapshot = await DeploymentBuildSnapshot.CaptureAsync(document, secrets, [], root, TestContext.Current.CancellationToken);
+        Assert.Equal("captured-install", snapshot.Configuration.Telemetry.InstallId);
+        Assert.True(snapshot.Configuration.Telemetry.IsEnabled);
+        Assert.Equal("C:/local-output.iso", snapshot.Configuration.General.IsoOutputPath);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_RejectsChangedUnattendAndCleansFailedCapture()
+    {
+        Directory.CreateDirectory(root);
+        string path = Path.Combine(root, "answer.xml");
+        File.WriteAllText(path, "changed");
+        using var secrets = new OobeAccountSecretState();
+        var document = new FoundryConfigurationDocument { Unattend = new() { IsEnabled = true, Files = [new() { Id = Guid.NewGuid().ToString("N"), SourcePath = path, ContentHash = new string('0', 64) }] } };
+        await Assert.ThrowsAsync<InvalidDataException>(() => DeploymentBuildSnapshot.CaptureAsync(document, secrets, [], root, TestContext.Current.CancellationToken));
+        Assert.Empty(Directory.EnumerateDirectories(root));
+    }
+
+    [Fact]
+    public async Task CaptureAsync_CancellationCleansPreparedState()
+    {
+        using var secrets = new OobeAccountSecretState();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => DeploymentBuildSnapshot.CaptureAsync(new(), secrets, [], root, new CancellationToken(true)));
+        Assert.False(Directory.Exists(root) && Directory.EnumerateDirectories(root).Any());
+    }
+
+    [Fact]
+    public async Task CaptureAsync_PreservesAutopilotSessionMetadataPasswordAndExactPfxBytes()
+    {
+        Directory.CreateDirectory(root);
+        string source = Path.Combine(root, "certificate.pfx");
+        byte[] original = [1, 2, 3, 4, 5];
+        File.WriteAllBytes(source, original);
+        var expiry = new DateTimeOffset(2040, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        using var secrets = new OobeAccountSecretState();
+        var document = new FoundryConfigurationDocument
+        {
+            Autopilot = new()
+            {
+                IsEnabled = true,
+                ProvisioningMode = AutopilotProvisioningMode.HardwareHashUpload,
+                HardwareHashUpload = new()
+                {
+                    Tenant = new() { TenantId = "tenant", ApplicationObjectId = "application", ClientId = "client", ServicePrincipalObjectId = "principal" },
+                    ActiveCertificate = new() { KeyId = "key", Thumbprint = "ABCDEF", ExpiresOnUtc = expiry },
+                    BootMediaCertificate = new() { PfxPath = source, PfxPassword = "OriginalCertificatePassword", ValidatedThumbprint = "ABCDEF", ValidatedExpiresOnUtc = expiry }
+                }
+            }
+        };
+        using DeploymentBuildSnapshot snapshot = await DeploymentBuildSnapshot.CaptureAsync(document, secrets, [], root, TestContext.Current.CancellationToken);
+        File.WriteAllBytes(source, [9, 9, 9]);
+        using var protection = snapshot.CreateDeploymentProtectionMaterial();
+        string json = snapshot.GenerateDeployConfigurationJson(deploymentSecretsKey: protection.DeploymentKey, protectionSettings: protection.Settings);
+        FoundryDeployConfigurationDocument deploy = JsonSerializer.Deserialize<FoundryDeployConfigurationDocument>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+        Assert.Equal(original, MediaSecretEnvelopeProtector.DecryptBytes(deploy.Autopilot.HardwareHashUpload.CertificatePfxSecret!, protection.DeploymentKey, MediaSecretEnvelopeProtector.DeploymentKeyId));
+        Assert.Equal("OriginalCertificatePassword", MediaSecretEnvelopeProtector.DecryptString(deploy.Autopilot.HardwareHashUpload.CertificatePfxPasswordSecret!, protection.DeploymentKey, MediaSecretEnvelopeProtector.DeploymentKeyId));
+        Assert.Null(snapshot.Configuration.Autopilot.HardwareHashUpload.BootMediaCertificate.PfxPassword);
+        Assert.Equal("ABCDEF", snapshot.Configuration.Autopilot.HardwareHashUpload.BootMediaCertificate.ValidatedThumbprint);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_PreservesAdditionalAccountPasswordAndIntentionalBlank()
+    {
+        using var secrets = new OobeAccountSecretState();
+        secrets.SetAdditionalAccountPassword("account", "AccountPassword123!");
+        secrets.SetAdditionalAccountConfirmation("account", "AccountPassword123!");
+        var document = new FoundryConfigurationDocument
+        {
+            General = new() { DeploymentProtection = new() { IsEnabled = true } },
+            Customization = new() { Oobe = new() { IsEnabled = true, AdditionalAccounts = [new() { Id = "account", UserName = "Technician", UsePassword = true }, new() { Id = "blank", UserName = "BlankAccount", UsePassword = false }] } }
+        };
+        Task<DeploymentBuildSnapshot> capture = DeploymentBuildSnapshot.CaptureAsync(document, secrets, "MediaPassword123!", root, TestContext.Current.CancellationToken);
+        secrets.Clear();
+        using DeploymentBuildSnapshot snapshot = await capture;
+        using var protection = snapshot.CreateDeploymentProtectionMaterial();
+        string json = snapshot.GenerateDeployConfigurationJson(deploymentSecretsKey: protection.DeploymentKey, protectionSettings: protection.Settings);
+        FoundryDeployConfigurationDocument deploy = JsonSerializer.Deserialize<FoundryDeployConfigurationDocument>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+        Assert.Equal("AccountPassword123!", MediaSecretEnvelopeProtector.DecryptString(deploy.Customization.Oobe.AdditionalAccounts[0].PasswordSecret!, protection.DeploymentKey, MediaSecretEnvelopeProtector.DeploymentKeyId));
+        Assert.True(deploy.Customization.Oobe.AdditionalAccounts[1].PasswordIsBlank);
+        Assert.Null(deploy.Customization.Oobe.AdditionalAccounts[1].PasswordSecret);
+    }
+    [Fact]
+    public async Task CaptureAsync_RejectsUnavailableActiveDependencies()
+    {
+        using var secrets = new OobeAccountSecretState();
+        var document = new FoundryConfigurationDocument
+        {
+            Network = new() { Dot1x = new() { IsEnabled = true, ProfileTemplatePath = Path.Combine(root, "missing.xml") } }
+        };
+        await Assert.ThrowsAnyAsync<IOException>(() => DeploymentBuildSnapshot.CaptureAsync(document, secrets, [], root, TestContext.Current.CancellationToken));
+        Assert.Empty(Directory.EnumerateDirectories(root));
+    }
+    public void Dispose()
+    {
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, true);
+        }
+    }
+}

--- a/src/Foundry.Core.Tests/Profiles/DeploymentProfileAssetServiceTests.cs
+++ b/src/Foundry.Core.Tests/Profiles/DeploymentProfileAssetServiceTests.cs
@@ -1,0 +1,218 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Models.Profiles;
+using Foundry.Core.Services.Profiles;
+
+namespace Foundry.Core.Tests.Profiles;
+
+public sealed class DeploymentProfileAssetServiceTests : IDisposable
+{
+    private readonly string root = Path.Combine(Path.GetTempPath(), "Foundry.ProfileAssets.Tests", Guid.NewGuid().ToString("N"));
+
+    public DeploymentProfileAssetServiceTests() => Directory.CreateDirectory(root);
+
+    [Fact]
+    public void Capture_WhenBuildIsStrict_SkipsInactiveMissingAndChangedSources()
+    {
+        string missing = Path.Combine(root, "missing.pfx");
+        string changedAnswer = Path.Combine(root, "changed.xml");
+        File.WriteAllText(changedAnswer, "changed");
+        FoundryConfigurationDocument configuration = new()
+        {
+            Network = new()
+            {
+                Dot1x = new() { ProfileTemplatePath = missing, CertificatePath = missing, RequiresCertificate = true },
+                WifiProvisioned = false,
+                Wifi = new() { IsEnabled = true, HasEnterpriseProfile = true, EnterpriseProfileTemplatePath = missing, CertificatePath = missing, RequiresCertificate = true }
+            },
+            Autopilot = new()
+            {
+                IsEnabled = true,
+                ProvisioningMode = AutopilotProvisioningMode.JsonProfile,
+                HardwareHashUpload = new() { BootMediaCertificate = new() { PfxPath = missing } }
+            },
+            Unattend = new()
+            {
+                Files = [new() { Id = "answer", SourcePath = changedAnswer, ContentHash = Convert.ToHexString(SHA256.HashData("original"u8)) }]
+            }
+        };
+
+        Assert.Empty(DeploymentProfileAssetService.Capture(configuration, true, requireContent: true));
+    }
+
+    [Fact]
+    public void Capture_WhenProfileIncludesDormantSource_PreservesItsBytes()
+    {
+        string source = Path.Combine(root, "dormant.pfx");
+        File.WriteAllBytes(source, [1, 2, 3]);
+        FoundryConfigurationDocument configuration = new() { Network = new() { Dot1x = new() { CertificatePath = source } } };
+        IReadOnlyList<DeploymentProfileAsset> assets = DeploymentProfileAssetService.Capture(configuration, true);
+        try { Assert.Equal(new byte[] { 1, 2, 3 }, Assert.Single(assets).Content); }
+        finally { DeploymentProfileAssetService.Clear(assets); }
+    }
+
+    [Fact]
+    public void Capture_WhenActiveTransportHasOptionalCertificate_PreservesBuildInput()
+    {
+        string source = Path.Combine(root, "selected.bin");
+        File.WriteAllBytes(source, [1, 2, 3]);
+        FoundryConfigurationDocument configuration = new()
+        {
+            Network = new() { Dot1x = new() { IsEnabled = true, ProfileTemplatePath = source, CertificatePath = source, RequiresCertificate = false } }
+        };
+        IReadOnlyList<DeploymentProfileAsset> assets = DeploymentProfileAssetService.Capture(configuration, true, requireContent: true);
+        try { Assert.Equal(new byte[] { 1, 2, 3 }, Assert.Single(assets, asset => asset.Kind == ProfileAssetKind.WiredCertificate).Content); }
+        finally { DeploymentProfileAssetService.Clear(assets); }
+    }
+
+    [Fact]
+    public void Capture_WhenProvisionedWifiIsActive_StillRequiresSelectedEnterpriseSource()
+    {
+        FoundryConfigurationDocument configuration = new()
+        {
+            Network = new()
+            {
+                WifiProvisioned = true,
+                Wifi = new() { IsEnabled = true, HasEnterpriseProfile = true, EnterpriseProfileTemplatePath = Path.Combine(root, "missing.xml") }
+            }
+        };
+        Assert.Throws<FileNotFoundException>(() => DeploymentProfileAssetService.Capture(configuration, true, requireContent: true));
+    }
+
+    [Fact]
+    public void Capture_WhenExcludedSourceIsUnavailable_KeepsOmissionWithoutClaimingVerifiedContent()
+    {
+        var configuration = new FoundryConfigurationDocument
+        {
+            Network = new NetworkSettings { Dot1x = new Dot1xSettings { CertificatePath = Path.Combine(root, "missing.pfx") } }
+        };
+        DeploymentProfileAsset asset = Assert.Single(DeploymentProfileAssetService.Capture(configuration, false));
+        Assert.Equal(ProfileValueState.Omitted, asset.State);
+        Assert.Null(asset.Content);
+        Assert.Null(asset.Sha256);
+    }
+
+    [Fact]
+    public void Capture_WhenContentIsExcluded_PreservesVerifiedFingerprintAndPasswordContext()
+    {
+        string source = Path.Combine(root, "certificate.pfx");
+        File.WriteAllBytes(source, [1, 2, 3]);
+        FoundryConfigurationDocument configuration = new() { Network = new() { Dot1x = new() { CertificatePath = source } } };
+        DeploymentProfileDocument omitted = new() { Configuration = configuration, Assets = DeploymentProfileAssetService.Capture(configuration, false) };
+        DeploymentProfileDocument included = new() { Configuration = configuration, Assets = DeploymentProfileAssetService.Capture(configuration, true) };
+        try
+        {
+            DeploymentProfileAsset asset = Assert.Single(omitted.Assets);
+            Assert.Equal(ProfileValueState.Omitted, asset.State);
+            Assert.Null(asset.Content);
+            Assert.Equal(Convert.ToHexString(SHA256.HashData(new byte[] { 1, 2, 3 })), asset.Sha256);
+            Assert.Equal(DeploymentProfileSecretBinding.Identity(ProfileSecretPurpose.WiredCertificatePassword, included),
+                DeploymentProfileSecretBinding.Identity(ProfileSecretPurpose.WiredCertificatePassword, omitted));
+            File.WriteAllBytes(source, [3, 2, 1]);
+            Assert.NotEqual(asset.Sha256, Assert.Single(DeploymentProfileAssetService.Capture(configuration, false)).Sha256);
+        }
+        finally { DeploymentProfileSecretBinding.Clear(included); }
+    }
+
+    [Fact]
+    public void Capture_WhenExcludedSourceExceedsLimit_RejectsBeforeReadingContent()
+    {
+        string source = Path.Combine(root, "large.pfx");
+        using (FileStream stream = File.Create(source)) stream.SetLength(DeploymentProfileAssetService.MaximumAssetBytes + 1);
+        FoundryConfigurationDocument configuration = new() { Network = new() { Dot1x = new() { CertificatePath = source } } };
+        Assert.Throws<InvalidDataException>(() => DeploymentProfileAssetService.Capture(configuration, false));
+    }
+
+    [Fact]
+    public void Materialize_UsesGeneratedPathsAndOriginalCapturedBytes()
+    {
+        string source = Path.Combine(root, "input.xml");
+        File.WriteAllText(source, "<profile>first</profile>");
+        FoundryConfigurationDocument configuration = new()
+        {
+            Network = new NetworkSettings { Dot1x = new Dot1xSettings { ProfileTemplatePath = source } }
+        };
+        IReadOnlyList<DeploymentProfileAsset> assets = DeploymentProfileAssetService.Capture(configuration, true);
+        File.WriteAllText(source, "<profile>second</profile>");
+        DeploymentProfileDocument profile = new()
+        {
+            Configuration = configuration,
+            Assets = [assets[0] with { RelativePath = "../../outside.xml" }]
+        };
+        string staging = Path.Combine(root, "staging");
+        FoundryConfigurationDocument restored = DeploymentProfileAssetService.Materialize(profile, staging);
+        Assert.StartsWith(staging + Path.DirectorySeparatorChar, restored.Network.Dot1x.ProfileTemplatePath!);
+        Assert.Equal("<profile>first</profile>", File.ReadAllText(restored.Network.Dot1x.ProfileTemplatePath!));
+        DeploymentProfileAssetService.Clear(assets);
+        Assert.All(assets[0].Content!, value => Assert.Equal(0, value));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Capture_WhenAnswerFileHasChanged_RequiresExplicitRefresh(bool includeContent)
+    {
+        string source = Path.Combine(root, "answer.xml");
+        File.WriteAllText(source, "changed");
+        var configuration = new FoundryConfigurationDocument
+        {
+            Unattend = new UnattendSettings
+            {
+                Files = [new UnattendFileSettings { Id = Guid.NewGuid().ToString("N"), SourcePath = source, ContentHash = Convert.ToHexString(SHA256.HashData("original"u8)) }]
+            }
+        };
+        Assert.Throws<InvalidDataException>(() => DeploymentProfileAssetService.Capture(configuration, includeContent));
+    }
+
+    [Fact]
+    public void Materialize_WhenDigestDoesNotMatch_RejectsBeforeWritingContent()
+    {
+        var profile = new DeploymentProfileDocument
+        {
+            Assets = [new DeploymentProfileAsset
+            {
+                Id = "wired-profile", Kind = ProfileAssetKind.WiredProfile, RelativePath = "profile.xml",
+                State = ProfileValueState.Present, Content = [1, 2, 3], Sha256 = new string('0', 64)
+            }]
+        };
+        string staging = Path.Combine(root, "invalid");
+        Assert.Throws<InvalidDataException>(() => DeploymentProfileAssetService.Materialize(profile, staging));
+        Assert.Empty(Directory.EnumerateFiles(staging));
+    }
+
+    [Fact]
+    public void SecretBinding_ChangesForAccountRenameButNotForLocalAssetRemapping()
+    {
+        var profile = new DeploymentProfileDocument
+        {
+            Configuration = new FoundryConfigurationDocument
+            {
+                Customization = new CustomizationSettings
+                {
+                    Oobe = new OobeSettings { AdditionalAccounts = [new OobeAdditionalAccountSettings { Id = "account", UserName = "original" }] }
+                }
+            },
+            Assets = [new DeploymentProfileAsset { Kind = ProfileAssetKind.WiredCertificate, Sha256 = new string('A', 64) }]
+        };
+        string original = DeploymentProfileSecretBinding.Identity(ProfileSecretPurpose.AdditionalAccountPassword, profile, "account");
+        DeploymentProfileDocument renamed = profile with
+        {
+            Configuration = profile.Configuration with
+            {
+                Customization = profile.Configuration.Customization with
+                {
+                    Oobe = profile.Configuration.Customization.Oobe with { AdditionalAccounts = [new OobeAdditionalAccountSettings { Id = "account", UserName = "renamed" }] }
+                }
+            }
+        };
+        Assert.NotEqual(original, DeploymentProfileSecretBinding.Identity(ProfileSecretPurpose.AdditionalAccountPassword, renamed, "account"));
+        Assert.Equal(DeploymentProfileSecretBinding.Identity(ProfileSecretPurpose.WiredCertificatePassword, profile),
+            DeploymentProfileSecretBinding.Identity(ProfileSecretPurpose.WiredCertificatePassword, renamed));
+    }
+
+    public void Dispose() => Directory.Delete(root, true);
+}

--- a/src/Foundry.Core.Tests/Profiles/DeploymentProfileMergeTests.cs
+++ b/src/Foundry.Core.Tests/Profiles/DeploymentProfileMergeTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Core.Models.Profiles;
+using Foundry.Core.Services.Profiles;
+
+namespace Foundry.Core.Tests.Profiles;
+
+public sealed class DeploymentProfileMergeTests
+{
+    [Theory]
+    [InlineData(ProfileValueState.Omitted, true)]
+    [InlineData(ProfileValueState.Unavailable, false)]
+    [InlineData(ProfileValueState.Deleted, false)]
+    [InlineData(ProfileValueState.Blank, false)]
+    public void Merge_OnlyOmittedMatchingContextRetainsLocalPassword(ProfileValueState state, bool retains)
+    {
+        Guid id = Guid.NewGuid();
+        var local = new DeploymentProfileDocument
+        {
+            ProfileId = id,
+            Secrets = new() { Entries = [new() { Purpose = ProfileSecretPurpose.WifiPassphrase, Identity = "network-context", State = ProfileValueState.Present, Value = [1, 2, 3] }] }
+        };
+        var incoming = new DeploymentProfileDocument
+        {
+            ProfileId = id,
+            Secrets = new() { Entries = [local.Secrets.Entries[0] with { State = state, Value = null }] }
+        };
+        DeploymentProfileDocument result = DeploymentProfileMerge.PreserveOmittedLocalValues(incoming, local);
+        Assert.Equal(retains ? ProfileValueState.Present : state, result.Secrets.Entries[0].State);
+        if (retains)
+        {
+            Assert.Equal(local.Secrets.Entries[0].Value, result.Secrets.Entries[0].Value);
+            DeploymentProfileSecretBinding.Clear(result);
+            Assert.Equal(new byte[] { 1, 2, 3 }, local.Secrets.Entries[0].Value);
+        }
+        else Assert.Null(result.Secrets.Entries[0].Value);
+    }
+
+    [Fact]
+    public void Merge_ChangedIdentityAndUnverifiedAssetsDoNotReuseLocalMaterial()
+    {
+        Guid id = Guid.NewGuid();
+        var local = new DeploymentProfileDocument
+        {
+            ProfileId = id,
+            Secrets = new() { Entries = [new() { Purpose = ProfileSecretPurpose.WifiPassphrase, Identity = "old-network", State = ProfileValueState.Present, Value = [1] }] },
+            Assets = [new() { Id = "certificate", Kind = ProfileAssetKind.WiredCertificate, State = ProfileValueState.Present, Sha256 = new string('A', 64), Content = [1] }]
+        };
+        var incoming = new DeploymentProfileDocument
+        {
+            ProfileId = id,
+            Secrets = new() { Entries = [local.Secrets.Entries[0] with { Identity = "new-network", State = ProfileValueState.Omitted, Value = null }] },
+            Assets = [local.Assets[0] with { Sha256 = null, State = ProfileValueState.Omitted, Content = null }]
+        };
+        DeploymentProfileDocument result = DeploymentProfileMerge.PreserveOmittedLocalValues(incoming, local);
+        Assert.Null(result.Secrets.Entries[0].Value);
+        Assert.Null(result.Assets[0].Content);
+    }
+}

--- a/src/Foundry.Core.Tests/Profiles/DeploymentProfilePackageServiceTests.cs
+++ b/src/Foundry.Core.Tests/Profiles/DeploymentProfilePackageServiceTests.cs
@@ -148,11 +148,10 @@ public sealed class DeploymentProfilePackageServiceTests
     }
 
     [Theory]
-    [InlineData(8)]
     [InlineData(9)]
     [InlineData(10)]
     [InlineData(13)]
-    public void Import_RejectsChangedFormatPurposeAndKdfCostBeforeDerivation(int offset)
+    public void Import_RejectsChangedPurposeAndKdfCostBeforeDerivation(int offset)
     {
         byte[] package = _service.Export(CreateProfile(), "password");
         package[offset] ^= 0x7f;
@@ -176,7 +175,6 @@ public sealed class DeploymentProfilePackageServiceTests
 
     [Theory]
     [InlineData("duplicate")]
-    [InlineData("future-schema")]
     [InlineData("unknown-property")]
     [InlineData("missing-state")]
     [InlineData("invalid-state")]
@@ -189,7 +187,6 @@ public sealed class DeploymentProfilePackageServiceTests
         byte[] invalid = RewriteAuthenticatedPayload(package, key, json => mutation switch
         {
             "duplicate" => json.Replace("\"formatVersion\":1", "\"formatVersion\":1,\"FormatVersion\":1", StringComparison.Ordinal),
-            "future-schema" => json.Replace($"\"schemaVersion\":{FoundryConfigurationDocument.CurrentSchemaVersion}", "\"schemaVersion\":2147483647", StringComparison.Ordinal),
             "unknown-property" => json.Replace("\"displayName\":", "\"nativeTarget\":\"arbitrary\",\"displayName\":", StringComparison.Ordinal),
             "missing-state" => json.Replace("\"state\":0,", string.Empty, StringComparison.Ordinal),
             "invalid-state" => json.Replace("\"state\":0", "\"state\":999", StringComparison.Ordinal),
@@ -200,12 +197,58 @@ public sealed class DeploymentProfilePackageServiceTests
     }
 
     [Fact]
+    public void Decrypt_DistinguishesFutureFormatsFromCorruptData()
+    {
+        byte[] key = new byte[32];
+        byte[] package = _service.Encrypt(CreateProfile(), key, ProfilePackagePurpose.LocalStorage);
+        byte[] futureSchema = RewriteAuthenticatedPayload(package, key, json => json.Replace(
+            $"\"schemaVersion\":{FoundryConfigurationDocument.CurrentSchemaVersion}", "\"schemaVersion\":2147483647", StringComparison.Ordinal));
+        byte[] futurePayload = RewriteAuthenticatedPayload(package, key, json => json.Replace("\"formatVersion\":1", "\"formatVersion\":2", StringComparison.Ordinal));
+        Assert.Throws<NotSupportedException>(() => _service.Decrypt(futureSchema, key, ProfilePackagePurpose.LocalStorage));
+        Assert.Throws<NotSupportedException>(() => _service.Decrypt(futurePayload, key, ProfilePackagePurpose.LocalStorage));
+        package[8]++;
+        Assert.Throws<NotSupportedException>(() => _service.Decrypt(package, key, ProfilePackagePurpose.LocalStorage));
+    }
+
+    [Fact]
     public void Export_RejectsAmbiguousAssetPathsAndSecretStates()
     {
         DeploymentProfileAsset asset = new() { Id = "a", RelativePath = "assets/a.xml", Kind = ProfileAssetKind.Unattend };
         Assert.Throws<InvalidDataException>(() => _service.Export(CreateProfile() with { Assets = [asset, asset with { Id = "b", RelativePath = "ASSETS/A.XML" }] }, "password"));
         DeploymentProfileSecret secret = new() { Identity = "a", State = ProfileValueState.Unavailable, Value = [1] };
         Assert.Throws<InvalidDataException>(() => _service.Export(CreateProfile() with { Secrets = new() { Entries = [secret] } }, "password"));
+    }
+
+    [Theory]
+    [InlineData(ProfileAssetKind.WiredProfile)]
+    [InlineData(ProfileAssetKind.WifiProfile)]
+    [InlineData(ProfileAssetKind.WiredCertificate)]
+    [InlineData(ProfileAssetKind.WifiCertificate)]
+    [InlineData(ProfileAssetKind.AutopilotCertificate)]
+    public void Encrypt_RejectsAmbiguousSingletonAssetsBeforeActivation(ProfileAssetKind kind)
+    {
+        DeploymentProfileAsset asset = new() { Id = "first", Kind = kind, RelativePath = "assets/first.bin" };
+        DeploymentProfileDocument profile = CreateProfile() with
+        {
+            Assets = [asset, asset with { Id = "second", RelativePath = "assets/second.bin" }]
+        };
+
+        Assert.Throws<InvalidDataException>(() => _service.Encrypt(profile, new byte[32], ProfilePackagePurpose.SharedRevision));
+    }
+
+    [Fact]
+    public void EncryptDecrypt_PreservesMultipleAnswerFileAssets()
+    {
+        DeploymentProfileAsset asset = new() { Id = "first", Kind = ProfileAssetKind.Unattend, RelativePath = "assets/first.xml" };
+        DeploymentProfileDocument profile = CreateProfile() with
+        {
+            Assets = [asset, asset with { Id = "second", RelativePath = "assets/second.xml" }]
+        };
+        byte[] key = new byte[32];
+
+        DeploymentProfileDocument imported = _service.Decrypt(_service.Encrypt(profile, key, ProfilePackagePurpose.SharedRevision), key, ProfilePackagePurpose.SharedRevision);
+
+        Assert.Equal(2, imported.Assets.Count);
     }
 
     [Fact]

--- a/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
+++ b/src/Foundry.Core/Models/Configuration/ConfigurationSchemaVersions.cs
@@ -6,7 +6,7 @@ namespace Foundry.Core.Models.Configuration;
 
 public static class ConfigurationSchemaVersions
 {
-    public const int FoundryCurrent = 14;
+    public const int FoundryCurrent = 15;
 
     public const int ConnectCurrent = 4;
 

--- a/src/Foundry.Core/Models/Profiles/DeploymentProfileDocument.cs
+++ b/src/Foundry.Core/Models/Profiles/DeploymentProfileDocument.cs
@@ -53,7 +53,7 @@ public sealed record DeploymentProfileAsset
 public enum ProfileValueState { Omitted, Unavailable, Deleted, Blank, Present }
 
 /// <summary>Allowlisted password families, independent of operating-system credential storage names.</summary>
-public enum ProfileSecretPurpose { DeploymentPassword, WifiPassphrase, AdministratorPassword, AdditionalAccountPassword, WiredCertificatePassword, WifiCertificatePassword, AutopilotCertificatePassword }
+public enum ProfileSecretPurpose { DeploymentPassword, WifiPassphrase, AdministratorPassword, AdditionalAccountPassword, WiredCertificatePassword, WifiCertificatePassword, AutopilotCertificatePassword, SharedProfileKey }
 
 /// <summary>Allowlisted portable inputs. Opaque files are included only when the caller explicitly supplies their bytes.</summary>
 public enum ProfileAssetKind { Unattend, WiredProfile, WifiProfile, WiredCertificate, WifiCertificate, AutopilotProfile, AutopilotCertificate }

--- a/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidator.cs
+++ b/src/Foundry.Core/Services/Configuration/NetworkConfigurationValidator.cs
@@ -89,9 +89,17 @@ public static class NetworkConfigurationValidator
 
         return settings with
         {
+            Dot1x = settings.Dot1x with
+            {
+                CertificatePfxPassword = null,
+                CertificatePfxPasswordSecret = null
+            },
             Wifi = settings.Wifi with
             {
-                Passphrase = null
+                Passphrase = null,
+                PassphraseSecret = null,
+                CertificatePfxPassword = null,
+                CertificatePfxPasswordSecret = null
             }
         };
     }

--- a/src/Foundry.Core/Services/Configuration/NetworkSecretState.cs
+++ b/src/Foundry.Core/Services/Configuration/NetworkSecretState.cs
@@ -8,11 +8,28 @@ namespace Foundry.Core.Services.Configuration;
 
 public sealed class NetworkSecretState
 {
+    private string? wifiIdentity;
+    private string? wiredCertificatePath;
+    private string? wifiCertificatePath;
+    private string? wiredCertificatePassword;
+    private string? wifiCertificatePassword;
+
     public string? PersonalWifiPassphrase { get; private set; }
 
     public void Update(NetworkSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
+
+        UpdateCertificate(settings.Dot1x.IsEnabled && settings.Dot1x.RequiresCertificate ? settings.Dot1x.CertificatePath : null,
+            settings.Dot1x.CertificatePfxPassword, ref wiredCertificatePath, ref wiredCertificatePassword);
+        UpdateCertificate(settings.Wifi.IsEnabled && settings.Wifi.RequiresCertificate ? settings.Wifi.CertificatePath : null,
+            settings.Wifi.CertificatePfxPassword, ref wifiCertificatePath, ref wifiCertificatePassword);
+        string identity = settings.Wifi.Ssid ?? string.Empty;
+        if (!string.Equals(wifiIdentity, identity, StringComparison.Ordinal))
+        {
+            PersonalWifiPassphrase = null;
+            wifiIdentity = identity;
+        }
 
         if (!RequiresPersonalWifiPassphrase(settings))
         {
@@ -33,7 +50,39 @@ public sealed class NetworkSecretState
 
     public NetworkSettings ApplyRequiredSecrets(NetworkSettings settings)
     {
-        return NetworkMediaReadinessEvaluator.ApplyRequiredSecrets(settings, PersonalWifiPassphrase);
+        NetworkSettings result = NetworkMediaReadinessEvaluator.ApplyRequiredSecrets(settings,
+            string.Equals(wifiIdentity, settings.Wifi.Ssid ?? string.Empty, StringComparison.Ordinal) ? PersonalWifiPassphrase : null);
+        return result with
+        {
+            Dot1x = result.Dot1x with
+            {
+                CertificatePfxPassword = string.Equals(wiredCertificatePath, result.Dot1x.CertificatePath, StringComparison.OrdinalIgnoreCase)
+                    ? wiredCertificatePassword : null
+            },
+            Wifi = result.Wifi with
+            {
+                CertificatePfxPassword = string.Equals(wifiCertificatePath, result.Wifi.CertificatePath, StringComparison.OrdinalIgnoreCase)
+                    ? wifiCertificatePassword : null
+            }
+        };
+    }
+
+    private static void UpdateCertificate(string? path, string? password, ref string? previousPath, ref string? previousPassword)
+    {
+        if (!string.Equals(path, previousPath, StringComparison.OrdinalIgnoreCase))
+        {
+            previousPassword = null;
+            previousPath = path;
+        }
+
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            previousPassword = null;
+        }
+        else if (password is not null)
+        {
+            previousPassword = password;
+        }
     }
 
     private static bool RequiresPersonalWifiPassphrase(NetworkSettings settings)

--- a/src/Foundry.Core/Services/Profiles/DeploymentBuildSnapshot.cs
+++ b/src/Foundry.Core/Services/Profiles/DeploymentBuildSnapshot.cs
@@ -1,0 +1,335 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Cryptography;
+using System.Security.Principal;
+using System.Text.Json;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Models.Configuration.Deploy;
+using Foundry.Core.Models.Profiles;
+using Foundry.Core.Services.Configuration;
+using Foundry.Core.Services.WinPe;
+using Foundry.Telemetry;
+
+namespace Foundry.Core.Services.Profiles;
+
+/// <summary>Owns one media build's frozen configuration, session secrets and private source copies.</summary>
+public sealed class DeploymentBuildSnapshot : IDisposable
+{
+    private const long MaximumDriverBytes = 2L * 1024 * 1024 * 1024;
+    private const int MaximumDriverEntries = 10_000;
+    private readonly OobeAccountSecretState accountSecrets = new();
+    private readonly char[] deploymentPassword;
+    private readonly char[]? wifiPassphrase;
+    private readonly char[]? wiredCertificatePassword;
+    private readonly char[]? wifiCertificatePassword;
+    private readonly char[]? autopilotCertificatePassword;
+    private readonly string privateRootDirectory;
+    private readonly string privateDirectory;
+    private FoundryConfigurationDocument configuration;
+    private bool isDisposed;
+
+    private DeploymentBuildSnapshot(FoundryConfigurationDocument source, ReadOnlySpan<char> password, string root)
+    {
+        configuration = CloneConfiguration(source);
+        deploymentPassword = password.ToArray();
+        wifiPassphrase = source.Network.Wifi.Passphrase?.ToCharArray();
+        wiredCertificatePassword = source.Network.Dot1x.CertificatePfxPassword?.ToCharArray();
+        wifiCertificatePassword = source.Network.Wifi.CertificatePfxPassword?.ToCharArray();
+        autopilotCertificatePassword = source.Autopilot.HardwareHashUpload.BootMediaCertificate.PfxPassword?.ToCharArray();
+        privateRootDirectory = Path.GetFullPath(root);
+        privateDirectory = Path.Combine(privateRootDirectory, Guid.NewGuid().ToString("N"));
+    }
+
+    /// <summary>Returns a detached configuration copy with stable staged paths and no plaintext passwords.</summary>
+    public FoundryConfigurationDocument Configuration
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(isDisposed, this);
+            return CloneConfiguration(configuration);
+        }
+    }
+
+    /// <summary>Copies configuration and secrets synchronously, then captures bounded source files off-thread before returning a usable snapshot.</summary>
+    public static Task<DeploymentBuildSnapshot> CaptureAsync(
+        FoundryConfigurationDocument configuration,
+        OobeAccountSecretState accountSecrets,
+        ReadOnlySpan<char> deploymentPassword,
+        string privateRootDirectory,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(accountSecrets);
+        ArgumentException.ThrowIfNullOrWhiteSpace(privateRootDirectory);
+        var snapshot = new DeploymentBuildSnapshot(configuration, deploymentPassword, privateRootDirectory);
+        try
+        {
+            snapshot.CopyAccountSecrets(accountSecrets);
+            return snapshot.PrepareAsync(cancellationToken);
+        }
+        catch
+        {
+            snapshot.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>Generates Connect only from captured credentials and private dependency copies.</summary>
+    public FoundryConnectProvisioningBundle CreateConnectProvisioningBundle(string stagingDirectoryPath, TelemetrySettings? telemetryOverride = null)
+    {
+        ObjectDisposedException.ThrowIf(isDisposed, this);
+        return new ConnectConfigurationGenerator().CreateProvisioningBundle(CreateGenerationDocument(telemetryOverride), stagingDirectoryPath);
+    }
+
+    /// <summary>Retains existing Deploy protection and account validation rules while using captured session material.</summary>
+    public string GenerateDeployConfigurationJson(TelemetrySettings? telemetryOverride = null, byte[]? deploymentSecretsKey = null, DeployProtectionSettings? protectionSettings = null)
+    {
+        ObjectDisposedException.ThrowIf(isDisposed, this);
+        if (!accountSecrets.Validate(configuration.Customization.Oobe).IsValid)
+        {
+            throw new InvalidOperationException("OOBE local account password confirmation is invalid.");
+        }
+        var generator = new DeployConfigurationGenerator();
+        return generator.Serialize(generator.Generate(CreateGenerationDocument(telemetryOverride), deploymentSecretsKey, protectionSettings, accountSecrets));
+    }
+
+    /// <summary>Creates fresh per-media protection using the confirmed password captured before preparation began.</summary>
+    public DeploymentMediaProtectionMaterial CreateDeploymentProtectionMaterial()
+    {
+        ObjectDisposedException.ThrowIf(isDisposed, this);
+        return configuration.General.DeploymentProtection.IsEnabled
+            ? DeploymentMediaProtectionService.CreateProtected(deploymentPassword)
+            : DeploymentMediaProtectionService.CreateUnprotected();
+    }
+
+    /// <summary>Clears owned password buffers and removes the private staging directory; cleanup errors are surfaced to the caller.</summary>
+    public void Dispose()
+    {
+        if (isDisposed)
+        {
+            return;
+        }
+        isDisposed = true;
+        accountSecrets.Dispose();
+        Clear(deploymentPassword);
+        Clear(wifiPassphrase);
+        Clear(wiredCertificatePassword);
+        Clear(wifiCertificatePassword);
+        Clear(autopilotCertificatePassword);
+        if (Directory.Exists(privateDirectory)
+            && string.Equals(Path.GetDirectoryName(Path.GetFullPath(privateDirectory)), privateRootDirectory, StringComparison.OrdinalIgnoreCase))
+        {
+            Directory.Delete(privateDirectory, recursive: true);
+        }
+    }
+
+    private async Task<DeploymentBuildSnapshot> PrepareAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Run(() => PrepareFiles(cancellationToken), cancellationToken).ConfigureAwait(false);
+            return this;
+        }
+        catch
+        {
+            Dispose();
+            throw;
+        }
+    }
+
+    private void PrepareFiles(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        CreatePrivateDirectory();
+        FoundryConfigurationDocument sources = SelectActiveSources(configuration);
+        IReadOnlyList<DeploymentProfileAsset> assets = DeploymentProfileAssetService.Capture(sources, includeContent: true, requireContent: true);
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            configuration = DeploymentProfileAssetService.Materialize(new DeploymentProfileDocument { Configuration = sources, Assets = assets }, privateDirectory);
+        }
+        finally
+        {
+            DeploymentProfileAssetService.Clear(assets);
+        }
+        if (!string.IsNullOrWhiteSpace(configuration.General.CustomDriverDirectoryPath))
+        {
+            string destination = Path.Combine(privateDirectory, "Drivers");
+            CopyDrivers(configuration.General.CustomDriverDirectoryPath, destination, cancellationToken);
+            configuration = configuration with { General = configuration.General with { CustomDriverDirectoryPath = destination } };
+        }
+        cancellationToken.ThrowIfCancellationRequested();
+    }
+
+    private void CreatePrivateDirectory()
+    {
+        Directory.CreateDirectory(privateRootDirectory);
+        using WindowsIdentity identity = WindowsIdentity.GetCurrent();
+        SecurityIdentifier user = identity.User ?? throw new InvalidOperationException("The current Windows user is unavailable.");
+        var security = new DirectorySecurity();
+        security.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+        security.AddAccessRule(new FileSystemAccessRule(user, FileSystemRights.FullControl,
+            InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit, PropagationFlags.None, AccessControlType.Allow));
+        new DirectoryInfo(privateDirectory).Create(security);
+    }
+
+    private static void CopyDrivers(string source, string destination, CancellationToken cancellationToken)
+    {
+        var pending = new Stack<(DirectoryInfo Source, string Destination)>();
+        pending.Push((new DirectoryInfo(source), destination));
+        long totalBytes = 0;
+        int entries = 0;
+        byte[] buffer = new byte[64 * 1024];
+        try
+        {
+            while (pending.TryPop(out (DirectoryInfo Source, string Destination) current))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if ((current.Source.Attributes & FileAttributes.ReparsePoint) != 0)
+                {
+                    throw new InvalidDataException("Custom driver snapshots do not follow reparse points.");
+                }
+                Directory.CreateDirectory(current.Destination);
+                foreach (FileSystemInfo entry in current.Source.EnumerateFileSystemInfos())
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (++entries > MaximumDriverEntries || (entry.Attributes & FileAttributes.ReparsePoint) != 0)
+                    {
+                        throw new InvalidDataException("Custom driver snapshots exceed the entry limit or contain a reparse point.");
+                    }
+                    string target = Path.Combine(current.Destination, entry.Name);
+                    if (entry is DirectoryInfo directory)
+                    {
+                        pending.Push((directory, target));
+                        continue;
+                    }
+                    using FileStream input = new(entry.FullName, FileMode.Open, FileAccess.Read, FileShare.Read);
+                    totalBytes += input.Length;
+                    if (totalBytes > MaximumDriverBytes)
+                    {
+                        throw new InvalidDataException("Custom driver snapshots exceed the supported size.");
+                    }
+                    using FileStream output = new(target, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+                    int count;
+                    while ((count = input.Read(buffer)) != 0)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        output.Write(buffer, 0, count);
+                    }
+                }
+            }
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(buffer);
+        }
+    }
+
+    private void CopyAccountSecrets(OobeAccountSecretState source)
+    {
+        Copy(source.GetAdministratorPasswordCopy(), accountSecrets.SetAdministratorPassword);
+        Copy(source.GetAdministratorConfirmationCopy(), accountSecrets.SetAdministratorConfirmation);
+        foreach (OobeAdditionalAccountSettings account in configuration.Customization.Oobe.AdditionalAccounts)
+        {
+            Copy(source.GetAdditionalAccountPasswordCopy(account.Id), value => accountSecrets.SetAdditionalAccountPassword(account.Id, value));
+            Copy(source.GetAdditionalAccountConfirmationCopy(account.Id), value => accountSecrets.SetAdditionalAccountConfirmation(account.Id, value));
+        }
+    }
+
+    private delegate void SetSecret(ReadOnlySpan<char> value);
+
+    private static void Copy(char[] buffer, SetSecret setter)
+    {
+        try
+        {
+            setter(buffer);
+        }
+        finally
+        {
+            Clear(buffer);
+        }
+    }
+
+    private FoundryConfigurationDocument CreateGenerationDocument(TelemetrySettings? telemetryOverride)
+    {
+        return configuration with
+        {
+            Network = configuration.Network with
+            {
+                Wifi = configuration.Network.Wifi with { Passphrase = AsString(wifiPassphrase), CertificatePfxPassword = AsString(wifiCertificatePassword) },
+                Dot1x = configuration.Network.Dot1x with { CertificatePfxPassword = AsString(wiredCertificatePassword) }
+            },
+            Autopilot = configuration.Autopilot with
+            {
+                HardwareHashUpload = configuration.Autopilot.HardwareHashUpload with
+                {
+                    BootMediaCertificate = configuration.Autopilot.HardwareHashUpload.BootMediaCertificate with { PfxPassword = AsString(autopilotCertificatePassword) }
+                }
+            },
+            Telemetry = telemetryOverride ?? configuration.Telemetry
+        };
+    }
+
+    private static FoundryConfigurationDocument CloneConfiguration(FoundryConfigurationDocument source)
+    {
+        AutopilotBootMediaCertificateSettings bootCertificate = source.Autopilot.HardwareHashUpload.BootMediaCertificate with { PfxPassword = null };
+        FoundryConfigurationDocument sanitized = source with
+        {
+            Network = source.Network with
+            {
+                Wifi = source.Network.Wifi with { Passphrase = null, PassphraseSecret = null, CertificatePfxPassword = null, CertificatePfxPasswordSecret = null },
+                Dot1x = source.Network.Dot1x with { CertificatePfxPassword = null, CertificatePfxPasswordSecret = null }
+            },
+            Autopilot = source.Autopilot with { HardwareHashUpload = source.Autopilot.HardwareHashUpload with { BootMediaCertificate = bootCertificate } }
+        };
+        byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(sanitized, ConfigurationJsonDefaults.SerializerOptions);
+        try
+        {
+            FoundryConfigurationDocument clone = JsonSerializer.Deserialize<FoundryConfigurationDocument>(bytes, ConfigurationJsonDefaults.SerializerOptions)!;
+            return clone with { Autopilot = clone.Autopilot with { HardwareHashUpload = clone.Autopilot.HardwareHashUpload with { BootMediaCertificate = bootCertificate } } };
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(bytes);
+        }
+    }
+
+    private static FoundryConfigurationDocument SelectActiveSources(FoundryConfigurationDocument source)
+    {
+        bool wifiEnabled = source.Network.WifiProvisioned && source.Network.Wifi.IsEnabled;
+        bool hardwareHashEnabled = source.Autopilot.IsEnabled && source.Autopilot.ProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload;
+        return source with
+        {
+            Network = source.Network with
+            {
+                Dot1x = source.Network.Dot1x.IsEnabled ? source.Network.Dot1x : source.Network.Dot1x with { ProfileTemplatePath = null, CertificatePath = null },
+                Wifi = source.Network.Wifi with
+                {
+                    EnterpriseProfileTemplatePath = wifiEnabled && source.Network.Wifi.HasEnterpriseProfile ? source.Network.Wifi.EnterpriseProfileTemplatePath : null,
+                    CertificatePath = wifiEnabled ? source.Network.Wifi.CertificatePath : null
+                }
+            },
+            Unattend = source.Unattend.IsEnabled ? source.Unattend : source.Unattend with { Files = [] },
+            Autopilot = source.Autopilot with
+            {
+                HardwareHashUpload = source.Autopilot.HardwareHashUpload with
+                {
+                    BootMediaCertificate = hardwareHashEnabled ? source.Autopilot.HardwareHashUpload.BootMediaCertificate : new()
+                }
+            }
+        };
+    }
+
+    private static string? AsString(char[]? value) => value is null ? null : new string(value);
+    private static void Clear(char[]? value)
+    {
+        if (value is not null)
+        {
+            CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(value.AsSpan()));
+        }
+    }
+}

--- a/src/Foundry.Core/Services/Profiles/DeploymentProfileAssetService.cs
+++ b/src/Foundry.Core/Services/Profiles/DeploymentProfileAssetService.cs
@@ -1,0 +1,198 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Models.Profiles;
+using Foundry.Core.Services.Configuration;
+
+namespace Foundry.Core.Services.Profiles;
+
+/// <summary>Captures exact selected dependencies and rebinds them to a private local staging directory.</summary>
+public static class DeploymentProfileAssetService
+{
+    public const int MaximumAssetBytes = 4 * 1024 * 1024;
+    public const int MaximumTotalBytes = 8 * 1024 * 1024;
+
+    /// <summary>Fingerprints bounded selected sources; only the caller's inclusion choice retains their sensitive bytes.</summary>
+    public static IReadOnlyList<DeploymentProfileAsset> Capture(FoundryConfigurationDocument configuration, bool includeContent, bool requireContent = false)
+    {
+        List<DeploymentProfileAsset> assets = [];
+        long total = 0;
+        bool wiredEnabled = configuration.Network.Dot1x.IsEnabled;
+        bool wifiEnabled = configuration.Network.WifiProvisioned && configuration.Network.Wifi.IsEnabled;
+        bool wifiProfileEnabled = wifiEnabled && configuration.Network.Wifi.HasEnterpriseProfile;
+        bool hardwareHashEnabled = configuration.Autopilot.IsEnabled && configuration.Autopilot.ProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload;
+        Add("wired-profile", ProfileAssetKind.WiredProfile, configuration.Network.Dot1x.ProfileTemplatePath, required: wiredEnabled, active: wiredEnabled);
+        Add("wifi-profile", ProfileAssetKind.WifiProfile, configuration.Network.Wifi.EnterpriseProfileTemplatePath, required: wifiProfileEnabled, active: wifiProfileEnabled);
+        Add("wired-certificate", ProfileAssetKind.WiredCertificate, configuration.Network.Dot1x.CertificatePath, required: wiredEnabled && configuration.Network.Dot1x.RequiresCertificate, active: wiredEnabled);
+        Add("wifi-certificate", ProfileAssetKind.WifiCertificate, configuration.Network.Wifi.CertificatePath, required: wifiEnabled && configuration.Network.Wifi.RequiresCertificate, active: wifiEnabled);
+        Add("autopilot-certificate", ProfileAssetKind.AutopilotCertificate, configuration.Autopilot.HardwareHashUpload.BootMediaCertificate.PfxPath,
+            required: hardwareHashEnabled, active: hardwareHashEnabled);
+        foreach (UnattendFileSettings file in configuration.Unattend.Files)
+        {
+            Add(file.Id, ProfileAssetKind.Unattend, file.SourcePath, file, configuration.Unattend.IsEnabled, configuration.Unattend.IsEnabled);
+        }
+
+        return assets;
+
+        void Add(string id, ProfileAssetKind kind, string? path, UnattendFileSettings? answerFile = null, bool required = false, bool active = true)
+        {
+            if (requireContent && !active) return;
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                if (!required) return;
+                if (includeContent && requireContent)
+                {
+                    Clear(assets);
+                    throw new FileNotFoundException("A required profile dependency is missing.");
+                }
+                assets.Add(new DeploymentProfileAsset
+                {
+                    Id = id,
+                    Kind = kind,
+                    RelativePath = $"assets/{(int)kind}-{id}.bin",
+                    State = includeContent ? ProfileValueState.Unavailable : ProfileValueState.Omitted,
+                    Sha256 = answerFile?.ContentHash
+                });
+                return;
+            }
+
+            byte[]? content = null;
+            try
+            {
+                ProfileValueState state = includeContent ? ProfileValueState.Present : ProfileValueState.Omitted;
+                string? digest = answerFile?.ContentHash;
+                try
+                {
+                    using FileStream stream = new(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+                    if (stream.Length > MaximumAssetBytes || total + stream.Length > MaximumTotalBytes)
+                    {
+                        throw new InvalidDataException("Profile dependencies exceed the supported size.");
+                    }
+
+                    content = new byte[checked((int)stream.Length)];
+                    stream.ReadExactly(content);
+                    total += content.Length;
+                    digest = Convert.ToHexString(SHA256.HashData(content));
+                    if (answerFile is not null && !string.Equals(digest, answerFile.ContentHash, StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidDataException("An answer-file source changed. Refresh it before saving the profile.");
+                    }
+                }
+                catch (Exception exception) when (!requireContent && (exception is IOException or UnauthorizedAccessException))
+                {
+                    if (content is not null) CryptographicOperations.ZeroMemory(content);
+                    content = null;
+                    state = includeContent ? ProfileValueState.Unavailable : ProfileValueState.Omitted;
+                }
+
+                assets.Add(new DeploymentProfileAsset
+                {
+                    Id = id,
+                    Kind = kind,
+                    RelativePath = $"assets/{(int)kind}-{Convert.ToHexString(SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(id)))}{SafeExtension(path)}",
+                    State = state,
+                    Sha256 = digest,
+                    Content = includeContent ? content : null
+                });
+                if (includeContent) content = null;
+            }
+            catch
+            {
+                Clear(assets);
+                throw;
+            }
+            finally
+            {
+                if (content is not null)
+                {
+                    CryptographicOperations.ZeroMemory(content);
+                }
+            }
+        }
+    }
+
+    /// <summary>Materializes verified bytes under generated filenames. Imported paths never select a destination.</summary>
+    public static FoundryConfigurationDocument Materialize(DeploymentProfileDocument profile, string privateDirectory)
+    {
+        Directory.CreateDirectory(privateDirectory);
+        Dictionary<(ProfileAssetKind Kind, string Id), string> paths = [];
+        long total = 0;
+        foreach (DeploymentProfileAsset asset in profile.Assets)
+        {
+            if (asset.State != ProfileValueState.Present)
+            {
+                continue;
+            }
+
+            byte[] content = asset.Content ?? throw new InvalidDataException("A profile dependency is missing.");
+            total += content.Length;
+            if (content.Length > MaximumAssetBytes || total > MaximumTotalBytes ||
+                !string.Equals(Convert.ToHexString(SHA256.HashData(content)), asset.Sha256, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidDataException("A profile dependency failed integrity validation.");
+            }
+
+            string path = Path.Combine(privateDirectory, Guid.NewGuid().ToString("N") + SafeExtension(asset.RelativePath));
+            paths.Add((asset.Kind, asset.Id), path);
+            using FileStream stream = new(path, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+            stream.Write(content);
+        }
+
+        FoundryConfigurationDocument document = profile.Configuration;
+        return document with
+        {
+            Network = document.Network with
+            {
+                Dot1x = document.Network.Dot1x with
+                {
+                    ProfileTemplatePath = Get(ProfileAssetKind.WiredProfile, "wired-profile"),
+                    CertificatePath = Get(ProfileAssetKind.WiredCertificate, "wired-certificate")
+                },
+                Wifi = document.Network.Wifi with
+                {
+                    EnterpriseProfileTemplatePath = Get(ProfileAssetKind.WifiProfile, "wifi-profile"),
+                    CertificatePath = Get(ProfileAssetKind.WifiCertificate, "wifi-certificate")
+                }
+            },
+            Unattend = document.Unattend with
+            {
+                Files = document.Unattend.Files.Select(file => file with { SourcePath = Get(ProfileAssetKind.Unattend, file.Id) ?? string.Empty }).ToArray()
+            },
+            Autopilot = document.Autopilot with
+            {
+                HardwareHashUpload = document.Autopilot.HardwareHashUpload with
+                {
+                    BootMediaCertificate = document.Autopilot.HardwareHashUpload.BootMediaCertificate with { PfxPath = Get(ProfileAssetKind.AutopilotCertificate, "autopilot-certificate") }
+                }
+            }
+        };
+
+        string? Get(ProfileAssetKind kind, string id) => paths.GetValueOrDefault((kind, id));
+    }
+
+    /// <summary>Clears owned source bytes when an export, activation, or build snapshot ends.</summary>
+    public static void Clear(IEnumerable<DeploymentProfileAsset> assets)
+    {
+        foreach (DeploymentProfileAsset asset in assets)
+        {
+            if (asset.Content is not null)
+            {
+                CryptographicOperations.ZeroMemory(asset.Content);
+            }
+        }
+    }
+
+    private static string SafeExtension(string path) => Path.GetExtension(path).ToLowerInvariant() switch
+    {
+        ".xml" => ".xml",
+        ".pfx" => ".pfx",
+        ".p12" => ".p12",
+        ".cer" => ".cer",
+        ".crt" => ".crt",
+        ".json" => ".json",
+        _ => ".bin"
+    };
+}

--- a/src/Foundry.Core/Services/Profiles/DeploymentProfileMerge.cs
+++ b/src/Foundry.Core/Services/Profiles/DeploymentProfileMerge.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Core.Models.Profiles;
+
+namespace Foundry.Core.Services.Profiles;
+
+/// <summary>Preserves explicitly omitted local values only when their authenticated logical context still matches.</summary>
+public static class DeploymentProfileMerge
+{
+    /// <summary>Returns independent owned buffers. Deletion, unavailable values, and changed contexts never fall back.</summary>
+    public static DeploymentProfileDocument PreserveOmittedLocalValues(DeploymentProfileDocument incoming, DeploymentProfileDocument local)
+    {
+        if (incoming.ProfileId != local.ProfileId)
+            throw new ArgumentException("Local values belong to a different profile.", nameof(local));
+        return incoming with
+        {
+            Secrets = new DeploymentProfileSecrets
+            {
+                Entries = incoming.Secrets.Entries.Select(secret =>
+                {
+                    DeploymentProfileSecret selected = secret;
+                    if (secret.State == ProfileValueState.Omitted)
+                    {
+                        selected = local.Secrets.Entries.SingleOrDefault(candidate => candidate.Purpose == secret.Purpose &&
+                            candidate.Identity == secret.Identity && candidate.State is ProfileValueState.Present or ProfileValueState.Blank) ?? secret;
+                    }
+                    return selected with { Value = selected.Value?.ToArray() };
+                }).ToArray()
+            },
+            Assets = incoming.Assets.Select(asset =>
+            {
+                DeploymentProfileAsset selected = asset;
+                if (asset.State == ProfileValueState.Omitted && asset.Sha256 is not null)
+                {
+                    selected = local.Assets.SingleOrDefault(candidate => candidate.Id == asset.Id && candidate.Kind == asset.Kind &&
+                        candidate.State == ProfileValueState.Present && string.Equals(candidate.Sha256, asset.Sha256, StringComparison.OrdinalIgnoreCase)) ?? asset;
+                }
+                return selected with { Content = selected.Content?.ToArray() };
+            }).ToArray()
+        };
+    }
+}

--- a/src/Foundry.Core/Services/Profiles/DeploymentProfilePackageService.cs
+++ b/src/Foundry.Core/Services/Profiles/DeploymentProfilePackageService.cs
@@ -150,6 +150,8 @@ public sealed class DeploymentProfilePackageService : IDeploymentProfilePackageS
 
     private static void ValidateEnvelope(ReadOnlySpan<byte> package, int mode)
     {
+        if (package.Length >= 10 && package[..8].SequenceEqual(Magic) && package[8] > DeploymentProfileDocument.CurrentFormatVersion)
+            throw new NotSupportedException("The encrypted profile format requires a newer Foundry version.");
         if (package.Length <= PayloadOffset + EncryptionOverhead || package.Length > DeploymentProfilePayload.MaximumPayloadBytes + PayloadOffset + EncryptionOverhead
             || !package[..8].SequenceEqual(Magic) || package[8] != DeploymentProfileDocument.CurrentFormatVersion || package[9] != mode
             || BinaryPrimitives.ReadInt32LittleEndian(package.Slice(10, 4)) != (mode == PassphraseMode ? Iterations : 0))

--- a/src/Foundry.Core/Services/Profiles/DeploymentProfilePayload.cs
+++ b/src/Foundry.Core/Services/Profiles/DeploymentProfilePayload.cs
@@ -48,6 +48,8 @@ internal static class DeploymentProfilePayload
             using JsonDocument json = JsonDocument.Parse(bytes, new() { MaxDepth = 32 });
             ValidateJson(json.RootElement);
             RequireProperties(json.RootElement, "formatVersion", "profileId", "displayName", "configuration", "secrets", "assets");
+            if (json.RootElement.GetProperty("formatVersion").GetInt32() > DeploymentProfileDocument.CurrentFormatVersion)
+                throw new NotSupportedException("The profile payload requires a newer Foundry version.");
             if (json.RootElement.GetProperty("formatVersion").GetInt32() != DeploymentProfileDocument.CurrentFormatVersion)
             {
                 throw new InvalidDataException("The profile payload format is unsupported.");
@@ -55,6 +57,8 @@ internal static class DeploymentProfilePayload
             JsonElement configuration = json.RootElement.GetProperty("configuration");
             RequireProperties(configuration, "schemaVersion");
             int schema = configuration.GetProperty("schemaVersion").GetInt32();
+            if (schema > FoundryConfigurationDocument.CurrentSchemaVersion)
+                throw new NotSupportedException("The profile authoring schema requires a newer Foundry version.");
             if (schema < 1 || schema > FoundryConfigurationDocument.CurrentSchemaVersion)
             {
                 throw new InvalidDataException("The profile authoring schema is unsupported.");
@@ -123,6 +127,7 @@ internal static class DeploymentProfilePayload
         }
         identities.Clear();
         var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var singletonKinds = new HashSet<ProfileAssetKind>();
         long totalBytes = 0;
         foreach (DeploymentProfileAsset asset in profile.Assets)
         {
@@ -130,6 +135,10 @@ internal static class DeploymentProfilePayload
                 || !IsIdentity(asset.Id) || !identities.Add(asset.Id) || !IsSafePath(asset.RelativePath) || !paths.Add(asset.RelativePath))
             {
                 throw new InvalidDataException("The profile asset record is invalid.");
+            }
+            if (asset.Kind is not (ProfileAssetKind.Unattend or ProfileAssetKind.AutopilotProfile) && !singletonKinds.Add(asset.Kind))
+            {
+                throw new InvalidDataException("A selected profile dependency cannot have multiple asset records.");
             }
             if (asset.State == ProfileValueState.Present)
             {

--- a/src/Foundry.Core/Services/Profiles/DeploymentProfileSecretBinding.cs
+++ b/src/Foundry.Core/Services/Profiles/DeploymentProfileSecretBinding.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Models.Profiles;
+
+namespace Foundry.Core.Services.Profiles;
+
+/// <summary>Binds passwords to public configuration identity, independently of local paths and credential targets.</summary>
+public static class DeploymentProfileSecretBinding
+{
+    /// <summary>Hashes only identity metadata. Password values never participate in identifiers or equality markers.</summary>
+    public static string Identity(ProfileSecretPurpose purpose, DeploymentProfileDocument profile, string? accountId = null)
+    {
+        FoundryConfigurationDocument configuration = profile.Configuration;
+        string[] context = purpose switch
+        {
+            ProfileSecretPurpose.DeploymentPassword => ["media-protection"],
+            ProfileSecretPurpose.WifiPassphrase => [configuration.Network.Wifi.Ssid ?? string.Empty, configuration.Network.Wifi.SecurityType ?? string.Empty],
+            ProfileSecretPurpose.AdministratorPassword => ["builtin-administrator"],
+            ProfileSecretPurpose.AdditionalAccountPassword => AccountContext(configuration.Customization.Oobe, accountId),
+            ProfileSecretPurpose.WiredCertificatePassword => [AssetHash(ProfileAssetKind.WiredCertificate)],
+            ProfileSecretPurpose.WifiCertificatePassword => [AssetHash(ProfileAssetKind.WifiCertificate)],
+            ProfileSecretPurpose.AutopilotCertificatePassword => [configuration.Autopilot.HardwareHashUpload.Tenant.TenantId ?? string.Empty,
+                configuration.Autopilot.HardwareHashUpload.Tenant.ClientId ?? string.Empty, AssetHash(ProfileAssetKind.AutopilotCertificate)],
+            _ => throw new ArgumentOutOfRangeException(nameof(purpose))
+        };
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new { purpose, context }))));
+
+        string AssetHash(ProfileAssetKind kind) => profile.Assets.SingleOrDefault(asset => asset.Kind == kind)?.Sha256 ?? "unavailable";
+    }
+
+    /// <summary>Releases all owned plaintext buffers after their session, export, or activation ends.</summary>
+    public static void Clear(DeploymentProfileDocument profile)
+    {
+        foreach (DeploymentProfileSecret secret in profile.Secrets.Entries)
+        {
+            if (secret.Value is not null)
+            {
+                CryptographicOperations.ZeroMemory(secret.Value);
+            }
+        }
+
+        DeploymentProfileAssetService.Clear(profile.Assets);
+    }
+
+    private static string[] AccountContext(OobeSettings settings, string? accountId)
+    {
+        OobeAdditionalAccountSettings account = settings.AdditionalAccounts.Single(account => account.Id == accountId);
+        return [account.Id, account.UserName ?? string.Empty, account.Type.ToString()];
+    }
+}

--- a/src/Foundry/App.xaml.cs
+++ b/src/Foundry/App.xaml.cs
@@ -99,6 +99,7 @@ namespace Foundry
                 MainWindow mainWindow = GetService<MainWindow>();
                 MainWindow = mainWindow;
                 mainWindow.Closed += OnMainWindowClosed;
+                mainWindow.AppWindow.Closing += OnMainWindowClosing;
 
                 mainWindow.Title = mainWindow.AppWindow.Title = FoundryApplicationInfo.AppNameAndVersion;
                 mainWindow.AppWindow.SetIcon("Assets/AppIcon.ico");
@@ -118,6 +119,7 @@ namespace Foundry
 
         private static async Task InitializeAppAsync()
         {
+            await GetService<DeploymentProfileCoordinator>().InitializeAsync();
             await GetService<IStartupReadinessService>().InitializeAsync();
             await TrackDailyActiveAsync();
             AppLogger.Information("Foundry WinUI startup completed.");
@@ -159,6 +161,49 @@ namespace Foundry
         private static void OnWinUiUnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
         {
             AppLogger.Fatal(e.Exception, "Unhandled WinUI exception.");
+        }
+
+        private bool closeApproved;
+        private bool closePending;
+
+        private async void OnMainWindowClosing(Microsoft.UI.Windowing.AppWindow sender, Microsoft.UI.Windowing.AppWindowClosingEventArgs args)
+        {
+            if (closeApproved) return;
+            args.Cancel = true;
+            if (GetService<IShellNavigationGuardService>().State is ShellNavigationState.OperationRunning or ShellNavigationState.InteractionPending) return;
+            if (closePending) return;
+            closePending = true;
+            try
+            {
+                var coordinator = GetService<DeploymentProfileCoordinator>();
+                using (coordinator.SuspendActivation())
+                {
+                    bool saved;
+                    try { saved = await coordinator.FlushBeforeCloseAsync().WaitAsync(TimeSpan.FromSeconds(10)); }
+                    catch (TimeoutException) { saved = false; }
+                    if (!saved)
+                    {
+                        var localization = GetService<Foundry.Services.Localization.IApplicationLocalizationService>();
+                        var dialog = new ContentDialog
+                        {
+                            XamlRoot = ((FrameworkElement)MainWindow.Content).XamlRoot,
+                            Title = localization.GetString("Profiles.Heading"),
+                            Content = localization.GetString(coordinator.StatusKey == "Profiles.Incomplete" ? "Profiles.Incomplete" : "Profiles.Failed"),
+                            PrimaryButtonText = localization.GetString("Common.Close"),
+                            CloseButtonText = localization.GetString("Common.Cancel"),
+                            DefaultButton = ContentDialogButton.Close
+                        };
+                        if (await dialog.ShowAsync() != ContentDialogResult.Primary) return;
+                    }
+                }
+                closeApproved = true;
+                MainWindow.Close();
+            }
+            catch (Exception ex)
+            {
+                AppLogger.Warning(ex, "Unable to finish saving the active profile before closing.");
+            }
+            finally { closePending = false; }
         }
 
         private void OnMainWindowClosed(object sender, WindowEventArgs args)

--- a/src/Foundry/Common/Constants.cs
+++ b/src/Foundry/Common/Constants.cs
@@ -39,7 +39,9 @@ namespace Foundry.Common
         public static readonly string OperatingSystemCacheDirectoryPath = Path.Combine(CacheDirectoryPath, "OperatingSystems");
         public static readonly string ToolCacheDirectoryPath = Path.Combine(CacheDirectoryPath, "Tools");
         public static readonly string WorkspacesDirectoryPath = Path.Combine(RootDirectoryPath, "Workspaces");
-        public static readonly string ConfigurationWorkspaceDirectoryPath = Path.Combine(WorkspacesDirectoryPath, "Configuration");
+        public static readonly string ConfigurationWorkspaceDirectoryPath = Path.Combine(UserRootDirectoryPath, "Configuration");
+        public static readonly string DeploymentProfilesDirectoryPath = Path.Combine(UserRootDirectoryPath, "Profiles");
+        public static readonly string LegacyFoundryConfigurationStatePath = Path.Combine(WorkspacesDirectoryPath, "Configuration", "foundry.config.json");
         public static readonly string WinPeWorkspaceDirectoryPath = Path.Combine(WorkspacesDirectoryPath, "WinPe");
         public static readonly string IsoWorkspaceDirectoryPath = Path.Combine(WorkspacesDirectoryPath, "Iso");
         public static readonly string TempDirectoryPath = Path.Combine(RootDirectoryPath, "Temp");

--- a/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Foundry/DependencyInjection/ServiceCollectionExtensions.cs
@@ -123,6 +123,13 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IOobeAccountSecretStateService, OobeAccountSecretStateService>();
         services.AddSingleton<IOobeAdditionalAccountDialogService, OobeAdditionalAccountDialogService>();
         services.AddSingleton<IFoundryConfigurationStateService, FoundryConfigurationStateService>();
+        services.AddSingleton<Foundry.Core.Services.Profiles.IDeploymentProfilePackageService, Foundry.Core.Services.Profiles.DeploymentProfilePackageService>();
+        services.AddSingleton(sp => new Foundry.Core.Services.Profiles.LocalDeploymentProfileRepository(
+            Constants.DeploymentProfilesDirectoryPath,
+            sp.GetRequiredService<Foundry.Utilities.Security.IWindowsCredentialStore>(),
+            sp.GetRequiredService<Foundry.Core.Services.Profiles.IDeploymentProfilePackageService>()));
+        services.AddSingleton<DeploymentProfileSessionService>();
+        services.AddSingleton<DeploymentProfileCoordinator>();
         services.AddSingleton<IWinPeLanguageDiscoveryService, WinPeLanguageDiscoveryService>();
         services.AddSingleton<IConfigurationOverviewService, ConfigurationOverviewService>();
         services.AddSingleton<IWinPeEmbeddedAssetService, WinPeEmbeddedAssetService>();
@@ -159,6 +166,10 @@ public static class ServiceCollectionExtensions
         services.AddTransient<StartMediaViewModel>();
         services.AddTransient<HomeLandingViewModel>();
         services.AddTransient<SettingsPageViewModel>();
+        services.AddTransient(provider => new DeploymentProfilesViewModel(
+            provider.GetRequiredService<DeploymentProfileCoordinator>(),
+            provider.GetRequiredService<IApplicationLocalizationService>(),
+            provider.GetRequiredService<IFilePickerService>()));
         services.AddTransient<GeneralSettingViewModel>();
         services.AddTransient<AdkPageViewModel>();
         services.AddTransient<AppUpdateSettingViewModel>();

--- a/src/Foundry/Services/Configuration/DeploymentProfileCoordinator.Staging.cs
+++ b/src/Foundry/Services/Configuration/DeploymentProfileCoordinator.Staging.cs
@@ -1,0 +1,169 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.AccessControl;
+using System.Security.Principal;
+
+namespace Foundry.Services.Configuration;
+
+public sealed partial class DeploymentProfileCoordinator
+{
+    private const string StagingLeaseFileName = ".lease";
+    private readonly List<StagingLease> stagingDirectories = [];
+    private static string StagingRoot => Path.Combine(Constants.DeploymentProfilesDirectoryPath, "Staging");
+
+    private string CreateStagingDirectory()
+    {
+        using FileStream rootLease = AcquireStagingRootLease();
+        CleanupAbandonedStagingDirectoriesCore();
+        string directory = Path.Combine(StagingRoot, Guid.NewGuid().ToString("N"));
+        CreatePrivateDirectory(directory);
+        FileStream lease = OpenStagingLease(directory);
+        stagingDirectories.Add(new StagingLease(directory, lease));
+        return directory;
+    }
+
+    private void CleanupAbandonedStagingDirectories()
+    {
+        try
+        {
+            using FileStream rootLease = AcquireStagingRootLease();
+            CleanupAbandonedStagingDirectoriesCore();
+        }
+        catch (Exception exception) when (IsStagingCleanupFailure(exception)) { }
+    }
+
+    private static void CleanupAbandonedStagingDirectoriesCore()
+    {
+        foreach (string directory in Directory.EnumerateDirectories(StagingRoot).Take(1024))
+        {
+            if (!Guid.TryParseExact(Path.GetFileName(directory), "N", out _)) continue;
+            try
+            {
+                ValidateStagingDirectory(directory);
+                using FileStream lease = OpenStagingLease(directory);
+                DeleteStagingContents(directory);
+                lease.Dispose();
+                File.Delete(Path.Combine(directory, StagingLeaseFileName));
+                Directory.Delete(directory, false);
+            }
+            catch (Exception exception) when (IsStagingCleanupFailure(exception)) { }
+        }
+    }
+
+    private void ClearStagingDirectories(bool releaseFailedLeases = false)
+    {
+        try
+        {
+            using FileStream rootLease = AcquireStagingRootLease();
+            foreach (StagingLease entry in stagingDirectories.ToArray())
+            {
+                try
+                {
+                    if (Directory.Exists(entry.Path))
+                    {
+                        ValidateStagingDirectory(entry.Path);
+                        entry.Lease ??= OpenStagingLease(entry.Path);
+                        DeleteStagingContents(entry.Path);
+                        entry.Lease.Dispose();
+                        entry.Lease = null;
+                        File.Delete(Path.Combine(entry.Path, StagingLeaseFileName));
+                        Directory.Delete(entry.Path, false);
+                    }
+                    entry.Lease?.Dispose();
+                    stagingDirectories.Remove(entry);
+                }
+                catch (Exception exception) when (IsStagingCleanupFailure(exception)) { }
+            }
+        }
+        catch (Exception exception) when (IsStagingCleanupFailure(exception)) { }
+        finally
+        {
+            if (releaseFailedLeases)
+            {
+                foreach (StagingLease entry in stagingDirectories)
+                {
+                    entry.Lease?.Dispose();
+                    entry.Lease = null;
+                }
+            }
+        }
+    }
+
+    private static FileStream AcquireStagingRootLease()
+    {
+        ValidateNoReparseAncestors(StagingRoot);
+        CreatePrivateDirectory(StagingRoot);
+        string path = Path.Combine(StagingRoot, ".cleanup-lock");
+        ValidateNoReparseAncestors(path);
+        return new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+    }
+
+    private static FileStream OpenStagingLease(string directory)
+    {
+        ValidateStagingDirectory(directory);
+        string path = Path.Combine(directory, StagingLeaseFileName);
+        ValidateNoReparseAncestors(path);
+        return new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+    }
+
+    private static void DeleteStagingContents(string directory)
+    {
+        ValidateStagingDirectory(directory);
+        // Materialized profile assets are flat. Never descend into an unexpected directory or link.
+        foreach (string path in Directory.EnumerateFileSystemEntries(directory))
+        {
+            if (Path.GetFileName(path) == StagingLeaseFileName) continue;
+            ValidateNoReparseAncestors(path);
+            if ((File.GetAttributes(path) & FileAttributes.Directory) != 0)
+                throw new IOException("A profile staging directory contains an unexpected subdirectory.");
+            File.Delete(path);
+        }
+    }
+
+    private static void ValidateStagingDirectory(string directory)
+    {
+        string fullPath = Path.GetFullPath(directory);
+        if (!string.Equals(Path.GetDirectoryName(fullPath), Path.GetFullPath(StagingRoot), StringComparison.OrdinalIgnoreCase) ||
+            !Guid.TryParseExact(Path.GetFileName(fullPath), "N", out _))
+            throw new IOException("The profile staging path is outside its owned directory.");
+        ValidateNoReparseAncestors(fullPath);
+    }
+
+    private static void ValidateNoReparseAncestors(string path)
+    {
+        for (string? current = Path.GetFullPath(path); current is not null; current = Path.GetDirectoryName(current))
+        {
+            try
+            {
+                if ((File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
+                    throw new IOException("Profile staging cannot use a redirected path.");
+            }
+            catch (FileNotFoundException) { }
+            catch (DirectoryNotFoundException) { }
+        }
+    }
+
+    private static void CreatePrivateDirectory(string path)
+    {
+        using WindowsIdentity identity = WindowsIdentity.GetCurrent();
+        var security = new DirectorySecurity();
+        security.SetAccessRuleProtection(true, false);
+        security.AddAccessRule(new FileSystemAccessRule(
+            identity.User ?? throw new InvalidOperationException("The current Windows user is unavailable."),
+            FileSystemRights.FullControl, InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+            PropagationFlags.None, AccessControlType.Allow));
+        var directory = new DirectoryInfo(path);
+        directory.Create(security);
+        directory.SetAccessControl(security);
+    }
+
+    private static bool IsStagingCleanupFailure(Exception exception) => exception is IOException or UnauthorizedAccessException;
+
+    private sealed class StagingLease(string path, FileStream lease)
+    {
+        public string Path { get; } = path;
+        public FileStream? Lease { get; set; } = lease;
+    }
+}

--- a/src/Foundry/Services/Configuration/DeploymentProfileCoordinator.Sync.cs
+++ b/src/Foundry/Services/Configuration/DeploymentProfileCoordinator.Sync.cs
@@ -1,0 +1,430 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Foundry.Core.Models.Profiles;
+using Foundry.Core.Services.Profiles;
+using Foundry.Services.Shell;
+using Foundry.Utilities.Security;
+
+namespace Foundry.Services.Configuration;
+
+public sealed partial class DeploymentProfileCoordinator
+{
+    private Guid? conflictRevision;
+
+    public async Task CreateSharedAsync(string rootPath, bool includeSecrets, bool rememberKey)
+    {
+        EnsureCanActivate();
+        ValidateSharedPath(rootPath);
+        await gate.WaitAsync(lifetime.Token);
+        try
+        {
+            LocalProfileDescriptor current = RequireActive();
+            byte[] key = RandomNumberGenerator.GetBytes(32);
+            try
+            {
+                LocalProfileEnrollment enrollment = new()
+                {
+                    RootPath = rootPath,
+                    RepositoryId = Guid.NewGuid(),
+                    ProfileId = current.ProfileId,
+                    KeyEpoch = 1,
+                    IsDirty = true,
+                    IsEnabled = true,
+                    IncludeSecrets = includeSecrets,
+                    RememberSharedKey = rememberKey
+                };
+                using SharedProfileRepository remote = OpenRemote(enrollment, key);
+                RequireSuccess(await remote.InitializeAsync(lifetime.Token));
+                await SaveCurrentAsync(enrollment: enrollment, sharedKey: key);
+                ClearSharedKey();
+                sessionSharedKey = key.ToArray();
+            }
+            finally { CryptographicOperations.ZeroMemory(key); }
+        }
+        finally { gate.Release(); }
+
+        await SynchronizeAsync();
+    }
+
+    /// <summary>Exports the shared key only into an explicitly requested passphrase-protected recovery package.</summary>
+    public async Task ExportRecoveryAsync(string path, string passphrase)
+    {
+        LocalProfileDescriptor current = RequireActive();
+        LocalProfileEnrollment enrollment = current.Enrollment ?? throw new InvalidOperationException("The profile is not shared.");
+        string absolute = Path.GetFullPath(path);
+        string sharedRoot = Path.GetFullPath(enrollment.RootPath).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        if (absolute.StartsWith(sharedRoot, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("Store the recovery package outside the shared repository.");
+        byte[] key = await GetSharedKeyAsync();
+        DeploymentProfileDocument profile = await session.CaptureAsync(current.ProfileId, current.DisplayName, enrollment.IncludeSecrets);
+        try
+        {
+            var invitation = new SharedInvitation(1, enrollment.RepositoryId, current.ProfileId, enrollment.KeyEpoch, enrollment.IncludeSecrets, Convert.ToBase64String(key));
+            DeploymentProfileSecret recovery = new()
+            {
+                Purpose = ProfileSecretPurpose.SharedProfileKey,
+                Identity = "shared-enrollment",
+                State = ProfileValueState.Present,
+                Value = JsonSerializer.SerializeToUtf8Bytes(invitation)
+            };
+            profile = profile with { Secrets = new DeploymentProfileSecrets { Entries = profile.Secrets.Entries.Append(recovery).ToArray() } };
+            await WriteAtomicAsync(path, await Task.Run(() => packages.Export(profile, passphrase.AsSpan())));
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(key);
+            DeploymentProfileSecretBinding.Clear(profile);
+        }
+    }
+
+    public async Task JoinSharedAsync(DeploymentProfileDocument invitationProfile, string rootPath, bool rememberSecrets, bool rememberKey)
+    {
+        EnsureCanActivate();
+        ValidateSharedPath(rootPath);
+        DeploymentProfileSecret record = invitationProfile.Secrets.Entries.Single(secret => secret.Purpose == ProfileSecretPurpose.SharedProfileKey);
+        SharedInvitation invitation = JsonSerializer.Deserialize<SharedInvitation>(record.Value!) ?? throw new InvalidDataException("Invalid recovery package.");
+        if (invitation.FormatVersion != 1 || invitation.RepositoryId == Guid.Empty || invitation.ProfileId != invitationProfile.ProfileId || invitation.KeyEpoch < 1)
+            throw new InvalidDataException("Invalid recovery identity.");
+        byte[] key = Convert.FromBase64String(invitation.Key);
+        if (key.Length != 32) throw new InvalidDataException("Invalid recovery key.");
+        await gate.WaitAsync(lifetime.Token);
+        try
+        {
+            if (Active is not null && editVersion != persistedEditVersion) await SaveCurrentAsync();
+            long version = editVersion;
+            LocalProfileEnrollment enrollment = new()
+            {
+                RootPath = rootPath,
+                RepositoryId = invitation.RepositoryId,
+                ProfileId = invitation.ProfileId,
+                KeyEpoch = invitation.KeyEpoch,
+                RememberSharedKey = rememberKey,
+                IsEnabled = true,
+                IncludeSecrets = invitation.IncludeSecrets
+            };
+            using SharedProfileRepository remote = OpenRemote(enrollment, key);
+            SharedProfileRepositoryResult result = await remote.LoadAsync(cancellationToken: lifetime.Token);
+            RequireSuccess(result);
+            SharedProfileSnapshot head = result.Snapshot ?? throw new InvalidDataException("The shared profile has no revision.");
+            if (head.Head.IsTombstone) throw new InvalidDataException("The shared profile was deleted.");
+            DeploymentProfileDocument profile = packages.Decrypt(head.EncryptedPayload, key, ProfilePackagePurpose.SharedRevision, SharedContext(enrollment));
+            try
+            {
+                if (profile.ProfileId != enrollment.ProfileId) throw new InvalidDataException("The shared profile identity does not match.");
+                enrollment = enrollment with { KnownRevisionId = head.Head.RevisionId };
+                string directory = CreateStagingDirectory();
+                var materialized = await Task.Run(() => DeploymentProfileAssetService.Materialize(profile, directory));
+                materialized = materialized with
+                {
+                    General = materialized.General with { IsoOutputPath = configuration.Current.General.IsoOutputPath },
+                    Telemetry = configuration.Current.Telemetry
+                };
+                profile = profile with { Configuration = materialized };
+                if (rememberSecrets) EnsureCompleteCheckpoint(profile);
+                EnsureUnchanged(version);
+                LocalProfileDescriptor descriptor = local.Save(Guid.NewGuid(), profile, rememberSecrets, null, enrollment, rememberKey ? key : null);
+                applying = true;
+                session.Activate(profile, materialized);
+                Active = descriptor;
+                persistedEditVersion = editVersion;
+                local.SetActive(descriptor.LocalId);
+                ClearSharedKey();
+                sessionSharedKey = key.ToArray();
+                HasConflict = false;
+                await RefreshAsync();
+            }
+            finally { DeploymentProfileSecretBinding.Clear(profile); }
+        }
+        finally
+        {
+            applying = false;
+            CryptographicOperations.ZeroMemory(key);
+            gate.Release();
+        }
+    }
+
+    public async Task SetSynchronizationEnabledAsync(bool enabled)
+    {
+        await gate.WaitAsync(lifetime.Token);
+        try
+        {
+            LocalProfileEnrollment enrollment = RequireActive().Enrollment ?? throw new InvalidOperationException("The profile is not shared.");
+            await SaveCurrentAsync(enrollment: enrollment with { IsEnabled = enabled });
+        }
+        finally { gate.Release(); }
+    }
+
+    public Task SynchronizeAsync() => SynchronizeAsync(false);
+
+    private async Task SynchronizeAsync(bool automatic)
+    {
+        if (Active?.Enrollment is not { } enrollment || automatic && !enrollment.IsEnabled ||
+            navigationGuard.State == ShellNavigationState.OperationRunning ||
+            navigationGuard.State == ShellNavigationState.InteractionPending && (automatic || !ownsNavigationGuard)) return;
+        if (automatic && Environment.TickCount64 - lastEditTick < 2000) return;
+        if (!await gate.WaitAsync(0)) return;
+        try
+        {
+            await SynchronizeCoreAsync(automatic);
+        }
+        catch (Exception ex) when (IsProfileFailure(ex)) { SetFailure(ex); }
+        finally { gate.Release(); }
+    }
+
+    private async Task SynchronizeCoreAsync(bool automatic)
+    {
+        LocalProfileDescriptor current = RequireActive();
+        LocalProfileEnrollment enrollment = current.Enrollment!;
+        byte[] key = await GetSharedKeyAsync();
+        try
+        {
+            using SharedProfileRepository remote = OpenRemote(enrollment, key);
+            SharedProfileRepositoryResult result = await remote.LoadAsync(enrollment.KnownRevisionId, lifetime.Token);
+            if (result.Status != SharedProfileRepositoryStatus.Success) { SetRemoteStatus(result.Status); return; }
+
+            if (enrollment.PendingOperationId is Guid operationId)
+            {
+                SharedProfileRepositoryResult reconciliation = await remote.ReconcileAsync(operationId, enrollment.KnownRevisionId, lifetime.Token);
+                if (reconciliation.Status == SharedProfileRepositoryStatus.Success)
+                {
+                    enrollment = enrollment with { KnownRevisionId = reconciliation.CommittedRevisionId, PendingOperationId = null, IsDirty = true };
+                    await SaveCurrentAsync(enrollment: enrollment);
+                    File.Delete(OutboxPath(current.LocalId, operationId));
+                    result = await remote.LoadAsync(enrollment.KnownRevisionId, lifetime.Token);
+                    if (result.Status != SharedProfileRepositoryStatus.Success) { SetRemoteStatus(result.Status); return; }
+                }
+                else if (reconciliation.Status == SharedProfileRepositoryStatus.NotCommitted)
+                {
+                    byte[] pending = await ReadBoundedAsync(OutboxPath(current.LocalId, operationId), 16 * 1024 * 1024 + 118);
+                    result = await remote.PublishAsync(pending, enrollment.KnownRevisionId, operationId, lifetime.Token);
+                    if (result.Status != SharedProfileRepositoryStatus.Success) { SetRemoteStatus(result.Status, result.Snapshot); return; }
+                    enrollment = enrollment with { KnownRevisionId = result.CommittedRevisionId, PendingOperationId = null, IsDirty = true };
+                    await SaveCurrentAsync(enrollment: enrollment);
+                    File.Delete(OutboxPath(current.LocalId, operationId));
+                }
+                else { SetRemoteStatus(reconciliation.Status); return; }
+            }
+
+            if (result.Snapshot?.Head.IsTombstone == true)
+            {
+                HasConflict = true;
+                conflictRevision = result.Snapshot.Head.RevisionId;
+                StatusKey = "Profiles.DeletedRemote";
+                Changed?.Invoke(this, EventArgs.Empty);
+                return;
+            }
+
+            bool remoteChanged = result.Snapshot?.Head.RevisionId != enrollment.KnownRevisionId;
+            bool dirty = enrollment.IsDirty || editVersion != persistedEditVersion;
+            if (remoteChanged && dirty) { SetRemoteStatus(SharedProfileRepositoryStatus.Conflict, result.Snapshot); return; }
+            if (remoteChanged && result.Snapshot is not null)
+            {
+                if (automatic && (!IsSettingsOpen || activationSuspensions > 0))
+                {
+                    StatusKey = "Profiles.UpdateAvailable";
+                    Changed?.Invoke(this, EventArgs.Empty);
+                    return;
+                }
+                await AcceptRemoteAsync(result.Snapshot, enrollment, key, automatic);
+            }
+            else if (dirty)
+            {
+                await PublishCurrentAsync(remote, enrollment, key);
+            }
+            else
+            {
+                StatusKey = "Profiles.Synchronized";
+                Changed?.Invoke(this, EventArgs.Empty);
+            }
+        }
+        finally { CryptographicOperations.ZeroMemory(key); }
+    }
+
+    private async Task PublishCurrentAsync(SharedProfileRepository remote, LocalProfileEnrollment enrollment, byte[] key)
+    {
+        LocalProfileDescriptor current = RequireActive();
+        long version = editVersion;
+        DeploymentProfileDocument profile = await session.CaptureAsync(current.ProfileId, current.DisplayName, enrollment.IncludeSecrets);
+        try
+        {
+            if (enrollment.IncludeSecrets) EnsureCompleteCheckpoint(profile);
+            byte[] payload = await Task.Run(() => packages.Encrypt(profile, key, ProfilePackagePurpose.SharedRevision, SharedContext(enrollment)));
+            Guid operationId = Guid.NewGuid();
+            await WriteAtomicAsync(OutboxPath(current.LocalId, operationId), payload);
+            await SaveCurrentAsync(enrollment: enrollment with { PendingOperationId = operationId, IsDirty = true });
+            SharedProfileRepositoryResult result = await remote.PublishAsync(payload, enrollment.KnownRevisionId, operationId, lifetime.Token);
+            if (result.Status != SharedProfileRepositoryStatus.Success) { SetRemoteStatus(result.Status, result.Snapshot); return; }
+            await SaveCurrentAsync(enrollment: enrollment with
+            {
+                KnownRevisionId = result.CommittedRevisionId,
+                PendingOperationId = null,
+                IsDirty = editVersion != version
+            });
+            File.Delete(OutboxPath(current.LocalId, operationId));
+            HasConflict = false;
+            StatusKey = "Profiles.Synchronized";
+            Changed?.Invoke(this, EventArgs.Empty);
+        }
+        finally { DeploymentProfileSecretBinding.Clear(profile); }
+    }
+
+    public async Task ResolveConflictAsync(bool useRemote)
+    {
+        EnsureCanActivate();
+        await gate.WaitAsync(lifetime.Token);
+        try
+        {
+            LocalProfileEnrollment enrollment = RequireActive().Enrollment ?? throw new InvalidOperationException("The profile is not shared.");
+            byte[] key = await GetSharedKeyAsync();
+            try
+            {
+                using SharedProfileRepository remote = OpenRemote(enrollment, key);
+                SharedProfileRepositoryResult result = await remote.LoadAsync(enrollment.KnownRevisionId, lifetime.Token);
+                RequireSuccess(result);
+                if (result.Snapshot?.Head.RevisionId != conflictRevision)
+                {
+                    SetRemoteStatus(SharedProfileRepositoryStatus.Conflict, result.Snapshot);
+                    return;
+                }
+                SharedProfileSnapshot snapshot = result.Snapshot ?? throw new InvalidDataException("The shared revision is missing.");
+                if (snapshot.Head.IsTombstone) throw new InvalidOperationException("Save the local profile as a copy to preserve your changes.");
+                if (useRemote) await AcceptRemoteAsync(snapshot, enrollment, key);
+                else
+                {
+                    enrollment = enrollment with { KnownRevisionId = snapshot.Head.RevisionId, PendingOperationId = null, IsDirty = true };
+                    await SaveCurrentAsync(enrollment: enrollment);
+                    await PublishCurrentAsync(remote, enrollment, key);
+                }
+            }
+            finally { CryptographicOperations.ZeroMemory(key); }
+        }
+        finally { gate.Release(); }
+    }
+
+    private async Task AcceptRemoteAsync(SharedProfileSnapshot snapshot, LocalProfileEnrollment enrollment, byte[] key, bool automatic = false)
+    {
+        EnsureCanActivate();
+        LocalProfileDescriptor current = RequireActive();
+        long version = editVersion;
+        DeploymentProfileDocument profile = packages.Decrypt(snapshot.EncryptedPayload, key, ProfilePackagePurpose.SharedRevision, SharedContext(enrollment));
+        try
+        {
+            if (profile.ProfileId != enrollment.ProfileId) throw new InvalidDataException("The shared profile identity does not match.");
+            DeploymentProfileDocument localProfile = await session.CaptureAsync(current.ProfileId, current.DisplayName, true);
+            try
+            {
+                DeploymentProfileDocument merged = DeploymentProfileMerge.PreserveOmittedLocalValues(profile, localProfile);
+                DeploymentProfileSecretBinding.Clear(profile);
+                profile = merged;
+            }
+            finally { DeploymentProfileSecretBinding.Clear(localProfile); }
+            string directory = CreateStagingDirectory();
+            var document = await Task.Run(() => DeploymentProfileAssetService.Materialize(profile, directory));
+            if (version != editVersion) { SetRemoteStatus(SharedProfileRepositoryStatus.Conflict, snapshot); return; }
+            if (automatic && (!IsSettingsOpen || activationSuspensions > 0 || navigationGuard.State == ShellNavigationState.OperationRunning)) return;
+            document = document with
+            {
+                General = document.General with
+                {
+                    IsoOutputPath = configuration.Current.General.IsoOutputPath,
+                    CustomDriverDirectoryPath = configuration.Current.General.CustomDriverDirectoryPath
+                },
+                Telemetry = configuration.Current.Telemetry
+            };
+            profile = profile with { Configuration = document };
+            if (current.RememberSecrets) EnsureCompleteCheckpoint(profile);
+            enrollment = enrollment with { KnownRevisionId = snapshot.Head.RevisionId, PendingOperationId = null, IsDirty = false };
+            LocalProfileDescriptor descriptor = local.Save(current.LocalId, profile, current.RememberSecrets, current.Revision, enrollment);
+            applying = true;
+            try { session.Activate(profile, document); }
+            catch
+            {
+                Active = null;
+                ClearSharedKey();
+                debounce?.Cancel();
+                throw;
+            }
+            Active = descriptor;
+            persistedEditVersion = editVersion;
+            HasConflict = false;
+            await RefreshAsync();
+        }
+        finally
+        {
+            applying = false;
+            DeploymentProfileSecretBinding.Clear(profile);
+        }
+    }
+
+    private async Task<byte[]> GetSharedKeyAsync()
+    {
+        if (sessionSharedKey is not null) return sessionSharedKey.ToArray();
+        LocalProfileDescriptor current = RequireActive();
+        using WindowsCredential? credential = await Task.Run(() => local.ReadSharedKey(current.LocalId));
+        return credential?.Secret.ToArray() ?? throw new LocalProfileLockedException(current.LocalId);
+    }
+
+    private async Task PollAsync()
+    {
+        using PeriodicTimer timer = new(TimeSpan.FromSeconds(30));
+        try
+        {
+            while (await timer.WaitForNextTickAsync(lifetime.Token))
+            {
+                Task? synchronization = null;
+                await dispatcher.EnqueueAsync(() => synchronization = SynchronizeAsync(true));
+                await synchronization!;
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    private static SharedProfileRepository OpenRemote(LocalProfileEnrollment enrollment, byte[] key) =>
+        new(enrollment.RootPath, enrollment.RepositoryId, enrollment.ProfileId, enrollment.KeyEpoch, key,
+            new SharedProfileRepositoryOptions { MaximumPayloadBytes = 16 * 1024 * 1024 + 118, MaximumHistoryCount = 4096 });
+
+    private static byte[] SharedContext(LocalProfileEnrollment enrollment) =>
+        Encoding.UTF8.GetBytes($"{enrollment.RepositoryId:N}/{enrollment.ProfileId:N}/{enrollment.KeyEpoch}");
+
+    private static string OutboxPath(Guid localId, Guid operationId)
+    {
+        string directory = Path.Combine(Constants.DeploymentProfilesDirectoryPath, "Outbox", localId.ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, operationId.ToString("N") + ".profile");
+    }
+
+    private static void ValidateSharedPath(string path)
+    {
+        if (!path.StartsWith(@"\\", StringComparison.Ordinal) || path.StartsWith(@"\\?", StringComparison.Ordinal) || path.StartsWith(@"\\.", StringComparison.Ordinal))
+            throw new ArgumentException("Select an authenticated SMB shared folder using its UNC path.");
+    }
+
+    private static void RequireSuccess(SharedProfileRepositoryResult result)
+    {
+        if (result.Status == SharedProfileRepositoryStatus.UnsupportedFormat) throw new NotSupportedException("The shared profile format is unsupported.");
+        if (result.Status != SharedProfileRepositoryStatus.Success) throw new IOException("The shared profile operation could not be completed.");
+    }
+
+    private void SetRemoteStatus(SharedProfileRepositoryStatus status, SharedProfileSnapshot? snapshot = null)
+    {
+        HasConflict = status == SharedProfileRepositoryStatus.Conflict;
+        if (HasConflict) conflictRevision = snapshot?.Head.RevisionId;
+        StatusKey = status switch
+        {
+            SharedProfileRepositoryStatus.Conflict => "Profiles.Conflict",
+            SharedProfileRepositoryStatus.Busy or SharedProfileRepositoryStatus.Unavailable => "Profiles.Offline",
+            SharedProfileRepositoryStatus.RollbackDetected => "Profiles.Rollback",
+            SharedProfileRepositoryStatus.HistoryLimitExceeded => "Profiles.HistoryLimit",
+            SharedProfileRepositoryStatus.UnsupportedFormat => "Profiles.Unsupported",
+            _ => "Profiles.Failed"
+        };
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    private sealed record SharedInvitation(int FormatVersion, Guid RepositoryId, Guid ProfileId, int KeyEpoch, bool IncludeSecrets, string Key);
+}

--- a/src/Foundry/Services/Configuration/DeploymentProfileCoordinator.cs
+++ b/src/Foundry/Services/Configuration/DeploymentProfileCoordinator.cs
@@ -1,0 +1,567 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+using Foundry.Core.Models.Profiles;
+using Foundry.Core.Services.Application;
+using Foundry.Core.Services.Profiles;
+using Foundry.Services.Shell;
+
+namespace Foundry.Services.Configuration;
+
+/// <summary>Coordinates local profile commits, activation, and background synchronization on the desktop dispatcher.</summary>
+public sealed partial class DeploymentProfileCoordinator : IDisposable
+{
+    private readonly LocalDeploymentProfileRepository local;
+    private readonly IDeploymentProfilePackageService packages;
+    private readonly DeploymentProfileSessionService session;
+    private readonly IFoundryConfigurationStateService configuration;
+    private readonly IAppDispatcher dispatcher;
+    private readonly IShellNavigationGuardService navigationGuard;
+    private readonly SemaphoreSlim gate = new(1, 1);
+    private readonly CancellationTokenSource lifetime = new();
+    private CancellationTokenSource? debounce;
+    private byte[]? sessionSharedKey;
+    private bool applying;
+    private bool initialized;
+    private long editVersion;
+    private long persistedEditVersion;
+    private long lastEditTick;
+    private Foundry.Core.Models.Configuration.FoundryConfigurationDocument? observedConfiguration;
+    private int activationSuspensions;
+    private ShellNavigationState suspendedNavigationState;
+    private bool ownsNavigationGuard;
+
+    public bool IsSettingsOpen { get; set; }
+
+    /// <summary>Defers automatic activation while the Settings card is collecting an operator decision.</summary>
+    public IDisposable SuspendActivation()
+    {
+        if (activationSuspensions > 0) throw new InvalidOperationException("Another profile interaction is already active.");
+        if (activationSuspensions == 0)
+        {
+            EnsureCanActivate();
+            suspendedNavigationState = navigationGuard.State;
+            ownsNavigationGuard = true;
+            navigationGuard.SetState(ShellNavigationState.InteractionPending);
+        }
+        activationSuspensions++;
+        return new ActivationSuspension(this);
+    }
+
+    public DeploymentProfileCoordinator(LocalDeploymentProfileRepository local, IDeploymentProfilePackageService packages,
+        DeploymentProfileSessionService session, IFoundryConfigurationStateService configuration,
+        IAppDispatcher dispatcher, IShellNavigationGuardService navigationGuard,
+        INetworkSecretStateService network, IDeploymentProtectionSecretStateService deployment, IOobeAccountSecretStateService accounts)
+    {
+        this.local = local;
+        this.packages = packages;
+        this.session = session;
+        this.configuration = configuration;
+        observedConfiguration = configuration.Current;
+        this.dispatcher = dispatcher;
+        this.navigationGuard = navigationGuard;
+        configuration.StateChanged += OnEdited;
+        network.Changed += OnEdited;
+        deployment.Changed += OnEdited;
+        accounts.Changed += OnEdited;
+    }
+
+    public event EventHandler? Changed;
+    public LocalProfileDescriptor? Active { get; private set; }
+    public IReadOnlyList<LocalProfileDescriptor> Profiles { get; private set; } = [];
+    public string StatusKey { get; private set; } = "Profiles.Ready";
+    public bool HasConflict { get; private set; }
+
+    /// <summary>Restores only this Windows user's selected local profile, preserving locked or incompatible data.</summary>
+    public async Task InitializeAsync()
+    {
+        if (initialized) return;
+        initialized = true;
+        try
+        {
+            await Task.Run(CleanupAbandonedStagingDirectories);
+            Profiles = await Task.Run(local.List);
+            Guid? selected = await Task.Run(local.GetActive);
+            if (selected is Guid id)
+            {
+                await ActivateAsync(id);
+            }
+            else if (Profiles.Count == 0)
+            {
+                await SaveAsCopyAsync("Default");
+            }
+        }
+        catch (Exception ex) when (IsProfileFailure(ex))
+        {
+            SetFailure(ex);
+        }
+
+        _ = PollAsync();
+    }
+
+    public async Task SaveAsync(bool? rememberSecrets = null)
+    {
+        await gate.WaitAsync(lifetime.Token);
+        try
+        {
+            await SaveCurrentAsync(rememberSecrets);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <summary>Flushes the latest draft before the window closes, leaving an incomplete checkpoint unchanged.</summary>
+    public async Task<bool> FlushBeforeCloseAsync()
+    {
+        debounce?.Cancel();
+        if (!await gate.WaitAsync(TimeSpan.FromSeconds(5))) return false;
+        try
+        {
+            if (Active is not null && editVersion != persistedEditVersion) await SaveCurrentAsync();
+            return editVersion == persistedEditVersion;
+        }
+        catch (Exception ex) when (IsProfileFailure(ex)) { SetFailure(ex); return false; }
+        finally { gate.Release(); }
+    }
+
+    public async Task SaveAsCopyAsync(string displayName)
+    {
+        EnsureCanActivate();
+        await gate.WaitAsync(lifetime.Token);
+        try
+        {
+            if (Active is not null && editVersion != persistedEditVersion)
+            {
+                try { await SaveCurrentAsync(); }
+                catch (IncompleteProfileCheckpointException) { }
+            }
+            Guid id = Guid.NewGuid();
+            long version = editVersion;
+            DeploymentProfileDocument profile = await session.CaptureAsync(id, displayName, false);
+            try
+            {
+                EnsureUnchanged(version);
+                LocalProfileDescriptor descriptor = local.Save(id, profile, false, null);
+                local.SetActive(id);
+                Active = descriptor;
+                persistedEditVersion = editVersion;
+                ClearSharedKey();
+                HasConflict = false;
+                await RefreshAsync();
+            }
+            finally
+            {
+                DeploymentProfileSecretBinding.Clear(profile);
+            }
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    public async Task ActivateAsync(Guid localId)
+    {
+        EnsureCanActivate();
+        await gate.WaitAsync(lifetime.Token);
+        try
+        {
+            if (Active is not null && editVersion != persistedEditVersion) await SaveCurrentAsync();
+            LocalProfileSnapshot snapshot = await Task.Run(() => local.Read(localId));
+            try
+            {
+                await ActivateDocumentAsync(snapshot.Profile, snapshot.Descriptor);
+                await Task.Run(() => local.SetActive(localId));
+            }
+            finally
+            {
+                DeploymentProfileSecretBinding.Clear(snapshot.Profile);
+            }
+
+            await RefreshAsync();
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    public async Task ForgetAsync()
+    {
+        EnsureCanActivate();
+        await gate.WaitAsync(lifetime.Token);
+        try
+        {
+            LocalProfileDescriptor current = RequireActive();
+            DeploymentProfileDocument profile = new()
+            {
+                ProfileId = current.ProfileId,
+                DisplayName = current.DisplayName,
+                Configuration = configuration.Current
+            };
+            LocalProfileEnrollment? enrollment = current.Enrollment is null ? null : current.Enrollment with
+            {
+                RememberSharedKey = false,
+                IsEnabled = false,
+                PendingOperationId = null,
+                IsDirty = true
+            };
+            Active = local.Save(current.LocalId, profile, false, current.Revision, enrollment);
+            debounce?.Cancel();
+            ClearSharedKey();
+            try
+            {
+                applying = true;
+                session.Activate(profile, profile.Configuration);
+                persistedEditVersion = editVersion;
+            }
+            finally
+            {
+                session.ClearSensitiveState();
+                applying = false;
+                ClearStagingDirectories();
+                DeploymentProfileSecretBinding.Clear(profile);
+            }
+
+            HasConflict = false;
+            ClearStagingDirectories();
+            await RefreshAsync();
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    public async Task RenameAsync(string displayName)
+    {
+        await gate.WaitAsync(lifetime.Token);
+        try
+        {
+            LocalProfileDescriptor current = RequireActive();
+            long version = editVersion;
+            DeploymentProfileDocument profile = await session.CaptureAsync(current.ProfileId, displayName, current.RememberSecrets);
+            try
+            {
+                if (current.RememberSecrets) EnsureCompleteCheckpoint(profile);
+                LocalProfileEnrollment? enrollment = current.Enrollment is null ? null : current.Enrollment with { IsDirty = true };
+                Active = await Task.Run(() => local.Save(current.LocalId, profile, current.RememberSecrets, current.Revision, enrollment));
+                persistedEditVersion = version;
+                await RefreshAsync();
+            }
+            finally { DeploymentProfileSecretBinding.Clear(profile); }
+        }
+        finally { gate.Release(); }
+    }
+
+    public async Task DeleteAsync(bool deleteShared = false)
+    {
+        EnsureCanActivate();
+        await gate.WaitAsync(lifetime.Token);
+        try
+        {
+            LocalProfileDescriptor current = RequireActive();
+            if (deleteShared && current.Enrollment is { } enrollment)
+            {
+                byte[] key = await GetSharedKeyAsync();
+                try
+                {
+                    using SharedProfileRepository remote = OpenRemote(enrollment, key);
+                    Guid expected = enrollment.KnownRevisionId ?? throw new InvalidOperationException("Synchronize the profile before deleting it.");
+                    SharedProfileRepositoryResult loaded = await remote.LoadAsync(expected, lifetime.Token);
+                    RequireSuccess(loaded);
+                    if (loaded.Snapshot?.Head.IsTombstone != true)
+                        RequireSuccess(await remote.TombstoneAsync(expected, Guid.NewGuid(), lifetime.Token));
+                }
+                finally { CryptographicOperations.ZeroMemory(key); }
+            }
+            bool cleanupPending = await Task.Run(() => local.Delete(current.LocalId, current.Revision));
+            debounce?.Cancel();
+            applying = true;
+            Active = null;
+            ClearSharedKey();
+            session.ClearSensitiveState();
+            ClearStagingDirectories();
+            var empty = new DeploymentProfileDocument
+            {
+                ProfileId = Guid.NewGuid(),
+                DisplayName = "Default",
+                Configuration = new()
+                {
+                    General = new() { IsoOutputPath = configuration.Current.General.IsoOutputPath },
+                    Telemetry = configuration.Current.Telemetry
+                }
+            };
+            session.Activate(empty, empty.Configuration);
+            persistedEditVersion = editVersion;
+            HasConflict = false;
+            await RefreshAsync();
+            if (cleanupPending)
+            {
+                StatusKey = "Profiles.CleanupPending";
+                Changed?.Invoke(this, EventArgs.Empty);
+            }
+        }
+        finally { applying = false; gate.Release(); }
+    }
+
+    public async Task ExportAsync(string path, string passphrase, bool includeSecrets)
+    {
+        LocalProfileDescriptor current = RequireActive();
+        DeploymentProfileDocument profile = await session.CaptureAsync(current.ProfileId, current.DisplayName, includeSecrets);
+        try
+        {
+            byte[] bytes = await Task.Run(() => packages.Export(profile, passphrase.AsSpan()));
+            await WriteAtomicAsync(path, bytes);
+        }
+        finally
+        {
+            DeploymentProfileSecretBinding.Clear(profile);
+        }
+    }
+
+    /// <summary>Decrypts and validates before the UI offers activation; imported data cannot change the current profile.</summary>
+    public async Task<DeploymentProfileDocument> PreviewImportAsync(string path, string passphrase)
+    {
+        byte[] bytes = await ReadBoundedAsync(path, 16 * 1024 * 1024 + 118);
+        return await Task.Run(() => packages.Import(bytes, passphrase.AsSpan()));
+    }
+
+    public async Task ImportAsCopyAsync(DeploymentProfileDocument imported, bool rememberSecrets)
+    {
+        EnsureCanActivate();
+        await gate.WaitAsync(lifetime.Token);
+        try
+        {
+            if (Active is not null && editVersion != persistedEditVersion) await SaveCurrentAsync();
+            long version = editVersion;
+            DeploymentProfileDocument profile = imported with
+            {
+                ProfileId = Guid.NewGuid(),
+                Secrets = new DeploymentProfileSecrets
+                {
+                    Entries = imported.Secrets.Entries.Where(secret => secret.Purpose != ProfileSecretPurpose.SharedProfileKey).ToArray()
+                }
+            };
+            string directory = CreateStagingDirectory();
+            var materialized = await Task.Run(() => DeploymentProfileAssetService.Materialize(profile, directory));
+            materialized = materialized with
+            {
+                General = materialized.General with { IsoOutputPath = configuration.Current.General.IsoOutputPath },
+                Telemetry = configuration.Current.Telemetry
+            };
+            profile = profile with { Configuration = materialized };
+            if (rememberSecrets) EnsureCompleteCheckpoint(profile);
+            EnsureUnchanged(version);
+            LocalProfileDescriptor descriptor = local.Save(Guid.NewGuid(), profile, rememberSecrets, null);
+            applying = true;
+            session.Activate(profile, materialized);
+            Active = descriptor;
+            persistedEditVersion = editVersion;
+            local.SetActive(descriptor.LocalId);
+            ClearSharedKey();
+            HasConflict = false;
+            await RefreshAsync();
+        }
+        finally
+        {
+            applying = false;
+            gate.Release();
+        }
+    }
+
+    private async Task SaveCurrentAsync(bool? rememberSecrets = null, LocalProfileEnrollment? enrollment = null, byte[]? sharedKey = null)
+    {
+        LocalProfileDescriptor current = RequireActive();
+        long version = editVersion;
+        bool remember = rememberSecrets ?? current.RememberSecrets;
+        DeploymentProfileDocument profile = await session.CaptureAsync(current.ProfileId, current.DisplayName, remember);
+        try
+        {
+            if (remember) EnsureCompleteCheckpoint(profile);
+            LocalProfileEnrollment? updated = enrollment ?? current.Enrollment;
+            if (enrollment is null && updated is not null && version != persistedEditVersion)
+                updated = updated with { IsDirty = true };
+            Active = await Task.Run(() => local.Save(current.LocalId, profile, remember, current.Revision, updated,
+                updated?.RememberSharedKey == true ? sharedKey : null));
+            persistedEditVersion = version;
+            await RefreshAsync();
+        }
+        finally
+        {
+            DeploymentProfileSecretBinding.Clear(profile);
+        }
+    }
+
+    private async Task ActivateDocumentAsync(DeploymentProfileDocument profile, LocalProfileDescriptor descriptor)
+    {
+        EnsureCanActivate();
+        long version = editVersion;
+        var document = profile.Configuration;
+        if (profile.Assets.Any(asset => asset.State == ProfileValueState.Present))
+        {
+            string directory = CreateStagingDirectory();
+            document = await Task.Run(() => DeploymentProfileAssetService.Materialize(profile, directory));
+        }
+
+        document = document with { Telemetry = configuration.Current.Telemetry };
+        EnsureUnchanged(version);
+        applying = true;
+        try
+        {
+            session.Activate(profile, document);
+            Active = descriptor;
+            persistedEditVersion = editVersion;
+            ClearSharedKey();
+            HasConflict = false;
+        }
+        finally
+        {
+            applying = false;
+        }
+    }
+
+    private void OnEdited(object? sender, EventArgs e)
+    {
+        if (ReferenceEquals(sender, configuration))
+        {
+            if (ReferenceEquals(observedConfiguration, configuration.Current)) return;
+            observedConfiguration = configuration.Current;
+        }
+        if (applying || Active is null || !initialized) return;
+        editVersion++;
+        lastEditTick = Environment.TickCount64;
+        debounce?.Cancel();
+        debounce?.Dispose();
+        debounce = CancellationTokenSource.CreateLinkedTokenSource(lifetime.Token);
+        _ = AutosaveAsync(debounce.Token);
+    }
+
+    private async Task AutosaveAsync(CancellationToken token)
+    {
+        try
+        {
+            await Task.Delay(750, token);
+            if (token.IsCancellationRequested) return;
+            await gate.WaitAsync(token);
+            try
+            {
+                if (Active is null || editVersion == persistedEditVersion) return;
+                LocalProfileEnrollment? enrollment = Active?.Enrollment;
+                await SaveCurrentAsync(enrollment: enrollment is null ? null : enrollment with { IsDirty = true });
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex) when (IsProfileFailure(ex)) { SetFailure(ex); }
+    }
+
+    private async Task RefreshAsync()
+    {
+        Profiles = await Task.Run(local.List);
+        if (Active is { } current)
+        {
+            Active = Profiles.FirstOrDefault(profile => profile.LocalId == current.LocalId && profile.Revision == current.Revision) ?? current;
+        }
+        StatusKey = Active?.CleanupPending == true ? "Profiles.CleanupPending" : "Profiles.Ready";
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    private LocalProfileDescriptor RequireActive() => Active ?? throw new InvalidOperationException("No local profile is selected.");
+    private void EnsureUnchanged(long version)
+    {
+        if (editVersion != version) throw new InvalidOperationException("The active draft changed. Retry the profile action.");
+        EnsureCanActivate();
+    }
+    private void EnsureCanActivate()
+    {
+        if (navigationGuard.State == ShellNavigationState.OperationRunning ||
+            navigationGuard.State == ShellNavigationState.InteractionPending && !ownsNavigationGuard)
+            throw new InvalidOperationException("Profile activation waits until the current operation finishes.");
+    }
+
+    private static bool IsProfileFailure(Exception exception) => exception is IOException or InvalidDataException or UnauthorizedAccessException or
+        System.ComponentModel.Win32Exception or CryptographicException or ArgumentException or InvalidOperationException or NotSupportedException or
+        System.Text.Json.JsonException or FormatException;
+
+    private void SetFailure(Exception exception)
+    {
+        StatusKey = exception is LocalProfileLockedException ? "Profiles.Locked" :
+            exception is IncompleteProfileCheckpointException ? "Profiles.Incomplete" :
+            exception is NotSupportedException ? "Profiles.Unsupported" : "Profiles.Failed";
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void ClearSharedKey()
+    {
+        if (sessionSharedKey is not null) CryptographicOperations.ZeroMemory(sessionSharedKey);
+        sessionSharedKey = null;
+    }
+
+    private static void EnsureCompleteCheckpoint(DeploymentProfileDocument profile)
+    {
+        if (profile.Secrets.Entries.Any(secret => secret.State is ProfileValueState.Unavailable or ProfileValueState.Omitted) ||
+            profile.Assets.Any(asset => asset.State is ProfileValueState.Unavailable or ProfileValueState.Omitted))
+            throw new IncompleteProfileCheckpointException();
+    }
+
+    private static Task<byte[]> ReadBoundedAsync(string path, int maximum) => Task.Run(async () =>
+    {
+        using FileStream stream = new(path, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.Asynchronous);
+        if (stream.Length > maximum) throw new InvalidDataException("The profile file exceeds the supported size.");
+        byte[] bytes = new byte[checked((int)stream.Length)];
+        await stream.ReadExactlyAsync(bytes);
+        return bytes;
+    });
+
+    private static Task WriteAtomicAsync(string path, byte[] bytes) => Task.Run(async () =>
+    {
+        string temporary = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
+        try
+        {
+            using (FileStream stream = new(temporary, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous))
+            {
+                await stream.WriteAsync(bytes);
+                stream.Flush(true);
+            }
+            File.Move(temporary, path, true);
+        }
+        finally { File.Delete(temporary); }
+    });
+
+    public void Dispose()
+    {
+        lifetime.Cancel();
+        debounce?.Cancel();
+        debounce?.Dispose();
+        ClearSharedKey();
+        ClearStagingDirectories(releaseFailedLeases: true);
+        lifetime.Dispose();
+    }
+
+    private sealed class ActivationSuspension(DeploymentProfileCoordinator owner) : IDisposable
+    {
+        private bool disposed;
+        public void Dispose()
+        {
+            if (disposed) return;
+            disposed = true;
+            owner.activationSuspensions--;
+            if (owner.activationSuspensions == 0 && owner.ownsNavigationGuard)
+            {
+                owner.ownsNavigationGuard = false;
+                owner.navigationGuard.SetState(owner.suspendedNavigationState);
+            }
+        }
+    }
+}
+
+/// <summary>Preserves the last complete remembered revision while the operator finishes a secret-bearing draft.</summary>
+public sealed class IncompleteProfileCheckpointException() : InvalidOperationException("Complete required passwords and source files before remembering or publishing secrets.");

--- a/src/Foundry/Services/Configuration/DeploymentProfileSessionService.cs
+++ b/src/Foundry/Services/Configuration/DeploymentProfileSessionService.cs
@@ -1,0 +1,259 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Foundry.Core.Models.Configuration;
+using Foundry.Core.Models.Profiles;
+using Foundry.Core.Services.Autopilot;
+using Foundry.Core.Services.Configuration;
+using Foundry.Core.Services.Profiles;
+using Foundry.Services.Autopilot;
+
+namespace Foundry.Services.Configuration;
+
+/// <summary>Transfers explicitly selected secrets between profile records and the desktop's volatile authoring state.</summary>
+public sealed class DeploymentProfileSessionService(
+    IFoundryConfigurationStateService configurationState,
+    INetworkSecretStateService networkSecrets,
+    IDeploymentProtectionSecretStateService deploymentSecrets,
+    IOobeAccountSecretStateService accountSecrets,
+    IAutopilotHardwareHashSessionState autopilotSession)
+{
+    /// <summary>Freezes configuration and owned password buffers before reading source files off the UI thread.</summary>
+    public Task<DeploymentProfileDocument> CaptureAsync(Guid profileId, string displayName, bool includeSecrets)
+    {
+        FoundryConfigurationDocument configuration = configurationState.Current with
+        {
+            Network = networkSecrets.ApplyRequiredSecrets(configurationState.Current.Network),
+            Autopilot = configurationState.Current.Autopilot with
+            {
+                HardwareHashUpload = configurationState.Current.Autopilot.HardwareHashUpload with { BootMediaCertificate = autopilotSession.BootMediaCertificate }
+            }
+        };
+        DeploymentProfileDocument profile = new()
+        {
+            ProfileId = profileId,
+            DisplayName = displayName,
+            Configuration = configuration
+        };
+        List<(DeploymentProfileSecret Secret, string? AccountId)> entries = [];
+        try
+        {
+            if (configuration.General.DeploymentProtection.IsEnabled)
+            {
+                AddPair(ProfileSecretPurpose.DeploymentPassword, deploymentSecrets.GetPasswordCopy(), deploymentSecrets.GetConfirmationCopy());
+            }
+
+            if (configuration.Network.WifiProvisioned && configuration.Network.Wifi.IsEnabled && !configuration.Network.Wifi.HasEnterpriseProfile &&
+                string.Equals(NetworkConfigurationValidator.NormalizeWifiSecurityType(configuration.Network.Wifi), NetworkConfigurationValidator.WifiSecurityPersonal, StringComparison.Ordinal))
+            {
+                Add(ProfileSecretPurpose.WifiPassphrase, configuration.Network.Wifi.Passphrase);
+            }
+
+            OobeSettings oobe = configuration.Customization.Oobe;
+            if (oobe.IsEnabled)
+            {
+                if (oobe.EnableAdministratorAccount && oobe.UseAdministratorPassword)
+                {
+                    AddPair(ProfileSecretPurpose.AdministratorPassword, accountSecrets.GetAdministratorPasswordCopy(), accountSecrets.GetAdministratorConfirmationCopy());
+                }
+
+                foreach (OobeAdditionalAccountSettings account in oobe.AdditionalAccounts.Where(account => account.UsePassword))
+                {
+                    AddPair(ProfileSecretPurpose.AdditionalAccountPassword, accountSecrets.GetAdditionalAccountPasswordCopy(account.Id), accountSecrets.GetAdditionalAccountConfirmationCopy(account.Id), account.Id);
+                }
+            }
+
+            if (IsPfx(configuration.Network.Dot1x.CertificatePath))
+            {
+                Add(ProfileSecretPurpose.WiredCertificatePassword, configuration.Network.Dot1x.CertificatePfxPassword);
+            }
+
+            if (IsPfx(configuration.Network.Wifi.CertificatePath))
+            {
+                Add(ProfileSecretPurpose.WifiCertificatePassword, configuration.Network.Wifi.CertificatePfxPassword);
+            }
+
+            if (!string.IsNullOrEmpty(configuration.Autopilot.HardwareHashUpload.BootMediaCertificate.PfxPath) ||
+                configuration.Autopilot.IsEnabled && configuration.Autopilot.ProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload)
+            {
+                Add(ProfileSecretPurpose.AutopilotCertificatePassword, configuration.Autopilot.HardwareHashUpload.BootMediaCertificate.PfxPassword);
+            }
+
+            profile = profile with { Configuration = FreezeConfiguration(configuration) };
+            configuration = profile.Configuration;
+            return CaptureFrozenAsync();
+        }
+        catch
+        {
+            ClearCapturedValues();
+            throw;
+        }
+
+        async Task<DeploymentProfileDocument> CaptureFrozenAsync()
+        {
+            try
+            {
+                return await Task.Run(() =>
+                {
+                    profile = profile with { Assets = DeploymentProfileAssetService.Capture(profile.Configuration, includeSecrets) };
+                    return profile with
+                    {
+                        Secrets = new DeploymentProfileSecrets
+                        {
+                            Entries = entries.Select(entry => entry.Secret with
+                            {
+                                Identity = DeploymentProfileSecretBinding.Identity(entry.Secret.Purpose, profile, entry.AccountId)
+                            }).ToArray()
+                        }
+                    };
+                }).ConfigureAwait(false);
+            }
+            catch
+            {
+                ClearCapturedValues();
+                DeploymentProfileAssetService.Clear(profile.Assets);
+                throw;
+            }
+        }
+
+        void ClearCapturedValues()
+        {
+            foreach (var entry in entries)
+            {
+                if (entry.Secret.Value is not null) CryptographicOperations.ZeroMemory(entry.Secret.Value);
+            }
+        }
+
+        static bool IsPfx(string? path) => Path.GetExtension(path)?.ToLowerInvariant() is ".pfx" or ".p12";
+
+        void Add(ProfileSecretPurpose purpose, string? value, string? accountId = null)
+        {
+            entries.Add((new DeploymentProfileSecret
+            {
+                Purpose = purpose,
+                State = !includeSecrets ? ProfileValueState.Omitted : value is null ? ProfileValueState.Unavailable : value.Length == 0 ? ProfileValueState.Blank : ProfileValueState.Present,
+                Value = includeSecrets && !string.IsNullOrEmpty(value) ? Encoding.UTF8.GetBytes(value) : null
+            }, accountId));
+        }
+
+        void AddPair(ProfileSecretPurpose purpose, char[] password, char[] confirmation, string? accountId = null)
+        {
+            try
+            {
+                bool confirmed = password.Length > 0 && password.AsSpan().SequenceEqual(confirmation) &&
+                    (purpose != ProfileSecretPurpose.DeploymentPassword || DeploymentProtectionPasswordRules.IsValid(password));
+                entries.Add((new DeploymentProfileSecret
+                {
+                    Purpose = purpose,
+                    State = !includeSecrets ? ProfileValueState.Omitted : !confirmed ? ProfileValueState.Unavailable : ProfileValueState.Present,
+                    Value = includeSecrets && confirmed && password.Length > 0 ? Encoding.UTF8.GetBytes(password) : null
+                }, accountId));
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(password.AsSpan()));
+                CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(confirmation.AsSpan()));
+            }
+        }
+    }
+
+    private static FoundryConfigurationDocument FreezeConfiguration(FoundryConfigurationDocument source)
+    {
+        AutopilotBootMediaCertificateSettings certificate = source.Autopilot.HardwareHashUpload.BootMediaCertificate with { PfxPassword = null };
+        FoundryConfigurationDocument sanitized = source with
+        {
+            Network = source.Network with
+            {
+                Wifi = source.Network.Wifi with { Passphrase = null, PassphraseSecret = null, CertificatePfxPassword = null, CertificatePfxPasswordSecret = null },
+                Dot1x = source.Network.Dot1x with { CertificatePfxPassword = null, CertificatePfxPasswordSecret = null }
+            },
+            Autopilot = source.Autopilot with { HardwareHashUpload = source.Autopilot.HardwareHashUpload with { BootMediaCertificate = certificate } }
+        };
+        byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(sanitized);
+        try
+        {
+            FoundryConfigurationDocument clone = JsonSerializer.Deserialize<FoundryConfigurationDocument>(bytes)!;
+            return clone with { Autopilot = clone.Autopilot with { HardwareHashUpload = clone.Autopilot.HardwareHashUpload with { BootMediaCertificate = certificate } } };
+        }
+        finally { CryptographicOperations.ZeroMemory(bytes); }
+    }
+
+    /// <summary>Clears volatile credentials without reading or writing configuration storage.</summary>
+    public void ClearSensitiveState()
+    {
+        networkSecrets.Update(new NetworkSettings());
+        deploymentSecrets.Clear();
+        accountSecrets.Update(new OobeSettings());
+        autopilotSession.ClearTenantConnection();
+        autopilotSession.BootMediaCertificate = new();
+    }
+
+    /// <summary>Restores matching secret contexts without establishing an authenticated Graph session.</summary>
+    public void Activate(DeploymentProfileDocument profile, FoundryConfigurationDocument materialized)
+    {
+        string? deploymentPassword = Get(ProfileSecretPurpose.DeploymentPassword);
+        string? administratorPassword = Get(ProfileSecretPurpose.AdministratorPassword);
+        var additionalPasswords = materialized.Customization.Oobe.AdditionalAccounts
+            .Select(account => (account.Id, Password: Get(ProfileSecretPurpose.AdditionalAccountPassword, account.Id))).ToArray();
+
+        materialized = materialized with
+        {
+            Network = materialized.Network with
+            {
+                Dot1x = materialized.Network.Dot1x with { CertificatePfxPassword = Get(ProfileSecretPurpose.WiredCertificatePassword) },
+                Wifi = materialized.Network.Wifi with
+                {
+                    Passphrase = Get(ProfileSecretPurpose.WifiPassphrase),
+                    CertificatePfxPassword = Get(ProfileSecretPurpose.WifiCertificatePassword)
+                }
+            }
+        };
+        AutopilotBootMediaCertificateSettings boot = materialized.Autopilot.HardwareHashUpload.BootMediaCertificate with
+        {
+            PfxPassword = Get(ProfileSecretPurpose.AutopilotCertificatePassword),
+            ValidatedThumbprint = null,
+            ValidatedExpiresOnUtc = null
+        };
+        DeploymentProfileAsset? pfx = profile.Assets.SingleOrDefault(asset => asset.Kind == ProfileAssetKind.AutopilotCertificate);
+        if (pfx?.Content is not null && boot.PfxPassword is not null)
+        {
+            AutopilotPfxValidationResult validation = AutopilotPfxCertificateValidator.Validate(pfx.Content, boot.PfxPassword);
+            if (validation.IsValid)
+            {
+                boot = boot with { ValidatedThumbprint = validation.Thumbprint, ValidatedExpiresOnUtc = validation.ExpiresOnUtc };
+            }
+        }
+
+        configurationState.Replace(materialized, () =>
+        {
+            ClearSensitiveState();
+            deploymentSecrets.SetPassword(deploymentPassword);
+            deploymentSecrets.SetConfirmation(deploymentPassword);
+            accountSecrets.SetAdministratorPassword(administratorPassword);
+            accountSecrets.SetAdministratorConfirmation(administratorPassword);
+            foreach ((string id, string? password) in additionalPasswords)
+            {
+                accountSecrets.SetAdditionalAccountPassword(id, password.AsSpan());
+                accountSecrets.SetAdditionalAccountConfirmation(id, password.AsSpan());
+            }
+            autopilotSession.BootMediaCertificate = boot;
+        });
+
+        string? Get(ProfileSecretPurpose purpose, string? accountId = null)
+        {
+            string identity = DeploymentProfileSecretBinding.Identity(purpose, profile, accountId);
+            DeploymentProfileSecret? secret = profile.Secrets.Entries.SingleOrDefault(secret => secret.Purpose == purpose && secret.Identity == identity);
+            return secret?.State switch
+            {
+                ProfileValueState.Blank => string.Empty,
+                ProfileValueState.Present => Encoding.UTF8.GetString(secret.Value!),
+                _ => null
+            };
+        }
+    }
+}

--- a/src/Foundry/Services/Configuration/FoundryConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/FoundryConfigurationStateService.cs
@@ -5,6 +5,7 @@
 using Foundry.Core.Models.Configuration;
 using Foundry.Core.Models.Configuration.Deploy;
 using Foundry.Core.Services.Configuration;
+using Foundry.Core.Services.Profiles;
 using Foundry.Core.Services.WinPe;
 using Foundry.Services.Autopilot;
 using Foundry.Telemetry;
@@ -17,7 +18,7 @@ using AppSettingsService = Foundry.Services.Settings.IAppSettingsService;
 namespace Foundry.Services.Configuration;
 
 /// <summary>
-/// Maintains the user-facing Foundry configuration state and generates deploy/connect payloads from it.
+/// Maintains authoring configuration, readiness checks and immutable build capture.
 /// </summary>
 /// <remarks>
 /// Secrets that should not be persisted are kept in <see cref="INetworkSecretStateService"/> and
@@ -27,7 +28,6 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
 {
     private readonly IFoundryConfigurationService foundryConfigurationService;
     private readonly IDeployConfigurationGenerator deployConfigurationGenerator;
-    private readonly IConnectConfigurationGenerator connectConfigurationGenerator;
     private readonly INetworkSecretStateService networkSecretStateService;
     private readonly IDeploymentProtectionSecretStateService deploymentProtectionSecretStateService;
     private readonly IOobeAccountSecretStateService oobeAccountSecretStateService;
@@ -42,7 +42,6 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
     public FoundryConfigurationStateService(
         IFoundryConfigurationService foundryConfigurationService,
         IDeployConfigurationGenerator deployConfigurationGenerator,
-        IConnectConfigurationGenerator connectConfigurationGenerator,
         INetworkSecretStateService networkSecretStateService,
         IDeploymentProtectionSecretStateService deploymentProtectionSecretStateService,
         IOobeAccountSecretStateService oobeAccountSecretStateService,
@@ -52,14 +51,18 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
     {
         this.foundryConfigurationService = foundryConfigurationService;
         this.deployConfigurationGenerator = deployConfigurationGenerator;
-        this.connectConfigurationGenerator = connectConfigurationGenerator;
         this.networkSecretStateService = networkSecretStateService;
         this.deploymentProtectionSecretStateService = deploymentProtectionSecretStateService;
         this.oobeAccountSecretStateService = oobeAccountSecretStateService;
         this.autopilotHardwareHashSessionState = autopilotHardwareHashSessionState;
         this.appSettingsService = appSettingsService;
         this.logger = logger.ForContext<FoundryConfigurationStateService>();
-        Current = SanitizeForPersistence(Load());
+        FoundryConfigurationDocument loaded = Load(out bool isLegacyMigration);
+        if (isLegacyMigration)
+        {
+            networkSecretStateService.Update(loaded.Network);
+        }
+        Current = SanitizeForPersistence(loaded);
         Save();
     }
 
@@ -68,6 +71,23 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
 
     /// <inheritdoc />
     public FoundryConfigurationDocument Current { get; private set; }
+
+    /// <inheritdoc />
+    public void Replace(FoundryConfigurationDocument document, Action restoreSecrets)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(restoreSecrets);
+        FoundryConfigurationDocument candidate = SanitizeForPersistence(document);
+        Save(candidate, throwOnFailure: true);
+        restoreSecrets();
+        networkSecretStateService.Update(document.Network);
+        oobeAccountSecretStateService.Update(document.Customization.Oobe);
+        Current = candidate;
+        validatedUnattendSettings = null;
+        unattendSourceValidations = [];
+        unattendRefreshRevision++;
+        StateChanged?.Invoke(this, EventArgs.Empty);
+    }
 
     /// <inheritdoc />
     public NetworkMediaReadinessEvaluation NetworkMediaReadiness => EvaluateNetworkMediaReadiness();
@@ -361,8 +381,7 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 
-    /// <inheritdoc />
-    public string GenerateDeployConfigurationJson(
+    private string GenerateDeployConfigurationJson(
         TelemetrySettings? telemetryOverride = null,
         byte[]? deploymentSecretsKey = null,
         DeployProtectionSettings? protectionSettings = null)
@@ -381,20 +400,35 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
     }
 
     /// <inheritdoc />
-    public FoundryConnectProvisioningBundle GenerateConnectProvisioningBundle(string stagingDirectoryPath, TelemetrySettings? telemetryOverride = null)
+    public Task<DeploymentBuildSnapshot> CaptureBuildSnapshotAsync(
+        string privateRootDirectory,
+        CancellationToken cancellationToken = default)
     {
-        FoundryConfigurationDocument document = Current with
+        FoundryConfigurationDocument document = CreateDocumentForDeployGeneration(telemetryOverride: null) with
         {
-            Network = networkSecretStateService.ApplyRequiredSecrets(Current.Network),
-            Telemetry = telemetryOverride ?? Current.Telemetry
+            Network = networkSecretStateService.ApplyRequiredSecrets(Current.Network)
         };
-
-        return connectConfigurationGenerator.CreateProvisioningBundle(document, stagingDirectoryPath);
+        using OobeAccountSecretState accountSecrets = CreateOobeAccountSecretStateForDeployGeneration(document.Customization.Oobe);
+        char[] password = document.General.DeploymentProtection.IsEnabled
+            ? deploymentProtectionSecretStateService.GetConfirmedPasswordCopy()
+            : [];
+        try
+        {
+            return DeploymentBuildSnapshot.CaptureAsync(
+                document, accountSecrets, password, privateRootDirectory, cancellationToken);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(password.AsSpan()));
+        }
     }
 
-    private FoundryConfigurationDocument Load()
+    private FoundryConfigurationDocument Load(out bool isLegacyMigration)
     {
-        if (!File.Exists(Constants.FoundryConfigurationStatePath))
+        isLegacyMigration = false;
+        string sourcePath = File.Exists(Constants.FoundryConfigurationStatePath)
+            ? Constants.FoundryConfigurationStatePath : Constants.LegacyFoundryConfigurationStatePath;
+        if (!File.Exists(sourcePath))
         {
             logger.Information("Foundry configuration state initialized from defaults.");
             return FoundryConfigurationMigration.ApplyLegacyGeneralSettings(
@@ -404,15 +438,31 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
 
         try
         {
-            string json = File.ReadAllText(Constants.FoundryConfigurationStatePath);
+            if (new FileInfo(sourcePath).Length > 16 * 1024 * 1024)
+            {
+                throw new NotSupportedException("The saved configuration exceeds the supported size.");
+            }
+
+            string json = File.ReadAllText(sourcePath);
+            using System.Text.Json.JsonDocument parsed = System.Text.Json.JsonDocument.Parse(json);
+            if (parsed.RootElement.TryGetProperty("schemaVersion", out System.Text.Json.JsonElement schema) &&
+                schema.GetInt32() > FoundryConfigurationDocument.CurrentSchemaVersion)
+            {
+                throw new NotSupportedException("The saved configuration requires a newer version of Foundry.");
+            }
+
             FoundryConfigurationDocument document = foundryConfigurationService.Deserialize(json);
+            isLegacyMigration = string.Equals(sourcePath, Constants.LegacyFoundryConfigurationStatePath, StringComparison.OrdinalIgnoreCase);
             logger.Information("Foundry configuration state loaded from disk.");
             return document;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Text.Json.JsonException or ArgumentException)
         {
             string backupPath = Constants.FoundryConfigurationStatePath + ".invalid";
-            TryMoveInvalidState(backupPath, ex);
+            if (sourcePath == Constants.FoundryConfigurationStatePath)
+            {
+                TryMoveInvalidState(backupPath, ex);
+            }
             return CreateDefaultDocument();
         }
     }
@@ -487,16 +537,6 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
         {
             BootMediaCertificate = autopilotHardwareHashSessionState.BootMediaCertificate
         };
-        if (settings.ProvisioningMode == AutopilotProvisioningMode.HardwareHashUpload &&
-            !autopilotHardwareHashSessionState.HasConnectedTenant)
-        {
-            hardwareHashUpload = hardwareHashUpload with
-            {
-                KnownGroupTags = [],
-                DefaultGroupTag = null
-            };
-        }
-
         return settings with
         {
             HardwareHashUpload = hardwareHashUpload
@@ -514,19 +554,31 @@ internal sealed class FoundryConfigurationStateService : IFoundryConfigurationSt
         };
     }
 
-    private void Save()
+    private void Save(FoundryConfigurationDocument? candidate = null, bool throwOnFailure = false)
     {
         try
         {
             Directory.CreateDirectory(Constants.ConfigurationWorkspaceDirectoryPath);
-            FoundryConfigurationDocument document = SanitizeForPersistence(Current);
+            FoundryConfigurationDocument document = candidate ?? SanitizeForPersistence(Current);
             string json = foundryConfigurationService.Serialize(document);
-            File.WriteAllText(Constants.FoundryConfigurationStatePath, json);
+            string temporaryPath = Constants.FoundryConfigurationStatePath + "." + Guid.NewGuid().ToString("N") + ".tmp";
+            try
+            {
+                File.WriteAllText(temporaryPath, json);
+                File.Move(temporaryPath, Constants.FoundryConfigurationStatePath, true);
+            }
+            finally
+            {
+                File.Delete(temporaryPath);
+            }
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             logger.Error(ex, "Failed to persist Foundry configuration state. StatePath={StatePath}", Constants.FoundryConfigurationStatePath);
-            throw;
+            if (throwOnFailure)
+            {
+                throw;
+            }
         }
     }
 

--- a/src/Foundry/Services/Configuration/IFoundryConfigurationStateService.cs
+++ b/src/Foundry/Services/Configuration/IFoundryConfigurationStateService.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Foundry.Core.Models.Configuration;
-using Foundry.Core.Models.Configuration.Deploy;
 using Foundry.Core.Services.Configuration;
+using Foundry.Core.Services.Profiles;
 using Foundry.Telemetry;
 
 namespace Foundry.Services.Configuration;
@@ -14,7 +14,7 @@ namespace Foundry.Services.Configuration;
 /// </summary>
 /// <remarks>
 /// <see cref="Current"/> is always safe to persist. Volatile network secrets are kept outside the document and
-/// merged only when <see cref="GenerateConnectProvisioningBundle"/> creates the Connect payload.
+/// merged into a detached document when <see cref="CaptureBuildSnapshotAsync"/> freezes build inputs.
 /// </remarks>
 public interface IFoundryConfigurationStateService
 {
@@ -27,6 +27,12 @@ public interface IFoundryConfigurationStateService
     /// Gets the current Foundry configuration document after removing values that must not be persisted.
     /// </summary>
     FoundryConfigurationDocument Current { get; }
+
+    /// <summary>Persists a validated profile before restoring its local secrets and publishing the active configuration.</summary>
+    void Replace(FoundryConfigurationDocument document, Action restoreSecrets);
+
+    /// <summary>Freezes current configuration and session secrets synchronously, then prepares private build dependencies off-thread.</summary>
+    Task<DeploymentBuildSnapshot> CaptureBuildSnapshotAsync(string privateRootDirectory, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the detailed network readiness evaluation used for media creation.
@@ -147,23 +153,4 @@ public interface IFoundryConfigurationStateService
     /// <param name="settings">New telemetry settings.</param>
     void UpdateTelemetry(TelemetrySettings settings);
 
-    /// <summary>
-    /// Generates Connect provisioning files after merging required volatile secrets back into the current network settings.
-    /// </summary>
-    /// <param name="stagingDirectoryPath">Directory where provisioning files should be staged.</param>
-    /// <param name="telemetryOverride">Optional runtime telemetry settings used only for the generated Connect document.</param>
-    /// <returns>The generated Connect provisioning bundle.</returns>
-    FoundryConnectProvisioningBundle GenerateConnectProvisioningBundle(string stagingDirectoryPath, TelemetrySettings? telemetryOverride = null);
-
-    /// <summary>
-    /// Generates the Deploy configuration JSON for the current Foundry configuration.
-    /// </summary>
-    /// <param name="telemetryOverride">Optional runtime telemetry settings used only for the generated Deploy document.</param>
-    /// <param name="deploymentSecretsKey">Optional Deploy secret key used for boot-media-only Deploy secrets.</param>
-    /// <param name="protectionSettings">Optional deployment media protection metadata.</param>
-    /// <returns>Serialized Deploy configuration JSON.</returns>
-    string GenerateDeployConfigurationJson(
-        TelemetrySettings? telemetryOverride = null,
-        byte[]? deploymentSecretsKey = null,
-        DeployProtectionSettings? protectionSettings = null);
 }

--- a/src/Foundry/Services/Shell/AppNavigationService.cs
+++ b/src/Foundry/Services/Shell/AppNavigationService.cs
@@ -24,7 +24,7 @@ internal sealed class AppNavigationService(
 
     public ObservableCollection<BreadcrumbEntry> Breadcrumbs { get; } = [];
 
-    private bool CanGoBack => frame?.CanGoBack == true && navigationGuard.State != ShellNavigationState.OperationRunning;
+    private bool CanGoBack => frame?.CanGoBack == true && navigationGuard.State is not (ShellNavigationState.OperationRunning or ShellNavigationState.InteractionPending);
 
     public bool IsBreadcrumbVisible =>
         currentRoute?.PageType == typeof(Views.SettingsPage) || currentRoute?.ParentPageType is not null;
@@ -87,7 +87,7 @@ internal sealed class AppNavigationService(
 
     public bool RefreshCurrentPage()
     {
-        if (frame is null || currentRoute is null)
+        if (frame is null || currentRoute is null || !IsRouteEnabled(currentRoute, navigationGuard.State))
         {
             return false;
         }
@@ -268,7 +268,7 @@ internal sealed class AppNavigationService(
 
         if (navigationView?.SettingsItem is NavigationViewItem settingsItem)
         {
-            settingsItem.IsEnabled = navigationGuard.State != ShellNavigationState.OperationRunning;
+            settingsItem.IsEnabled = navigationGuard.State is not (ShellNavigationState.OperationRunning or ShellNavigationState.InteractionPending);
         }
 
         if (raiseStateChanged)
@@ -281,7 +281,7 @@ internal sealed class AppNavigationService(
     {
         ShellNavigationState.Ready => true,
         ShellNavigationState.AdkBlocked => route.IsAvailableWhenAdkBlocked,
-        ShellNavigationState.OperationRunning => false,
+        ShellNavigationState.OperationRunning or ShellNavigationState.InteractionPending => false,
         _ => false
     };
 }

--- a/src/Foundry/Services/Shell/ShellNavigationState.cs
+++ b/src/Foundry/Services/Shell/ShellNavigationState.cs
@@ -22,5 +22,10 @@ public enum ShellNavigationState
     /// <summary>
     /// Navigation is restricted while a long-running operation is active.
     /// </summary>
-    OperationRunning
+    OperationRunning,
+
+    /// <summary>
+    /// Navigation is restricted while a profile action owns its own dialog.
+    /// </summary>
+    InteractionPending
 }

--- a/src/Foundry/Strings/ar-SA/Resources.resw
+++ b/src/Foundry/Strings/ar-SA/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>خيارات نشر Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>فتح</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>ملف التعريف النشط</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>المزامنة التلقائية</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>تم حفظ ملف التعريف، لكن لا تزال بيانات الاعتماد القديمة بحاجة إلى إزالة. أعد المحاولة عندما يتاح مدير بيانات الاعتماد في Windows.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>تأكيد عبارة المرور</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>تتطلب التغييرات المتعارضة اتخاذ قرار.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>اختر نسخة أو احفظ نسخة إضافية للاحتفاظ بكلتيهما. سيتم استبدال النسخة الأخرى.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>متابعة</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>إنشاء ملف تعريف مشترك</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>حذف ملف التعريف المحلي</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>حذف ملف التعريف المشترك أيضًا</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>هل تريد حذف ملف التعريف المشترك لجميع عمليات التثبيت؟ يجب على المحررين الآخرين حفظ نسخ من عملهم.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>هل تريد حذف ملف التعريف المحلي هذا؟ صدّر نسخة احتياطية أولًا إذا لزم الأمر.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>تم حذف ملف التعريف المشترك. احفظ نسخة محلية للاحتفاظ بعملك.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>تذكّر كلمات المرور ونقل ملفات التعريف ومزامنة الإعدادات المشتركة.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>تصدير ملف تعريف مشفّر</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>تصدير ملف الاسترداد</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>فشلت العملية. تحقّق من الملف وعبارة المرور والأذونات والاتصال.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>نسيان بيانات الاعتماد</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>هل تريد نسيان كلمات المرور المحفوظة والمفتاح المشترك لملف التعريف المحلي هذا؟ لن تتغير وسائط النشر الحالية.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>ملفات تعريف النشر</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>امتلأ سجل الإصدارات المشترك. أنشئ مستودعًا مشتركًا جديدًا.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>استيراد كنسخة</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>تضمين البيانات السرية والملفات الحساسة</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>أكمل كلمات المرور وملفات المصدر المطلوبة قبل تذكّر البيانات السرية أو نشرها.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>الانضمام باستخدام ملف الاسترداد</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>الاحتفاظ بالنسخة المحلية</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>يحفظ مدير بيانات الاعتماد في Windows كلمات المرور لمستخدم Windows هذا على هذا الكمبيوتر.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>بيانات الاعتماد المحفوظة غير متاحة لمستخدم Windows هذا.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>إدارة</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>هناك {0} من الملفات المفقودة أو غير المضمّنة. راجع مساراتها قبل إنشاء وسائط النشر.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>اسم ملف التعريف</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>المشاركة مشغولة أو غير متاحة. تم الاحتفاظ بالعمل المحلي.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>عبارة المرور</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+الملفات: {1}
+البيانات السرية: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>جاهز</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>احتفظ بملف الاسترداد المشفّر وعبارة المرور الخاصة به خارج المجلد المشترك.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>تذكّر كلمات المرور</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>تذكّر المفتاح المشترك</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>إعادة تسمية</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>سيؤدي هذا إلى استبدال الإعدادات النشطة. احفظ نسخة أولًا للاحتفاظ بعملك.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>تغيّر سجل الإصدارات المشترك بشكل غير متوقع. استعد نسخة موثوقة.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>حفظ نسخة</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>يمكن للمستلمين الذين يملكون مفتاح ملف التعريف قراءة البيانات السرية والمفاتيح الخاصة للشهادات المضمّنة.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>المجلد المشترك</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>استخدم مشاركة SMB 3 مرجعية واحدة مع فرض التشفير. المجلدات المنسوخة عبر المزامنة السحابية غير مدعومة.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>المزامنة الآن</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>تمت المزامنة</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>يستخدم ملف التعريف هذا تنسيقًا غير مدعوم. حدّث Foundry قبل فتحه.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>يتوفر تحديث مشترك. اختر «المزامنة الآن» لتطبيقه.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>استخدام النسخة المشتركة</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>أكمل الحقول المطلوبة، واستخدم مسار مشاركة UNC، وأدخل عبارتي مرور متطابقتين.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>عام</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>تذكّر كلمات المرور ونقل ملفات التعريف ومزامنة الإعدادات المشتركة.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>ملفات تعريف النشر</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/bg-BG/Resources.resw
+++ b/src/Foundry/Strings/bg-BG/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Опции за разполагане на Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Отваряне</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Активен профил</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Автоматично синхронизиране</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Профилът е запазен, но старите идентификационни данни все още трябва да бъдат премахнати. Опитайте отново, когато диспечерът на идентификационни данни на Windows е достъпен.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Потвърждаване на паролата</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Конфликтните промени изискват решение.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Изберете версия или запазете копие, за да запазите и двете. Другата версия ще бъде заменена.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Продължаване</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Създаване на споделен профил</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Изтриване на локален профил</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Изтриване и на споделения профил</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Да се изтрие ли споделеният профил за всички инсталации? Другите редактори трябва да запазят работата си като копие.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Да се изтрие ли този локален профил? При нужда първо експортирайте резервно копие.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Споделеният профил е изтрит. Запазете локално копие, за да запазите работата си.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Запомняйте пароли, прехвърляйте профили и синхронизирайте споделени настройки.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Експортиране на шифрован профил</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Експортиране на файл за възстановяване</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Операцията е неуспешна. Проверете файла, паролата, разрешенията и връзката.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Забравяне на идентификационни данни</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Да се забравят ли запазените пароли и споделеният ключ за този локален профил? Съществуващите носители остават непроменени.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Профили за разполагане</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Споделената история е пълна. Създайте ново споделено хранилище.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Импортиране като копие</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Включване на тайни и поверителни файлове</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Попълнете необходимите пароли и изходни файлове, преди да запомняте или публикувате тайни.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Присъединяване чрез файл за възстановяване</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Запазване на локалната версия</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Диспечерът на идентификационни данни на Windows съхранява паролите за този потребител на този компютър.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Запазените идентификационни данни са недостъпни за този потребител на Windows.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Управление</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} файла липсват или са пропуснати. Проверете пътищата им, преди да създадете носител.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Име на профила</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Споделената папка е заета или недостъпна. Локалната работа е запазена.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Парола</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Файлове: {1}
+Тайни: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Готово</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Съхранявайте шифрования файл за възстановяване и паролата му извън споделената папка.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Запомняне на пароли</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Запомняне на споделения ключ</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Преименуване</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Това заменя активната конфигурация. Първо запазете копие, за да запазите работата си.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Споделената история се промени неочаквано. Възстановете от надеждно копие.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Запазване като копие</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Получателите с ключа на профила могат да четат включените тайни и частни ключове на сертификати.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Споделена папка</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Използвайте един основен споделен ресурс SMB 3 със задължително шифроване. Папки, дублирани в облака, не се поддържат.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Синхронизиране сега</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Синхронизирано</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Този профил използва неподдържан формат. Актуализирайте Foundry, преди да го отворите.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Налична е споделена актуализация. Изберете „Синхронизиране сега“, за да я приложите.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Използване на споделената версия</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Попълнете задължителните полета, използвайте UNC път и въведете еднакви пароли.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>генерал</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Запомняйте пароли, прехвърляйте профили и синхронизирайте споделени настройки.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Профили за разполагане</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/cs-CZ/Resources.resw
+++ b/src/Foundry/Strings/cs-CZ/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Možnosti nasazení Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Otevřít</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Aktivní profil</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Automatická synchronizace</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Profil byl uložen, ale staré přihlašovací údaje je ještě nutné odstranit. Zkuste to znovu, až bude Správce pověření systému Windows dostupný.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Potvrdit heslovou frázi</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Konfliktní změny vyžadují rozhodnutí.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Vyberte verzi nebo uložte kopii pro zachování obou. Druhá verze bude nahrazena.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Pokračovat</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Vytvořit sdílený profil</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Odstranit místní profil</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Odstranit také sdílený profil</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Odstranit sdílený profil pro všechny instalace? Ostatní editoři musí uložit svou práci jako kopii.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Odstranit tento místní profil? V případě potřeby nejprve exportujte zálohu.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Sdílený profil byl odstraněn. Uložte místní kopii, abyste zachovali práci.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Pamatujte si hesla, přenášejte profily a synchronizujte sdílená nastavení.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Exportovat šifrovaný profil</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Exportovat soubor pro obnovení</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Operace selhala. Zkontrolujte soubor, heslovou frázi, oprávnění a připojení.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Zapomenout přihlašovací údaje</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Zapomenout uložená hesla a sdílený klíč tohoto místního profilu? Existující média zůstanou beze změny.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Profily nasazení</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Sdílená historie je plná. Vytvořte nové sdílené úložiště.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importovat jako kopii</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Zahrnout tajné údaje a důvěrné soubory</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Před zapamatováním nebo publikováním tajných údajů doplňte požadovaná hesla a zdrojové soubory.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Připojit pomocí souboru pro obnovení</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Zachovat místní verzi</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Správce pověření Windows ukládá hesla pro tohoto uživatele Windows na tomto počítači.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Uložené přihlašovací údaje nejsou tomuto uživateli Windows dostupné.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Spravovat</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>Počet chybějících nebo vynechaných souborů: {0}. Před vytvořením média zkontrolujte jejich cesty.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Název profilu</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Sdílení je zaneprázdněné nebo nedostupné. Místní práce je zachována.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Heslová fráze</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Soubory: {1}
+Tajné údaje: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Připraveno</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Šifrovaný soubor pro obnovení a jeho heslovou frázi uchovávejte mimo sdílenou složku.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Zapamatovat hesla</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Zapamatovat sdílený klíč</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Přejmenovat</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Tím nahradíte aktivní konfiguraci. Nejprve uložte kopii, abyste zachovali práci.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Sdílená historie se neočekávaně změnila. Obnovte důvěryhodnou kopii.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Uložit jako kopii</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Příjemci s klíčem profilu mohou číst zahrnuté tajné údaje a soukromé klíče certifikátů.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Sdílená složka</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Použijte jedno autoritativní sdílení SMB 3 s povinným šifrováním. Složky zrcadlené do cloudu nejsou podporovány.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Synchronizovat nyní</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Synchronizováno</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Tento profil používá nepodporovaný formát. Před otevřením aktualizujte Foundry.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Sdílená aktualizace je připravena. Použijte ji volbou Synchronizovat nyní.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Použít sdílenou verzi</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Vyplňte povinná pole, použijte sdílenou cestu UNC a zadejte shodné heslové fráze.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Generál</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Pamatujte si hesla, přenášejte profily a synchronizujte sdílená nastavení.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Profily nasazení</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/da-DK/Resources.resw
+++ b/src/Foundry/Strings/da-DK/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Indstillinger for Windows-udrulning</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Åbn</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Aktiv profil</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Automatisk synkronisering</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Profilen blev gemt, men gamle legitimationsoplysninger skal stadig fjernes. Prøv igen, når Windows Legitimationsstyring er tilgængelig.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Bekræft adgangssætning</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Modstridende ændringer kræver en beslutning.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Vælg en version, eller gem en kopi for at bevare begge. Den anden version erstattes.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Fortsæt</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Opret delt profil</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Slet lokal profil</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Slet også den delte profil</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Slet den delte profil for alle installationer? Andre redaktører skal gemme deres arbejde som en kopi.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Slet denne lokale profil? Eksportér først en sikkerhedskopi, hvis nødvendigt.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Den delte profil blev slettet. Gem en lokal kopi for at bevare arbejdet.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Husk adgangskoder, overfør profiler, og synkroniser delte indstillinger.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Eksportér krypteret profil</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Eksportér gendannelsesfil</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Handlingen mislykkedes. Kontrollér fil, adgangssætning, tilladelser og forbindelse.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Glem legitimationsoplysninger</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Glem gemte adgangskoder og den delte nøgle for denne lokale profil? Eksisterende medier ændres ikke.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Udrulningsprofiler</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Den delte historik er fuld. Opret et nyt delt lager.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importér som kopi</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Medtag hemmeligheder og fortrolige filer</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Udfyld nødvendige adgangskoder og kildefiler, før du husker eller udgiver hemmeligheder.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Tilslut via gendannelsesfil</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Behold lokal version</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Windows Legitimationsstyring gemmer adgangskoder for denne Windows-bruger på denne pc.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Gemte legitimationsoplysninger er utilgængelige for denne Windows-bruger.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Administrer</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} filer mangler eller er udeladt. Kontrollér deres stier, før du opretter medier.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Profilnavn</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Delingen er optaget eller utilgængelig. Lokalt arbejde bevares.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Adgangssætning</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Filer: {1}
+Hemmeligheder: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Klar</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Opbevar den krypterede gendannelsesfil og dens adgangssætning uden for den delte mappe.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Husk adgangskoder</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Husk den delte nøgle</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Omdøb</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Dette erstatter den aktive konfiguration. Gem først en kopi for at bevare arbejdet.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Den delte historik blev ændret uventet. Gendan fra en betroet kopi.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Gem som kopi</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Modtagere med profilnøglen kan læse medtagne hemmeligheder og private certifikatnøgler.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Delt mappe</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Brug én autoritativ SMB 3-deling med påkrævet kryptering. Mapper spejlet i skyen understøttes ikke.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Synkroniser nu</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Synkroniseret</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Denne profil bruger et format, der ikke understøttes. Opdater Foundry, før du åbner den.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>En delt opdatering er klar. Vælg Synkroniser nu for at anvende den.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Brug delt version</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Udfyld påkrævede felter, brug en delt UNC-sti, og indtast ens adgangssætninger.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Generelt</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Husk adgangskoder, overfør profiler, og synkroniser delte indstillinger.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Udrulningsprofiler</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/de-DE/Resources.resw
+++ b/src/Foundry/Strings/de-DE/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Windows-Bereitstellungsoptionen</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Öffnen</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Aktives Profil</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Automatisch synchronisieren</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Das Profil wurde gespeichert, aber alte Anmeldedaten müssen noch entfernt werden. Versuchen Sie es erneut, sobald die Windows-Anmeldeinformationsverwaltung verfügbar ist.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Passphrase bestätigen</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Widersprüchliche Änderungen erfordern eine Entscheidung.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Eine Version auswählen oder eine Kopie speichern, um beide zu behalten. Die andere Version wird ersetzt.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Weiter</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Gemeinsames Profil erstellen</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Lokales Profil löschen</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Auch das gemeinsame Profil löschen</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Das gemeinsame Profil für alle Installationen löschen? Andere Bearbeiter müssen ihre Arbeit als Kopie speichern.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Dieses lokale Profil löschen? Bei Bedarf zuerst eine Sicherung exportieren.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Das gemeinsame Profil wurde gelöscht. Eine lokale Kopie zum Erhalt der Arbeit speichern.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Kennwörter speichern, Profile übertragen und gemeinsame Einstellungen synchronisieren.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Verschlüsseltes Profil exportieren</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Wiederherstellungsdatei exportieren</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Vorgang fehlgeschlagen. Datei, Passphrase, Berechtigungen und Verbindung prüfen.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Anmeldedaten vergessen</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Gespeicherte Kennwörter und den gemeinsamen Schlüssel dieses lokalen Profils vergessen? Vorhandene Medien bleiben unverändert.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Bereitstellungsprofile</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Der gemeinsame Verlauf ist voll. Ein neues gemeinsames Repository erstellen.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Als Kopie importieren</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Geheimnisse und vertrauliche Dateien einschließen</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Vervollständigen Sie erforderliche Passwörter und Quelldateien, bevor Sie Geheimnisse speichern oder veröffentlichen.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Mit Wiederherstellungsdatei beitreten</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Lokale Version behalten</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Die Windows-Anmeldeinformationsverwaltung speichert Kennwörter für diesen Windows-Benutzer auf diesem PC.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Gespeicherte Anmeldedaten sind für diesen Windows-Benutzer nicht verfügbar.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Verwalten</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} Dateien fehlen oder wurden ausgelassen. Prüfen Sie ihre Pfade vor dem Erstellen des Mediums.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Profilname</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Die Freigabe ist belegt oder nicht verfügbar. Lokale Arbeit bleibt erhalten.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Passphrase</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Dateien: {1}
+Geheimnisse: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Bereit</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Die verschlüsselte Wiederherstellungsdatei und ihre Passphrase außerhalb des freigegebenen Ordners aufbewahren.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Kennwörter speichern</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Gemeinsamen Schlüssel speichern</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Umbenennen</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Dies ersetzt die aktive Konfiguration. Zuerst eine Kopie speichern, um die Arbeit zu behalten.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Der gemeinsame Verlauf hat sich unerwartet geändert. Aus einer vertrauenswürdigen Kopie wiederherstellen.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Als Kopie speichern</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Empfänger mit dem Profilschlüssel können enthaltene Geheimnisse und private Zertifikatschlüssel lesen.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Freigegebener Ordner</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Eine maßgebliche SMB-3-Freigabe mit vorgeschriebener Verschlüsselung verwenden. Cloudgespiegelte Ordner werden nicht unterstützt.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Jetzt synchronisieren</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Synchronisiert</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Dieses Profil verwendet ein nicht unterstütztes Format. Aktualisieren Sie Foundry, bevor Sie es öffnen.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Eine gemeinsame Aktualisierung ist bereit. Zum Übernehmen jetzt synchronisieren.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Gemeinsame Version verwenden</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Pflichtfelder ausfüllen, einen UNC-Freigabepfad verwenden und übereinstimmende Passphrasen eingeben.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Allgemein</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Kennwörter speichern, Profile übertragen und gemeinsame Einstellungen synchronisieren.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Bereitstellungsprofile</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/el-GR/Resources.resw
+++ b/src/Foundry/Strings/el-GR/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Επιλογές ανάπτυξης Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Άνοιγμα</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Ενεργό προφίλ</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Αυτόματος συγχρονισμός</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Το προφίλ αποθηκεύτηκε, αλλά τα παλιά διαπιστευτήρια χρειάζονται ακόμη διαγραφή. Δοκιμάστε ξανά όταν η Διαχείριση διαπιστευτηρίων των Windows είναι διαθέσιμη.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Επιβεβαίωση φράσης πρόσβασης</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Οι αντικρουόμενες αλλαγές απαιτούν απόφαση.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Επιλέξτε έκδοση ή αποθηκεύστε αντίγραφο για να διατηρήσετε και τις δύο. Η άλλη έκδοση θα αντικατασταθεί.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Συνέχεια</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Δημιουργία κοινόχρηστου προφίλ</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Διαγραφή τοπικού προφίλ</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Διαγραφή και του κοινόχρηστου προφίλ</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Να διαγραφεί το κοινόχρηστο προφίλ για κάθε εγκατάσταση; Οι άλλοι συντάκτες πρέπει να αποθηκεύσουν την εργασία τους ως αντίγραφο.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Να διαγραφεί αυτό το τοπικό προφίλ; Εξαγάγετε πρώτα αντίγραφο ασφαλείας αν χρειάζεται.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Το κοινόχρηστο προφίλ διαγράφηκε. Αποθηκεύστε τοπικό αντίγραφο για να διατηρήσετε την εργασία σας.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Απομνημόνευση κωδικών, μεταφορά προφίλ και συγχρονισμός κοινόχρηστων ρυθμίσεων.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Εξαγωγή κρυπτογραφημένου προφίλ</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Εξαγωγή αρχείου ανάκτησης</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Η ενέργεια απέτυχε. Ελέγξτε το αρχείο, τη φράση πρόσβασης, τα δικαιώματα και τη σύνδεση.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Διαγραφή διαπιστευτηρίων</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Να διαγραφούν οι αποθηκευμένοι κωδικοί και το κοινόχρηστο κλειδί αυτού του τοπικού προφίλ; Τα υπάρχοντα μέσα δεν αλλάζουν.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Προφίλ ανάπτυξης</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Το κοινόχρηστο ιστορικό είναι πλήρες. Δημιουργήστε νέο κοινόχρηστο αποθετήριο.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Εισαγωγή ως αντίγραφο</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Συμπερίληψη μυστικών και εμπιστευτικών αρχείων</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Συμπληρώστε τους απαιτούμενους κωδικούς και τα αρχεία προέλευσης πριν απομνημονεύσετε ή δημοσιεύσετε μυστικά.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Σύνδεση από αρχείο ανάκτησης</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Διατήρηση τοπικής έκδοσης</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Η Διαχείριση διαπιστευτηρίων των Windows αποθηκεύει κωδικούς για αυτόν τον χρήστη σε αυτόν τον υπολογιστή.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Τα αποθηκευμένα διαπιστευτήρια δεν είναι διαθέσιμα για αυτόν τον χρήστη Windows.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Διαχείριση</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} αρχεία λείπουν ή έχουν παραλειφθεί. Ελέγξτε τις διαδρομές τους πριν δημιουργήσετε μέσα.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Όνομα προφίλ</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Ο κοινόχρηστος φάκελος είναι απασχολημένος ή μη διαθέσιμος. Η τοπική εργασία διατηρείται.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Φράση πρόσβασης</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Αρχεία: {1}
+Μυστικά: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Έτοιμο</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Φυλάξτε το κρυπτογραφημένο αρχείο ανάκτησης και τη φράση πρόσβασής του εκτός του κοινόχρηστου φακέλου.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Απομνημόνευση κωδικών</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Απομνημόνευση κοινόχρηστου κλειδιού</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Μετονομασία</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Αυτό αντικαθιστά την ενεργή διαμόρφωση. Αποθηκεύστε πρώτα αντίγραφο για να διατηρήσετε την εργασία σας.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Το κοινόχρηστο ιστορικό άλλαξε απροσδόκητα. Επαναφέρετε από αξιόπιστο αντίγραφο.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Αποθήκευση ως αντίγραφο</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Οι παραλήπτες με το κλειδί προφίλ μπορούν να διαβάσουν τα συμπεριλαμβανόμενα μυστικά και ιδιωτικά κλειδιά πιστοποιητικών.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Κοινόχρηστος φάκελος</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Χρησιμοποιήστε έναν επίσημο κοινόχρηστο πόρο SMB 3 με υποχρεωτική κρυπτογράφηση. Οι φάκελοι που αντιγράφονται στο cloud δεν υποστηρίζονται.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Συγχρονισμός τώρα</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Συγχρονίστηκε</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Αυτό το προφίλ χρησιμοποιεί μη υποστηριζόμενη μορφή. Ενημερώστε το Foundry πριν το ανοίξετε.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Μια κοινόχρηστη ενημέρωση είναι έτοιμη. Επιλέξτε «Συγχρονισμός τώρα» για εφαρμογή.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Χρήση κοινόχρηστης έκδοσης</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Συμπληρώστε τα απαιτούμενα πεδία, χρησιμοποιήστε κοινόχρηστη διαδρομή UNC και ίδιες φράσεις πρόσβασης.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Στρατηγός</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Απομνημόνευση κωδικών, μεταφορά προφίλ και συγχρονισμός κοινόχρηστων ρυθμίσεων.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Προφίλ ανάπτυξης</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/en-GB/Resources.resw
+++ b/src/Foundry/Strings/en-GB/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Windows deployment options</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Active profile</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Automatic sync</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>The profile was saved, but old credentials still need cleanup. Retry when Windows Credential Manager is available.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Confirm passphrase</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Conflicting changes need a decision.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Choose a version or save a copy to preserve both. The other version will be replaced.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Continue</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Create shared profile</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Delete local profile</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Also delete the shared profile</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Delete the shared profile for every installation? Other editors must save their work as a copy.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Delete this local profile? Export a backup first if needed.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>The shared profile was deleted. Save a local copy to keep your work.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Remember passwords, transfer profiles, and synchronize shared settings.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Export encrypted profile</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Export recovery file</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Operation failed. Check the file, passphrase, permissions, and connection.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Forget credentials</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Forget saved passwords and the shared key for this local profile? Existing media is unchanged.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Deployment profiles</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Shared history is full. Create a new shared repository.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Import as copy</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Include secrets and confidential files</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Complete required passwords and source files before remembering or publishing secrets.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Join from recovery file</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Keep local version</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Windows Credential Manager stores passwords for this Windows user on this PC.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Saved credentials are unavailable for this Windows user.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Manage</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} files are missing or omitted. Review their paths before building media.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Profile name</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>The share is busy or unavailable. Local work is preserved.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Passphrase</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Files: {1}
+Secrets: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Ready</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Keep the encrypted recovery file and its passphrase outside the shared folder.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Remember passwords</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Remember the shared key</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Rename</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>This replaces the active configuration. Save a copy first to keep your work.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Shared history changed unexpectedly. Restore from a trusted copy.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Save as copy</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Recipients with the profile key can read included secrets and certificate private keys.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Shared folder</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Use one authoritative SMB 3 share with encryption required. Cloud-mirrored folders are unsupported.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Sync now</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Synchronized</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>This profile uses an unsupported format. Update Foundry before opening it.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>A shared update is ready. Select Sync now to apply it.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Use shared version</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Complete required fields, use a UNC shared path, and enter matching passphrases.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>General</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Remember passwords, transfer profiles, and synchronize shared settings.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Deployment profiles</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/en-US/Resources.resw
+++ b/src/Foundry/Strings/en-US/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>OS selection</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Active profile</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Automatic sync</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>The profile was saved, but old credentials still need cleanup. Retry when Windows Credential Manager is available.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Confirm passphrase</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Conflicting changes need a decision.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Choose a version or save a copy to preserve both. The other version will be replaced.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Continue</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Create shared profile</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Delete local profile</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Also delete the shared profile</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Delete the shared profile for every installation? Other editors must save their work as a copy.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Delete this local profile? Export a backup first if needed.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>The shared profile was deleted. Save a local copy to keep your work.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Remember passwords, transfer profiles, and synchronize shared settings.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Export encrypted profile</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Export recovery file</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Operation failed. Check the file, passphrase, permissions, and connection.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Forget credentials</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Forget saved passwords and the shared key for this local profile? Existing media is unchanged.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Deployment profiles</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Shared history is full. Create a new shared repository.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Import as copy</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Include secrets and confidential files</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Complete required passwords and source files before remembering or publishing secrets.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Join from recovery file</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Keep local version</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Windows Credential Manager stores passwords for this Windows user on this PC.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Saved credentials are unavailable for this Windows user.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Manage</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} files are missing or omitted. Review their paths before building media.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Profile name</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>The share is busy or unavailable. Local work is preserved.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Passphrase</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Files: {1}
+Secrets: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Ready</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Keep the encrypted recovery file and its passphrase outside the shared folder.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Remember passwords</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Remember the shared key</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Rename</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>This replaces the active configuration. Save a copy first to keep your work.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Shared history changed unexpectedly. Restore from a trusted copy.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Save as copy</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Recipients with the profile key can read included secrets and certificate private keys.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Shared folder</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Use one authoritative SMB 3 share with encryption required. Cloud-mirrored folders are unsupported.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Sync now</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Synchronized</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>This profile uses an unsupported format. Update Foundry before opening it.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>A shared update is ready. Select Sync now to apply it.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Use shared version</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Complete required fields, use a UNC shared path, and enter matching passphrases.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>General</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Remember passwords, transfer profiles, and synchronize shared settings.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Deployment profiles</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/es-ES/Resources.resw
+++ b/src/Foundry/Strings/es-ES/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Opciones de implementación de Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Abrir</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Perfil activo</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Sincronización automática</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>El perfil se guardó, pero quedan credenciales antiguas por eliminar. Reinténtelo cuando el Administrador de credenciales de Windows esté disponible.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Confirmar frase de contraseña</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Los cambios en conflicto requieren una decisión.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Elegir una versión o guardar una copia para conservar ambas. La otra versión se reemplazará.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Continuar</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Crear perfil compartido</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Eliminar perfil local</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Eliminar también el perfil compartido</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>¿Eliminar el perfil compartido para todas las instalaciones? Los demás editores deben guardar una copia de su trabajo.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>¿Eliminar este perfil local? Exportar primero una copia de seguridad si es necesario.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Se eliminó el perfil compartido. Guardar una copia local para conservar el trabajo.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Recordar contraseñas, transferir perfiles y sincronizar ajustes compartidos.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Exportar perfil cifrado</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Exportar archivo de recuperación</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Error en la operación. Revisar el archivo, la frase de contraseña, los permisos y la conexión.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Olvidar credenciales</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>¿Olvidar las contraseñas guardadas y la clave compartida de este perfil local? Los medios existentes no cambian.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Perfiles de implementación</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>El historial compartido está lleno. Crear un repositorio compartido nuevo.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importar como copia</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Incluir secretos y archivos confidenciales</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Complete las contraseñas y los archivos de origen necesarios antes de recordar o publicar secretos.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Unirse con archivo de recuperación</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Conservar versión local</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>El Administrador de credenciales de Windows guarda las contraseñas para este usuario de Windows en este PC.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Las credenciales guardadas no están disponibles para este usuario de Windows.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Administrar</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>Faltan o se han omitido {0} archivos. Revise sus rutas antes de crear el medio.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Nombre del perfil</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>El recurso compartido está ocupado o no disponible. El trabajo local se conserva.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Frase de contraseña</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Archivos: {1}
+Secretos: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Listo</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Guardar el archivo de recuperación cifrado y su frase de contraseña fuera de la carpeta compartida.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Recordar contraseñas</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Recordar la clave compartida</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Cambiar nombre</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Esto reemplaza la configuración activa. Guardar primero una copia para conservar el trabajo.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>El historial compartido cambió inesperadamente. Restaurar una copia de confianza.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Guardar una copia</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Los destinatarios con la clave del perfil pueden leer los secretos y las claves privadas de certificados incluidos.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Carpeta compartida</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Usar un único recurso SMB 3 de referencia con cifrado obligatorio. No se admiten carpetas replicadas en la nube.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Sincronizar ahora</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Sincronizado</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Este perfil usa un formato no compatible. Actualice Foundry antes de abrirlo.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Hay una actualización compartida lista. Seleccionar Sincronizar ahora para aplicarla.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Usar versión compartida</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Completar los campos obligatorios, usar una ruta compartida UNC e introducir frases de contraseña coincidentes.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>General</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Recordar contraseñas, transferir perfiles y sincronizar ajustes compartidos.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Perfiles de implementación</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/es-MX/Resources.resw
+++ b/src/Foundry/Strings/es-MX/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Opciones de implementación de Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Abrir</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Perfil activo</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Sincronización automática</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>El perfil se guardó, pero quedan credenciales antiguas por eliminar. Reinténtelo cuando el Administrador de credenciales de Windows esté disponible.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Confirmar frase de contraseña</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Los cambios en conflicto requieren una decisión.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Elegir una versión o guardar una copia para conservar ambas. La otra versión se reemplazará.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Continuar</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Crear perfil compartido</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Eliminar perfil local</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Eliminar también el perfil compartido</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>¿Eliminar el perfil compartido para todas las instalaciones? Los demás editores deben guardar una copia de su trabajo.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>¿Eliminar este perfil local? Exportar primero una copia de seguridad si es necesario.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Se eliminó el perfil compartido. Guardar una copia local para conservar el trabajo.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Recordar contraseñas, transferir perfiles y sincronizar ajustes compartidos.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Exportar perfil cifrado</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Exportar archivo de recuperación</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Error en la operación. Revisar el archivo, la frase de contraseña, los permisos y la conexión.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Olvidar credenciales</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>¿Olvidar las contraseñas guardadas y la clave compartida de este perfil local? Los medios existentes no cambian.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Perfiles de implementación</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>El historial compartido está lleno. Crear un repositorio compartido nuevo.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importar como copia</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Incluir secretos y archivos confidenciales</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Complete las contraseñas y los archivos de origen necesarios antes de recordar o publicar secretos.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Unirse con archivo de recuperación</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Conservar versión local</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>El Administrador de credenciales de Windows guarda las contraseñas para este usuario de Windows en este PC.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Las credenciales guardadas no están disponibles para este usuario de Windows.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Administrar</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>Faltan o se han omitido {0} archivos. Revise sus rutas antes de crear el medio.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Nombre del perfil</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>El recurso compartido está ocupado o no disponible. El trabajo local se conserva.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Frase de contraseña</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Archivos: {1}
+Secretos: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Listo</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Guardar el archivo de recuperación cifrado y su frase de contraseña fuera de la carpeta compartida.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Recordar contraseñas</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Recordar la clave compartida</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Cambiar nombre</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Esto reemplaza la configuración activa. Guardar primero una copia para conservar el trabajo.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>El historial compartido cambió inesperadamente. Restaurar una copia de confianza.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Guardar una copia</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Los destinatarios con la clave del perfil pueden leer los secretos y las claves privadas de certificados incluidos.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Carpeta compartida</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Usar un único recurso SMB 3 de referencia con cifrado obligatorio. No se admiten carpetas replicadas en la nube.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Sincronizar ahora</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Sincronizado</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Este perfil usa un formato no compatible. Actualice Foundry antes de abrirlo.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Hay una actualización compartida lista. Seleccionar Sincronizar ahora para aplicarla.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Usar versión compartida</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Completar los campos obligatorios, usar una ruta compartida UNC e introducir frases de contraseña coincidentes.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>General</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Recordar contraseñas, transferir perfiles y sincronizar ajustes compartidos.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Perfiles de implementación</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/et-EE/Resources.resw
+++ b/src/Foundry/Strings/et-EE/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Windowsi juurutussuvandid</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Ava</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Aktiivne profiil</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Automaatne sünkroonimine</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Profiil salvestati, kuid vanad identimisandmed tuleb veel eemaldada. Proovige uuesti, kui Windowsi identimisteabe haldur on saadaval.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Kinnita paroolifraas</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Vastuolulised muudatused nõuavad otsust.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Valige versioon või salvestage koopia mõlema säilitamiseks. Teine versioon asendatakse.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Jätka</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Loo jagatud profiil</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Kustuta kohalik profiil</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Kustuta ka jagatud profiil</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Kas kustutada jagatud profiil kõigist installidest? Teised muutjad peavad oma töö koopiana salvestama.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Kas kustutada see kohalik profiil? Vajaduse korral eksportige esmalt varukoopia.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Jagatud profiil kustutati. Töö säilitamiseks salvestage kohalik koopia.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Jätke paroolid meelde, teisaldage profiile ja sünkroonige jagatud sätteid.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Ekspordi krüptitud profiil</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Ekspordi taastefail</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Toiming nurjus. Kontrollige faili, paroolifraasi, õigusi ja ühendust.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Unusta identimisteave</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Kas unustada selle kohaliku profiili salvestatud paroolid ja jagatud võti? Olemasolev andmekandja ei muutu.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Juurutusprofiilid</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Jagatud ajalugu on täis. Looge uus jagatud hoidla.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Impordi koopiana</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Kaasa saladused ja konfidentsiaalsed failid</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Enne saladuste meeldejätmist või avaldamist täitke nõutud paroolid ja lähtefailid.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Liitu taastefaili kaudu</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Säilita kohalik versioon</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Windowsi identimisteabe haldur salvestab paroolid selle Windowsi kasutaja jaoks selles arvutis.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Salvestatud identimisteave pole sellele Windowsi kasutajale saadaval.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Halda</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} faili puudub või on välja jäetud. Enne andmekandja loomist kontrollige nende teid.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Profiili nimi</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Jagatud ressurss on hõivatud või kättesaamatu. Kohalik töö säilib.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Paroolifraas</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Failid: {1}
+Saladused: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Valmis</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Hoidke krüptitud taastefaili ja selle paroolifraasi väljaspool jagatud kausta.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Jäta paroolid meelde</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Jäta jagatud võti meelde</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Nimeta ümber</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>See asendab aktiivse konfiguratsiooni. Töö säilitamiseks salvestage esmalt koopia.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Jagatud ajalugu muutus ootamatult. Taastage usaldusväärsest koopiast.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Salvesta koopiana</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Profiilivõtmega adressaadid saavad lugeda kaasatud saladusi ja sertifikaatide privaatvõtmeid.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Jagatud kaust</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Kasutage ühte põhilist SMB 3 jagatud ressurssi, kus krüptimine on kohustuslik. Pilve peegeldatavaid kaustu ei toetata.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Sünkrooni kohe</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Sünkroonitud</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>See profiil kasutab toetamata vormingut. Enne selle avamist värskendage Foundryt.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Jagatud värskendus on valmis. Rakendamiseks valige „Sünkrooni kohe”.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Kasuta jagatud versiooni</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Täitke nõutud väljad, kasutage UNC jagatud teed ja sisestage kattuvad paroolifraasid.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Kindral</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Jätke paroolid meelde, teisaldage profiile ja sünkroonige jagatud sätteid.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Juurutusprofiilid</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/fi-FI/Resources.resw
+++ b/src/Foundry/Strings/fi-FI/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Windowsin käyttöönottoasetukset</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Avaa</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Aktiivinen profiili</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Automaattinen synkronointi</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Profiili tallennettiin, mutta vanhat tunnistetiedot on vielä poistettava. Yritä uudelleen, kun Windowsin tunnistetietojen hallinta on käytettävissä.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Vahvista salalause</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Ristiriitaiset muutokset edellyttävät päätöstä.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Valitse versio tai säilytä molemmat tallentamalla kopio. Toinen versio korvataan.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Jatka</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Luo jaettu profiili</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Poista paikallinen profiili</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Poista myös jaettu profiili</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Poistetaanko jaettu profiili kaikista asennuksista? Muiden muokkaajien on tallennettava työnsä kopiona.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Poistetaanko tämä paikallinen profiili? Vie tarvittaessa ensin varmuuskopio.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Jaettu profiili poistettiin. Säilytä työ tallentamalla paikallinen kopio.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Muista salasanat, siirrä profiileja ja synkronoi jaetut asetukset.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Vie salattu profiili</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Vie palautustiedosto</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Toiminto epäonnistui. Tarkista tiedosto, salalause, oikeudet ja yhteys.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Unohda tunnistetiedot</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Unohdetaanko tämän paikallisen profiilin tallennetut salasanat ja jaettu avain? Nykyiset tietovälineet eivät muutu.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Käyttöönottoprofiilit</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Jaettu historia on täynnä. Luo uusi jaettu säilö.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Tuo kopiona</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Sisällytä salaisuudet ja luottamukselliset tiedostot</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Täydennä tarvittavat salasanat ja lähdetiedostot ennen salaisuuksien muistamista tai julkaisemista.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Liity palautustiedoston avulla</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Säilytä paikallinen versio</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Windowsin tunnistetietojen hallinta tallentaa salasanat tälle Windows-käyttäjälle tällä tietokoneella.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Tallennetut tunnistetiedot eivät ole tämän Windows-käyttäjän käytettävissä.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Hallitse</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} tiedostoa puuttuu tai on jätetty pois. Tarkista niiden polut ennen tietovälineen luomista.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Profiilin nimi</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Jako on varattu tai ei käytettävissä. Paikallinen työ säilytetään.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Salalause</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Tiedostot: {1}
+Salaisuudet: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Valmis</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Säilytä salattu palautustiedosto ja sen salalause jaetun kansion ulkopuolella.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Muista salasanat</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Muista jaettu avain</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Nimeä uudelleen</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Tämä korvaa aktiivisen määrityksen. Säilytä työ tallentamalla ensin kopio.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Jaettu historia muuttui odottamatta. Palauta luotetusta kopiosta.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Tallenna kopiona</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Profiiliavaimen haltijat voivat lukea sisällytetyt salaisuudet ja varmenteiden yksityiset avaimet.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Jaettu kansio</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Käytä yhtä ensisijaista SMB 3 -jakoa, jossa salaus on pakollinen. Pilvipeilattuja kansioita ei tueta.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Synkronoi nyt</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Synkronoitu</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Tämä profiili käyttää muotoa, jota ei tueta. Päivitä Foundry ennen sen avaamista.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Jaettu päivitys on valmis. Ota se käyttöön valitsemalla Synkronoi nyt.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Käytä jaettua versiota</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Täytä pakolliset kentät, käytä jaettua UNC-polkua ja anna samat salalauseet.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Kenraali</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Muista salasanat, siirrä profiileja ja synkronoi jaetut asetukset.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Käyttöönottoprofiilit</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/fr-CA/Resources.resw
+++ b/src/Foundry/Strings/fr-CA/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Options de déploiement Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Ouvrir</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Profil actif</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Synchronisation automatique</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Le profil a été enregistré, mais d’anciens identifiants restent à supprimer. Réessayez lorsque le Gestionnaire d’identification Windows sera disponible.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Confirmer la phrase secrète</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Les modifications en conflit nécessitent une décision.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Choisir une version ou enregistrer une copie pour conserver les deux. L’autre version sera remplacée.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Continuer</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Créer un profil partagé</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Supprimer le profil local</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Supprimer aussi le profil partagé</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Supprimer le profil partagé pour toutes les installations ? Les autres utilisateurs doivent enregistrer une copie de leur travail.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Supprimer ce profil local ? Exporter d’abord une sauvegarde si nécessaire.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Le profil partagé a été supprimé. Enregistrer une copie locale pour conserver votre travail.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Mémoriser les mots de passe, transférer les profils et synchroniser les paramètres partagés.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Exporter le profil chiffré</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Exporter le fichier de récupération</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Échec de l’opération. Vérifier le fichier, la phrase secrète, les autorisations et la connexion.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Oublier les identifiants</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Oublier les mots de passe enregistrés et la clé partagée de ce profil local ? Les supports existants restent inchangés.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Profils de déploiement</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>L’historique partagé est plein. Créer un nouveau dépôt partagé.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importer une copie</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Inclure les secrets et fichiers confidentiels</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Renseignez les mots de passe et fichiers sources requis avant de mémoriser ou de publier des secrets.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Rejoindre avec un fichier de récupération</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Conserver la version locale</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Le Gestionnaire d’informations d’identification Windows stocke les mots de passe pour cet utilisateur Windows sur ce PC.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Les identifiants enregistrés sont indisponibles pour cet utilisateur Windows.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Gérer</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} fichiers sont manquants ou omis. Vérifiez leurs chemins avant de créer le support.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Nom du profil</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Le partage est occupé ou indisponible. Le travail local est conservé.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Phrase secrète</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Fichiers : {1}
+Secrets : {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Prêt</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Conserver le fichier de récupération chiffré et sa phrase secrète hors du dossier partagé.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Mémoriser les mots de passe</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Mémoriser la clé partagée</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Renommer</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>La configuration active sera remplacée. Enregistrer d’abord une copie pour conserver votre travail.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>L’historique partagé a changé de façon inattendue. Restaurer une copie de confiance.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Enregistrer une copie</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Les destinataires disposant de la clé du profil peuvent lire les secrets et clés privées de certificat inclus.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Dossier partagé</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Utiliser un seul partage SMB 3 faisant autorité, avec chiffrement obligatoire. Les dossiers répliqués dans le cloud ne sont pas pris en charge.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Synchroniser maintenant</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Synchronisé</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Ce profil utilise un format non pris en charge. Mettez Foundry à jour avant de l’ouvrir.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Une mise à jour partagée est prête. Sélectionner Synchroniser maintenant pour l’appliquer.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Utiliser la version partagée</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Remplir les champs obligatoires, utiliser un chemin partagé UNC et saisir des phrases secrètes identiques.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Échec de la connexion</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Général</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Mémoriser les mots de passe, transférer les profils et synchroniser les paramètres partagés.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Profils de déploiement</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configurez la manière dont Foundry OSD se connecte aux services en ligne.</value>

--- a/src/Foundry/Strings/fr-FR/Resources.resw
+++ b/src/Foundry/Strings/fr-FR/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Options de déploiement Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Ouvrir</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Profil actif</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Synchronisation automatique</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Le profil a été enregistré, mais d’anciens identifiants restent à supprimer. Réessayez lorsque le Gestionnaire d’identification Windows sera disponible.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Confirmer la phrase secrète</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Les modifications en conflit nécessitent une décision.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Choisir une version ou enregistrer une copie pour conserver les deux. L’autre version sera remplacée.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Continuer</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Créer un profil partagé</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Supprimer le profil local</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Supprimer aussi le profil partagé</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Supprimer le profil partagé pour toutes les installations ? Les autres utilisateurs doivent enregistrer une copie de leur travail.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Supprimer ce profil local ? Exporter d’abord une sauvegarde si nécessaire.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Le profil partagé a été supprimé. Enregistrer une copie locale pour conserver votre travail.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Mémoriser les mots de passe, transférer les profils et synchroniser les paramètres partagés.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Exporter le profil chiffré</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Exporter le fichier de récupération</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Échec de l’opération. Vérifier le fichier, la phrase secrète, les autorisations et la connexion.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Oublier les identifiants</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Oublier les mots de passe enregistrés et la clé partagée de ce profil local ? Les supports existants restent inchangés.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Profils de déploiement</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>L’historique partagé est plein. Créer un nouveau dépôt partagé.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importer une copie</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Inclure les secrets et fichiers confidentiels</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Renseignez les mots de passe et fichiers sources requis avant de mémoriser ou de publier des secrets.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Rejoindre avec un fichier de récupération</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Conserver la version locale</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Le Gestionnaire d’informations d’identification Windows stocke les mots de passe pour cet utilisateur Windows sur ce PC.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Les identifiants enregistrés sont indisponibles pour cet utilisateur Windows.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Gérer</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} fichiers sont manquants ou omis. Vérifiez leurs chemins avant de créer le support.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Nom du profil</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Le partage est occupé ou indisponible. Le travail local est conservé.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Phrase secrète</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Fichiers : {1}
+Secrets : {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Prêt</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Conserver le fichier de récupération chiffré et sa phrase secrète hors du dossier partagé.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Mémoriser les mots de passe</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Mémoriser la clé partagée</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Renommer</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>La configuration active sera remplacée. Enregistrer d’abord une copie pour conserver votre travail.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>L’historique partagé a changé de façon inattendue. Restaurer une copie de confiance.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Enregistrer une copie</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Les destinataires disposant de la clé du profil peuvent lire les secrets et clés privées de certificat inclus.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Dossier partagé</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Utiliser un seul partage SMB 3 faisant autorité, avec chiffrement obligatoire. Les dossiers répliqués dans le cloud ne sont pas pris en charge.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Synchroniser maintenant</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Synchronisé</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Ce profil utilise un format non pris en charge. Mettez Foundry à jour avant de l’ouvrir.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Une mise à jour partagée est prête. Sélectionner Synchroniser maintenant pour l’appliquer.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Utiliser la version partagée</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Remplir les champs obligatoires, utiliser un chemin partagé UNC et saisir des phrases secrètes identiques.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Échec de la connexion</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Général</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Mémoriser les mots de passe, transférer les profils et synchroniser les paramètres partagés.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Profils de déploiement</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configurez la manière dont Foundry OSD se connecte aux services en ligne.</value>

--- a/src/Foundry/Strings/he-IL/Resources.resw
+++ b/src/Foundry/Strings/he-IL/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>אפשרויות פריסת Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>פתיחה</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>הפרופיל הפעיל</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>סנכרון אוטומטי</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>הפרופיל נשמר, אך עדיין יש להסיר אישורים ישנים. יש לנסות שוב כאשר מנהל האישורים של Windows יהיה זמין.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>אישור ביטוי הסיסמה</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>יש להחליט כיצד לטפל בשינויים המתנגשים.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>יש לבחור גרסה או לשמור עותק כדי לשמר את שתיהן. הגרסה האחרת תוחלף.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>המשך</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>יצירת פרופיל משותף</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>מחיקת פרופיל מקומי</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>מחיקת הפרופיל המשותף גם כן</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>למחוק את הפרופיל המשותף בכל ההתקנות? עורכים אחרים יצטרכו לשמור עותק של עבודתם.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>למחוק פרופיל מקומי זה? במידת הצורך, יש לייצא גיבוי תחילה.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>הפרופיל המשותף נמחק. יש לשמור עותק מקומי כדי לשמר את העבודה.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>שמירת סיסמאות, העברת פרופילים וסנכרון הגדרות משותפות.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>ייצוא פרופיל מוצפן</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>ייצוא קובץ שחזור</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>הפעולה נכשלה. יש לבדוק את הקובץ, ביטוי הסיסמה, ההרשאות והחיבור.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>מחיקת אישורים שמורים</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>למחוק את הסיסמאות השמורות ואת המפתח המשותף של פרופיל מקומי זה? מדיית הפריסה הקיימת לא תשתנה.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>פרופילי פריסה</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>ההיסטוריה המשותפת מלאה. יש ליצור מאגר משותף חדש.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>ייבוא כעותק</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>כלילת נתונים סודיים וקבצים חסויים</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>יש להשלים את הסיסמאות ואת קובצי המקור הנדרשים לפני שמירה או פרסום של נתונים סודיים.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>הצטרפות באמצעות קובץ שחזור</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>שמירת הגרסה המקומית</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>מנהל האישורים של Windows שומר סיסמאות עבור משתמש Windows זה במחשב זה.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>האישורים השמורים אינם זמינים למשתמש Windows זה.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>ניהול</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} קבצים חסרים או לא נכללו. יש לבדוק את הנתיבים שלהם לפני יצירת מדיית הפריסה.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>שם הפרופיל</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>השיתוף תפוס או אינו זמין. העבודה המקומית נשמרת.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>ביטוי סיסמה</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+קבצים: {1}
+נתונים סודיים: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>מוכן</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>יש לשמור את קובץ השחזור המוצפן ואת ביטוי הסיסמה שלו מחוץ לתיקייה המשותפת.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>שמירת סיסמאות</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>שמירת המפתח המשותף</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>שינוי שם</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>פעולה זו תחליף את התצורה הפעילה. יש לשמור עותק תחילה כדי לשמר את העבודה.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>ההיסטוריה המשותפת השתנתה באופן בלתי צפוי. יש לשחזר מעותק מהימן.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>שמירה כעותק</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>נמענים המחזיקים במפתח הפרופיל יכולים לקרוא את הנתונים הסודיים ואת המפתחות הפרטיים של האישורים הכלולים בו.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>תיקייה משותפת</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>יש להשתמש בשיתוף SMB 3 מרכזי יחיד המחייב הצפנה. תיקיות המשוכפלות דרך הענן אינן נתמכות.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>סנכרון עכשיו</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>מסונכרן</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>פרופיל זה משתמש בתבנית שאינה נתמכת. יש לעדכן את Foundry לפני פתיחתו.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>עדכון משותף מוכן. יש לבחור בסנכרון עכשיו כדי להחיל אותו.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>שימוש בגרסה המשותפת</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>יש למלא את שדות החובה, להשתמש בנתיב שיתוף UNC ולהזין ביטויי סיסמה תואמים.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>כללי</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>שמירת סיסמאות, העברת פרופילים וסנכרון הגדרות משותפות.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>פרופילי פריסה</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/hr-HR/Resources.resw
+++ b/src/Foundry/Strings/hr-HR/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Mogućnosti implementacije sustava Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Otvori</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Aktivni profil</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Automatska sinkronizacija</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Profil je spremljen, ali stare vjerodajnice još treba ukloniti. Pokušajte ponovno kada Upravitelj vjerodajnica sustava Windows bude dostupan.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Potvrdi zaporku</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Sukobljene promjene zahtijevaju odluku.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Odaberi verziju ili spremi kopiju da zadržiš obje. Druga verzija bit će zamijenjena.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Nastavi</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Stvori zajednički profil</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Izbriši lokalni profil</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Izbriši i zajednički profil</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Izbrisati zajednički profil za sve instalacije? Ostali urednici moraju spremiti svoj rad kao kopiju.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Izbrisati ovaj lokalni profil? Po potrebi najprije izvezi sigurnosnu kopiju.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Zajednički profil je izbrisan. Spremi lokalnu kopiju za očuvanje rada.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Zapamtite lozinke, prenesite profile i sinkronizirajte zajedničke postavke.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Izvezi šifrirani profil</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Izvezi datoteku za oporavak</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Radnja nije uspjela. Provjeri datoteku, zaporku, dozvole i vezu.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Zaboravi vjerodajnice</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Zaboraviti spremljene lozinke i zajednički ključ ovog lokalnog profila? Postojeći mediji ostaju nepromijenjeni.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Profili implementacije</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Zajednička povijest je puna. Stvori novo zajedničko spremište.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Uvezi kao kopiju</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Uključi tajne podatke i povjerljive datoteke</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Unesite potrebne lozinke i izvorne datoteke prije pamćenja ili objavljivanja tajni.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Pridruži se datotekom za oporavak</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Zadrži lokalnu verziju</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Upravitelj vjerodajnica sustava Windows pohranjuje lozinke za ovog korisnika sustava Windows na ovom računalu.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Spremljene vjerodajnice nisu dostupne ovom korisniku sustava Windows.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Upravljaj</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>Broj datoteka koje nedostaju ili su izostavljene: {0}. Provjerite njihove putanje prije izrade medija.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Naziv profila</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Zajednički resurs je zauzet ili nedostupan. Lokalni rad je sačuvan.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Zaporka</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Datoteke: {1}
+Tajni podaci: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Spremno</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Šifriranu datoteku za oporavak i njezinu zaporku čuvaj izvan zajedničke mape.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Zapamti lozinke</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Zapamti zajednički ključ</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Preimenuj</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Ovo zamjenjuje aktivnu konfiguraciju. Najprije spremi kopiju za očuvanje rada.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Zajednička povijest neočekivano se promijenila. Vrati pouzdanu kopiju.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Spremi kao kopiju</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Primatelji s ključem profila mogu čitati uključene tajne podatke i privatne ključeve certifikata.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Zajednička mapa</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Upotrijebi jedan mjerodavni SMB 3 resurs s obveznim šifriranjem. Mape zrcaljene u oblaku nisu podržane.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Sinkroniziraj sada</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Sinkronizirano</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Ovaj profil koristi nepodržani format. Ažurirajte Foundry prije otvaranja.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Zajedničko ažuriranje je spremno. Odaberi Sinkroniziraj sada za primjenu.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Upotrijebi zajedničku verziju</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Ispuni obvezna polja, upotrijebi zajedničku UNC putanju i unesi jednake zaporke.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>General</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Zapamtite lozinke, prenesite profile i sinkronizirajte zajedničke postavke.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Profili implementacije</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/hu-HU/Resources.resw
+++ b/src/Foundry/Strings/hu-HU/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Windows-telepítési lehetőségek</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Megnyitás</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Aktív profil</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Automatikus szinkronizálás</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>A profil mentve lett, de a régi hitelesítő adatokat még el kell távolítani. Próbálja újra, amikor a Windows Hitelesítőadat-kezelő elérhető.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Jelmondat megerősítése</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Az ütköző módosításokról dönteni kell.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Válasszon egy verziót, vagy mentsen másolatot mindkettő megtartásához. A másik verzió lecserélődik.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Folytatás</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Megosztott profil létrehozása</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Helyi profil törlése</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>A megosztott profil törlése is</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Törli a megosztott profilt minden telepítéshez? A többi szerkesztőnek másolatként kell mentenie a munkáját.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Törli ezt a helyi profilt? Szükség esetén először exportáljon biztonsági másolatot.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>A megosztott profilt törölték. Munkája megőrzéséhez mentsen helyi másolatot.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Jelszavak megjegyzése, profilok átvitele és megosztott beállítások szinkronizálása.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Titkosított profil exportálása</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Helyreállítási fájl exportálása</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>A művelet sikertelen. Ellenőrizze a fájlt, jelmondatot, jogosultságokat és kapcsolatot.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Hitelesítő adatok elfelejtése</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Elfelejti e helyi profil mentett jelszavait és megosztott kulcsát? A meglévő adathordozók nem változnak.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Telepítési profilok</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>A megosztott előzmények megteltek. Hozzon létre új megosztott tárhelyet.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importálás másolatként</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Titkos adatok és bizalmas fájlok hozzáadása</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>A titkok megjegyzése vagy közzététele előtt adja meg a szükséges jelszavakat és forrásfájlokat.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Csatlakozás helyreállítási fájllal</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Helyi verzió megtartása</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>A Windows Hitelesítőadat-kezelő ezen a gépen ehhez a Windows-felhasználóhoz tárolja a jelszavakat.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>A mentett hitelesítő adatok nem érhetők el ennek a Windows-felhasználónak.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Kezelés</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} fájl hiányzik vagy ki lett hagyva. Az adathordozó létrehozása előtt ellenőrizze az elérési útjukat.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Profil neve</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>A megosztás foglalt vagy nem érhető el. A helyi munka megmarad.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Jelmondat</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Fájlok: {1}
+Titkos adatok: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Kész</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>A titkosított helyreállítási fájlt és jelmondatát a megosztott mappán kívül tárolja.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Jelszavak megjegyzése</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Megosztott kulcs megjegyzése</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Átnevezés</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Ez lecseréli az aktív konfigurációt. Munkája megőrzéséhez először mentsen másolatot.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>A megosztott előzmények váratlanul megváltoztak. Állítson vissza egy megbízható másolatot.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Mentés másolatként</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>A profilkulccsal rendelkező címzettek olvashatják a mellékelt titkos adatokat és tanúsítványok magánkulcsait.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Megosztott mappa</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Egyetlen mérvadó SMB 3-megosztást használjon kötelező titkosítással. A felhőbe tükrözött mappák nem támogatottak.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Szinkronizálás most</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Szinkronizálva</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Ez a profil nem támogatott formátumot használ. Megnyitása előtt frissítse a Foundryt.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Megosztott frissítés érhető el. Az alkalmazásához válassza a Szinkronizálás most lehetőséget.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Megosztott verzió használata</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Töltse ki a kötelező mezőket, használjon UNC-megosztási útvonalat és egyező jelmondatokat.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>tábornok</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Jelszavak megjegyzése, profilok átvitele és megosztott beállítások szinkronizálása.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Telepítési profilok</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/it-IT/Resources.resw
+++ b/src/Foundry/Strings/it-IT/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Opzioni di distribuzione di Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Apri</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Profilo attivo</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Sincronizzazione automatica</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Il profilo è stato salvato, ma alcune vecchie credenziali devono ancora essere rimosse. Riprovare quando Gestione credenziali di Windows sarà disponibile.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Conferma passphrase</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Le modifiche in conflitto richiedono una decisione.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Scegli una versione o salva una copia per conservarle entrambe. L'altra versione verrà sostituita.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Continua</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Crea profilo condiviso</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Elimina profilo locale</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Elimina anche il profilo condiviso</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Eliminare il profilo condiviso per tutte le installazioni? Gli altri utenti devono salvare una copia del proprio lavoro.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Eliminare questo profilo locale? Se necessario, esporta prima un backup.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Il profilo condiviso è stato eliminato. Salva una copia locale per conservare il lavoro.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Memorizza password, trasferisci profili e sincronizza impostazioni condivise.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Esporta profilo crittografato</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Esporta file di ripristino</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Operazione non riuscita. Controlla file, passphrase, autorizzazioni e connessione.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Dimentica credenziali</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Dimenticare le password salvate e la chiave condivisa di questo profilo locale? I supporti esistenti non cambiano.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Profili di distribuzione</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>La cronologia condivisa è piena. Crea un nuovo repository condiviso.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importa come copia</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Includi segreti e file riservati</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Completare le password e i file di origine richiesti prima di memorizzare o pubblicare segreti.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Partecipa tramite file di ripristino</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Mantieni versione locale</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Gestione credenziali di Windows memorizza le password per questo utente Windows su questo PC.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Le credenziali salvate non sono disponibili per questo utente Windows.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Gestisci</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} file sono mancanti o omessi. Verificare i percorsi prima di creare il supporto.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Nome profilo</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>La condivisione è occupata o non disponibile. Il lavoro locale viene conservato.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Passphrase</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+File: {1}
+Segreti: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Pronto</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Conserva il file di ripristino crittografato e la passphrase fuori dalla cartella condivisa.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Memorizza password</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Memorizza la chiave condivisa</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Rinomina</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>La configurazione attiva verrà sostituita. Salva prima una copia per conservare il lavoro.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>La cronologia condivisa è cambiata inaspettatamente. Ripristina una copia attendibile.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Salva una copia</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>I destinatari con la chiave del profilo possono leggere i segreti e le chiavi private dei certificati inclusi.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Cartella condivisa</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Usa un'unica condivisione SMB 3 autorevole con crittografia obbligatoria. Le cartelle replicate nel cloud non sono supportate.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Sincronizza ora</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Sincronizzato</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Questo profilo usa un formato non supportato. Aggiornare Foundry prima di aprirlo.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>È disponibile un aggiornamento condiviso. Seleziona Sincronizza ora per applicarlo.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Usa versione condivisa</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Compila i campi obbligatori, usa un percorso condiviso UNC e inserisci passphrase uguali.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Generale</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Memorizza password, trasferisci profili e sincronizza impostazioni condivise.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Profili di distribuzione</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/ja-JP/Resources.resw
+++ b/src/Foundry/Strings/ja-JP/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Windows 展開オプション</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>開く</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>現在のプロファイル</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>自動同期</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>プロファイルは保存されましたが、古い資格情報の削除が必要です。Windows 資格情報マネージャーが利用可能になったら、もう一度お試しください。</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>パスフレーズの確認</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>変更が競合しています。使用するバージョンを選択してください。</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>使用するバージョンを選択するか、コピーを保存して両方を残してください。もう一方のバージョンは置き換えられます。</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>続行</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>共有プロファイルを作成</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>ローカルプロファイルを削除</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>共有プロファイルも削除</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>すべてのインストール先で共有プロファイルを削除しますか？他の編集者は作業内容をコピーとして保存する必要があります。</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>このローカルプロファイルを削除しますか？必要に応じて、先にバックアップをエクスポートしてください。</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>共有プロファイルは削除されました。作業内容を残すには、ローカルコピーを保存してください。</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>パスワードの保存、プロファイルの転送、共有設定の同期を行います。</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>暗号化プロファイルをエクスポート</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>回復ファイルをエクスポート</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>操作に失敗しました。ファイル、パスフレーズ、アクセス許可、接続を確認してください。</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>保存済み資格情報を削除</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>このローカルプロファイルの保存済みパスワードと共有キーを削除しますか？既存のメディアは変更されません。</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>展開プロファイル</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>共有履歴が上限に達しました。新しい共有リポジトリを作成してください。</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>コピーとしてインポート</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>秘密情報と機密ファイルを含める</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>秘密情報を保存または公開する前に、必要なパスワードとソースファイルをすべて揃えてください。</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>回復ファイルから参加</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>ローカルバージョンを保持</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Windows 資格情報マネージャーは、この PC の現在の Windows ユーザー用にパスワードを保存します。</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>この Windows ユーザーでは、保存済みの資格情報を利用できません。</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>管理</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} 個のファイルが見つからないか、含まれていません。メディアを作成する前にパスを確認してください。</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>プロファイル名</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>共有先が使用中か、利用できません。ローカルの作業内容は保持されます。</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>パスフレーズ</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+ファイル: {1}
+秘密情報: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>準備完了</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>暗号化された回復ファイルとそのパスフレーズは、共有フォルダーの外部に保管してください。</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>パスワードを保存</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>共有キーを保存</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>名前の変更</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>現在の設定が置き換えられます。作業内容を残すには、先にコピーを保存してください。</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>共有履歴が予期せず変更されました。信頼できるコピーから復元してください。</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>コピーとして保存</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>プロファイルのキーを持つ受信者は、含まれている秘密情報や証明書の秘密キーを読み取ることができます。</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>共有フォルダー</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>暗号化を必須にした単一の SMB 3 共有を正規の保存先として使用してください。クラウド経由で複製されるフォルダーはサポートされません。</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>今すぐ同期</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>同期済み</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>このプロファイルはサポートされていない形式を使用しています。開く前に Foundry を更新してください。</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>共有プロファイルの更新があります。「今すぐ同期」を選択して適用してください。</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>共有バージョンを使用</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>必須項目を入力し、UNC 共有パスを指定してください。パスフレーズは確認用と一致させてください。</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>一般</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>パスワードの保存、プロファイルの転送、共有設定の同期を行います。</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>展開プロファイル</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/ko-KR/Resources.resw
+++ b/src/Foundry/Strings/ko-KR/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Windows 배포 옵션</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>열기</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>활성 프로필</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>자동 동기화</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>프로필은 저장되었지만 이전 자격 증명을 아직 정리해야 합니다. Windows 자격 증명 관리자를 사용할 수 있을 때 다시 시도하세요.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>암호 구문 확인</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>변경 사항이 충돌합니다. 사용할 버전을 결정해야 합니다.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>버전을 선택하거나 복사본을 저장하여 두 버전을 모두 보존하세요. 다른 버전은 대체됩니다.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>계속</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>공유 프로필 만들기</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>로컬 프로필 삭제</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>공유 프로필도 삭제</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>모든 설치 환경에서 공유 프로필을 삭제할까요? 다른 편집자는 작업을 복사본으로 저장해야 합니다.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>이 로컬 프로필을 삭제할까요? 필요한 경우 먼저 백업을 내보내세요.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>공유 프로필이 삭제되었습니다. 작업을 보존하려면 로컬 복사본을 저장하세요.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>암호를 저장하고 프로필을 전송하며 공유 설정을 동기화합니다.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>암호화된 프로필 내보내기</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>복구 파일 내보내기</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>작업에 실패했습니다. 파일, 암호 구문, 권한 및 연결을 확인하세요.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>저장된 자격 증명 삭제</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>이 로컬 프로필의 저장된 암호와 공유 키를 삭제할까요? 기존 미디어는 변경되지 않습니다.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>배포 프로필</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>공유 기록이 한도에 도달했습니다. 새 공유 저장소를 만드세요.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>복사본으로 가져오기</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>비밀 정보 및 기밀 파일 포함</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>비밀 정보를 저장하거나 게시하기 전에 필요한 암호와 원본 파일을 모두 준비하세요.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>복구 파일로 참여</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>로컬 버전 유지</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Windows 자격 증명 관리자는 이 PC의 현재 Windows 사용자에 대해 암호를 저장합니다.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>이 Windows 사용자는 저장된 자격 증명을 사용할 수 없습니다.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>관리</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>파일 {0}개가 없거나 포함되지 않았습니다. 미디어를 만들기 전에 해당 경로를 확인하세요.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>프로필 이름</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>공유 위치가 사용 중이거나 사용할 수 없습니다. 로컬 작업은 유지됩니다.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>암호 구문</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+파일: {1}
+비밀 정보: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>준비됨</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>암호화된 복구 파일과 해당 암호 구문을 공유 폴더 외부에 보관하세요.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>암호 저장</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>공유 키 저장</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>이름 바꾸기</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>활성 구성이 바뀝니다. 작업을 보존하려면 먼저 복사본을 저장하세요.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>공유 기록이 예기치 않게 변경되었습니다. 신뢰할 수 있는 복사본에서 복원하세요.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>복사본으로 저장</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>프로필 키를 가진 수신자는 포함된 비밀 정보와 인증서 개인 키를 읽을 수 있습니다.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>공유 폴더</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>암호화를 필수로 설정한 단일 SMB 3 공유를 기준 저장소로 사용하세요. 클라우드를 통해 복제되는 폴더는 지원되지 않습니다.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>지금 동기화</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>동기화됨</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>이 프로필은 지원되지 않는 형식을 사용합니다. 열기 전에 Foundry를 업데이트하세요.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>공유 업데이트가 준비되었습니다. 적용하려면 지금 동기화를 선택하세요.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>공유 버전 사용</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>필수 항목을 입력하고 UNC 공유 경로를 사용하며 암호 구문이 확인 값과 일치하는지 확인하세요.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>일반</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>암호를 저장하고 프로필을 전송하며 공유 설정을 동기화합니다.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>배포 프로필</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/lt-LT/Resources.resw
+++ b/src/Foundry/Strings/lt-LT/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Windows diegimo parinktys</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Atidaryti</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Aktyvus profilis</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Automatinis sinchronizavimas</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Profilis įrašytas, bet senus kredencialus dar reikia pašalinti. Bandykite dar kartą, kai bus pasiekiamas Windows kredencialų tvarkytuvas.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Patvirtinkite slaptafrazę</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Nesuderinamiems pakeitimams reikia sprendimo.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Pasirinkite versiją arba įrašykite kopiją, kad išsaugotumėte abi. Kita versija bus pakeista.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Tęsti</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Kurti bendrinamą profilį</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Naikinti vietinį profilį</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Taip pat naikinti bendrinamą profilį</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Naikinti bendrinamą profilį visose įdiegtose programose? Kiti redaktoriai turi įrašyti savo darbą kaip kopiją.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Naikinti šį vietinį profilį? Jei reikia, pirmiausia eksportuokite atsarginę kopiją.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Bendrinamas profilis panaikintas. Įrašykite vietinę kopiją, kad išsaugotumėte darbą.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Įsiminkite slaptažodžius, perkelkite profilius ir sinchronizuokite bendrinamus parametrus.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Eksportuoti užšifruotą profilį</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Eksportuoti atkūrimo failą</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Operacija nepavyko. Patikrinkite failą, slaptafrazę, teises ir ryšį.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Pamiršti kredencialus</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Pamiršti šio vietinio profilio įrašytus slaptažodžius ir bendrinamą raktą? Esama laikmena nesikeis.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Diegimo profiliai</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Bendrinama istorija pilna. Sukurkite naują bendrinamą saugyklą.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importuoti kaip kopiją</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Įtraukti paslaptis ir konfidencialius failus</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Prieš įsimindami arba skelbdami paslaptis pateikite reikiamus slaptažodžius ir šaltinio failus.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Prisijungti iš atkūrimo failo</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Palikti vietinę versiją</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Windows kredencialų tvarkytuvas saugo slaptažodžius šiam Windows naudotojui šiame kompiuteryje.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Įrašyti kredencialai šiam Windows naudotojui nepasiekiami.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Tvarkyti</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>Trūksta arba praleista {0} failų. Prieš kurdami laikmeną patikrinkite jų kelius.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Profilio pavadinimas</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Bendrinamas išteklius užimtas arba nepasiekiamas. Vietinis darbas išsaugomas.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Slaptafrazė</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Failai: {1}
+Paslaptys: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Paruošta</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Užšifruotą atkūrimo failą ir jo slaptafrazę laikykite už bendrinamo aplanko ribų.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Įsiminti slaptažodžius</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Įsiminti bendrinamą raktą</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Pervardyti</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Tai pakeis aktyvią konfigūraciją. Pirmiausia įrašykite kopiją, kad išsaugotumėte darbą.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Bendrinama istorija netikėtai pasikeitė. Atkurkite iš patikimos kopijos.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Įrašyti kopiją</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Gavėjai, turintys profilio raktą, gali skaityti įtrauktas paslaptis ir privačiuosius sertifikatų raktus.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Bendrinamas aplankas</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Naudokite vieną pagrindinį SMB 3 bendrinamą išteklių su privalomu šifravimu. Debesyje dubliuojami aplankai nepalaikomi.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Sinchronizuoti dabar</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Sinchronizuota</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Šis profilis naudoja nepalaikomą formatą. Prieš atidarydami atnaujinkite Foundry.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Paruoštas bendrinamas naujinimas. Norėdami jį pritaikyti, pasirinkite „Sinchronizuoti dabar“.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Naudoti bendrinamą versiją</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Užpildykite privalomus laukus, naudokite UNC bendrinimo kelią ir įveskite sutampančias slaptafrazes.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Generolas</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Įsiminkite slaptažodžius, perkelkite profilius ir sinchronizuokite bendrinamus parametrus.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Diegimo profiliai</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/lv-LV/Resources.resw
+++ b/src/Foundry/Strings/lv-LV/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Windows izvietošanas opcijas</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Atvērt</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Aktīvais profils</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Automātiska sinhronizācija</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Profils tika saglabāts, bet vecie akreditācijas dati vēl jānoņem. Mēģiniet vēlreiz, kad Windows akreditācijas datu pārvaldnieks būs pieejams.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Apstiprināt paroles frāzi</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Konfliktējošām izmaiņām nepieciešams lēmums.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Izvēlieties versiju vai saglabājiet kopiju, lai paturētu abas. Otra versija tiks aizstāta.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Turpināt</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Izveidot koplietotu profilu</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Dzēst lokālo profilu</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Dzēst arī koplietoto profilu</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Vai dzēst koplietoto profilu visām instalācijām? Citiem redaktoriem jāsaglabā savs darbs kā kopija.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Vai dzēst šo lokālo profilu? Ja nepieciešams, vispirms eksportējiet dublējumu.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Koplietotais profils tika dzēsts. Saglabājiet lokālu kopiju, lai paturētu savu darbu.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Atcerieties paroles, pārsūtiet profilus un sinhronizējiet koplietotos iestatījumus.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Eksportēt šifrētu profilu</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Eksportēt atkopšanas failu</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Darbība neizdevās. Pārbaudiet failu, paroles frāzi, atļaujas un savienojumu.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Aizmirst akreditācijas datus</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Vai aizmirst šī lokālā profila saglabātās paroles un koplietoto atslēgu? Esošie datu nesēji netiks mainīti.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Izvietošanas profili</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Koplietotā vēsture ir pilna. Izveidojiet jaunu koplietotu krātuvi.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importēt kā kopiju</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Iekļaut noslēpumus un konfidenciālus failus</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Pirms noslēpumu atcerēšanās vai publicēšanas norādiet nepieciešamās paroles un avota failus.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Pievienoties no atkopšanas faila</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Paturēt lokālo versiju</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Windows akreditācijas datu pārvaldnieks glabā paroles šim Windows lietotājam šajā datorā.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Saglabātie akreditācijas dati šim Windows lietotājam nav pieejami.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Pārvaldīt</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>Trūkst vai ir izlaisti {0} faili. Pirms datu nesēja izveides pārbaudiet to ceļus.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Profila nosaukums</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Koplietojums ir aizņemts vai nav pieejams. Lokālais darbs tiek saglabāts.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Paroles frāze</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Faili: {1}
+Noslēpumi: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Gatavs</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Glabājiet šifrēto atkopšanas failu un tā paroles frāzi ārpus koplietotās mapes.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Atcerēties paroles</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Atcerēties koplietoto atslēgu</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Pārdēvēt</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Tas aizstās aktīvo konfigurāciju. Vispirms saglabājiet kopiju, lai paturētu savu darbu.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Koplietotā vēsture negaidīti mainījās. Atjaunojiet no uzticamas kopijas.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Saglabāt kā kopiju</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Saņēmēji ar profila atslēgu var lasīt iekļautos noslēpumus un sertifikātu privātās atslēgas.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Koplietotā mape</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Izmantojiet vienu galveno SMB 3 koplietojumu ar obligātu šifrēšanu. Mākonī spoguļotas mapes netiek atbalstītas.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Sinhronizēt tagad</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Sinhronizēts</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Šis profils izmanto neatbalstītu formātu. Pirms tā atvēršanas atjauniniet Foundry.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Ir pieejams koplietots atjauninājums. Lai to lietotu, atlasiet “Sinhronizēt tagad”.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Izmantot koplietoto versiju</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Aizpildiet obligātos laukus, izmantojiet UNC koplietojuma ceļu un ievadiet vienādas paroles frāzes.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Ģenerālis</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Atcerieties paroles, pārsūtiet profilus un sinhronizējiet koplietotos iestatījumus.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Izvietošanas profili</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/nb-NO/Resources.resw
+++ b/src/Foundry/Strings/nb-NO/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Alternativer for Windows-utrulling</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Åpne</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Aktiv profil</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Automatisk synkronisering</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Profilen ble lagret, men gamle legitimasjoner må fortsatt fjernes. Prøv igjen når Windows Legitimasjonsbehandling er tilgjengelig.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Bekreft passfrase</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Motstridende endringer krever en avgjørelse.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Velg en versjon eller lagre en kopi for å beholde begge. Den andre versjonen erstattes.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Fortsett</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Opprett delt profil</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Slett lokal profil</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Slett også den delte profilen</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Slett den delte profilen for alle installasjoner? Andre redaktører må lagre arbeidet som en kopi.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Slett denne lokale profilen? Eksporter først en sikkerhetskopi ved behov.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Den delte profilen ble slettet. Lagre en lokal kopi for å beholde arbeidet.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Husk passord, overfør profiler og synkroniser delte innstillinger.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Eksporter kryptert profil</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Eksporter gjenopprettingsfil</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Handlingen mislyktes. Kontroller fil, passfrase, tillatelser og tilkobling.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Glem legitimasjon</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Glem lagrede passord og den delte nøkkelen for denne lokale profilen? Eksisterende medier endres ikke.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Utrullingsprofiler</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Den delte historikken er full. Opprett et nytt delt lager.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importer som kopi</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Ta med hemmeligheter og fortrolige filer</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Fyll ut nødvendige passord og kildefiler før du husker eller publiserer hemmeligheter.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Bli med via gjenopprettingsfil</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Behold lokal versjon</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Windows Legitimasjonsbehandling lagrer passord for denne Windows-brukeren på denne PC-en.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Lagret legitimasjon er utilgjengelig for denne Windows-brukeren.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Administrer</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} filer mangler eller er utelatt. Kontroller filbanene før du oppretter medier.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Profilnavn</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Delingen er opptatt eller utilgjengelig. Lokalt arbeid beholdes.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Passfrase</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Filer: {1}
+Hemmeligheter: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Klar</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Oppbevar den krypterte gjenopprettingsfilen og passfrasen utenfor den delte mappen.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Husk passord</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Husk den delte nøkkelen</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Gi nytt navn</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Dette erstatter den aktive konfigurasjonen. Lagre først en kopi for å beholde arbeidet.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Den delte historikken ble endret uventet. Gjenopprett fra en pålitelig kopi.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Lagre som kopi</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Mottakere med profilnøkkelen kan lese inkluderte hemmeligheter og private sertifikatnøkler.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Delt mappe</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Bruk én autoritativ SMB 3-deling med påkrevd kryptering. Mapper speilet i skyen støttes ikke.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Synkroniser nå</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Synkronisert</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Denne profilen bruker et format som ikke støttes. Oppdater Foundry før du åpner den.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>En delt oppdatering er klar. Velg Synkroniser nå for å bruke den.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Bruk delt versjon</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Fyll ut påkrevde felt, bruk en delt UNC-bane og angi like passfraser.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Generelt</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Husk passord, overfør profiler og synkroniser delte innstillinger.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Utrullingsprofiler</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/nl-NL/Resources.resw
+++ b/src/Foundry/Strings/nl-NL/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Windows-implementatieopties</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Openen</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Actief profiel</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Automatisch synchroniseren</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Het profiel is opgeslagen, maar oude referenties moeten nog worden verwijderd. Probeer het opnieuw wanneer Windows Referentiebeheer beschikbaar is.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Wachtwoordzin bevestigen</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Conflicterende wijzigingen vereisen een beslissing.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Kies een versie of sla een kopie op om beide te bewaren. De andere versie wordt vervangen.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Doorgaan</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Gedeeld profiel maken</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Lokaal profiel verwijderen</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Ook het gedeelde profiel verwijderen</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Het gedeelde profiel voor alle installaties verwijderen? Andere bewerkers moeten hun werk als kopie opslaan.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Dit lokale profiel verwijderen? Exporteer zo nodig eerst een back-up.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Het gedeelde profiel is verwijderd. Sla een lokale kopie op om uw werk te bewaren.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Wachtwoorden onthouden, profielen overdragen en gedeelde instellingen synchroniseren.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Versleuteld profiel exporteren</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Herstelbestand exporteren</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Bewerking mislukt. Controleer bestand, wachtwoordzin, machtigingen en verbinding.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Referenties vergeten</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Opgeslagen wachtwoorden en de gedeelde sleutel voor dit lokale profiel vergeten? Bestaande media blijven ongewijzigd.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Implementatieprofielen</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>De gedeelde geschiedenis is vol. Maak een nieuwe gedeelde opslagplaats.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importeren als kopie</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Geheimen en vertrouwelijke bestanden opnemen</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Vul vereiste wachtwoorden en bronbestanden aan voordat u geheimen onthoudt of publiceert.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Deelnemen via herstelbestand</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Lokale versie behouden</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Windows Referentiebeheer bewaart wachtwoorden voor deze Windows-gebruiker op deze pc.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Opgeslagen referenties zijn niet beschikbaar voor deze Windows-gebruiker.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Beheren</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} bestanden ontbreken of zijn weggelaten. Controleer hun paden voordat u media maakt.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Profielnaam</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>De share is bezet of niet beschikbaar. Lokaal werk blijft bewaard.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Wachtwoordzin</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Bestanden: {1}
+Geheimen: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Gereed</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Bewaar het versleutelde herstelbestand en de wachtwoordzin buiten de gedeelde map.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Wachtwoorden onthouden</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Gedeelde sleutel onthouden</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Naam wijzigen</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Dit vervangt de actieve configuratie. Sla eerst een kopie op om uw werk te bewaren.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>De gedeelde geschiedenis is onverwacht gewijzigd. Herstel een vertrouwde kopie.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Opslaan als kopie</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Ontvangers met de profielsleutel kunnen opgenomen geheimen en privésleutels van certificaten lezen.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Gedeelde map</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Gebruik één gezaghebbende SMB 3-share met verplichte versleuteling. Cloudgespiegelde mappen worden niet ondersteund.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Nu synchroniseren</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Gesynchroniseerd</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Dit profiel gebruikt een niet-ondersteunde indeling. Werk Foundry bij voordat u het opent.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Een gedeelde update is gereed. Kies Nu synchroniseren om deze toe te passen.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Gedeelde versie gebruiken</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Vul verplichte velden in, gebruik een gedeeld UNC-pad en voer overeenkomende wachtwoordzinnen in.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Algemeen</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Wachtwoorden onthouden, profielen overdragen en gedeelde instellingen synchroniseren.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Implementatieprofielen</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/pl-PL/Resources.resw
+++ b/src/Foundry/Strings/pl-PL/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Opcje wdrażania systemu Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Otwórz</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Aktywny profil</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Automatyczna synchronizacja</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Profil został zapisany, ale stare poświadczenia nadal wymagają usunięcia. Spróbuj ponownie, gdy Menedżer poświadczeń systemu Windows będzie dostępny.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Potwierdź frazę hasła</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Sprzeczne zmiany wymagają decyzji.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Wybierz wersję lub zapisz kopię, aby zachować obie. Druga wersja zostanie zastąpiona.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Kontynuuj</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Utwórz profil współdzielony</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Usuń profil lokalny</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Usuń także profil współdzielony</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Usunąć profil współdzielony dla wszystkich instalacji? Pozostali edytorzy muszą zapisać kopię swojej pracy.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Usunąć ten profil lokalny? W razie potrzeby najpierw wyeksportuj kopię zapasową.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Profil współdzielony usunięto. Zapisz kopię lokalną, aby zachować pracę.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Zapamiętuj hasła, przenoś profile i synchronizuj wspólne ustawienia.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Eksportuj zaszyfrowany profil</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Eksportuj plik odzyskiwania</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Operacja nie powiodła się. Sprawdź plik, frazę hasła, uprawnienia i połączenie.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Zapomnij poświadczenia</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Zapomnieć zapisane hasła i wspólny klucz tego profilu lokalnego? Istniejące nośniki pozostaną bez zmian.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Profile wdrażania</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Historia współdzielona jest pełna. Utwórz nowe wspólne repozytorium.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importuj jako kopię</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Dołącz sekrety i poufne pliki</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Uzupełnij wymagane hasła i pliki źródłowe przed zapamiętaniem lub opublikowaniem sekretów.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Dołącz z pliku odzyskiwania</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Zachowaj wersję lokalną</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Menedżer poświadczeń Windows przechowuje hasła tego użytkownika Windows na tym komputerze.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Zapisane poświadczenia są niedostępne dla tego użytkownika Windows.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Zarządzaj</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>Brakuje lub pominięto {0} plików. Sprawdź ich ścieżki przed utworzeniem nośnika.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Nazwa profilu</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Udział jest zajęty lub niedostępny. Praca lokalna jest zachowana.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Fraza hasła</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Pliki: {1}
+Sekrety: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Gotowe</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Zaszyfrowany plik odzyskiwania i jego frazę hasła przechowuj poza udostępnionym folderem.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Zapamiętaj hasła</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Zapamiętaj klucz współdzielony</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Zmień nazwę</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>To zastąpi aktywną konfigurację. Najpierw zapisz kopię, aby zachować pracę.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Historia współdzielona zmieniła się nieoczekiwanie. Przywróć zaufaną kopię.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Zapisz jako kopię</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Odbiorcy posiadający klucz profilu mogą odczytać dołączone sekrety i klucze prywatne certyfikatów.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Folder udostępniony</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Używaj jednego nadrzędnego udziału SMB 3 z wymaganym szyfrowaniem. Foldery replikowane w chmurze nie są obsługiwane.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Synchronizuj teraz</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Zsynchronizowano</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Ten profil używa nieobsługiwanego formatu. Zaktualizuj Foundry przed jego otwarciem.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Aktualizacja współdzielona jest gotowa. Wybierz Synchronizuj teraz, aby ją zastosować.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Użyj wersji współdzielonej</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Wypełnij wymagane pola, użyj ścieżki udziału UNC i wpisz identyczne frazy hasła.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Generał</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Zapamiętuj hasła, przenoś profile i synchronizuj wspólne ustawienia.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Profile wdrażania</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/pt-BR/Resources.resw
+++ b/src/Foundry/Strings/pt-BR/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Opções de implantação do Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Abrir</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Perfil ativo</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Sincronização automática</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>O perfil foi salvo, mas as credenciais antigas ainda precisam ser removidas. Tente novamente quando o Gerenciador de Credenciais do Windows estiver disponível.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Confirmar frase secreta</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>As alterações conflitantes exigem uma decisão.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Escolha uma versão ou salve uma cópia para preservar ambas. A outra versão será substituída.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Continuar</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Criar perfil compartilhado</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Excluir perfil local</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Excluir também o perfil compartilhado</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Excluir o perfil compartilhado de todas as instalações? Outros editores devem salvar seu trabalho como uma cópia.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Excluir este perfil local? Exporte um backup primeiro, se necessário.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>O perfil compartilhado foi excluído. Salve uma cópia local para preservar seu trabalho.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Lembre senhas, transfira perfis e sincronize configurações compartilhadas.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Exportar perfil criptografado</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Exportar arquivo de recuperação</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>A operação falhou. Verifique o arquivo, a frase secreta, as permissões e a conexão.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Esquecer credenciais</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Esquecer as senhas salvas e a chave compartilhada deste perfil local? As mídias existentes não serão alteradas.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Perfis de implantação</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>O histórico compartilhado está cheio. Crie um novo repositório compartilhado.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importar como cópia</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Incluir segredos e arquivos confidenciais</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Preencha as senhas e os arquivos de origem necessários antes de lembrar ou publicar segredos.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Ingressar pelo arquivo de recuperação</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Manter versão local</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>O Gerenciador de Credenciais do Windows armazena senhas para este usuário do Windows neste computador.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>As credenciais salvas estão indisponíveis para este usuário do Windows.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Gerenciar</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} arquivos estão ausentes ou foram omitidos. Revise seus caminhos antes de criar a mídia.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Nome do perfil</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>O compartilhamento está ocupado ou indisponível. O trabalho local é preservado.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Frase secreta</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Arquivos: {1}
+Segredos: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Pronto</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Mantenha o arquivo de recuperação criptografado e sua frase secreta fora da pasta compartilhada.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Lembrar senhas</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Lembrar a chave compartilhada</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Renomear</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Isso substitui a configuração ativa. Salve uma cópia primeiro para preservar seu trabalho.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>O histórico compartilhado mudou inesperadamente. Restaure de uma cópia confiável.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Salvar como cópia</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Destinatários com a chave do perfil podem ler os segredos incluídos e as chaves privadas dos certificados.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Pasta compartilhada</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Use um único compartilhamento SMB 3 autoritativo com criptografia obrigatória. Pastas espelhadas na nuvem não são compatíveis.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Sincronizar agora</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Sincronizado</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Este perfil usa um formato incompatível. Atualize o Foundry antes de abri-lo.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Uma atualização compartilhada está pronta. Selecione Sincronizar agora para aplicá-la.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Usar versão compartilhada</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Preencha os campos obrigatórios, use um caminho compartilhado UNC e digite frases secretas iguais.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Geral</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Lembre senhas, transfira perfis e sincronize configurações compartilhadas.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Perfis de implantação</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/pt-PT/Resources.resw
+++ b/src/Foundry/Strings/pt-PT/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Opções de implementação do Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Abrir</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Perfil ativo</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Sincronização automática</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>O perfil foi guardado, mas ainda é necessário remover credenciais antigas. Tente novamente quando o Gestor de Credenciais do Windows estiver disponível.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Confirmar frase de acesso</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>As alterações em conflito exigem uma decisão.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Escolher uma versão ou guardar uma cópia para preservar ambas. A outra versão será substituída.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Continuar</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Criar perfil partilhado</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Eliminar perfil local</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Eliminar também o perfil partilhado</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Eliminar o perfil partilhado para todas as instalações? Os outros editores devem guardar uma cópia do seu trabalho.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Eliminar este perfil local? Exportar primeiro uma cópia de segurança, se necessário.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>O perfil partilhado foi eliminado. Guardar uma cópia local para preservar o trabalho.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Memorizar palavras-passe, transferir perfis e sincronizar definições partilhadas.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Exportar perfil encriptado</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Exportar ficheiro de recuperação</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>A operação falhou. Verificar ficheiro, frase de acesso, permissões e ligação.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Esquecer credenciais</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Esquecer as palavras-passe guardadas e a chave partilhada deste perfil local? Os suportes existentes não são alterados.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Perfis de implementação</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>O histórico partilhado está cheio. Criar um novo repositório partilhado.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importar como cópia</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Incluir segredos e ficheiros confidenciais</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Preencha as palavras-passe e os ficheiros de origem necessários antes de memorizar ou publicar segredos.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Aderir com ficheiro de recuperação</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Manter versão local</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>O Gestor de Credenciais do Windows guarda palavras-passe para este utilizador Windows neste PC.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>As credenciais guardadas estão indisponíveis para este utilizador Windows.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Gerir</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} ficheiros estão em falta ou foram omitidos. Verifique os caminhos antes de criar o suporte.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Nome do perfil</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>A partilha está ocupada ou indisponível. O trabalho local é preservado.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Frase de acesso</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Ficheiros: {1}
+Segredos: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Pronto</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Guardar o ficheiro de recuperação encriptado e a frase de acesso fora da pasta partilhada.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Memorizar palavras-passe</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Memorizar a chave partilhada</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Mudar o nome</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Isto substitui a configuração ativa. Guardar primeiro uma cópia para preservar o trabalho.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>O histórico partilhado mudou inesperadamente. Restaurar uma cópia fidedigna.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Guardar como cópia</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Os destinatários com a chave do perfil podem ler os segredos e chaves privadas de certificados incluídos.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Pasta partilhada</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Usar uma única partilha SMB 3 de referência com encriptação obrigatória. Pastas replicadas na nuvem não são suportadas.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Sincronizar agora</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Sincronizado</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Este perfil utiliza um formato não suportado. Atualize o Foundry antes de o abrir.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Está pronta uma atualização partilhada. Selecionar Sincronizar agora para a aplicar.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Usar versão partilhada</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Preencher os campos obrigatórios, usar um caminho partilhado UNC e introduzir frases de acesso iguais.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Geral</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Memorizar palavras-passe, transferir perfis e sincronizar definições partilhadas.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Perfis de implementação</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/ro-RO/Resources.resw
+++ b/src/Foundry/Strings/ro-RO/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Opțiuni de implementare Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Deschide</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Profil activ</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Sincronizare automată</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Profilul a fost salvat, dar acreditările vechi trebuie încă eliminate. Reîncercați când Managerul de acreditări Windows este disponibil.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Confirmă fraza de acces</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Modificările în conflict necesită o decizie.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Alegeți o versiune sau salvați o copie pentru a le păstra pe ambele. Cealaltă versiune va fi înlocuită.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Continuă</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Creează profil partajat</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Șterge profilul local</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Șterge și profilul partajat</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Ștergeți profilul partajat pentru toate instalările? Ceilalți editori trebuie să își salveze lucrul ca o copie.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Ștergeți acest profil local? Exportați mai întâi o copie de rezervă dacă este necesar.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Profilul partajat a fost șters. Salvați o copie locală pentru a păstra lucrul.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Memorați parole, transferați profiluri și sincronizați setările partajate.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Exportă profilul criptat</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Exportă fișierul de recuperare</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Operația a eșuat. Verificați fișierul, fraza de acces, permisiunile și conexiunea.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Uită acreditările</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Uitați parolele salvate și cheia partajată a acestui profil local? Mediile existente rămân neschimbate.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Profiluri de implementare</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Istoricul partajat este plin. Creați un depozit partajat nou.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importă ca o copie</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Include secrete și fișiere confidențiale</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Completați parolele și fișierele sursă necesare înainte de a memora sau publica secrete.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Alătură-te folosind fișierul de recuperare</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Păstrează versiunea locală</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Managerul de acreditări Windows stochează parolele acestui utilizator Windows pe acest PC.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Acreditările salvate nu sunt disponibile pentru acest utilizator Windows.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Gestionează</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} fișiere lipsesc sau sunt omise. Verificați căile acestora înainte de a crea suportul.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Numele profilului</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Partajarea este ocupată sau indisponibilă. Lucrul local este păstrat.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Frază de acces</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Fișiere: {1}
+Secrete: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Pregătit</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Păstrați fișierul de recuperare criptat și fraza sa de acces în afara folderului partajat.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Memorează parolele</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Memorează cheia partajată</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Redenumește</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Aceasta înlocuiește configurația activă. Salvați mai întâi o copie pentru a păstra lucrul.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Istoricul partajat s-a schimbat neașteptat. Restaurați o copie de încredere.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Salvează o copie</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Destinatarii cu cheia profilului pot citi secretele și cheile private ale certificatelor incluse.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Folder partajat</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Folosiți o singură partajare SMB 3 autoritativă cu criptare obligatorie. Folderele oglindite în cloud nu sunt acceptate.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Sincronizează acum</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Sincronizat</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Acest profil folosește un format neacceptat. Actualizați Foundry înainte de a-l deschide.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>O actualizare partajată este pregătită. Selectați Sincronizează acum pentru a o aplica.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Folosește versiunea partajată</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Completați câmpurile obligatorii, folosiți o cale partajată UNC și introduceți fraze de acces identice.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>general</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Memorați parole, transferați profiluri și sincronizați setările partajate.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Profiluri de implementare</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/ru-RU/Resources.resw
+++ b/src/Foundry/Strings/ru-RU/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Параметры развертывания Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Открыть</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Активный профиль</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Автоматическая синхронизация</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Профиль сохранён, но старые учётные данные ещё нужно удалить. Повторите попытку, когда диспетчер учётных данных Windows станет доступен.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Подтвердите парольную фразу</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Конфликтующие изменения требуют решения.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Выберите версию или сохраните копию, чтобы оставить обе. Другая версия будет заменена.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Продолжить</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Создать общий профиль</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Удалить локальный профиль</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Также удалить общий профиль</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Удалить общий профиль для всех установок? Другие редакторы должны сохранить свою работу как копию.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Удалить этот локальный профиль? При необходимости сначала экспортируйте резервную копию.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Общий профиль удалён. Сохраните локальную копию, чтобы не потерять работу.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Сохраняйте пароли, переносите профили и синхронизируйте общие настройки.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Экспорт зашифрованного профиля</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Экспорт файла восстановления</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Операция не выполнена. Проверьте файл, парольную фразу, разрешения и подключение.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Забыть учётные данные</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Забыть сохранённые пароли и общий ключ этого локального профиля? Существующие носители не изменятся.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Профили развёртывания</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Общая история заполнена. Создайте новый общий репозиторий.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Импортировать как копию</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Включить секреты и конфиденциальные файлы</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Укажите необходимые пароли и исходные файлы перед сохранением или публикацией секретов.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Подключиться из файла восстановления</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Сохранить локальную версию</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Диспетчер учётных данных Windows хранит пароли для этого пользователя Windows на этом компьютере.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Сохранённые учётные данные недоступны для этого пользователя Windows.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Управление</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>Отсутствуют или пропущены файлы: {0}. Проверьте их пути перед созданием носителя.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Имя профиля</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Общий ресурс занят или недоступен. Локальная работа сохранена.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Парольная фраза</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Файлы: {1}
+Секреты: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Готово</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Храните зашифрованный файл восстановления и его парольную фразу вне общей папки.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Запомнить пароли</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Запомнить общий ключ</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Переименовать</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Активная конфигурация будет заменена. Сначала сохраните копию, чтобы не потерять работу.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Общая история неожиданно изменилась. Восстановите её из доверенной копии.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Сохранить копию</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Получатели с ключом профиля могут читать включённые секреты и закрытые ключи сертификатов.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Общая папка</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Используйте один основной общий ресурс SMB 3 с обязательным шифрованием. Папки, зеркалируемые в облако, не поддерживаются.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Синхронизировать сейчас</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Синхронизировано</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Этот профиль использует неподдерживаемый формат. Обновите Foundry перед его открытием.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Доступно общее обновление. Нажмите «Синхронизировать сейчас», чтобы применить его.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Использовать общую версию</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Заполните обязательные поля, укажите общий путь UNC и введите совпадающие парольные фразы.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Общий</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Сохраняйте пароли, переносите профили и синхронизируйте общие настройки.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Профили развёртывания</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/sk-SK/Resources.resw
+++ b/src/Foundry/Strings/sk-SK/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Možnosti nasadenia Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Otvoriť</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Aktívny profil</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Automatická synchronizácia</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Profil bol uložený, ale staré prihlasovacie údaje treba ešte odstrániť. Skúste to znova, keď bude Správca poverení systému Windows dostupný.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Potvrdiť prístupovú frázu</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Konfliktné zmeny vyžadujú rozhodnutie.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Vyberte verziu alebo uložte kópiu na zachovanie oboch. Druhá verzia sa nahradí.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Pokračovať</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Vytvoriť zdieľaný profil</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Odstrániť miestny profil</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Odstrániť aj zdieľaný profil</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Odstrániť zdieľaný profil pre všetky inštalácie? Ostatní editori musia uložiť svoju prácu ako kópiu.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Odstrániť tento miestny profil? V prípade potreby najprv exportujte zálohu.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Zdieľaný profil bol odstránený. Uložte miestnu kópiu na zachovanie práce.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Zapamätajte si heslá, prenášajte profily a synchronizujte zdieľané nastavenia.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Exportovať šifrovaný profil</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Exportovať súbor na obnovenie</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Operácia zlyhala. Skontrolujte súbor, prístupovú frázu, povolenia a pripojenie.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Zabudnúť prihlasovacie údaje</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Zabudnúť uložené heslá a zdieľaný kľúč tohto miestneho profilu? Existujúce médiá zostanú nezmenené.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Profily nasadenia</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Zdieľaná história je plná. Vytvorte nové zdieľané úložisko.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importovať ako kópiu</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Zahrnúť tajné údaje a dôverné súbory</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Pred zapamätaním alebo publikovaním tajných údajov doplňte požadované heslá a zdrojové súbory.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Pripojiť zo súboru na obnovenie</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Ponechať miestnu verziu</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Správca poverení Windows ukladá heslá pre tohto používateľa Windows v tomto počítači.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Uložené prihlasovacie údaje nie sú pre tohto používateľa Windows dostupné.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Spravovať</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>Počet chýbajúcich alebo vynechaných súborov: {0}. Pred vytvorením média skontrolujte ich cesty.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Názov profilu</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Zdieľanie je zaneprázdnené alebo nedostupné. Miestna práca sa zachová.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Prístupová fráza</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Súbory: {1}
+Tajné údaje: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Pripravené</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Šifrovaný súbor na obnovenie a jeho prístupovú frázu uchovávajte mimo zdieľaného priečinka.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Zapamätať heslá</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Zapamätať zdieľaný kľúč</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Premenovať</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Týmto nahradíte aktívnu konfiguráciu. Najprv uložte kópiu na zachovanie práce.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Zdieľaná história sa neočakávane zmenila. Obnovte dôveryhodnú kópiu.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Uložiť ako kópiu</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Príjemcovia s kľúčom profilu môžu čítať zahrnuté tajné údaje a súkromné kľúče certifikátov.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Zdieľaný priečinok</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Použite jedno autoritatívne zdieľanie SMB 3 s povinným šifrovaním. Priečinky zrkadlené v cloude nie sú podporované.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Synchronizovať teraz</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Synchronizované</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Tento profil používa nepodporovaný formát. Pred otvorením aktualizujte Foundry.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Zdieľaná aktualizácia je pripravená. Použite ju voľbou Synchronizovať teraz.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Použiť zdieľanú verziu</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Vyplňte povinné polia, použite zdieľanú cestu UNC a zadajte zhodné prístupové frázy.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>generál</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Zapamätajte si heslá, prenášajte profily a synchronizujte zdieľané nastavenia.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Profily nasadenia</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/sl-SI/Resources.resw
+++ b/src/Foundry/Strings/sl-SI/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Možnosti uvajanja sistema Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Odpri</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Aktivni profil</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Samodejna sinhronizacija</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Profil je shranjen, vendar je treba stare poverilnice še odstraniti. Poskusite znova, ko bo upravitelj poverilnic Windows na voljo.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Potrdi geselno frazo</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Sporne spremembe zahtevajo odločitev.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Izberite različico ali shranite kopijo, da ohranite obe. Druga različica bo zamenjana.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Nadaljuj</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Ustvari skupni profil</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Izbriši lokalni profil</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Izbriši tudi skupni profil</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Izbrišem skupni profil za vse namestitve? Drugi uredniki morajo svoje delo shraniti kot kopijo.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Izbrišem ta lokalni profil? Po potrebi najprej izvozite varnostno kopijo.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Skupni profil je bil izbrisan. Shranite lokalno kopijo, da ohranite delo.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Zapomnite si gesla, prenašajte profile in sinhronizirajte skupne nastavitve.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Izvozi šifrirani profil</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Izvozi obnovitveno datoteko</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Dejanje ni uspelo. Preverite datoteko, geselno frazo, dovoljenja in povezavo.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Pozabi poverilnice</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Pozabim shranjena gesla in skupni ključ tega lokalnega profila? Obstoječi mediji ostanejo nespremenjeni.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Profili uvajanja</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Skupna zgodovina je polna. Ustvarite novo skupno shrambo.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Uvozi kot kopijo</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Vključi skrivnosti in zaupne datoteke</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Pred shranjevanjem ali objavo skrivnosti izpolnite zahtevana gesla in izvorne datoteke.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Pridruži se z obnovitveno datoteko</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Obdrži lokalno različico</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Upravitelj poverilnic Windows shrani gesla za tega uporabnika Windows v tem računalniku.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Shranjene poverilnice temu uporabniku Windows niso na voljo.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Upravljaj</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>Število manjkajočih ali izpuščenih datotek: {0}. Pred ustvarjanjem medija preverite njihove poti.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Ime profila</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Skupna raba je zasedena ali ni na voljo. Lokalno delo se ohrani.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Geselna fraza</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Datoteke: {1}
+Skrivnosti: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Pripravljeno</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Šifrirano obnovitveno datoteko in njeno geselno frazo hranite zunaj mape v skupni rabi.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Zapomni si gesla</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Zapomni si skupni ključ</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Preimenuj</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>To zamenja aktivno konfiguracijo. Najprej shranite kopijo, da ohranite delo.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Skupna zgodovina se je nepričakovano spremenila. Obnovite zaupanja vredno kopijo.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Shrani kot kopijo</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Prejemniki s ključem profila lahko berejo vključene skrivnosti in zasebne ključe potrdil.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Mapa v skupni rabi</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Uporabite eno avtoritativno skupno rabo SMB 3 z obveznim šifriranjem. Mape, zrcaljene v oblak, niso podprte.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Sinhroniziraj zdaj</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Sinhronizirano</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Ta profil uporablja nepodprto obliko. Pred odpiranjem posodobite Foundry.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Skupna posodobitev je pripravljena. Za uporabo izberite Sinhroniziraj zdaj.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Uporabi skupno različico</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Izpolnite obvezna polja, uporabite skupno pot UNC in vnesite enaki geselni frazi.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Splošno</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Zapomnite si gesla, prenašajte profile in sinhronizirajte skupne nastavitve.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Profili uvajanja</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/sr-Latn-RS/Resources.resw
+++ b/src/Foundry/Strings/sr-Latn-RS/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Opcije primene operativnog sistema Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Otvori</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Aktivni profil</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Automatska sinhronizacija</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Profil je sačuvan, ali stare akreditive još treba ukloniti. Pokušajte ponovo kada Windows upravljač akreditivima bude dostupan.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Potvrdi pristupnu frazu</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Sukobljene izmene zahtevaju odluku.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Izaberi verziju ili sačuvaj kopiju da zadržiš obe. Druga verzija će biti zamenjena.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Nastavi</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Napravi deljeni profil</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Obriši lokalni profil</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Obriši i deljeni profil</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Obrisati deljeni profil za sve instalacije? Ostali urednici moraju sačuvati svoj rad kao kopiju.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Obrisati ovaj lokalni profil? Po potrebi prvo izvezi rezervnu kopiju.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Deljeni profil je obrisan. Sačuvaj lokalnu kopiju da zadržiš rad.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Zapamtite lozinke, prenesite profile i sinhronizujte deljena podešavanja.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Izvezi šifrovani profil</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Izvezi datoteku za oporavak</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Radnja nije uspela. Proveri datoteku, pristupnu frazu, dozvole i vezu.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Zaboravi akreditive</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Zaboraviti sačuvane lozinke i deljeni ključ ovog lokalnog profila? Postojeći mediji ostaju nepromenjeni.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Profili primene</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Deljena istorija je puna. Napravi novo deljeno spremište.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Uvezi kao kopiju</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Uključi tajne podatke i poverljive datoteke</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Unesite potrebne lozinke i izvorne datoteke pre pamćenja ili objavljivanja tajni.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Pridruži se datotekom za oporavak</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Zadrži lokalnu verziju</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Windows upravljač akreditivima čuva lozinke za ovog Windows korisnika na ovom računaru.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Sačuvani akreditivi nisu dostupni ovom Windows korisniku.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Upravljaj</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>Broj datoteka koje nedostaju ili su izostavljene: {0}. Proverite njihove putanje pre pravljenja medija.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Naziv profila</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Deljeni resurs je zauzet ili nedostupan. Lokalni rad je sačuvan.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Pristupna fraza</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Datoteke: {1}
+Tajni podaci: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Spremno</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Šifrovanu datoteku za oporavak i njenu pristupnu frazu čuvaj van deljene fascikle.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Zapamti lozinke</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Zapamti deljeni ključ</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Preimenuj</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Ovo zamenjuje aktivnu konfiguraciju. Prvo sačuvaj kopiju da zadržiš rad.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Deljena istorija se neočekivano promenila. Vrati pouzdanu kopiju.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Sačuvaj kao kopiju</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Primaoci sa ključem profila mogu čitati uključene tajne podatke i privatne ključeve sertifikata.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Deljena fascikla</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Koristi jedan merodavni SMB 3 resurs sa obaveznim šifrovanjem. Fascikle preslikane u oblaku nisu podržane.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Sinhronizuj sada</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Sinhronizovano</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Ovaj profil koristi nepodržan format. Ažurirajte Foundry pre otvaranja.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Deljeno ažuriranje je spremno. Izaberi Sinhronizuj sada da ga primeniš.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Koristi deljenu verziju</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Popuni obavezna polja, koristi deljenu UNC putanju i unesi jednake pristupne fraze.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>general</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Zapamtite lozinke, prenesite profile i sinhronizujte deljena podešavanja.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Profili primene</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/sv-SE/Resources.resw
+++ b/src/Foundry/Strings/sv-SE/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Distributionsalternativ för Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Öppna</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Aktiv profil</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Automatisk synkronisering</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Profilen sparades, men gamla autentiseringsuppgifter behöver fortfarande tas bort. Försök igen när Windows Autentiseringshanteraren är tillgänglig.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Bekräfta lösenfras</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Motstridiga ändringar kräver ett beslut.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Välj en version eller spara en kopia för att behålla båda. Den andra versionen ersätts.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Fortsätt</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Skapa delad profil</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Ta bort lokal profil</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Ta även bort den delade profilen</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Ta bort den delade profilen för alla installationer? Andra redigerare måste spara sitt arbete som en kopia.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Ta bort denna lokala profil? Exportera först en säkerhetskopia vid behov.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Den delade profilen togs bort. Spara en lokal kopia för att behålla arbetet.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Kom ihåg lösenord, överför profiler och synkronisera delade inställningar.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Exportera krypterad profil</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Exportera återställningsfil</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Åtgärden misslyckades. Kontrollera fil, lösenfras, behörigheter och anslutning.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Glöm autentiseringsuppgifter</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Glöm sparade lösenord och den delade nyckeln för denna lokala profil? Befintliga medier ändras inte.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Distributionsprofiler</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Den delade historiken är full. Skapa en ny delad lagringsplats.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Importera som kopia</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Inkludera hemligheter och konfidentiella filer</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Fyll i nödvändiga lösenord och källfiler innan du sparar eller publicerar hemligheter.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Anslut via återställningsfil</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Behåll lokal version</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Autentiseringshanteraren i Windows lagrar lösenord för denna Windows-användare på den här datorn.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Sparade autentiseringsuppgifter är otillgängliga för denna Windows-användare.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Hantera</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} filer saknas eller har utelämnats. Kontrollera sökvägarna innan du skapar medier.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Profilnamn</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Resursen är upptagen eller otillgänglig. Lokalt arbete bevaras.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Lösenfras</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Filer: {1}
+Hemligheter: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Klar</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Förvara den krypterade återställningsfilen och dess lösenfras utanför den delade mappen.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Kom ihåg lösenord</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Kom ihåg den delade nyckeln</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Byt namn</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Detta ersätter den aktiva konfigurationen. Spara först en kopia för att behålla arbetet.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Den delade historiken ändrades oväntat. Återställ från en betrodd kopia.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Spara som kopia</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Mottagare med profilnyckeln kan läsa inkluderade hemligheter och privata certifikatnycklar.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Delad mapp</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Använd en enda auktoritativ SMB 3-resurs med obligatorisk kryptering. Molnspeglade mappar stöds inte.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Synkronisera nu</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Synkroniserad</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Profilen använder ett format som inte stöds. Uppdatera Foundry innan du öppnar den.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>En delad uppdatering är klar. Välj Synkronisera nu för att tillämpa den.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Använd delad version</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Fyll i obligatoriska fält, använd en delad UNC-sökväg och ange matchande lösenfraser.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Allmänt</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Kom ihåg lösenord, överför profiler och synkronisera delade inställningar.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Distributionsprofiler</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/th-TH/Resources.resw
+++ b/src/Foundry/Strings/th-TH/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>ตัวเลือกการปรับใช้ Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>เปิด</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>โปรไฟล์ที่ใช้งาน</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>ซิงค์อัตโนมัติ</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>บันทึกโปรไฟล์แล้ว แต่ยังต้องล้างข้อมูลประจำตัวเก่า โปรดลองอีกครั้งเมื่อตัวจัดการข้อมูลประจำตัวของ Windows พร้อมใช้งาน</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>ยืนยันวลีรหัสผ่าน</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>การเปลี่ยนแปลงขัดแย้งกัน โปรดเลือกวิธีจัดการ</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>เลือกหนึ่งเวอร์ชัน หรือบันทึกสำเนาเพื่อเก็บทั้งสองเวอร์ชัน อีกเวอร์ชันจะถูกแทนที่</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>ดำเนินการต่อ</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>สร้างโปรไฟล์ที่แชร์</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>ลบโปรไฟล์ในเครื่อง</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>ลบโปรไฟล์ที่แชร์ด้วย</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>ต้องการลบโปรไฟล์ที่แชร์สำหรับการติดตั้งทั้งหมดหรือไม่ ผู้แก้ไขคนอื่นต้องบันทึกงานของตนเป็นสำเนา</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>ต้องการลบโปรไฟล์ในเครื่องนี้หรือไม่ หากจำเป็น ให้ส่งออกข้อมูลสำรองก่อน</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>โปรไฟล์ที่แชร์ถูกลบแล้ว โปรดบันทึกสำเนาในเครื่องเพื่อเก็บงานของคุณไว้</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>จดจำรหัสผ่าน โอนโปรไฟล์ และซิงค์การตั้งค่าที่แชร์</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>ส่งออกโปรไฟล์ที่เข้ารหัส</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>ส่งออกไฟล์กู้คืน</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>ดำเนินการไม่สำเร็จ โปรดตรวจสอบไฟล์ วลีรหัสผ่าน สิทธิ์ และการเชื่อมต่อ</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>ลบข้อมูลประจำตัวที่บันทึกไว้</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>ต้องการลบรหัสผ่านที่บันทึกไว้และคีย์ที่แชร์ของโปรไฟล์ในเครื่องนี้หรือไม่ สื่อที่มีอยู่จะไม่เปลี่ยนแปลง</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>โปรไฟล์การปรับใช้</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>ประวัติที่แชร์เต็มแล้ว โปรดสร้างที่เก็บข้อมูลที่แชร์ใหม่</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>นำเข้าเป็นสำเนา</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>รวมข้อมูลลับและไฟล์ที่เป็นความลับ</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>โปรดระบุรหัสผ่านและเตรียมไฟล์ต้นทางที่จำเป็นให้ครบก่อนจดจำหรือเผยแพร่ข้อมูลลับ</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>เข้าร่วมผ่านไฟล์กู้คืน</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>เก็บเวอร์ชันในเครื่อง</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>ตัวจัดการข้อมูลประจำตัวของ Windows จัดเก็บรหัสผ่านสำหรับผู้ใช้ Windows คนนี้บนพีซีเครื่องนี้</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>ผู้ใช้ Windows คนนี้ไม่สามารถใช้ข้อมูลประจำตัวที่บันทึกไว้ได้</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>จัดการ</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>มีไฟล์ {0} ไฟล์ที่หายไปหรือไม่ได้รวมไว้ โปรดตรวจสอบเส้นทางของไฟล์เหล่านี้ก่อนสร้างสื่อ</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>ชื่อโปรไฟล์</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>ตำแหน่งที่แชร์ไม่ว่างหรือไม่พร้อมใช้งาน งานในเครื่องยังคงถูกเก็บไว้</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>วลีรหัสผ่าน</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+ไฟล์: {1}
+ข้อมูลลับ: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>พร้อม</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>เก็บไฟล์กู้คืนที่เข้ารหัสและวลีรหัสผ่านไว้นอกโฟลเดอร์ที่แชร์</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>จดจำรหัสผ่าน</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>จดจำคีย์ที่แชร์</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>เปลี่ยนชื่อ</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>การดำเนินการนี้จะแทนที่การกำหนดค่าที่ใช้งานอยู่ โปรดบันทึกสำเนาก่อนเพื่อเก็บงานของคุณไว้</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>ประวัติที่แชร์เปลี่ยนแปลงโดยไม่คาดคิด โปรดกู้คืนจากสำเนาที่เชื่อถือได้</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>บันทึกเป็นสำเนา</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>ผู้รับที่มีคีย์ของโปรไฟล์สามารถอ่านข้อมูลลับและคีย์ส่วนตัวของใบรับรองที่รวมอยู่ได้</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>โฟลเดอร์ที่แชร์</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>ใช้ตำแหน่งที่แชร์ผ่าน SMB 3 เพียงแห่งเดียวเป็นแหล่งข้อมูลหลัก และกำหนดให้ต้องเข้ารหัส ไม่รองรับโฟลเดอร์ที่ทำสำเนาผ่านคลาวด์</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>ซิงค์ตอนนี้</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>ซิงค์แล้ว</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>โปรไฟล์นี้ใช้รูปแบบที่ไม่รองรับ โปรดอัปเดต Foundry ก่อนเปิด</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>มีการอัปเดตที่แชร์พร้อมใช้งาน เลือกซิงค์ตอนนี้เพื่อนำไปใช้</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>ใช้เวอร์ชันที่แชร์</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>กรอกข้อมูลในช่องที่จำเป็น ใช้เส้นทางที่แชร์แบบ UNC และป้อนวลีรหัสผ่านให้ตรงกัน</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>ทั่วไป</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>จดจำรหัสผ่าน โอนโปรไฟล์ และซิงค์การตั้งค่าที่แชร์</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>โปรไฟล์การปรับใช้</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/tr-TR/Resources.resw
+++ b/src/Foundry/Strings/tr-TR/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Windows dağıtım seçenekleri</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Aç</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Etkin profil</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Otomatik eşitleme</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Profil kaydedildi ancak eski kimlik bilgilerinin temizlenmesi gerekiyor. Windows Kimlik Bilgileri Yöneticisi kullanılabilir olduğunda yeniden deneyin.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Parolayı doğrula</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Çakışan değişiklikler için karar gerekiyor.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Bir sürüm seçin veya ikisini de korumak için bir kopya kaydedin. Diğer sürüm değiştirilecektir.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Devam</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Paylaşılan profil oluştur</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Yerel profili sil</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Paylaşılan profili de sil</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Paylaşılan profil tüm kurulumlar için silinsin mi? Diğer düzenleyenler çalışmalarını kopya olarak kaydetmelidir.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Bu yerel profil silinsin mi? Gerekirse önce bir yedek dışa aktarın.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Paylaşılan profil silindi. Çalışmanızı korumak için yerel bir kopya kaydedin.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Parolaları hatırlayın, profilleri aktarın ve paylaşılan ayarları eşitleyin.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Şifreli profili dışa aktar</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Kurtarma dosyasını dışa aktar</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>İşlem başarısız oldu. Dosyayı, parolayı, izinleri ve bağlantıyı kontrol edin.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Kimlik bilgilerini unut</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Bu yerel profilin kaydedilen parolaları ve paylaşılan anahtarı unutulsun mu? Mevcut medya değişmez.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Dağıtım profilleri</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Paylaşılan geçmiş dolu. Yeni bir paylaşılan depo oluşturun.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Kopya olarak içe aktar</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Gizli bilgileri ve gizli dosyaları dahil et</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Gizli bilgileri hatırlamadan veya yayımlamadan önce gerekli parolaları ve kaynak dosyaları tamamlayın.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Kurtarma dosyasından katıl</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Yerel sürümü koru</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Windows Kimlik Bilgileri Yöneticisi parolaları bu bilgisayardaki bu Windows kullanıcısı için saklar.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Kaydedilen kimlik bilgileri bu Windows kullanıcısı için kullanılamıyor.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Yönet</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>{0} dosya eksik veya atlanmış. Medya oluşturmadan önce yollarını gözden geçirin.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Profil adı</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Paylaşım meşgul veya kullanılamıyor. Yerel çalışma korunur.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Parola</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Dosyalar: {1}
+Gizli bilgiler: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Hazır</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Şifreli kurtarma dosyasını ve parolasını paylaşılan klasörün dışında saklayın.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Parolaları hatırla</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Paylaşılan anahtarı hatırla</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Yeniden adlandır</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Bu, etkin yapılandırmayı değiştirir. Çalışmanızı korumak için önce bir kopya kaydedin.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Paylaşılan geçmiş beklenmedik şekilde değişti. Güvenilir bir kopyadan geri yükleyin.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Kopya olarak kaydet</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Profil anahtarına sahip alıcılar dahil edilen gizli bilgileri ve sertifika özel anahtarlarını okuyabilir.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Paylaşılan klasör</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Şifrelemenin zorunlu olduğu tek bir yetkili SMB 3 paylaşımı kullanın. Buluta yansıtılan klasörler desteklenmez.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Şimdi eşitle</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Eşitlendi</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Bu profil desteklenmeyen bir biçim kullanıyor. Açmadan önce Foundry'yi güncelleyin.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Paylaşılan güncelleme hazır. Uygulamak için Şimdi eşitle'yi seçin.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Paylaşılan sürümü kullan</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Zorunlu alanları doldurun, UNC paylaşım yolu kullanın ve eşleşen parolalar girin.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Genel</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Parolaları hatırlayın, profilleri aktarın ve paylaşılan ayarları eşitleyin.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Dağıtım profilleri</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/uk-UA/Resources.resw
+++ b/src/Foundry/Strings/uk-UA/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Параметри розгортання Windows</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>Відкрити</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>Активний профіль</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>Автоматична синхронізація</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>Профіль збережено, але старі облікові дані ще потрібно видалити. Повторіть спробу, коли диспетчер облікових даних Windows стане доступним.</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>Підтвердьте парольну фразу</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>Конфліктні зміни потребують рішення.</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>Виберіть версію або збережіть копію, щоб залишити обидві. Іншу версію буде замінено.</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>Продовжити</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>Створити спільний профіль</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>Видалити локальний профіль</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>Також видалити спільний профіль</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>Видалити спільний профіль для всіх інсталяцій? Інші редактори мають зберегти свою роботу як копію.</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>Видалити цей локальний профіль? За потреби спочатку експортуйте резервну копію.</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>Спільний профіль видалено. Збережіть локальну копію, щоб не втратити роботу.</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>Зберігайте паролі, переносіть профілі та синхронізуйте спільні налаштування.</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>Експорт зашифрованого профілю</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>Експорт файлу відновлення</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>Операція не вдалася. Перевірте файл, парольну фразу, дозволи та підключення.</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>Забути облікові дані</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>Забути збережені паролі та спільний ключ цього локального профілю? Наявні носії не зміняться.</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>Профілі розгортання</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>Спільна історія заповнена. Створіть нове спільне сховище.</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>Імпортувати як копію</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>Включити секрети та конфіденційні файли</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>Укажіть потрібні паролі та вихідні файли перед запам’ятовуванням або публікацією секретів.</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>Приєднатися з файлу відновлення</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>Зберегти локальну версію</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Диспетчер облікових даних Windows зберігає паролі для цього користувача Windows на цьому комп’ютері.</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>Збережені облікові дані недоступні для цього користувача Windows.</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>Керування</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>Відсутні або пропущені файли: {0}. Перевірте їхні шляхи перед створенням носія.</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>Ім’я профілю</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>Спільний ресурс зайнятий або недоступний. Локальну роботу збережено.</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>Парольна фраза</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+Файли: {1}
+Секрети: {2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>Готово</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>Зберігайте зашифрований файл відновлення та його парольну фразу поза спільною папкою.</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>Запам’ятати паролі</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>Запам’ятати спільний ключ</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>Перейменувати</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>Це замінить активну конфігурацію. Спершу збережіть копію, щоб не втратити роботу.</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>Спільна історія несподівано змінилася. Відновіть її з надійної копії.</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>Зберегти як копію</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>Одержувачі з ключем профілю можуть читати включені секрети та приватні ключі сертифікатів.</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>Спільна папка</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>Використовуйте один основний спільний ресурс SMB 3 з обов’язковим шифруванням. Папки з дзеркалюванням у хмару не підтримуються.</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>Синхронізувати зараз</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>Синхронізовано</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>Цей профіль використовує непідтримуваний формат. Оновіть Foundry перед його відкриттям.</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>Доступне спільне оновлення. Виберіть «Синхронізувати зараз», щоб застосувати його.</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>Використати спільну версію</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>Заповніть обов’язкові поля, вкажіть спільний шлях UNC і введіть однакові парольні фрази.</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>Загальний</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>Зберігайте паролі, переносіть профілі та синхронізуйте спільні налаштування.</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>Профілі розгортання</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/zh-CN/Resources.resw
+++ b/src/Foundry/Strings/zh-CN/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Windows 部署选项</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>打开</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>当前配置文件</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>自动同步</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>配置文件已保存，但旧凭据仍需清理。请在 Windows 凭据管理器可用时重试。</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>确认密码短语</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>更改存在冲突，需要选择处理方式。</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>请选择一个版本，或保存副本以保留两个版本。另一个版本将被替换。</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>继续</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>创建共享配置文件</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>删除本地配置文件</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>同时删除共享配置文件</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>要为所有安装删除此共享配置文件吗？其他编辑者必须将自己的工作保存为副本。</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>要删除此本地配置文件吗？如有需要，请先导出备份。</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>共享配置文件已删除。请保存本地副本以保留工作。</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>记住密码、传输配置文件并同步共享设置。</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>导出加密配置文件</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>导出恢复文件</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>操作失败。请检查文件、密码短语、权限和连接。</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>清除已保存的凭据</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>要清除此本地配置文件已保存的密码和共享密钥吗？现有介质不会改变。</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>部署配置文件</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>共享历史记录已满。请创建新的共享存储库。</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>导入为副本</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>包含机密信息和保密文件</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>请先补全必需的密码和源文件，再保存或发布机密信息。</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>通过恢复文件加入</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>保留本地版本</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Windows 凭据管理器会在此电脑上为当前 Windows 用户存储密码。</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>当前 Windows 用户无法使用已保存的凭据。</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>管理</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>有 {0} 个文件缺失或未包含。请在创建介质前检查其路径。</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>配置文件名称</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>共享位置正忙或不可用。本地工作已保留。</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>密码短语</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+文件：{1}
+机密信息：{2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>就绪</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>请将加密恢复文件及其密码短语保管在共享文件夹之外。</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>记住密码</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>记住共享密钥</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>重命名</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>此操作将替换当前配置。请先保存副本以保留工作。</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>共享历史记录发生了意外更改。请从可信副本恢复。</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>另存为副本</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>持有配置文件密钥的接收者可以读取其中的机密信息和证书私钥。</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>共享文件夹</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>请使用唯一的主 SMB 3 共享，并强制启用加密。不支持通过云端镜像同步的文件夹。</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>立即同步</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>已同步</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>此配置文件使用不受支持的格式。请先更新 Foundry 再打开。</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>共享更新已就绪。请选择“立即同步”以应用更新。</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>使用共享版本</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>请填写必填字段，使用 UNC 共享路径，并输入一致的密码短语。</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>一般</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>记住密码、传输配置文件并同步共享设置。</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>部署配置文件</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/Strings/zh-TW/Resources.resw
+++ b/src/Foundry/Strings/zh-TW/Resources.resw
@@ -2211,6 +2211,164 @@
   <data name="OsSelectionPageHeader.Title" xml:space="preserve">
     <value>Windows 部署選項</value>
   </data>
+  <data name="Profiles.Activate" xml:space="preserve">
+    <value>開啟</value>
+  </data>
+  <data name="Profiles.Active" xml:space="preserve">
+    <value>目前的設定檔</value>
+  </data>
+  <data name="Profiles.AutoSync" xml:space="preserve">
+    <value>自動同步</value>
+  </data>
+  <data name="Profiles.CleanupPending" xml:space="preserve">
+    <value>設定檔已儲存，但仍需清除舊認證。請在 Windows 認證管理員可用時重試。</value>
+  </data>
+  <data name="Profiles.ConfirmPassphrase" xml:space="preserve">
+    <value>確認複雜密碼</value>
+  </data>
+  <data name="Profiles.Conflict" xml:space="preserve">
+    <value>變更發生衝突，需要決定處理方式。</value>
+  </data>
+  <data name="Profiles.ConflictWarning" xml:space="preserve">
+    <value>請選擇一個版本，或儲存複本以保留兩個版本。另一個版本將被取代。</value>
+  </data>
+  <data name="Profiles.Continue" xml:space="preserve">
+    <value>繼續</value>
+  </data>
+  <data name="Profiles.CreateShared" xml:space="preserve">
+    <value>建立共用設定檔</value>
+  </data>
+  <data name="Profiles.Delete" xml:space="preserve">
+    <value>刪除本機設定檔</value>
+  </data>
+  <data name="Profiles.DeleteShared" xml:space="preserve">
+    <value>同時刪除共用設定檔</value>
+  </data>
+  <data name="Profiles.DeleteSharedWarning" xml:space="preserve">
+    <value>要為所有安裝刪除此共用設定檔嗎？其他編輯者必須將自己的工作儲存為複本。</value>
+  </data>
+  <data name="Profiles.DeleteWarning" xml:space="preserve">
+    <value>要刪除此本機設定檔嗎？如有需要，請先匯出備份。</value>
+  </data>
+  <data name="Profiles.DeletedRemote" xml:space="preserve">
+    <value>共用設定檔已刪除。請儲存本機複本以保留工作。</value>
+  </data>
+  <data name="Profiles.Description" xml:space="preserve">
+    <value>記住密碼、傳輸設定檔並同步共用設定。</value>
+  </data>
+  <data name="Profiles.Export" xml:space="preserve">
+    <value>匯出加密設定檔</value>
+  </data>
+  <data name="Profiles.ExportRecovery" xml:space="preserve">
+    <value>匯出復原檔案</value>
+  </data>
+  <data name="Profiles.Failed" xml:space="preserve">
+    <value>操作失敗。請檢查檔案、複雜密碼、權限和連線。</value>
+  </data>
+  <data name="Profiles.Forget" xml:space="preserve">
+    <value>清除已儲存的認證</value>
+  </data>
+  <data name="Profiles.ForgetWarning" xml:space="preserve">
+    <value>要清除此本機設定檔已儲存的密碼和共用金鑰嗎？現有媒體不會變更。</value>
+  </data>
+  <data name="Profiles.Heading" xml:space="preserve">
+    <value>部署設定檔</value>
+  </data>
+  <data name="Profiles.HistoryLimit" xml:space="preserve">
+    <value>共用歷程記錄已滿。請建立新的共用存放庫。</value>
+  </data>
+  <data name="Profiles.Import" xml:space="preserve">
+    <value>匯入為複本</value>
+  </data>
+  <data name="Profiles.IncludeSecrets" xml:space="preserve">
+    <value>包含機密資訊和保密檔案</value>
+  </data>
+  <data name="Profiles.Incomplete" xml:space="preserve">
+    <value>請先備妥必要的密碼和來源檔案，再儲存或發佈機密資訊。</value>
+  </data>
+  <data name="Profiles.JoinShared" xml:space="preserve">
+    <value>透過復原檔案加入</value>
+  </data>
+  <data name="Profiles.KeepLocal" xml:space="preserve">
+    <value>保留本機版本</value>
+  </data>
+  <data name="Profiles.LocalPrivacy" xml:space="preserve">
+    <value>Windows 認證管理員會在這部電腦上為目前的 Windows 使用者儲存密碼。</value>
+  </data>
+  <data name="Profiles.Locked" xml:space="preserve">
+    <value>目前的 Windows 使用者無法使用已儲存的認證。</value>
+  </data>
+  <data name="Profiles.Manage" xml:space="preserve">
+    <value>管理</value>
+  </data>
+  <data name="Profiles.MissingAssets" xml:space="preserve">
+    <value>有 {0} 個檔案遺失或未包含在內。請在建立媒體前檢查其路徑。</value>
+  </data>
+  <data name="Profiles.Name" xml:space="preserve">
+    <value>設定檔名稱</value>
+  </data>
+  <data name="Profiles.Offline" xml:space="preserve">
+    <value>共用位置忙碌或無法使用。本機工作會予以保留。</value>
+  </data>
+  <data name="Profiles.Passphrase" xml:space="preserve">
+    <value>複雜密碼</value>
+  </data>
+  <data name="Profiles.Preview" xml:space="preserve">
+    <value>{0}
+檔案：{1}
+機密資訊：{2}</value>
+  </data>
+  <data name="Profiles.Ready" xml:space="preserve">
+    <value>就緒</value>
+  </data>
+  <data name="Profiles.RecoveryWarning" xml:space="preserve">
+    <value>請將加密的復原檔案及其複雜密碼保管在共用資料夾之外。</value>
+  </data>
+  <data name="Profiles.Remember" xml:space="preserve">
+    <value>記住密碼</value>
+  </data>
+  <data name="Profiles.RememberKey" xml:space="preserve">
+    <value>記住共用金鑰</value>
+  </data>
+  <data name="Profiles.Rename" xml:space="preserve">
+    <value>重新命名</value>
+  </data>
+  <data name="Profiles.ReplaceWarning" xml:space="preserve">
+    <value>此操作將取代目前的組態。請先儲存複本以保留工作。</value>
+  </data>
+  <data name="Profiles.Rollback" xml:space="preserve">
+    <value>共用歷程記錄發生非預期的變更。請從受信任的複本還原。</value>
+  </data>
+  <data name="Profiles.SaveCopy" xml:space="preserve">
+    <value>另存為複本</value>
+  </data>
+  <data name="Profiles.ShareWarning" xml:space="preserve">
+    <value>持有設定檔金鑰的收件者可以讀取內含的機密資訊和憑證私密金鑰。</value>
+  </data>
+  <data name="Profiles.SharedFolder" xml:space="preserve">
+    <value>共用資料夾</value>
+  </data>
+  <data name="Profiles.SmbWarning" xml:space="preserve">
+    <value>請以單一 SMB 3 共用作為正式資料來源，並強制啟用加密。不支援透過雲端鏡像同步的資料夾。</value>
+  </data>
+  <data name="Profiles.SyncNow" xml:space="preserve">
+    <value>立即同步</value>
+  </data>
+  <data name="Profiles.Synchronized" xml:space="preserve">
+    <value>已同步</value>
+  </data>
+  <data name="Profiles.Unsupported" xml:space="preserve">
+    <value>此設定檔使用不支援的格式。請先更新 Foundry 再開啟。</value>
+  </data>
+  <data name="Profiles.UpdateAvailable" xml:space="preserve">
+    <value>共用更新已就緒。請選取「立即同步」以套用更新。</value>
+  </data>
+  <data name="Profiles.UseRemote" xml:space="preserve">
+    <value>使用共用版本</value>
+  </data>
+  <data name="Profiles.Validation" xml:space="preserve">
+    <value>請填寫必填欄位、使用 UNC 共用路徑，並輸入相符的複雜密碼。</value>
+  </data>
   <data name="Proxy.Status.FailedTitle" xml:space="preserve">
     <value>Connection failed</value>
   </data>
@@ -2324,6 +2482,12 @@
   </data>
   <data name="SettingsPage_GeneralCard.Header" xml:space="preserve">
     <value>一般</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Description" xml:space="preserve">
+    <value>記住密碼、傳輸設定檔並同步共用設定。</value>
+  </data>
+  <data name="SettingsPage_ProfilesCard.Header" xml:space="preserve">
+    <value>部署設定檔</value>
   </data>
   <data name="SettingsPage_ProxyCard.Description" xml:space="preserve">
     <value>Configure how Foundry OSD connects to online services.</value>

--- a/src/Foundry/ViewModels/AdkPageViewModel.cs
+++ b/src/Foundry/ViewModels/AdkPageViewModel.cs
@@ -159,6 +159,7 @@ public sealed partial class AdkPageViewModel : ObservableObject, IDisposable
 
     private async Task RunBlockingAdkOperationAsync(Func<CancellationToken, Task<AdkInstallationStatus>> operation)
     {
+        if (shellNavigationGuardService.State is ShellNavigationState.OperationRunning or ShellNavigationState.InteractionPending) return;
         // ADK setup can display UAC and modifies machine-level components, so the shell blocks navigation while it runs.
         shellNavigationGuardService.SetState(ShellNavigationState.OperationRunning);
 

--- a/src/Foundry/ViewModels/DeploymentProfilesViewModel.cs
+++ b/src/Foundry/ViewModels/DeploymentProfilesViewModel.cs
@@ -1,0 +1,239 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.ObjectModel;
+using System.Security.Cryptography;
+using Foundry.Core.Models.Profiles;
+using Foundry.Core.Services.Application;
+using Foundry.Core.Services.Profiles;
+using Foundry.Services.Configuration;
+using Foundry.Services.Localization;
+
+namespace Foundry.ViewModels;
+
+/// <summary>Coordinates profile actions while the view owns native dialog and password-control lifetimes.</summary>
+public sealed partial class DeploymentProfilesViewModel : ObservableObject
+{
+    private readonly DeploymentProfileCoordinator coordinator;
+    private readonly IApplicationLocalizationService localization;
+    private readonly IFilePickerService picker;
+    private bool attached;
+
+    internal DeploymentProfilesViewModel(DeploymentProfileCoordinator coordinator,
+        IApplicationLocalizationService localization, IFilePickerService picker)
+    {
+        this.coordinator = coordinator;
+        this.localization = localization;
+        this.picker = picker;
+    }
+
+    internal Func<ProfileDialogRequest, Task<ProfileDialogResponse?>>? ShowDialogAsync { get; set; }
+    public ObservableCollection<LocalProfileDescriptor> Profiles { get; } = [];
+    [ObservableProperty] public partial LocalProfileDescriptor? SelectedProfile { get; set; }
+    [ObservableProperty] public partial bool IsBusy { get; set; }
+    [ObservableProperty] public partial string Status { get; set; } = string.Empty;
+    public bool CanInteract => !IsBusy;
+    public Visibility BusyVisibility => IsBusy ? Visibility.Visible : Visibility.Collapsed;
+    public bool HasActive => coordinator.Active is not null;
+    public bool IsShared => coordinator.Active?.Enrollment is not null;
+    public bool RememberSecrets => coordinator.Active?.RememberSecrets == true;
+    public bool SyncEnabled => coordinator.Active?.Enrollment?.IsEnabled == true;
+    public Visibility ConflictVisibility => coordinator.HasConflict && coordinator.StatusKey != "Profiles.DeletedRemote" ? Visibility.Visible : Visibility.Collapsed;
+    public string Text(string key) => localization.GetString(key);
+
+    internal void Attach()
+    {
+        if (attached) return;
+        attached = true;
+        coordinator.IsSettingsOpen = true;
+        coordinator.Changed += OnChanged;
+        Refresh();
+    }
+
+    internal void Detach()
+    {
+        attached = false;
+        coordinator.IsSettingsOpen = false;
+        coordinator.Changed -= OnChanged;
+    }
+
+    internal void Refresh()
+    {
+        Profiles.Clear();
+        foreach (LocalProfileDescriptor profile in coordinator.Profiles) Profiles.Add(profile);
+        SelectedProfile = Profiles.FirstOrDefault(profile => profile.LocalId == coordinator.Active?.LocalId);
+        Status = Text(coordinator.StatusKey);
+        OnPropertyChanged(string.Empty);
+    }
+
+    private void OnChanged(object? sender, EventArgs e) => Refresh();
+    partial void OnIsBusyChanged(bool value)
+    {
+        OnPropertyChanged(nameof(CanInteract));
+        OnPropertyChanged(nameof(BusyVisibility));
+    }
+
+    [RelayCommand]
+    private Task ActivateAsync() => RunAsync(async () =>
+    {
+        if (SelectedProfile is not { } selected || selected.LocalId == coordinator.Active?.LocalId) return;
+        if (await ConfirmAsync("Profiles.Activate", "Profiles.ReplaceWarning")) await coordinator.ActivateAsync(selected.LocalId);
+    });
+
+    [RelayCommand]
+    private Task SaveCopyAsync() => RunAsync(async () =>
+    {
+        ProfileDialogResponse? result = await DialogAsync(new("Profiles.SaveCopy") { Name = coordinator.Active?.DisplayName ?? string.Empty });
+        if (result is not null) await coordinator.SaveAsCopyAsync(result.Name.Trim());
+    });
+
+    [RelayCommand]
+    private Task RenameAsync() => RunAsync(async () =>
+    {
+        ProfileDialogResponse? result = await DialogAsync(new("Profiles.Rename") { Name = coordinator.Active?.DisplayName ?? string.Empty });
+        if (result is not null) await coordinator.RenameAsync(result.Name.Trim());
+    });
+
+    [RelayCommand]
+    private Task RememberAsync() => RunAsync(async () =>
+    {
+        ProfileDialogResponse? result = await DialogAsync(new("Profiles.Remember")
+        { Message = Text("Profiles.LocalPrivacy"), RememberOption = true, Remember = RememberSecrets });
+        if (result is not null) await coordinator.SaveAsync(result.Remember);
+    });
+
+    [RelayCommand]
+    private Task ForgetAsync() => RunAsync(async () =>
+    {
+        if (await ConfirmAsync("Profiles.Forget", "Profiles.ForgetWarning")) await coordinator.ForgetAsync();
+    });
+
+    [RelayCommand]
+    private Task DeleteAsync() => RunAsync(async () =>
+    {
+        ProfileDialogResponse? result = await DialogAsync(new("Profiles.Delete")
+        { Message = Text("Profiles.DeleteWarning"), DeleteSharedOption = IsShared });
+        if (result is null) return;
+        if (result.DeleteShared && !await ConfirmAsync("Profiles.DeleteShared", "Profiles.DeleteSharedWarning")) return;
+        await coordinator.DeleteAsync(result.DeleteShared);
+    });
+
+    [RelayCommand] private Task ExportAsync() => RunAsync(() => ExportFileAsync(false));
+    [RelayCommand] private Task ExportRecoveryAsync() => RunAsync(() => ExportFileAsync(true));
+
+    private async Task ExportFileAsync(bool recovery)
+    {
+        string title = recovery ? "Profiles.ExportRecovery" : "Profiles.Export";
+        string? path = await picker.PickSaveFileAsync(new(Text(title), recovery ? "Foundry-recovery" : "Foundry-profile",
+            new FilePickerTypeChoice[] { new(Text("Profiles.Heading"), new string[] { ".foundryprofile" }) }, ".foundryprofile"));
+        if (path is null) return;
+        ProfileDialogResponse? result = await DialogAsync(new(title)
+        {
+            Message = Text(recovery ? "Profiles.RecoveryWarning" : "Profiles.ShareWarning"),
+            Passphrase = true,
+            ConfirmPassphrase = true,
+            IncludeSecretsOption = !recovery
+        });
+        if (result is null) return;
+        if (recovery) await coordinator.ExportRecoveryAsync(path, result.Password);
+        else await coordinator.ExportAsync(path, result.Password, result.IncludeSecrets);
+    }
+
+    [RelayCommand] private Task ImportAsync() => RunAsync(() => ImportFileAsync(false));
+    [RelayCommand] private Task JoinSharedAsync() => RunAsync(() => ImportFileAsync(true));
+
+    private async Task ImportFileAsync(bool join)
+    {
+        string title = join ? "Profiles.JoinShared" : "Profiles.Import";
+        string? path = await picker.PickOpenFileAsync(new(Text(title), new string[] { ".foundryprofile" }));
+        if (path is null) return;
+        ProfileDialogResponse? password = await DialogAsync(new(title) { Passphrase = true });
+        if (password is null) return;
+        DeploymentProfileDocument profile = await coordinator.PreviewImportAsync(path, password.Password);
+        try
+        {
+            int secrets = profile.Secrets.Entries.Count(secret => secret.State is ProfileValueState.Present or ProfileValueState.Blank);
+            int assets = profile.Assets.Count(asset => asset.State == ProfileValueState.Present);
+            string preview = localization.FormatString("Profiles.Preview", profile.DisplayName, assets, secrets);
+            int missingAssets = profile.Assets.Count(asset => asset.State is ProfileValueState.Omitted or ProfileValueState.Unavailable);
+            if (missingAssets > 0) preview += "\n\n" + localization.FormatString("Profiles.MissingAssets", missingAssets);
+            ProfileDialogResponse? result = await DialogAsync(new(title)
+            {
+                Message = preview + "\n\n" + Text("Profiles.ShareWarning") + "\n\n" + Text("Profiles.ReplaceWarning"),
+                RememberOption = true,
+                SharedKeyOption = join,
+                SharePathOption = join
+            });
+            if (result is null) return;
+            if (join) await coordinator.JoinSharedAsync(profile, result.SharePath.Trim(), result.Remember, result.RememberKey);
+            else await coordinator.ImportAsCopyAsync(profile, result.Remember);
+        }
+        finally { DeploymentProfileSecretBinding.Clear(profile); }
+    }
+
+    [RelayCommand]
+    private Task CreateSharedAsync() => RunAsync(async () =>
+    {
+        ProfileDialogResponse? result = await DialogAsync(new("Profiles.CreateShared")
+        { Message = Text("Profiles.ShareWarning"), SharePathOption = true, IncludeSecretsOption = true, SharedKeyOption = true });
+        if (result is not null) await coordinator.CreateSharedAsync(result.SharePath.Trim(), result.IncludeSecrets, result.RememberKey);
+    });
+
+    [RelayCommand] private Task SynchronizeAsync() => RunAsync(coordinator.SynchronizeAsync);
+    [RelayCommand] private Task ToggleSyncAsync() => RunAsync(() => coordinator.SetSynchronizationEnabledAsync(!SyncEnabled));
+    [RelayCommand] private Task UseRemoteAsync() => ResolveAsync(true);
+    [RelayCommand] private Task KeepLocalAsync() => ResolveAsync(false);
+
+    private Task ResolveAsync(bool useRemote) => RunAsync(async () =>
+    {
+        if (await ConfirmAsync(useRemote ? "Profiles.UseRemote" : "Profiles.KeepLocal", "Profiles.ConflictWarning"))
+            await coordinator.ResolveConflictAsync(useRemote);
+    });
+
+    private async Task<bool> ConfirmAsync(string title, string message) =>
+        await DialogAsync(new(title) { Message = Text(message) }) is not null;
+
+    private Task<ProfileDialogResponse?> DialogAsync(ProfileDialogRequest request) =>
+        ShowDialogAsync?.Invoke(request) ?? Task.FromResult<ProfileDialogResponse?>(null);
+
+    private async Task RunAsync(Func<Task> action)
+    {
+        if (IsBusy) return;
+        IsBusy = true;
+        try
+        {
+            using IDisposable suspension = coordinator.SuspendActivation();
+            await action();
+            Refresh();
+        }
+        catch (OperationCanceledException) { }
+        catch (LocalProfileLockedException) { Status = Text("Profiles.Locked"); }
+        catch (IncompleteProfileCheckpointException) { Status = Text("Profiles.Incomplete"); }
+        catch (NotSupportedException) { Status = Text("Profiles.Unsupported"); }
+        catch (Exception exception) when (exception is IOException or InvalidDataException or FormatException or UnauthorizedAccessException or ArgumentException or
+            InvalidOperationException or CryptographicException or System.ComponentModel.Win32Exception or
+            System.Runtime.InteropServices.COMException or System.Text.Json.JsonException)
+        { Status = Text("Profiles.Failed"); }
+        finally { IsBusy = false; }
+    }
+}
+
+/// <summary>Dialog layout inputs; no configuration mutation occurs in the view.</summary>
+internal sealed record ProfileDialogRequest(string Title)
+{
+    public string? Message { get; init; }
+    public string? Name { get; init; }
+    public bool Passphrase { get; init; }
+    public bool ConfirmPassphrase { get; init; }
+    public bool IncludeSecretsOption { get; init; }
+    public bool RememberOption { get; init; }
+    public bool Remember { get; init; }
+    public bool SharedKeyOption { get; init; }
+    public bool SharePathOption { get; init; }
+    public bool DeleteSharedOption { get; init; }
+}
+
+/// <summary>Transient dialog values; callers never log or persist the package passphrase.</summary>
+internal sealed record ProfileDialogResponse(string Name, string Password, bool IncludeSecrets, bool Remember,
+    bool RememberKey, string SharePath, bool DeleteShared);

--- a/src/Foundry/ViewModels/NetworkConfigurationViewModel.cs
+++ b/src/Foundry/ViewModels/NetworkConfigurationViewModel.cs
@@ -28,6 +28,18 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
     private bool isApplyingState = true;
     private bool isSavingState;
 
+    [ObservableProperty]
+    public partial string CertificatePasswordLabel { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string Dot1xCertificatePassword { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string WifiCertificatePassword { get; set; } = string.Empty;
+
+    partial void OnDot1xCertificatePasswordChanged(string value) => SaveState();
+    partial void OnWifiCertificatePasswordChanged(string value) => SaveState();
+
     public NetworkConfigurationViewModel(
         IFoundryConfigurationStateService configurationStateService,
         INetworkSecretStateService networkSecretStateService,
@@ -403,6 +415,10 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
 
     partial void OnDot1xCertificatePathChanged(string value)
     {
+        if (!isApplyingState)
+        {
+            Dot1xCertificatePassword = string.Empty;
+        }
         SaveState();
         RefreshPresentationState();
     }
@@ -439,6 +455,11 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
 
     partial void OnWifiSsidChanged(string value)
     {
+        if (!isApplyingState)
+        {
+            WifiPassphrase = string.Empty;
+            networkSecretStateService.ClearPersonalWifiPassphrase();
+        }
         SaveState();
         RefreshPresentationState();
     }
@@ -494,6 +515,10 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
 
     partial void OnWifiCertificatePathChanged(string value)
     {
+        if (!isApplyingState)
+        {
+            WifiCertificatePassword = string.Empty;
+        }
         SaveState();
         RefreshPresentationState();
     }
@@ -553,10 +578,12 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
     private void ApplyState(NetworkSettings settings)
     {
         isApplyingState = true;
+        settings = networkSecretStateService.ApplyRequiredSecrets(settings);
         IsDot1xEnabled = settings.Dot1x.IsEnabled;
         Dot1xProfileTemplatePath = settings.Dot1x.ProfileTemplatePath ?? string.Empty;
         IsDot1xCertificateRequired = settings.Dot1x.RequiresCertificate;
         Dot1xCertificatePath = settings.Dot1x.CertificatePath ?? string.Empty;
+        Dot1xCertificatePassword = settings.Dot1x.CertificatePfxPassword ?? string.Empty;
 
         IsWifiProvisioned = settings.WifiProvisioned || settings.Wifi.IsEnabled;
         IsWifiConfigured = settings.Wifi.IsEnabled;
@@ -566,6 +593,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
         WifiEnterpriseProfileTemplatePath = settings.Wifi.EnterpriseProfileTemplatePath ?? string.Empty;
         IsWifiCertificateRequired = settings.Wifi.RequiresCertificate;
         WifiCertificatePath = settings.Wifi.CertificatePath ?? string.Empty;
+        WifiCertificatePassword = settings.Wifi.CertificatePfxPassword ?? string.Empty;
         IsWiredDot1xProfileRoamingEnabled = settings.RoamWiredDot1xProfileToWindows;
         IsWiredDot1xPrivateKeyMaterialRoamingRequested = settings.RoamWiredDot1xPrivateKeyMaterialToWindows;
         IsWifiProfileRoamingEnabled = settings.RoamWifiProfileToWindows;
@@ -610,6 +638,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
                 AuthenticationMode = NetworkAuthenticationMode.MachineOnly,
                 AllowRuntimeCredentials = false,
                 RequiresCertificate = IsDot1xEnabled && IsDot1xCertificateRequired,
+                CertificatePfxPassword = IsDot1xCertificatePathEnabled ? Dot1xCertificatePassword : null,
                 CertificatePath = IsDot1xCertificatePathEnabled && !string.IsNullOrWhiteSpace(Dot1xCertificatePath)
                     ? Dot1xCertificatePath.Trim()
                     : null
@@ -634,6 +663,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
                 EnterpriseAuthenticationMode = NetworkAuthenticationMode.UserOnly,
                 AllowRuntimeCredentials = false,
                 RequiresCertificate = IsWifiEnterpriseSectionEnabled && IsWifiCertificateRequired,
+                CertificatePfxPassword = IsWifiCertificatePathEnabled ? WifiCertificatePassword : null,
                 CertificatePath = IsWifiCertificatePathEnabled && !string.IsNullOrWhiteSpace(WifiCertificatePath)
                     ? WifiCertificatePath.Trim()
                     : null
@@ -662,6 +692,7 @@ public sealed partial class NetworkConfigurationViewModel : ObservableObject, ID
     {
         ProfileTemplateLabel = localizationService.GetString("Network.ProfileTemplateLabel");
         Dot1xCertificateLabel = localizationService.GetString("Dot1x.CertificateLabel");
+        CertificatePasswordLabel = localizationService.GetString("Autopilot.HardwareHashBootMediaCertificatePasswordLabel");
         RequiresCertificateText = localizationService.GetString("Network.RequiresCertificateLabel");
         WifiConfiguredText = localizationService.GetString("Wifi.ConfigureLabel");
         WifiSsidLabel = localizationService.GetString("Wifi.SsidLabel");

--- a/src/Foundry/ViewModels/StartMediaViewModel.cs
+++ b/src/Foundry/ViewModels/StartMediaViewModel.cs
@@ -5,7 +5,6 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using Foundry.Core.Models.Configuration;
@@ -13,6 +12,7 @@ using Foundry.Core.Services.Autopilot;
 using Foundry.Core.Services.Application;
 using Foundry.Core.Services.Configuration;
 using Foundry.Core.Services.Media;
+using Foundry.Core.Services.Profiles;
 using Foundry.Core.Services.Telemetry;
 using Foundry.Core.Services.WinPe;
 using Foundry.Services.Adk;
@@ -44,7 +44,6 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     private readonly IFilePickerService filePickerService;
     private readonly IFoundryConfigurationStateService foundryConfigurationStateService;
     private readonly IConfigurationOverviewService configurationOverviewService;
-    private readonly IDeploymentProtectionSecretStateService deploymentProtectionSecretStateService;
     private readonly INetworkSecretStateService networkSecretStateService;
     private readonly ITelemetryService telemetryService;
     private readonly IOperationProgressService operationProgressService;
@@ -81,7 +80,6 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         IFilePickerService filePickerService,
         IFoundryConfigurationStateService foundryConfigurationStateService,
         IConfigurationOverviewService configurationOverviewService,
-        IDeploymentProtectionSecretStateService deploymentProtectionSecretStateService,
         INetworkSecretStateService networkSecretStateService,
         ITelemetryService telemetryService,
         IOperationProgressService operationProgressService,
@@ -103,7 +101,6 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         this.filePickerService = filePickerService;
         this.foundryConfigurationStateService = foundryConfigurationStateService;
         this.configurationOverviewService = configurationOverviewService;
-        this.deploymentProtectionSecretStateService = deploymentProtectionSecretStateService;
         this.networkSecretStateService = networkSecretStateService;
         this.telemetryService = telemetryService;
         this.operationProgressService = operationProgressService;
@@ -400,13 +397,13 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private async Task CreateIsoAsync()
     {
-        if (IsMediaOperationRunning || isRefreshingUnattendSources)
+        if (IsMediaOperationRunning || isRefreshingUnattendSources || shellNavigationGuardService.State != ShellNavigationState.Ready)
         {
             return;
         }
 
         await RefreshUnattendSourcesAsync();
-        if (isDisposed)
+        if (isDisposed || shellNavigationGuardService.State != ShellNavigationState.Ready)
         {
             return;
         }
@@ -430,13 +427,13 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private async Task CreateUsbAsync()
     {
-        if (IsMediaOperationRunning || isRefreshingUnattendSources)
+        if (IsMediaOperationRunning || isRefreshingUnattendSources || shellNavigationGuardService.State != ShellNavigationState.Ready)
         {
             return;
         }
 
         await RefreshUnattendSourcesAsync();
-        if (isDisposed)
+        if (isDisposed || shellNavigationGuardService.State != ShellNavigationState.Ready)
         {
             return;
         }
@@ -461,32 +458,12 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             return;
         }
 
-        WinPeUsbDiskCandidate selectedDisk = options.SelectedUsbDisk;
-        bool confirmed = await dialogService.ConfirmAsync(new ConfirmationDialogRequest(
-            localizationService.GetString("StartMedia.CreateUsb.ConfirmTitle"),
-            string.Format(
-                localizationService.GetString("StartMedia.CreateUsb.ConfirmMessage"),
-                selectedDisk.DiskNumber,
-                selectedDisk.FriendlyName,
-                FormatByteSize(selectedDisk.SizeBytes)),
-            localizationService.GetString("StartMedia.CreateUsb.ConfirmPrimary"),
-            localizationService.GetString("Common.Cancel")));
-
-        if (!confirmed)
-        {
-            logger.Information(
-                "Final USB media creation cancelled before formatting. DiskNumber={DiskNumber}, DiskName={DiskName}",
-                selectedDisk.DiskNumber,
-                selectedDisk.FriendlyName);
-            return;
-        }
-
         await RunFinalMediaOperationAsync(FinalMediaTarget.Usb, options);
     }
 
     private async Task RunFinalMediaOperationAsync(FinalMediaTarget target, MediaPreflightOptions options)
     {
-        if (IsMediaOperationRunning)
+        if (IsMediaOperationRunning || shellNavigationGuardService.State != ShellNavigationState.Ready)
         {
             return;
         }
@@ -495,7 +472,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         ResetProgressLogSampling();
         RefreshEvaluation();
         // Final media operations can format disks or overwrite ISO output, so the shell remains locked until completion.
-        shellNavigationGuardService.SetState(ShellNavigationState.OperationRunning);
+        shellNavigationGuardService.SetState(ShellNavigationState.InteractionPending);
         string terminalStatus = string.Empty;
         string? successMessage = null;
         Stopwatch stopwatch = Stopwatch.StartNew();
@@ -513,6 +490,9 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         };
         WinPeDiagnostic? failureDiagnostic = null;
         DeploymentMediaProtectionMaterial? deploymentProtectionMaterial = null;
+        DeploymentBuildSnapshot? snapshot = null;
+        FoundryConfigurationDocument capturedConfiguration = foundryConfigurationStateService.Current;
+        bool shouldTrackMedia = true;
 
         using IDisposable operationIdScope = LogContext.PushProperty("OperationId", operationId);
         using IDisposable workflowScope = LogContext.PushProperty("Workflow", "boot_media_creation");
@@ -522,7 +502,21 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
         try
         {
-            deploymentProtectionMaterial = CreateDeploymentProtectionMaterial();
+            options = options with
+            {
+                DriverVendors = options.DriverVendors.ToArray(),
+                AvailableWinPeLanguages = options.AvailableWinPeLanguages.ToArray()
+            };
+            snapshot = await foundryConfigurationStateService.CaptureBuildSnapshotAsync(
+                Path.Combine(Constants.UserRootDirectoryPath, "BuildSnapshots"), CancellationToken.None);
+            capturedConfiguration = snapshot.Configuration;
+            options = options with { CustomDriverDirectoryPath = capturedConfiguration.General.CustomDriverDirectoryPath };
+            if (target == FinalMediaTarget.Usb && !await ConfirmUsbFormattingAsync(options.SelectedUsbDisk!))
+            {
+                shouldTrackMedia = false;
+                return;
+            }
+            deploymentProtectionMaterial = snapshot.CreateDeploymentProtectionMaterial();
             string startStatus = target switch
             {
                 FinalMediaTarget.Iso => localizationService.GetString("StartMedia.Operation.CreatingIso"),
@@ -531,6 +525,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             };
 
             operationProgressService.Start(OperationKind.MediaCreation, startStatus);
+            shellNavigationGuardService.SetState(ShellNavigationState.OperationRunning);
             logger.Information(
                 "Final media creation started. Target={Target}, Architecture={Architecture}, WinPeLanguage={WinPeLanguage}, IsoOutputPath={IsoOutputPath}, UsbDiskNumber={UsbDiskNumber}, UsbDiskName={UsbDiskName}",
                 target,
@@ -542,12 +537,12 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
             if (target == FinalMediaTarget.Iso)
             {
-                _ = await CreateIsoMediaAsync(options, deploymentProtectionMaterial, telemetryProgressTracker, CancellationToken.None);
+                _ = await CreateIsoMediaAsync(options, snapshot, deploymentProtectionMaterial, telemetryProgressTracker, CancellationToken.None);
                 successMessage = localizationService.GetString("StartMedia.Operation.IsoSuccessMessage");
             }
             else if (target == FinalMediaTarget.UsbUpdate)
             {
-                WinPeUsbProvisionResult usbResult = await UpdateUsbMediaAsync(options, deploymentProtectionMaterial, telemetryProgressTracker, CancellationToken.None);
+                WinPeUsbProvisionResult usbResult = await UpdateUsbMediaAsync(options, snapshot, deploymentProtectionMaterial, telemetryProgressTracker, CancellationToken.None);
                 successMessage = string.Format(
                     CultureInfo.CurrentCulture,
                     localizationService.GetString("StartMedia.Operation.UsbUpdateSuccessMessage"),
@@ -556,7 +551,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             }
             else
             {
-                WinPeUsbProvisionResult usbResult = await CreateUsbMediaAsync(options, deploymentProtectionMaterial, telemetryProgressTracker, CancellationToken.None);
+                WinPeUsbProvisionResult usbResult = await CreateUsbMediaAsync(options, snapshot, deploymentProtectionMaterial, telemetryProgressTracker, CancellationToken.None);
                 successMessage = string.Format(
                     CultureInfo.CurrentCulture,
                     localizationService.GetString("StartMedia.Operation.UsbSuccessMessage"),
@@ -628,26 +623,67 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         finally
         {
             deploymentProtectionMaterial?.Dispose();
-            await TrackMediaCreatedAsync(
-                target,
-                options,
-                success,
-                success ? null : telemetryProgressTracker.CurrentStepName,
-                stopwatch.Elapsed,
-                operationId,
-                failureDiagnostic,
-                CancellationToken.None);
-            shellNavigationGuardService.SetState(adkService.CurrentStatus.CanCreateMedia
-                ? ShellNavigationState.Ready
-                : ShellNavigationState.AdkBlocked);
-            operationProgressService.Reset(terminalStatus);
-            IsMediaOperationRunning = false;
-            RefreshEvaluation();
+            try
+            {
+                snapshot?.Dispose();
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                logger.Warning(exception, "Private media build sources could not be fully removed.");
+            }
+            try
+            {
+                if (shouldTrackMedia)
+                {
+                    await TrackMediaCreatedAsync(
+                        target,
+                        options,
+                        capturedConfiguration,
+                        success,
+                        success ? null : telemetryProgressTracker.CurrentStepName,
+                        stopwatch.Elapsed,
+                        operationId,
+                        failureDiagnostic,
+                        CancellationToken.None);
+                }
+            }
+            finally
+            {
+
+                shellNavigationGuardService.SetState(adkService.CurrentStatus.CanCreateMedia
+                    ? ShellNavigationState.Ready
+                    : ShellNavigationState.AdkBlocked);
+                operationProgressService.Reset(terminalStatus);
+                IsMediaOperationRunning = false;
+                RefreshEvaluation();
+            }
         }
+    }
+
+    private async Task<bool> ConfirmUsbFormattingAsync(WinPeUsbDiskCandidate selectedDisk)
+    {
+        bool confirmed = await dialogService.ConfirmAsync(new ConfirmationDialogRequest(
+            localizationService.GetString("StartMedia.CreateUsb.ConfirmTitle"),
+            string.Format(
+                localizationService.GetString("StartMedia.CreateUsb.ConfirmMessage"),
+                selectedDisk.DiskNumber,
+                selectedDisk.FriendlyName,
+                FormatByteSize(selectedDisk.SizeBytes)),
+            localizationService.GetString("StartMedia.CreateUsb.ConfirmPrimary"),
+            localizationService.GetString("Common.Cancel")));
+        if (!confirmed)
+        {
+            logger.Information(
+                "Final USB media creation cancelled before formatting. DiskNumber={DiskNumber}, DiskName={DiskName}",
+                selectedDisk.DiskNumber,
+                selectedDisk.FriendlyName);
+        }
+        return confirmed;
     }
 
     private async Task<string> CreateIsoMediaAsync(
         MediaPreflightOptions options,
+        DeploymentBuildSnapshot snapshot,
         DeploymentMediaProtectionMaterial deploymentProtectionMaterial,
         MediaCreationTelemetryProgressTracker telemetryProgressTracker,
         CancellationToken cancellationToken)
@@ -658,6 +694,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         {
             workspace = await PrepareMediaWorkspaceAsync(
                 options,
+                snapshot,
                 includeRuntimePayloadInImage: true,
                 deploymentProtectionMaterial,
                 telemetryProgressTracker: telemetryProgressTracker,
@@ -693,6 +730,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private async Task<WinPeUsbProvisionResult> CreateUsbMediaAsync(
         MediaPreflightOptions options,
+        DeploymentBuildSnapshot snapshot,
         DeploymentMediaProtectionMaterial deploymentProtectionMaterial,
         MediaCreationTelemetryProgressTracker telemetryProgressTracker,
         CancellationToken cancellationToken)
@@ -709,6 +747,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         {
             workspace = await PrepareMediaWorkspaceAsync(
                 options,
+                snapshot,
                 includeRuntimePayloadInImage: false,
                 deploymentProtectionMaterial,
                 telemetryProgressTracker: telemetryProgressTracker,
@@ -761,6 +800,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private async Task<WinPeUsbProvisionResult> UpdateUsbMediaAsync(
         MediaPreflightOptions options,
+        DeploymentBuildSnapshot snapshot,
         DeploymentMediaProtectionMaterial deploymentProtectionMaterial,
         MediaCreationTelemetryProgressTracker telemetryProgressTracker,
         CancellationToken cancellationToken)
@@ -777,6 +817,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
         {
             workspace = await PrepareMediaWorkspaceAsync(
                 options,
+                snapshot,
                 includeRuntimePayloadInImage: false,
                 deploymentProtectionMaterial,
                 telemetryProgressTracker: telemetryProgressTracker,
@@ -827,6 +868,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private async Task<PreparedMediaWorkspace> PrepareMediaWorkspaceAsync(
         MediaPreflightOptions options,
+        DeploymentBuildSnapshot snapshot,
         bool includeRuntimePayloadInImage,
         DeploymentMediaProtectionMaterial deploymentProtectionMaterial,
         MediaCreationTelemetryProgressTracker telemetryProgressTracker,
@@ -851,8 +893,8 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                 Constants.WinPeWorkspaceDirectoryPath,
                 Constants.WinPeWorkspaceDirectoryPath);
             runtimePayloadProvisioning = AddReleaseRuntimeProvisioning(runtimePayloadProvisioning);
-            TelemetrySettings connectTelemetrySettings = CreateRuntimeTelemetrySettings(ResolveRuntimePayloadSource(runtimePayloadProvisioning.Connect));
-            TelemetrySettings deployTelemetrySettings = CreateRuntimeTelemetrySettings(ResolveRuntimePayloadSource(runtimePayloadProvisioning.Deploy));
+            TelemetrySettings connectTelemetrySettings = snapshot.Configuration.Telemetry with { RuntimePayloadSource = ResolveRuntimePayloadSource(runtimePayloadProvisioning.Connect) };
+            TelemetrySettings deployTelemetrySettings = snapshot.Configuration.Telemetry with { RuntimePayloadSource = ResolveRuntimePayloadSource(runtimePayloadProvisioning.Deploy) };
 
             logger.Debug(
                 "Final media workspace preparation started. Architecture={Architecture}, WinPeLanguage={WinPeLanguage}, SignatureMode={SignatureMode}, BootImageSource={BootImageSource}, IncludeRuntimePayloadInImage={IncludeRuntimePayloadInImage}, DriverVendorCount={DriverVendorCount}, HasCustomDriverDirectory={HasCustomDriverDirectory}, IsAutopilotEnabled={IsAutopilotEnabled}, IsConnectRuntimeProvisioningEnabled={IsConnectRuntimeProvisioningEnabled}, ConnectRuntimeSource={ConnectRuntimeSource}, IsDeployRuntimeProvisioningEnabled={IsDeployRuntimeProvisioningEnabled}, DeployRuntimeSource={DeployRuntimeSource}",
@@ -906,14 +948,14 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             artifactRuntimePayloadProvisioning = runtimePreparation.Value!;
 
             telemetryProgressTracker.SetCurrentStep(MediaCreationStepNames.GenerateProvisioningPayloads);
-            FoundryConnectProvisioningBundle connectBundle = foundryConfigurationStateService.GenerateConnectProvisioningBundle(
+            FoundryConnectProvisioningBundle connectBundle = snapshot.CreateConnectProvisioningBundle(
                 Path.Combine(artifact.WorkingDirectoryPath, "Provisioning"),
                 connectTelemetrySettings);
             logger.Debug(
                 "Generated local provisioning payloads. ConnectAssetFileCount={ConnectAssetFileCount}, HasMediaSecretsKey={HasMediaSecretsKey}, AutopilotProfileCount={AutopilotProfileCount}",
                 connectBundle.AssetFiles.Count,
                 connectBundle.MediaSecretsKey is { Length: > 0 },
-                options.IsAutopilotEnabled ? foundryConfigurationStateService.Current.Autopilot.Profiles.Count : 0);
+                options.IsAutopilotEnabled ? snapshot.Configuration.Autopilot.Profiles.Count : 0);
 
             telemetryProgressTracker.SetCurrentStep(MediaCreationStepNames.PrepareWinPeWorkspace);
             IProgress<WinPeWorkspacePreparationStage> workspacePreparationProgress =
@@ -937,6 +979,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
                         WinPeLanguage = options.WinPeLanguage,
                         AssetProvisioning = CreateAssetProvisioningOptions(
                             options,
+                            snapshot,
                             tools,
                             connectBundle,
                             deploymentProtectionMaterial,
@@ -990,6 +1033,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
 
     private WinPeMountedImageAssetProvisioningOptions CreateAssetProvisioningOptions(
         MediaPreflightOptions options,
+        DeploymentBuildSnapshot snapshot,
         WinPeToolPaths tools,
         FoundryConnectProvisioningBundle connectBundle,
         DeploymentMediaProtectionMaterial deploymentProtectionMaterial,
@@ -1013,46 +1057,28 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             IanaWindowsTimeZoneMapJson = embeddedAssetService.GetIanaWindowsTimeZoneMapJson(),
             FoundryBootstrapConfiguration = new FoundryBootstrapConfigurationDocument
             {
-                Telemetry = CreateRuntimeTelemetrySettings(ResolveRuntimePayloadSource(runtimePayloadProvisioning.Bootstrap))
+                Telemetry = snapshot.Configuration.Telemetry with { RuntimePayloadSource = ResolveRuntimePayloadSource(runtimePayloadProvisioning.Bootstrap) }
             },
             FoundryConnectConfigurationJson = connectBundle.ConfigurationJson,
-            DeployConfigurationJson = foundryConfigurationStateService.GenerateDeployConfigurationJson(
+            DeployConfigurationJson = snapshot.GenerateDeployConfigurationJson(
                 deployTelemetrySettings,
                 deploymentProtectionMaterial.DeploymentKey,
                 deploymentProtectionMaterial.Settings),
             NetworkSecretsKey = connectBundle.MediaSecretsKey,
             DeploymentSecretsKey = deploymentProtectionMaterial.DeploymentKey,
             IsDeploymentProtectionEnabled = deploymentProtectionMaterial.Settings.IsEnabled,
-            Unattend = foundryConfigurationStateService.Current.Unattend,
+            Unattend = snapshot.Configuration.Unattend,
             FoundryConnectAssetFiles = connectBundle.AssetFiles,
             AutopilotProvisioningMode = options.IsAutopilotEnabled
                 ? options.AutopilotProvisioningMode
                 : AutopilotProvisioningMode.JsonProfile,
             Oa3ToolSourcePath = oa3ToolSourcePath,
             AutopilotProfiles = options.IsAutopilotEnabled && options.AutopilotProvisioningMode == AutopilotProvisioningMode.JsonProfile
-                ? foundryConfigurationStateService.Current.Autopilot.Profiles
+                ? snapshot.Configuration.Autopilot.Profiles
                 : [],
             ConnectProvisioningSource = ResolveProvisioningSource(runtimePayloadProvisioning.Connect),
             DeployProvisioningSource = ResolveProvisioningSource(runtimePayloadProvisioning.Deploy)
         };
-    }
-
-    private DeploymentMediaProtectionMaterial CreateDeploymentProtectionMaterial()
-    {
-        if (!foundryConfigurationStateService.Current.General.DeploymentProtection.IsEnabled)
-        {
-            return DeploymentMediaProtectionService.CreateUnprotected();
-        }
-
-        char[] password = deploymentProtectionSecretStateService.GetConfirmedPasswordCopy();
-        try
-        {
-            return DeploymentMediaProtectionService.CreateProtected(password);
-        }
-        finally
-        {
-            CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(password.AsSpan()));
-        }
     }
 
     private static WinPeProvisioningSource ResolveProvisioningSource(WinPeRuntimePayloadApplicationOptions options)
@@ -1644,6 +1670,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
     private async Task TrackMediaCreatedAsync(
         FinalMediaTarget target,
         MediaPreflightOptions options,
+        FoundryConfigurationDocument capturedConfiguration,
         bool success,
         string? failedStepName,
         TimeSpan duration,
@@ -1670,7 +1697,7 @@ public sealed partial class StartMediaViewModel : ObservableObject, IDisposable
             bootMediaTarget,
             bootMediaUsbOperation,
             options,
-            foundryConfigurationStateService.Current,
+            capturedConfiguration,
             success,
             failedStepName,
             duration,

--- a/src/Foundry/Views/DeploymentProfilesControl.xaml
+++ b/src/Foundry/Views/DeploymentProfilesControl.xaml
@@ -1,0 +1,124 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<UserControl x:Class="Foundry.Views.DeploymentProfilesControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel Spacing="8">
+        <ContentControl
+            HorizontalContentAlignment="Stretch"
+            IsEnabled="{x:Bind ViewModel.CanInteract, Mode=OneWay}">
+            <StackPanel Spacing="8">
+                <Grid ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ComboBox
+                        HorizontalAlignment="Stretch"
+                        DisplayMemberPath="DisplayName"
+                        Header="{x:Bind ViewModel.Text('Profiles.Active')}"
+                        ItemsSource="{x:Bind ViewModel.Profiles}"
+                        SelectedItem="{x:Bind ViewModel.SelectedProfile, Mode=TwoWay}" />
+                    <Button
+                        Grid.Column="1"
+                        VerticalAlignment="Bottom"
+                        Command="{x:Bind ViewModel.ActivateCommand}"
+                        Content="{x:Bind ViewModel.Text('Profiles.Activate')}" />
+                </Grid>
+                <Grid ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Button
+                        HorizontalAlignment="Left"
+                        Command="{x:Bind ViewModel.SaveCopyCommand}"
+                        Content="{x:Bind ViewModel.Text('Profiles.SaveCopy')}" />
+                    <Button
+                        Grid.Column="1"
+                        Content="{x:Bind ViewModel.Text('Profiles.Manage')}">
+                        <Button.Flyout>
+                            <MenuFlyout>
+                                <MenuFlyoutItem
+                                    Command="{x:Bind ViewModel.RenameCommand}"
+                                    IsEnabled="{x:Bind ViewModel.HasActive, Mode=OneWay}"
+                                    Text="{x:Bind ViewModel.Text('Profiles.Rename')}" />
+                                <MenuFlyoutItem
+                                    Command="{x:Bind ViewModel.RememberCommand}"
+                                    IsEnabled="{x:Bind ViewModel.HasActive, Mode=OneWay}"
+                                    Text="{x:Bind ViewModel.Text('Profiles.Remember')}" />
+                                <MenuFlyoutItem
+                                    Command="{x:Bind ViewModel.ForgetCommand}"
+                                    IsEnabled="{x:Bind ViewModel.HasActive, Mode=OneWay}"
+                                    Text="{x:Bind ViewModel.Text('Profiles.Forget')}" />
+                                <MenuFlyoutSeparator />
+                                <MenuFlyoutItem
+                                    Command="{x:Bind ViewModel.ExportCommand}"
+                                    IsEnabled="{x:Bind ViewModel.HasActive, Mode=OneWay}"
+                                    Text="{x:Bind ViewModel.Text('Profiles.Export')}" />
+                                <MenuFlyoutItem
+                                    Command="{x:Bind ViewModel.ImportCommand}"
+                                    Text="{x:Bind ViewModel.Text('Profiles.Import')}" />
+                                <MenuFlyoutSeparator />
+                                <MenuFlyoutItem
+                                    Command="{x:Bind ViewModel.CreateSharedCommand}"
+                                    IsEnabled="{x:Bind ViewModel.HasActive, Mode=OneWay}"
+                                    Text="{x:Bind ViewModel.Text('Profiles.CreateShared')}" />
+                                <MenuFlyoutItem
+                                    Command="{x:Bind ViewModel.JoinSharedCommand}"
+                                    Text="{x:Bind ViewModel.Text('Profiles.JoinShared')}" />
+                                <MenuFlyoutItem
+                                    Command="{x:Bind ViewModel.ExportRecoveryCommand}"
+                                    IsEnabled="{x:Bind ViewModel.IsShared, Mode=OneWay}"
+                                    Text="{x:Bind ViewModel.Text('Profiles.ExportRecovery')}" />
+                                <MenuFlyoutSeparator />
+                                <MenuFlyoutItem
+                                    Command="{x:Bind ViewModel.DeleteCommand}"
+                                    IsEnabled="{x:Bind ViewModel.HasActive, Mode=OneWay}"
+                                    Text="{x:Bind ViewModel.Text('Profiles.Delete')}" />
+                            </MenuFlyout>
+                        </Button.Flyout>
+                    </Button>
+                </Grid>
+                <ContentControl
+                    HorizontalContentAlignment="Stretch"
+                    IsEnabled="{x:Bind ViewModel.IsShared, Mode=OneWay}">
+                    <StackPanel
+                        Orientation="Horizontal"
+                        Spacing="8">
+                        <Button
+                            Command="{x:Bind ViewModel.SynchronizeCommand}"
+                            Content="{x:Bind ViewModel.Text('Profiles.SyncNow')}" />
+                        <ToggleButton
+                            Command="{x:Bind ViewModel.ToggleSyncCommand}"
+                            Content="{x:Bind ViewModel.Text('Profiles.AutoSync')}"
+                            IsChecked="{x:Bind ViewModel.SyncEnabled, Mode=OneWay}" />
+                    </StackPanel>
+                </ContentControl>
+                <StackPanel
+                    Spacing="8"
+                    Visibility="{x:Bind ViewModel.ConflictVisibility, Mode=OneWay}">
+                    <TextBlock
+                        Text="{x:Bind ViewModel.Text('Profiles.ConflictWarning')}"
+                        TextWrapping="Wrap" />
+                    <StackPanel
+                        Orientation="Horizontal"
+                        Spacing="8">
+                        <Button
+                            Command="{x:Bind ViewModel.UseRemoteCommand}"
+                            Content="{x:Bind ViewModel.Text('Profiles.UseRemote')}" />
+                        <Button
+                            Command="{x:Bind ViewModel.KeepLocalCommand}"
+                            Content="{x:Bind ViewModel.Text('Profiles.KeepLocal')}" />
+                    </StackPanel>
+                </StackPanel>
+            </StackPanel>
+        </ContentControl>
+        <TextBlock
+            AutomationProperties.LiveSetting="Polite"
+            Text="{x:Bind ViewModel.Status, Mode=OneWay}"
+            TextWrapping="Wrap" />
+        <ProgressBar
+            IsIndeterminate="{x:Bind ViewModel.IsBusy, Mode=OneWay}"
+            Visibility="{x:Bind ViewModel.BusyVisibility, Mode=OneWay}" />
+    </StackPanel>
+</UserControl>

--- a/src/Foundry/Views/DeploymentProfilesControl.xaml.cs
+++ b/src/Foundry/Views/DeploymentProfilesControl.xaml.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Foundry Project contributors.
+// Licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using Foundry.Core.Services.Application;
+using Foundry.Services.Localization;
+
+namespace Foundry.Views;
+
+/// <summary>Hosts native profile dialogs and clears password controls after each interaction.</summary>
+public sealed partial class DeploymentProfilesControl : UserControl
+{
+    private readonly IApplicationLocalizationService localization = App.GetService<IApplicationLocalizationService>();
+    private readonly IFilePickerService picker = App.GetService<IFilePickerService>();
+    public DeploymentProfilesViewModel ViewModel { get; } = App.GetService<DeploymentProfilesViewModel>();
+
+    public DeploymentProfilesControl()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        ViewModel.ShowDialogAsync = ShowDialogAsync;
+        ViewModel.Attach();
+        localization.LanguageChanged += OnLanguageChanged;
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        localization.LanguageChanged -= OnLanguageChanged;
+        ViewModel.Detach();
+        ViewModel.ShowDialogAsync = null;
+    }
+
+    private void OnLanguageChanged(object? sender, ApplicationLanguageChangedEventArgs e)
+    {
+        if (DispatcherQueue.HasThreadAccess) UpdateLanguage();
+        else DispatcherQueue.TryEnqueue(UpdateLanguage);
+    }
+
+    private void UpdateLanguage() { ViewModel.Refresh(); Bindings.Update(); }
+
+    private async Task<ProfileDialogResponse?> ShowDialogAsync(ProfileDialogRequest request)
+    {
+        string T(string key) => localization.GetString(key);
+        var content = new StackPanel { Spacing = 12, MinWidth = 280 };
+        if (request.Message is not null) content.Children.Add(new TextBlock { Text = request.Message, TextWrapping = TextWrapping.Wrap });
+        var name = new TextBox { Header = T("Profiles.Name"), Text = request.Name ?? string.Empty, MaxLength = 120 };
+        var password = new PasswordBox { Header = T("Profiles.Passphrase"), MaxLength = 1024, PasswordRevealMode = PasswordRevealMode.Hidden };
+        var confirmation = new PasswordBox { Header = T("Profiles.ConfirmPassphrase"), MaxLength = 1024, PasswordRevealMode = PasswordRevealMode.Hidden };
+        var include = new CheckBox { Content = T("Profiles.IncludeSecrets"), IsChecked = false };
+        var remember = new CheckBox { Content = T("Profiles.Remember"), IsChecked = request.Remember };
+        var sharedKey = new CheckBox { Content = T("Profiles.RememberKey"), IsChecked = false };
+        var deleteShared = new CheckBox { Content = T("Profiles.DeleteShared"), IsChecked = false };
+        var share = new TextBox { Header = T("Profiles.SharedFolder"), PlaceholderText = @"\\server\share\profile", MaxLength = 1024, FlowDirection = FlowDirection.LeftToRight };
+        if (request.Name is not null) content.Children.Add(name);
+        if (request.Passphrase) content.Children.Add(password);
+        if (request.ConfirmPassphrase) content.Children.Add(confirmation);
+        if (request.IncludeSecretsOption) content.Children.Add(include);
+        if (request.RememberOption) content.Children.Add(remember);
+        if (request.SharedKeyOption) content.Children.Add(sharedKey);
+        if (request.RememberOption || request.SharedKeyOption)
+            content.Children.Add(new TextBlock { Text = T("Profiles.LocalPrivacy"), TextWrapping = TextWrapping.Wrap });
+        if (request.SharePathOption)
+        {
+            content.Children.Add(share);
+            var browse = new Button { Content = T("Common.Browse") };
+            browse.Click += async (_, _) =>
+            {
+                try
+                {
+                    string? path = await picker.PickFolderAsync(new(T("Profiles.SharedFolder")));
+                    if (path is not null) share.Text = path;
+                }
+                catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or ArgumentException or
+                    InvalidOperationException or System.Runtime.InteropServices.COMException)
+                { share.PlaceholderText = T("Profiles.Failed"); }
+            };
+            content.Children.Add(browse);
+            content.Children.Add(new TextBlock { Text = T("Profiles.SmbWarning"), TextWrapping = TextWrapping.Wrap });
+        }
+        if (request.DeleteSharedOption) content.Children.Add(deleteShared);
+        var validation = new TextBlock { TextWrapping = TextWrapping.Wrap, Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["SystemFillColorCriticalBrush"] };
+        content.Children.Add(validation);
+        var dialog = new ContentDialog
+        {
+            XamlRoot = XamlRoot,
+            Title = T(request.Title),
+            PrimaryButtonText = T("Profiles.Continue"),
+            CloseButtonText = T("Common.Cancel"),
+            DefaultButton = ContentDialogButton.Close,
+            Content = new ScrollViewer { Content = content, MaxHeight = 500 }
+        };
+        dialog.PrimaryButtonClick += (_, args) =>
+        {
+            bool invalid = request.Name is not null && string.IsNullOrWhiteSpace(name.Text) ||
+                request.Passphrase && string.IsNullOrEmpty(password.Password) ||
+                request.ConfirmPassphrase && password.Password != confirmation.Password ||
+                request.SharePathOption && !share.Text.Trim().StartsWith(@"\\", StringComparison.Ordinal);
+            args.Cancel = invalid;
+            validation.Text = invalid ? T("Profiles.Validation") : string.Empty;
+        };
+        try
+        {
+            if (await dialog.ShowAsync() != ContentDialogResult.Primary) return null;
+            return new(name.Text, password.Password, include.IsChecked == true, remember.IsChecked == true,
+                sharedKey.IsChecked == true, share.Text, deleteShared.IsChecked == true);
+        }
+        finally { password.Password = string.Empty; confirmation.Password = string.Empty; }
+    }
+}

--- a/src/Foundry/Views/EthernetDot1xPage.xaml
+++ b/src/Foundry/Views/EthernetDot1xPage.xaml
@@ -87,6 +87,9 @@
                                     Command="{x:Bind ViewModel.BrowseDot1xCertificateCommand}"
                                     Content="{x:Bind ViewModel.BrowseButtonText, Mode=OneWay}" />
                             </Grid>
+                            <PasswordBox
+                                Header="{x:Bind ViewModel.CertificatePasswordLabel, Mode=OneWay}"
+                                Password="{x:Bind ViewModel.Dot1xCertificatePassword, Mode=TwoWay}" />
                             <TextBlock
                                 Foreground="{ThemeResource SystemFillColorCriticalBrush}"
                                 Text="{x:Bind ViewModel.Dot1xCertificateValidationMessage, Mode=OneWay}"

--- a/src/Foundry/Views/MainWindow.xaml.cs
+++ b/src/Foundry/Views/MainWindow.xaml.cs
@@ -435,7 +435,7 @@ namespace Foundry.Views
         {
             foreach (NavigationViewItem item in NavView.FooterMenuItems.OfType<NavigationViewItem>())
             {
-                item.IsEnabled = state != ShellNavigationState.OperationRunning;
+                item.IsEnabled = state is not (ShellNavigationState.OperationRunning or ShellNavigationState.InteractionPending);
             }
         }
 
@@ -457,7 +457,7 @@ namespace Foundry.Views
             ToolTipService.SetToolTip(item, description);
             AutomationProperties.SetName(item, item.Content?.ToString() ?? string.Empty);
             AutomationProperties.SetHelpText(item, description);
-            item.IsEnabled = shellNavigationGuardService.State != ShellNavigationState.OperationRunning;
+            item.IsEnabled = shellNavigationGuardService.State is not (ShellNavigationState.OperationRunning or ShellNavigationState.InteractionPending);
         }
 
         private void RefreshUpdateFooterItem()
@@ -499,7 +499,7 @@ namespace Foundry.Views
             AutomationProperties.SetName(item, ViewModel.UpdateFooterTitle);
             AutomationProperties.SetHelpText(item, ViewModel.UpdateFooterToolTip);
             AutomationProperties.SetItemStatus(item, ViewModel.UpdateFooterToolTip);
-            item.IsEnabled = shellNavigationGuardService.State != ShellNavigationState.OperationRunning;
+            item.IsEnabled = shellNavigationGuardService.State is not (ShellNavigationState.OperationRunning or ShellNavigationState.InteractionPending);
         }
 
         private void RemoveUpdateFooterItem()
@@ -531,7 +531,7 @@ namespace Foundry.Views
             ToolTipService.SetToolTip(item, description);
             AutomationProperties.SetName(item, item.Content?.ToString() ?? string.Empty);
             AutomationProperties.SetHelpText(item, description);
-            item.IsEnabled = shellNavigationGuardService.State != ShellNavigationState.OperationRunning;
+            item.IsEnabled = shellNavigationGuardService.State is not (ShellNavigationState.OperationRunning or ShellNavigationState.InteractionPending);
         }
 
         private void EnsureExternalBugReportFooterItem()
@@ -552,12 +552,12 @@ namespace Foundry.Views
             ToolTipService.SetToolTip(item, description);
             AutomationProperties.SetName(item, item.Content?.ToString() ?? string.Empty);
             AutomationProperties.SetHelpText(item, description);
-            item.IsEnabled = shellNavigationGuardService.State != ShellNavigationState.OperationRunning;
+            item.IsEnabled = shellNavigationGuardService.State is not (ShellNavigationState.OperationRunning or ShellNavigationState.InteractionPending);
         }
 
         private void NavigateToUpdateSettingsPage()
         {
-            if (shellNavigationGuardService.State == ShellNavigationState.OperationRunning)
+            if (shellNavigationGuardService.State is ShellNavigationState.OperationRunning or ShellNavigationState.InteractionPending)
             {
                 return;
             }
@@ -595,7 +595,7 @@ namespace Foundry.Views
             string failureMessageResourceKey,
             string target)
         {
-            if (shellNavigationGuardService.State == ShellNavigationState.OperationRunning)
+            if (shellNavigationGuardService.State is ShellNavigationState.OperationRunning or ShellNavigationState.InteractionPending)
             {
                 return;
             }
@@ -647,7 +647,7 @@ namespace Foundry.Views
 
         private async Task ShowAboutDialogAsync()
         {
-            if (shellNavigationGuardService.State == ShellNavigationState.OperationRunning)
+            if (shellNavigationGuardService.State is ShellNavigationState.OperationRunning or ShellNavigationState.InteractionPending)
             {
                 return;
             }

--- a/src/Foundry/Views/SettingsPage.xaml
+++ b/src/Foundry/Views/SettingsPage.xaml
@@ -14,6 +14,15 @@
         HorizontalAlignment="Stretch"
         VerticalScrollBarVisibility="Auto">
         <StackPanel Spacing="{ThemeResource FoundryCompactStackSpacing}">
+            <wct:SettingsCard x:Name="DeploymentProfilesCard"
+                x:Uid="SettingsPage_ProfilesCard"
+                HorizontalContentAlignment="Stretch"
+                ContentAlignment="Vertical">
+                <wct:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE8A5;" />
+                </wct:SettingsCard.HeaderIcon>
+                <views:DeploymentProfilesControl />
+            </wct:SettingsCard>
             <wct:SettingsCard x:Name="GeneralSettingsCard"
                 x:Uid="SettingsPage_GeneralCard"
                 Click="GeneralSettingsCard_Click"

--- a/src/Foundry/Views/SettingsPage.xaml.cs
+++ b/src/Foundry/Views/SettingsPage.xaml.cs
@@ -49,6 +49,8 @@ namespace Foundry.Views
 
         private void ApplyLocalizedText()
         {
+            DeploymentProfilesCard.Header = localizationService.GetString("SettingsPage_ProfilesCard.Header");
+            DeploymentProfilesCard.Description = localizationService.GetString("SettingsPage_ProfilesCard.Description");
             TelemetryCard.Header = localizationService.GetString("SettingsPage_TelemetryCard.Header");
             TelemetryCard.Description = localizationService.GetString("SettingsPage_TelemetryCard.Description");
             RemoteDiagnosticsCard.Header = localizationService.GetString("SettingsPage_RemoteDiagnosticsCard.Header");

--- a/src/Foundry/Views/WifiPage.xaml
+++ b/src/Foundry/Views/WifiPage.xaml
@@ -155,6 +155,9 @@
                                     Command="{x:Bind ViewModel.BrowseWifiCertificateCommand}"
                                     Content="{x:Bind ViewModel.BrowseButtonText, Mode=OneWay}" />
                             </Grid>
+                            <PasswordBox
+                                Header="{x:Bind ViewModel.CertificatePasswordLabel, Mode=OneWay}"
+                                Password="{x:Bind ViewModel.WifiCertificatePassword, Mode=TwoWay}" />
                             <TextBlock
                                 Foreground="{ThemeResource SystemFillColorCriticalBrush}"
                                 Text="{x:Bind ViewModel.WifiCertificateValidationMessage, Mode=OneWay}"


### PR DESCRIPTION
## Summary

Add the Deployment profiles card to Settings with named local profiles, optional remembered passwords, encrypted import/export, and shared SMB synchronization with explicit conflict resolution.

## Reason

Operators can reuse deployment configurations across sessions and installations without transferring workstation settings or silently overwriting another editor's changes.

## Main changes

- Integrate WCM-backed local revisions, shared enrollment/recovery, pending-publication reconciliation, and independent retention/sharing choices.
- Restore passwords only in matching contexts; preserve complete checkpoints and handle locked, omitted, deleted, and unsupported data explicitly.
- Freeze media configuration, credentials, dependencies, and local drivers before generation; isolate and clean confidential staging.
- Migrate authoring settings to per-user storage, retain existing proxy compatibility, and provide network PFX password fields.
- Translate 54 profile resource keys into all 38 locales and remove replaced live-generation APIs.
- Bump the released authoring schema from 14 to 15; retain Connect/Deploy schemas and media-secret contracts.

## Testing

- Full Release x64 solution build with warnings as errors: zero warnings/errors.
- All seven executable test projects: 2,240 passed, zero failed/skipped.
- External session harness: 19 checks; staging lifecycle harness: 12 checks, including real NTFS junction/ACL cases.
- Resource key, duplicate, blank value, placeholder, and reference checks: 54 keys across 38 locales.
- Two independent deep review passes, including obsolete code, translations, and test relevance; actionable findings fixed and rechecked.
- Repository formatting verification and git diff checks pass.
- Native WinUI interactions, actual SMB multi-client/failover behavior, and full media creation are covered by the manual acceptance checklist; they are not claimed as executed here.

Related issue: #339
Parent integration PR: #345
GitBook documentation: https://github.com/foundry-osd/GitBook/pull/21

This child targets the integration branch. The parent PR remains open for maintainer merge.

ARM64 CI exposed a cancellation/disposal race in the existing proxy-authentication test server. Its shutdown now waits for the cancelled accept loop before closing the listener. The focused Core rerun passed all 819 tests; the updated commit is checked again by both CI architectures.
